### PR TITLE
[Workflow] Group options into a single workflow step options dataclass

### DIFF
--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -12,9 +12,10 @@ from ray.workflow.step_function import WorkflowStepFunction
 
 from ray.workflow import virtual_actor_class
 from ray.workflow import storage as storage_base
-from ray.workflow.common import (
-    WorkflowStatus, ensure_ray_initialized, Workflow, Event,
-    WorkflowRunningError, WorkflowNotFoundError, WorkflowStepRuntimeOptions, StepType)
+from ray.workflow.common import (WorkflowStatus, ensure_ray_initialized,
+                                 Workflow, Event, WorkflowRunningError,
+                                 WorkflowNotFoundError,
+                                 WorkflowStepRuntimeOptions, StepType)
 from ray.workflow import serialization
 from ray.workflow.event_listener import (EventListener, EventListenerType,
                                          TimerListener)

--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -14,7 +14,7 @@ from ray.workflow import virtual_actor_class
 from ray.workflow import storage as storage_base
 from ray.workflow.common import (
     WorkflowStatus, ensure_ray_initialized, Workflow, Event,
-    WorkflowRunningError, WorkflowNotFoundError, WorkflowStepOptions, StepType)
+    WorkflowRunningError, WorkflowNotFoundError, WorkflowStepRuntimeOptions, StepType)
 from ray.workflow import serialization
 from ray.workflow.event_listener import (EventListener, EventListenerType,
                                          TimerListener)
@@ -71,7 +71,7 @@ def init(storage: "Optional[Union[str, Storage]]" = None) -> None:
     serialization.init_manager()
 
 
