### PR TITLE
[Doc] Update instruction on starting Ray cluster for Ray client

### DIFF
--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -57,18 +57,18 @@ Ray client should be used when you want to connect a script or an interactive sh
 How do you use the Ray client?
 ------------------------------
 
-Step 1: set up your Ray cluster
+Step 1: Set up your Ray cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, you'll want to create a remote Ray cluster. Follow the directions in :ref:`ref-cluster-quick-start` to do this.
-
-If using the :doc:`Ray cluster launcher <cloud>`, the remote cluster will be listening on port ``10001`` of the head node. If necessary, you can modify this port by setting ``--ray-client-server-port`` to the ``ray start`` `command <http://127.0.0.1:5500/doc/_build/html/package-ref.html#ray-start>`_.
-
-If not using the :doc:`Ray cluster launcher <cloud>`, you can start the "Ray Client Server" manually on the head node of your remote cluster by running the following:
+First, you'll want to create a Ray cluster. To start a Ray cluster locally, you can run
 
 .. code-block:: bash
 
-    python -m ray.util.client.server [--host host_ip] [--port port] [--redis-address address] [--redis-password password]
+   ray start --head
+
+To start a Ray cluster remote, you can follow the directions in :ref:`ref-cluster-quick-start`.
+
+In both cases, the Ray client server will be listening on port ``10001`` of the head node by default. If necessary, you can modify this port by specifying ``--ray-client-server-port=...`` to the ``ray start`` `command <http://127.0.0.1:5500/doc/_build/html/package-ref.html#ray-start>`_.
 
 Step 2: Check ports
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -68,7 +68,7 @@ If you have a running Ray cluster (version >= 1.5), Ray client server is likely 
 
 To start a Ray cluster remotely, you can follow the directions in :ref:`ref-cluster-quick-start`.
 
-If necessary, you can modify the Ray client server port to be other than ``10001``, by specifying ``--ray-client-server-port=...`` to the ``ray start`` `command <http://127.0.0.1:5500/doc/_build/html/package-ref.html#ray-start>`_.
+If necessary, you can modify the Ray client server port to be other than ``10001``, by specifying ``--ray-client-server-port=...`` to the ``ray start`` :ref:`command <ray-start-doc>`.
 
 Step 2: Check ports
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -60,15 +60,15 @@ How do you use the Ray client?
 Step 1: Set up your Ray cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, you'll want to create a Ray cluster. To start a Ray cluster locally, you can run
+If you have a running Ray cluster (version >= 1.5), Ray client server is likely already running on port ``10001`` of the head node by default. Otherwise, you'll want to create a Ray cluster. To start a Ray cluster locally, you can run
 
 .. code-block:: bash
 
    ray start --head
 
-To start a Ray cluster remote, you can follow the directions in :ref:`ref-cluster-quick-start`.
+To start a Ray cluster remotely, you can follow the directions in :ref:`ref-cluster-quick-start`.
 
-In both cases, the Ray client server will be listening on port ``10001`` of the head node by default. If necessary, you can modify this port by specifying ``--ray-client-server-port=...`` to the ``ray start`` `command <http://127.0.0.1:5500/doc/_build/html/package-ref.html#ray-start>`_.
+If necessary, you can modify the Ray client server port to be other than ``10001``, by specifying ``--ray-client-server-port=...`` to the ``ray start`` `command <http://127.0.0.1:5500/doc/_build/html/package-ref.html#ray-start>`_.
 
 Step 2: Check ports
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray client-server is started with Ray cluster by default now. We can clarify the instruction to start Ray client server for users.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
