### PR TITLE
[RLlib; Docs overhaul] Docstring cleanup: Trainer, trainer_template, Callbacks.

### DIFF
--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -14,6 +14,7 @@ from ray.rllib.utils.typing import AgentID, PolicyID
 import psutil
 
 if TYPE_CHECKING:
+    from ray.rllib.agents.trainer import Trainer
     from ray.rllib.evaluation import RolloutWorker
 
 
@@ -46,16 +47,16 @@ class DefaultCallbacks:
         """Callback run on the rollout worker before each episode starts.
 
         Args:
-            worker (RolloutWorker): Reference to the current rollout worker.
-            base_env (BaseEnv): BaseEnv running the episode. The underlying
+            worker: Reference to the current rollout worker.
+            base_env: BaseEnv running the episode. The underlying
                 env object can be gotten by calling base_env.get_unwrapped().
-            policies (dict): Mapping of policy id to policy objects. In single
+            policies: Mapping of policy id to policy objects. In single
                 agent mode there will only be a single "default" policy.
-            episode (MultiAgentEpisode): Episode object which contains episode
+            episode: Episode object which contains episode
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
-            env_index (EnvID): Obsoleted: The ID of the environment, which the
+            env_index: Obsoleted: The ID of the environment, which the
                 episode belongs to.
             kwargs: Forward compatibility placeholder.
         """
@@ -201,12 +202,13 @@ class DefaultCallbacks:
 
         pass
 
-    def on_train_result(self, *, trainer, result: dict, **kwargs) -> None:
+    def on_train_result(self, *, trainer: "Trainer", result: dict,
+                        **kwargs) -> None:
         """Called at the end of Trainable.train().
 
         Args:
-            trainer (Trainer): Current trainer instance.
-            result (dict): Dict of results returned from trainer.train() call.
+            trainer: Current trainer instance.
+            result: Dict of results returned from trainer.train() call.
                 You can mutate this object to add additional metrics.
             kwargs: Forward compatibility placeholder.
         """

--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -36,14 +36,9 @@ class DefaultCallbacks:
                 "a class extending rllib.agents.callbacks.DefaultCallbacks")
         self.legacy_callbacks = legacy_callbacks_dict or {}
 
-    def on_episode_start(self,
-                         *,
-                         worker: "RolloutWorker",
-                         base_env: BaseEnv,
+    def on_episode_start(self, *, worker: "RolloutWorker", base_env: BaseEnv,
                          policies: Dict[PolicyID, Policy],
-                         episode: MultiAgentEpisode,
-                         env_index: Optional[int] = None,
-                         **kwargs) -> None:
+                         episode: MultiAgentEpisode, **kwargs) -> None:
         """Callback run on the rollout worker before each episode starts.
 
         Args:
@@ -56,8 +51,6 @@ class DefaultCallbacks:
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
-            env_index: Obsoleted: The ID of the environment, which the
-                episode belongs to.
             kwargs: Forward compatibility placeholder.
         """
 
@@ -74,7 +67,6 @@ class DefaultCallbacks:
                         base_env: BaseEnv,
                         policies: Optional[Dict[PolicyID, Policy]] = None,
                         episode: MultiAgentEpisode,
-                        env_index: Optional[int] = None,
                         **kwargs) -> None:
         """Runs on each episode step.
 
@@ -89,8 +81,6 @@ class DefaultCallbacks:
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
-            env_index (EnvID): Obsoleted: The ID of the environment, which the
-                episode belongs to.
             kwargs: Forward compatibility placeholder.
         """
 
@@ -100,14 +90,9 @@ class DefaultCallbacks:
                 "episode": episode
             })
 
