### PR TITLE
[event] enable the event module in dashboard by default

### DIFF
--- a/dashboard/modules/event/event_agent.py
+++ b/dashboard/modules/event/event_agent.py
@@ -6,7 +6,6 @@ from typing import Union
 import ray._private.utils as utils
 import ray.dashboard.utils as dashboard_utils
 import ray.dashboard.consts as dashboard_consts
-from ray.ray_constants import env_bool
 from ray.dashboard.utils import async_loop_forever, create_task
 from ray.dashboard.modules.event import event_consts
 from ray.dashboard.modules.event.event_utils import monitor_events
@@ -17,8 +16,6 @@ logger = logging.getLogger(__name__)
 routes = dashboard_utils.ClassMethodRouteTable
 
 
-@dashboard_utils.dashboard_module(
-    enable=env_bool(event_consts.EVENT_MODULE_ENVIRONMENT_KEY, False))
 class EventAgent(dashboard_utils.DashboardAgentModule):
     def __init__(self, dashboard_agent):
         super().__init__(dashboard_agent)

--- a/dashboard/modules/event/event_consts.py
+++ b/dashboard/modules/event/event_consts.py
@@ -1,7 +1,6 @@
 from ray.ray_constants import env_integer
 from ray.core.generated import event_pb2
 
-EVENT_MODULE_ENVIRONMENT_KEY = "RAY_DASHBOARD_MODULE_EVENT"
 LOG_ERROR_EVENT_STRING_LENGTH_LIMIT = 1000
 RETRY_CONNECT_TO_DASHBOARD_INTERVAL_SECONDS = 2
 # Monitor events

--- a/dashboard/modules/event/event_head.py
+++ b/dashboard/modules/event/event_head.py
@@ -7,7 +7,6 @@ from collections import OrderedDict, defaultdict
 import aiohttp.web
 
 import ray.dashboard.utils as dashboard_utils
-from ray.ray_constants import env_bool
 from ray.dashboard.modules.event import event_consts
 from ray.dashboard.modules.event.event_utils import (
     parse_event_strings,
@@ -24,8 +23,6 @@ JobEvents = OrderedDict
 dashboard_utils._json_compatible_types.add(JobEvents)
 
 
-@dashboard_utils.dashboard_module(
-    enable=env_bool(event_consts.EVENT_MODULE_ENVIRONMENT_KEY, False))
 class EventHead(dashboard_utils.DashboardHeadModule,
                 event_pb2_grpc.ReportEventServiceServicer):
     def __init__(self, dashboard_head):

--- a/dashboard/modules/event/tests/test_event.py
+++ b/dashboard/modules/event/tests/test_event.py
@@ -62,8 +62,7 @@ def _test_logger(name, log_file, max_bytes, backup_count):
     return logger
 
 
-def test_event_basic(enable_event_module, disable_aiohttp_cache,
-                     ray_start_with_dashboard):
+def test_event_basic(disable_aiohttp_cache, ray_start_with_dashboard):
     assert (wait_until_server_available(ray_start_with_dashboard["webui_url"]))
     webui_url = format_web_url(ray_start_with_dashboard["webui_url"])
     session_dir = ray_start_with_dashboard["session_dir"]
@@ -113,8 +112,8 @@ def test_event_basic(enable_event_module, disable_aiohttp_cache,
     wait_for_condition(_check_events, timeout=15)
 
 
-def test_event_message_limit(enable_event_module, small_event_line_limit,
-                             disable_aiohttp_cache, ray_start_with_dashboard):
+def test_event_message_limit(small_event_line_limit, disable_aiohttp_cache,
+                             ray_start_with_dashboard):
     event_read_line_length_limit = small_event_line_limit
     assert (wait_until_server_available(ray_start_with_dashboard["webui_url"]))
     webui_url = format_web_url(ray_start_with_dashboard["webui_url"])
@@ -175,7 +174,7 @@ def test_event_message_limit(enable_event_module, small_event_line_limit,
 
 
 @pytest.mark.asyncio
-async def test_monitor_events(enable_event_module):
+async def test_monitor_events():
     with tempfile.TemporaryDirectory() as temp_dir:
         common = event_pb2.Event.SourceType.Name(event_pb2.Event.COMMON)
         common_log = os.path.join(temp_dir, f"event_{common}.log")

--- a/dashboard/tests/conftest.py
+++ b/dashboard/tests/conftest.py
@@ -11,13 +11,6 @@ def enable_test_module():
 
 
 @pytest.fixture
-def enable_event_module():
-    os.environ["RAY_DASHBOARD_MODULE_EVENT"] = "true"
-    yield
-    os.environ.pop("RAY_DASHBOARD_MODULE_EVENT", None)
-
-
-@pytest.fixture
 def disable_aiohttp_cache():
     os.environ["RAY_DASHBOARD_NO_CACHE"] = "true"
     yield


### PR DESCRIPTION
## Why are these changes needed?

Event framework is ready to use. We should always load event modules in dashboard.