### PR TITLE
[Threaded actor] Fix threaded actor race condition

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -308,7 +308,6 @@ std::shared_ptr<CoreWorker> CoreWorkerProcess::GetWorker(
 
 std::shared_ptr<CoreWorker> CoreWorkerProcess::GetGlobalWorker() {
   absl::ReaderMutexLock lock(&mutex_);
-  RAY_CHECK(global_worker_) << "global_worker_ must not be NULL";
   return global_worker_;
 }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -292,7 +292,9 @@ CoreWorker &CoreWorkerProcess::GetCoreWorker() {
 void CoreWorkerProcess::SetCurrentThreadWorkerId(const WorkerID &worker_id) {
   EnsureInitialized();
   if (core_worker_process->options_.num_workers == 1) {
-    RAY_CHECK(core_worker_process->GetGlobalWorker()->GetWorkerID() == worker_id);
+    auto global_worker = core_worker_process->GetGlobalWorker();
+    RAY_CHECK(global_worker) << "Global worker must not be NULL.";
+    RAY_CHECK(global_worker->GetWorkerID() == worker_id);
     return;
   }
   current_core_worker_ = core_worker_process->GetWorker(worker_id);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -85,7 +85,7 @@ void CoreWorkerProcess::Initialize(const CoreWorkerOptions &options) {
 }
 
 void CoreWorkerProcess::Shutdown() {
-  RAY_LOG(INFO) << "Shutdown. Core worker process will be deleted";
+  RAY_LOG(DEBUG) << "Shutdown. Core worker process will be deleted";
   if (!core_worker_process) {
     return;
   }
@@ -291,14 +291,10 @@ CoreWorker &CoreWorkerProcess::GetCoreWorker() {
 
 void CoreWorkerProcess::SetCurrentThreadWorkerId(const WorkerID &worker_id) {
   EnsureInitialized();
-  RAY_LOG(INFO) << "1";
   if (core_worker_process->options_.num_workers == 1) {
-    RAY_LOG(INFO) << "2";
     RAY_CHECK(core_worker_process->GetGlobalWorker()->GetWorkerID() == worker_id);
-    RAY_LOG(INFO) << "3";
     return;
   }
-  RAY_LOG(INFO) << "4";
   current_core_worker_ = core_worker_process->GetWorker(worker_id);
 }
 
@@ -360,7 +356,7 @@ void CoreWorkerProcess::RunTaskExecutionLoop() {
       worker = core_worker_process->CreateWorker();
     }
     worker->RunTaskExecutionLoop();
-    RAY_LOG(INFO) << "Task execution loop terminated";
+    RAY_LOG(DEBUG) << "Task execution loop terminated. Removing the global worker.";
     core_worker_process->RemoveWorker(worker);
   } else {
     std::vector<std::thread> worker_threads;
@@ -370,7 +366,7 @@ void CoreWorkerProcess::RunTaskExecutionLoop() {
         auto worker = core_worker_process->CreateWorker();
         worker->RunTaskExecutionLoop();
         RAY_LOG(INFO) << "Task execution loop terminated for a thread "
-                      << std::to_string(i);
+                      << std::to_string(i) << ". Removing a worker.";
         core_worker_process->RemoveWorker(worker);
       });
     }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -369,7 +369,8 @@ void CoreWorkerProcess::RunTaskExecutionLoop() {
         SetThreadName("worker.task" + std::to_string(i));
         auto worker = core_worker_process->CreateWorker();
         worker->RunTaskExecutionLoop();
-        RAY_LOG(INFO) << "Task execution loop terminated for a thread " << std::to_string(i);
+        RAY_LOG(INFO) << "Task execution loop terminated for a thread "
+                      << std::to_string(i);
         core_worker_process->RemoveWorker(worker);
       });
     }

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -636,5 +636,11 @@ void CoreWorkerDirectTaskReceiver::SetMaxActorConcurrency(bool is_asyncio,
   fiber_max_concurrency_ = fiber_max_concurrency;
 }
 
+void CoreWorkerDirectTaskReceiver::Stop() {
+  for (const auto &it : actor_scheduling_queues_) {
+    it.second->Stop();
+  }
+}
+
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -365,8 +365,10 @@ class BoundedExecutor {
     });
   }
 
