### PR TITLE
[Placement Group] Fix the implicit value change from uint32_t -> uint64_t for pg scheduling retry

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -230,8 +230,8 @@ RAY_CONFIG(uint32_t, gcs_lease_worker_retry_interval_ms, 200)
 /// Duration to wait between retries for creating actor in gcs server.
 RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 /// Exponential backoff params for gcs to retry creating a placement group
-RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_min_interval_ms, 200)
-RAY_CONFIG(uint32_t, gcs_create_placement_group_retry_max_interval_ms, 5000)
+RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_min_interval_ms, 200)
+RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_max_interval_ms, 5000)
 RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5);
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -230,8 +230,8 @@ RAY_CONFIG(uint32_t, gcs_lease_worker_retry_interval_ms, 200)
 /// Duration to wait between retries for creating actor in gcs server.
 RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 /// Exponential backoff params for gcs to retry creating a placement group
-RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_min_interval_ms, 200)
-RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_max_interval_ms, 5000)
+RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_min_interval_ms, 100)
+RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_max_interval_ms, 1000)
 RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5);
 /// Maximum number of destroyed actors in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -336,8 +336,6 @@ class ExponentialBackOff {
   }
 
   uint64_t Next() {
-    RAY_LOG(ERROR) << "Max value: " << max_value_;
-    RAY_LOG(ERROR) << "Current: " << curr_value_;
     auto ret = curr_value_;
     curr_value_ = curr_value_ * multiplier_;
     curr_value_ = std::min(curr_value_, max_value_);

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -336,6 +336,8 @@ class ExponentialBackOff {
   }
 
   uint64_t Next() {
+    RAY_LOG(ERROR) << "Max value: " << max_value_;
+    RAY_LOG(ERROR) << "Current: " << curr_value_;
     auto ret = curr_value_;
     curr_value_ = curr_value_ * multiplier_;
     curr_value_ = std::min(curr_value_, max_value_);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It seems like the ray_config_def has uint32_t value, which is incorrectly converted to uint64_t, which is the argument of ExponentialBackoff class. This fixes the issue. Previously, the max value (5000ms) was converted to (700ms).

This means we can avoid having huge load without having 5 seconds exponential backoff delay. So, I also reduced the value. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
