### PR TITLE
[RLlib; Docs overhaul] Docstring cleanup: Policies, policy_templates.

### DIFF
--- a/rllib/policy/dynamic_tf_policy.py
+++ b/rllib/policy/dynamic_tf_policy.py
@@ -36,22 +36,6 @@ class DynamicTFPolicy(TFPolicy):
     Do not sub-class this class directly (neither should you sub-class
     TFPolicy), but rather use rllib.policy.tf_policy_template.build_tf_policy
     to generate your custom tf (graph-mode or eager) Policy classes.
-
-    Initialization of this class occurs in two phases.
-      * Phase 1: the model is created and model variables are initialized.
-      * Phase 2: a fake batch of data is created, sent to the trajectory
-        postprocessor, and then used to create placeholders for the loss
-        function. The loss and stats functions are initialized with these
-        placeholders.
-
-    Initialization defines the static graph.
-
-    Attributes:
-        observation_space (gym.Space): observation space of the policy.
-        action_space (gym.Space): action space of the policy.
-        config (dict): config of the policy
-        model (ModelV2): TF model instance
-        dist_class (type): TF action distribution class
     """
 
     @DeveloperAPI
@@ -88,42 +72,39 @@ class DynamicTFPolicy(TFPolicy):
             obs_include_prev_action_reward=DEPRECATED_VALUE):
         """Initializes a DynamicTFPolicy instance.
 
+        Initialization oxf this class occurs in two phases and defines the
+        static graph.
+
+        Phase 1: The model is created and model variables are initialized.
+
+        Phase 2: A fake batch of data is created, sent to the trajectory
+        postprocessor, and then used to create placeholders for the loss
+        function. The loss and stats functions are initialized with these
+        placeholders.
+
         Args:
-            observation_space (gym.spaces.Space): Observation space of the
-                policy.
-            action_space (gym.spaces.Space): Action space of the policy.
-            config (TrainerConfigDict): Policy-specific configuration data.
-            loss_fn (Callable[[Policy, ModelV2, Type[TFActionDistribution],
-                SampleBatch], TensorType]): Function that returns a loss tensor
-                for the policy graph.
-            stats_fn (Optional[Callable[[Policy, SampleBatch],
-                Dict[str, TensorType]]]): Optional function that returns a dict
-                of TF fetches given the policy and batch input tensors.
-            grad_stats_fn (Optional[Callable[[Policy, SampleBatch,
-                ModelGradients], Dict[str, TensorType]]]):
-                Optional function that returns a dict of TF fetches given the
-                policy, sample batch, and loss gradient tensors.
-            before_loss_init (Optional[Callable[
-                [Policy, gym.spaces.Space, gym.spaces.Space,
-                TrainerConfigDict], None]]): Optional function to run prior to
+            observation_space: Observation space of the policy.
+            action_space: Action space of the policy.
+            config: Policy-specific configuration data.
+            loss_fn: Function that returns a loss tensor for the policy graph.
+            stats_fn: Optional function that returns a dict of TF fetches
+                given the policy and batch input tensors.
+            grad_stats_fn: Optional function that returns a dict of TF
+                fetches given the policy, sample batch, and loss gradient
+                tensors.
+            before_loss_init: Optional function to run prior to
                 loss init that takes the same arguments as __init__.
-            make_model (Optional[Callable[[Policy, gym.spaces.Space,
-                gym.spaces.Space, TrainerConfigDict], ModelV2]]): Optional
-                function that returns a ModelV2 object given
-                policy, obs_space, action_space, and policy config.
+            make_model: Optional function that returns a ModelV2 object
+                given policy, obs_space, action_space, and policy config.
                 All policy variables should be created in this function. If not
                 specified, a default model will be created.
-            action_sampler_fn (Optional[Callable[[Policy, ModelV2, Dict[
-                str, TensorType], TensorType, TensorType], Tuple[TensorType,
-                TensorType]]]): A callable returning a sampled action and its
+            action_sampler_fn: A callable returning a sampled action and its
                 log-likelihood given Policy, ModelV2, input_dict, explore,
                 timestep, and is_training.
-            action_distribution_fn (Optional[Callable[[Policy, ModelV2,
-                Dict[str, TensorType], TensorType, TensorType],
-                Tuple[TensorType, type, List[TensorType]]]]): A callable
-                returning distribution inputs (parameters), a dist-class to
-                generate an action distribution object from, and
-                internal-state outputs (or an empty list if not applicable).
+            action_distribution_fn: A callable returning distribution inputs
+                (parameters), a dist-class to generate an action distribution
+                object from, and internal-state outputs (or an empty list if
+                not applicable).
                 Note: No Exploration hooks have to be called from within
                 `action_distribution_fn`. It's should only perform a simple
                 forward pass through some model.
@@ -131,14 +112,13 @@ class DynamicTFPolicy(TFPolicy):
                 inputs.
                 The callable takes as inputs: Policy, ModelV2, input_dict,
                 explore, timestep, is_training.
-            existing_inputs (Optional[Dict[str, tf1.placeholder]]): When
-                copying a policy, this specifies an existing dict of
-                placeholders to use instead of defining new ones.
-            existing_model (Optional[ModelV2]): When copying a policy, this
-                specifies an existing model to clone and share weights with.
-            get_batch_divisibility_req (Optional[Callable[[Policy], int]]):
-                Optional callable that returns the divisibility requirement for
-                sample batches. If None, will assume a value of 1.
+            existing_inputs: When copying a policy, this specifies an existing
+                dict of placeholders to use instead of defining new ones.
+            existing_model: When copying a policy, this specifies an existing
+                model to clone and share weights with.
+            get_batch_divisibility_req: Optional callable that returns the
+                divisibility requirement for sample batches. If None, will
+                assume a value of 1.
         """
         if obs_include_prev_action_reward != DEPRECATED_VALUE:
             deprecation_warning(

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -180,8 +180,8 @@ class Policy(metaclass=ABCMeta):
             kwargs: Forward compatibility placeholder.
 
         Returns:
-            Tuple consisting of the action, the list of RNN state outputs (if any),
-            and a dictionary of extra features (if any).
+            Tuple consisting of the action, the list of RNN state outputs (if
+            any), and a dictionary of extra features (if any).
         """
         # Build the input-dict used for the call to
         # `self.compute_actions_from_input_dict()`.

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -5,7 +5,7 @@ from gym.spaces import Box
 import logging
 import numpy as np
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional, Type, TYPE_CHECKING
 
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.policy.sample_batch import SampleBatch
@@ -58,58 +58,64 @@ PolicySpec.__new__.__defaults__ = (None, None, None, None)
 
 @DeveloperAPI
 class Policy(metaclass=ABCMeta):
-    """An agent policy and loss, i.e., a TFPolicy or other subclass.
+    """Policy base class: Calculates actions, losses, and holds NN models.
 
-    This object defines how to act in the environment, and also losses used to
-    improve the policy based on its experiences. Note that both policy and
-    loss are defined together for convenience, though the policy itself is
-    logically separate.
+    Policy is the abstract superclass for all DL-framework specific sub-classes
+    (e.g. TFPolicy or TorchPolicy). It exposes APIs to
 
-    All policies can directly extend Policy, however TensorFlow users may
-    find TFPolicy simpler to implement. TFPolicy also enables RLlib
-    to apply TensorFlow-specific optimizations such as fusing multiple policy
-    graphs and multi-GPU support.
+    1) Compute actions from observation (and possibly other) inputs.
+    2) Manage the Policy's NN model(s), like exporting and loading their
+       weights.
+    3) Postprocess a given trajectory from the environment or other input
+       via the `postprocess_trajectory` method.
+    4) Compute losses from a train batch.
+    5) Perform updates from a train batch on the NN-models (this normally
+       includes loss calculations) either a) in one monolithic step
+       (`train_on_batch`) or b) via batch pre-loading, then n steps of actual
+       loss computations and updates (`load_batch_into_buffer` +
+       `learn_on_loaded_batch`).
 
-    Attributes:
-        observation_space (gym.Space): Observation space of the policy. For
-            complex spaces (e.g., Dict), this will be flattened version of the
-            space, and you can access the original space via
-            ``observation_space.original_space``.
-        action_space (gym.Space): Action space of the policy.
-        exploration (Exploration): The exploration object to use for
-            computing actions, or None.
+    Note: It is not recommended to sub-class Policy directly, but rather use
+    one of the following two convenience methods:
+    `rllib.policy.policy_template::build_policy_class` (PyTorch) or
+    `rllib.policy.tf_policy_template::build_tf_policy_class` (TF).
     """
 
     @DeveloperAPI
-    def __init__(self, observation_space: gym.spaces.Space,
-                 action_space: gym.spaces.Space, config: TrainerConfigDict):
-        """Initialize the graph.
-
-        This is the standard constructor for policies. The policy
-        class you pass into RolloutWorker will be constructed with
-        these arguments.
+    def __init__(self, observation_space: gym.Space, action_space: gym.Space,
+                 config: TrainerConfigDict):
+        """Initializes a Policy instance.
 
         Args:
-            observation_space (gym.spaces.Space): Observation space of the
+            observation_space: Observation space of the
                 policy.
-            action_space (gym.spaces.Space): Action space of the policy.
-            config (TrainerConfigDict): Policy-specific configuration data.
+            action_space: Action space of the policy.
+            config: A complete Trainer/Policy config dict. For the default
+                config keys and values, see rllib/trainer/trainer.py.
         """
