### PR TITLE
Added retry logic in test_basic::test_ray_options

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -323,15 +323,13 @@ def test_ray_options(shutdown_only):
 
     without_options = ray.get(foo.remote(ray.available_resources()))
     with_options = ray.get(
-            foo.options(
-                num_cpus=3,
-                num_gpus=4,
-                memory=50 * 2**20,
-                resources={
-                    "custom1": 0.5
-                }).remote(ray.available_resources()))
-
-
+        foo.options(
+            num_cpus=3,
+            num_gpus=4,
+            memory=50 * 2**20,
+            resources={
+                "custom1": 0.5
+            }).remote(ray.available_resources()))
 
     to_check = ["CPU", "GPU", "memory", "custom1"]
     for key in to_check:

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -303,39 +303,44 @@ def test_ray_options(shutdown_only):
 
     @ray.remote(
         num_cpus=2, num_gpus=3, memory=150 * 2**20, resources={"custom1": 1})
-    def foo(initial_resources):
+    def foo(expected_resources):
         # Possibly wait until the available resources have been updated
         # (there might be a delay due to heartbeats)
         retries = 10
-        keys = ["CPU", "GPU", "memory", "custom1"]
+        keys = ["CPU", "GPU", "custom1"]
         while retries >= 0:
             resources = ray.available_resources()
             do_return = True
             for key in keys:
-                if resources[key] == initial_resources[key]:
+                if resources[key] != expected_resources[key]:
+                    print(key, resources[key], expected_resources[key])
                     do_return = False
                     break
             if do_return:
-                return resources
-            time.sleep(0.2)
+                return resources["memory"]
+            time.sleep(0.1)
             retries -= 1
         raise RuntimeError("Number of retries exceeded")
 
-    without_options = ray.get(foo.remote(ray.available_resources()))
-    with_options = ray.get(
+    expected_resources_without_options = {
+        "CPU": 8.0,
+        "GPU": 7.0,
+        "custom1": 1.0
+    }
+    memory_available_without_options = ray.get(
+        foo.remote(expected_resources_without_options))
+
+    expected_resources_with_options = {"CPU": 7.0, "GPU": 6.0, "custom1": 1.5}
+    memory_available_with_options = ray.get(
         foo.options(
             num_cpus=3,
             num_gpus=4,
             memory=50 * 2**20,
             resources={
                 "custom1": 0.5
-            }).remote(ray.available_resources()))
+            }).remote(expected_resources_with_options))
 
-    to_check = ["CPU", "GPU", "memory", "custom1"]
-    for key in to_check:
-        print(key, without_options[key], with_options[key])
-        assert without_options[key] != with_options[key], key
-    assert without_options != with_options
+    assert memory_available_without_options < memory_available_with_options
 
 
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Discussed in https://github.com/ray-project/ray/issues/19800#issuecomment-953238138

Quoting here,

> I don't think this necessarily fixes it because the updates could still be delayed so resources and updated might have the same values, but it could the old and not the updated values. A better fix would look like this:

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/19800 (not be closed yet)


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
