### PR TITLE
[Serve] [Serve Autoscaler] Base autoscaling decisions on target num replicas, not current num replicas

### DIFF
--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -120,7 +120,6 @@ class BasicAutoscalingPolicy(AutoscalingPolicy):
     def get_decision_num_replicas(self,
                                   current_num_ongoing_requests: List[float],
                                   curr_target_num_replicas: int) -> int:
-        print("decision counter: ", self.decision_counter)
         if len(current_num_ongoing_requests) == 0:
             return curr_target_num_replicas
 

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -70,19 +70,19 @@ class AutoscalingPolicy:
     @abstractmethod
     def get_decision_num_replicas(self,
                                   current_num_ongoing_requests: List[float],
-                                  curr_num_replicas: int) -> int:
+                                  curr_target_num_replicas: int) -> int:
         """Make a decision to scale backends.
 
         Arguments:
             current_num_ongoing_requests: List[float]: List of number of
                 ongoing requests for each replica.
-            curr_num_replicas (int): The number of replicas that the backend
-                currently has.
+            curr_target_num_replicas (int): The number of replicas that the
+                deployment is currently trying to scale to.
 
         Returns:
             int: The new number of replicas to scale this backend to.
         """
-        return curr_num_replicas
+        return curr_target_num_replicas
 
 
 class BasicAutoscalingPolicy(AutoscalingPolicy):
@@ -119,17 +119,17 @@ class BasicAutoscalingPolicy(AutoscalingPolicy):
 
     def get_decision_num_replicas(self,
                                   current_num_ongoing_requests: List[float],
-                                  curr_num_replicas: int) -> int:
-
+                                  curr_target_num_replicas: int) -> int:
+        print("decision counter: ", self.decision_counter)
         if len(current_num_ongoing_requests) == 0:
-            return curr_num_replicas
+            return curr_target_num_replicas
 
-        decision_num_replicas = curr_num_replicas
+        decision_num_replicas = curr_target_num_replicas
 
         desired_num_replicas = calculate_desired_num_replicas(
             self.config, current_num_ongoing_requests)
         # Scale up.
-        if desired_num_replicas > curr_num_replicas:
+        if desired_num_replicas > curr_target_num_replicas:
             # If the previous decision was to scale down (the counter was
             # negative), we reset it and then increment it (set to 1).
             # Otherwise, just increment.
@@ -144,7 +144,7 @@ class BasicAutoscalingPolicy(AutoscalingPolicy):
                 decision_num_replicas = desired_num_replicas
 
         # Scale down.
-        elif desired_num_replicas < curr_num_replicas:
+        elif desired_num_replicas < curr_target_num_replicas:
             # If the previous decision was to scale up (the counter was
             # positive), reset it to zero before decrementing.
             if self.decision_counter > 0:
@@ -154,10 +154,6 @@ class BasicAutoscalingPolicy(AutoscalingPolicy):
             # Only actually scale the replicas if we've made this decision for
             # 'scale_down_consecutive_periods' in a row.
             if self.decision_counter < -self.scale_down_consecutive_periods:
-                # TODO(architkulkarni): curr_replicas will now slowly adjust
-                # until it gets to decision_num_replicas, but we will be making
-                # future decision_counter calculations on this moving
-                # curr_replicas value.  Is this okay?
                 self.decision_counter = 0
                 decision_num_replicas = desired_num_replicas
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -170,7 +170,8 @@ class ServeController:
 
             decision_num_replicas = (
                 autoscaling_policy.get_decision_num_replicas(
-                    current_num_ongoing_requests, len(running_replicas)))
+                    current_num_ongoing_requests=current_num_ongoing_requests,
+                    curr_target_num_replicas=backend_config.num_replicas))
             new_backend_config.num_replicas = decision_num_replicas
 
             new_backend_info = copy(backend_info)

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -271,7 +271,7 @@ def test_replicas_delayed_startup():
         max_replicas=200,
         target_num_ongoing_requests_per_replica=1,
         upscale_delay_s=0,
-        downscale_delay_s=0)
+        downscale_delay_s=100000)
 
     policy = BasicAutoscalingPolicy(config)
 
@@ -285,6 +285,11 @@ def test_replicas_delayed_startup():
 
     # Two new replicas spun up during this timestep.
     new_num_replicas = policy.get_decision_num_replicas([100, 20, 3], 100)
+    assert new_num_replicas == 123
+
+    # A lot of queries got drained and a lot of replicas started up, but
+    # new_num_replicas should not decrease, because of the downscale delay.
+    new_num_replicas = policy.get_decision_num_replicas([6, 2, 1, 1], 123)
     assert new_num_replicas == 123
 
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -1,5 +1,4 @@
 import sys
-import time
 
 import pytest
 from unittest import mock
@@ -172,19 +171,6 @@ def test_initial_num_replicas(mock, serve_instance):
     assert get_num_running_replicas(controller, A) == 2
 
 
