### PR TITLE
[tune] Fix local checkpoint deletion for remote trials

### DIFF
--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -323,8 +323,7 @@ class Trial:
         self.sync_on_checkpoint = sync_on_checkpoint
         self.checkpoint_manager = CheckpointManager(
             keep_checkpoints_num, checkpoint_score_attr,
-            CheckpointDeleter(self._trainable_name(), self.runner,
-                              ray.util.get_node_ip_address()))
+            CheckpointDeleter(self._trainable_name(), self.runner))
 
         # Restoration fields
         self.restore_path = restore_path

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -13,7 +13,7 @@ import uuid
 
 import ray
 import ray.cloudpickle as cloudpickle
-from ray.exceptions import GetTimeoutError, RayActorError
+from ray.exceptions import RayActorError
 from ray.tune import TuneError
 from ray.tune.checkpoint_manager import Checkpoint, CheckpointManager
 # NOTE(rkn): We import ray.tune.registry here instead of importing the names we
@@ -34,7 +34,6 @@ from ray.util.annotations import DeveloperAPI
 from ray._private.utils import binary_to_hex, hex_to_binary
 
 DEBUG_PRINT_INTERVAL = 5
-CHECKPOINT_DELETER_NODE_IP_GET_TIMEOUT = 15
 logger = logging.getLogger(__name__)
 
 
@@ -86,26 +85,9 @@ class ExportFormat:
 class CheckpointDeleter:
     """Checkpoint deleter callback for a runner."""
 
-    def __init__(self,
-                 trial_id,
-                 runner,
-                 node_ip,
-                 timeout: int = CHECKPOINT_DELETER_NODE_IP_GET_TIMEOUT):
+    def __init__(self, trial_id, runner):
         self.trial_id = trial_id
         self.runner = runner
-        self.node_ip = node_ip
-        self._runner_ip = None
-        self.timeout = timeout
-
-    @property
-    def runner_ip(self):
-        if not self._runner_ip:
-            try:
-                self._runner_ip = ray.get(
-                    self.runner.get_current_ip.remote(), timeout=self.timeout)
-            except GetTimeoutError:
-                pass
-        return self._runner_ip
 
     def __call__(self, checkpoint):
         """Requests checkpoint deletion asynchronously.
@@ -119,20 +101,22 @@ class CheckpointDeleter:
         if checkpoint.storage == Checkpoint.PERSISTENT and checkpoint.value:
             logger.debug("Trial %s: Deleting checkpoint %s", self.trial_id,
                          checkpoint.value)
+
+            # TODO(ujvl): Batch remote deletes.
+            # We first delete the remote checkpoint. If it is on the same
+            # node as the driver, it will also remove the local copy.
+            self.runner.delete_checkpoint.remote(checkpoint.value)
+
             checkpoint_path = checkpoint.value
 
             # Delete local copy, if any exists.
-            if self.runner_ip != self.node_ip and os.path.exists(
-                    checkpoint_path):
+            if os.path.exists(checkpoint_path):
                 try:
                     checkpoint_dir = TrainableUtil.find_checkpoint_dir(
                         checkpoint_path)
                     shutil.rmtree(checkpoint_dir)
                 except FileNotFoundError:
                     logger.warning("Checkpoint dir not found during deletion.")
-
-            # TODO(ujvl): Batch remote deletes.
-            self.runner.delete_checkpoint.remote(checkpoint.value)
 
 
 class TrialInfo:
@@ -340,7 +324,7 @@ class Trial:
         self.checkpoint_manager = CheckpointManager(
             keep_checkpoints_num, checkpoint_score_attr,
             CheckpointDeleter(self._trainable_name(), self.runner,
-                              self.node_ip))
+                              ray.util.get_node_ip_address()))
 
         # Restoration fields
         self.restore_path = restore_path
@@ -554,15 +538,13 @@ class Trial:
             self._default_result_or_future = (
                 runner.get_auto_filled_metrics.remote(debug_metrics_only=True))
         self.checkpoint_manager.delete = CheckpointDeleter(
-            self._trainable_name(), runner, self.node_ip)
+            self._trainable_name(), runner)
         # No need to invalidate state cache: runner is not stored in json
         # self.invalidate_json_state()
 
     def set_location(self, location):
         """Sets the location of the trial."""
         self.location = location
-        if self.checkpoint_manager.delete:
-            self.checkpoint_manager.delete.node_ip = self.node_ip
         # No need to invalidate state cache: location is not stored in json
         # self.invalidate_json_state()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The changes in #18318 introduced a regression for non-durable trainables - checkpoint copies on the driver were not removed anymore, as the runner ip always equaled the node ip. 

Instead we can fix both problems by simply calling the remote delete function before we check for a local copy. This will work for both durable and non-durable trainables.

## Related issue number

This PR partly reverts #18318

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
