### PR TITLE
[tune] Verbosely/gracefully handle empty experiment checkpoints

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -585,7 +585,7 @@ class TrialRunner:
                 search_alg=self._search_alg,
                 force=force)
 
-    def resume(self, run_errored_only=False) -> bool:
+    def resume(self, run_errored_only=False):
         """Resumes all checkpointed trials from previous run.
 
         Requires user to manually re-register their objects. Also stops
@@ -630,8 +630,6 @@ class TrialRunner:
                 self.add_trial(new_trial)
             else:
                 self.add_trial(trial)
-
-        return True
 
     def update_pending_trial_resources(
             self, resources: Union[dict, PlacementGroupFactory]):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sometimes remote experiment directories don't contain data - in that case we want to throw insightful and actionable error messages/warnings.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