-class MockTimer:
-    def __init__(self, start_time=None):
-        if start_time is None:
-            start_time = time.time()
-        self._curr = start_time
-
-    def time(self):
-        return self._curr
-
-    def advance(self, by):
-        self._curr += by
-
-
 def test_upscale_downscale_delay():
     """Unit test for upscale_delay_s and downscale_delay_s."""
 
@@ -209,11 +195,12 @@ def test_upscale_downscale_delay():
     for i in range(upscale_wait_periods):
         new_num_replicas = policy.get_decision_num_replicas(
             current_num_ongoing_requests=overload_requests,
-            curr_num_replicas=1)
+            curr_target_num_replicas=1)
         assert new_num_replicas == 1, i
 
     new_num_replicas = policy.get_decision_num_replicas(
-        current_num_ongoing_requests=overload_requests, curr_num_replicas=1)
+        current_num_ongoing_requests=overload_requests,
+        curr_target_num_replicas=1)
     assert new_num_replicas == 2
 
     no_requests = [0, 0]
@@ -221,55 +208,59 @@ def test_upscale_downscale_delay():
     # We should scale down only after enough consecutive scale-down decisions.
     for i in range(downscale_wait_periods):
         new_num_replicas = policy.get_decision_num_replicas(
-            current_num_ongoing_requests=no_requests, curr_num_replicas=2)
+            current_num_ongoing_requests=no_requests,
+            curr_target_num_replicas=2)
         assert new_num_replicas == 2, i
 
     new_num_replicas = policy.get_decision_num_replicas(
-        current_num_ongoing_requests=no_requests, curr_num_replicas=2)
+        current_num_ongoing_requests=no_requests, curr_target_num_replicas=2)
     assert new_num_replicas == 1
 
     # Get some scale-up decisions, but not enough to trigger a scale up.
     for i in range(int(upscale_wait_periods / 2)):
         new_num_replicas = policy.get_decision_num_replicas(
             current_num_ongoing_requests=overload_requests,
-            curr_num_replicas=1)
+            curr_target_num_replicas=1)
         assert new_num_replicas == 1, i
 
     # Interrupt with a scale-down decision.
     policy.get_decision_num_replicas(
-        current_num_ongoing_requests=[0], curr_num_replicas=1)
+        current_num_ongoing_requests=[0], curr_target_num_replicas=1)
 
     # The counter should be reset, so it should require `upscale_wait_periods`
     # more periods before we actually scale up.
     for i in range(upscale_wait_periods):
         new_num_replicas = policy.get_decision_num_replicas(
             current_num_ongoing_requests=overload_requests,
-            curr_num_replicas=1)
+            curr_target_num_replicas=1)
         assert new_num_replicas == 1, i
 
     new_num_replicas = policy.get_decision_num_replicas(
-        current_num_ongoing_requests=overload_requests, curr_num_replicas=1)
+        current_num_ongoing_requests=overload_requests,
+        curr_target_num_replicas=1)
     assert new_num_replicas == 2
 
     # Get some scale-down decisions, but not enough to trigger a scale down.
     for i in range(int(downscale_wait_periods / 2)):
         new_num_replicas = policy.get_decision_num_replicas(
-            current_num_ongoing_requests=no_requests, curr_num_replicas=2)
+            current_num_ongoing_requests=no_requests,
+            curr_target_num_replicas=2)
         assert new_num_replicas == 2, i
 
     # Interrupt with a scale-up decision.
     policy.get_decision_num_replicas(
-        current_num_ongoing_requests=[100, 100], curr_num_replicas=2)
+        current_num_ongoing_requests=[100, 100], curr_target_num_replicas=2)
 
     # The counter should be reset so it should require `downscale_wait_periods`
     # more periods before we actually scale down.
     for i in range(downscale_wait_periods):
         new_num_replicas = policy.get_decision_num_replicas(
-            current_num_ongoing_requests=no_requests, curr_num_replicas=2)
+            current_num_ongoing_requests=no_requests,
+            curr_target_num_replicas=2)
         assert new_num_replicas == 2, i
 
     new_num_replicas = policy.get_decision_num_replicas(
-        current_num_ongoing_requests=no_requests, curr_num_replicas=2)
+        current_num_ongoing_requests=no_requests, curr_target_num_replicas=2)
     assert new_num_replicas == 1
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously the autoscaler exhibited the following incorrect behavior:

1. A single initial replica is flooded with requests
2. Autoscaler responds by setting a high target number of replicas `N`
3. The number of requests remains high, even as a new replica starts up
4. Due to downscale delay, autoscaler opts to not change the number of replicas, but this was incorrectly done by setting `num_replicas` to be the current *actual* number of replicas, which is still 1 (because the new replicas haven't started yet).  So the backend config is updated with num_replicas=1, causing an immediate scale down back to 1 replica.

The `num_replicas` in step 4 should actually be set to the current *target* number of replicas, `N`.

This PR fixes this bug and adds a unit test.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/18925
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
