### PR TITLE
[Core][CoreWorker][RFC] graceful shutdown if GetCoreWorker is null

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -190,10 +190,20 @@ CoreWorkerProcess::~CoreWorkerProcess() {
   }
 }
 
-void CoreWorkerProcess::EnsureInitialized() {
-  RAY_CHECK(core_worker_process)
-      << "The core worker process is not initialized yet or already "
-      << "shutdown.";
+void CoreWorkerProcess::EnsureInitialized(bool quick_exit) {
+  if (core_worker_process != nullptr) {
+    return;
+  }
+
+  if (quick_exit) {
+    RAY_LOG(ERROR) << "The core worker process is not initialized yet or already "
+                   << "shutdown.";
+    QuickExit(/*logging-enabled*/ false);
+  } else {
+    RAY_CHECK(core_worker_process)
+        << "The core worker process is not initialized yet or already "
+        << "shutdown.";
+  }
 }
 
 void CoreWorkerProcess::HandleAtExit() { core_worker_process.reset(); }
@@ -266,7 +276,7 @@ std::shared_ptr<CoreWorker> CoreWorkerProcess::TryGetWorker(const WorkerID &work
 }
 
 CoreWorker &CoreWorkerProcess::GetCoreWorker() {
-  EnsureInitialized();
+  EnsureInitialized(/*quick_exit*/ true);
   if (core_worker_process->options_.num_workers == 1) {
     auto global_worker = core_worker_process->GetGlobalWorker();
     if (core_worker_process->ShouldCreateGlobalWorkerOnConstruction() && !global_worker) {
@@ -289,7 +299,7 @@ CoreWorker &CoreWorkerProcess::GetCoreWorker() {
 }
 
 void CoreWorkerProcess::SetCurrentThreadWorkerId(const WorkerID &worker_id) {
-  EnsureInitialized();
+  EnsureInitialized(/*quick_exit*/ false);
   if (core_worker_process->options_.num_workers == 1) {
     RAY_CHECK(core_worker_process->GetGlobalWorker()->GetWorkerID() == worker_id);
     return;
@@ -345,7 +355,7 @@ void CoreWorkerProcess::RemoveWorker(std::shared_ptr<CoreWorker> worker) {
 }
 
 void CoreWorkerProcess::RunTaskExecutionLoop() {
-  EnsureInitialized();
+  EnsureInitialized(/*quick_exit*/ false);
   RAY_CHECK(core_worker_process->options_.worker_type == WorkerType::WORKER);
   if (core_worker_process->options_.num_workers == 1) {
     // Run the task loop in the current thread only if the number of workers is 1.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -301,8 +301,10 @@ class CoreWorkerProcess {
 
   /// Check that the core worker environment is initialized for this process.
   ///
+  /// \param[in] quick_exit If set to true, quick exit if uninitialized without
+  /// crash.
   /// \return Void.
-  static void EnsureInitialized();
+  static void EnsureInitialized(bool quick_exit);
 
   static void HandleAtExit();
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

There are cases that the language frontend calls GetCoreWorker() after the worker has already been shutdown. Currently this results in a crash and causes confusions. 


```
pid=3714) [2021-10-21 10:50:23,596 C 3714 33544237] core_worker.cc:194:  Check failed: core_worker_process The core worker process is not initialized yet or already shutdown.
(pid=3714) *** StackTrace Information ***
(pid=3714)     ray::GetCallTrace()
(pid=3714)     ray::SpdLogMessage::Flush()
(pid=3714)     ray::SpdLogMessage::~SpdLogMessage()
(pid=3714)     ray::RayLog::~RayLog()
(pid=3714)     ray::core::CoreWorkerProcess::EnsureInitialized()
(pid=3714)     ray::core::CoreWorkerProcess::GetCoreWorker()
(pid=3714)     __pyx_pw_3ray_7_raylet_10CoreWorker_23get_worker_id()
(pid=3714)     _PyMethodDef_RawFastCallKeywords
(pid=3714)     _PyMethodDescr_FastCallKeywords
(pid=3714)     call_function
(pid=3714)     _PyEval_EvalFrameDefault
(pid=3714)     function_code_fastcall
(pid=3714)     property_descr_get
(pid=3714)     _PyObject_GenericGetAttrWithDict
(pid=3714)     _PyEval_EvalFrameDefault
(pid=3714)     _PyEval_EvalCodeWithName
(pid=3714)     _PyFunction_FastCallKeywords
(pid=3714)     call_function
(pid=3714)     _PyEval_EvalFrameDefault
(pid=3714)     function_code_fastcall
(pid=3714)     call_function
(pid=3714)     _PyEval_EvalFrameDefault
(pid=3714)     function_code_fastcall
(pid=3714)     method_call
(pid=3714)     PyObject_Call
(pid=3714)     _PyEval_EvalFrameDefault
(pid=3714)     function_code_fastcall
(pid=3714)     call_function
(pid=3714)     _PyEval_EvalFrameDefault
(pid=3714)     function_code_fastcall
(pid=3714)     call_function
(pid=3714)     _PyEval_EvalFrameDefault
(pid=3714)     function_code_fastcall
(pid=3714)     method_call
(pid=3714)     PyObject_Call
(pid=3714)     t_bootstrap
(pid=3714)     pythread_wrapper
(pid=3714)     _pthread_start
(pid=3714)     thread_start
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
