### PR TITLE
[wip][client] move version mismatch check before runtime_env uploaded

### DIFF
--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -84,10 +84,11 @@ class _ClientContext:
                 _credentials=_credentials,
                 metadata=metadata,
                 connection_retries=connection_retries)
-            self.api.worker = self.client_worker
-            self.client_worker._server_init(job_config, ray_init_kwargs)
             conn_info = self.client_worker.connection_info()
             self._check_versions(conn_info, ignore_version)
+
+            self.api.worker = self.client_worker
+            self.client_worker._server_init(job_config, ray_init_kwargs)
             self._register_serializers()
             return conn_info
         except Exception:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Client hangs without any explanation when 1.7+ local tries to connect to 1.6 or lower server, since server hangs when trying to handle the way 1.7+ uploads runtime envs. Move the version check to before _server_init (which handles runtime_env) so that a warning/error is raised before the connection starts hanging.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
