### PR TITLE
[Test] Add small scale threaded actor test

### DIFF
--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -205,8 +205,8 @@ def test_threaded_actor_integration_test_stress(ray_start_cluster):
             self.death_probability = death_probability
             self.children = [
                 Child.options(
-                    max_concurrency=max_concurrency
-                ).remote(death_probability) for _ in range(num_children)
+                    max_concurrency=max_concurrency).remote(death_probability)
+                for _ in range(num_children)
             ]
 
         def ping(self, num_pings):
@@ -223,13 +223,12 @@ def test_threaded_actor_integration_test_stress(ray_start_cluster):
 
         def kill(self):
             # Clean up children.
-            ray.get([child.__ray_terminate__.remote() for child in self.children])
+            ray.get(
+                [child.__ray_terminate__.remote() for child in self.children])
 
     parents = [
-        Parent.options(
-            max_concurrency=max_concurrency
-        ).remote(num_children, death_probability)
-        for _ in range(num_parents)
+        Parent.options(max_concurrency=max_concurrency).remote(
+            num_children, death_probability) for _ in range(num_parents)
     ]
 
     start = time.time()
@@ -244,8 +243,8 @@ def test_threaded_actor_integration_test_stress(ray_start_cluster):
             parent_index = np.random.randint(len(parents))
             parents[parent_index].kill.remote()
             parents[parent_index] = Parent.options(
-                max_concurrency=max_concurrency
-            ).remote(num_children, death_probability)
+                max_concurrency=max_concurrency).remote(
+                    num_children, death_probability)
         loop_times.append(time.time() - loop_start)
     result = {}
     print("Finished in: {}s".format(time.time() - start))
@@ -264,10 +263,8 @@ def test_threaded_actor_integration_test_stress(ray_start_cluster):
 
     # Make sure parents are still scheduleable.
     parents = [
-        Parent.options(
-            max_concurrency=max_concurrency
-        ).remote(num_children, death_probability)
-        for _ in range(num_parents)
+        Parent.options(max_concurrency=max_concurrency).remote(
+            num_children, death_probability) for _ in range(num_parents)
     ]
     ray.get([parent.ping.remote(10) for parent in parents])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Port test_dead_actor with 10 max_concurrency to the CI for a sanity check. (this is not the repro test)

This can pretty easily reproduce this error msg; 
```python3
2021-10-25 15:07:16,796	WARNING worker.py:1218 -- The actor or task with ID ffffffffffffffff1ab08acbe91bab6c32ecde9901000000 cannot be scheduled right now. You can ignore this message if this Ray cluster is expected to auto-scale or if you specified a runtime_env for this actor or task, which may take time to install.  Otherwise, this is likely due to all cluster resources being claimed by actors. To resolve the issue, consider creating fewer actors or increasing the resources available to this Ray cluster.
Required resources for this actor or task: {CPU: 1.000000}
Available resources on this node: {2.000000/2.000000 CPU, 432533200.000000 GiB/432533200.000000 GiB memory, 7680000.000000 GiB/7680000.000000 GiB object_store_memory, 1.000000/1.000000 node:127.0.0.1}
In total there are 0 pending tasks and 4 pending actors on this node.
```

I will make an issue to investigate this after the PR is merged

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
