### PR TITLE
[Dashboard] Fix gpu utilization in actor details pane

### DIFF
--- a/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/ActorDetailsPane.tsx
@@ -147,8 +147,8 @@ const ActorDetailsPane: React.FC<ActorDetailsPaneProps> = ({ actor }) => {
               {actor.gpus.map((gpu) => {
                 const gpuUtilization = gpu.utilizationGpu ? (
                   <UsageBar
-                    percent={gpu.utilizationGpu * 100}
-                    text={`${gpu.utilizationGpu * 100}%`}
+                    percent={gpu.utilizationGpu}
+                    text={`${gpu.utilizationGpu}%`}
                   />
                 ) : (
                   <Typography


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The GPU usages in ActorDetialsPane are unexpectedly multiplied by 100. The value of `gpu.utilizationGpu` is already within the range of 0-100.

![Screenshot-dashboard](https://user-images.githubusercontent.com/16078332/139448398-f5441aec-ab00-4d6d-ac67-2a07d4c1aafb.png)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
