### PR TITLE
[core] Fix the wrong error message in gcs for worker exits

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -824,7 +824,8 @@ void CoreWorker::Exit(
     task_execution_service_.post(
         [this, exit_type, creation_task_exception_pb_bytes]() {
           if (exit_type == rpc::WorkerExitType::CREATION_TASK_ERROR ||
-              exit_type == rpc::WorkerExitType::INTENDED_EXIT) {
+              exit_type == rpc::WorkerExitType::INTENDED_EXIT ||
+              exit_type == rpc::WorkerExitType::IDLE_EXIT) {
             // Notify the raylet about this exit.
             // Only CREATION_TASK_ERROR and INTENDED_EXIT needs to disconnect
             // manually.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -712,7 +712,7 @@ void GcsActorManager::OnWorkerDead(
     const rpc::WorkerExitType disconnect_type,
     const std::shared_ptr<rpc::RayException> &creation_task_exception) {
   std::string message = absl::StrCat(
-      "Worker ", worker_id, " on node ", node_id,
+      "Worker ", worker_id.Hex(), " on node ", node_id.Hex(),
       " exits, type=", rpc::WorkerExitType_Name(disconnect_type),
       ", has creation_task_exception = ", (creation_task_exception != nullptr));
   if (creation_task_exception != nullptr) {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -719,11 +719,11 @@ void GcsActorManager::OnWorkerDead(
     absl::StrAppend(&message, " Formatted creation task exception: ",
                     creation_task_exception->formatted_exception_string());
   }
-  if (request.worker_failure().exit_type() == rpc::WorkerExitType::INTENDED_EXIT ||
-      request.worker_failure().exit_type() == rpc::WorkerExitType::IDLE_EXIT) {
+  if (disconnect_type == rpc::WorkerExitType::INTENDED_EXIT ||
+      disconnect_type == rpc::WorkerExitType::IDLE_EXIT) {
     RAY_LOG(DEBUG) << message;
   } else {
-    RAY_LOG(ERROR) << message;
+    RAY_LOG(WARNING) << message;
   }
 
   bool need_reconstruct = disconnect_type != rpc::WorkerExitType::INTENDED_EXIT &&

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.cc
@@ -26,7 +26,7 @@ void GcsWorkerManager::HandleReportWorkerFailure(
   const auto worker_id = WorkerID::FromBinary(worker_address.worker_id());
   const auto node_id = NodeID::FromBinary(worker_address.raylet_id());
   std::string message = absl::StrCat(
-      "Reporting worker exit, worker id = ", worker_id, ", node id = ", node_id,
+      "Reporting worker exit, worker id = ", worker_id.Hex(), ", node id = ", node_id.Hex(),
       ", address = ", worker_address.ip_address(),
       ", exit_type = ", rpc::WorkerExitType_Name(request.worker_failure().exit_type()),
       request.worker_failure().has_creation_task_exception());

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.cc
@@ -25,18 +25,16 @@ void GcsWorkerManager::HandleReportWorkerFailure(
   const rpc::Address worker_address = request.worker_failure().worker_address();
   const auto worker_id = WorkerID::FromBinary(worker_address.worker_id());
   const auto node_id = NodeID::FromBinary(worker_address.raylet_id());
-  std::stringstream log_stream;
-  log_stream << "Reporting worker failure, worker id = " << worker_id
-             << ", node id = " << node_id << ", address = " << worker_address.ip_address()
-             << ", exit_type = "
-             << rpc::WorkerExitType_Name(request.worker_failure().exit_type())
-             << ", has creation task exception = "
-             << request.worker_failure().has_creation_task_exception();
+  std::string message = absl::StrCat(
+      "Reporting worker exit, worker id = ", worker_id, ", node id = ", node_id,
+      ", address = ", worker_address.ip_address(),
+      ", exit_type = ", rpc::WorkerExitType_Name(request.worker_failure().exit_type()),
+      request.worker_failure().has_creation_task_exception());
   if (request.worker_failure().exit_type() == rpc::WorkerExitType::INTENDED_EXIT ||
       request.worker_failure().exit_type() == rpc::WorkerExitType::IDLE_EXIT) {
-    RAY_LOG(INFO) << log_stream.str();
+    RAY_LOG(DEBUG) << message;
   } else {
-    RAY_LOG(WARNING) << log_stream.str()
+    RAY_LOG(WARNING) << message
                      << ". Unintentional worker failures have been reported. If there "
                         "are lots of this logs, that might indicate there are "
                         "unexpected failures in the cluster.";

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.cc
@@ -26,8 +26,8 @@ void GcsWorkerManager::HandleReportWorkerFailure(
   const auto worker_id = WorkerID::FromBinary(worker_address.worker_id());
   const auto node_id = NodeID::FromBinary(worker_address.raylet_id());
   std::string message = absl::StrCat(
-      "Reporting worker exit, worker id = ", worker_id.Hex(), ", node id = ", node_id.Hex(),
-      ", address = ", worker_address.ip_address(),
+      "Reporting worker exit, worker id = ", worker_id.Hex(),
+      ", node id = ", node_id.Hex(), ", address = ", worker_address.ip_address(),
       ", exit_type = ", rpc::WorkerExitType_Name(request.worker_failure().exit_type()),
       request.worker_failure().has_creation_task_exception());
   if (request.worker_failure().exit_type() == rpc::WorkerExitType::INTENDED_EXIT ||

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.cc
@@ -32,7 +32,8 @@ void GcsWorkerManager::HandleReportWorkerFailure(
              << rpc::WorkerExitType_Name(request.worker_failure().exit_type())
              << ", has creation task exception = "
              << request.worker_failure().has_creation_task_exception();
-  if (request.worker_failure().exit_type() == rpc::WorkerExitType::INTENDED_EXIT) {
+  if (request.worker_failure().exit_type() == rpc::WorkerExitType::INTENDED_EXIT ||
+      request.worker_failure().exit_type() == rpc::WorkerExitType::IDLE_EXIT) {
     RAY_LOG(INFO) << log_stream.str();
   } else {
     RAY_LOG(WARNING) << log_stream.str()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is a couple of type of worker exits, for IDLE_EXIT and INTENDED_EXIT we shouldn't treat them as error.
This PR fixed several issues:
- Send exit to raylet if it's IDLE_EXIT
- Re-organize the log in gcs and make the normal message as DEBUG log. Only output the true failures as ERROR/WARNING log.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #19451
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