-def make_step_decorator(step_options: "WorkflowStepOptions",
+def make_step_decorator(step_options: "WorkflowStepRuntimeOptions",
                         name: Optional[str] = None,
                         metadata: Optional[Dict[str, Any]] = None):
     def decorator(func):
@@ -96,7 +96,7 @@ def step(*args, **kwargs):
 
     """
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
-        options = WorkflowStepOptions.make(step_type=StepType.FUNCTION)
+        options = WorkflowStepRuntimeOptions.make(step_type=StepType.FUNCTION)
         return make_step_decorator(options)(args[0])
     if len(args) != 0:
         raise ValueError(f"Invalid arguments for step decorator {args}")
@@ -106,7 +106,7 @@ def step(*args, **kwargs):
     metadata = kwargs.pop("metadata", None)
     ray_options = kwargs
 
-    options = WorkflowStepOptions.make(
+    options = WorkflowStepRuntimeOptions.make(
         step_type=StepType.FUNCTION,
         catch_exceptions=catch_exceptions,
         max_retries=max_retries,

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -184,7 +184,9 @@ class WorkflowData:
 
     def to_metadata(self) -> Dict[str, Any]:
         f = self.func_body
-        # TODO(suquark): "name" here is different from the "name" field.
+        # TODO(suquark): "name" is the field of WorkflowData,
+        # however it is not used in the metadata below.
+        # "name" in the metadata is different from the "name" field.
         # Maybe rename it to avoid confusion.
         metadata = {
             "name": get_module(f) + "." + get_qualname(f),

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -115,7 +115,7 @@ def calculate_identifier(obj: Any) -> str:
 
 
 @dataclass
-class WorkflowStepOptions:
+class WorkflowStepRuntimeOptions:
     """Options that will affect a workflow step at runtime."""
     # Type of the step.
     step_type: "StepType"
@@ -178,7 +178,7 @@ class WorkflowData:
     # name of the step
     name: str
     # Workflow step options provided by users.
-    step_options: WorkflowStepOptions
+    step_options: WorkflowStepRuntimeOptions
     # meta data to store
     user_metadata: Dict[str, Any]
 

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -116,6 +116,7 @@ def calculate_identifier(obj: Any) -> str:
 
 @dataclass
 class WorkflowStepOptions:
+    """Options that will affect a workflow step at runtime."""
     # Type of the step.
     step_type: "StepType"
     # Whether the user want to handle the exception manually.
@@ -124,6 +125,31 @@ class WorkflowStepOptions:
     max_retries: int
     # ray_remote options
     ray_options: Dict[str, Any]
+
+    @classmethod
+    def make(cls,
+             *,
+             step_type,
+             catch_exceptions=None,
+             max_retries=None,
+             ray_options=None):
+        if max_retries is None:
+            max_retries = 3
+        elif not isinstance(max_retries, int) or max_retries < 1:
+            raise ValueError("max_retries should be greater or equal to 1.")
+        if catch_exceptions is None:
+            catch_exceptions = False
+        if max_retries is None:
+            max_retries = 3
+        if ray_options is None:
+            ray_options = {}
+        elif not isinstance(ray_options, dict):
+            raise ValueError("ray_options must be a dict.")
+        return cls(
+            step_type=step_type,
+            catch_exceptions=catch_exceptions,
+            max_retries=max_retries,
+            ray_options=ray_options)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -134,12 +160,12 @@ class WorkflowStepOptions:
         }
 
     @classmethod
-    def from_dict(cls, metadata: Dict[str, Any]):
+    def from_dict(cls, value: Dict[str, Any]):
         return cls(
-            step_type=StepType[metadata["step_type"]],
-            max_retries=metadata["max_retries"],
-            catch_exceptions=metadata["catch_exceptions"],
-            ray_options=metadata["ray_options"],
+            step_type=StepType[value["step_type"]],
+            max_retries=value["max_retries"],
+            catch_exceptions=value["catch_exceptions"],
+            ray_options=value["ray_options"],
         )
 
 

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -125,7 +125,7 @@ class WorkflowStepOptions:
     # ray_remote options
     ray_options: Dict[str, Any]
 
-    def to_metadata(self) -> Dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "step_type": self.step_type,
             "max_retries": self.max_retries,
@@ -134,7 +134,7 @@ class WorkflowStepOptions:
         }
 
     @classmethod
-    def from_metadata(cls, metadata: Dict[str, Any]):
+    def from_dict(cls, metadata: Dict[str, Any]):
         return cls(
             step_type=StepType[metadata["step_type"]],
             max_retries=metadata["max_retries"],
@@ -164,7 +164,7 @@ class WorkflowData:
             "name": get_module(f) + "." + get_qualname(f),
             "workflows": [w.step_id for w in self.inputs.workflows],
             "workflow_refs": [wr.step_id for wr in self.inputs.workflow_refs],
-            "step_options": self.step_options.to_metadata(),
+            "step_options": self.step_options.to_dict(),
             "user_metadata": self.user_metadata,
         }
         return metadata

--- a/python/ray/workflow/recovery.py
+++ b/python/ray/workflow/recovery.py
@@ -99,14 +99,12 @@ def _construct_resume_workflow_from_step(
 
         args, kwargs = reader.load_step_args(step_id, input_workflows,
                                              workflow_refs)
-
-        recovery_workflow: Workflow = _recover_workflow_step.options(
-            max_retries=result.max_retries,
-            catch_exceptions=result.catch_exceptions,
-            **result.ray_options).step(args, kwargs, input_workflows,
-                                       workflow_refs)
+        step_options = result.step_options
+        recovery_workflow: Workflow = _recover_workflow_step.step(
+            args, kwargs, input_workflows, workflow_refs)
         recovery_workflow._step_id = step_id
-        recovery_workflow.data.step_type = result.step_type
+        # override step_options
+        recovery_workflow.data.step_options = step_options
         return recovery_workflow
 
 

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -28,7 +28,7 @@ from ray.workflow.common import (
 
 if TYPE_CHECKING:
     from ray.workflow.common import (WorkflowRef, WorkflowInputs,
-                                     WorkflowStepOptions)
+                                     WorkflowStepRuntimeOptions)
     from ray.workflow.workflow_context import WorkflowStepContext
 
 StepInputTupleToResolve = Tuple[ObjectRef, List[ObjectRef], List[ObjectRef]]
@@ -221,7 +221,7 @@ def commit_step(store: workflow_storage.WorkflowStorage, step_id: "StepID",
         outer_most_step_id=context.outer_most_step_id)
 
 
-def _wrap_run(func: Callable, options: "WorkflowStepOptions", *args,
+def _wrap_run(func: Callable, options: "WorkflowStepRuntimeOptions", *args,
               **kwargs) -> Tuple[Any, Any]:
     """Wrap the function and execute it.
 
@@ -313,7 +313,7 @@ def _wrap_run(func: Callable, options: "WorkflowStepOptions", *args,
 def _workflow_step_executor(func: Callable, context: "WorkflowStepContext",
                             step_id: "StepID",
                             baked_inputs: "_BakedWorkflowInputs",
-                            options: "WorkflowStepOptions") -> Any:
+                            options: "WorkflowStepRuntimeOptions") -> Any:
     """Executor function for workflow step.
 
     Args:

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -27,7 +27,9 @@ from ray.workflow.common import (
 )
 
 if TYPE_CHECKING:
-    from ray.workflow.common import (WorkflowRef, WorkflowInputs)
+    from ray.workflow.common import (WorkflowRef, WorkflowInputs,
+                                     WorkflowStepOptions)
+    from ray.workflow.workflow_context import WorkflowStepContext
 
 StepInputTupleToResolve = Tuple[ObjectRef, List[ObjectRef], List[ObjectRef]]
 
@@ -146,17 +148,17 @@ def execute_workflow(workflow: "Workflow") -> "WorkflowExecutionResult":
     workflow_data = workflow.data
     baked_inputs = _BakedWorkflowInputs.from_workflow_inputs(
         workflow_data.inputs)
+    step_options = workflow_data.step_options
     persisted_output, volatile_output = _workflow_step_executor.options(
-        **workflow_data.ray_options).remote(
-            workflow_data.step_type, workflow_data.func_body,
+        **step_options.ray_options).remote(
+            workflow_data.func_body,
             workflow_context.get_workflow_step_context(), workflow.step_id,
-            baked_inputs, workflow_data.catch_exceptions,
-            workflow_data.max_retries)
+            baked_inputs, workflow_data.step_options)
 
     if not isinstance(persisted_output, WorkflowOutputType):
         raise TypeError("Unexpected return type of the workflow.")
 
-    if workflow_data.step_type != StepType.READONLY_ACTOR_METHOD:
+    if step_options.step_type != StepType.READONLY_ACTOR_METHOD:
         _record_step_status(workflow.step_id, WorkflowStatus.RUNNING,
                             [volatile_output])
 
@@ -193,12 +195,14 @@ async def _write_step_inputs(wf_storage: workflow_storage.WorkflowStorage,
 
 
 def commit_step(store: workflow_storage.WorkflowStorage, step_id: "StepID",
-                ret: Union["Workflow", Any], exception: Optional[Exception]):
+                ret: Union["Workflow", Any], *,
+                exception: Optional[Exception]):
     """Checkpoint the step output.
     Args:
         store: The storage the current workflow is using.
         step_id: The ID of the step.
         ret: The returned object of the workflow step.
+        exception: The exception caught by the step.
     """
     from ray.workflow.common import Workflow
     if isinstance(ret, Workflow):
@@ -217,8 +221,7 @@ def commit_step(store: workflow_storage.WorkflowStorage, step_id: "StepID",
         outer_most_step_id=context.outer_most_step_id)
 
 
-def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
-              catch_exceptions: bool, max_retries: int, *args,
+def _wrap_run(func: Callable, options: "WorkflowStepOptions", *args,
               **kwargs) -> Tuple[Any, Any]:
     """Wrap the function and execute it.
 
@@ -240,9 +243,8 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
     +-----------------------------+-------+--------+----------------------+
 
     Args:
-        step_type: The type of the step producing the result.
-        catch_exceptions: True if we would like to catch the exception.
-        max_retries: Max retry times for failure.
+        func: The function body.
+        options: Step execution params.
 
     Returns:
         State and output.
@@ -251,15 +253,15 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
     result = None
     # max_retries are for application level failure.
     # For ray failure, we should use max_retries.
-    for i in range(max_retries):
+    for i in range(options.max_retries):
         logger.info(f"{get_step_status_info(WorkflowStatus.RUNNING)}"
-                    f"\t[{i+1}/{max_retries}]")
+                    f"\t[{i + 1}/{options.max_retries}]")
         try:
             result = func(*args, **kwargs)
             exception = None
             break
         except BaseException as e:
