### PR TITLE
Test revert 18701 ci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -149,13 +149,15 @@ build:ci-github --experimental_repository_cache_hardlinks # GitHub Actions has l
 build:ci-github --disk_cache=~/ray-bazel-cache
 build:ci-github --remote_cache="https://storage.googleapis.com/ray-bazel-cache"
 test:ci --flaky_test_attempts=3
-test:ci --genrule_strategy=local
+test:ci --nocache_test_results
+test:ci --spawn_strategy=local
 test:ci --test_output=errors
 test:ci --test_verbose_timeout_warnings
 test:ci-debug -c dbg
 test:ci-debug --copt="-g"
 test:ci-debug --flaky_test_attempts=3
-test:ci-debug --genrule_strategy=local
+test:ci-debug --nocache_test_results
+test:ci-debug --spawn_strategy=local
 test:ci-debug --test_output=errors
 test:ci-debug --test_verbose_timeout_warnings
 

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -48,10 +48,7 @@ RUN echo "ulimit -c 0" >> /root/.bashrc
 
 # Setup Bazel caches
 RUN (echo "build --remote_cache=${REMOTE_CACHE_URL}" >> /root/.bazelrc); \
-    # Prevent uploading binary asserts to the cache.
     (if [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then (echo "build --remote_upload_local_results=false" >> /root/.bazelrc); fi); \
-    # Not use cached test results to ensure post-merge CI can discover flakiness.
-    (if [ "${BUILDKITE_BRANCH}" == "master" ]; then (echo "test --nocache_test_results" >> /root/.bazelrc); fi); \
     cat /root/.bazelrc
 
 RUN mkdir /ray

--- a/rllib/agents/ddpg/apex.py
+++ b/rllib/agents/ddpg/apex.py
@@ -17,6 +17,8 @@ APEX_DDPG_DEFAULT_CONFIG = DDPGTrainer.merge_trainer_configs(
         "num_gpus": 0,
         "num_workers": 32,
         "buffer_size": 2000000,
+        # TODO(jungong) : update once Apex supports replay_buffer_config
+        "replay_buffer_config": None,
         "learning_starts": 50000,
         "train_batch_size": 512,
         "rollout_fragment_length": 50,

--- a/rllib/agents/ddpg/ddpg.py
+++ b/rllib/agents/ddpg/ddpg.py
@@ -5,6 +5,7 @@ from ray.rllib.agents.trainer import with_common_config
 from ray.rllib.agents.dqn.dqn import GenericOffPolicyTrainer
 from ray.rllib.agents.ddpg.ddpg_tf_policy import DDPGTFPolicy
 from ray.rllib.policy.policy import Policy
+from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 from ray.rllib.utils.typing import TrainerConfigDict
 
 logger = logging.getLogger(__name__)
@@ -90,7 +91,11 @@ DEFAULT_CONFIG = with_common_config({
     # === Replay buffer ===
     # Size of the replay buffer. Note that if async_updates is set, then
     # each worker will have a replay buffer of this size.
-    "buffer_size": 50000,
+    "buffer_size": DEPRECATED_VALUE,
+    "replay_buffer_config": {
+        "type": "LocalReplayBuffer",
+        "capacity": 50000,
+    },
     # Set this to True, if you want the contents of your buffer(s) to be
     # stored in any saved checkpoints as well.
     # Warnings will be created if:

--- a/rllib/agents/dqn/dqn.py
+++ b/rllib/agents/dqn/dqn.py
@@ -158,7 +158,8 @@ def execution_plan(workers: WorkerSet, config: TrainerConfigDict,
         LocalIterator[dict]: A local iterator over training metrics.
     """
     assert "local_replay_buffer" in kwargs, (
-        "DQN execution plan requires a local replay buffer.")
+        "GenericOffPolicyTrainer execution plan requires a "
+        "local replay buffer.")
 
     # Assign to Trainer, so we can store the LocalReplayBuffer's
     # data when we save checkpoints.

--- a/rllib/agents/dqn/dqn_tf_policy.py
+++ b/rllib/agents/dqn/dqn_tf_policy.py
@@ -241,14 +241,16 @@ def build_q_losses(policy: Policy, model, _,
     # q network evaluation
     q_t, q_logits_t, q_dist_t, _ = compute_q_values(
         policy,
-        model, {"obs": train_batch[SampleBatch.CUR_OBS]},
+        model,
+        SampleBatch({"obs": train_batch[SampleBatch.CUR_OBS]}),
         state_batches=None,
         explore=False)
 
     # target q network evalution
     q_tp1, q_logits_tp1, q_dist_tp1, _ = compute_q_values(
         policy,
-        policy.target_model, {"obs": train_batch[SampleBatch.NEXT_OBS]},
+        policy.target_model,
+        SampleBatch({"obs": train_batch[SampleBatch.NEXT_OBS]}),
         state_batches=None,
         explore=False)
     if not hasattr(policy, "target_q_func_vars"):
@@ -267,7 +269,7 @@ def build_q_losses(policy: Policy, model, _,
         q_tp1_using_online_net, q_logits_tp1_using_online_net, \
             q_dist_tp1_using_online_net, _ = compute_q_values(
                 policy, model,
-                {"obs": train_batch[SampleBatch.NEXT_OBS]},
+                SampleBatch({"obs": train_batch[SampleBatch.NEXT_OBS]}),
                 state_batches=None,
                 explore=False)
         q_tp1_best_using_online_net = tf.argmax(q_tp1_using_online_net, 1)
@@ -334,7 +336,7 @@ def setup_late_mixins(policy: Policy, obs_space: gym.spaces.Space,
 
 def compute_q_values(policy: Policy,
                      model: ModelV2,
-                     input_dict,
+                     input_batch: SampleBatch,
                      state_batches=None,
                      seq_lens=None,
                      explore=None,
@@ -342,7 +344,8 @@ def compute_q_values(policy: Policy,
 
     config = policy.config
 
-    model_out, state = model(input_dict, state_batches or [], seq_lens)
+    input_batch.is_training = is_training
+    model_out, state = model(input_batch, state_batches or [], seq_lens)
 
     if config["num_atoms"] > 1:
         (action_scores, z, support_logits_per_action, logits,

--- a/rllib/agents/dqn/dqn_tf_policy.py
+++ b/rllib/agents/dqn/dqn_tf_policy.py
@@ -242,7 +242,9 @@ def build_q_losses(policy: Policy, model, _,
     q_t, q_logits_t, q_dist_t, _ = compute_q_values(
         policy,
         model,
-        SampleBatch({"obs": train_batch[SampleBatch.CUR_OBS]}),
+        SampleBatch({
+            "obs": train_batch[SampleBatch.CUR_OBS]
+        }),
         state_batches=None,
         explore=False)
 
@@ -250,7 +252,9 @@ def build_q_losses(policy: Policy, model, _,
     q_tp1, q_logits_tp1, q_dist_tp1, _ = compute_q_values(
         policy,
         policy.target_model,
-        SampleBatch({"obs": train_batch[SampleBatch.NEXT_OBS]}),
+        SampleBatch({
+            "obs": train_batch[SampleBatch.NEXT_OBS]
+        }),
         state_batches=None,
         explore=False)
     if not hasattr(policy, "target_q_func_vars"):

--- a/rllib/agents/qmix/qmix.py
+++ b/rllib/agents/qmix/qmix.py
@@ -7,6 +7,7 @@ from ray.rllib.execution.rollout_ops import ParallelRollouts, ConcatBatches
 from ray.rllib.execution.train_ops import TrainOneStep, UpdateTargetNetwork
 from ray.rllib.execution.metric_ops import StandardMetricsReporting
 from ray.rllib.execution.concurrency_ops import Concurrently
+from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 
 # yapf: disable
 # __sphinx_doc_begin__
@@ -58,7 +59,6 @@ DEFAULT_CONFIG = with_common_config({
     # === Replay buffer ===
     # Size of the replay buffer in batches (not timesteps!).
     "buffer_size": 1000,
-
     # === Optimization ===
     # Learning rate for RMSProp optimizer
     "lr": 0.0005,

--- a/rllib/agents/sac/sac.py
+++ b/rllib/agents/sac/sac.py
@@ -96,7 +96,11 @@ DEFAULT_CONFIG = with_common_config({
 
     # === Replay buffer ===
     # Size of the replay buffer (in time steps).
-    "buffer_size": int(1e6),
+    "buffer_size": DEPRECATED_VALUE,
+    "replay_buffer_config": {
+        "type": "LocalReplayBuffer",
+        "capacity": int(1e6),
+    },
     # Set this to True, if you want the contents of your buffer(s) to be
     # stored in any saved checkpoints as well.
     # Warnings will be created if:

--- a/rllib/contrib/maddpg/maddpg.py
+++ b/rllib/contrib/maddpg/maddpg.py
@@ -15,6 +15,7 @@ from ray.rllib.agents.trainer import COMMON_CONFIG, with_common_config
 from ray.rllib.agents.dqn.dqn import GenericOffPolicyTrainer
 from ray.rllib.contrib.maddpg.maddpg_policy import MADDPGTFPolicy
 from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
+from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 from ray.rllib.utils import merge_dicts
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,11 @@ DEFAULT_CONFIG = with_common_config({
     # === Replay buffer ===
     # Size of the replay buffer. Note that if async_updates is set, then
     # each worker will have a replay buffer of this size.
-    "buffer_size": int(1e6),
+    "buffer_size": DEPRECATED_VALUE,
+    "replay_buffer_config": {
+        "type": "LocalReplayBuffer",
+        "capacity": int(1e6),
+    },
     # Observation compression. Note that compression makes simulation slow in
     # MPE.
     "compress_observations": False,

--- a/rllib/examples/models/batch_norm_model.py
+++ b/rllib/examples/models/batch_norm_model.py
@@ -65,7 +65,7 @@ class KerasBatchNormModel(TFModelV2):
         # Have to batch the is_training flag (B=1).
         out, self._value_out = self.base_model(
             [input_dict["obs"],
-             tf.expand_dims(input_dict["is_training"], 0)])
+             tf.expand_dims(input_dict.is_training, 0)])
         return out, []
 
     @override(ModelV2)

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -602,15 +602,14 @@ def build_eager_tf_policy(
                                  "`action_sampler_fn`!")
 
             seq_lens = tf.ones(len(obs_batch), dtype=tf.int32)
-            input_dict = {
-                SampleBatch.CUR_OBS: tf.convert_to_tensor(obs_batch),
-                "is_training": tf.constant(False),
-            }
+            input_batch = SampleBatch({
+                SampleBatch.CUR_OBS: tf.convert_to_tensor(obs_batch)},
+                _is_training=False)
             if prev_action_batch is not None:
-                input_dict[SampleBatch.PREV_ACTIONS] = \
+                input_batch[SampleBatch.PREV_ACTIONS] = \
                     tf.convert_to_tensor(prev_action_batch)
             if prev_reward_batch is not None:
-                input_dict[SampleBatch.PREV_REWARDS] = \
+                input_batch[SampleBatch.PREV_REWARDS] = \
                     tf.convert_to_tensor(prev_reward_batch)
 
             # Exploration hook before each forward pass.
@@ -621,12 +620,12 @@ def build_eager_tf_policy(
                 dist_inputs, dist_class, _ = action_distribution_fn(
                     self,
                     self.model,
-                    input_dict[SampleBatch.CUR_OBS],
+                    input_batch,
                     explore=False,
                     is_training=False)
             # Default log-likelihood calculation.
             else:
-                dist_inputs, _ = self.model(input_dict, state_batches,
+                dist_inputs, _ = self.model(input_batch, state_batches,
                                             seq_lens)
                 dist_class = self.dist_class
 

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -602,8 +602,10 @@ def build_eager_tf_policy(
                                  "`action_sampler_fn`!")
 
             seq_lens = tf.ones(len(obs_batch), dtype=tf.int32)
-            input_batch = SampleBatch({
-                SampleBatch.CUR_OBS: tf.convert_to_tensor(obs_batch)},
+            input_batch = SampleBatch(
+                {
+                    SampleBatch.CUR_OBS: tf.convert_to_tensor(obs_batch)
+                },
                 _is_training=False)
             if prev_action_batch is not None:
                 input_batch[SampleBatch.PREV_ACTIONS] = \


### PR DESCRIPTION
## Why are these changes needed?

Test RLlib CI after 18701 is reverted.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
