### PR TITLE
[k8s] Set default operator image to 1.7.0 temporarily

### DIFF
--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -3,7 +3,7 @@
 # RayCluster settings:
 
 # image is Ray image to use for the head and workers of this Ray cluster.
-image: rayproject/ray:latest
+image: rayproject/ray:1.7.0
 # headPodType is the podType used for the Ray head node (as configured below).
 headPodType: rayHeadType
 # podTypes is the list of pod configurations available for use as Ray nodes.
@@ -96,7 +96,8 @@ namespacedOperator: false
 # in which to launch the operator.
 operatorNamespace: default
 # operatorImage - The image used in the operator deployment.
-operatorImage: rayproject/ray:latest
+operatorImage: rayproject/ray:1.7.0
+# The current recommended operator image rayproject/ray:1.7.0.
 # `rayproject/ray:latest` contains the latest official release version of Ray.
 # `rayproject/ray:nightly` runs the current master version of Ray.
 # For a particular official release version of Ray, use `rayproject/ray:1.x.y`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray 1.7.1 introduced a regression that prevents cluster startup. The regression is not present in 1.7.0 and was resolved in 1.8.0.
Until the 1.8.0 release, set the default image to 1.7.0.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
