### PR TITLE
Move controller grace period to notification function

### DIFF
--- a/python/ray/serve/backend_state.py
+++ b/python/ray/serve/backend_state.py
@@ -691,7 +691,8 @@ class BackendState:
                 f"{new_backend_replica.replica_tag}, backend_tag: {self._name}"
             )
 
-        self._long_poll_host_update_time = time.time() + CONTROLLER_STARTUP_GRACE_PERIOD_S # noqa: E501
+        self._long_poll_host_update_time = time.time(
+        ) + CONTROLLER_STARTUP_GRACE_PERIOD_S  # noqa: E501
 
         # This halts all traffic in cluster.
         self._notify_running_replicas_changed()
@@ -711,8 +712,8 @@ class BackendState:
         ]
 
     def _notify_running_replicas_changed(self):
-        if (self._long_poll_host_update_time and
-                time.time() > self._long_poll_host_update_time):
+        if (self._long_poll_host_update_time
+                and time.time() > self._long_poll_host_update_time):
             self._long_poll_host.notify_changed(
                 (LongPollNamespace.RUNNING_REPLICAS, self._name),
                 self.get_running_replica_infos(),


### PR DESCRIPTION
This is tech debt left during serve FT work, initial attempt is to avoid forcing updates to all existing replicas during controller recovery as we put all replicas in recovery state and expecting majority of them will be back to running again, but sleeping on controller for each deployment is not really solving the problem.

We have multiple problems in long polling client that needs to be resolved .. maybe have a better picture of controller recovery, but this should be a net win to improve current behavior.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
