### PR TITLE
[Serve] Good error message when Serve not installed and ensure Serve installs ray[default]

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -203,7 +203,6 @@
       python/ray/tests/test_runtime_env_ray_minimal
     - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
       python/ray/tests/test_serve_ray_minimal
-    # TODO(archit)
 - label: ":python: (Flaky tests)"
   conditions: ["RAY_CI_PYTHON_AFFECTED", "RAY_CI_SERVE_AFFECTED", "RAY_CI_RLLIB_AFFECTED", "RAY_CI_TUNE_AFFECTED"]
   commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -201,6 +201,8 @@
       python/ray/tests/test_basic_3
     - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
       python/ray/tests/test_runtime_env_ray_minimal
+    - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
+      python/ray/tests/test_serve_ray_minimal
     # TODO(archit)
 - label: ":python: (Flaky tests)"
   conditions: ["RAY_CI_PYTHON_AFFECTED", "RAY_CI_SERVE_AFFECTED", "RAY_CI_RLLIB_AFFECTED", "RAY_CI_TUNE_AFFECTED"]

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -1,7 +1,12 @@
-from ray.serve.api import (start, get_replica_context, shutdown, ingress,
-                           deployment, get_deployment, list_deployments)
-from ray.serve.batching import batch
-from ray.serve.config import HTTPOptions
+try:
+    from ray.serve.api import (start, get_replica_context, shutdown, ingress,
+                               deployment, get_deployment, list_deployments)
+    from ray.serve.batching import batch
+    from ray.serve.config import HTTPOptions
+except ModuleNotFoundError as e:
+    e.msg += (". You can run `pip install ray[serve]` to install all Ray Serve"
+              " dependencies.")
+    raise e
 
 # Mute the warning because Serve sometimes intentionally calls
 # ray.get inside async actors.

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -4,8 +4,9 @@ try:
     from ray.serve.batching import batch
     from ray.serve.config import HTTPOptions
 except ModuleNotFoundError as e:
-    e.msg += (". You can run `pip install ray[serve]` to install all Ray Serve"
-              " dependencies.")
+    e.msg += (
+        ". You can run `pip install 'ray[serve]'` to install all Ray Serve"
+        " dependencies.")
     raise e
 
 # Mute the warning because Serve sometimes intentionally calls

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -319,6 +319,14 @@ py_test(
     deps = ["//:ray_lib"],
 )
 
+py_test(
+    name = "test_serve_ray_minimal",
+    size = "small",
+    srcs = SRCS + ["test_serve_ray_minimal.py"],
+    tags = ["exclusive", "team:serve"],
+    deps = ["//:ray_lib"],
+)
+
 # TODO(ekl) we can't currently support tagging these as flaky since there's
 # no way to filter by both flaky and client mode tests in bazel.
 py_test_module_list(

--- a/python/ray/tests/test_serve_ray_minimal.py
+++ b/python/ray/tests/test_serve_ray_minimal.py
@@ -15,6 +15,7 @@ import pytest
 def test_errr_msg():
     with pytest.raises(ModuleNotFoundError, match="install ray\[serve\]"):
         from ray import serve
+        serve.start()
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_serve_ray_minimal.py
+++ b/python/ray/tests/test_serve_ray_minimal.py
@@ -12,8 +12,8 @@ import pytest
 @pytest.mark.skipif(
     os.environ.get("RAY_MINIMAL") != "1",
     reason="This test is only run in CI with a minimal Ray installation.")
-def test_errr_msg():
-    with pytest.raises(ModuleNotFoundError, match="install ray\[serve\]"):
+def test_error_msg():
+    with pytest.raises(ModuleNotFoundError, match="install 'ray\[serve\]'"):
         from ray import serve
         serve.start()
 

--- a/python/ray/tests/test_serve_ray_minimal.py
+++ b/python/ray/tests/test_serve_ray_minimal.py
@@ -1,0 +1,21 @@
+"""
+Test that Serve gives good error message when no deps are installed.
+This tests exist in the ray/tests/ directory instead of ray/serve/tests because
+it needs not to have dependencies on serve's conftest.py.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test is only run in CI with a minimal Ray installation.")
+def test_errr_msg():
+    with pytest.raises(ModuleNotFoundError, match="install ray\[serve\]"):
+        from ray import serve
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", "-s", __file__])

--- a/python/setup.py
+++ b/python/setup.py
@@ -212,7 +212,8 @@ if setup_spec.type == SetupType.RAY:
     }
 
     # Ray Serve depends on the Ray dashboard components.
-    setup_spec.extras["serve"] += setup_spec.extras["default"]
+    setup_spec.extras["serve"] = list(
+        set(setup_spec.extras["serve"] + setup_spec.extras["default"]))
 
     if RAY_EXTRA_CPP:
         setup_spec.extras["cpp"] = ["ray-cpp==" + setup_spec.version]

--- a/python/setup.py
+++ b/python/setup.py
@@ -211,6 +211,9 @@ if setup_spec.type == SetupType.RAY:
         ],
     }
 
+    # Ray Serve depends on the Ray dashboard componenents.
+    setup_spec.extras["serve"] += setup_spec.extras["default"]
+
     if RAY_EXTRA_CPP:
         setup_spec.extras["cpp"] = ["ray-cpp==" + setup_spec.version]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -211,7 +211,7 @@ if setup_spec.type == SetupType.RAY:
         ],
     }
 
-    # Ray Serve depends on the Ray dashboard componenents.
+    # Ray Serve depends on the Ray dashboard components.
     setup_spec.extras["serve"] += setup_spec.extras["default"]
 
     if RAY_EXTRA_CPP:


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #19262 
Closes #19303
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