-    def on_episode_end(self,
-                       *,
-                       worker: "RolloutWorker",
-                       base_env: BaseEnv,
+    def on_episode_end(self, *, worker: "RolloutWorker", base_env: BaseEnv,
                        policies: Dict[PolicyID, Policy],
-                       episode: MultiAgentEpisode,
-                       env_index: Optional[int] = None,
-                       **kwargs) -> None:
+                       episode: MultiAgentEpisode, **kwargs) -> None:
         """Runs when an episode is done.
 
         Args:
@@ -121,8 +106,6 @@ class DefaultCallbacks:
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
-            env_index (EnvID): Obsoleted: The ID of the environment, which the
-                episode belongs to.
             kwargs: Forward compatibility placeholder.
         """
 

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -531,12 +531,19 @@ def with_common_config(
 class Trainer(Trainable):
     """An RLlib algorithm responsible for optimizing one or more Policies.
 
-    Trainers contain a WorkerSet (self.workers), normally used to generate
-    environment samples in parallel (`self.workers.remote_workers()`) and
-    to compute and apply learning updates (`self.workers.local_worker()`).
+    Trainers contain a WorkerSet under `self.workers`. A WorkerSet is
+    normally composed of a single local worker
+    (self.workers.local_worker()), used to compute and apply learning updates,
+    and optionally one or more remote workers (self.workers.remote_workers()),
+    used to generate environment samples in parallel.
 
-    Each worker (remotes and local) contains a full PolicyMap (1 Policy
-    for single-agent training, 1 or more policies for multi-agent training).
+    Each worker (remotes or local) contains a PolicyMap, which itself
+    may contain either one policy for single-agent training or one or more
+    policies for multi-agent training. Policies are synchronized
+    automatically from time to time using ray.remote calls. The exact
+    synchronization logic depends on the specific algorithm (Trainer) used,
+    but this usually happens from local worker to all remote workers and
+    after each training update.
 
     You can write your own Trainer sub-classes by using the
     rllib.agents.trainer_template.py::build_traing() utility function.
@@ -705,6 +712,8 @@ class Trainer(Trainable):
         self.local_replay_buffer = (
             self._create_local_replay_buffer_if_necessary(self.config))
 
+        # Make the call to self._init. Sub-classes should override this
+        # method to implement custom initialization logic.
         self._init(self.config, self.env_creator)
 
         # Evaluation setup.
@@ -740,6 +749,21 @@ class Trainer(Trainable):
                 policy_class=self._policy_class,
                 config=evaluation_config,
                 num_workers=self.config["evaluation_num_workers"])
+
+    @DeveloperAPI
+    def _init(self, config: TrainerConfigDict,
+              env_creator: Callable[[EnvContext], EnvType]) -> None:
+        """Subclasses should override this for custom initialization.
+
+        In the case of Trainer, this is called from inside `self.setup()`.
+
+        Args:
+            config: Algorithm-specific configuration dict.
+            env_creator: A callable taking an EnvContext as only arg and
+                returning an environment (of any type: e.g. gym.Env, RLlib
+                BaseEnv, MultiAgentEnv, etc..).
+        """
+        raise NotImplementedError
 
     @override(Trainable)
     @PublicAPI
@@ -1304,34 +1328,38 @@ class Trainer(Trainable):
     def export_policy_model(self,
                             export_dir: str,
                             policy_id: PolicyID = DEFAULT_POLICY_ID,
-                            onnx: Optional[int] = None):
+                            onnx: Optional[int] = None) -> None:
         """Exports policy model with given policy_id to a local directory.
 
         Args:
-            export_dir (string): Writable local directory.
-            policy_id (string): Optional policy id to export.
-            onnx (int): If given, will export model in ONNX format. The
+            export_dir: Writable local directory.
+            policy_id: Optional policy id to export.
+            onnx: If given, will export model in ONNX format. The
                 value of this parameter set the ONNX OpSet version to use.
+                If None, the output format will be DL framework specific.
 
         Example:
             >>> trainer = MyTrainer()
             >>> for _ in range(10):
             >>>     trainer.train()
-            >>> trainer.export_policy_model("/tmp/export_dir")
+            >>> trainer.export_policy_model("/tmp/dir")
+            >>> trainer.export_policy_model("/tmp/dir/onnx", onnx=1)
         """
         self.get_policy(policy_id).export_model(export_dir, onnx)
 
     @DeveloperAPI
-    def export_policy_checkpoint(self,
-                                 export_dir: str,
-                                 filename_prefix: str = "model",
-                                 policy_id: PolicyID = DEFAULT_POLICY_ID):
+    def export_policy_checkpoint(
+            self,
+            export_dir: str,
+            filename_prefix: str = "model",
+            policy_id: PolicyID = DEFAULT_POLICY_ID,
+    ) -> None:
         """Exports policy model checkpoint to a local directory.
 
         Args:
-            export_dir (string): Writable local directory.
-            filename_prefix (string): file name prefix of checkpoint files.
-            policy_id (string): Optional policy id to export.
+            export_dir: Writable local directory.
+            filename_prefix: file name prefix of checkpoint files.
+            policy_id: Optional policy id to export.
 
         Example:
             >>> trainer = MyTrainer()
@@ -1343,14 +1371,16 @@ class Trainer(Trainable):
                                                      filename_prefix)
 
     @DeveloperAPI