-            if i + 1 == max_retries:
+            if i + 1 == options.max_retries:
                 retry_msg = "Maximum retry reached, stop retry."
             else:
                 retry_msg = "The step will be retried."
@@ -268,13 +270,14 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
                 f" {e}. {retry_msg}")
             exception = e
 
-    if catch_exceptions:
+    step_type = options.step_type
+    if options.catch_exceptions:
         if step_type == StepType.FUNCTION:
             if isinstance(result, Workflow):
                 # When it returns a nested workflow, catch_exception
                 # should be passed recursively.
                 assert exception is None
-                result.data.catch_exceptions = True
+                result.data.step_options.catch_exceptions = True
                 persisted_output, volatile_output = result, None
             else:
                 persisted_output, volatile_output = (result, exception), None
@@ -282,7 +285,7 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
             # virtual actors do not persist exception
             persisted_output, volatile_output = result[0], (result[1],
                                                             exception)
-        elif step_type == StepType.READONLY_ACTOR_METHOD:
+        elif options.step_type == StepType.READONLY_ACTOR_METHOD:
             persisted_output, volatile_output = None, (result, exception)
         else:
             raise ValueError(f"Unknown StepType '{step_type}'")
@@ -290,7 +293,8 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
         if exception is not None:
             if step_type != StepType.READONLY_ACTOR_METHOD:
                 status = WorkflowStatus.FAILED
-                _record_step_status(step_id, status)
+                _record_step_status(workflow_context.get_current_step_id(),
+                                    status)
                 logger.info(get_step_status_info(status))
             raise exception
         if step_type == StepType.FUNCTION:
