### PR TITLE
[data] Add serialized size estimator to block builder

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -352,11 +352,10 @@ class Dataset(Generic[T]):
             splits = [self]
 
         # Coalesce each split into a single block.
-        reduce_task = cached_remote_fn(_shuffle_reduce)
+        reduce_task = cached_remote_fn(_shuffle_reduce).options(num_returns=2)
         reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))
         reduce_out = [
-            reduce_task.options(num_returns=2).remote(
-                *s.get_internal_block_refs()) for s in splits
+            reduce_task.remote(*s.get_internal_block_refs()) for s in splits
         ]
         del splits  # Early-release memory.
         new_blocks, new_metadata = zip(*reduce_out)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -355,9 +355,8 @@ class Dataset(Generic[T]):
         reduce_task = cached_remote_fn(_shuffle_reduce)
         reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))
         reduce_out = [
-            reduce_task.options(
-                num_returns=2).remote(*s.get_internal_block_refs())
-            for s in splits
+            reduce_task.options(num_returns=2).remote(
+                *s.get_internal_block_refs()) for s in splits
         ]
         del splits  # Early-release memory.
         new_blocks, new_metadata = zip(*reduce_out)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -213,8 +213,8 @@ class Dataset(Generic[T]):
                 elif isinstance(applied, pd.core.frame.DataFrame):
                     applied = pa.Table.from_pandas(applied)
                 else:
