### PR TITLE
Add a stronger resource leak check to pg unit tests.

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -680,6 +680,34 @@ def is_placement_group_removed(pg):
     return table["state"] == "REMOVED"
 
 
+def placement_group_assert_no_leak(pgs_created):
+    for pg in pgs_created:
+        ray.util.remove_placement_group(pg)
+
+    def wait_for_pg_removed():
+        for pg_entry in ray.util.placement_group_table().values():
+            if pg_entry["state"] != "REMOVED":
+                return False
+        return True
+
+    wait_for_condition(wait_for_pg_removed)
+
+    cluster_resources = ray.cluster_resources()
+    cluster_resources.pop("memory")
+    cluster_resources.pop("object_store_memory")
+
+    def wait_for_resource_recovered():
+        for resource, val in ray.available_resources().items():
+            if (resource in cluster_resources
+                    and cluster_resources[resource] != val):
+                return False
+            if "_group_" in resource:
+                return False
+        return True
+
+    wait_for_condition(wait_for_resource_recovered)
+
+
 def setup_tls():
     """Sets up required environment variables for tls"""
     if sys.platform == "darwin":

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -397,3 +397,10 @@ def unstable_spilling_config(request, tmp_path):
     ])
 def slow_spilling_config(request, tmp_path):
     yield create_object_spilling_config(request, tmp_path)
+
+
+@pytest.fixture
+def ray_start_cluster(request):
+    param = getattr(request, "param", {})
+    with _ray_start_cluster(**param) as res:
+        yield res

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -397,10 +397,3 @@ def unstable_spilling_config(request, tmp_path):
     ])
 def slow_spilling_config(request, tmp_path):
     yield create_object_spilling_config(request, tmp_path)
-
-
-@pytest.fixture
-def ray_start_cluster(request):
-    param = getattr(request, "param", {})
-    with _ray_start_cluster(**param) as res:
-        yield res

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -11,7 +11,8 @@ import ray
 import ray.cluster_utils
 
 from ray._private.test_utils import (get_other_nodes, wait_for_condition,
-                                     is_placement_group_removed)
+                                     is_placement_group_removed,
+                                     placement_group_assert_no_leak)
 from ray._raylet import PlacementGroupID
 from ray.util.placement_group import PlacementGroup
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
@@ -39,6 +40,8 @@ def test_placement_ready(ray_start_regular, connect_to_client):
         a = Actor.options(num_cpus=1, placement_group=pg).remote()
         ray.get(a.v.remote())
         ray.get(pg.ready())
+
+        placement_group_assert_no_leak([pg])
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -93,6 +96,7 @@ def test_placement_group_pack(ray_start_cluster, connect_to_client):
         node_of_actor_1 = actor_info_1["Address"]["NodeID"]
         node_of_actor_2 = actor_info_2["Address"]["NodeID"]
         assert node_of_actor_1 == node_of_actor_2
+        placement_group_assert_no_leak([placement_group])
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -149,6 +153,8 @@ def test_placement_group_strict_pack(ray_start_cluster, connect_to_client):
         node_of_actor_2 = actor_info_2["Address"]["NodeID"]
         assert node_of_actor_1 == node_of_actor_2
 
+        placement_group_assert_no_leak([placement_group])
+
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
 def test_placement_group_spread(ray_start_cluster, connect_to_client):
@@ -196,6 +202,8 @@ def test_placement_group_spread(ray_start_cluster, connect_to_client):
         node_of_actor_1 = actor_info_1["Address"]["NodeID"]
         node_of_actor_2 = actor_info_2["Address"]["NodeID"]
         assert node_of_actor_1 != node_of_actor_2
+
+        placement_group_assert_no_leak([placement_group])
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -257,6 +265,8 @@ def test_placement_group_strict_spread(ray_start_cluster, connect_to_client):
         assert node_of_actor_1 != node_of_actor_3
         assert node_of_actor_2 != node_of_actor_3
 
