### PR TITLE
[CI] narrow down tests that run when files change

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -26,6 +26,12 @@ epilogue_commands: &epilogue_commands |-
 steps:
 - label: ":mac: :apple: Wheels and Jars"
   <<: *common
+  conditions:
+    [
+      "RAY_CI_MACOS_WHEELS_AFFECTED",
+      "RAY_CI_JAVA_AFFECTED",
+      "RAY_CI_STREAMING_JAVA_AFFECTED",
+    ]
   commands:
     # Cleanup environments
     - ./ci/travis/upload_build_info.sh
@@ -60,6 +66,7 @@ steps:
 
 
 - label: ":mac: :apple: Ray C++ and Libraries"
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   <<: *common
   commands:
     - *prelude_commands
@@ -69,6 +76,7 @@ steps:
     - *epilogue_commands
 
 - label: ":mac: :apple: Worker"
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   <<: *common
   commands:
     - *prelude_commands
@@ -77,6 +85,7 @@ steps:
 
 - label: ":mac: :apple: Small and Large"
   <<: *common
+  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
   commands:
     - *prelude_commands
     - bazel test $(./scripts/bazel_export_options) --config=ci
@@ -88,6 +97,7 @@ steps:
 
 - label: ":mac: :apple: Medium A-J"
   <<: *common
+  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
   commands:
     - *prelude_commands
     - bazel test --config=ci $(./scripts/bazel_export_options) --test_env=CI
@@ -97,6 +107,7 @@ steps:
 
 - label: ":mac: :apple: Medium K-Z"
   <<: *common
+  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
   commands:
     - *prelude_commands
     - bazel test --config=ci $(./scripts/bazel_export_options) --test_env=CI
@@ -106,6 +117,7 @@ steps:
 
 - label: ":mac: :apple: :snowflake: Flaky"
   <<: *common
+  conditions: [ "RAY_CI_PYTHON_AFFECTED", "RAY_CI_SERVE_AFFECTED", "RAY_CI_RLLIB_AFFECTED", "RAY_CI_TUNE_AFFECTED" ]
   commands:
     - *prelude_commands
     - ./ci/travis/install-dependencies.sh

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -66,8 +66,8 @@ steps:
 
 
 - label: ":mac: :apple: Ray C++ and Libraries"
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   <<: *common
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - *prelude_commands
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
@@ -76,8 +76,8 @@ steps:
     - *epilogue_commands
 
 - label: ":mac: :apple: Worker"
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   <<: *common
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - *prelude_commands
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -26,12 +26,6 @@ epilogue_commands: &epilogue_commands |-
 steps:
 - label: ":mac: :apple: Wheels and Jars"
   <<: *common
-  conditions:
-    [
-      "RAY_CI_MACOS_WHEELS_AFFECTED",
-      "RAY_CI_JAVA_AFFECTED",
-      "RAY_CI_STREAMING_JAVA_AFFECTED",
-    ]
   commands:
     # Cleanup environments
     - ./ci/travis/upload_build_info.sh
@@ -67,7 +61,6 @@ steps:
 
 - label: ":mac: :apple: Ray C++ and Libraries"
   <<: *common
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - *prelude_commands
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
@@ -77,7 +70,6 @@ steps:
 
 - label: ":mac: :apple: Worker"
   <<: *common
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - *prelude_commands
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
@@ -85,7 +77,6 @@ steps:
 
 - label: ":mac: :apple: Small and Large"
   <<: *common
-  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
   commands:
     - *prelude_commands
     - bazel test $(./scripts/bazel_export_options) --config=ci
@@ -97,7 +88,6 @@ steps:
 
 - label: ":mac: :apple: Medium A-J"
   <<: *common
-  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
   commands:
     - *prelude_commands
     - bazel test --config=ci $(./scripts/bazel_export_options) --test_env=CI
@@ -107,7 +97,6 @@ steps:
 
 - label: ":mac: :apple: Medium K-Z"
   <<: *common