-                    raise ValueError("The map batches UDF returned a type "
-                                     f"{type(applied)}, which is not allowed. "
+                    raise ValueError("The map batches UDF returned the value "
+                                     f"{applied}, which is not allowed. "
                                      "The return type must be either list, "
                                      "pandas.DataFrame, or pyarrow.Table")
                 builder.add_block(applied)

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -122,6 +122,7 @@ class ArrowBlockBuilder(BlockBuilder[T]):
             self._columns[key].append(value)
         self._num_rows += 1
         self._compact_if_needed()
+        assert self._running_mean.n > 0, self._running_mean
 
     def add_block(self, block: "pyarrow.Table") -> None:
         assert isinstance(block, pyarrow.Table), block
@@ -148,6 +149,7 @@ class ArrowBlockBuilder(BlockBuilder[T]):
     def get_estimated_memory_usage(self) -> int:
         if self._num_rows == 0:
             return 0
+        assert self._num_rows >= self._running_mean.n
         return int(
             self._running_mean.mean * (self._num_rows / self._running_mean.n))
 

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -115,6 +115,7 @@ class ArrowBlockBuilder(BlockBuilder[T]):
         self._num_rows = 0
         # Increases 10x each compaction until reaching max size.
         self._compaction_threshold = 1
+        self._num_compactions = 0
 
     def add(self, item: Union[dict, ArrowRow]) -> None:
         if isinstance(item, ArrowRow):
@@ -170,6 +171,7 @@ class ArrowBlockBuilder(BlockBuilder[T]):
         self._tables.append(block)
         self._running_mean.add(block.nbytes, weight=block.num_rows)
         self._columns.clear()
+        self._num_compactions += 1
 
 
 class ArrowBlockAccessor(BlockAccessor):

--- a/python/ray/data/impl/block_builder.py
+++ b/python/ray/data/impl/block_builder.py
@@ -17,3 +17,7 @@ class BlockBuilder(Generic[T]):
     def build(self) -> Block:
         """Build the block."""
         raise NotImplementedError
+
+    def get_estimated_memory_usage(self) -> int:
+        """Return the estimated memory usage so far in bytes."""
+        raise NotImplementedError

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     import pyarrow
 
 from ray.data.impl.block_builder import BlockBuilder
+from ray.data.impl.size_estimator import SizeEstimator
 from ray.data.block import Block, BlockAccessor, BlockMetadata, \
     T, U, KeyType, AggType
 
@@ -21,16 +22,23 @@ SortKeyT = Union[None, Callable[[T], Any]]
 class SimpleBlockBuilder(BlockBuilder[T]):
     def __init__(self):
         self._items = []
+        self._size_estimator = SizeEstimator()
 
     def add(self, item: T) -> None:
         self._items.append(item)
+        self._size_estimator.add(item)
 
     def add_block(self, block: List[T]) -> None:
         assert isinstance(block, list), block
         self._items.extend(block)
+        for item in block:
+            self._size_estimator.add(item)
 
     def build(self) -> Block:
         return list(self._items)
+
+    def get_estimated_memory_usage(self) -> int:
+        return self._size_estimator.size_bytes()
 
 
 class SimpleBlockAccessor(BlockAccessor):

--- a/python/ray/data/impl/size_estimator.py
+++ b/python/ray/data/impl/size_estimator.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+import ray
+
+
+class SizeEstimator:
+    """Efficiently estimates the Ray serialized size of a stream of items.
+
+    For efficiency, this only samples a fraction of the added items for real
+    Ray-serialization.
+    """
+
+    def __init__(self):
+        self._running_mean = RunningMean()
+        self._count = 0
+
+    def add(self, item: Any) -> None:
+        self._count += 1
+        if self._count < 10:
+            self._running_mean.add(self._real_size(item), weight=1)
+        elif self._count < 100:
+            if self._count % 10 == 0:
+                self._running_mean.add(self._real_size(item), weight=10)
+        elif self._count % 100 == 0:
+            self._running_mean.add(self._real_size(item), weight=100)
+
+    def size_bytes(self) -> int:
+        return int(self._running_mean.mean * self._count)
+
+    def _real_size(self, item: Any) -> int:
+        return ray.worker.global_worker.get_serialization_context().serialize(item).total_bytes
+
+
+# This is adapted from the RLlib MeanStdFilter, referencing:
+# http://www.johndcook.com/blog/standard_deviation/
+class RunningMean:
+    def __init__(self):
+        self._n = 0
+        self._M = 0
+
+    def add(self, x: int, weight: int = 1) -> None:
+        n1 = self._n
+        n2 = weight
+        n = n1 + n2
+        delta = self._M - x
+        delta2 = delta * delta
+        M = (n1 * self._M + n2 * x) / n
+        self._n = n
+        self._M = M
+
+    @property
+    def n(self) -> int:
+        return self._n
+
+    @property
+    def mean(self) -> float:
+        return self._M
+
+    def __repr__(self):
+        return "(n={}, mean={})".format(self.n, self.mean)

--- a/python/ray/data/impl/size_estimator.py
+++ b/python/ray/data/impl/size_estimator.py
@@ -16,9 +16,9 @@ class SizeEstimator:
 
     def add(self, item: Any) -> None:
         self._count += 1
-        if self._count < 10:
+        if self._count <= 10:
             self._running_mean.add(self._real_size(item), weight=1)
-        elif self._count < 100:
+        elif self._count <= 100:
             if self._count % 10 == 0:
                 self._running_mean.add(self._real_size(item), weight=10)
         elif self._count % 100 == 0:

--- a/python/ray/data/impl/size_estimator.py
+++ b/python/ray/data/impl/size_estimator.py
@@ -39,6 +39,8 @@ class RunningMean:
         self._M = 0
 
     def add(self, x: int, weight: int = 1) -> None:
+        if weight == 0:
+            return
         n1 = self._n
         n2 = weight
         n = n1 + n2

--- a/python/ray/data/impl/size_estimator.py
+++ b/python/ray/data/impl/size_estimator.py
@@ -28,7 +28,8 @@ class SizeEstimator:
         return int(self._running_mean.mean * self._count)
 
     def _real_size(self, item: Any) -> int:
-        return ray.worker.global_worker.get_serialization_context().serialize(item).total_bytes
+        return ray.worker.global_worker.get_serialization_context().serialize(
+            item).total_bytes
 
 
 # This is adapted from the RLlib MeanStdFilter, referencing:
@@ -43,7 +44,6 @@ class RunningMean:
         n2 = weight
         n = n1 + n2
         delta = self._M - x
-        delta2 = delta * delta
         M = (n1 * self._M + n2 * x) / n
         self._n = n
         self._M = M

--- a/python/ray/data/impl/size_estimator.py
+++ b/python/ray/data/impl/size_estimator.py
@@ -35,26 +35,26 @@ class SizeEstimator:
 # Adapted from the RLlib MeanStdFilter.
 class RunningMean:
     def __init__(self):
-        self._n = 0
-        self._M = 0
+        self._weight = 0
+        self._mean = 0
 
     def add(self, x: int, weight: int = 1) -> None:
         if weight == 0:
             return
-        n1 = self._n
+        n1 = self._weight
         n2 = weight
         n = n1 + n2
-        M = (n1 * self._M + n2 * x) / n
-        self._n = n
-        self._M = M
+        M = (n1 * self._mean + n2 * x) / n
+        self._weight = n
+        self._mean = M
 
     @property
     def n(self) -> int:
-        return self._n
+        return self._weight
 
     @property
     def mean(self) -> float:
-        return self._M
+        return self._mean
 
     def __repr__(self):
         return "(n={}, mean={})".format(self.n, self.mean)

--- a/python/ray/data/impl/size_estimator.py
+++ b/python/ray/data/impl/size_estimator.py
@@ -32,8 +32,7 @@ class SizeEstimator:
             item).total_bytes
 
 
