### PR TITLE
[ci/release] Report error to database on alert

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -1945,6 +1945,7 @@ def run_test(test_config_file: str,
             # If we get an alert, the test failed.
             logger.error(f"Alert has been raised for {test_suite}/{test_name} "
                          f"({category}): {alert}")
+            result["status"] = "error (alert raised)"
             report_kwargs["status"] = "error (alert raised)"
 
             # For printing/reporting to the database


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, if an alert was raised, the buildkite build would fail (be red), but the database would see a success. Instead we should report an error to the database as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