-  conditions: [ "RAY_CI_PYTHON_AFFECTED" ]
   commands:
     - *prelude_commands
     - bazel test --config=ci $(./scripts/bazel_export_options) --test_env=CI
@@ -117,7 +106,6 @@ steps:
 
 - label: ":mac: :apple: :snowflake: Flaky"
   <<: *common
-  conditions: [ "RAY_CI_PYTHON_AFFECTED", "RAY_CI_SERVE_AFFECTED", "RAY_CI_RLLIB_AFFECTED", "RAY_CI_TUNE_AFFECTED" ]
   commands:
     - *prelude_commands
     - ./ci/travis/install-dependencies.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -166,7 +166,7 @@
     - ./ci/travis/ci.sh test_cpp
 
 - label: ":cpp: Tests"
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
+  conditions: [ "RAY_CI_CORE_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=llvm $(./scripts/bazel_export_options)
@@ -175,7 +175,7 @@
       -- //:all -rllib/... -core_worker_test
 
 - label: ":cpp: Tests (ASAN)"
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
+  conditions: [ "RAY_CI_CORE_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=asan-clang $(./scripts/bazel_export_options)
@@ -185,7 +185,7 @@
       -- //:all -//:core_worker_test
 
 - label: ":cpp: Tests (UBSAN)"
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
+  conditions: [ "RAY_CI_CORE_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=ubsan $(./scripts/bazel_export_options)
@@ -195,7 +195,7 @@
       -- //:all -//:core_worker_test -//:logging_test
 
 - label: ":cpp: Tests (TSAN)"
-  conditions: [ "RAY_CI_CPP_AFFECTED" ]
+  conditions: [ "RAY_CI_CORE_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=tsan-clang $(./scripts/bazel_export_options)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -160,11 +160,13 @@
     - bash streaming/src/test/run_streaming_queue_test.sh
 
 - label: ":cpp: Worker"
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - ./ci/travis/ci.sh test_cpp
 
 - label: ":cpp: Tests"
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=llvm $(./scripts/bazel_export_options)
@@ -173,6 +175,7 @@
       -- //:all -rllib/... -core_worker_test
 
 - label: ":cpp: Tests (ASAN)"
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=asan-clang $(./scripts/bazel_export_options)
@@ -182,6 +185,7 @@
       -- //:all -//:core_worker_test
 
 - label: ":cpp: Tests (UBSAN)"
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=ubsan $(./scripts/bazel_export_options)
@@ -191,6 +195,7 @@
       -- //:all -//:core_worker_test -//:logging_test
 
 - label: ":cpp: Tests (TSAN)"
+  conditions: [ "RAY_CI_CPP_AFFECTED" ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci --config=tsan-clang $(./scripts/bazel_export_options)

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
     RAY_CI_RLLIB_AFFECTED = 0  # Whether RLlib minimal tests should be run.
     RAY_CI_RLLIB_FULL_AFFECTED = 0  # Whether full RLlib tests should be run.
     RAY_CI_SERVE_AFFECTED = 0
+    RAY_CI_CORE_CPP_AFFECTED = 0
     RAY_CI_CPP_AFFECTED = 0
     RAY_CI_JAVA_AFFECTED = 0
     RAY_CI_PYTHON_AFFECTED = 0
@@ -201,6 +202,7 @@ if __name__ == "__main__":
                 RAY_CI_TRAIN_AFFECTED = 1
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_SERVE_AFFECTED = 1
+                RAY_CI_CORE_CPP_AFFECTED = 1
                 RAY_CI_CPP_AFFECTED = 1
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_PYTHON_AFFECTED = 1
@@ -225,6 +227,7 @@ if __name__ == "__main__":
                 RAY_CI_TRAIN_AFFECTED = 1
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_SERVE_AFFECTED = 1
+                RAY_CI_CORE_CPP_AFFECTED = 1
                 RAY_CI_CPP_AFFECTED = 1
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_PYTHON_AFFECTED = 1
@@ -263,6 +266,7 @@ if __name__ == "__main__":
         "RAY_CI_SERVE_AFFECTED={}".format(RAY_CI_SERVE_AFFECTED),
         "RAY_CI_DASHBOARD_AFFECTED={}".format(RAY_CI_DASHBOARD_AFFECTED),
         "RAY_CI_DOC_AFFECTED={}".format(RAY_CI_DOC_AFFECTED),
+        "RAY_CI_CORE_CPP_AFFECTED={}".format(RAY_CI_CORE_CPP_AFFECTED),
         "RAY_CI_CPP_AFFECTED={}".format(RAY_CI_CPP_AFFECTED),
         "RAY_CI_JAVA_AFFECTED={}".format(RAY_CI_JAVA_AFFECTED),
         "RAY_CI_PYTHON_AFFECTED={}".format(RAY_CI_PYTHON_AFFECTED),

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -74,7 +74,6 @@ if __name__ == "__main__":
     RAY_CI_TUNE_AFFECTED = 0
     RAY_CI_SGD_AFFECTED = 0
     RAY_CI_TRAIN_AFFECTED = 0
-    RAY_CI_ONLY_RLLIB_AFFECTED = 0  # Whether only RLlib is affected.
     RAY_CI_RLLIB_AFFECTED = 0  # Whether RLlib minimal tests should be run.
     RAY_CI_RLLIB_FULL_AFFECTED = 0  # Whether full RLlib tests should be run.
     RAY_CI_SERVE_AFFECTED = 0
@@ -254,21 +253,11 @@ if __name__ == "__main__":
         RAY_CI_STREAMING_JAVA_AFFECTED = 1
         RAY_CI_DASHBOARD_AFFECTED = 1
 
-    if not RAY_CI_TUNE_AFFECTED and not RAY_CI_SERVE_AFFECTED and \
-            not RAY_CI_JAVA_AFFECTED and not RAY_CI_PYTHON_AFFECTED and not \
-            RAY_CI_STREAMING_CPP_AFFECTED and \
-            not RAY_CI_STREAMING_PYTHON_AFFECTED and \
-            not RAY_CI_STREAMING_JAVA_AFFECTED and \
-            not RAY_CI_SGD_AFFECTED and\
-            not RAY_CI_TRAIN_AFFECTED:
-        RAY_CI_ONLY_RLLIB_AFFECTED = 1
-
     # Log the modified environment variables visible in console.
     output_string = " ".join([
         "RAY_CI_TUNE_AFFECTED={}".format(RAY_CI_TUNE_AFFECTED),
         "RAY_CI_SGD_AFFECTED={}".format(RAY_CI_SGD_AFFECTED),
         "RAY_CI_TRAIN_AFFECTED={}".format(RAY_CI_TRAIN_AFFECTED),
-        "RAY_CI_ONLY_RLLIB_AFFECTED={}".format(RAY_CI_ONLY_RLLIB_AFFECTED),
         "RAY_CI_RLLIB_AFFECTED={}".format(RAY_CI_RLLIB_AFFECTED),
         "RAY_CI_RLLIB_FULL_AFFECTED={}".format(RAY_CI_RLLIB_FULL_AFFECTED),
         "RAY_CI_SERVE_AFFECTED={}".format(RAY_CI_SERVE_AFFECTED),

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -181,7 +181,6 @@ if __name__ == "__main__":
                 RAY_CI_STREAMING_JAVA_AFFECTED = 1
             elif changed_file.startswith("cpp/"):
                 RAY_CI_CPP_AFFECTED = 1
-                RAY_CI_STREAMING_CPP_AFFECTED = 1
             elif changed_file.startswith("docker/"):
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
@@ -246,6 +245,7 @@ if __name__ == "__main__":
         RAY_CI_RLLIB_FULL_AFFECTED = 1
         RAY_CI_SERVE_AFFECTED = 1
         RAY_CI_CPP_AFFECTED = 1
+        RAY_CI_CORE_CPP_AFFECTED
         RAY_CI_JAVA_AFFECTED = 1
         RAY_CI_PYTHON_AFFECTED = 1
         RAY_CI_DOC_AFFECTED = 1

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
     RAY_CI_RLLIB_AFFECTED = 0  # Whether RLlib minimal tests should be run.
     RAY_CI_RLLIB_FULL_AFFECTED = 0  # Whether full RLlib tests should be run.
     RAY_CI_SERVE_AFFECTED = 0
+    RAY_CI_CPP_AFFECTED = 0
     RAY_CI_JAVA_AFFECTED = 0
     RAY_CI_PYTHON_AFFECTED = 0
     RAY_CI_LINUX_WHEELS_AFFECTED = 0
@@ -178,6 +179,9 @@ if __name__ == "__main__":
             elif changed_file.startswith("java/"):
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_STREAMING_JAVA_AFFECTED = 1
+            elif changed_file.startswith("cpp/"):
+                RAY_CI_CPP_AFFECTED = 1
+                RAY_CI_STREAMING_CPP_AFFECTED = 1
             elif changed_file.startswith("docker/"):
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
@@ -198,6 +202,7 @@ if __name__ == "__main__":
                 RAY_CI_TRAIN_AFFECTED = 1
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_SERVE_AFFECTED = 1
+                RAY_CI_CPP_AFFECTED = 1
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_PYTHON_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
@@ -221,6 +226,7 @@ if __name__ == "__main__":
                 RAY_CI_TRAIN_AFFECTED = 1
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_SERVE_AFFECTED = 1
+                RAY_CI_CPP_AFFECTED = 1
                 RAY_CI_JAVA_AFFECTED = 1
                 RAY_CI_PYTHON_AFFECTED = 1
                 RAY_CI_DOC_AFFECTED = 1
@@ -237,6 +243,7 @@ if __name__ == "__main__":
         RAY_CI_RLLIB_AFFECTED = 1
         RAY_CI_RLLIB_FULL_AFFECTED = 1
         RAY_CI_SERVE_AFFECTED = 1
+        RAY_CI_CPP_AFFECTED = 1
         RAY_CI_JAVA_AFFECTED = 1
         RAY_CI_PYTHON_AFFECTED = 1
         RAY_CI_DOC_AFFECTED = 1
@@ -267,6 +274,7 @@ if __name__ == "__main__":
         "RAY_CI_SERVE_AFFECTED={}".format(RAY_CI_SERVE_AFFECTED),
         "RAY_CI_DASHBOARD_AFFECTED={}".format(RAY_CI_DASHBOARD_AFFECTED),
         "RAY_CI_DOC_AFFECTED={}".format(RAY_CI_DOC_AFFECTED),
+        "RAY_CI_CPP_AFFECTED={}".format(RAY_CI_CPP_AFFECTED),
         "RAY_CI_JAVA_AFFECTED={}".format(RAY_CI_JAVA_AFFECTED),
         "RAY_CI_PYTHON_AFFECTED={}".format(RAY_CI_PYTHON_AFFECTED),
         "RAY_CI_LINUX_WHEELS_AFFECTED={}".format(RAY_CI_LINUX_WHEELS_AFFECTED),

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
         RAY_CI_RLLIB_FULL_AFFECTED = 1
         RAY_CI_SERVE_AFFECTED = 1
         RAY_CI_CPP_AFFECTED = 1
-        RAY_CI_CORE_CPP_AFFECTED
+        RAY_CI_CORE_CPP_AFFECTED = 1
         RAY_CI_JAVA_AFFECTED = 1
         RAY_CI_PYTHON_AFFECTED = 1
         RAY_CI_DOC_AFFECTED = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This change should reduce a bit of CI time and cost. Before, C++ tests are always run with any change. This PR runs C++ tests only when files under `src/`, or other files not explicitly associated with `Java`, `Python`, 'tune` etc, are changed.

Also, remove the no longer used `RAY_CI_ONLY_RLLIB_AFFECTED`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