-# This is adapted from the RLlib MeanStdFilter, referencing:
-# http://www.johndcook.com/blog/standard_deviation/
+# Adapted from the RLlib MeanStdFilter.
 class RunningMean:
     def __init__(self):
         self._n = 0
@@ -43,7 +42,6 @@ class RunningMean:
         n1 = self._n
         n2 = weight
         n = n1 + n2
-        delta = self._M - x
         M = (n1 * self._M + n2 * x) / n
         self._n = n
         self._M = M

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -10,7 +10,7 @@ ARROW_SMALL_VALUE = {"value": "a" * 100}
 ARROW_LARGE_VALUE = {"value": "a" * 10000}
 
 
-def assert_close(actual, expected, tolerance=.5):
+def assert_close(actual, expected, tolerance=.3):
     print("assert_close", actual, expected)
     assert abs(actual - expected) / expected < tolerance, \
         (actual, expected)
@@ -39,37 +39,37 @@ def test_py_size_diff_values(ray_start_regular_shared):
     assert b.get_estimated_memory_usage() == 0
     for _ in range(10):
         b.add(LARGE_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 100000)
+    assert_close(b.get_estimated_memory_usage(), 100120)
     for _ in range(100):
         b.add(SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 110000)
+    assert_close(b.get_estimated_memory_usage(), 121120)
     for _ in range(100):
         b.add(LARGE_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 1110000)
+    assert_close(b.get_estimated_memory_usage(), 1166875)
     for _ in range(100):
         b.add(LARGE_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 2110000)
-    b.add_block([SMALL_VALUE] * 10000)
-    assert_close(b.get_estimated_memory_usage(), 2210000)
-    assert len(b.build()) == 10310
+    assert_close(b.get_estimated_memory_usage(), 2182927)
+    b.add_block([SMALL_VALUE] * 1000)
+    assert_close(b.get_estimated_memory_usage(), 2240613)
+    assert len(b.build()) == 1310
 
 
 def test_arrow_size(ray_start_regular_shared):
     b = ArrowBlockBuilder()
     assert b.get_estimated_memory_usage() == 0
     b.add(ARROW_SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 111)
+    assert_close(b.get_estimated_memory_usage(), 118)
     b.add(ARROW_SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 222)
+    assert_close(b.get_estimated_memory_usage(), 236)
     for _ in range(8):
         b.add(ARROW_SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 1110)
+    assert_close(b.get_estimated_memory_usage(), 1180)
     for _ in range(90):
         b.add(ARROW_SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 11100)
+    assert_close(b.get_estimated_memory_usage(), 11800)
     for _ in range(900):
         b.add(ARROW_SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 111000)
+    assert_close(b.get_estimated_memory_usage(), 118000)
     assert b.build().num_rows == 1000
 
 