+  /// Stop the thread pool.
   void Stop() { pool_.stop(); }
 
+  /// Join the thread pool.
   void Join() { pool_.join(); }
 
  private:
@@ -426,11 +428,16 @@ class PoolManager final {
     return default_thread_pool_;
   }
 
+  /// Stop and join the thread pools that the pool manager owns.
   void Stop() {
     if (default_thread_pool_) {
-      RAY_LOG(INFO) << "Thread pool stopped";
+      RAY_LOG(DEBUG) << "Default pool is stopping.";
       default_thread_pool_->Stop();
+      RAY_LOG(INFO) << "Default pool is joining. If the 'Default pool is joined.' "
+                       "message is not printed after this, the worker is probably "
+                       "hanging because the actor task is running an infinite loop.";
       default_thread_pool_->Join();
+      RAY_LOG(INFO) << "Default pool is joined.";
     }
 
     for (const auto &it : name_to_thread_pool_index_) {

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -346,7 +346,47 @@ class FiberStateManager final {
   std::shared_ptr<FiberState> default_fiber_ = nullptr;
 };
 
-class BoundedExecutor;
+/// Wraps a thread-pool to block posts until the pool has free slots. This is used
+/// by the SchedulingQueue to provide backpressure to clients.
+class BoundedExecutor {
+ public:
+  BoundedExecutor(int max_concurrency)
+      : num_running_(0), max_concurrency_(max_concurrency), pool_(max_concurrency){};
+
+  /// Posts work to the pool, blocking if no free threads are available.
+  void PostBlocking(std::function<void()> fn) {
+    mu_.LockWhen(absl::Condition(this, &BoundedExecutor::ThreadsAvailable));
+    num_running_ += 1;
+    mu_.Unlock();
+    boost::asio::post(pool_, [this, fn]() {
+      fn();
+      absl::MutexLock lock(&mu_);
+      num_running_ -= 1;
+    });
+  }
+  
+  void Stop() {
+    pool_.stop();
+  }
+
+  void Join() {
+    pool_.join();
+  }
+
+ private:
+  bool ThreadsAvailable() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    return num_running_ < max_concurrency_;
+  }
+
+  /// Protects access to the counters below.
+  absl::Mutex mu_;
+  /// The number of currently running tasks.
+  int num_running_ GUARDED_BY(mu_);
+  /// The max number of concurrently running tasks allowed.
+  const int max_concurrency_;
+  /// The underlying thread pool for running tasks.
+  boost::asio::thread_pool pool_;
+};
 
 /// A manager that manages a set of thread pool. which will perform
 /// the methods defined in one concurrency group.
@@ -388,6 +428,21 @@ class PoolManager final {
       return functions_to_thread_pool_index_[fd->ToString()];
     }
     return default_thread_pool_;
+  }
+
+  void Stop() {
+    if (default_thread_pool_) {
+      RAY_LOG(INFO) << "Thread pool stopped";
+      default_thread_pool_->Stop();
+      default_thread_pool_->Join();
+    }
+
+    for (const auto &it : name_to_thread_pool_index_) {
+      it.second->Stop();
+    }
+    for (const auto &it : name_to_thread_pool_index_) {
+      it.second->Join();
+    }
   }
 
  private:
@@ -489,40 +544,6 @@ class DependencyWaiterImpl : public DependencyWaiter {
   DependencyWaiterInterface &dependency_client_;
 };
 