-    def import_policy_model_from_h5(self,
-                                    import_file: str,
-                                    policy_id: PolicyID = DEFAULT_POLICY_ID):
+    def import_policy_model_from_h5(
+            self,
+            import_file: str,
+            policy_id: PolicyID = DEFAULT_POLICY_ID,
+    ) -> None:
         """Imports a policy's model with given policy_id from a local h5 file.
 
         Args:
-            import_file (str): The h5 file to import from.
-            policy_id (string): Optional policy id to import into.
+            import_file: The h5 file to import from.
+            policy_id: Optional policy id to import into.
 
         Example:
             >>> trainer = MyTrainer()
@@ -1383,39 +1413,51 @@ class Trainer(Trainable):
         return checkpoint_path
 
     @override(Trainable)
-    def load_checkpoint(self, checkpoint_path: str):
+    def load_checkpoint(self, checkpoint_path: str) -> None:
         extra_data = pickle.load(open(checkpoint_path, "rb"))
         self.__setstate__(extra_data)
 
     @override(Trainable)
-    def log_result(self, result: ResultDict):
+    def log_result(self, result: ResultDict) -> None:
+        # Log after the callback is invoked, so that the user has a chance
+        # to mutate the result.
         self.callbacks.on_train_result(trainer=self, result=result)
-        # log after the callback is invoked, so that the user has a chance
-        # to mutate the result
+        # Then log according to Trainable's logging logic.
         Trainable.log_result(self, result)
 
     @override(Trainable)
-    def cleanup(self):
+    def cleanup(self) -> None:
+        # Stop all workers.
         if hasattr(self, "workers"):
             self.workers.stop()
+        # Stop all optimizers.
         if hasattr(self, "optimizer") and self.optimizer:
             self.optimizer.stop()
+        # Then stop according to Trainable's logic.
+        Trainable.stop(self)
 
     @classmethod
     @override(Trainable)
     def default_resource_request(
             cls, config: PartialTrainerConfigDict) -> \
             Union[Resources, PlacementGroupFactory]:
-        cf = dict(cls._default_config, **config)
 
-        eval_config = cf["evaluation_config"]
+        # Default logic for RLlib algorithms (Trainers):
+        # Create one bundle per individual worker (local or remote).
+        # Use `num_cpus_for_driver` and `num_gpus` for the local worker and
+        # `num_cpus_per_worker` and `num_gpus_per_worker` for the remote
+        # workers to determine their CPU/GPU resource needs.
+
+        # Convenience config handles.
+        cf = dict(cls._default_config, **config)
+        eval_cf = cf["evaluation_config"]
 
         # TODO(ekl): add custom resources here once tune supports them
         # Return PlacementGroupFactory containing all needed resources
         # (already properly defined as device bundles).
         return PlacementGroupFactory(
             bundles=[{
-                # Driver.
+                # Local worker.
                 "CPU": cf["num_cpus_for_driver"],
                 "GPU": 0 if cf["_fake_gpus"] else cf["num_gpus"],
             }] + [
@@ -1428,10 +1470,10 @@ class Trainer(Trainable):
                 {
                     # Evaluation workers.
                     # Note: The local eval worker is located on the driver CPU.
-                    "CPU": eval_config.get("num_cpus_per_worker",
-                                           cf["num_cpus_per_worker"]),
-                    "GPU": eval_config.get("num_gpus_per_worker",
-                                           cf["num_gpus_per_worker"]),
+                    "CPU": eval_cf.get("num_cpus_per_worker",
+                                       cf["num_cpus_per_worker"]),
+                    "GPU": eval_cf.get("num_gpus_per_worker",
+                                       cf["num_gpus_per_worker"]),
                 } for _ in range(cf["evaluation_num_workers"])
             ] if cf["evaluation_interval"] else []),
             strategy=config.get("placement_strategy", "PACK"))
@@ -1442,32 +1484,32 @@ class Trainer(Trainable):
         pass
 
     @DeveloperAPI
-    def _init(self, config: TrainerConfigDict,
-              env_creator: Callable[[EnvContext], EnvType]):
-        """Subclasses should override this for custom initialization."""
-        raise NotImplementedError
-
-    @DeveloperAPI
     def _make_workers(
-            self, *, env_creator: Callable[[EnvContext], EnvType],
+            self,
+            *,
+            env_creator: Callable[[EnvContext], EnvType],
             validate_env: Optional[Callable[[EnvType, EnvContext], None]],
-            policy_class: Type[Policy], config: TrainerConfigDict,
-            num_workers: int) -> WorkerSet:
+            policy_class: Type[Policy],
+            config: TrainerConfigDict,
+            num_workers: int,
+    ) -> WorkerSet:
         """Default factory method for a WorkerSet running under this Trainer.
 
         Override this method by passing a custom `make_workers` into
         `build_trainer`.
 
         Args:
-            env_creator (callable): A function that return and Env given an env
+            env_creator: A function that return and Env given an env
                 config.
-            validate_env (Optional[Callable[[EnvType, EnvContext], None]]):
-                Optional callable to validate the generated environment (only
-                on worker=0).
-            policy (Type[Policy]): The Policy class to use for creating the
-                policies of the workers.
-            config (TrainerConfigDict): The Trainer's config.
-            num_workers (int): Number of remote rollout workers to create.
+            validate_env: Optional callable to validate the generated
+                environment. The env to be checked is the one returned from
+                the env creator, which may be a (single, not-yet-vectorized)
+                gym.Env or your custom RLlib env type (e.g. MultiAgentEnv,
+                VectorEnv, BaseEnv, etc..).
+            policy_class: The Policy class to use for creating the policies
+                of the workers.
+            config: The Trainer's config.
+            num_workers: Number of remote rollout workers to create.
                 0 for local only.
 
         Returns:

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1339,8 +1339,8 @@ class Trainer(Trainable):
             >>>     trainer.train()
             >>> trainer.export_policy_checkpoint("/tmp/export_dir")
         """
-        self.get_policy(policy_id).export_checkpoint(
-            export_dir, filename_prefix)
+        self.get_policy(policy_id).export_checkpoint(export_dir,
+                                                     filename_prefix)
 
     @DeveloperAPI
     def import_policy_model_from_h5(self,

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -75,58 +75,50 @@ def build_trainer(
         allow_unknown_subkeys: Optional[List[str]] = None,
         override_all_subkeys_if_type_changes: Optional[List[str]] = None,
 ) -> Type[Trainer]:
-    """Helper function for defining a custom trainer.
+    """Helper function for defining a custom Trainer class.
 
     Functions will be run in this order to initialize the trainer:
-        1. Config setup: validate_config, get_policy
-        2. Worker setup: before_init, execution_plan
-        3. Post setup: after_init
+        1. Config setup: validate_config, get_policy.
+        2. Worker setup: before_init, execution_plan.
+        3. Post setup: after_init.
 
     Args:
-        name (str): name of the trainer (e.g., "PPO")
-        default_config (Optional[TrainerConfigDict]): The default config dict
-            of the algorithm, otherwise uses the Trainer default config.
-        validate_config (Optional[Callable[[TrainerConfigDict], None]]):
-            Optional callable that takes the config to check for correctness.
-            It may mutate the config as needed.
-        default_policy (Optional[Type[Policy]]): The default Policy class to
-            use if `get_policy_class` returns None.
-        get_policy_class (Optional[Callable[
-            TrainerConfigDict, Optional[Type[Policy]]]]): Optional callable
-            that takes a config and returns the policy class or None. If None
-            is returned, will use `default_policy` (which must be provided
-            then).
-        validate_env (Optional[Callable[[EnvType, EnvContext], None]]):
-            Optional callable to validate the generated environment (only
-            on worker=0).
-        before_init (Optional[Callable[[Trainer], None]]): Optional callable to
-            run before anything is constructed inside Trainer (Workers with
-            Policies, execution plan, etc..). Takes the Trainer instance as
-            argument.
-        after_init (Optional[Callable[[Trainer], None]]): Optional callable to
-            run at the end of trainer init (after all Workers and the exec.
-            plan have been constructed). Takes the Trainer instance as
-            argument.
-        before_evaluate_fn (Optional[Callable[[Trainer], None]]): Callback to
-            run before evaluation. This takes the trainer instance as argument.
-        mixins (list): list of any class mixins for the returned trainer class.
+        name: name of the trainer (e.g., "PPO")
+        default_config: The default config dict of the algorithm,
+            otherwise uses the Trainer default config.
+        validate_config: Optional callable that takes the config to check
+            for correctness. It may mutate the config as needed.
+        default_policy: The default Policy class to use if `get_policy_class`
+            returns None.
+        get_policy_class: Optional callable that takes a config and returns
+            the policy class or None. If None is returned, will use
+            `default_policy` (which must be provided then).
+        validate_env: Optional callable to validate the generated environment
+            (only on worker=0).
+        before_init: Optional callable to run before anything is constructed
+            inside Trainer (Workers with Policies, execution plan, etc..).
+            Takes the Trainer instance as argument.
+        after_init: Optional callable to run at the end of trainer init
+            (after all Workers and the exec. plan have been constructed).
+            Takes the Trainer instance as argument.
+        before_evaluate_fn: Callback to run before evaluation. This takes
+            the trainer instance as argument.
+        mixins: List of any class mixins for the returned trainer class.
             These mixins will be applied in order and will have higher
             precedence than the Trainer class.
-        execution_plan (Optional[Callable[[WorkerSet, TrainerConfigDict],
-            Iterable[ResultDict]]]): Optional callable that sets up the
+        execution_plan: Optional callable that sets up the
             distributed execution workflow.
-        allow_unknown_configs (bool): Whether to allow unknown top-level config
-            keys.
-        allow_unknown_subkeys (Optional[List[str]]): List of top-level keys
+        allow_unknown_configs: Whether to allow unknown top-level config keys.
+        allow_unknown_subkeys: List of top-level keys
             with value=dict, for which new sub-keys are allowed to be added to
             the value dict. Appends to Trainer class defaults.
-        override_all_subkeys_if_type_changes (Optional[List[str]]): List of top
-            level keys with value=dict, for which we always override the entire
-            value (dict), iff the "type" key in that value dict changes.
-            Appends to Trainer class defaults.
+        override_all_subkeys_if_type_changes: List of top level keys with
+            value=dict, for which we always override the entire value (dict),
+            iff the "type" key in that value dict changes. Appends to Trainer
+            class defaults.
 
     Returns:
-        Type[Trainer]: A Trainer sub-class configured by the specified args.
+        A Trainer sub-class configured by the specified args.
     """
 
     original_kwargs = locals().copy()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Docstring cleanup: Trainer, trainer_template, Callbacks.

- Cleanup docstrings.
- Remove type hints in Args list (already in the signature).
- Remve type hint from "Returns" (already in signature).
- Add docstrings where missing.
- Re-sort some class methods (by their importance, private/public, deprecated, etc..).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
