### PR TITLE
[Serve] Fix shutdown protocol again

### DIFF
--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -366,7 +366,8 @@ class RayServeReplica:
         # destructor is called only once.
         try:
             if hasattr(self.callable, "__del__"):
-                self.callable.__del__()
+                # Make sure to accept `async def __del__(self)` as well.
+                await sync_to_async(self.callable.__del__)()
         except Exception as e:
             logger.exception(
                 f"Exception during graceful shutdown of replica: {e}")

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -558,22 +558,25 @@ def test_fastapiwrapper_constructor_before_startup_hooks(serve_instance):
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_fastapi_shutdown_hook(serve_instance):
     # https://github.com/ray-project/ray/issues/18349
-    signal = SignalActor.remote()
+    shutdown_signal = SignalActor.remote()
+    del_signal = SignalActor.remote()
 
     app = FastAPI()
 
     @app.on_event("shutdown")
     def call_signal():
-        signal.send.remote()
+        shutdown_signal.send.remote()
 
     @serve.deployment
     @serve.ingress(app)
     class A:
-        pass
+        def __del__(self):
+            del_signal.send.remote()
 
     A.deploy()
     A.delete()
-    ray.get(signal.wait.remote(), timeout=20)
+    ray.get(shutdown_signal.wait.remote(), timeout=20)
+    ray.get(del_signal.wait.remote(), timeout=20)
 
 
 def test_fastapi_method_redefinition(serve_instance):


### PR DESCRIPTION
## Why are these changes needed?

Previous implementation of the shutdown protocol has two bugs:
- The asgi shutdown needs to run in event loop. But because the del method is synchronous, we can't await in there. The run_until_complete actually doesn't work because the event loop is already running.
- It doesn't call the super class's del method.
- 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #18349

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
