### PR TITLE
Add 'local' Tag to `@com_github_antirez_redis//:bin`

### DIFF
--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -28,7 +28,7 @@ genrule(
         rm -r -f -- "$${tmpdir}"
     """,
     visibility = ["//visibility:public"],
-    tags = ["build"],
+    tags = ["local"],
 )
 
 # This library is for internal hiredis use, because hiredis assumes a

--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -28,6 +28,7 @@ genrule(
         rm -r -f -- "$${tmpdir}"
     """,
     visibility = ["//visibility:public"],
+    tags = ["build"],
 )
 
 # This library is for internal hiredis use, because hiredis assumes a


### PR DESCRIPTION
## Why are these changes needed?

We are testing building Ray remotely using [bazel-buildfarm](https://github.com/bazelbuild/bazel-buildfarm).

We found that `@com_github_antirez_redis//:bin` has some non-bazel-standard build scripts, and it can't be built remotely(see <https://github.com/bazelbuild/bazel-buildfarm/issues/935>)

Since it's a small build action, I think it's not worth diving into it. This PR adds a 'local' tag to it to force it to be built locally.


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
