### PR TITLE
Revert "Revert "[Test] Fix flaky test_gpu test (#19524)" (#19562)"

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -550,7 +550,7 @@ def test_gpu(monkeypatch):
             def get_location(self):
                 return ray.worker.global_worker.node.unique_id
 
-        @ray.remote(num_cpus=0.5)
+        @ray.remote(num_cpus=1)
         def task_cpu():
             time.sleep(10)
             return ray.worker.global_worker.node.unique_id
@@ -558,7 +558,8 @@ def test_gpu(monkeypatch):
         @ray.remote(num_returns=2, num_gpus=0.5)
         def launcher():
             a = Actor1.remote()
-            task_results = [task_cpu.remote() for _ in range(n)]
+            # Leave one cpu for the actor.
+            task_results = [task_cpu.remote() for _ in range(n - 1)]
             actor_results = [a.get_location.remote() for _ in range(n)]
             return ray.get(task_results + actor_results
                            ), ray.worker.global_worker.node.unique_id


### PR DESCRIPTION
This reverts commit 7daf28f348c6cf6561e41e31350881ed0a6b4c82.

Still keep parallelism as 1 until I fix other issues. But deflaking test_gpu can be checked in independently.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
