### PR TITLE
[docs] add dask compatibility for 1.8.0

### DIFF
--- a/doc/source/data/dask-on-ray.rst
+++ b/doc/source/data/dask-on-ray.rst
@@ -30,6 +30,8 @@ workload. Using the Dask-on-Ray scheduler, the entire Dask ecosystem can be exec
 
      * - Ray Version
        - Dask Version
+     * - ``1.8.0``
+       - ``2021.9.1``
      * - ``1.7.0``
        - ``2021.9.1``
      * - ``1.6.0``


### PR DESCRIPTION
## Why are these changes needed?

@jjyao : "ray 1.8 is compatible with latest dask 2021.9.1"

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