@@ -306,40 +310,44 @@ def _wrap_run(func: Callable, step_type: StepType, step_id: "StepID",
 
 
 @ray.remote(num_returns=2)
-def _workflow_step_executor(step_type: StepType, func: Callable,
-                            context: workflow_context.WorkflowStepContext,
+def _workflow_step_executor(func: Callable, context: "WorkflowStepContext",
                             step_id: "StepID",
                             baked_inputs: "_BakedWorkflowInputs",
-                            catch_exceptions: bool, max_retries: int) -> Any:
+                            options: "WorkflowStepOptions") -> Any:
     """Executor function for workflow step.
 
     Args:
-        step_type: The type of workflow step.
+        step_id: ID of the step.
         func: The workflow step function.
-        context: Workflow step context. Used to access correct storage etc.
-        step_id: The ID of the step.
         baked_inputs: The processed inputs for the step.
-        catch_exceptions: If set to be true, return
-            (Optional[Result], Optional[Error]) instead of Result.
-        max_retries: Max number of retries encounter of a failure.
+        context: Workflow step context. Used to access correct storage etc.
+        options: Parameters for workflow step execution.
 
     Returns:
         Workflow step output.
     """
+    # Part 1: update the context for the step
     workflow_context.update_workflow_step_context(context, step_id)
+    context = workflow_context.get_workflow_step_context()
+    step_type = options.step_type
+
+    # Part 2: resolve inputs
     args, kwargs = _resolve_step_inputs(baked_inputs)
+
+    # Part 3: execute the step
     store = workflow_storage.get_workflow_storage()
     try:
         step_prerun_metadata = {"start_time": time.time()}
         store.save_step_prerun_metadata(step_id, step_prerun_metadata)
-        persisted_output, volatile_output = _wrap_run(
-            func, step_type, step_id, catch_exceptions, max_retries, *args,
-            **kwargs)
+        persisted_output, volatile_output = _wrap_run(func, options, *args,
+                                                      **kwargs)
         step_postrun_metadata = {"end_time": time.time()}
         store.save_step_postrun_metadata(step_id, step_postrun_metadata)
     except Exception as e:
-        commit_step(store, step_id, None, e)
+        commit_step(store, step_id, None, exception=e)
         raise e
+
+    # Part 4: save outputs
     if step_type == StepType.READONLY_ACTOR_METHOD:
         if isinstance(volatile_output, Workflow):
             raise TypeError(
@@ -348,7 +356,7 @@ def _workflow_step_executor(step_type: StepType, func: Callable,
         assert not isinstance(persisted_output, Workflow)
     else:
         store = workflow_storage.get_workflow_storage()
-        commit_step(store, step_id, persisted_output, None)
+        commit_step(store, step_id, persisted_output, exception=None)
         outer_most_step_id = context.outer_most_step_id
         if isinstance(persisted_output, Workflow):
             if step_type == StepType.FUNCTION:

--- a/python/ray/workflow/step_function.py
+++ b/python/ray/workflow/step_function.py
@@ -96,8 +96,8 @@ class WorkflowStepFunction:
         # TODO(suquark): The options seems drops items that we did not
         # specify (e.g., the name become "None" if we did not pass
         # name to the options). This does not seem correct to me.
-        step_options = WorkflowStepRuntimeOptions(
-            StepType.FUNCTION,
+        step_options = WorkflowStepRuntimeOptions.make(
+            step_type=StepType.FUNCTION,
             catch_exceptions=catch_exceptions,
             max_retries=max_retries,
             ray_options=ray_options,

--- a/python/ray/workflow/step_function.py
+++ b/python/ray/workflow/step_function.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, Any, Optional
 from ray._private import signature
 from ray.workflow import serialization_context
 from ray.workflow.common import (Workflow, WorkflowData, StepType,
-                                 ensure_ray_initialized, WorkflowStepOptions)
+                                 ensure_ray_initialized, WorkflowStepRuntimeOptions)
 from ray.util.annotations import PublicAPI
 
 
@@ -15,7 +15,7 @@ class WorkflowStepFunction:
     def __init__(self,
                  func: Callable,
                  *,
-                 step_options: "WorkflowStepOptions" = None,
+                 step_options: "WorkflowStepRuntimeOptions" = None,
                  name: Optional[str] = None,
                  metadata: Optional[Dict[str, Any]] = None):
         if metadata is not None:
@@ -29,7 +29,7 @@ class WorkflowStepFunction:
                         "metadata values must be JSON serializable, "
                         "however '{}' has a value whose {}.".format(k, e))
         if step_options is None:
-            step_options = WorkflowStepOptions.make(
+            step_options = WorkflowStepRuntimeOptions.make(
                 step_type=StepType.FUNCTION)
         self._func = func
         self._step_options = step_options
@@ -95,7 +95,7 @@ class WorkflowStepFunction:
         # TODO(suquark): The options seems drops items that we did not
         # specify (e.g., the name become "None" if we did not pass
         # name to the options). This does not seem correct to me.
-        step_options = WorkflowStepOptions(
+        step_options = WorkflowStepRuntimeOptions(
             StepType.FUNCTION,
             catch_exceptions=catch_exceptions,
             max_retries=max_retries,

--- a/python/ray/workflow/step_function.py
+++ b/python/ray/workflow/step_function.py
@@ -5,7 +5,8 @@ from typing import Callable, Dict, Any, Optional
 from ray._private import signature
 from ray.workflow import serialization_context
 from ray.workflow.common import (Workflow, WorkflowData, StepType,
-                                 ensure_ray_initialized, WorkflowStepRuntimeOptions)
+                                 ensure_ray_initialized,
+                                 WorkflowStepRuntimeOptions)
 from ray.util.annotations import PublicAPI
 
 

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -8,7 +8,7 @@ from ray.workflow import storage
 from ray.workflow.workflow_storage import asyncio_run
 from ray.workflow.common import (
     StepType,
-    WorkflowStepOptions,
+    WorkflowStepRuntimeOptions,
     WorkflowNotFoundError,
 )
 from ray.workflow.tests import utils
@@ -134,7 +134,7 @@ def test_workflow_storage(workflow_start_regular):
     wf_storage = workflow_storage.WorkflowStorage(workflow_id,
                                                   storage.get_global_storage())
     step_id = "some_step"
-    step_options = WorkflowStepOptions(
+    step_options = WorkflowStepRuntimeOptions(
         step_type=StepType.FUNCTION,
         catch_exceptions=False,
         max_retries=1,
@@ -218,7 +218,7 @@ def test_workflow_storage(workflow_start_regular):
             wf_storage._key_step_function_body(step_id), some_func))
     asyncio_run(wf_storage._put(wf_storage._key_step_args(step_id), args))
     inspect_result = wf_storage.inspect_step(step_id)
-    step_options = WorkflowStepOptions(
+    step_options = WorkflowStepRuntimeOptions(
         step_type=StepType.FUNCTION,
         catch_exceptions=False,
         max_retries=1,

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -8,6 +8,7 @@ from ray.workflow import storage
 from ray.workflow.workflow_storage import asyncio_run
 from ray.workflow.common import (
     StepType,
+    WorkflowStepOptions,
     WorkflowNotFoundError,
 )
 from ray.workflow.tests import utils
@@ -133,14 +134,16 @@ def test_workflow_storage(workflow_start_regular):
     wf_storage = workflow_storage.WorkflowStorage(workflow_id,
                                                   storage.get_global_storage())
     step_id = "some_step"
+    step_options = WorkflowStepOptions(
+        step_type=StepType.FUNCTION,
+        catch_exceptions=False,
+        max_retries=1,
+        ray_options={})
     input_metadata = {
         "name": "test_basic_workflows.append1",
-        "step_type": StepType.FUNCTION,
         "workflows": ["def"],
         "workflow_refs": ["some_ref"],
-        "max_retries": 1,
-        "catch_exceptions": False,
-        "ray_options": {},
+        "step_options": step_options.to_metadata(),
     }
     output_metadata = {
         "output_step_id": "a12423",
@@ -215,13 +218,17 @@ def test_workflow_storage(workflow_start_regular):
             wf_storage._key_step_function_body(step_id), some_func))
     asyncio_run(wf_storage._put(wf_storage._key_step_args(step_id), args))
     inspect_result = wf_storage.inspect_step(step_id)
-    assert inspect_result == workflow_storage.StepInspectResult(
+    step_options = WorkflowStepOptions(
         step_type=StepType.FUNCTION,
+        catch_exceptions=False,
+        max_retries=1,
+        ray_options={})
+    assert inspect_result == workflow_storage.StepInspectResult(
         args_valid=True,
         func_body_valid=True,
         workflows=input_metadata["workflows"],
         workflow_refs=input_metadata["workflow_refs"],
-        ray_options={})
+        step_options=step_options)
     assert inspect_result.is_recoverable()
 
     step_id = "some_step4"
@@ -234,11 +241,10 @@ def test_workflow_storage(workflow_start_regular):
             wf_storage._key_step_function_body(step_id), some_func))
     inspect_result = wf_storage.inspect_step(step_id)
     assert inspect_result == workflow_storage.StepInspectResult(
-        step_type=StepType.FUNCTION,
         func_body_valid=True,
         workflows=input_metadata["workflows"],
         workflow_refs=input_metadata["workflow_refs"],
-        ray_options={})
+        step_options=step_options)
     assert not inspect_result.is_recoverable()
 
     step_id = "some_step5"
@@ -248,10 +254,9 @@ def test_workflow_storage(workflow_start_regular):
             True))
     inspect_result = wf_storage.inspect_step(step_id)
     assert inspect_result == workflow_storage.StepInspectResult(
-        step_type=StepType.FUNCTION,
         workflows=input_metadata["workflows"],
         workflow_refs=input_metadata["workflow_refs"],
-        ray_options={})
+        step_options=step_options)
     assert not inspect_result.is_recoverable()
 
     step_id = "some_step6"

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -143,7 +143,7 @@ def test_workflow_storage(workflow_start_regular):
         "name": "test_basic_workflows.append1",
         "workflows": ["def"],
         "workflow_refs": ["some_ref"],
