### PR TITLE
[serve] Increase control loop period from 100ms -> 500ms

### DIFF
--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -20,7 +20,7 @@ DEFAULT_CHECKPOINT_PATH = "ray://"
 ASYNC_CONCURRENCY = int(1e6)
 
 # How often to call the control loop on the controller.
-CONTROL_LOOP_PERIOD_S = 0.1
+CONTROL_LOOP_PERIOD_S = 0.5
 
 # Upon controller failure and recovery with running actor names,
 # we will update replica handles that halt all traffic to the cluster.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We had the control loop tuned very low previously due to having extra states (`SHOULD_START` and `SHOULD_STOP`), which made responsiveness suffer. We should be able to increase this now, reducing CPU usage especially for large clusters.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
