### PR TITLE
[Test] skip the placement group restart test temporarily

### DIFF
--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -36,6 +36,9 @@ def get_ray_status_output(address):
     }
 
 
+@pytest.mark.skip(
+    reason=("Flaky in the master. The feature is not officially "
+            "supported yet, so we just disable it."))
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [
         generate_system_config_map(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

GCS restart is not an officially supported feature, and it is flaky in the master. We disable it until it is fixed. cc @clay4444 I will create an issue, so please handle this! 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