-        "step_options": step_options.to_metadata(),
+        "step_options": step_options.to_dict(),
     }
     output_metadata = {
         "output_step_id": "a12423",

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -12,7 +12,7 @@ from ray.util.inspect import (is_function_or_method, is_class_method,
 from ray._private import signature
 
 from ray.workflow.common import (slugify, WorkflowData, Workflow, WorkflowRef,
-                                 StepType, WorkflowStepOptions)
+                                 StepType, WorkflowStepRuntimeOptions)
 from ray.workflow import serialization_context
 from ray.workflow.storage import Storage, get_global_storage
 from ray.workflow.workflow_storage import WorkflowStorage
@@ -176,7 +176,7 @@ class _VirtualActorMethodHelper:
     from raw class methods."""
 
     def __init__(self, original_class, method: Callable, method_name: str,
-                 options: WorkflowStepOptions):
+                 options: WorkflowStepRuntimeOptions):
         self._original_class = original_class
         self._original_method = method
         # Extract the signature of the method. This will be used
@@ -259,7 +259,7 @@ class _VirtualActorMethodHelper:
                     raise ValueError(
                         "metadata values must be JSON serializable, "
                         "however '{}' has a value whose {}.".format(k, e))
-        options = WorkflowStepOptions.make(
+        options = WorkflowStepRuntimeOptions.make(
             step_type=self._options.step_type,
             catch_exceptions=catch_exceptions,
             max_retries=max_retries,
@@ -298,7 +298,7 @@ class VirtualActorMetadata:
                 step_type = StepType.READONLY_ACTOR_METHOD
             else:
                 step_type = StepType.ACTOR_METHOD
-            options = WorkflowStepOptions.make(step_type=step_type)
+            options = WorkflowStepRuntimeOptions.make(step_type=step_type)
             self.methods[method_name] = _VirtualActorMethodHelper(
                 original_class, method, method_name, options=options)
 

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -117,7 +117,7 @@ class ActorMethod(ActorMethodBase):
             catch_exceptions=catch_exceptions,
             name=name,
             metadata=metadata,
-            ray_options=ray_options,
+            **ray_options,
         )
         return ActorMethod(self._actor_ref(), self._method_name, method_helper)
 
@@ -176,7 +176,7 @@ class _VirtualActorMethodHelper:
     from raw class methods."""
 
     def __init__(self, original_class, method: Callable, method_name: str,
-                 options: WorkflowStepRuntimeOptions):
+                 runtime_options: WorkflowStepRuntimeOptions):
         self._original_class = original_class
         self._original_method = method
         # Extract the signature of the method. This will be used
@@ -199,7 +199,7 @@ class _VirtualActorMethodHelper:
 
         self._method = method
         self._method_name = method_name
-        self._options = options
+        self._options = runtime_options
         self._name = None
         self._user_metadata = {}
 
@@ -268,7 +268,7 @@ class _VirtualActorMethodHelper:
             self._original_class,
             self._original_method,
             self._method_name,
-            options=options)
+            runtime_options=options)
 
         _self._name = name
         _self._user_metadata = metadata
@@ -300,7 +300,7 @@ class VirtualActorMetadata:
                 step_type = StepType.ACTOR_METHOD
             options = WorkflowStepRuntimeOptions.make(step_type=step_type)
             self.methods[method_name] = _VirtualActorMethodHelper(
-                original_class, method, method_name, options=options)
+                original_class, method, method_name, runtime_options=options)
 
     def generate_random_actor_id(self) -> str:
         """Generate random actor ID."""

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -2,7 +2,7 @@ import abc
 import functools
 import inspect
 import logging
-from typing import List, TYPE_CHECKING, Any, Tuple, Dict
+from typing import TYPE_CHECKING, Any, Tuple, Dict, Callable
 import uuid
 import json
 import weakref
@@ -64,9 +64,11 @@ class ActorMethod(ActorMethodBase):
         _method_name: The name of the actor method.
     """
 
-    def __init__(self, actor, method_name):
+    def __init__(self, actor, method_name,
+                 method_helper: "_VirtualActorMethodHelper"):
         self._actor_ref = weakref.ref(actor)
         self._method_name = method_name
+        self._method_helper = method_helper
 
     def __call__(self, *args, **kwargs):
         raise TypeError("Actor methods cannot be called directly. Instead "
@@ -110,38 +112,16 @@ class ActorMethod(ActorMethodBase):
             The actor method itself.
         """
 
-        if max_retries is not None:
-            if not isinstance(max_retries, int) or max_retries < 1:
-                raise ValueError(
-                    "max_retries should be greater or equal to 1.")
-        if metadata is not None:
-            if not isinstance(metadata, dict):
-                raise ValueError("metadata must be a dict.")
-            for k, v in metadata.items():
-                try:
-                    json.dumps(v)
-                except TypeError as e:
-                    raise ValueError(
-                        "metadata values must be JSON serializable, "
-                        "however '{}' has a value whose {}.".format(k, e))
+        method_helper = self._method_helper.options(
+            max_retries=max_retries,
+            catch_exceptions=catch_exceptions,
+            name=name,
+            metadata=metadata,
+            ray_options=ray_options,
+        )
+        return ActorMethod(self._actor_ref(), self._method_name, method_helper)
 