-        self.observation_space = observation_space
-        self.action_space = action_space
+        self.observation_space: gym.Space = observation_space
+        self.action_space: gym.Space = action_space
+        # The base struct of the action space.
+        # E.g. action-space = gym.spaces.Dict({"a": Discrete(2)}) ->
+        # action_space_struct = {"a": Discrete(2)}
         self.action_space_struct = get_base_struct_from_space(action_space)
-        self.config = config
+
+        self.config: TrainerConfigDict = config
+        # Create the callbacks object to use for handling custom callbacks.
         if self.config.get("callbacks"):
             self.callbacks: "DefaultCallbacks" = self.config.get("callbacks")()
         else:
             from ray.rllib.agents.callbacks import DefaultCallbacks
             self.callbacks: "DefaultCallbacks" = DefaultCallbacks()
+
         # The global timestep, broadcast down from time to time from the
-        # driver.
-        self.global_timestep = 0
+        # local worker to all remote workers.
+        self.global_timestep: int = 0
+
         # The action distribution class to use for action sampling, if any.
         # Child classes may set this.
-        self.dist_class = None
+        self.dist_class: Optional[Type] = None
+
         # Maximal view requirements dict for `learn_on_batch()` and
         # `compute_actions` calls.
         # View requirements will be automatically filtered out later based
@@ -122,55 +128,9 @@ class Policy(metaclass=ABCMeta):
             for k, v in view_reqs.items():
                 if k not in self.view_requirements:
                     self.view_requirements[k] = v
+        # Whether the Model's initial state (method) has been added
+        # automatically based on the given view requirements of the model.
         self._model_init_state_automatically_added = False
-
-    @abstractmethod
-    @DeveloperAPI
-    def compute_actions(
-            self,
-            obs_batch: Union[List[TensorStructType], TensorStructType],
-            state_batches: Optional[List[TensorType]] = None,
-            prev_action_batch: Union[List[TensorStructType],
-                                     TensorStructType] = None,
-            prev_reward_batch: Union[List[TensorStructType],
-                                     TensorStructType] = None,
-            info_batch: Optional[Dict[str, list]] = None,
-            episodes: Optional[List["MultiAgentEpisode"]] = None,
-            explore: Optional[bool] = None,
-            timestep: Optional[int] = None,
-            **kwargs) -> \
-            Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
-        """Computes actions for the current policy.
-
-        Args:
-            obs_batch: Batch of observations.
-            state_batches: List of RNN state input batches, if any.
-            prev_action_batch: Batch of previous action values.
-            prev_reward_batch: Batch of previous rewards.
-            info_batch (Optional[Dict[str, list]]): Batch of info objects.
-            episodes (Optional[List[MultiAgentEpisode]] ): List of
-                MultiAgentEpisode, one for each obs in obs_batch. This provides
-                access to all of the internal episode state, which may be
-                useful for model-based or multiagent algorithms.
-            explore (Optional[bool]): Whether to pick an exploitation or
-                exploration action. Set to None (default) for using the
-                value of `self.config["explore"]`.
-            timestep (Optional[int]): The current (sampling) time step.
-
-        Keyword Args:
-            kwargs: forward compatibility placeholder
-
-        Returns:
-            Tuple:
-                actions (TensorType): Batch of output actions, with shape like
-                    [BATCH_SIZE, ACTION_SHAPE].
-                state_outs (List[TensorType]): List of RNN state output
-                    batches, if any, each with shape [BATCH_SIZE, STATE_SIZE].
-                info (List[dict]): Dictionary of extra feature batches, if any,
-                    with shape like
-                    {"f1": [BATCH_SIZE, ...], "f2": [BATCH_SIZE, ...]}.
-        """
-        raise NotImplementedError
 
     @DeveloperAPI
     def compute_single_action(
@@ -188,7 +148,16 @@ class Policy(metaclass=ABCMeta):
             # Kwars placeholder for future compatibility.
             **kwargs) -> \
             Tuple[TensorStructType, List[TensorType], Dict[str, TensorType]]:
-        """Unbatched version of compute_actions.
+        """Computes and returns a single (B=1) action value.
+
+        Takes an input dict (usually a SampleBatch) as its main data input.
+        This allows for using this method in case a more complex input pattern
+        (view requirements) is needed, for example when the Model requires the
+        last n observations, the last m actions/rewards, or a combination
+        of any of these.
+        Alternatively, in case no complex inputs are required, takes a single
+        `obs` values (and possibly single state values, prev-action/reward
+        values, etc..).
 
         Args:
             obs: Single observation.
@@ -208,12 +177,11 @@ class Policy(metaclass=ABCMeta):
             timestep: The current (sampling) time step.
 
         Keyword Args:
-            kwargs: Forward compatibility.
+            kwargs: Forward compatibility placeholder.
 
         Returns:
-            - actions: Single action.
-            - state_outs: List of RNN state outputs, if any.
-            - info: Dictionary of extra features, if any.
+            Tuple consisting of the action, the list of RNN state outputs (if any),
+            and a dictionary of extra features (if any).
         """
         # Build the input-dict used for the call to
         # `self.compute_actions_from_input_dict()`.
@@ -275,8 +243,11 @@ class Policy(metaclass=ABCMeta):
             Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
         """Computes actions from collected samples (across multiple-agents).
 
-        Uses the currently "forward-pass-registered" samples from the collector
-        to construct the input_dict for the Model.
+        Takes an input dict (usually a SampleBatch) as its main data input.
+        This allows for using this method in case a more complex input pattern
+        (view requirements) is needed, for example when the Model requires the
+        last n observations, the last m actions/rewards, or a combination
+        of any of these.
 
         Args:
             input_dict: A SampleBatch or input dict containing the Tensors
@@ -294,14 +265,12 @@ class Policy(metaclass=ABCMeta):
             kwargs: Forward compatibility placeholder.
 
         Returns:
-            Tuple:
-                actions (TensorType): Batch of output actions, with shape
-                    like [BATCH_SIZE, ACTION_SHAPE].
-                state_outs (List[TensorType]): List of RNN state output
-                    batches, if any, each with shape [BATCH_SIZE, STATE_SIZE].
-                info (dict): Dictionary of extra feature batches, if any, with
-                    shape like
-                    {"f1": [BATCH_SIZE, ...], "f2": [BATCH_SIZE, ...]}.
+            actions: Batch of output actions, with shape like
+                [BATCH_SIZE, ACTION_SHAPE].
+            state_outs: List of RNN state output
+                batches, if any, each with shape [BATCH_SIZE, STATE_SIZE].
+            info: Dictionary of extra feature batches, if any, with shape like
+                {"f1": [BATCH_SIZE, ...], "f2": [BATCH_SIZE, ...]}.
         """
         # Default implementation just passes obs, prev-a/r, and states on to
         # `self.compute_actions()`.
@@ -320,6 +289,53 @@ class Policy(metaclass=ABCMeta):
             **kwargs,
         )
 
+    @abstractmethod
+    @DeveloperAPI
+    def compute_actions(
+            self,
+            obs_batch: Union[List[TensorStructType], TensorStructType],
+            state_batches: Optional[List[TensorType]] = None,
+            prev_action_batch: Union[List[TensorStructType],
+                                     TensorStructType] = None,
+            prev_reward_batch: Union[List[TensorStructType],
+                                     TensorStructType] = None,
+            info_batch: Optional[Dict[str, list]] = None,
+            episodes: Optional[List["MultiAgentEpisode"]] = None,
+            explore: Optional[bool] = None,
+            timestep: Optional[int] = None,
+            **kwargs) -> \
+            Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
+        """Computes actions for the current policy.
+
+        Args:
+            obs_batch: Batch of observations.
+            state_batches: List of RNN state input batches, if any.
+            prev_action_batch: Batch of previous action values.
+            prev_reward_batch: Batch of previous rewards.
+            info_batch: Batch of info objects.
+            episodes: List of MultiAgentEpisodes, one for each obs in
+                obs_batch. This provides access to all of the internal
+                episode state, which may be useful for model-based or
+                multi-agent algorithms.
+            explore: Whether to pick an exploitation or exploration action.
+                Set to None (default) for using the value of
+                `self.config["explore"]`.
+            timestep: The current (sampling) time step.
+
+        Keyword Args:
+            kwargs: Forward compatibility placeholder
+
+        Returns:
+            actions (TensorType): Batch of output actions, with shape like
+                [BATCH_SIZE, ACTION_SHAPE].
+            state_outs (List[TensorType]): List of RNN state output
+                batches, if any, each with shape [BATCH_SIZE, STATE_SIZE].
+            info (List[dict]): Dictionary of extra feature batches, if any,
+                with shape like
+                {"f1": [BATCH_SIZE, ...], "f2": [BATCH_SIZE, ...]}.
+        """
+        raise NotImplementedError
+
     @DeveloperAPI
     def compute_log_likelihoods(
             self,
@@ -334,26 +350,24 @@ class Policy(metaclass=ABCMeta):
     ) -> TensorType:
         """Computes the log-prob/likelihood for a given action and observation.
 
