### PR TITLE
Suppress tsan false positive in :gcs_pub_sub_test / absl::Mutex

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -100,6 +100,7 @@ build:tsan --linkopt -fsanitize=thread
 # This config is only for running TSAN with LLVM toolchain on Linux.
 build:tsan-clang --config=tsan
 build:tsan-clang --config=llvm
+test:tsan --test_env=TSAN_OPTIONS="report_atomic_races=0"
 
 # Memory sanitizer configuration
 build:asan --strip=never


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes a flaky tsan test that flakes much more often with event stats enabled (though it also flaked before for the same reason).

The root cause seems to be a tsan false positive, similar to https://github.com/google/sanitizers/issues/953