### PR TITLE
[tune] Only try to sync driver if sync_to_driver is actually enabled

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -418,7 +418,7 @@ class SyncerCallback(Callback):
         from ray.tune.durable_trainable import DurableTrainable
 
         trial_syncer = self._get_trial_syncer(trial)
-        if trial.sync_on_checkpoint:
+        if trial.sync_on_checkpoint and self._sync_function is not False:
             try:
                 # Wait for any other syncs to finish. We need to sync again
                 # after this to handle checkpoints taken mid-sync.

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -418,6 +418,9 @@ class SyncerCallback(Callback):
         from ray.tune.durable_trainable import DurableTrainable
 
         trial_syncer = self._get_trial_syncer(trial)
+        # If the sync_function is False, syncing to driver is disabled.
+        # In every other case (valid values include None, True Callable,
+        # NodeSyncer) syncing to driver is enabled.
         if trial.sync_on_checkpoint and self._sync_function is not False:
             try:
                 # Wait for any other syncs to finish. We need to sync again


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we try to sync to driver even if `sync_to_driver=False`. A no-op is called, but the checkpoint is not detected afterwards (which is expected), so errors are thrown (which should not be the case).

Additionally, because the callback fails, the checkpoint manager is not called, and remote checkpoints are not deleted. This leads to `keep_checkpoints_num` being disobeyed when `sync_to_driver=False`.

This functionality was caught and will be tested in a (wip) release test.


## Related issue number

Closes #19192

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