+        The log-likelihood is calculated using this Policy's action
+        distribution class (self.dist_class).
+
         Args:
-            actions (Union[List[TensorType], TensorType]): Batch of actions,
-                for which to retrieve the log-probs/likelihoods (given all
-                other inputs: obs, states, ..).
-            obs_batch (Union[List[TensorType], TensorType]): Batch of
-                observations.
-            state_batches (Optional[List[TensorType]]): List of RNN state input
-                batches, if any.
-            prev_action_batch (Optional[Union[List[TensorType], TensorType]]):
-                Batch of previous action values.
-            prev_reward_batch (Optional[Union[List[TensorType], TensorType]]):
-                Batch of previous rewards.
-            actions_normalized (bool): Is the given `actions` already
-                 normalized (between -1.0 and 1.0) or not? If not and
-                 `normalize_actions=True`, we need to normalize the given
-                 actions first, before calculating log likelihoods.
+            actions: Batch of actions, for which to retrieve the
+                log-probs/likelihoods (given all other inputs: obs,
+                states, ..).
+            obs_batch: Batch of observations.
+            state_batches: List of RNN state input batches, if any.
+            prev_action_batch: Batch of previous action values.
+            prev_reward_batch: Batch of previous rewards.
+            actions_normalized: Is the given `actions` already normalized
+                (between -1.0 and 1.0) or not? If not and
+                `normalize_actions=True`, we need to normalize the given
+                actions first, before calculating log likelihoods.
 
         Returns:
-            TensorType: Batch of log probs/likelihoods, with shape:
-                [BATCH_SIZE].
+            Batch of log probs/likelihoods, with shape: [BATCH_SIZE].
         """
         raise NotImplementedError
 
@@ -368,73 +382,136 @@ class Policy(metaclass=ABCMeta):
 
         This will be called on each trajectory fragment computed during policy
         evaluation. Each fragment is guaranteed to be only from one episode.
+        The given fragment may or may not contain the end of this episode,
+        depending on the `batch_mode=truncate_episodes|complete_episodes`,
+        `rollout_fragment_length`, and other settings.
 
         Args:
-            sample_batch (SampleBatch): batch of experiences for the policy,
+            sample_batch: batch of experiences for the policy,
                 which will contain at most one episode trajectory.
-            other_agent_batches (dict): In a multi-agent env, this contains a
+            other_agent_batches: In a multi-agent env, this contains a
                 mapping of agent ids to (policy, agent_batch) tuples
                 containing the policy and experiences of the other agents.
-            episode (Optional[MultiAgentEpisode]): An optional multi-agent
-                episode object to provide access to all of the
-                internal episode state, which may be useful for model-based or
-                multi-agent algorithms.
+            episode: An optional multi-agent episode object to provide
+                access to all of the internal episode state, which may
+                be useful for model-based or multi-agent algorithms.
 
         Returns:
-            SampleBatch: Postprocessed sample batch.
+            The postprocessed sample batch.
         """
+        # The default implementation just returns the same, unaltered batch.
         return sample_batch
 
     @DeveloperAPI
     def learn_on_batch(self, samples: SampleBatch) -> Dict[str, TensorType]:
-        """Fused compute gradients and apply gradients call.
+        """Perform one learning update, given `samples`.
 
-        Either this or the combination of compute/apply grads must be
-        implemented by subclasses.
+        Either this method or the combination of `compute_gradients` and
+        `apply_gradients` must be implemented by subclasses.
 
         Args:
-            samples (SampleBatch): The SampleBatch object to learn from.
+            samples: The SampleBatch object to learn from.
 
         Returns:
-            Dict[str, TensorType]: Dictionary of extra metadata from
-                compute_gradients().
+            Dictionary of extra metadata from `compute_gradients()`.
 
         Examples:
             >>> sample_batch = ev.sample()
             >>> ev.learn_on_batch(sample_batch)
         """
-
+        # The default implementation is simply a fused `compute_gradients` plus
+        # `apply_gradients` call.
         grads, grad_info = self.compute_gradients(samples)
         self.apply_gradients(grads)
         return grad_info
 
     @DeveloperAPI
-    def compute_gradients(self, postprocessed_batch: SampleBatch) -> \
-            Tuple[ModelGradients, Dict[str, TensorType]]:
-        """Computes gradients against a batch of experiences.
+    def load_batch_into_buffer(self, batch: SampleBatch,
+                               buffer_index: int = 0) -> int:
+        """Bulk-loads the given SampleBatch into the devices' memories.
 
-        Either this or learn_on_batch() must be implemented by subclasses.
+        The data is split equally across all the Policy's devices.
+        If the data is not evenly divisible by the batch size, excess data
+        should be discarded.
 
         Args:
-            postprocessed_batch (SampleBatch): The SampleBatch object to use
+            batch: The SampleBatch to load.
+            buffer_index: The index of the buffer (a MultiGPUTowerStack) to use
+                on the devices. The number of buffers on each device depends
+                on the value of the `num_multi_gpu_tower_stacks` config key.
+
+        Returns:
+            The number of tuples loaded per device.
+        """
+        raise NotImplementedError
+
+    @DeveloperAPI
+    def get_num_samples_loaded_into_buffer(self, buffer_index: int = 0) -> int:
+        """Returns the number of currently loaded samples in the given buffer.
+
+        Args:
+            buffer_index: The index of the buffer (a MultiGPUTowerStack)
+                to use on the devices. The number of buffers on each device
+                depends on the value of the `num_multi_gpu_tower_stacks` config
+                key.
+
+        Returns:
+            The number of tuples loaded per device.
+        """
+        raise NotImplementedError
+
+    @DeveloperAPI
+    def learn_on_loaded_batch(self, offset: int = 0, buffer_index: int = 0):
+        """Runs a single step of SGD on an already loaded data in a buffer.
+
+        Runs an SGD step over a slice of the pre-loaded batch, offset by
+        the `offset` argument (useful for performing n minibatch SGD
+        updates repeatedly on the same, already pre-loaded data).
+
+        Updates the model weights based on the averaged per-device gradients.
+
+        Args:
+            offset: Offset into the preloaded data. Used for pre-loading
+                a train-batch once to a device, then iterating over
+                (subsampling through) this batch n times doing minibatch SGD.
+            buffer_index: The index of the buffer (a MultiGPUTowerStack)
+                to take the already pre-loaded data from. The number of buffers
+                on each device depends on the value of the
+                `num_multi_gpu_tower_stacks` config key.
+
+        Returns:
+            The outputs of extra_ops evaluated over the batch.
+        """
+        raise NotImplementedError
+
+    @DeveloperAPI
+    def compute_gradients(self, postprocessed_batch: SampleBatch) -> \
+            Tuple[ModelGradients, Dict[str, TensorType]]:
+        """Computes gradients given a batch of experiences.
+
+        Either this in combination with `apply_gradients()` or
+        `learn_on_batch()` must be implemented by subclasses.
+
+        Args:
+            postprocessed_batch: The SampleBatch object to use
                 for calculating gradients.
 
         Returns:
-            Tuple[ModelGradients, Dict[str, TensorType]]:
-                - List of gradient output values.
-                - Extra policy-specific info values.
+            grads: List of gradient output values.
+            grad_info: Extra policy-specific info values.
         """
         raise NotImplementedError
 
     @DeveloperAPI
     def apply_gradients(self, gradients: ModelGradients) -> None:
-        """Applies previously computed gradients.
+        """Applies the (previously) computed gradients.
 
-        Either this or learn_on_batch() must be implemented by subclasses.
+        Either this in combination with `compute_gradients()` or
+        `learn_on_batch()` must be implemented by subclasses.
 
         Args:
-            gradients (ModelGradients): The already calculated gradients to
-                apply to this Policy.
+            gradients: The already calculated gradients to apply to this
+                Policy.
         """
         raise NotImplementedError
 
@@ -443,10 +520,13 @@ class Policy(metaclass=ABCMeta):
         """Returns model weights.
 
         Note: The return value of this method will reside under the "weights"
-        key in the return value of Policy.get_state().
+        key in the return value of Policy.get_state(). Model weights are only
+        one part of a Policy's state. Other state information contains:
+        optimizer variables, exploration state, and global state vars such as
+        the sampling timestep.
 
         Returns:
-            ModelWeights: Serializable copy or view of model weights.
+            Serializable copy or view of model weights.
         """
         raise NotImplementedError
 
@@ -454,33 +534,30 @@ class Policy(metaclass=ABCMeta):
     def set_weights(self, weights: ModelWeights) -> None:
         """Sets this Policy's model's weights.
 
+        Note: Model weights are only one part of a Policy's state. Other
+        state information contains: optimizer variables, exploration state,
+        and global state vars such as the sampling timestep.
+
         Args:
-            weights (ModelWeights): Serializable copy or view of model weights.
+            weights: Serializable copy or view of model weights.
         """
         raise NotImplementedError
 
     @DeveloperAPI
     def get_exploration_state(self) -> Dict[str, TensorType]:
-        """Returns the current exploration information of this policy.
-
-        This information depends on the policy's Exploration object.
+        """Returns the state of this Policy's exploration component.
 
         Returns:
-            Dict[str, TensorType]: Serializable information on the
-                `self.exploration` object.
+            Serializable information on the `self.exploration` object.
         """
         return self.exploration.get_state()
