### PR TITLE
[tune] Remove magic results (e.g. config) before calculating trial result metrics

### DIFF
--- a/python/ray/tune/tests/test_experiment_analysis_mem.py
+++ b/python/ray/tune/tests/test_experiment_analysis_mem.py
@@ -11,6 +11,7 @@ import numpy as np
 import ray
 from ray.tune import (run, Trainable, sample_from, Analysis,
                       ExperimentAnalysis, grid_search)
+from ray.tune.result import DEBUG_METRICS
 from ray.tune.utils.mock import MyTrainableClass
 from ray.tune.utils.serialization import TuneFunctionEncoder
 
@@ -163,10 +164,12 @@ class ExperimentAnalysisInMemorySuite(unittest.TestCase):
                 "id": 1
             }).trials
 
-        self.assertNotIn("pid", trial.metric_analysis)
+        for metric in DEBUG_METRICS:
+            self.assertNotIn(metric, trial.metric_analysis)
+            self.assertNotIn(metric, trial.metric_n_steps)
+
         self.assertTrue(not any(
             metric.startswith("config") for metric in trial.metric_analysis))
-        self.assertNotIn("pid", trial.metric_n_steps)
         self.assertTrue(not any(
             metric.startswith("config") for metric in trial.metric_n_steps))
 

--- a/python/ray/tune/tests/test_experiment_analysis_mem.py
+++ b/python/ray/tune/tests/test_experiment_analysis_mem.py
@@ -150,6 +150,26 @@ class ExperimentAnalysisInMemorySuite(unittest.TestCase):
         self.assertAlmostEqual(min_avg_10, min(
             np.mean(scores[:, -10:], axis=1)))
 
+    def testRemoveMagicResults(self):
+        [trial] = run(
+            self.MockTrainable,
+            name="analysis_remove_exp",
+            local_dir=self.test_dir,
+            stop={
+                "training_iteration": 9
+            },
+            num_samples=1,
+            config={
+                "id": 1
+            }).trials
+
+        self.assertNotIn("pid", trial.metric_analysis)
+        self.assertTrue(not any(
+            metric.startswith("config") for metric in trial.metric_analysis))
+        self.assertNotIn("pid", trial.metric_n_steps)
+        self.assertTrue(not any(
+            metric.startswith("config") for metric in trial.metric_n_steps))
+
 
 class AnalysisSuite(unittest.TestCase):
     @classmethod

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -21,7 +21,7 @@ from ray.tune.checkpoint_manager import Checkpoint, CheckpointManager
 # have been defined yet. See https://github.com/ray-project/ray/issues/1716.
 from ray.tune.registry import get_trainable_cls, validate_trainable
 from ray.tune.result import (DEFAULT_RESULTS_DIR, DONE, NODE_IP, PID,
-                             TRAINING_ITERATION, TRIAL_ID)
+                             TRAINING_ITERATION, TRIAL_ID, DEBUG_METRICS)
 from ray.tune.resources import Resources, \
     json_to_resources, resources_to_json
 from ray.tune.utils.placement_groups import PlacementGroupFactory, \
@@ -661,7 +661,11 @@ class Trial:
         self.last_result = result
         self.last_update_time = time.time()
 
-        for metric, value in flatten_dict(result).items():
+        metric_result = copy.deepcopy(self.last_result)
+        for remove_metric in DEBUG_METRICS:
+            metric_result.pop(remove_metric, None)
+
+        for metric, value in flatten_dict(metric_result).items():
             if isinstance(value, Number):
                 if metric not in self.metric_analysis:
                     self.metric_analysis[metric] = {

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -661,7 +661,7 @@ class Trial:
         self.last_result = result
         self.last_update_time = time.time()
 
-        metric_result = copy.deepcopy(self.last_result)
+        metric_result = self.last_result.copy()
         for remove_metric in DEBUG_METRICS:
             metric_result.pop(remove_metric, None)
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Addresses the application-layer memory issue in https://github.com/ray-project/ray/issues/19309#issuecomment-947890213

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
