### PR TITLE
[CI] Allow release tests infra to accept buildkite artifacts

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -483,8 +483,10 @@ def create_test_step(
             + pip_requirements_command \
             + step_conf["commands"]
 
-    step_conf["label"] = f"{test_name} ({ray_branch}) - " \
-                         f"{ray_test_branch}/{ray_test_repo}"
+    step_conf["label"] = (
+        f"{test_name} "
+        f"({'custom_wheels_url' if ray_wheels_str else ray_branch}) - "
+        f"{ray_test_branch}/{ray_test_repo}")
     return step_conf
 
 

--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -483,7 +483,7 @@ def create_test_step(
             + pip_requirements_command \
             + step_conf["commands"]
 
-    step_conf["label"] = f"{ray_wheels_str}{test_name} ({ray_branch}) - " \
+    step_conf["label"] = f"{test_name} ({ray_branch}) - " \
                          f"{ray_test_branch}/{ray_test_repo}"
     return step_conf
 

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -378,6 +378,7 @@ def commit_or_url(commit_or_url: str) -> str:
         if "s3-us-west-2.amazonaws" in commit_or_url:
             return commit_or_url
         # Resolve the redirects for buildkite artifacts
+        # This is needed because otherwise pip won't recognize the file name.
         if "buildkite.com" in commit_or_url and "artifacts" in commit_or_url:
             return requests.head(commit_or_url, allow_redirects=True).url
 

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -374,8 +374,12 @@ def wheel_exists(ray_version, git_branch, git_commit):
 
 def commit_or_url(commit_or_url: str) -> str:
     if commit_or_url.startswith("http"):
-        # Assume URL
-        return commit_or_url
+        # Directly return the S3 url
+        if "s3-us-west-2.amazonaws" in commit_or_url:
+            return commit_or_url
+        # Resolve the redirects for buildkite artifacts
+        if "buildkite.com" in commit_or_url and "artifacts" in commit_or_url:
+            return requests.head(commit_or_url, allow_redirects=True).url
 
     # Else, assume commit
     os.environ["RAY_COMMIT"] = commit_or_url
@@ -2079,6 +2083,7 @@ if __name__ == "__main__":
         logger.info(f"Using Ray wheels provided from URL/commit: "
                     f"{ray_wheels}")
         url = commit_or_url(str(ray_wheels))
+        logger.info(f"Resolved url link is: {url}")
         # Overwrite with actual URL
         os.environ["RAY_WHEELS"] = url
     elif not args.check:


### PR DESCRIPTION
e2e.py accepts s3 urls, this commit makes it possible to accept buildkite urls. 

manually tested.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
