### PR TITLE
[CI] Add ratchet for deep learning dependencies

### DIFF
--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -65,6 +65,18 @@ def get_commit_range():
     return commit_range
 
 
+def check_ml_deps_in_sync(all_changed_files):
+    file_set = set(all_changed_files)
+    if "python/requirements/ml/requirements_dl.txt" in file_set != \
+            "python/requirements/requirements_ml_docker.txt" in file_set:
+        raise RuntimeError("A change was identified in either "
+                           "requirements_dl.txt or in "
+                           "requirements_ml_docker.txt, but not in both. "
+                           "If the dependencies in one file is changed, "
+                           "then they should be reflected in the other as "
+                           "well.")
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -96,6 +108,8 @@ if __name__ == "__main__":
         print(pformat(commit_range), file=sys.stderr)
         print(pformat(files), file=sys.stderr)
 
+        check_ml_deps_in_sync(all_changed_files=files)
+
         # Dry run py_dep_analysis.py to see which tests we would have run.
         try:
             graph = pda.build_dep_graph()
@@ -122,6 +136,7 @@ if __name__ == "__main__":
         ]
 
         for changed_file in files:
+
             if changed_file.startswith("python/ray/tune"):
                 RAY_CI_DOC_AFFECTED = 1
                 RAY_CI_TUNE_AFFECTED = 1

--- a/python/requirements/ml/requirements_dl.txt
+++ b/python/requirements/ml/requirements_dl.txt
@@ -1,8 +1,8 @@
 # These requirements are used for the CI and CPU-only Docker images so we install CPU only versions of torch.
 # For GPU Docker images, you should install requirements_ml_docker.txt instead.
 
-tensorflow==2.6.0
-tensorflow-probability==0.14.0
+tensorflow==2.5.0
+tensorflow-probability==0.13.0
 
 torch==1.9.0;sys_platform=="darwin"
 torchvision==0.10.0;sys_platform=="darwin"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Currently, deep learning dependencies are specified in 2 separate files: `requirements_dl.txt` for CPU versions to use for the CI, and `requirements_ml_docker.txt` for CUDA enabled version to use for the GPU Docker images. If versions are upgraded/changed in one of these files, we should make sure they are changed in the other file as well. This PR adds a ratchet to make sure that build will fail unless changes are made to both files.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