-
-    @Deprecated(new="get_exploration_state", error=False)
-    def get_exploration_info(self) -> Dict[str, TensorType]:
-        return self.get_exploration_state()
 
     @DeveloperAPI
     def is_recurrent(self) -> bool:
         """Whether this Policy holds a recurrent Model.
 
         Returns:
-            bool: True if this Policy has-a RNN-based Model.
+            True if this Policy has-a RNN-based Model.
         """
         return False
 
@@ -503,69 +580,16 @@ class Policy(metaclass=ABCMeta):
         return []
 
     @DeveloperAPI
-    def load_batch_into_buffer(self, batch: SampleBatch,
-                               buffer_index: int = 0) -> int:
-        """Bulk-loads the given SampleBatch into the devices' memories.
-
-        The data is split equally across all the devices. If the data is not
-        evenly divisible by the batch size, excess data should be discarded.
-
-        Args:
-            batch (SampleBatch): The SampleBatch to load.
-            buffer_index (int): The index of the buffer (a MultiGPUTowerStack)
-                to use on the devices.
-
-        Returns:
-            int: The number of tuples loaded per device.
-        """
-        raise NotImplementedError
-
-    @DeveloperAPI
-    def get_num_samples_loaded_into_buffer(self, buffer_index: int = 0) -> int:
-        """Returns the number of currently loaded samples in the given buffer.
-
-        Args:
-            batch (SampleBatch): The SampleBatch to load.
-            buffer_index (int): The index of the buffer (a MultiGPUTowerStack)
-                to use on the devices.
-
-        Returns:
-            int: The number of tuples loaded per device.
-        """
-        raise NotImplementedError
-
-    @DeveloperAPI
-    def learn_on_loaded_batch(self, offset: int = 0, buffer_index: int = 0):
-        """Runs a single step of SGD on already loaded data in a buffer.
-
-        Runs an SGD step over a slice of the pre-loaded batch, offset by
-        the `offset` argument (useful for performing n minibatch SGD
-        updates repeatedly on the same, already pre-loaded data).
-
-        Updates shared model weights based on the averaged per-device
-        gradients.
-
-        Args:
-            offset (int): Offset into the preloaded data. Used for pre-loading
-                a train-batch once to a device, then iterating over
-                (subsampling through) this batch n times doing minibatch SGD.
-            buffer_index (int): The index of the buffer (a MultiGPUTowerStack)
-                to take the already pre-loaded data from.
-
-        Returns:
-            The outputs of extra_ops evaluated over the batch.
-        """
-        raise NotImplementedError
-
-    @DeveloperAPI
     def get_state(self) -> Union[Dict[str, TensorType], List[TensorType]]:
-        """Returns all local state.
+        """Returns the entire current state of this Policy.
 
         Note: Not to be confused with an RNN model's internal state.
+        State includes the Model(s)' weights, optimizer weights,
+        the exploration component's state, as well as global variables, such
+        as sampling timesteps.
 
         Returns:
-            Union[Dict[str, TensorType], List[TensorType]]: Serialized local
-                state.
+            Serialized local state.
         """
         state = {
             # All the policy's weights.
@@ -576,11 +600,14 @@ class Policy(metaclass=ABCMeta):
         return state
 
     @DeveloperAPI
-    def set_state(self, state: object) -> None:
-        """Restores all local state to the provided `state`.
+    def set_state(
+            self,
+            state: Union[Dict[str, TensorType], List[TensorType]],
+    ) -> None:
+        """Restores the entire current state of this Policy from `state`.
 
         Args:
-            state (object): The new state to set this policy to. Can be
+            state: The new state to set this policy to. Can be
                 obtained by calling `self.get_state()`.
         """
         self.set_weights(state["weights"])
@@ -597,6 +624,15 @@ class Policy(metaclass=ABCMeta):
         # Store the current global time step (sum over all policies' sample
         # steps).
         self.global_timestep = global_vars["timestep"]