@@ -78,24 +78,24 @@ def test_arrow_size_diff_values(ray_start_regular_shared):
     assert b.get_estimated_memory_usage() == 0
     b.add(ARROW_LARGE_VALUE)
     assert b._num_compactions == 0
-    assert_close(b.get_estimated_memory_usage(), 10000)
+    assert_close(b.get_estimated_memory_usage(), 10019)
     b.add(ARROW_LARGE_VALUE)
     assert b._num_compactions == 0
-    assert_close(b.get_estimated_memory_usage(), 20000)
+    assert_close(b.get_estimated_memory_usage(), 20038)
     for _ in range(10):
         b.add(ARROW_SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 20000)
+    assert_close(b.get_estimated_memory_usage(), 25178)
     for _ in range(100):
         b.add(ARROW_SMALL_VALUE)
     assert b._num_compactions == 0
-    assert_close(b.get_estimated_memory_usage(), 30000)
+    assert_close(b.get_estimated_memory_usage(), 35394)
     for _ in range(13000):
         b.add(ARROW_LARGE_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 130200000)
+    assert_close(b.get_estimated_memory_usage(), 130131680)
     assert b._num_compactions == 2
     for _ in range(4000):
         b.add(ARROW_LARGE_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 170200000)
+    assert_close(b.get_estimated_memory_usage(), 170129189)
     assert b._num_compactions == 3
     assert b.build().num_rows == 17112
 
@@ -109,7 +109,7 @@ def test_arrow_size_add_block(ray_start_regular_shared):
     for _ in range(5):
         b2.add_block(block)
     assert b2._num_compactions == 0
-    assert_close(b2.get_estimated_memory_usage(), 100000000)
+    assert_close(b2.get_estimated_memory_usage(), 100040020)
     assert b2.build().num_rows == 10000
 
 

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -76,6 +76,7 @@ def test_arrow_size_diff_values(ray_start_regular_shared):
     b = ArrowBlockBuilder()
     assert b.get_estimated_memory_usage() == 0
     b.add(ARROW_LARGE_VALUE)
+    assert b._num_compactions == 1
     assert_close(b.get_estimated_memory_usage(), 10000)
     b.add(ARROW_LARGE_VALUE)
     assert_close(b.get_estimated_memory_usage(), 20000)
@@ -84,10 +85,12 @@ def test_arrow_size_diff_values(ray_start_regular_shared):
     assert_close(b.get_estimated_memory_usage(), 100000)
     for _ in range(100):
         b.add(ARROW_SMALL_VALUE)
+    assert b._num_compactions == 2
     assert_close(b.get_estimated_memory_usage(), 200000)
     for _ in range(10000):
         b.add(ARROW_LARGE_VALUE)
     assert_close(b.get_estimated_memory_usage(), 100200000)
+    assert b._num_compactions == 4
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -1,9 +1,8 @@
-import ray
+import pytest
 
 from ray.tests.conftest import *  # noqa
 from ray.data.impl.simple_block import SimpleBlockBuilder
 from ray.data.impl.arrow_block import ArrowBlockBuilder
-
 
 SMALL_VALUE = "a" * 100
 LARGE_VALUE = "a" * 10000

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -1,0 +1,57 @@
+import ray
+
+from ray.tests.conftest import *  # noqa
+from ray.data.impl.simple_block import SimpleBlockBuilder
+
+
+SMALL_VALUE = "a" * 100
+LARGE_VALUE = "a" * 10000
+
+
+def assert_close(actual, expected, tolerance=.5):
+    print("assert_close", actual, expected)
+    assert abs(actual - expected) / expected < tolerance, \
+        (actual, expected)
+
+
+def test_py_size(ray_start_regular_shared):
+    b = SimpleBlockBuilder()
+    assert b.get_estimated_memory_usage() == 0
+    b.add(SMALL_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 111)
+    b.add(SMALL_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 222)
+    for _ in range(8):
+        b.add(SMALL_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 1110)
+    for _ in range(90):
+        b.add(SMALL_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 11100)
+    for _ in range(900):
+        b.add(SMALL_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 111000)
+
+
+def test_py_size_diff_values(ray_start_regular_shared):
+    b = SimpleBlockBuilder()
+    assert b.get_estimated_memory_usage() == 0
+    for _ in range(10):
+        b.add(LARGE_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 100000)
+    for _ in range(100):
+        b.add(SMALL_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 110000)
+    for _ in range(100):
+        b.add(LARGE_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 1110000)
+    for _ in range(100):
+        b.add(LARGE_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 2110000)
+    for _ in range(1000):
+        b.add(SMALL_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 2210000)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -29,9 +29,9 @@ def test_py_size(ray_start_regular_shared):
     for _ in range(90):
         b.add(SMALL_VALUE)
     assert_close(b.get_estimated_memory_usage(), 11100)
