### PR TITLE
move jsonschema to core dependencies and update default AutoscalerPrometheusMetrics 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -231,6 +231,8 @@
       python/ray/tests/test_basic_2
     - bazel test --test_output=streamed --config=ci $(./scripts/bazel_export_options)
       python/ray/tests/test_basic_3
+    - bazel test --test_output=streamed --config=ci $(./scripts/bazel_export_options)
+      python/ray/tests/test_output
     - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
       python/ray/tests/test_runtime_env_ray_minimal
     - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -231,7 +231,7 @@
       python/ray/tests/test_basic_2
     - bazel test --test_output=streamed --config=ci $(./scripts/bazel_export_options)
       python/ray/tests/test_basic_3
-    - bazel test --test_output=streamed --config=ci $(./scripts/bazel_export_options)
+    - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
       python/ray/tests/test_output
     - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
       python/ray/tests/test_runtime_env_ray_minimal

--- a/ci/travis/check_minimal_install.py
+++ b/ci/travis/check_minimal_install.py
@@ -15,7 +15,6 @@ DEFAULT_BLACKLIST = [
     "aioredis",
     "colorful",
     "py-spy",
-    "jsonschema",
     # "requests",
     "gpustat",
     "opencensus",

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -12,7 +12,8 @@ try:
     class AutoscalerPrometheusMetrics:
         def __init__(self, registry: CollectorRegistry = None):
             self.registry: CollectorRegistry = registry or \
-                CollectorRegistry(auto_describe=True)
+                                               CollectorRegistry(
+                                                   auto_describe=True)
             # Buckets: 5 seconds, 10 seconds, 20 seconds, 30 seconds,
             #          45 seconds, 1 minute, 1.5 minutes, 2 minutes,
             #          3 minutes, 4 minutes, 5 minutes, 6 minutes,
@@ -139,5 +140,16 @@ try:
                 registry=self.registry)
 except ImportError:
 
-    def AutoscalerPrometheusMetrics():
-        return None
+    class NullMetric:
+        def set(self, value):
+            pass
+
+        def observe(self, value):
+            pass
+
+        def inc(self):
+            pass
+
+    class AutoscalerPrometheusMetrics(object):
+        def __getattr__(self, attr):
+            return NullMetric()

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -352,9 +352,6 @@ def test_output():
     outputs = subprocess.check_output(
         [sys.executable, __file__, "_ray_instance"],
         stderr=subprocess.STDOUT).decode()
-    print("=======")
-    print(outputs)
-    print("=======")
     lines = outputs.split("\n")
     for line in lines:
         print(line)

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -352,13 +352,25 @@ def test_output():
     outputs = subprocess.check_output(
         [sys.executable, __file__, "_ray_instance"],
         stderr=subprocess.STDOUT).decode()
+    print("=======")
+    print(outputs)
+    print("=======")
     lines = outputs.split("\n")
     for line in lines:
         print(line)
-    assert len(lines) == 2, lines
+    if os.environ.get("RAY_MINIMAL") == "1":
+        # Without "View the Ray dashboard"
+        assert len(lines) == 1, lines
+    else:
+        # With "View the Ray dashboard"
+        assert len(lines) == 2, lines
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+# TODO: fix this test to support minimal installation
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test currently fails with minimal install.")
 def test_output_on_driver_shutdown(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=16)

--- a/python/setup.py
+++ b/python/setup.py
@@ -196,7 +196,6 @@ if setup_spec.type == SetupType.RAY:
             "aioredis < 2",
             "colorful",
             "py-spy >= 0.2.0",
-            "jsonschema",
             "requests",
             "gpustat >= 1.0.0b1",  # for windows
             "opencensus",
@@ -246,6 +245,7 @@ if setup_spec.type == SetupType.RAY:
         "dataclasses; python_version < '3.7'",
         "filelock",
         "grpcio >= 1.28.1",
+        "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",
         "numpy >= 1.19.3; python_version >= '3.9'",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some additional warnings/errors are logged as part of https://github.com/ray-project/ray/pull/18724 that should not be exposed.

This PR helps improve the experience by:
1. Moving `jsonschema` to core dependencies as Autoscaler is now always active and requires it.
2. Updating the default `AutoscalerPrometheusMetrics` to use when `prometheus_client` is not installed so that no-ops will occur rather than raise errors.
### Example error
```
>>> import ray
>>> ray.init()
2021-10-27 23:04:54,528	WARNING worker.py:1192 -- The autoscaler failed with the following error:
Traceback (most recent call last):
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/autoscaler.py", line 687, in reset
    validate_config(new_config)
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/util.py", line 89, in validate_config
    raise e from None
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/util.py", line 86, in validate_config
    import jsonschema
ModuleNotFoundError: No module named 'jsonschema'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/autoscaler.py", line 689, in reset
    self.prom_metrics.config_validation_exceptions.inc()
AttributeError: 'NoneType' object has no attribute 'config_validation_exceptions'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/monitor.py", line 421, in run
    self._initialize_autoscaler()
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/monitor.py", line 224, in _initialize_autoscaler
    prom_metrics=self.prom_metrics)
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/autoscaler.py", line 139, in __init__
    self.reset(errors_fatal=True)
  File "/Users/matt/workspace/ray/python/ray/autoscaler/_private/autoscaler.py", line 758, in reset
    self.prom_metrics.reset_exceptions.inc()
AttributeError: 'NoneType' object has no attribute 'reset_exceptions'

{'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': '127.0.0.1:6379', 'object_store_address': '/tmp/ray/session_2021-10-27_23-04-52_813505_49990/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2021-10-27_23-04-52_813505_49990/sockets/raylet', 'webui_url': None, 'session_dir': '/tmp/ray/session_2021-10-27_23-04-52_813505_49990', 'metrics_export_port': 52236, 'node_id': '80eff9b5f4bd5a97eb9fea46dc405a5bc86efcd52b85eebeaab6dbbb'}
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #19825

## Checks

Successfully ran `pip install -e python` and verified that `python -c "import ray; ray.init()"` does not log any warnings/errors.

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

### Test Changes:

`test_output.py` is added to the `Minimal install` test step. Two changes need to be made:
1. `test_output`: Without `default` extras, the output will be missing the line:
```
INFO services.py:1253 -- View the Ray dashboard at http://127.0.0.1:8265
```
2. `test_output_on_driver_shutdown`: Further investigation is needed for the expected behavior here. This test was originally added on 10/21/21 and is not included in the 1.8.0 branch. Skipping for now.