### PR TITLE
Enable deployment on Serve of functions that take no parameters

### DIFF
--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -287,9 +287,15 @@ class RayServeReplica:
         start = time.time()
         method_to_call = None
         try:
-            method_to_call = sync_to_async(
-                self.get_runner_method(request_item))
-            result = await method_to_call(*args, **kwargs)
+            runner_method = self.get_runner_method(request_item)
+            method_to_call = sync_to_async(runner_method)
+            result = None
+            if len(inspect.signature(runner_method).parameters) > 0:
+                result = await method_to_call(*args, **kwargs)
+            else:
+                # The method doesn't take in anything, including the request
+                # information, so we pass nothing into it
+                result = await method_to_call()
 
             result = await self.ensure_serializable_response(result)
             self.request_counter.inc()

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -85,24 +85,37 @@ def test_starlette_response(serve_instance):
     assert resp.status_code == 418
 
 
-def test_deploy_function_no_params(serve_instance):
-    @serve.deployment
-    def d():
-        return "Hello world!"
+def test_deploy_sync_function_no_params(serve_instance):
+    @serve.deployment()
+    def sync_d():
+        return "sync!"
 
     serve.start()
-    d.deploy()
 
-    assert requests.get("http://localhost:8000/d").text == "Hello world!"
-    assert ray.get(d.get_handle().remote()) == "Hello world!"
+    sync_d.deploy()
+    assert requests.get("http://localhost:8000/sync_d").text == "sync!"
+    assert ray.get(sync_d.get_handle().remote()) == "sync!"
 
 
-def test_deploy_class_no_params(serve_instance):
+def test_deploy_async_function_no_params(serve_instance):
+    @serve.deployment()
+    async def async_d():
+        await asyncio.sleep(5)
+        return "async!"
+
+    serve.start()
+
+    async_d.deploy()
+    assert requests.get("http://localhost:8000/async_d").text == "async!"
+    assert ray.get(async_d.get_handle().remote()) == "async!"
+
+
+def test_deploy_sync_class_no_params(serve_instance):
     @serve.deployment
     class Counter:
         def __init__(self):
             self.count = 0
-        
+
         def __call__(self):
             self.count += 1
             return {"count": self.count}
@@ -113,6 +126,30 @@ def test_deploy_class_no_params(serve_instance):
     assert requests.get("http://127.0.0.1:8000/Counter").json() == {"count": 1}
     assert requests.get("http://127.0.0.1:8000/Counter").json() == {"count": 2}
     assert ray.get(Counter.get_handle().remote()) == {"count": 3}
+
+
+def test_deploy_async_class_no_params(serve_instance):
+    @serve.deployment
+    class AsyncCounter:
+        async def __init__(self):
+            await asyncio.sleep(5)
+            self.count = 0
+
+        async def __call__(self):
+            self.count += 1
+            await asyncio.sleep(5)
+            return {"count": self.count}
+
+    serve.start()
+    AsyncCounter.deploy()
+
+    assert requests.get("http://127.0.0.1:8000/AsyncCounter").json() == {
+        "count": 1
+    }
+    assert requests.get("http://127.0.0.1:8000/AsyncCounter").json() == {
+        "count": 2
+    }
+    assert ray.get(AsyncCounter.get_handle().remote()) == {"count": 3}
 
 
 def test_user_config(serve_instance):

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -884,17 +884,6 @@ def test_input_validation():
         Base.options(max_concurrent_queries=-1)
 
 
-def test_deploy_function_no_params(serve_instance):
-    @serve.deployment
-    def d():
-        return "Hello world!"
-
-    serve.start()
-    d.deploy()
-
-    assert requests.get("http://localhost:8000/d").text == "Hello world!"
-
-
 def test_deployment_properties():
     class DClass():
         pass

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -884,6 +884,17 @@ def test_input_validation():
         Base.options(max_concurrent_queries=-1)
 
 
+def test_deploy_function_no_params(serve_instance):
+    @serve.deployment
+    def d():
+        return "Hello world!"
+
+    serve.start()
+    d.deploy()
+
+    assert requests.get("http://localhost:8000/d").text == "Hello world!"
+
+
 def test_deployment_properties():
     class DClass():
         pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, functions that take no parameters can be deployed on Serve. However, when a request is made to the deployment over HTTP, the function will error out since it has no parameters. This PR allows functions with no parameters to successfully execute requests over HTTP without erroring out.

This PR was tested by adding a unit test called `test_deploy_function_no_params` to `test_deploy.py` that checks whether functions with no parameters run HTTP requests successfully. The PR also passed all other tests from `test_deploy.py`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #12178
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
