### PR TITLE
[RLlib] Issue 19878: Re-instate bare_metal_policy example script

### DIFF
--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -17,6 +17,7 @@ supersuit==2.6.6
 pybullet==3.1.7
 # For tests on RecSim and Kaggle envs.
 recsim==0.2.4
+tensorflow_estimator==2.6.0
 
 # Other.
 # ------

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1418,14 +1418,12 @@ py_test(
     srcs = ["env/wrappers/tests/test_unity3d_env.py"]
 )
 
-# Taken out due to
-# AttributeError: module 'tensorflow.tools.docs.doc_controls' has no attribute 'inheritable_header
-#py_test(
-#    name = "env/wrappers/tests/test_recsim_wrapper",
-#    tags = ["team:ml", "env"],
-#    size = "small",
-#    srcs = ["env/wrappers/tests/test_recsim_wrapper.py"]
-#)
+py_test(
+    name = "env/wrappers/tests/test_recsim_wrapper",
+    tags = ["team:ml", "env"],
+    size = "small",
+    srcs = ["env/wrappers/tests/test_recsim_wrapper.py"]
+)
 
 py_test(
     name = "env/wrappers/tests/test_exception_wrapper",

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1418,12 +1418,14 @@ py_test(
     srcs = ["env/wrappers/tests/test_unity3d_env.py"]
 )
 
-py_test(
-    name = "env/wrappers/tests/test_recsim_wrapper",
-    tags = ["team:ml", "env"],
-    size = "small",
-    srcs = ["env/wrappers/tests/test_recsim_wrapper.py"]
-)
+# Taken out due to
+# AttributeError: module 'tensorflow.tools.docs.doc_controls' has no attribute 'inheritable_header
+#py_test(
+#    name = "env/wrappers/tests/test_recsim_wrapper",
+#    tags = ["team:ml", "env"],
+#    size = "small",
+#    srcs = ["env/wrappers/tests/test_recsim_wrapper.py"]
+#)
 
 py_test(
     name = "env/wrappers/tests/test_exception_wrapper",
@@ -2010,7 +2012,7 @@ py_test(
     name = "examples/bare_metal_policy_with_custom_view_reqs",
     main = "examples/bare_metal_policy_with_custom_view_reqs.py",
     tags = ["team:ml", "examples", "examples_B"],
-    size = "small",
+    size = "medium",
     srcs = ["examples/bare_metal_policy_with_custom_view_reqs.py"],
 )
 

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2006,14 +2006,13 @@ py_test(
     args = ["--as-test", "--framework=torch", "--stop-reward=150", "--num-cpus=4"]
 )
 
-# times-out: #
-#py_test(
-#    name = "examples/bare_metal_policy_with_custom_view_reqs",
-#    main = "examples/bare_metal_policy_with_custom_view_reqs.py",
-#    tags = ["team:ml", "examples", "examples_B"],
-#    size = "small",
-#    srcs = ["examples/bare_metal_policy_with_custom_view_reqs.py"],
-#)
+py_test(
+    name = "examples/bare_metal_policy_with_custom_view_reqs",
+    main = "examples/bare_metal_policy_with_custom_view_reqs.py",
+    tags = ["team:ml", "examples", "examples_B"],
+    size = "small",
+    srcs = ["examples/bare_metal_policy_with_custom_view_reqs.py"],
+)
 
 py_test(
     name = "examples/batch_norm_model_ppo_tf",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

- Issue 19878: Re-instate bare_metal_policy example script.
- Pin tensorflow_estimator version (which made RLlib's recsim test case fail).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Issue #19878

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #19878

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
