### PR TITLE
[runtime_env] Fix hash length in URI

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -107,7 +107,7 @@ def _hash_directory(
     It'll go through all the files in the directory and xor
     hash(file_name, file_content) to create a hash value.
     """
-    hash_val = b"0"
+    hash_val = b"0" * 8
     BUF_SIZE = 4096 * 1024
 
     def handler(path: Path):

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -89,6 +89,11 @@ class TestGetURIForDirectory:
             os.rmdir("d1")
             os.rmdir("d2")
 
+    def test_uri_hash_length(self, random_dir):
+        uri = get_uri_for_directory(random_dir)
+        hex_hash = uri.split("_")[-1][:-len(".zip")]
+        assert len(hex_hash) == 16
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestUploadPackageIfNeeded:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before:
```
2021-10-26 22:43:36,795 INFO packaging.py:329 -- Creating a file package 'gcs://_ray_pkg_6a.zip' for local directory 'src'.
2021-10-26 22:43:36,916 INFO packaging.py:185 -- Pushing file package 'gcs://_ray_pkg_6a.zip' (5.02MiB) to Ray cluster...
2021-10-26 22:43:36,923 INFO packaging.py:189 -- Successfully pushed local file package 'gcs://_ray_pkg_6a.zip'.
```

After:
```
2021-10-26 22:43:36,795 INFO packaging.py:329 -- Creating a file package 'gcs://_ray_pkg_716afad0aebbb593.zip' for local directory 'src'.
2021-10-26 22:43:36,916 INFO packaging.py:185 -- Pushing file package 'gcs://_ray_pkg_716afad0aebbb593.zip' (5.02MiB) to Ray cluster...
2021-10-26 22:43:36,923 INFO packaging.py:189 -- Successfully pushed local file package 'gcs://_ray_pkg_716afad0aebbb593.zip'.
```

## Related issue number

Closes https://github.com/ray-project/ray/issues/19776

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