+        placement_group_assert_no_leak([placement_group])
+
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
 def test_placement_group_actor_resource_ids(ray_start_cluster,
@@ -278,6 +288,7 @@ def test_placement_group_actor_resource_ids(ray_start_cluster,
         resources = ray.get(a1.f.remote())
         assert len(resources) == 1, resources
         assert "CPU_group_" in list(resources.keys())[0], resources
+        placement_group_assert_no_leak([g1])
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -312,6 +323,8 @@ def test_placement_group_task_resource_ids(ray_start_cluster,
         assert ("CPU_group_0_" in keys[0]
                 or "CPU_group_0_" in keys[1]), resources
 
+        placement_group_assert_no_leak([g1])
+
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
 def test_placement_group_hang(ray_start_cluster, connect_to_client):
@@ -337,6 +350,8 @@ def test_placement_group_hang(ray_start_cluster, connect_to_client):
         resources = ray.get(o1)
         assert len(resources) == 1, resources
         assert "CPU_group_" in list(resources.keys())[0], resources
+
+        placement_group_assert_no_leak([g1])
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -435,6 +450,8 @@ def test_remove_pending_placement_group(ray_start_cluster, connect_to_client):
         # Make sure this task is still schedulable.
         assert ray.get(f.remote()) == 3
 
+        placement_group_assert_no_leak([placement_group])
+
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
 def test_placement_group_table(ray_start_cluster, connect_to_client):
@@ -451,6 +468,7 @@ def test_placement_group_table(ray_start_cluster, connect_to_client):
     for _ in range(num_nodes):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
+    pgs_created = []
 
     with connect_to_client_or_not(connect_to_client):
         # Originally placement group creation should be pending because
@@ -460,6 +478,7 @@ def test_placement_group_table(ray_start_cluster, connect_to_client):
         bundles = [{"CPU": 2, "GPU": 1}, {"CPU": 2}]
         placement_group = ray.util.placement_group(
             name=name, strategy=strategy, bundles=bundles)
+        pgs_created.append(placement_group)
         result = ray.util.placement_group_table(placement_group)
         assert result["name"] == name
         assert result["strategy"] == strategy
@@ -481,14 +500,16 @@ def test_placement_group_table(ray_start_cluster, connect_to_client):
 
         # Add tow more placement group for placement group table test.
         second_strategy = "SPREAD"
-        ray.util.placement_group(
-            name="second_placement_group",
-            strategy=second_strategy,
-            bundles=bundles)
-        ray.util.placement_group(
-            name="third_placement_group",
-            strategy=second_strategy,
-            bundles=bundles)
+        pgs_created.append(
+            ray.util.placement_group(
+                name="second_placement_group",
+                strategy=second_strategy,
+                bundles=bundles))
+        pgs_created.append(
+            ray.util.placement_group(
+                name="third_placement_group",
+                strategy=second_strategy,
+                bundles=bundles))
 
         placement_group_table = ray.util.placement_group_table()
         assert len(placement_group_table) == 3
@@ -502,6 +523,8 @@ def test_placement_group_table(ray_start_cluster, connect_to_client):
             get_name_set.add(placement_group_data["name"])
 
         assert true_name_set == get_name_set
+
+        placement_group_assert_no_leak(pgs_created)
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -522,6 +545,7 @@ def test_cuda_visible_devices(ray_start_cluster, connect_to_client):
 
         devices = ray.get(o1)
         assert devices == "0", devices
+        placement_group_assert_no_leak([g1])
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -592,6 +616,7 @@ def test_placement_group_reschedule_when_node_dead(ray_start_cluster,
         ray.get(actor_4.value.remote())
         ray.get(actor_5.value.remote())
         ray.get(actor_6.value.remote())
+        placement_group_assert_no_leak([placement_group])
         ray.shutdown()
 
 

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -13,7 +13,8 @@ import ray._private.gcs_utils as gcs_utils
 
 from ray._private.test_utils import (
     generate_system_config_map, kill_actor_and_wait_for_failure,
-    run_string_as_driver, wait_for_condition, get_error_message)
+    run_string_as_driver, wait_for_condition, get_error_message,
+    placement_group_assert_no_leak)
 from ray.util.placement_group import get_current_placement_group
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 
@@ -58,6 +59,8 @@ def test_check_bundle_index(ray_start_cluster, connect_to_client):
 
         with pytest.raises(ValueError, match="bundle index must be -1"):
             Actor.options(placement_group_bundle_index=0).remote()
+
+        placement_group_assert_no_leak([placement_group])
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a stronger resource leak check to pg tests.

To avoid making too many flaky tests, I am adding this to `test_placement_group.py` and `test_placement_group_mini_integreation` first. I will eventually check all tests 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
