### PR TITLE
Fix test_tls_auth.py on Windows 

### DIFF
--- a/python/ray/tests/test_tls_auth.py
+++ b/python/ray/tests/test_tls_auth.py
@@ -143,7 +143,7 @@ ray_client.connect("localhost:10001")
 print(ray.is_initialized())
      """,
         env=tls_env)
-    assert out == "True\n"
+    assert out.strip() == "True"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

The `test_tls_auth.py` tests are failing on Windows because of extra windows return characters.

From: https://github.com/ray-project/ray/pull/18631/checks
```
 >       assert out == "True\n"
E       AssertionError: assert 'True\r\n' == 'True\n'
E         - True
E         + True

E         ?     +

\\?\C:\Users\RUNNER~1\AppData\Local\Temp\Bazel.runfiles_2icwkach\runfiles\com_github_ray_project_ray\python\ray\tests\test_tls_auth.py:146: AssertionError
```

@ericl it seems the Windows test didn't run on the [final commit](https://github.com/ray-project/ray/pull/18631/commits/7fb64f03dcb61f7cc00899b780fbaf0a3ddab3b6) of my PR
