### PR TITLE
[docs/usability] Apple Silicon support

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -154,6 +154,21 @@ The latest Ray Java snapshot can be found in `sonatype repository <https://oss.s
 
   If you want to run your Java code in a multi-node Ray cluster, it's better to exclude Ray jars when packaging your code to avoid jar conficts if the versions (installed Ray with ``pip install`` and maven dependencies) don't match.
 
+.. _apple-silcon-supprt:
+
+Apple Silicon Support
+---------------------
+
+Ray has experimental support for machines running Apple Silicon (such as M1 macs). To get started:
+
+1. Install `miniforge <https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh>`_.
+2. Ensure that the ``grpcio`` package is installed via forge and **not pypi**: ``pip uninstall grpcio; conda install grpcio``.
+3. Install Ray as you normally would: ``pip install ray``.
+
+.. note::
+
+  At this time, Apple Silicon ray wheels are being published for **releass only**. As support stabilizes, nightly wheels will be published in the future.
+
 .. _windows-support:
 
 Windows Support

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,19 @@ def _configure_system():
                            "an internal component by another module). Please "
                            "make sure you are using pickle5 >= 0.0.10 because "
                            "previous versions may leak memory.")
+
+    # Check that grpc can actually be imported on Apple Silicon. Some package
+    # managers (such as `pip`) can't properly install the grpcio library yet,
+    # so provide a proactive error message if that's the case.
+    if platform.system() == "Darwin" and platform.machine() == "arm64":
+        try:
+            import grpcio  # noqa: F401
+        except ImportError:
+            logger.fatal("Failed to import grpc on Apple Silicon. On Apple "
+                         "Silicon machines, try `pip uninstall grpcio; conda "
+                         "install grpcio`. Check out "
+                         "https://docs.ray.io/en/master/installation.html"
+                         "#apple-silicon-support for more details.")
 
     if "OMP_NUM_THREADS" not in os.environ:
         logger.debug("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -33,13 +33,14 @@ def _configure_system():
     # so provide a proactive error message if that's the case.
     if platform.system() == "Darwin" and platform.machine() == "arm64":
         try:
-            import grpcio  # noqa: F401
+            import grpc  # noqa: F401
         except ImportError:
-            logger.fatal("Failed to import grpc on Apple Silicon. On Apple "
-                         "Silicon machines, try `pip uninstall grpcio; conda "
-                         "install grpcio`. Check out "
-                         "https://docs.ray.io/en/master/installation.html"
-                         "#apple-silicon-support for more details.")
+            raise ImportError(
+                "Failed to import grpc on Apple Silicon. On Apple"
+                " Silicon machines, try `pip uninstall grpcio; conda "
+                "install grpcio`. Check out "
+                "https://docs.ray.io/en/master/installation.html"
+                "#apple-silicon-support for more details.")
 
     if "OMP_NUM_THREADS" not in os.environ:
         logger.debug("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR puts the final touches on apple silicon support. There are 3 main caveats to supporting M1 macs right now (described in the docs):

1. Requires using forge.
2. Requires special installation instructions to get grpc working (this is an underlying grpc issue, so ideally it will be fixed upstream).
3. We're only publishing release wheels, not nightlies right now.

This also includes a grpc import check to ensure that we provide an actionable error message if the user tries the regular `pip install ray` process to properly install grpcio. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
