### PR TITLE
[RLlib]: bug fix, should be input_dict['is_training']

### DIFF
--- a/rllib/examples/models/batch_norm_model.py
+++ b/rllib/examples/models/batch_norm_model.py
@@ -65,7 +65,7 @@ class KerasBatchNormModel(TFModelV2):
         # Have to batch the is_training flag (B=1).
         out, self._value_out = self.base_model(
             [input_dict["obs"],
-             tf.expand_dims(input_dict.is_training, 0)])
+             tf.expand_dims(input_dict["is_training"], 0)])
         return out, []
 
     @override(ModelV2)
@@ -110,7 +110,7 @@ class BatchNormModel(TFModelV2):
                 # Add a batch norm layer
                 last_layer = tf1.layers.batch_normalization(
                     last_layer,
-                    training=input_dict.is_training,
+                    training=input_dict["is_training"],
                     name="bn_{}".format(i))
 
             output = tf1.layers.dense(


### PR DESCRIPTION
## Why are these changes needed?

Bug fix. In this case, it should be input_dict["is_training"]

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
