### PR TITLE
Revert "Try enabling event stats by default (#19650)"

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -22,7 +22,8 @@
 RAY_CONFIG(uint64_t, debug_dump_period_milliseconds, 10000)
 
 /// Whether to enable Ray event stats collection.
-RAY_CONFIG(bool, event_stats, true)
+/// TODO(ekl) this seems to segfault Java unit tests when on by default?
+RAY_CONFIG(bool, event_stats, false)
 
 /// Whether to enable Ray legacy scheduler warnings. These are replaced by
 /// autoscaler messages after https://github.com/ray-project/ray/pull/18724.


### PR DESCRIPTION
This reverts commit 6081cf870eaf37dcfdedb08c81a0178790853fcf.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The PR caused linux://python/ray/tests:test_placement_group_mini_integration to become very flaky, as well as https://github.com/ray-project/ray/pull/19720/files