-        func_cls = self
-
-        class FuncWrapper(ActorMethodBase):
-            def run_async(self, *args, **kwargs):
-                return func_cls._run(
-                    args=args,
-                    kwargs=kwargs,
-                    max_retries=max_retries,
-                    catch_exceptions=catch_exceptions,
-                    name=name,
-                    metadata=metadata,
-                    **ray_options)
-
-        return FuncWrapper()
-
-    def _run(self, args: Tuple[Any], kwargs: Dict[str, Any],
-             **options) -> "ObjectRef":
+    def _run(self, args: Tuple[Any], kwargs: Dict[str, Any]) -> "ObjectRef":
         actor = self._actor_ref()
         if actor is None:
             raise RuntimeError("Lost reference to actor. One common cause is "
@@ -152,7 +132,7 @@ class ActorMethod(ActorMethodBase):
                                "actor.method.run()' instead.")
         try:
             return actor._actor_method_call(
-                self._method_name, args=args, kwargs=kwargs, options=options)
+                self._method_helper, args=args, kwargs=kwargs)
         except TypeError as exc:  # capture a friendlier stacktrace
             raise TypeError(
                 "Invalid input arguments for virtual actor "
@@ -162,10 +142,12 @@ class ActorMethod(ActorMethodBase):
         return {
             "actor": self._actor_ref(),
             "method_name": self._method_name,
+            "method_helper": self._method_helper,
         }
 
     def __setstate__(self, state):
-        self.__init__(state["actor"], state["method_name"])
+        self.__init__(state["actor"], state["method_name"],
+                      state["method_helper"])
 
 
 def __getstate(instance):
@@ -189,6 +171,118 @@ def __setstate(instance, v):
         instance.__dict__ = json.loads(v)
 
 
+class _VirtualActorMethodHelper:
+    """This is a helper class for managing options and creating workflow steps
+    from raw class methods."""
+
+    def __init__(self, original_class, method: Callable, method_name: str):
+        self._original_class = original_class
+        self._original_method = method
+        # Extract the signature of the method. This will be used
+        # to catch some errors if the methods are called with inappropriate
+        # arguments.
+
+        # Whether or not this method requires binding of its first
+        # argument. For class and static methods, we do not want to bind
+        # the first argument, but we do for instance methods
+        method = inspect.unwrap(method)
+        is_bound = (is_class_method(method)
+                    or is_static_method(original_class, method_name))
+
+        # Print a warning message if the method signature is not
+        # supported. We don't raise an exception because if the actor
+        # inherits from a class that has a method whose signature we
+        # don't support, there may not be much the user can do about it.
+        self._signature = signature.extract_signature(
+            method, ignore_first=not is_bound)
+
+        self._method = method
+        self._method_name = method_name
+        self._readonly = getattr(method, "__virtual_actor_readonly__", False)
+        if self._readonly:
+            step_type = StepType.READONLY_ACTOR_METHOD
+        else:
+            step_type = StepType.ACTOR_METHOD
+        self._options = WorkflowStepOptions(
+            step_type=step_type,
+            max_retries=1,
+            catch_exceptions=False,
+            ray_options={},
+        )
+        self._name = None
+        self._user_metadata = {}
+
+        # attach properties to the original function, so we can create a
+        # workflow step with the original function inside a virtual actor.
+        self._original_method.step = self.step
+        self._original_method.options = self.options
+
+    @property
+    def readonly(self) -> bool:
+        return self._readonly
+
+    def step(self, *args, **kwargs):
+        flattened_args = signature.flatten_args(self._signature, args, kwargs)
+        actor_id = workflow_context.get_current_workflow_id()
+        if not self._readonly:
+            if self._method_name == "__init__":
+                state_ref = None
+            else:
+                ws = WorkflowStorage(actor_id, get_global_storage())
+                state_ref = WorkflowRef(ws.get_entrypoint_step_id())
+            # This is a hack to insert a positional argument.
+            flattened_args = [signature.DUMMY_TYPE, state_ref] + flattened_args
+        workflow_inputs = serialization_context.make_workflow_inputs(
+            flattened_args)
+
+        if self._readonly:
+            _actor_method = _wrap_readonly_actor_method(
+                actor_id, self._original_class, self._method_name)
+        else:
+            _actor_method = _wrap_actor_method(self._original_class,
+                                               self._method_name)
+        workflow_data = WorkflowData(
+            func_body=_actor_method,
+            inputs=workflow_inputs,
+            name=self._name,
+            step_options=self._options,
+            user_metadata=self._user_metadata,
+        )
+        wf = Workflow(workflow_data)
+        return wf
+
+    def options(self,
+                *,
+                max_retries=1,
+                catch_exceptions=False,
+                name=None,
+                metadata=None,
+                **ray_options) -> "_VirtualActorMethodHelper":
+        if not isinstance(max_retries, int) or max_retries < 1:
+            raise ValueError("max_retries should be greater or equal to 1.")
+        if metadata is not None:
+            if not isinstance(metadata, dict):
+                raise ValueError("metadata must be a dict.")
+            for k, v in metadata.items():
+                try:
+                    json.dumps(v)
+                except TypeError as e:
+                    raise ValueError(
+                        "metadata values must be JSON serializable, "
+                        "however '{}' has a value whose {}.".format(k, e))
+        _self = _VirtualActorMethodHelper(
+            self._original_class, self._original_method, self._method_name)
+        _self._options.max_retries = max_retries
+        _self._options.catch_exceptions = catch_exceptions
+        _self._options.ray_options = ray_options
+        _self._name = name
+        _self._user_metadata = metadata
+        return _self
+
+    def __call__(self, *args, **kwargs):
+        return self._original_method(*args, **kwargs)
+
+
 class VirtualActorMetadata:
     """Recording the metadata of a virtual actor class, including
     the signatures of its methods etc."""
@@ -201,127 +295,14 @@ class VirtualActorMetadata:
         self.module = original_class.__module__
         self.name = original_class.__name__
         self.qualname = original_class.__qualname__
-        self.methods = dict(actor_methods)
-
-        # Extract the signatures of each of the methods. This will be used
-        # to catch some errors if the methods are called with inappropriate
-        # arguments.
-        self.signatures = {}
+        self.methods = {}
         for method_name, method in actor_methods:
-            # Whether or not this method requires binding of its first
-            # argument. For class and static methods, we do not want to bind
-            # the first argument, but we do for instance methods
-            method = inspect.unwrap(method)
-            is_bound = (is_class_method(method)
-                        or is_static_method(original_class, method_name))
-
-            # Print a warning message if the method signature is not
-            # supported. We don't raise an exception because if the actor
-            # inherits from a class that has a method whose signature we
-            # don't support, there may not be much the user can do about it.
-            self.signatures[method_name] = signature.extract_signature(
-                method, ignore_first=not is_bound)
-
-        for method_name, method in actor_methods:
-
-            def step(method_name, method, options, *args, **kwargs):
-                options = options or {}
-                step_options = {}
-                max_retries = options.pop("max_retries", None)
-                if max_retries is not None:
-                    if not isinstance(max_retries, int) or max_retries < 1:
-                        raise ValueError(
-                            "max_retries should be greater or equal to 1.")
-                    step_options["max_retries"] = max_retries
-                catch_exceptions = options.pop("catch_exceptions", None)
-                if catch_exceptions is not None:
-                    step_options["catch_exceptions"] = catch_exceptions
-                name = options.pop("name", None)
-                if name is not None:
-                    step_options["name"] = name
-                metadata = options.pop("metadata", None)
-                if metadata is not None:
-                    if not isinstance(metadata, dict):
-                        raise ValueError("metadata must be a dict.")
-                    for k, v in metadata.items():
-                        try:
-                            json.dumps(v)
-                        except TypeError as e:
-                            raise ValueError(
-                                "metadata values must be JSON serializable, "
-                                "however '{}' has a value whose {}.".format(
-                                    k, e))
-                    step_options["metadata"] = metadata
-                readonly = getattr(method, "__virtual_actor_readonly__", False)
-                flattened_args = self.flatten_args(method_name, args, kwargs)
-                actor_id = workflow_context.get_current_workflow_id()
-                if not readonly:
-                    if method_name == "__init__":
-                        state_ref = None
-                    else:
-                        ws = WorkflowStorage(actor_id, get_global_storage())
-                        state_ref = WorkflowRef(ws.get_entrypoint_step_id())
-                    # This is a hack to insert a positional argument.
-                    flattened_args = [signature.DUMMY_TYPE, state_ref
-                                      ] + flattened_args
-                workflow_inputs = serialization_context.make_workflow_inputs(
-                    flattened_args)
-
-                if readonly:
-                    _actor_method = _wrap_readonly_actor_method(
-                        actor_id, self.cls, method_name)
-                    step_type = StepType.READONLY_ACTOR_METHOD
-                else:
-                    _actor_method = _wrap_actor_method(self.cls, method_name)
-                    step_type = StepType.ACTOR_METHOD
-                _step_options = WorkflowStepOptions(
-                    step_type=step_type,
-                    max_retries=step_options.get("max_retries", 1),
-                    catch_exceptions=step_options.get("catch_exceptions",
-                                                      False),
-                    # remaining options are Ray options
-                    ray_options=options,
-                )
-                workflow_data = WorkflowData(
-                    func_body=_actor_method,
-                    inputs=workflow_inputs,
-                    name=step_options.get("name", None),
-                    step_options=_step_options,
-                    user_metadata=step_options.get("metadata", {}),
-                )
-                wf = Workflow(workflow_data)
-                return wf
-
-            method.step = functools.partial(step, method_name, method, None)
-
-            def _options(method_name, method, **options):
-                def _method(*args, **kwargs):
-                    return method(*args, **kwargs)
-
-                _method.step = functools.partial(step, method_name, method,
-                                                 options)
-                return _method
-
-            method.options = functools.partial(_options, method_name, method)
+            self.methods[method_name] = _VirtualActorMethodHelper(
+                original_class, method, method_name)
 
     def generate_random_actor_id(self) -> str:
         """Generate random actor ID."""
         return f"{slugify(self.qualname)}.{uuid.uuid4()}"
-
-    def flatten_args(self, method_name: str, args: Tuple[Any],
-                     kwargs: Dict[str, Any]) -> List[Any]:
-        """Check and flatten arguments of the actor method.
-
-        Args:
-            method_name: The name of the actor method in the actor class.
-            args: Positional arguments.
-            kwargs: Keywords arguments.
-
-        Returns:
-            Flattened arguments.
-        """
-        return signature.flatten_args(self.signatures[method_name], args,
-                                      kwargs)
 
 
 class VirtualActorClassBase(metaclass=abc.ABCMeta):
@@ -516,7 +497,8 @@ class VirtualActor:
     def _create(self, args: Tuple[Any], kwargs: Dict[str, Any]):
         workflow_storage = WorkflowStorage(self._actor_id, self._storage)
         workflow_storage.save_actor_class_body(self._metadata.cls)
-        ref = self._actor_method_call("__init__", args, kwargs)
+        method_helper = self._metadata.methods["__init__"]
+        ref = self._actor_method_call(method_helper, args, kwargs)
         workflow_manager = get_or_create_management_actor()
         # keep the ref in a list to prevent dereference
         ray.get(workflow_manager.init_actor.remote(self._actor_id, [ref]))
@@ -533,23 +515,18 @@ class VirtualActor:
         workflow_manager = get_or_create_management_actor()
         return ray.get(workflow_manager.actor_ready.remote(self._actor_id))
 
-    def __getattr__(self, item):
-        if item in self._metadata.signatures:
-            return ActorMethod(self, item)
-        raise AttributeError(f"No method with name '{item}'")
+    def __getattr__(self, method_name):
+        if method_name in self._metadata.methods:
+            return ActorMethod(self, method_name,
+                               self._metadata.methods[method_name])
+        raise AttributeError(f"No method with name '{method_name}'")
 
-    def _actor_method_call(self, method_name: str, args, kwargs,
-                           options=None) -> "ObjectRef":
-        options = options or {}
-        cls = self._metadata.cls
-        method = getattr(cls, method_name, None)
-        if method is None:
-            raise AttributeError(f"Method '{method_name}' does not exist.")
+    def _actor_method_call(self, method_helper: _VirtualActorMethodHelper,
+                           args, kwargs) -> "ObjectRef":
         with workflow_context.workflow_step_context(self._actor_id,
                                                     self._storage.storage_url):
-            wf = method.options(**options).step(*args, **kwargs)
-            readonly = getattr(method, "__virtual_actor_readonly__", False)
-            if readonly:
+            wf = method_helper.step(*args, **kwargs)
+            if method_helper.readonly:
                 return execute_workflow(wf).volatile_output
             else:
                 return wf.run_async(self._actor_id)

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -274,7 +274,6 @@ class VirtualActorMetadata:
                 else:
                     _actor_method = _wrap_actor_method(self.cls, method_name)
                     step_type = StepType.ACTOR_METHOD
-                # TODO(suquark): Support actor options.
                 _step_options = WorkflowStepOptions(
                     step_type=step_type,
                     max_retries=step_options.get("max_retries", 1),

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -85,8 +85,8 @@ class ActorMethod(ActorMethodBase):
 
     def options(self,
                 *,
-                max_retries: int = None,
-                catch_exceptions: bool = None,
+                max_retries: int = 1,
+                catch_exceptions: bool = False,
                 name: str = None,
                 metadata: Dict[str, Any] = None,
                 **ray_options) -> ActorMethodBase:

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -194,7 +194,7 @@ class WorkflowManagementActor:
             logger.info(f"Workflow job [id={workflow_id}] started.")
         return result
 
-    def gen_step_id(self, workflow_id: str, step_name: str) -> int:
+    def gen_step_id(self, workflow_id: str, step_name: str) -> str:
         wf_store = workflow_storage.WorkflowStorage(workflow_id, self._store)
         idx = wf_store.gen_step_id(step_name)
         if idx == 0:

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -12,9 +12,9 @@ import ray
 from ray import cloudpickle
 from ray._private import signature
 from ray.workflow import storage
-from ray.workflow.common import (Workflow, StepID, WorkflowMetaData,
-                                 WorkflowStatus, WorkflowRef,
-                                 WorkflowNotFoundError, WorkflowStepRuntimeOptions)
+from ray.workflow.common import (
+    Workflow, StepID, WorkflowMetaData, WorkflowStatus, WorkflowRef,
+    WorkflowNotFoundError, WorkflowStepRuntimeOptions)
 from ray.workflow import workflow_context
 from ray.workflow import serialization
 from ray.workflow import serialization_context

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -14,7 +14,7 @@ from ray._private import signature
 from ray.workflow import storage
 from ray.workflow.common import (Workflow, StepID, WorkflowMetaData,
                                  WorkflowStatus, WorkflowRef,
-                                 WorkflowNotFoundError, WorkflowStepOptions)
+                                 WorkflowNotFoundError, WorkflowStepRuntimeOptions)
 from ray.workflow import workflow_context
 from ray.workflow import serialization
 from ray.workflow import serialization_context
@@ -73,7 +73,7 @@ class StepInspectResult:
     # The dynamically referenced workflows in the input of the workflow.
     workflow_refs: Optional[List[str]] = None
     # The options of the workflow step.
-    step_options: Optional[WorkflowStepOptions] = None
+    step_options: Optional[WorkflowStepRuntimeOptions] = None
     # step throw exception
     step_raised_exception: bool = False
 
@@ -337,7 +337,7 @@ class WorkflowStorage:
                 func_body_valid=(STEP_FUNC_BODY in keys),
                 workflows=metadata["workflows"],
                 workflow_refs=metadata["workflow_refs"],
-                step_options=WorkflowStepOptions.from_dict(
+                step_options=WorkflowStepRuntimeOptions.from_dict(
                     metadata["step_options"]),
                 step_raised_exception=(STEP_EXCEPTION in keys),
             )

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -337,7 +337,7 @@ class WorkflowStorage:
                 func_body_valid=(STEP_FUNC_BODY in keys),
                 workflows=metadata["workflows"],
                 workflow_refs=metadata["workflow_refs"],
-                step_options=WorkflowStepOptions.from_metadata(
+                step_options=WorkflowStepOptions.from_dict(
                     metadata["step_options"]),
                 step_raised_exception=(STEP_EXCEPTION in keys),
             )

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -13,8 +13,8 @@ from ray import cloudpickle
 from ray._private import signature
 from ray.workflow import storage
 from ray.workflow.common import (Workflow, StepID, WorkflowMetaData,
-                                 WorkflowStatus, WorkflowRef, StepType,
-                                 WorkflowNotFoundError)
+                                 WorkflowStatus, WorkflowRef,
+                                 WorkflowNotFoundError, WorkflowStepOptions)
 from ray.workflow import workflow_context
 from ray.workflow import serialization
 from ray.workflow import serialization_context
