### PR TITLE
[Serve] /api/snapshot works with all  Serve KVStores

### DIFF
--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -28,7 +28,7 @@ import ray._private.gcs_utils as gcs_utils
 
 # Explicitly importing it here because it is a ray core tests utility (
 # not in the tree)
-from ray.tests.conftest import ray_start_with_dashboard
+from ray.tests.conftest import ray_start_with_dashboard  # noqa: F401
 
 
 @pytest.fixture
@@ -550,7 +550,8 @@ def test_local_store_recovery():
     "ray_start_with_dashboard", [{
         "num_cpus": 4
     }], indirect=True)
-def test_snapshot_always_written_to_internal_kv(ray_start_with_dashboard):
+def test_snapshot_always_written_to_internal_kv(
+        ray_start_with_dashboard):  # noqa: F811
     # https://github.com/ray-project/ray/issues/19752
     _, tmp_path = mkstemp()
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -26,6 +26,10 @@ from ray._private.test_utils import run_string_as_driver, wait_for_condition
 from ray._private.services import new_port
 import ray._private.gcs_utils as gcs_utils
 
+# Explicitly importing it here because it is a ray core tests utility (
+# not in the tree)
+from ray.tests.conftest import ray_start_with_dashboard
+
 
 @pytest.fixture
 def ray_cluster():
@@ -539,6 +543,52 @@ def test_local_store_recovery():
     serve.start(detached=True, _checkpoint_path=f"file://{tmp_path}")
     wait_for_condition(check)
     crash()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+@pytest.mark.parametrize(
+    "ray_start_with_dashboard", [{
+        "num_cpus": 4
+    }], indirect=True)
+def test_snapshot_always_written_to_internal_kv(ray_start_with_dashboard):
+    # https://github.com/ray-project/ray/issues/19752
+    _, tmp_path = mkstemp()
+
+    @serve.deployment()
+    def hello(_):
+        return "hello"
+
+    def check():
+        try:
+            resp = requests.get("http://localhost:8000/hello")
+            assert resp.text == "hello"
+            return True
+        except Exception:
+            return False
+
+    serve.start(detached=True, _checkpoint_path=f"file://{tmp_path}")
+    hello.deploy()
+    check()
+
+    webui_url = ray_start_with_dashboard["webui_url"]
+
+    def get_deployment_snapshot():
+        snapshot = requests.get(f"http://{webui_url}/api/snapshot").json()[
+            "data"]["snapshot"]
+        return snapshot["deployments"]
+
+    # Make sure /api/snapshot return non-empty deployment status.
+    def verify_snapshot():
+        return get_deployment_snapshot() != {}
+
+    wait_for_condition(verify_snapshot)
+
+    # Sanity check the snapshot is correct
+    snapshot = get_deployment_snapshot()
+    assert len(snapshot) == 1
+    hello_deployment = list(snapshot.values())[0]
+    assert hello_deployment["name"] == "hello"
+    assert hello_deployment["status"] == "RUNNING"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Make sure that the snapshot is written to the internal kv regardless of checkpoint location.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #19752
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
