### PR TITLE
[Documentation] Fix quotes for windows installations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,8 +168,8 @@ RLlib Quick Start
 
 .. code-block:: bash
 
-  pip install tensorflow  # or tensorflow-gpu
-  pip install "ray[rllib]"
+    pip install tensorflow  # or tensorflow-gpu
+    pip install "ray[rllib]"
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -168,8 +168,8 @@ RLlib Quick Start
 
 .. code-block:: bash
 
-    pip install tensorflow  # or tensorflow-gpu
-    pip install "ray[rllib]"
+  pip install tensorflow  # or tensorflow-gpu
+  pip install "ray[rllib]"
 
 .. code-block:: python
 

--- a/doc/source/cluster/quickstart.rst
+++ b/doc/source/cluster/quickstart.rst
@@ -34,19 +34,19 @@ Before we start, you will need to install some Python dependencies as follows:
 
         .. code-block:: shell
 
-            $ pip install -U 'ray[default]' boto3
+            $ pip install -U "ray[default]" boto3
 
     .. group-tab:: Azure
 
         .. code-block:: shell
 
-            $ pip install -U 'ray[default]' azure-cli azure-core
+            $ pip install -U "ray[default]" azure-cli azure-core
 
     .. group-tab:: GCP
 
         .. code-block:: shell
 
-            $ pip install -U 'ray[default]' google-api-python-client
+            $ pip install -U "ray[default]" google-api-python-client
 
 Next, if you're not set up to use your cloud provider from the command line, you'll have to configure your credentials:
 

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -150,7 +150,7 @@ Creating Datasets
 
 .. tip::
 
-   Run ``pip install ray[data]`` to get started!
+   Run ``pip install "ray[data]"`` to get started!
 
 Get started by creating Datasets from synthetic data using ``ray.data.range()`` and ``ray.data.from_items()``. Datasets can hold either plain Python objects (schema is a Python type), or Arrow records (schema is Arrow).
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -121,7 +121,7 @@ Ray provides Python, Java, and *EXPERIMENTAL* C++ API. And Ray uses Tasks (funct
 
     .. code-block:: shell
 
-      pip install ray[cpp]
+      pip install "ray[cpp]"
       mkdir ray-template && ray cpp --generate-bazel-project-template-to ray-template
 
     | - The project template comes with a simple example application. You can try this example out in 2 ways:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -16,15 +16,15 @@ You can install the latest official version of Ray as follows.
   pip install -U ray  # minimal install
 
   # To install Ray with support for the dashboard + cluster launcher, run
-  # `pip install -U 'ray[default]'`
+  # `pip install -U "ray[default]"`
 
 To install Ray libraries:
 
 .. code-block:: bash
 
-  pip install -U ray[tune]  # installs Ray + dependencies for Ray Tune
-  pip install -U ray[rllib]  # installs Ray + dependencies for Ray RLlib
-  pip install -U ray[serve]  # installs Ray + dependencies for Ray Serve
+  pip install -U "ray[tune]"  # installs Ray + dependencies for Ray Tune
+  pip install -U "ray[rllib]"  # installs Ray + dependencies for Ray RLlib
+  pip install -U "ray[serve]"  # installs Ray + dependencies for Ray Serve
 
 
 **Note for Windows Users:** To use Ray on Windows, Visual C++ runtime must be installed (see :ref:`Windows Dependencies <windows-dependencies>` section). If you run into any issues, please see the :ref:`Windows Support <windows-support>` section.

--- a/doc/source/ray-dashboard.rst
+++ b/doc/source/ray-dashboard.rst
@@ -23,7 +23,7 @@ To use the dashboard, first install Ray with the proper dependencies:
 
 .. code-block:: bash
 
-  pip install 'ray[default]'
+  pip install "ray[default]"
 
 You can access the dashboard through its default URL, **localhost:8265**.
 (Note that the port number increases if the default port is not available).

--- a/doc/source/ray-metrics.rst
+++ b/doc/source/ray-metrics.rst
@@ -21,7 +21,7 @@ First, install Ray with the proper dependencies:
 
 .. code-block:: bash
 
-  pip install 'ray[default]'
+  pip install "ray[default]"
 
 Ray exposes its metrics in Prometheus format. This allows us to easily scrape them using Prometheus.
 

--- a/doc/source/ray-overview/index.rst
+++ b/doc/source/ray-overview/index.rst
@@ -170,7 +170,7 @@ Tune Quick Start
 
     .. code-block:: bash
 
-        $ pip install 'ray[tune]'
+        $ pip install "ray[tune]"
 
 
 This example runs a small grid search with an iterative training function.
@@ -195,8 +195,8 @@ RLlib Quick Start
 
 .. code-block:: bash
 
-  pip install tensorflow  # or tensorflow-gpu
-  pip install ray[rllib]
+    pip install tensorflow  # or tensorflow-gpu
+    pip install "ray[rllib]"
 
 .. code-block:: python
 

--- a/doc/source/ray-overview/index.rst
+++ b/doc/source/ray-overview/index.rst
@@ -195,8 +195,8 @@ RLlib Quick Start
 
 .. code-block:: bash
 
-    pip install tensorflow  # or tensorflow-gpu
-    pip install "ray[rllib]"
+  pip install tensorflow  # or tensorflow-gpu
+  pip install "ray[rllib]"
 
 .. code-block:: python
 

--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -25,7 +25,7 @@ RLlib has extra dependencies on top of ``ray``. First, you'll need to install ei
 
 .. code-block:: bash
 
-  pip install 'ray[rllib]'
+  pip install "ray[rllib]"
 
 Then, you can try out training in the following equivalent ways:
 

--- a/doc/source/tune/_tutorials/tune-sklearn.py
+++ b/doc/source/tune/_tutorials/tune-sklearn.py
@@ -23,7 +23,7 @@ Overview
 
 Ray Tune's Scikit-learn APIs allows you to easily leverage Bayesian Optimization, HyperBand, and other cutting edge tuning techniques by simply toggling a few parameters. It also supports and provides examples for many other frameworks with Scikit-Learn wrappers such as Skorch (Pytorch), KerasClassifiers (Keras), and XGBoostClassifiers (XGBoost).
 
-Run ``pip install ray[tune] tune-sklearn`` to get started.
+Run ``pip install "ray[tune]" tune-sklearn`` to get started.
 
 Walkthrough
 -----------

--- a/doc/source/tune/index.rst
+++ b/doc/source/tune/index.rst
@@ -24,7 +24,7 @@ Tune is a Python library for experiment execution and hyperparameter tuning at a
 Quick Start
 -----------
 
-To run this example, install the following: ``pip install 'ray[tune]'``.
+To run this example, install the following: ``pip install "ray[tune]"``.
 
 This example runs a parallel grid search to optimize an example objective function.
 

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -311,7 +311,7 @@ def _bootstrap_config(config: Dict[str, Any],
         cli_logger.abort(
             "Not all Ray autoscaler dependencies were found. "
             "In Ray 1.4+, the Ray CLI, autoscaler, and dashboard will "
-            "only be usable via `pip install 'ray[default]'`. Please "
+            "only be usable via `pip install \"ray[default]\"`. Please "
             "update your install command.")
     resolved_config = provider_cls.bootstrap_config(config)
 

--- a/python/ray/autoscaler/_private/local/coordinator_node_provider.py
+++ b/python/ray/autoscaler/_private/local/coordinator_node_provider.py
@@ -49,7 +49,7 @@ class CoordinatorSenderNodeProvider(NodeProvider):
             logger.exception(
                 "Not all Ray Autoscaler dependencies were found. "
                 "In Ray 1.4+, the Ray CLI, autoscaler, and dashboard will "
-                "only be usable via `pip install 'ray[default]'`. Please "
+                "only be usable via `pip install \"ray[default]\"`. Please "
                 "update your install command.")
             raise
 

--- a/python/ray/autoscaler/_private/staroid/node_provider.py
+++ b/python/ray/autoscaler/_private/staroid/node_provider.py
@@ -26,7 +26,7 @@ def _try_import_requests():
             "'requests' was not found, which is needed for "
             "this cluster configuration. "
             "Download this dependency by running `pip install requests` "
-            "or `pip install 'ray[default]'`.") from None
+            "or `pip install \"ray[default]\"`.") from None
     return requests
 
 

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -5,7 +5,7 @@ try:
     from ray.serve.config import HTTPOptions
 except ModuleNotFoundError as e:
     e.msg += (
-        ". You can run `pip install 'ray[serve]'` to install all Ray Serve"
+        ". You can run `pip install \"ray[serve]\"` to install all Ray Serve"
         " dependencies.")
     raise e
 

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -178,7 +178,7 @@ class TBXLogger(Logger):
         except ImportError:
             if log_once("tbx-install"):
                 logger.info(
-                    "pip install 'ray[tune]' to see TensorBoard files.")
+                    "pip install \"ray[tune]\" to see TensorBoard files.")
             raise
         self._file_writer = SummaryWriter(self.logdir, flush_secs=30)
         self.last_result = None
