### PR TITLE
Try fixing reference counting issue with manual _owner assignment

### DIFF
--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -36,7 +36,9 @@ def _set_future_helper(
 
 cdef class ObjectRef(BaseID):
 
-    def __init__(self, id, owner_addr="", call_site_data=""):
+    def __init__(
+            self, id, owner_addr="", call_site_data="",
+            skip_adding_local_ref=False):
         check_id(id)
         self.data = CObjectID.FromBinary(<c_string>id)
         self.owner_addr = owner_addr
@@ -48,7 +50,8 @@ cdef class ObjectRef(BaseID):
         # But there are still some dummy object refs being created outside the
         # context of a core worker.
         if hasattr(worker, "core_worker"):
-            worker.core_worker.add_object_ref_reference(self)
+            if not skip_adding_local_ref:
+                worker.core_worker.add_object_ref_reference(self)
             self.in_core_worker = True
 
     def __dealloc__(self):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -297,7 +297,12 @@ class Worker:
             self.core_worker.put_serialized_object(
                 serialized_value,
                 object_ref=object_ref,
-                owner_address=owner_address))
+                owner_address=owner_address),
+                # If the owner address is set, then the initial reference is
+                # already acquired internally in CoreWorker::CreateOwned.
+                # TODO(ekl) we should unify the code path more with the others
+                # to avoid this special case.
+                skip_adding_local_ref=(owner_address is not None))
 
     def raise_errors(self, data_metadata_pairs, object_refs):
         out = self.deserialize_objects(data_metadata_pairs, object_refs)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -298,11 +298,11 @@ class Worker:
                 serialized_value,
                 object_ref=object_ref,
                 owner_address=owner_address),
-                # If the owner address is set, then the initial reference is
-                # already acquired internally in CoreWorker::CreateOwned.
-                # TODO(ekl) we should unify the code path more with the others
-                # to avoid this special case.
-                skip_adding_local_ref=(owner_address is not None))
+            # If the owner address is set, then the initial reference is
+            # already acquired internally in CoreWorker::CreateOwned.
+            # TODO(ekl) we should unify the code path more with the others
+            # to avoid this special case.
+            skip_adding_local_ref=(owner_address is not None))
 
     def raise_errors(self, data_metadata_pairs, object_refs):
         out = self.deserialize_objects(data_metadata_pairs, object_refs)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1081,7 +1081,8 @@ void CoreWorker::GetOwnershipInfo(const ObjectID &object_id, rpc::Address *owner
          "(ObjectID.from_binary(...)) cannot be serialized because Ray does not know "
          "which task will create them. "
          "If this was not how your object ID was generated, please file an issue "
-         "at https://github.com/ray-project/ray/issues/";
+         "at https://github.com/ray-project/ray/issues/: "
+      << object_id;
 
   rpc::GetObjectStatusReply object_status;
   // Optimization: if the object exists, serialize and inline its status. This also

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1198,7 +1198,8 @@ Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
     // Because in the remote worker's `HandleAssignObjectOwner`,
     // a `WaitForRefRemoved` RPC request will be sent back to
     // the current worker. So we need to make sure ref count is > 0
-    // by invoking `AddLocalReference` first.
+    // by invoking `AddLocalReference` first. Note that in worker.py we set
+    // skip_adding_local_ref=True to avoid double referencing the object.
     AddLocalReference(*object_id);
     RAY_UNUSED(reference_counter_->AddBorrowedObject(*object_id, ObjectID::Nil(),
                                                      real_owner_address));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The underlying cause of https://github.com/ray-project/ray/issues/19659 seems to be that the creator of the object is retaining an extra local reference to the object. This means that WaitForRefRemoved() sent from the owner to the creator never returns, meaning the owner never learns about the new borrower (i.e., the driver) of the object. Hence, when the creator is killed, the reference on the driver is lost.

This PR tries to fix this by remove that extra local reference, by creating the borrowed object with initial ref count of 0.

The issue also seems related to https://github.com/ray-project/ray/issues/18456 (but here there isn't any sys.exit).

## Related issue number
 Closes https://github.com/ray-project/ray/issues/19659
 (required for https://github.com/ray-project/ray/pull/19660)