-/// Wraps a thread-pool to block posts until the pool has free slots. This is used
-/// by the SchedulingQueue to provide backpressure to clients.
-class BoundedExecutor {
- public:
-  BoundedExecutor(int max_concurrency)
-      : num_running_(0), max_concurrency_(max_concurrency), pool_(max_concurrency){};
-
-  /// Posts work to the pool, blocking if no free threads are available.
-  void PostBlocking(std::function<void()> fn) {
-    mu_.LockWhen(absl::Condition(this, &BoundedExecutor::ThreadsAvailable));
-    num_running_ += 1;
-    mu_.Unlock();
-    boost::asio::post(pool_, [this, fn]() {
-      fn();
-      absl::MutexLock lock(&mu_);
-      num_running_ -= 1;
-    });
-  }
-
- private:
-  bool ThreadsAvailable() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-    return num_running_ < max_concurrency_;
-  }
-
-  /// Protects access to the counters below.
-  absl::Mutex mu_;
-  /// The number of currently running tasks.
-  int num_running_ GUARDED_BY(mu_);
-  /// The max number of concurrently running tasks allowed.
-  const int max_concurrency_;
-  /// The underlying thread pool for running tasks.
-  boost::asio::thread_pool pool_;
-};
-
 /// Used to implement task queueing at the worker. Abstraction to provide a common
 /// interface for actor tasks as well as normal ones.
 class SchedulingQueue {
@@ -540,6 +561,7 @@ class SchedulingQueue {
   virtual bool TaskQueueEmpty() const = 0;
   virtual size_t Size() const = 0;
   virtual size_t Steal(rpc::StealTasksReply *reply) = 0;
+  virtual void Stop() = 0;
   virtual bool CancelTaskIfFound(TaskID task_id) = 0;
   virtual ~SchedulingQueue(){};
 };
@@ -575,6 +597,12 @@ class ActorSchedulingQueue : public SchedulingQueue {
   }
 
   virtual ~ActorSchedulingQueue() = default;
+
+  void Stop() {
+    if (pool_manager_) {
+      pool_manager_->Stop();
+    }
+  }
 
   bool TaskQueueEmpty() const {
     RAY_CHECK(false) << "TaskQueueEmpty() not implemented for actor queues";
@@ -747,6 +775,10 @@ class NormalSchedulingQueue : public SchedulingQueue {
  public:
   NormalSchedulingQueue(){};
 
+  void Stop() {
+    // No-op
+  }
+
   bool TaskQueueEmpty() const {
     absl::MutexLock lock(&mu_);
     return pending_normal_tasks_.empty();
@@ -895,6 +927,8 @@ class CoreWorkerDirectTaskReceiver {
                         rpc::SendReplyCallback send_reply_callback);
 
   bool CancelQueuedNormalTask(TaskID task_id);
+
+  void Stop();
 
  protected:
   /// Cache the concurrency groups of actors.

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -364,14 +364,10 @@ class BoundedExecutor {
       num_running_ -= 1;
     });
   }
-  
-  void Stop() {
-    pool_.stop();
-  }
 
-  void Join() {
-    pool_.join();
-  }
+  void Stop() { pool_.stop(); }
+
+  void Join() { pool_.join(); }
 
  private:
   bool ThreadsAvailable() EXCLUSIVE_LOCKS_REQUIRED(mu_) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes the root cause of threaded actor thread SIGSEGV issue by properly joining the thread pool.

Basically threaded actors are executed in this way;

io_service (HandlePushTask) (post to)-> task_execution_service  (post to)-> thread_pool

But our shutdown hook only stops the task_execution service, which is why there are still tasks running in the thread pool that accesses core workers instances (e.g., process & threads).

We basically stop the threadpool and join before we stop the task execution loop. In this way, we can properly waits until all threads pool operations are terminated.

I verified this fixes the segfault issues from https://github.com/ray-project/ray/pull/19746.

## Related issue number

Closes https://github.com/ray-project/ray/issues/19748

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