@@ -603,7 +603,7 @@ class TBXLoggerCallback(LoggerCallback):
         except ImportError:
             if log_once("tbx-install"):
                 logger.info(
-                    "pip install 'ray[tune]' to see TensorBoard files.")
+                    "pip install \"ray[tune]\" to see TensorBoard files.")
             raise
         self._trial_writer: Dict["Trial", SummaryWriter] = {}
         self._trial_result: Dict["Trial", Dict] = {}

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -214,7 +214,7 @@ class ProxyManager():
                                "runtime_env feature were found on the "
                                "cluster. To install the required "
                                "dependencies, please run `pip install "
-                               "'ray[default]'` on all cluster nodes.")
+                               "\"ray[default]\"` on all cluster nodes.")
         create_env_request = runtime_env_agent_pb2.CreateRuntimeEnvRequest(
             serialized_runtime_env=serialized_runtime_env,
             job_id=f"ray_client_server_{specific_server.port}".encode("utf-8"))

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -134,7 +134,7 @@ void AgentManager::CreateRuntimeEnv(
   if (!should_start_agent_) {
     RAY_LOG(ERROR) << "Not all required Ray dependencies for the runtime_env "
                       "feature were found. To install the required dependencies, "
-                   << "please run `pip install 'ray[default]'`.";
+                   << "please run `pip install \"ray[default]\"`.";
     // Execute the callback after the currently executing callback finishes.  Otherwise
     // the task may be erased from the dispatch queue during the queue iteration in
     // ClusterTaskManager::DispatchScheduledTasksToWorkers(), invalidating the iterator


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Escaping on the windows shell with `'` doesn't work, we need to use `"`. Otherwise you get an error like
```
ERROR: Invalid requirement "'ray[default]'"
```
or
```
ERROR: Invalid requirement "'ray[rllib]'"
```
or
```
ERROR: Invalid requirement "'ray[tune]'"
```
or
```
ERROR: Invalid requirement "'ray[serve]'"
```
or
```
ERROR: Invalid requirement "'ray[data]'"
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