-    for _ in range(900):
-        b.add(SMALL_VALUE)
+    b.add_block([SMALL_VALUE] * 900)
     assert_close(b.get_estimated_memory_usage(), 111000)
+    assert len(b.build()) == 1000
 
 
 def test_py_size_diff_values(ray_start_regular_shared):
@@ -49,9 +49,9 @@ def test_py_size_diff_values(ray_start_regular_shared):
     for _ in range(100):
         b.add(LARGE_VALUE)
     assert_close(b.get_estimated_memory_usage(), 2110000)
-    for _ in range(1000):
-        b.add(SMALL_VALUE)
+    b.add_block([SMALL_VALUE] * 10000)
     assert_close(b.get_estimated_memory_usage(), 2210000)
+    assert len(b.build()) == 10310
 
 
 def test_arrow_size(ray_start_regular_shared):
@@ -70,27 +70,47 @@ def test_arrow_size(ray_start_regular_shared):
     for _ in range(900):
         b.add(ARROW_SMALL_VALUE)
     assert_close(b.get_estimated_memory_usage(), 111000)
+    assert b.build().num_rows == 1000
 
 
 def test_arrow_size_diff_values(ray_start_regular_shared):
     b = ArrowBlockBuilder()
     assert b.get_estimated_memory_usage() == 0
     b.add(ARROW_LARGE_VALUE)
-    assert b._num_compactions == 1
+    assert b._num_compactions == 0
     assert_close(b.get_estimated_memory_usage(), 10000)
     b.add(ARROW_LARGE_VALUE)
+    assert b._num_compactions == 0
     assert_close(b.get_estimated_memory_usage(), 20000)
-    for _ in range(8):
+    for _ in range(10):
         b.add(ARROW_SMALL_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 100000)
+    assert_close(b.get_estimated_memory_usage(), 20000)
     for _ in range(100):
         b.add(ARROW_SMALL_VALUE)
-    assert b._num_compactions == 2
-    assert_close(b.get_estimated_memory_usage(), 200000)
-    for _ in range(10000):
+    assert b._num_compactions == 0
+    assert_close(b.get_estimated_memory_usage(), 30000)
+    for _ in range(13000):
         b.add(ARROW_LARGE_VALUE)
-    assert_close(b.get_estimated_memory_usage(), 100200000)
-    assert b._num_compactions == 4
+    assert_close(b.get_estimated_memory_usage(), 130200000)
+    assert b._num_compactions == 2
+    for _ in range(4000):
+        b.add(ARROW_LARGE_VALUE)
+    assert_close(b.get_estimated_memory_usage(), 170200000)
+    assert b._num_compactions == 3
+    assert b.build().num_rows == 17112
+
+
+def test_arrow_size_add_block(ray_start_regular_shared):
+    b = ArrowBlockBuilder()
+    for _ in range(2000):
+        b.add(ARROW_LARGE_VALUE)
+    block = b.build()
+    b2 = ArrowBlockBuilder()
+    for _ in range(5):
+        b2.add_block(block)
+    assert b2._num_compactions == 0
+    assert_close(b2.get_estimated_memory_usage(), 100000000)
+    assert b2.build().num_rows == 10000
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a size estimator for the Simple/Arrow block builders, which can efficiently estimate the memory usage so far. It also optimizes the Arrow block builder to materialize items into tables periodically.

## Related issue number

Part 2/3 of #18317
