### PR TITLE
[data] Make ArrowRow string repr less scary

### DIFF
--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -173,11 +173,11 @@ Get started by creating Datasets from synthetic data using ``ray.data.range()`` 
     # -> Dataset(num_blocks=200, num_rows=10000, schema={col1: int64, col2: string})
 
     ds.show(5)
-    # -> ArrowRow({'col1': 0, 'col2': '0'})
-    # -> ArrowRow({'col1': 1, 'col2': '1'})
-    # -> ArrowRow({'col1': 2, 'col2': '2'})
-    # -> ArrowRow({'col1': 3, 'col2': '3'})
-    # -> ArrowRow({'col1': 4, 'col2': '4'})
+    # -> {'col1': 0, 'col2': '0'}
+    # -> {'col1': 1, 'col2': '1'}
+    # -> {'col1': 2, 'col2': '2'}
+    # -> {'col1': 3, 'col2': '3'}
+    # -> {'col1': 4, 'col2': '4'}
 
     ds.schema()
     # -> col1: int64
@@ -264,7 +264,7 @@ To take advantage of vectorized functions, use ``.map_batches()``. Note that you
         lambda df: df.applymap(lambda x: x * 2), batch_format="pandas")
     # -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1927.62it/s]
     ds.take(5)
-    # -> [ArrowRow({'value': 0}), ArrowRow({'value': 2}), ...]
+    # -> [{'value': 0}, {'value': 2}, ...]
 
 By default, transformations are executed using Ray tasks. For transformations that require setup, specify ``compute="actors"`` and Ray will use an autoscaling actor pool to execute your transforms instead. The following is an end-to-end example of reading, transforming, and saving batch inference results using Datasets:
 

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -14,7 +14,7 @@ class CSVDatasource(FileBasedDatasource):
     Examples:
         >>> source = CSVDatasource()
         >>> ray.data.read_datasource(source, paths="/path/to/dir").take()
-        ... [ArrowRow({"a": 1, "b": "foo"}), ...]
+        ... [{"a": 1, "b": "foo"}, ...]
     """
 
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args):

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -229,8 +229,8 @@ class RandomIntRowDatasource(Datasource[ArrowRow]):
     Examples:
         >>> source = RandomIntRowDatasource()
         >>> ray.data.read_datasource(source, n=10, num_columns=2).take()
-        ... ArrowRow({'c_0': 1717767200176864416, 'c_1': 999657309586757214})
-        ... ArrowRow({'c_0': 4983608804013926748, 'c_1': 1160140066899844087})
+        ... {'c_0': 1717767200176864416, 'c_1': 999657309586757214}
+        ... {'c_0': 4983608804013926748, 'c_1': 1160140066899844087}
     """
 
     def prepare_read(self, parallelism: int, n: int,

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -14,7 +14,7 @@ class JSONDatasource(FileBasedDatasource):
     Examples:
         >>> source = JSONDatasource()
         >>> ray.data.read_datasource(source, paths="/path/to/dir").take()
-        ... [ArrowRow({"a": 1, "b": "foo"}), ...]
+        ... [{"a": 1, "b": "foo"}, ...]
     """
 
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args):

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -29,7 +29,7 @@ class ParquetDatasource(FileBasedDatasource):
     Examples:
         >>> source = ParquetDatasource()
         >>> ray.data.read_datasource(source, paths="/path/to/dir").take()
-        ... [ArrowRow({"a": 1, "b": "foo"}), ...]
+        ... [{"a": 1, "b": "foo"}, ...]
     """
 
     def prepare_read(

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -57,7 +57,7 @@ class ArrowRow:
         return self.as_pydict() == other
 
     def __str__(self):
-        return "ArrowRow({})".format(self.as_pydict())
+        return str(self.as_pydict())
 
     def __repr__(self):
         return str(self)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -368,7 +368,7 @@ def test_tensors(ray_start_regular_shared):
     res = ray.data.range_tensor(10).map_batches(
         lambda t: t + 2, batch_format="pandas").take(2)
     assert str(res) == \
-        "[ArrowRow({'value': array([2])}), ArrowRow({'value': array([3])})]"
+        "[{'value': array([2])}, {'value': array([3])}]"
 
 
 def test_tensor_array_ops(ray_start_regular_shared):
@@ -831,7 +831,7 @@ def test_numpy_roundtrip(ray_start_regular_shared, fs, data_path):
         "Dataset(num_blocks=2, num_rows=None, "
         "schema={value: <ArrowTensorType: shape=(1,), dtype=int64>})")
     assert str(ds.take(2)) == \
-        "[ArrowRow({'value': array([0])}), ArrowRow({'value': array([1])})]"
+        "[{'value': array([0])}, {'value': array([1])}]"
 
 
 def test_numpy_read(ray_start_regular_shared, tmp_path):
@@ -844,7 +844,7 @@ def test_numpy_read(ray_start_regular_shared, tmp_path):
         "Dataset(num_blocks=1, num_rows=None, "
         "schema={value: <ArrowTensorType: shape=(1,), dtype=int64>})")
     assert str(ds.take(2)) == \
-        "[ArrowRow({'value': array([0])}), ArrowRow({'value': array([1])})]"
+        "[{'value': array([0])}, {'value': array([1])}]"
 
 
 @pytest.mark.parametrize("fs,data_path,endpoint_url", [
@@ -871,7 +871,7 @@ def test_numpy_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     assert len(arr2) == 5
     assert arr1.sum() == 10
     assert arr2.sum() == 35
-    assert str(ds.take(1)) == "[ArrowRow({'value': array([0])})]"
+    assert str(ds.take(1)) == "[{'value': array([0])}]"
 
 
 def test_read_text(ray_start_regular_shared, tmp_path):
@@ -973,7 +973,7 @@ def test_convert_types(ray_start_regular_shared):
     plain_ds = ray.data.range(1)
     arrow_ds = plain_ds.map(lambda x: {"a": x})
     assert arrow_ds.take() == [{"a": 0}]
-    assert "ArrowRow" in arrow_ds.map(lambda x: str(x)).take()[0]
+    assert "ArrowRow" in arrow_ds.map(lambda x: str(type(x))).take()[0]
 
     arrow_ds = ray.data.range_arrow(1)
     assert arrow_ds.map(lambda x: "plain_{}".format(x["value"])).take() \


### PR DESCRIPTION
Since ArrowRow behaves basically like a py dict, avoid showing it in the output of `ds.show()`, since it can be a bit distracting.