### PR TITLE
[RLlib] clean up all the SampleBatch['is_training'] deprecation warnings

### DIFF
--- a/rllib/agents/dqn/dqn_tf_policy.py
+++ b/rllib/agents/dqn/dqn_tf_policy.py
@@ -342,7 +342,7 @@ def compute_q_values(policy: Policy,
 
     config = policy.config
 
-    input_dict["is_training"] = policy._get_is_training_placeholder()
+    input_dict.is_training = policy._get_is_training_placeholder()
     model_out, state = model(input_dict, state_batches or [], seq_lens)
 
     if config["num_atoms"] > 1:

--- a/rllib/agents/dqn/dqn_torch_policy.py
+++ b/rllib/agents/dqn/dqn_torch_policy.py
@@ -350,7 +350,7 @@ def compute_q_values(policy: Policy,
                      is_training: bool = False):
     config = policy.config
 
-    input_dict["is_training"] = is_training
+    input_dict.is_training = is_training
     model_out, state = model(input_dict, state_batches or [], seq_lens)
 
     if config["num_atoms"] > 1:

--- a/rllib/agents/sac/sac_tf_model.py
+++ b/rllib/agents/sac/sac_tf_model.py
@@ -248,7 +248,7 @@ class SACTFModel(TFModelV2):
             input_dict = {"obs": model_out}
         # Switch on training mode (when getting Q-values, we are usually in
         # training).
-        input_dict["is_training"] = True
+        input_dict.is_training = True
 
         out, _ = net(input_dict, [], None)
         return out

--- a/rllib/agents/sac/sac_torch_model.py
+++ b/rllib/agents/sac/sac_torch_model.py
@@ -256,7 +256,7 @@ class SACTorchModel(TorchModelV2, nn.Module):
             input_dict = {"obs": model_out}
         # Switch on training mode (when getting Q-values, we are usually in
         # training).
-        input_dict["is_training"] = True
+        input_dict.is_training = True
 
         out, _ = net(input_dict, [], None)
         return out

--- a/rllib/examples/models/batch_norm_model.py
+++ b/rllib/examples/models/batch_norm_model.py
@@ -65,7 +65,7 @@ class KerasBatchNormModel(TFModelV2):
         # Have to batch the is_training flag (B=1).
         out, self._value_out = self.base_model(
             [input_dict["obs"],
-             tf.expand_dims(input_dict["is_training"], 0)])
+             tf.expand_dims(input_dict.is_training, 0)])
         return out, []
 
     @override(ModelV2)
@@ -110,7 +110,7 @@ class BatchNormModel(TFModelV2):
                 # Add a batch norm layer
                 last_layer = tf1.layers.batch_normalization(
                     last_layer,
-                    training=input_dict["is_training"],
+                    training=input_dict.is_training,
                     name="bn_{}".format(i))
 
             output = tf1.layers.dense(

--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -213,7 +213,6 @@ class ModelV2:
                 while "state_in_{}".format(i) in input_dict:
                     state.append(input_dict["state_in_{}".format(i)])
                     i += 1
-            input_dict["is_training"] = input_dict.is_training
         else:
             restored = input_dict.copy()
 
@@ -268,7 +267,7 @@ class ModelV2:
         """
 
         input_dict = train_batch.copy()
-        input_dict["is_training"] = is_training
+        input_dict.is_training = is_training
         states = []
         i = 0
         while "state_in_{}".format(i) in input_dict:

--- a/rllib/policy/dynamic_tf_policy.py
+++ b/rllib/policy/dynamic_tf_policy.py
@@ -649,7 +649,7 @@ class DynamicTFPolicy(TFPolicy):
              if SampleBatch.SEQ_LENS in train_batch else []))
 
         if "is_training" in self._loss_input_dict:
-            del self._loss_input_dict["is_training"]
+            del self._loss_input_dict.is_training
 
         # Call the grads stats fn.
         # TODO: (sven) rename to simply stats_fn to match eager and torch.

--- a/rllib/policy/dynamic_tf_policy.py
+++ b/rllib/policy/dynamic_tf_policy.py
@@ -649,7 +649,7 @@ class DynamicTFPolicy(TFPolicy):
              if SampleBatch.SEQ_LENS in train_batch else []))
 
         if "is_training" in self._loss_input_dict:
-            del self._loss_input_dict.is_training
+            del self._loss_input_dict["is_training"]
 
         # Call the grads stats fn.
         # TODO: (sven) rename to simply stats_fn to match eager and torch.

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -388,7 +388,7 @@ def build_eager_tf_policy(
                 )
 
             self._is_training = True
-            postprocessed_batch["is_training"] = True
+            postprocessed_batch.is_training = True
             stats = self._learn_on_batch_eager(postprocessed_batch)
             stats.update({"custom_metrics": learn_stats})
             return stats
@@ -412,7 +412,7 @@ def build_eager_tf_policy(
             )
 
             self._is_training = True
-            samples["is_training"] = True
+            samples.is_training = True
             return self._compute_gradients_eager(samples)
 
         @convert_eager_inputs


### PR DESCRIPTION
## Why are these changes needed?

So RLlib codebase doesn't use anything deprecated ourselves.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
