### PR TITLE
Fix idle worker leak issue if it received a SIGTERM when DrainAndShutdown.

### DIFF
--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -12,7 +12,8 @@ import signal
 import ray
 import ray.cluster_utils
 
-from ray._private.test_utils import (run_string_as_driver_nonblocking, RayTestTimeoutException,
+from ray._private.test_utils import (run_string_as_driver_nonblocking,
+                                     RayTestTimeoutException,
                                      wait_for_pid_to_exit, wait_for_condition)
 
 logger = logging.getLogger(__name__)
@@ -792,7 +793,7 @@ print(ray.get(obj))
 """
     driver_script = driver_template.format(
         address=ray_start_regular["redis_address"])
-    
+
     driver_proc = run_string_as_driver_nonblocking(driver_script)
 
     try:

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -750,6 +750,7 @@ def test_max_call_tasks(ray_start_regular):
 
 
 # This case tests that the worker leaked issue when task finished with errors.
+# See https://github.com/ray-project/ray/issues/19639.
 #
 # Case steps are:
 #   1. Start a driver which creates a normal task with a long sleeping. This

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -770,14 +770,14 @@ from ray.experimental.internal_kv import _internal_kv_put
 ray.init(address="{address}", namespace="test")
 
 @ray.remote
-def normal_task(large):
+def normal_task(large1, large2):
     # Record the pid of this normal task.
     _internal_kv_put("NORMAL_TASK_PID", str(os.getpid()))
     time.sleep(60 * 60)
     return "normaltask"
 
 large = ray.put(np.zeros(100 * 2**10, dtype=np.int8))
-obj = normal_task.remote(large)
+obj = normal_task.remote(large, large)
 print(ray.get(obj))
 """
     driver_script = driver_template.format(
@@ -804,8 +804,7 @@ print(ray.get(obj))
     driver_proc.send_signal(signal.SIGTERM)
     # Sleep here to make sure raylet has triggered cleaning up
     # the idle workers.
-    time.sleep(10)
-    assert not psutil.pid_exists(normal_task_pid)
+    wait_for_condition(lambda: not psutil.pid_exists(normal_task_pid), 10)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -12,7 +12,7 @@ import signal
 import ray
 import ray.cluster_utils
 
-from ray._private.test_utils import (run_string_as_driver, run_string_as_driver_nonblocking, RayTestTimeoutException,
+from ray._private.test_utils import (run_string_as_driver_nonblocking, RayTestTimeoutException,
                                      wait_for_pid_to_exit, wait_for_condition)
 
 logger = logging.getLogger(__name__)
@@ -768,11 +768,11 @@ ray.init(address="{address}", namespace="test")
 class KvStore:
     def __init__(self):
         self.__data = dict()
-        
+
     def put(self, k, v):
         self.__data[k] = v
         return True
-        
+
     def get(self, k):
         return self.__data[k]
 

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -758,7 +758,8 @@ def test_max_call_tasks(ray_start_regular):
 #   3. After the normal task being reconstructed, we send a SIGTERM to the
 #      driver to make it offline and expects Ray collects the idle workers for
 #      the previous nomral task.
-def test_whether_worker_leaked_when_task_finished_with_errors(ray_start_regular):
+def test_whether_worker_leaked_when_task_finished_with_errors(
+        ray_start_regular):
     driver_template = """
 import ray
 import os
@@ -785,7 +786,7 @@ print(ray.get(obj))
     driver_proc = run_string_as_driver_nonblocking(driver_script)
     try:
         driver_proc.wait(10)
-    except Exception as e:
+    except Exception:
         pass
 
     wait_for_condition(lambda: _internal_kv_exists("NORMAL_TASK_PID"), 10)
@@ -799,8 +800,8 @@ print(ray.get(obj))
         curr_pid_bytes = _internal_kv_get("NORMAL_TASK_PID")
         return curr_pid_bytes is not None \
             and int(curr_pid_bytes) != normal_task_pid
-    wait_for_condition(lambda: normal_task_was_reconstructed(), 10)
 
+    wait_for_condition(lambda: normal_task_was_reconstructed(), 10)
     driver_proc.send_signal(signal.SIGTERM)
     # Sleep here to make sure raylet has triggered cleaning up
     # the idle workers.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -832,6 +832,8 @@ void CoreWorker::Exit(
   RAY_CHECK_OK(
       local_raylet_client_->NotifyDirectCallTaskBlocked(/*release_resources*/ true));
 
+  RAY_LOG(DEBUG) << "Exit signal received, remove all local references.";
+  reference_counter_->ReleaseAllLocalReferences();
   // Callback to shutdown.
   auto shutdown = [this, exit_type, creation_task_exception_pb_bytes]() {
     // To avoid problems, make sure shutdown is always called from the same

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -834,8 +834,8 @@ void CoreWorker::Exit(
 
   RAY_LOG(DEBUG) << "Exit signal received, remove all local references.";
   /// Since this core worker is exiting, it's necessary to release all local references,
-  /// otherwise this worker propobly be leaked.
-  /// Details can be refered at the issue: https://github.com/ray-project/ray/issues/19639
+  /// otherwise the frontend code may not release its references and this worker will be leaked.
+  /// See https://github.com/ray-project/ray/issues/19639.
   reference_counter_->ReleaseAllLocalReferences();
   // Callback to shutdown.
   auto shutdown = [this, exit_type, creation_task_exception_pb_bytes]() {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -834,8 +834,8 @@ void CoreWorker::Exit(
 
   RAY_LOG(DEBUG) << "Exit signal received, remove all local references.";
   /// Since this core worker is exiting, it's necessary to release all local references,
-  /// otherwise the frontend code may not release its references and this worker will be leaked.
-  /// See https://github.com/ray-project/ray/issues/19639.
+  /// otherwise the frontend code may not release its references and this worker will be
+  /// leaked. See https://github.com/ray-project/ray/issues/19639.
   reference_counter_->ReleaseAllLocalReferences();
   // Callback to shutdown.
   auto shutdown = [this, exit_type, creation_task_exception_pb_bytes]() {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -833,6 +833,9 @@ void CoreWorker::Exit(
       local_raylet_client_->NotifyDirectCallTaskBlocked(/*release_resources*/ true));
 
   RAY_LOG(DEBUG) << "Exit signal received, remove all local references.";
+  /// Since this core worker is exiting, it's necessary to release all local references,
+  /// otherwise this worker propobly be leaked.
+  /// Details can be refered at the issue: https://github.com/ray-project/ray/issues/19639
   reference_counter_->ReleaseAllLocalReferences();
   // Callback to shutdown.
   auto shutdown = [this, exit_type, creation_task_exception_pb_bytes]() {

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -30,6 +30,24 @@ namespace {}  // namespace
 namespace ray {
 namespace core {
 
+inline void InternalUpdateLocalRefCountIndexHelper(
+    const ObjectID &object_id, bool increase,
+    absl::flat_hash_map<ObjectID, int32_t> *local_ref_counts) {
+  auto it = local_ref_counts->find(object_id);
+  if (it == local_ref_counts->end()) {
+    local_ref_counts->emplace(object_id, 0);
+  }
+
+  if (increase) {
+    ++(*local_ref_counts)[object_id];
+  } else {
+    if ((*local_ref_counts)[object_id] == 0) {
+      return;
+    }
+    --(*local_ref_counts)[object_id];
+  }
+}
+
 bool ReferenceCounter::OwnObjects() const {
   absl::MutexLock lock(&mutex_);
   return !object_id_refs_.empty();
@@ -228,6 +246,9 @@ void ReferenceCounter::AddLocalReference(const ObjectID &object_id,
   }
   bool was_in_use = it->second.RefCount() > 0;
   it->second.local_ref_count++;
+
+  InternalUpdateLocalRefCountIndexHelper(object_id, /*increase=*/true,
+                                         &local_ref_counts_);
   RAY_LOG(DEBUG) << "Add local reference " << object_id;
   PRINT_REF_COUNT(it);
   if (!was_in_use && it->second.RefCount() > 0) {
@@ -244,6 +265,18 @@ void ReferenceCounter::SetNestedRefInUseRecursive(ReferenceTable::iterator inner
       contained_in_it->second.has_nested_refs_to_report = true;
       SetNestedRefInUseRecursive(contained_in_it);
     }
+  }
+}
+
+void ReferenceCounter::ReleaseAllLocalReferences() {
+  absl::flat_hash_map<ObjectID, int32_t> all_local_refs;
+  {
+    absl::MutexLock lock(&mutex_);
+    /// A copy to avoid iter invalidation.
+    all_local_refs = local_ref_counts_;
+  }
+  for (auto &ref : all_local_refs) {
+    RemoveLocalReference(ref.first, nullptr);
   }
 }
 
@@ -266,6 +299,8 @@ void ReferenceCounter::RemoveLocalReference(const ObjectID &object_id,
     return;
   }
   it->second.local_ref_count--;
+  InternalUpdateLocalRefCountIndexHelper(object_id, /*increase=*/false,
+                                         &local_ref_counts_);
   RAY_LOG(DEBUG) << "Remove local reference " << object_id;
   PRINT_REF_COUNT(it);
   if (it->second.RefCount() == 0) {

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -250,7 +250,6 @@ void ReferenceCounter::SetNestedRefInUseRecursive(ReferenceTable::iterator inner
 void ReferenceCounter::ReleaseAllLocalReferences() {
   absl::MutexLock lock(&mutex_);
   for (auto &ref : object_id_refs_) {
-    /// Remove multiple times.
     for (int i = ref.second.local_ref_count; i > 0; --i) {
       RemoveLocalReferenceInternal(ref.first, nullptr);
     }

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -792,6 +792,12 @@ class ReferenceCounter : public ReferenceCounterInterface,
                                     const ObjectID &object_id,
                                     const rpc::WorkerAddress &borrower_addr);
 
+  /// Internally decrease the local reference count for the ObjectID by one.
+  /// Note this requires `mutex_` lock is held.
+  void RemoveLocalReferenceInternal(const ObjectID &object_id,
+                                    std::vector<ObjectID> *deleted)
+      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
   /// Address of our RPC server. This is used to determine whether we own a
   /// given object or not, by comparing our WorkerID with the WorkerID of the
   /// object's owner.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -473,6 +473,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   bool IsObjectReconstructable(const ObjectID &object_id) const;
 
+  /// Relase all local references which registered on this local.
+  void ReleaseAllLocalReferences();
+
  private:
   struct Reference {
     /// Constructor for a reference whose origin is unknown.
@@ -819,6 +822,10 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// removed from this set once its Reference has been deleted
   /// locally.
   absl::flat_hash_set<ObjectID> freed_objects_ GUARDED_BY(mutex_);
+
+  /// Index that all local reference counts to speed up the process of releasing
+  /// all local references when shutdown.
+  absl::flat_hash_map<ObjectID, int32_t> local_ref_counts_ GUARDED_BY(mutex_);
 
   /// The callback to call once an object ID that we own is no longer in scope
   /// and it has no tasks that depend on it that may be retried in the future.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -473,7 +473,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   bool IsObjectReconstructable(const ObjectID &object_id) const;
 
-  /// Relase all local references which registered on this local.
+  /// Release all local references which registered on this local.
   void ReleaseAllLocalReferences();
 
  private:

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -792,8 +792,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
                                     const ObjectID &object_id,
                                     const rpc::WorkerAddress &borrower_addr);
 
-  /// Internally decrease the local reference count for the ObjectID by one.
-  /// Note this requires `mutex_` lock is held.
+  /// Decrease the local reference count for the ObjectID by one.
+  /// This method is internal and not thread-safe. mutex_ lock must be held before
+  /// calling this method.
   void RemoveLocalReferenceInternal(const ObjectID &object_id,
                                     std::vector<ObjectID> *deleted)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -823,10 +823,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// locally.
   absl::flat_hash_set<ObjectID> freed_objects_ GUARDED_BY(mutex_);
 
-  /// Index that all local reference counts to speed up the process of releasing
-  /// all local references when shutdown.
-  absl::flat_hash_map<ObjectID, int32_t> local_ref_counts_ GUARDED_BY(mutex_);
-
   /// The callback to call once an object ID that we own is no longer in scope
   /// and it has no tasks that depend on it that may be retried in the future.
   /// The object's Reference will be erased after this callback.


### PR DESCRIPTION
This PR fixes the issue that worker might be leaked if task finished with some errors.
See #19639 for more details.

close #19639