### PR TITLE
[CI] Deflake test metrics

### DIFF
--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -134,11 +134,16 @@ def test_multi_node_metrics_export_port_discovery(ray_start_cluster):
         # Make sure we can ping Prometheus endpoints.
         def test_prometheus_endpoint():
             response = requests.get(
-                "http://localhost:{}".format(metrics_export_port))
+                "http://localhost:{}".format(metrics_export_port),
+                # Fail the request early on if connection timeout
+                timeout=0.01)
             return response.status_code == 200
 
         assert wait_until_succeeded_without_exception(
-            test_prometheus_endpoint, (requests.exceptions.ConnectionError, ))
+            test_prometheus_endpoint,
+            (requests.exceptions.ConnectionError, ),
+            # The dashboard takes more than 2s to startup.
+            timeout_ms=5000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #19715

Verified no longer flaky by running it in build box environment. The dashboard takes more than 2s to startup. But the test `wait_until_succeeded_without_exception` timeout after 1s.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
