### PR TITLE
[ray client] Add test that ray.init doesn't require resources to connect

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -786,7 +786,7 @@ def test_failed_task(ray_start_shared_local_modes, error_pubsub):
 
 @pytest.mark.parametrize(
     "call_ray_start",
-    ["ray start --head --ray-client-server-port 25553 --num-cpus=0"],
+    ["ray start --head --ray-client-server-port 25553 --num-cpus 0"],
     indirect=True)
 @pytest.mark.parametrize("use_client", [True, False])
 def test_init_requires_no_resources(call_ray_start, use_client):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -784,5 +784,24 @@ def test_failed_task(ray_start_shared_local_modes, error_pubsub):
         assert False
 
 
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25553 --num-cpus=0"],
+    indirect=True)
+@pytest.mark.parametrize("use_client", [True, False])
+def test_init_requires_no_resources(call_ray_start, use_client):
+    if use_client:
+        address = call_ray_start
+        ray.init(address)
+    else:
+        ray.init("ray://localhost:25553")
+
+    @ray.remote(num_cpus=0)
+    def f():
+        pass
+
+    ray.get(f.remote())
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -784,24 +784,5 @@ def test_failed_task(ray_start_shared_local_modes, error_pubsub):
         assert False
 
 
-@pytest.mark.parametrize(
-    "call_ray_start",
-    ["ray start --head --ray-client-server-port 25553 --num-cpus 0"],
-    indirect=True)
-@pytest.mark.parametrize("use_client", [True, False])
-def test_init_requires_no_resources(call_ray_start, use_client):
-    if use_client:
-        address = call_ray_start
-        ray.init(address)
-    else:
-        ray.init("ray://localhost:25553")
-
-    @ray.remote(num_cpus=0)
-    def f():
-        pass
-
-    ray.get(f.remote())
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -746,5 +746,24 @@ def test_wrapped_actor_creation(call_ray_start):
     run_wrapped_actor_creation()
 
 
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25553 --num-cpus 0"],
+    indirect=True)
+@pytest.mark.parametrize("use_client", [True, False])
+def test_init_requires_no_resources(call_ray_start, use_client):
+    if use_client:
+        address = call_ray_start
+        ray.init(address)
+    else:
+        ray.init("ray://localhost:25553")
+
+    @ray.remote(num_cpus=0)
+    def f():
+        pass
+
+    ray.get(f.remote())
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -752,6 +752,7 @@ def test_wrapped_actor_creation(call_ray_start):
     indirect=True)
 @pytest.mark.parametrize("use_client", [True, False])
 def test_init_requires_no_resources(call_ray_start, use_client):
+    import ray
     if use_client:
         address = call_ray_start
         ray.init(address)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/19621

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
