### PR TITLE
Add `ssh_control_master` config option (issue #18795)

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -303,7 +303,7 @@ class SSHOptions:
         if control_path:
             self.arg_dict.update({
                 "ControlMaster": "auto",
-                "ControlPath": "{}/%C".format(control_path),
+                "ControlPath": "{}".format(control_path),
                 "ControlPersist": "10s",
             })
         self.arg_dict.update(kwargs)
@@ -322,11 +322,13 @@ class SSHCommandRunner(CommandRunnerInterface):
     def __init__(self, log_prefix, node_id, provider, auth_config,
                  cluster_name, process_runner, use_internal_ip):
 
-        ssh_control_hash = hashlib.md5(cluster_name.encode()).hexdigest()
         ssh_user_hash = hashlib.md5(getuser().encode()).hexdigest()
-        ssh_control_path = "/tmp/ray_ssh_{}/{}".format(
-            ssh_user_hash[:HASH_MAX_LENGTH],
-            ssh_control_hash[:HASH_MAX_LENGTH])
+        ssh_control_path = auth_config.get("ssh_control_path", None)
+        if not ssh_control_path:
+            ssh_control_hash = hashlib.md5(cluster_name.encode()).hexdigest()
+            ssh_control_path = "/tmp/ray_ssh_{}/{}/%C".format(
+                ssh_user_hash[:HASH_MAX_LENGTH],
+                ssh_control_hash[:HASH_MAX_LENGTH])
 
         self.cluster_name = cluster_name
         self.log_prefix = log_prefix

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -198,6 +198,9 @@
                 "ssh_private_key": { 
                     "type": "string"
                 },
+                "ssh_control_path": {
+                    "type": "string"
+                },
                 "ssh_proxy_command": {
                     "description": "A value for ProxyCommand ssh option, for connecting through proxies. Example: nc -x proxy.example.com:1234 %h %p",
                     "type": "string"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The `ssh` command used by `ray` overrides settings in `~/.ssh/config`. The user may not be able to connect to other nodes in their environment without manually setting up ControlMaster connections prior to invoking `ray up`.

## Related issue number
#18795 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing (only run `test_basic.py` so far). Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
