### PR TITLE
increase long poll timeout and wrk trial cpu resource

### DIFF
--- a/python/ray/serve/long_poll.py
+++ b/python/ray/serve/long_poll.py
@@ -15,7 +15,7 @@ from ray.serve.utils import logger
 # that will slow down, or even block controller actor's event loop if near
 # its max_concurrency limit. Therefore we timeout a polling request after
 # a few seconds and let each client retry on their end.
-LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S = 5
+LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S = 60
 
 
 class LongPollNamespace(Enum):

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -147,7 +147,7 @@ def main(num_replicas: Optional[int], num_deployments: Optional[int],
     all_endpoints = list(serve.list_deployments().keys())
     for endpoint in all_endpoints:
         rst_ray_refs.append(
-            warm_up_one_cluster.options(num_cpus=0.01).remote(
+            warm_up_one_cluster.options(num_cpus=0).remote(
                 10, http_host, http_port, endpoint))
     for endpoint in ray.get(rst_ray_refs):
         logger.info(f"Finished warming up {endpoint}")

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -147,7 +147,7 @@ def main(num_replicas: Optional[int], num_deployments: Optional[int],
     all_endpoints = list(serve.list_deployments().keys())
     for endpoint in all_endpoints:
         rst_ray_refs.append(
-            warm_up_one_cluster.options(num_cpus=0.1).remote(
+            warm_up_one_cluster.options(num_cpus=0.01).remote(
                 10, http_host, http_port, endpoint))
     for endpoint in ray.get(rst_ray_refs):
         logger.info(f"Finished warming up {endpoint}")


### PR DESCRIPTION
5s timeout on long polling is making multi deployment test flaky on master, too short for large # of deployment tests.

in addition there's some wrk trial resource starvation issue on nightly tests, we try to kick off parallel wrk tests where each requires 0.1 CPU but ended up locking 10 CPUs  for 100 deployment test. 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