+
+    @DeveloperAPI
+    def export_checkpoint(self, export_dir: str) -> None:
+        """Export Policy checkpoint to local directory.
+
+        Args:
+            export_dir (str): Local writable directory.
+        """
+        raise NotImplementedError
 
     @DeveloperAPI
     def export_model(self, export_dir: str,
@@ -627,9 +663,12 @@ class Policy(metaclass=ABCMeta):
     def get_session(self) -> Optional["tf1.Session"]:
         """Returns tf.Session object to use for computing actions or None.
 
+        Note: This method only applies to TFPolicy sub-classes. All other
+        sub-classes should expect a None to be returned from this method.
+
         Returns:
-            Optional[tf1.Session]: The tf Session to use for computing actions
-                and losses with this policy.
+            The tf Session to use for computing actions and losses with
+                this policy or None.
         """
         return None
 
@@ -935,11 +974,6 @@ class Policy(metaclass=ABCMeta):
                     vr["state_out_{}".format(i)] = ViewRequirement(
                         space=space, used_for_training=True)
 
-    @Deprecated(new="save", error=False)
-    def export_checkpoint(self, export_dir: str) -> None:
-        """Export Policy checkpoint to local directory.
-
-        Args:
-            export_dir (str): Local writable directory.
-        """
-        raise NotImplementedError
+    @Deprecated(new="get_exploration_state", error=False)
+    def get_exploration_info(self) -> Dict[str, TensorType]:
+        return self.get_exploration_state()

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -49,11 +49,6 @@ class TFPolicy(Policy):
 
     Input tensors are typically shaped like [BATCH_SIZE, ...].
 
-    Attributes:
-        observation_space (gym.Space): observation space of the policy.
-        action_space (gym.Space): action space of the policy.
-        model (rllib.models.Model): RLlib model used for the policy.
-
     Examples:
         >>> policy = TFPolicySubclass(
             sess, obs_input, sampled_action, loss, loss_inputs)
@@ -75,7 +70,7 @@ class TFPolicy(Policy):
                  sampled_action: TensorType,
                  loss: Union[TensorType, List[TensorType]],
                  loss_inputs: List[Tuple[str, TensorType]],
-                 model: ModelV2 = None,
+                 model: Optional[ModelV2] = None,
                  sampled_action_logp: Optional[TensorType] = None,
                  action_input: Optional[TensorType] = None,
                  log_likelihood: Optional[TensorType] = None,
@@ -94,60 +89,52 @@ class TFPolicy(Policy):
         """Initializes a Policy object.
 
         Args:
-            observation_space (gym.spaces.Space): Observation space of the env.
-            action_space (gym.spaces.Space): Action space of the env.
-            config (TrainerConfigDict): The Policy config dict.
-            sess (tf1.Session): The TensorFlow session to use.
-            obs_input (TensorType): Input placeholder for observations, of
-                shape [BATCH_SIZE, obs...].
-            sampled_action (TensorType): Tensor for sampling an action, of
-                shape [BATCH_SIZE, action...]
-            loss (Union[TensorType, List[TensorType]]): Scalar policy loss
-                output tensor or a list thereof (in case there is more than
-                one loss).
-            loss_inputs (List[Tuple[str, TensorType]]): A (name, placeholder)
-                tuple for each loss input argument. Each placeholder name must
+            observation_space: Observation space of the policy.
+            action_space: Action space of the policy.
+            config: Policy-specific configuration data.
+            sess: The TensorFlow session to use.
+            obs_input: Input placeholder for observations, of shape
+                [BATCH_SIZE, obs...].
+            sampled_action: Tensor for sampling an action, of shape
+                [BATCH_SIZE, action...]
+            loss: Scalar policy loss output tensor or a list thereof
+                (in case there is more than one loss).
+            loss_inputs: A (name, placeholder) tuple for each loss input
+                argument. Each placeholder name must
                 correspond to a SampleBatch column key returned by
                 postprocess_trajectory(), and has shape [BATCH_SIZE, data...].
                 These keys will be read from postprocessed sample batches and
                 fed into the specified placeholders during loss computation.
-            model (ModelV2): used to integrate custom losses and
-                stats from user-defined RLlib models.
-            sampled_action_logp (Optional[TensorType]): log probability of the
-                sampled action.
-            action_input (Optional[TensorType]): Input placeholder for actions
-                for logp/log-likelihood calculations.
-            log_likelihood (Optional[TensorType]): Tensor to calculate the
-                log_likelihood (given action_input and obs_input).
-            dist_class (Optional[type]): An optional ActionDistribution class
-                to use for generating a dist object from distribution inputs.
-            dist_inputs (Optional[TensorType]): Tensor to calculate the
-                distribution inputs/parameters.
-            state_inputs (Optional[List[TensorType]]): List of RNN state input
-                Tensors.
-            state_outputs (Optional[List[TensorType]]): List of RNN state
-                output Tensors.
-            prev_action_input (Optional[TensorType]): placeholder for previous
-                actions.
-            prev_reward_input (Optional[TensorType]): placeholder for previous
-                rewards.
-            seq_lens (Optional[TensorType]): Placeholder for RNN sequence
-                lengths, of shape [NUM_SEQUENCES].
+            model: The optional ModelV2 to use for calculating actions and
+                losses.
+            sampled_action_logp: log probability of the sampled action.
+            action_input: Input placeholder for actions for
+                logp/log-likelihood calculations.
+            log_likelihood: Tensor to calculate the log_likelihood (given
+                action_input and obs_input).
+            dist_class: An optional ActionDistribution class to use for
+                generating a dist object from distribution inputs.
+            dist_inputs: Tensor to calculate the distribution
+                inputs/parameters.
+            state_inputs: List of RNN state input Tensors.
+            state_outputs: List of RNN state output Tensors.
+            prev_action_input: placeholder for previous actions.
+            prev_reward_input: placeholder for previous rewards.
+            seq_lens: Placeholder for RNN sequence lengths, of shape
+                [NUM_SEQUENCES].
                 Note that NUM_SEQUENCES << BATCH_SIZE. See
                 policy/rnn_sequencing.py for more information.
-            max_seq_len (int): Max sequence length for LSTM training.
-            batch_divisibility_req (int): pad all agent experiences batches to
+            max_seq_len: Max sequence length for LSTM training.
+            batch_divisibility_req: pad all agent experiences batches to
                 multiples of this value. This only has an effect if not using
                 a LSTM model.
-            update_ops (List[TensorType]): override the batchnorm update ops
+            update_ops: override the batchnorm update ops
                 to run when applying gradients. Otherwise we run all update
                 ops found in the current variable scope.
-            explore (Optional[Union[TensorType, bool]]): Placeholder for
-                `explore` parameter into call to
+            explore: Placeholder for `explore` parameter into call to
                 Exploration.get_exploration_action. Explicitly set this to
                 False for not creating any Exploration component.
-            timestep (Optional[TensorType]): Placeholder for the global
-                sampling timestep.
+            timestep: Placeholder for the global sampling timestep.
         """
         self.framework = "tf"
         super().__init__(observation_space, action_space, config)
@@ -282,130 +269,34 @@ class TFPolicy(Policy):
             self._log_likelihood = self.dist_class(
                 self._dist_inputs, self.model).logp(self._action_input)
 
-    def variables(self):
-        """Return the list of all savable variables for this policy."""
-        if isinstance(self.model, tf.keras.Model):
-            return self.model.variables
-        else:
-            return self.model.variables()
-
-    def get_placeholder(self, name) -> "tf1.placeholder":
-        """Returns the given action or loss input placeholder by name.
-
-        If the loss has not been initialized and a loss input placeholder is
-        requested, an error is raised.
-
-        Args:
-            name (str): The name of the placeholder to return. One of
-                SampleBatch.CUR_OBS|PREV_ACTION/REWARD or a valid key from
-                `self._loss_input_dict`.
-
-        Returns:
-            tf1.placeholder: The placeholder under the given str key.
-        """
-        if name == SampleBatch.CUR_OBS:
-            return self._obs_input
-        elif name == SampleBatch.PREV_ACTIONS:
-            return self._prev_action_input
-        elif name == SampleBatch.PREV_REWARDS:
-            return self._prev_reward_input
-
-        assert self._loss_input_dict, \
-            "You need to populate `self._loss_input_dict` before " \
-            "`get_placeholder()` can be called"
-        return self._loss_input_dict[name]
-
     @override(Policy)
-    def get_session(self) -> Optional["tf1.Session"]:
-        """Returns a reference to the TF session for this policy."""
-        return self._sess
+    def compute_actions_from_input_dict(
+            self,
+            input_dict: Union[SampleBatch, Dict[str, TensorType]],
+            explore: bool = None,
+            timestep: Optional[int] = None,
+            episodes: Optional[List["MultiAgentEpisode"]] = None,
+            **kwargs) -> \
+            Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
 
-    def loss_initialized(self) -> bool:
-        """Returns whether the loss term(s) have been initialized."""
-        return len(self._losses) > 0
+        explore = explore if explore is not None else self.config["explore"]
+        timestep = timestep if timestep is not None else self.global_timestep
 
-    def _initialize_loss(self, losses: List[TensorType],
-                         loss_inputs: List[Tuple[str, TensorType]]) -> None:
-        """Initializes the loss op from given loss tensor and placeholders.
+        builder = TFRunBuilder(self.get_session(),
+                               "compute_actions_from_input_dict")
+        obs_batch = input_dict[SampleBatch.OBS]
+        to_fetch = self._build_compute_actions(
+            builder, input_dict=input_dict, explore=explore, timestep=timestep)
 
-        Args:
-            loss (List[TensorType]): The list of loss ops returned by some
-                loss function.
-            loss_inputs (List[Tuple[str, TensorType]]): The list of Tuples:
-                (name, tf1.placeholders) needed for calculating the loss.
-        """
-        self._loss_input_dict = dict(loss_inputs)
-        self._loss_input_dict_no_rnn = {
-            k: v
-            for k, v in self._loss_input_dict.items()
-            if (v not in self._state_inputs and v != self._seq_lens)
-        }
-        for i, ph in enumerate(self._state_inputs):
-            self._loss_input_dict["state_in_{}".format(i)] = ph
+        # Execute session run to get action (and other fetches).
+        fetched = builder.get(to_fetch)
 
-        if self.model and not isinstance(self.model, tf.keras.Model):
-            self._losses = force_list(
-                self.model.custom_loss(losses, self._loss_input_dict))
-            self._stats_fetches.update({"model": self.model.metrics()})
-        else:
-            self._losses = losses
-        # Backward compatibility.
-        self._loss = self._losses[0] if self._losses is not None else None
+        # Update our global timestep by the batch size.
+        self.global_timestep += len(obs_batch) if isinstance(obs_batch, list) \
+            else len(input_dict) if isinstance(input_dict, SampleBatch) \
+            else obs_batch.shape[0]
 
-        if not self._optimizers:
-            self._optimizers = force_list(self.optimizer())
-            # Backward compatibility.
-            self._optimizer = self._optimizers[0] if self._optimizers else None
-
-        # Supporting more than one loss/optimizer.
-        if self.config["_tf_policy_handles_more_than_one_loss"]:
-            self._grads_and_vars = []
-            self._grads = []
-            for group in self.gradients(self._optimizers, self._losses):
-                g_and_v = [(g, v) for (g, v) in group if g is not None]
-                self._grads_and_vars.append(g_and_v)
-                self._grads.append([g for (g, _) in g_and_v])
-        # Only one optimizer and and loss term.
-        else:
-            self._grads_and_vars = [
-                (g, v)
-                for (g, v) in self.gradients(self._optimizer, self._loss)
-                if g is not None
-            ]
-            self._grads = [g for (g, _) in self._grads_and_vars]
-
-        if self.model:
-            self._variables = ray.experimental.tf_utils.TensorFlowVariables(
-                [], self.get_session(), self.variables())
-
-        # Gather update ops for any batch norm layers.
-        if len(self.devices) <= 1:
-            if not self._update_ops:
-                self._update_ops = tf1.get_collection(
-                    tf1.GraphKeys.UPDATE_OPS,
-                    scope=tf1.get_variable_scope().name)
-            if self._update_ops:
-                logger.info("Update ops to run on apply gradient: {}".format(
-                    self._update_ops))
-            with tf1.control_dependencies(self._update_ops):
-                self._apply_op = self.build_apply_op(
-                    optimizer=self._optimizers
-                    if self.config["_tf_policy_handles_more_than_one_loss"]
-                    else self._optimizer,
-                    grads_and_vars=self._grads_and_vars)
-
-        if log_once("loss_used"):
-            logger.debug("These tensors were used in the loss functions:"
-                         f"\n{summarize(self._loss_input_dict)}\n")
-
-        self.get_session().run(tf1.global_variables_initializer())
-
-        # TensorFlowVariables holing a flat list of all our optimizers'
-        # variables.
-        self._optimizer_variables = \
-            ray.experimental.tf_utils.TensorFlowVariables(
-                [v for o in self._optimizers for v in o.variables()],
-                self.get_session())
+        return fetched
 
     @override(Policy)
     def compute_actions(
@@ -444,35 +335,6 @@ class TFPolicy(Policy):
         self.global_timestep += \
             len(obs_batch) if isinstance(obs_batch, list) \
             else tree.flatten(obs_batch)[0].shape[0]
-
-        return fetched
-
-    @override(Policy)
-    def compute_actions_from_input_dict(
-            self,
-            input_dict: Union[SampleBatch, Dict[str, TensorType]],
-            explore: bool = None,
-            timestep: Optional[int] = None,
-            episodes: Optional[List["MultiAgentEpisode"]] = None,
-            **kwargs) -> \
-            Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
-
-        explore = explore if explore is not None else self.config["explore"]
-        timestep = timestep if timestep is not None else self.global_timestep
-
-        builder = TFRunBuilder(self.get_session(),
-                               "compute_actions_from_input_dict")
-        obs_batch = input_dict[SampleBatch.OBS]
-        to_fetch = self._build_compute_actions(
-            builder, input_dict=input_dict, explore=explore, timestep=timestep)
-
-        # Execute session run to get action (and other fetches).
-        fetched = builder.get(to_fetch)
-
-        # Update our global timestep by the batch size.
-        self.global_timestep += len(obs_batch) if isinstance(obs_batch, list) \
-            else len(input_dict) if isinstance(input_dict, SampleBatch) \
-            else obs_batch.shape[0]
 
         return fetched
 
@@ -568,6 +430,16 @@ class TFPolicy(Policy):
 
     @override(Policy)
     @DeveloperAPI
+    def get_weights(self) -> Union[Dict[str, TensorType], List[TensorType]]:
+        return self._variables.get_weights()
+
+    @override(Policy)
+    @DeveloperAPI
+    def set_weights(self, weights) -> None:
+        return self._variables.set_weights(weights)
+
+    @override(Policy)
+    @DeveloperAPI
     def get_exploration_state(self) -> Dict[str, TensorType]:
         return self.exploration.get_state(sess=self.get_session())
 
@@ -577,13 +449,13 @@ class TFPolicy(Policy):
 
     @override(Policy)
     @DeveloperAPI
-    def get_weights(self) -> Union[Dict[str, TensorType], List[TensorType]]:
-        return self._variables.get_weights()
+    def is_recurrent(self) -> bool:
+        return len(self._state_inputs) > 0
 
     @override(Policy)
     @DeveloperAPI
-    def set_weights(self, weights) -> None:
-        return self._variables.set_weights(weights)
+    def num_state_tensors(self) -> int:
+        return len(self._state_inputs)
 
     @override(Policy)
     @DeveloperAPI
@@ -615,10 +487,26 @@ class TFPolicy(Policy):
 
     @override(Policy)
     @DeveloperAPI
+    def export_checkpoint(self,
+                          export_dir: str,
+                          filename_prefix: str = "model") -> None:
+        """Export tensorflow checkpoint to export_dir."""
+        try:
+            os.makedirs(export_dir)
+        except OSError as e:
+            # ignore error if export dir already exists
+            if e.errno != errno.EEXIST:
+                raise
+        save_path = os.path.join(export_dir, filename_prefix)
+        with self.get_session().graph.as_default():
+            saver = tf1.train.Saver()
+            saver.save(self.get_session(), save_path)
+
+    @override(Policy)
+    @DeveloperAPI
     def export_model(self, export_dir: str,
                      onnx: Optional[int] = None) -> None:
         """Export tensorflow graph to export_dir for serving."""
-
         if onnx:
             try:
                 import tf2onnx
@@ -669,29 +557,137 @@ class TFPolicy(Policy):
 
     @override(Policy)
     @DeveloperAPI
-    def export_checkpoint(self,
-                          export_dir: str,
-                          filename_prefix: str = "model") -> None:
-        """Export tensorflow checkpoint to export_dir."""
-        try:
-            os.makedirs(export_dir)
-        except OSError as e:
-            # ignore error if export dir already exists
-            if e.errno != errno.EEXIST:
-                raise
-        save_path = os.path.join(export_dir, filename_prefix)
-        with self.get_session().graph.as_default():
-            saver = tf1.train.Saver()
-            saver.save(self.get_session(), save_path)
-
-    @override(Policy)
-    @DeveloperAPI
     def import_model_from_h5(self, import_file: str) -> None:
         """Imports weights into tf model."""
         # Make sure the session is the right one (see issue #7046).
         with self.get_session().graph.as_default():
             with self.get_session().as_default():
                 return self.model.import_from_h5(import_file)
+
+    @override(Policy)
+    def get_session(self) -> Optional["tf1.Session"]:
+        """Returns a reference to the TF session for this policy."""
+        return self._sess
+
+    def variables(self):
+        """Return the list of all savable variables for this policy."""
+        if isinstance(self.model, tf.keras.Model):
+            return self.model.variables
+        else:
+            return self.model.variables()
+
+    def get_placeholder(self, name) -> "tf1.placeholder":
+        """Returns the given action or loss input placeholder by name.
+
+        If the loss has not been initialized and a loss input placeholder is
+        requested, an error is raised.
+
+        Args:
+            name (str): The name of the placeholder to return. One of
+                SampleBatch.CUR_OBS|PREV_ACTION/REWARD or a valid key from
+                `self._loss_input_dict`.
+
+        Returns:
+            tf1.placeholder: The placeholder under the given str key.
+        """
+        if name == SampleBatch.CUR_OBS:
+            return self._obs_input
+        elif name == SampleBatch.PREV_ACTIONS:
+            return self._prev_action_input
+        elif name == SampleBatch.PREV_REWARDS:
+            return self._prev_reward_input
+
+        assert self._loss_input_dict, \
+            "You need to populate `self._loss_input_dict` before " \
+            "`get_placeholder()` can be called"
+        return self._loss_input_dict[name]
+
+    def loss_initialized(self) -> bool:
+        """Returns whether the loss term(s) have been initialized."""
+        return len(self._losses) > 0
+
+    def _initialize_loss(self, losses: List[TensorType],
+                         loss_inputs: List[Tuple[str, TensorType]]) -> None:
+        """Initializes the loss op from given loss tensor and placeholders.
+
+        Args:
+            loss (List[TensorType]): The list of loss ops returned by some
+                loss function.
+            loss_inputs (List[Tuple[str, TensorType]]): The list of Tuples:
+                (name, tf1.placeholders) needed for calculating the loss.
+        """
+        self._loss_input_dict = dict(loss_inputs)
+        self._loss_input_dict_no_rnn = {
+            k: v
+            for k, v in self._loss_input_dict.items()
+            if (v not in self._state_inputs and v != self._seq_lens)
+        }
+        for i, ph in enumerate(self._state_inputs):
+            self._loss_input_dict["state_in_{}".format(i)] = ph
+
+        if self.model and not isinstance(self.model, tf.keras.Model):
+            self._losses = force_list(
+                self.model.custom_loss(losses, self._loss_input_dict))
+            self._stats_fetches.update({"model": self.model.metrics()})
+        else:
+            self._losses = losses
+        # Backward compatibility.
+        self._loss = self._losses[0] if self._losses is not None else None
+
+        if not self._optimizers:
+            self._optimizers = force_list(self.optimizer())
+            # Backward compatibility.
+            self._optimizer = self._optimizers[0] if self._optimizers else None
+
+        # Supporting more than one loss/optimizer.
+        if self.config["_tf_policy_handles_more_than_one_loss"]:
+            self._grads_and_vars = []
+            self._grads = []
+            for group in self.gradients(self._optimizers, self._losses):
+                g_and_v = [(g, v) for (g, v) in group if g is not None]
+                self._grads_and_vars.append(g_and_v)
+                self._grads.append([g for (g, _) in g_and_v])
+        # Only one optimizer and and loss term.
+        else:
+            self._grads_and_vars = [
+                (g, v)
+                for (g, v) in self.gradients(self._optimizer, self._loss)
+                if g is not None
+            ]
+            self._grads = [g for (g, _) in self._grads_and_vars]
+
+        if self.model:
+            self._variables = ray.experimental.tf_utils.TensorFlowVariables(
+                [], self.get_session(), self.variables())
+
+        # Gather update ops for any batch norm layers.
+        if len(self.devices) <= 1:
+            if not self._update_ops:
+                self._update_ops = tf1.get_collection(
+                    tf1.GraphKeys.UPDATE_OPS,
+                    scope=tf1.get_variable_scope().name)
+            if self._update_ops:
+                logger.info("Update ops to run on apply gradient: {}".format(
+                    self._update_ops))
+            with tf1.control_dependencies(self._update_ops):
+                self._apply_op = self.build_apply_op(
+                    optimizer=self._optimizers
+                    if self.config["_tf_policy_handles_more_than_one_loss"]
+                    else self._optimizer,
+                    grads_and_vars=self._grads_and_vars)
+
+        if log_once("loss_used"):
+            logger.debug("These tensors were used in the loss functions:"
+                         f"\n{summarize(self._loss_input_dict)}\n")
+
+        self.get_session().run(tf1.global_variables_initializer())
+
+        # TensorFlowVariables holing a flat list of all our optimizers'
+        # variables.
+        self._optimizer_variables = \
+            ray.experimental.tf_utils.TensorFlowVariables(
+                [v for o in self._optimizers for v in o.variables()],
+                self.get_session())
 
     @DeveloperAPI
     def copy(self,
@@ -710,16 +706,6 @@ class TFPolicy(Policy):
             TFPolicy: A copy of self.
         """
         raise NotImplementedError
-
-    @override(Policy)
-    @DeveloperAPI
-    def is_recurrent(self) -> bool:
-        return len(self._state_inputs) > 0
-
-    @override(Policy)
-    @DeveloperAPI
-    def num_state_tensors(self) -> int:
-        return len(self._state_inputs)
 
     @DeveloperAPI
     def extra_compute_action_feed_dict(self) -> Dict[TensorType, TensorType]:

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -106,7 +106,9 @@ class TFPolicy(Policy):
                 These keys will be read from postprocessed sample batches and
                 fed into the specified placeholders during loss computation.
             model: The optional ModelV2 to use for calculating actions and
-                losses.
+                losses. If not None, TFPolicy will provide functionality for
+                getting variables, calling the model's custom loss (if
+                provided), and importing weights into the model.
             sampled_action_logp: log probability of the sampled action.
             action_input: Input placeholder for actions for
                 logp/log-likelihood calculations.
@@ -559,6 +561,9 @@ class TFPolicy(Policy):
     @DeveloperAPI
     def import_model_from_h5(self, import_file: str) -> None:
         """Imports weights into tf model."""
+        if self.model is None:
+            raise NotImplementedError("No `self.model` to import into!")
+
         # Make sure the session is the right one (see issue #7046).
         with self.get_session().graph.as_default():
             with self.get_session().as_default():
@@ -571,7 +576,9 @@ class TFPolicy(Policy):
 
     def variables(self):
         """Return the list of all savable variables for this policy."""
-        if isinstance(self.model, tf.keras.Model):
+        if self.model is None:
+            raise NotImplementedError("No `self.model` to get variables for!")
+        elif isinstance(self.model, tf.keras.Model):
             return self.model.variables
         else:
             return self.model.variables()

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -40,15 +40,7 @@ logger = logging.getLogger(__name__)
 
 @DeveloperAPI
 class TorchPolicy(Policy):
-    """Template for a PyTorch policy and loss to use with RLlib.
-
-    Attributes:
-        observation_space (gym.Space): observation space of the policy.
-        action_space (gym.Space): action space of the policy.
-        config (dict): config of the policy.
-        model (TorchModel): Torch model instance.
-        dist_class (type): Torch action distribution class.
-    """
+    """PyTorch specific Policy class to use with RLlib."""
 
     @DeveloperAPI
     def __init__(
@@ -73,59 +65,48 @@ class TorchPolicy(Policy):
             get_batch_divisibility_req: Optional[Callable[[Policy],
                                                           int]] = None,
     ):
-        """Build a policy from policy and loss torch modules.
-
-        Note that model will be placed on GPU device if CUDA_VISIBLE_DEVICES
-        is set. Only single GPU is supported for now.
+        """Initializes a TorchPolicy instance.
 
         Args:
-            observation_space (gym.spaces.Space): observation space of the
-                policy.
-            action_space (gym.spaces.Space): action space of the policy.
-            config (TrainerConfigDict): The Policy config dict.
-            model (ModelV2): PyTorch policy module. Given observations as
+            observation_space: Observation space of the policy.
+            action_space: Action space of the policy.
+            config: The Policy's config dict.
+            model: PyTorch policy module. Given observations as
                 input, this module must return a list of outputs where the
                 first item is action logits, and the rest can be any value.
-            loss (Callable[[Policy, ModelV2, Type[TorchDistributionWrapper],
-                SampleBatch], Union[TensorType, List[TensorType]]]): Callable
-                that returns a single scalar loss or a list of loss terms.
-            action_distribution_class (Type[TorchDistributionWrapper]): Class
-                for a torch action distribution.
-            action_sampler_fn (Callable[[TensorType, List[TensorType]],
-                Tuple[TensorType, TensorType]]): A callable returning a
-                sampled action and its log-likelihood given Policy, ModelV2,
-                input_dict, explore, timestep, and is_training.
-            action_distribution_fn (Optional[Callable[[Policy, ModelV2,
-                ModelInputDict, TensorType, TensorType],
-                Tuple[TensorType, type, List[TensorType]]]]): A callable
-                returning distribution inputs (parameters), a dist-class to
-                generate an action distribution object from, and
-                internal-state outputs (or an empty list if not applicable).
-                Note: No Exploration hooks have to be called from within
-                `action_distribution_fn`. It's should only perform a simple
-                forward pass through some model.
+            loss: Callable that returns one or more (a list of) scalar loss
+                terms.
+            action_distribution_class: Class for a torch action distribution.
+            action_sampler_fn: A callable returning a sampled action and
+                its log-likelihood given Policy, ModelV2, input_dict,
+                explore, timestep, and is_training.
+            action_distribution_fn: A callable returning distribution inputs
+                (parameters), a dist-class to generate an action distribution
+                object from, and internal-state outputs (or an empty list if
+                not applicable). Note: No Exploration hooks have to be called
+                from within `action_distribution_fn`. It's should only perform
+                a simple forward pass through some model.
                 If None, pass inputs through `self.model()` to get distribution
                 inputs.
                 The callable takes as inputs: Policy, ModelV2, ModelInputDict,
                 explore, timestep, is_training.
-            max_seq_len (int): Max sequence length for LSTM training.
-            get_batch_divisibility_req (Optional[Callable[[Policy], int]]]):
-                Optional callable that returns the divisibility requirement
-                for sample batches given the Policy.
+            max_seq_len: Max sequence length for LSTM training.
+            get_batch_divisibility_req: Optional callable that returns the
+                divisibility requirement for sample batches given the Policy.
         """
         self.framework = "torch"
         super().__init__(observation_space, action_space, config)
 
         # Create multi-GPU model towers, if necessary.
         # - The central main model will be stored under self.model, residing
-        #   on self.device.
+        #   on self.device (normally, a CPU).
         # - Each GPU will have a copy of that model under
         #   self.model_gpu_towers, matching the devices in self.devices.
         # - Parallelization is done by splitting the train batch and passing
         #   it through the model copies in parallel, then averaging over the
         #   resulting gradients, applying these averages on the main model and
         #   updating all towers' weights from the main model.
-        # - In case of just one device (1 (fake) GPU or 1 CPU), no
+        # - In case of just one device (1 (fake or real) GPU or 1 CPU), no
         #   parallelization will be done.
 
         # Get devices to build the graph on.
@@ -142,7 +123,7 @@ class TorchPolicy(Policy):
         # Place on one or more CPU(s) when either:
         # - Fake GPU mode.
         # - num_gpus=0 (either set by user or we are in local_mode=True).
-        # - no GPUs available.
+        # - No GPUs available.
         if config["_fake_gpus"] or num_gpus == 0 or not gpu_ids:
             logger.info("TorchPolicy (worker={}) running on {}.".format(
                 worker_idx
@@ -245,6 +226,30 @@ class TorchPolicy(Policy):
             (get_batch_divisibility_req or 1)
 
     @override(Policy)
+    def compute_actions_from_input_dict(
+            self,
+            input_dict: Dict[str, TensorType],
+            explore: bool = None,
+            timestep: Optional[int] = None,
+            **kwargs) -> \
+            Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
+
+        with torch.no_grad():
+            # Pass lazy (torch) tensor dict to Model as `input_dict`.
+            input_dict = self._lazy_tensor_dict(input_dict)
+            input_dict.is_training = False
+            # Pack internal state inputs into (separate) list.
+            state_batches = [
+                input_dict[k] for k in input_dict.keys() if "state_in" in k[:8]
+            ]
+            # Calculate RNN sequence lengths.
+            seq_lens = np.array([1] * len(input_dict["obs"])) \
+                if state_batches else None
+
+            return self._compute_action_helper(input_dict, state_batches,
+                                               seq_lens, explore, timestep)
+
+    @override(Policy)
     @DeveloperAPI
     def compute_actions(
             self,
@@ -279,132 +284,6 @@ class TorchPolicy(Policy):
             ]
             return self._compute_action_helper(input_dict, state_batches,
                                                seq_lens, explore, timestep)
-
-    @override(Policy)
-    def compute_actions_from_input_dict(
-            self,
-            input_dict: Dict[str, TensorType],
-            explore: bool = None,
-            timestep: Optional[int] = None,
-            **kwargs) -> \
-            Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
-
-        with torch.no_grad():
-            # Pass lazy (torch) tensor dict to Model as `input_dict`.
-            input_dict = self._lazy_tensor_dict(input_dict)
-            input_dict.is_training = False
-            # Pack internal state inputs into (separate) list.
-            state_batches = [
-                input_dict[k] for k in input_dict.keys() if "state_in" in k[:8]
-            ]
-            # Calculate RNN sequence lengths.
-            seq_lens = np.array([1] * len(input_dict["obs"])) \
-                if state_batches else None
-
-            return self._compute_action_helper(input_dict, state_batches,
-                                               seq_lens, explore, timestep)
-
-    @with_lock
-    def _compute_action_helper(self, input_dict, state_batches, seq_lens,
-                               explore, timestep):
-        """Shared forward pass logic (w/ and w/o trajectory view API).
-
-        Returns:
-            Tuple:
-                - actions, state_out, extra_fetches, logp.
-        """
-        explore = explore if explore is not None else self.config["explore"]
-        timestep = timestep if timestep is not None else self.global_timestep
-        self._is_recurrent = state_batches is not None and state_batches != []
-
-        # Switch to eval mode.
-        if self.model:
-            self.model.eval()
-
-        if self.action_sampler_fn:
-            action_dist = dist_inputs = None
-            actions, logp, state_out = self.action_sampler_fn(
-                self,
-                self.model,
-                input_dict,
-                state_batches,
-                explore=explore,
-                timestep=timestep)
-        else:
-            # Call the exploration before_compute_actions hook.
-            self.exploration.before_compute_actions(
-                explore=explore, timestep=timestep)
-            if self.action_distribution_fn:
-                # Try new action_distribution_fn signature, supporting
-                # state_batches and seq_lens.
-                try:
-                    dist_inputs, dist_class, state_out = \
-                        self.action_distribution_fn(
-                            self,
-                            self.model,
-                            input_dict=input_dict,
-                            state_batches=state_batches,
-                            seq_lens=seq_lens,
-                            explore=explore,
-                            timestep=timestep,
-                            is_training=False)
-                # Trying the old way (to stay backward compatible).
-                # TODO: Remove in future.
-                except TypeError as e:
-                    if "positional argument" in e.args[0] or \
-                            "unexpected keyword argument" in e.args[0]:
-                        dist_inputs, dist_class, state_out = \
-                            self.action_distribution_fn(
-                                self,
-                                self.model,
-                                input_dict[SampleBatch.CUR_OBS],
-                                explore=explore,
-                                timestep=timestep,
-                                is_training=False)
-                    else:
-                        raise e
-            else:
-                dist_class = self.dist_class
-                dist_inputs, state_out = self.model(input_dict, state_batches,
-                                                    seq_lens)
-
-            if not (isinstance(dist_class, functools.partial)
-                    or issubclass(dist_class, TorchDistributionWrapper)):
-                raise ValueError(
-                    "`dist_class` ({}) not a TorchDistributionWrapper "
-                    "subclass! Make sure your `action_distribution_fn` or "
-                    "`make_model_and_action_dist` return a correct "
-                    "distribution class.".format(dist_class.__name__))
-
-            action_dist = dist_class(dist_inputs, self.model)
-
-            # Get the exploration action from the forward results.
-            actions, logp = \
-                self.exploration.get_exploration_action(
-                    action_distribution=action_dist,
-                    timestep=timestep,
-                    explore=explore)
-
-        input_dict[SampleBatch.ACTIONS] = actions
-
-        # Add default and custom fetches.
-        extra_fetches = self.extra_action_out(input_dict, state_batches,
-                                              self.model, action_dist)
-
-        # Action-dist inputs.
-        if dist_inputs is not None:
-            extra_fetches[SampleBatch.ACTION_DIST_INPUTS] = dist_inputs
-
-        # Action-logp and action-prob.
-        if logp is not None:
-            extra_fetches[SampleBatch.ACTION_PROB] = \
-                torch.exp(logp.float())
-            extra_fetches[SampleBatch.ACTION_LOGP] = logp
-
-        # Update our global timestep by the batch size.
-        self.global_timestep += len(input_dict[SampleBatch.CUR_OBS])
-
-        return convert_to_non_torch_type((actions, state_out, extra_fetches))
 
     @with_lock
     @override(Policy)
@@ -943,6 +822,107 @@ class TorchPolicy(Policy):
         """Imports weights into torch model."""
         return self.model.import_from_h5(import_file)
 
+    @with_lock
+    def _compute_action_helper(self, input_dict, state_batches, seq_lens,
+                               explore, timestep):
+        """Shared forward pass logic (w/ and w/o trajectory view API).
+
+        Returns:
+            Tuple:
+                - actions, state_out, extra_fetches, logp.
+        """
+        explore = explore if explore is not None else self.config["explore"]
+        timestep = timestep if timestep is not None else self.global_timestep
+        self._is_recurrent = state_batches is not None and state_batches != []
+
+        # Switch to eval mode.
+        if self.model:
+            self.model.eval()
+
+        if self.action_sampler_fn:
+            action_dist = dist_inputs = None
+            actions, logp, state_out = self.action_sampler_fn(
+                self,
+                self.model,
+                input_dict,
+                state_batches,
+                explore=explore,
+                timestep=timestep)
+        else:
+            # Call the exploration before_compute_actions hook.
+            self.exploration.before_compute_actions(
+                explore=explore, timestep=timestep)
+            if self.action_distribution_fn:
+                # Try new action_distribution_fn signature, supporting
+                # state_batches and seq_lens.
+                try:
+                    dist_inputs, dist_class, state_out = \
+                        self.action_distribution_fn(
+                            self,
+                            self.model,
+                            input_dict=input_dict,
+                            state_batches=state_batches,
+                            seq_lens=seq_lens,
+                            explore=explore,
+                            timestep=timestep,
+                            is_training=False)
+                # Trying the old way (to stay backward compatible).
+                # TODO: Remove in future.
+                except TypeError as e:
+                    if "positional argument" in e.args[0] or \
+                            "unexpected keyword argument" in e.args[0]:
+                        dist_inputs, dist_class, state_out = \
+                            self.action_distribution_fn(
+                                self,
+                                self.model,
+                                input_dict[SampleBatch.CUR_OBS],
+                                explore=explore,
+                                timestep=timestep,
+                                is_training=False)
+                    else:
+                        raise e
+            else:
+                dist_class = self.dist_class
+                dist_inputs, state_out = self.model(input_dict, state_batches,
+                                                    seq_lens)
+
+            if not (isinstance(dist_class, functools.partial)
+                    or issubclass(dist_class, TorchDistributionWrapper)):
+                raise ValueError(
+                    "`dist_class` ({}) not a TorchDistributionWrapper "
+                    "subclass! Make sure your `action_distribution_fn` or "
+                    "`make_model_and_action_dist` return a correct "
+                    "distribution class.".format(dist_class.__name__))
+            action_dist = dist_class(dist_inputs, self.model)
+
+            # Get the exploration action from the forward results.
+            actions, logp = \
+                self.exploration.get_exploration_action(
+                    action_distribution=action_dist,
+                    timestep=timestep,
+                    explore=explore)
+
+        input_dict[SampleBatch.ACTIONS] = actions
+
+        # Add default and custom fetches.
+        extra_fetches = self.extra_action_out(input_dict, state_batches,
+                                              self.model, action_dist)
+
+        # Action-dist inputs.
+        if dist_inputs is not None:
+            extra_fetches[SampleBatch.ACTION_DIST_INPUTS] = dist_inputs
+
+        # Action-logp and action-prob.
+        if logp is not None:
+            extra_fetches[SampleBatch.ACTION_PROB] = \
+                torch.exp(logp.float())
+            extra_fetches[SampleBatch.ACTION_LOGP] = logp
+
+        # Update our global timestep by the batch size.
+        self.global_timestep += len(input_dict[SampleBatch.CUR_OBS])
+
+        return convert_to_non_torch_type((actions, state_out, extra_fetches))
+
     def _lazy_tensor_dict(self, postprocessed_batch: SampleBatch, device=None):
         # TODO: (sven): Keep for a while to ensure backward compatibility.
         if not isinstance(postprocessed_batch, SampleBatch):
@@ -1082,7 +1062,7 @@ class TorchPolicy(Policy):
 #   and for all possible hyperparams, not just lr.
 @DeveloperAPI
 class LearningRateSchedule:
-    """Mixin for TFPolicy that adds a learning rate schedule."""
+    """Mixin for TorchPolicy that adds a learning rate schedule."""
 
     @DeveloperAPI
     def __init__(self, lr, lr_schedule):

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -77,17 +77,36 @@ class TorchPolicy(Policy):
             loss: Callable that returns one or more (a list of) scalar loss
                 terms.
             action_distribution_class: Class for a torch action distribution.
-            action_sampler_fn: A callable returning a sampled action and
-                its log-likelihood given Policy, ModelV2, input_dict,
-                explore, timestep, and is_training.
+            action_sampler_fn: A callable returning a sampled action and its
+                log-likelihood given Policy, ModelV2, input_dict, state batches
+                (optional), explore, and timestep.
+                Provide `action_sampler_fn` if you would like to have full
+                control over the action computation step, including the
+                model forward pass, possible sampling from a distribution,
+                and exploration logic.
+                Note: If `action_sampler_fn` is given, `action_distribution_fn`
+                must be None. If both `action_sampler_fn` and
+                `action_distribution_fn` are None, RLlib will simply pass
+                inputs through `self.model` to get distribution inputs, create
+                the distribution object, sample from it, and apply some
+                exploration logic to the results.
+                The callable takes as inputs: Policy, ModelV2, input_dict
+                (SampleBatch), state_batches (optional), explore, and timestep.
             action_distribution_fn: A callable returning distribution inputs
                 (parameters), a dist-class to generate an action distribution
                 object from, and internal-state outputs (or an empty list if
-                not applicable). Note: No Exploration hooks have to be called
-                from within `action_distribution_fn`. It's should only perform
-                a simple forward pass through some model.
-                If None, pass inputs through `self.model()` to get distribution
-                inputs.
+                not applicable).
+                Provide `action_distribution_fn` if you would like to only
+                customize the model forward pass call. The resulting
+                distribution parameters are then used by RLlib to create a
+                distribution object, sample from it, and execute any
+                exploration logic.
+                Note: If `action_distribution_fn` is given, `action_sampler_fn`
+                must be None. If both `action_sampler_fn` and
+                `action_distribution_fn` are None, RLlib will simply pass
+                inputs through `self.model` to get distribution inputs, create
+                the distribution object, sample from it, and apply some
+                exploration logic to the results.
                 The callable takes as inputs: Policy, ModelV2, ModelInputDict,
                 explore, timestep, is_training.
             max_seq_len: Max sequence length for LSTM training.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Docstring cleanup: Policies, policy_templates.

- Cleanup docstrings.
- Remove type hints in Args list (already in the signature).
- Remve type hint from "Returns" (already in signature).
- Add docstrings where missing.
- Re-sort some class methods (by their importance, private/public, deprecated, etc..).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
