### PR TITLE
Bumped time limit in ``test_cancel::test_comprehensive``

### DIFF
--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -150,7 +150,7 @@ def test_comprehensive(ray_start_regular, use_force):
         ray.get(a, timeout=10)
 
     with pytest.raises(valid_exceptions(use_force)):
-        ray.get(a2, timeout=10)
+        ray.get(a2, timeout=40)
 
     signaler.send.remote()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Discussed in https://github.com/ray-project/ray/issues/19800#issue-1037733558 (3rd point),

Quoting,

> The following test fails due to timing out of the second statement. However, when the limit is bumped from 10 to 30 it starts passing. So, I want to know whether to make a PR with a bump in timeout limit or investigate further why this thing is slow.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