@@ -72,14 +72,8 @@ class StepInspectResult:
     workflows: Optional[List[str]] = None
     # The dynamically referenced workflows in the input of the workflow.
     workflow_refs: Optional[List[str]] = None
-    # The num of retry for application exception
-    max_retries: int = 1
-    # Whether the user want to handle the exception mannually
-    catch_exceptions: bool = False
-    # ray_remote options
-    ray_options: Optional[Dict[str, Any]] = None
-    # type of workflow step
-    step_type: Optional[StepType] = None
+    # The options of the workflow step.
+    step_options: Optional[WorkflowStepOptions] = None
     # step throw exception
     step_raised_exception: bool = False
 
@@ -343,10 +337,8 @@ class WorkflowStorage:
                 func_body_valid=(STEP_FUNC_BODY in keys),
                 workflows=metadata["workflows"],
                 workflow_refs=metadata["workflow_refs"],
-                max_retries=metadata.get("max_retries"),
-                catch_exceptions=metadata.get("catch_exceptions"),
-                ray_options=metadata.get("ray_options", {}),
-                step_type=StepType[metadata.get("step_type")],
+                step_options=WorkflowStepOptions.from_metadata(
+                    metadata["step_options"]),
                 step_raised_exception=(STEP_EXCEPTION in keys),
             )
         except Exception:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently there are too much arguments & duplications in the workflow code. I group them into a single dataclass. This implementation is isolated from the workflow checkpoint API PR. I want to merge this PR before the checkpoint PR so the reviewers won't feel confused.

This PR also fixes some type annotation errors. It also enforces using named arguments for long argument list, which benefits code changes later.


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
