### PR TITLE
Revert "[RLlib; Docs overhaul] Docstring cleanup: Evaluation (#19783)"

### DIFF
--- a/rllib/agents/a3c/a3c_tf_policy.py
+++ b/rllib/agents/a3c/a3c_tf_policy.py
@@ -5,20 +5,20 @@ import gym
 import ray
 from ray.rllib.agents.ppo.ppo_tf_policy import ValueNetworkMixin
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.evaluation.episode import Episode
 from ray.rllib.evaluation.postprocessing import compute_gae_for_sample_batch, \
     Postprocessing
-from ray.rllib.models.action_dist import ActionDistribution
-from ray.rllib.models.modelv2 import ModelV2
-from ray.rllib.policy.policy import Policy
+from ray.rllib.policy.tf_policy_template import build_tf_policy
 from ray.rllib.policy.tf_policy import LearningRateSchedule, \
     EntropyCoeffSchedule
-from ray.rllib.policy.tf_policy_template import build_tf_policy
 from ray.rllib.utils.annotations import Deprecated
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.tf_ops import explained_variance
+from ray.rllib.policy.policy import Policy
 from ray.rllib.utils.typing import TrainerConfigDict, TensorType, \
     PolicyID, LocalOptimizer, ModelGradients
+from ray.rllib.models.action_dist import ActionDistribution
+from ray.rllib.models.modelv2 import ModelV2
+from ray.rllib.evaluation import MultiAgentEpisode
 
 tf1, tf, tfv = try_import_tf()
 
@@ -31,7 +31,7 @@ def postprocess_advantages(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[Dict[PolicyID, SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
 
     return compute_gae_for_sample_batch(policy, sample_batch,
                                         other_agent_batches, episode)

--- a/rllib/agents/a3c/a3c_torch_policy.py
+++ b/rllib/agents/a3c/a3c_torch_policy.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict
 
 import ray
 from ray.rllib.agents.ppo.ppo_torch_policy import ValueNetworkMixin
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.postprocessing import compute_gae_for_sample_batch, \
     Postprocessing
 from ray.rllib.models.action_dist import ActionDistribution
@@ -30,7 +30,7 @@ def add_advantages(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[Dict[PolicyID, SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
 
     return compute_gae_for_sample_batch(policy, sample_batch,
                                         other_agent_batches, episode)

--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 from ray.rllib.env import BaseEnv
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation import MultiAgentEpisode
 from ray.rllib.utils.annotations import PublicAPI
 from ray.rllib.utils.deprecation import deprecation_warning
 from ray.rllib.utils.typing import AgentID, PolicyID
@@ -35,23 +35,28 @@ class DefaultCallbacks:
                 "a class extending rllib.agents.callbacks.DefaultCallbacks")
         self.legacy_callbacks = legacy_callbacks_dict or {}
 
-    def on_episode_start(self, *, worker: "RolloutWorker", base_env: BaseEnv,
-                         policies: Dict[PolicyID, Policy], episode: Episode,
+    def on_episode_start(self,
+                         *,
+                         worker: "RolloutWorker",
+                         base_env: BaseEnv,
+                         policies: Dict[PolicyID, Policy],
+                         episode: MultiAgentEpisode,
+                         env_index: Optional[int] = None,
                          **kwargs) -> None:
         """Callback run on the rollout worker before each episode starts.
 
         Args:
             worker: Reference to the current rollout worker.
             base_env: BaseEnv running the episode. The underlying
-                sub environment objects can be retrieved by calling
+                sub environment objects can be received by calling
                 `base_env.get_sub_environments()`.
             policies: Mapping of policy id to policy objects. In single
                 agent mode there will only be a single "default" policy.
-            episode: Episode object which contains the episode's
+            episode (MultiAgentEpisode): Episode object which contains episode
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
-            env_index: Obsoleted: The ID of the environment, which the
+            env_index (EnvID): Obsoleted: The ID of the environment, which the
                 episode belongs to.
             kwargs: Forward compatibility placeholder.
         """
@@ -68,19 +73,20 @@ class DefaultCallbacks:
                         worker: "RolloutWorker",
                         base_env: BaseEnv,
                         policies: Optional[Dict[PolicyID, Policy]] = None,
-                        episode: Episode,
+                        episode: MultiAgentEpisode,
+                        env_index: Optional[int] = None,
                         **kwargs) -> None:
         """Runs on each episode step.
 
         Args:
             worker (RolloutWorker): Reference to the current rollout worker.
             base_env (BaseEnv): BaseEnv running the episode. The underlying
-                sub environment objects can be retrieved by calling
+                sub environment objects can be gotten by calling
                 `base_env.get_sub_environments()`.
             policies (Optional[Dict[PolicyID, Policy]]): Mapping of policy id
                 to policy objects. In single agent mode there will only be a
                 single "default_policy".
-            episode (Episode): Episode object which contains episode
+            episode (MultiAgentEpisode): Episode object which contains episode
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
@@ -95,8 +101,13 @@ class DefaultCallbacks:
                 "episode": episode
             })
 
-    def on_episode_end(self, *, worker: "RolloutWorker", base_env: BaseEnv,
-                       policies: Dict[PolicyID, Policy], episode: Episode,
+    def on_episode_end(self,
+                       *,
+                       worker: "RolloutWorker",
+                       base_env: BaseEnv,
+                       policies: Dict[PolicyID, Policy],
+                       episode: MultiAgentEpisode,
+                       env_index: Optional[int] = None,
                        **kwargs) -> None:
         """Runs when an episode is done.
 
@@ -108,7 +119,7 @@ class DefaultCallbacks:
             policies (Dict[PolicyID, Policy]): Mapping of policy id to policy
                 objects. In single agent mode there will only be a single
                 "default_policy".
-            episode (Episode): Episode object which contains episode
+            episode (MultiAgentEpisode): Episode object which contains episode
                 state. You can use the `episode.user_data` dict to store
                 temporary data, and `episode.custom_metrics` to store custom
                 metrics for the episode.
@@ -125,7 +136,7 @@ class DefaultCallbacks:
             })
 
     def on_postprocess_trajectory(
-            self, *, worker: "RolloutWorker", episode: Episode,
+            self, *, worker: "RolloutWorker", episode: MultiAgentEpisode,
             agent_id: AgentID, policy_id: PolicyID,
             policies: Dict[PolicyID, Policy], postprocessed_batch: SampleBatch,
             original_batches: Dict[AgentID, SampleBatch], **kwargs) -> None:
@@ -137,7 +148,7 @@ class DefaultCallbacks:
 
         Args:
             worker (RolloutWorker): Reference to the current rollout worker.
-            episode (Episode): Episode object.
+            episode (MultiAgentEpisode): Episode object.
             agent_id (str): Id of the current agent.
             policy_id (str): Id of the current policy for the agent.
             policies (dict): Mapping of policy id to policy objects. In single
@@ -242,7 +253,7 @@ class MemoryTrackingCallbacks(DefaultCallbacks):
                        worker: "RolloutWorker",
                        base_env: BaseEnv,
                        policies: Dict[PolicyID, Policy],
-                       episode: Episode,
+                       episode: MultiAgentEpisode,
                        env_index: Optional[int] = None,
                        **kwargs) -> None:
         snapshot = tracemalloc.take_snapshot()
@@ -300,7 +311,7 @@ class MultiCallbacks(DefaultCallbacks):
                          worker: "RolloutWorker",
                          base_env: BaseEnv,
                          policies: Dict[PolicyID, Policy],
-                         episode: Episode,
+                         episode: MultiAgentEpisode,
                          env_index: Optional[int] = None,
                          **kwargs) -> None:
         for callback in self._callback_list:
@@ -317,7 +328,7 @@ class MultiCallbacks(DefaultCallbacks):
                         worker: "RolloutWorker",
                         base_env: BaseEnv,
                         policies: Optional[Dict[PolicyID, Policy]] = None,
-                        episode: Episode,
+                        episode: MultiAgentEpisode,
                         env_index: Optional[int] = None,
                         **kwargs) -> None:
         for callback in self._callback_list:
@@ -334,7 +345,7 @@ class MultiCallbacks(DefaultCallbacks):
                        worker: "RolloutWorker",
                        base_env: BaseEnv,
                        policies: Dict[PolicyID, Policy],
-                       episode: Episode,
+                       episode: MultiAgentEpisode,
                        env_index: Optional[int] = None,
                        **kwargs) -> None:
         for callback in self._callback_list:
@@ -347,7 +358,7 @@ class MultiCallbacks(DefaultCallbacks):
                 **kwargs)
 
     def on_postprocess_trajectory(
-            self, *, worker: "RolloutWorker", episode: Episode,
+            self, *, worker: "RolloutWorker", episode: MultiAgentEpisode,
             agent_id: AgentID, policy_id: PolicyID,
             policies: Dict[PolicyID, Policy], postprocessed_batch: SampleBatch,
             original_batches: Dict[AgentID, SampleBatch], **kwargs) -> None:

--- a/rllib/agents/dreamer/dreamer_torch_policy.py
+++ b/rllib/agents/dreamer/dreamer_torch_policy.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 import ray
 from ray.rllib.agents.dreamer.utils import FreezeParameters
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation import MultiAgentEpisode
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.policy_template import build_policy_class
@@ -247,7 +247,7 @@ def preprocess_episode(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[Dict[AgentID, SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
     """Batch format should be in the form of (s_t, a_(t-1), r_(t-1))
     When t=0, the resetted obs is paired with action and reward of 0.
     """

--- a/rllib/agents/marwil/marwil_tf_policy.py
+++ b/rllib/agents/marwil/marwil_tf_policy.py
@@ -59,7 +59,7 @@ def postprocess_advantages(
         other_agent_batches (Optional[Dict[PolicyID, SampleBatch]]): Optional
             dict of AgentIDs mapping to other agents' trajectory data (from the
             same episode). NOTE: The other agents use the same policy.
-        episode (Optional[Episode]): Optional multi-agent episode
+        episode (Optional[MultiAgentEpisode]): Optional multi-agent episode
             object in which the agents operated.
 
     Returns:

--- a/rllib/agents/pg/utils.py
+++ b/rllib/agents/pg/utils.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.postprocessing import compute_advantages
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
@@ -10,7 +10,7 @@ def post_process_advantages(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[List[SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
     """Adds the "advantages" column to `sample_batch`.
 
     Args:
@@ -18,7 +18,7 @@ def post_process_advantages(
         sample_batch (SampleBatch): The actual sample batch to post-process.
         other_agent_batches (Optional[List[SampleBatch]]): Optional list of
             other agents' SampleBatch objects.
-        episode (Episode): The multi-agent episode object, from which
+        episode (MultiAgentEpisode): The multi-agent episode object, from which
             `sample_batch` was generated.
 
     Returns:

--- a/rllib/agents/ppo/appo_tf_policy.py
+++ b/rllib/agents/ppo/appo_tf_policy.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Type, Union
 from ray.rllib.agents.impala import vtrace_tf as vtrace
 from ray.rllib.agents.impala.vtrace_tf_policy import _make_time_major, \
     clip_gradients, choose_optimizer
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.postprocessing import compute_gae_for_sample_batch, \
     Postprocessing
 from ray.rllib.models.tf.tf_action_dist import Categorical
@@ -325,7 +325,7 @@ def postprocess_trajectory(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[Dict[AgentID, SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
     """Postprocesses a trajectory and returns the processed trajectory.
 
     The trajectory contains only data from one episode and from one agent.
@@ -343,7 +343,7 @@ def postprocess_trajectory(
         other_agent_batches (Optional[Dict[PolicyID, SampleBatch]]): Optional
             dict of AgentIDs mapping to other agents' trajectory data (from the
             same episode). NOTE: The other agents use the same policy.
-        episode (Optional[Episode]): Optional multi-agent episode
+        episode (Optional[MultiAgentEpisode]): Optional multi-agent episode
             object in which the agents operated.
 
     Returns:

--- a/rllib/agents/ppo/ppo_tf_policy.py
+++ b/rllib/agents/ppo/ppo_tf_policy.py
@@ -7,7 +7,7 @@ import logging
 from typing import Dict, List, Optional, Type, Union
 
 import ray
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.postprocessing import compute_gae_for_sample_batch, \
     Postprocessing
 from ray.rllib.models.modelv2 import ModelV2
@@ -357,7 +357,7 @@ def postprocess_ppo_gae(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[Dict[AgentID, SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
 
     return compute_gae_for_sample_batch(policy, sample_batch,
                                         other_agent_batches, episode)

--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -16,7 +16,7 @@ from ray.rllib.agents.dqn.dqn_tf_policy import postprocess_nstep_and_prio, \
     PRIO_WEIGHTS
 from ray.rllib.agents.sac.sac_tf_model import SACTFModel
 from ray.rllib.agents.sac.sac_torch_model import SACTorchModel
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.models import ModelCatalog, MODEL_DEFAULTS
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.tf.tf_action_dist import Beta, Categorical, \
@@ -106,7 +106,7 @@ def postprocess_trajectory(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[Dict[AgentID, SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
     """Postprocesses a trajectory and returns the processed trajectory.
 
     The trajectory contains only data from one episode and from one agent.
@@ -124,7 +124,7 @@ def postprocess_trajectory(
         other_agent_batches (Optional[Dict[AgentID, SampleBatch]]): Optional
             dict of AgentIDs mapping to other agents' trajectory data (from the
             same episode). NOTE: The other agents use the same policy.
-        episode (Optional[Episode]): Optional multi-agent episode
+        episode (Optional[MultiAgentEpisode]): Optional multi-agent episode
             object in which the agents operated.
 
     Returns:

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -19,7 +19,7 @@ from ray.rllib.env.multi_agent_env import MultiAgentEnv
 from ray.rllib.env.utils import gym_env_creator
 from ray.rllib.evaluation.collectors.simple_list_collector import \
     SimpleListCollector
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
 from ray.rllib.evaluation.worker_set import WorkerSet
@@ -1086,7 +1086,7 @@ class Trainer(Trainable):
             full_fetch: bool = False,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
-            episode: Optional[Episode] = None,
+            episode: Optional[MultiAgentEpisode] = None,
             unsquash_action: Optional[bool] = None,
             clip_action: Optional[bool] = None,
 
@@ -1240,7 +1240,7 @@ class Trainer(Trainable):
             full_fetch: bool = False,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
-            episodes: Optional[List[Episode]] = None,
+            episodes: Optional[List[MultiAgentEpisode]] = None,
             unsquash_actions: Optional[bool] = None,
             clip_actions: Optional[bool] = None,
             # Deprecated.

--- a/rllib/evaluation/__init__.py
+++ b/rllib/evaluation/__init__.py
@@ -1,4 +1,4 @@
-from ray.rllib.evaluation.episode import Episode, MultiAgentEpisode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
 from ray.rllib.evaluation.sample_batch_builder import (
     SampleBatchBuilder, MultiAgentSampleBatchBuilder)
@@ -17,6 +17,5 @@ __all__ = [
     "AsyncSampler",
     "compute_advantages",
     "collect_metrics",
-    "Episode",
-    "MultiAgentEpisode",  # Deprecated -> Use `Episode` instead.
+    "MultiAgentEpisode",
 ]

--- a/rllib/evaluation/collectors/sample_collector.py
+++ b/rllib/evaluation/collectors/sample_collector.py
@@ -2,7 +2,7 @@ from abc import abstractmethod, ABCMeta
 import logging
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.policy.policy_map import PolicyMap
 from ray.rllib.policy.sample_batch import MultiAgentBatch, SampleBatch
 from ray.rllib.utils.typing import AgentID, EnvID, EpisodeID, PolicyID, \
@@ -57,7 +57,7 @@ class SampleCollector(metaclass=ABCMeta):
         self.count_steps_by = count_steps_by
 
     @abstractmethod
-    def add_init_obs(self, episode: Episode, agent_id: AgentID,
+    def add_init_obs(self, episode: MultiAgentEpisode, agent_id: AgentID,
                      policy_id: PolicyID, t: int,
                      init_obs: TensorType) -> None:
         """Adds an initial obs (after reset) to this collector.
@@ -70,7 +70,7 @@ class SampleCollector(metaclass=ABCMeta):
         called for that same agent/episode-pair.
 
         Args:
-            episode (Episode): The Episode, for which we
+            episode (MultiAgentEpisode): The MultiAgentEpisode, for which we
                 are adding an Agent's initial observation.
             agent_id (AgentID): Unique id for the agent we are adding
                 values for.
@@ -126,11 +126,11 @@ class SampleCollector(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def episode_step(self, episode: Episode) -> None:
+    def episode_step(self, episode: MultiAgentEpisode) -> None:
         """Increases the episode step counter (across all agents) by one.
 
         Args:
-            episode (Episode): Episode we are stepping through.
+            episode (MultiAgentEpisode): Episode we are stepping through.
                 Useful for handling counting b/c it is called once across
                 all agents that are inside this episode.
         """
@@ -200,7 +200,7 @@ class SampleCollector(metaclass=ABCMeta):
 
     @abstractmethod
     def postprocess_episode(self,
-                            episode: Episode,
+                            episode: MultiAgentEpisode,
                             is_done: bool = False,
                             check_dones: bool = False,
                             build: bool = False) -> Optional[MultiAgentBatch]:
@@ -214,7 +214,7 @@ class SampleCollector(metaclass=ABCMeta):
         correctly added to the buffers.
 
         Args:
-            episode (Episode): The Episode object for which
+            episode (MultiAgentEpisode): The Episode object for which
                 to post-process data.
             is_done (bool): Whether the given episode is actually terminated
                 (all agents are done OR we hit a hard horizon). If True, the

--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Tuple, TYPE_CHECKING, Union
 
 from ray.rllib.env.base_env import _DUMMY_AGENT_ID
 from ray.rllib.evaluation.collectors.sample_collector import SampleCollector
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.policy_map import PolicyMap
 from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
@@ -505,11 +505,11 @@ class SimpleListCollector(SampleCollector):
         # Maps episode ID to the (non-built) individual agent steps in this
         # episode.
         self.agent_steps: Dict[EpisodeID, int] = collections.defaultdict(int)
-        # Maps episode ID to Episode.
-        self.episodes: Dict[EpisodeID, Episode] = {}
+        # Maps episode ID to MultiAgentEpisode.
+        self.episodes: Dict[EpisodeID, MultiAgentEpisode] = {}
 
     @override(SampleCollector)
-    def episode_step(self, episode: Episode) -> None:
+    def episode_step(self, episode: MultiAgentEpisode) -> None:
         episode_id = episode.episode_id
         # In the rase case that an "empty" step is taken at the beginning of
         # the episode (none of the agents has an observation in the obs-dict
@@ -550,8 +550,8 @@ class SimpleListCollector(SampleCollector):
                      if not self.multiple_episodes_in_batch else ""))
 
     @override(SampleCollector)
-    def add_init_obs(self, episode: Episode, agent_id: AgentID, env_id: EnvID,
-                     policy_id: PolicyID, t: int,
+    def add_init_obs(self, episode: MultiAgentEpisode, agent_id: AgentID,
+                     env_id: EnvID, policy_id: PolicyID, t: int,
                      init_obs: TensorType) -> None:
         # Make sure our mappings are up to date.
         agent_key = (episode.episode_id, agent_id)
@@ -707,7 +707,7 @@ class SimpleListCollector(SampleCollector):
     @override(SampleCollector)
     def postprocess_episode(
             self,
-            episode: Episode,
+            episode: MultiAgentEpisode,
             is_done: bool = False,
             check_dones: bool = False,
             build: bool = False) -> Union[None, SampleBatch, MultiAgentBatch]:
@@ -834,7 +834,7 @@ class SimpleListCollector(SampleCollector):
         if build:
             return self._build_multi_agent_batch(episode)
 
-    def _build_multi_agent_batch(self, episode: Episode) -> \
+    def _build_multi_agent_batch(self, episode: MultiAgentEpisode) -> \
             Union[MultiAgentBatch, SampleBatch]:
 
         ma_batch = {}

--- a/rllib/evaluation/episode.py
+++ b/rllib/evaluation/episode.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 import numpy as np
 import random
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import List, Dict, Callable, Any, TYPE_CHECKING
 
 from ray.rllib.env.base_env import _DUMMY_AGENT_ID
 from ray.rllib.policy.policy_map import PolicyMap
-from ray.rllib.utils.annotations import Deprecated, DeveloperAPI
+from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.utils.deprecation import deprecation_warning
 from ray.rllib.utils.spaces.space_utils import flatten_to_single_ndarray
 from ray.rllib.utils.typing import SampleBatchType, AgentID, PolicyID, \
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 @DeveloperAPI
-class Episode:
+class MultiAgentEpisode:
     """Tracks the current state of a (possibly multi-agent) episode.
 
     Attributes:
@@ -53,28 +53,15 @@ class Episode:
     def __init__(
             self,
             policies: PolicyMap,
-            policy_mapping_fn: Callable[[AgentID, "Episode", "RolloutWorker"],
-                                        PolicyID],
+            policy_mapping_fn: Callable[
+                [AgentID, "MultiAgentEpisode", "RolloutWorker"], PolicyID],
             batch_builder_factory: Callable[[],
                                             "MultiAgentSampleBatchBuilder"],
             extra_batch_callback: Callable[[SampleBatchType], None],
             env_id: EnvID,
             *,
-            worker: Optional["RolloutWorker"] = None,
+            worker: "RolloutWorker" = None,
     ):
-        """Initializes an Episode instance.
-
-        Args:
-            policies: The PolicyMap object (mapping PolicyIDs to Policy
-                objects) to use for determining, which policy is used for
-                which agent.
-            policy_mapping_fn: The mapping function mapping AgentIDs to
-                PolicyIDs.
-            batch_builder_factory:
-            extra_batch_callback:
-            env_id: The environment's ID in which this episode runs.
-            worker: The RolloutWorker instance, in which this episode runs.
-        """
         self.new_batch_builder: Callable[
             [], "MultiAgentSampleBatchBuilder"] = batch_builder_factory
         self.add_extra_batch: Callable[[SampleBatchType],
@@ -93,8 +80,9 @@ class Episode:
         self.media: Dict[str, Any] = {}
         self.policy_map: PolicyMap = policies
         self._policies = self.policy_map  # backward compatibility
-        self.policy_mapping_fn: Callable[[AgentID, "Episode", "RolloutWorker"],
-                                         PolicyID] = policy_mapping_fn
+        self.policy_mapping_fn: Callable[[
+            AgentID, "MultiAgentEpisode", "RolloutWorker"
+        ], PolicyID] = policy_mapping_fn
         self._next_agent_index: int = 0
         self._agent_to_index: Dict[AgentID, int] = {}
         self._agent_to_policy: Dict[AgentID, PolicyID] = {}
@@ -104,10 +92,20 @@ class Episode:
         self._agent_to_last_done: Dict[AgentID, bool] = {}
         self._agent_to_last_info: Dict[AgentID, EnvInfoDict] = {}
         self._agent_to_last_action: Dict[AgentID, EnvActionType] = {}
-        self._agent_to_last_extra_action_outs: Dict[AgentID, dict] = {}
+        self._agent_to_last_pi_info: Dict[AgentID, dict] = {}
         self._agent_to_prev_action: Dict[AgentID, EnvActionType] = {}
         self._agent_reward_history: Dict[AgentID, List[int]] = defaultdict(
             list)
+
+    # TODO: Deprecated.
+    @property
+    def _policy_mapping_fn(self):
+        deprecation_warning(
+            old="MultiAgentEpisode._policy_mapping_fn",
+            new="MultiAgentEpisode.policy_mapping_fn",
+            error=False,
+        )
+        return self.policy_mapping_fn
 
     @DeveloperAPI
     def soft_reset(self) -> None:
@@ -128,17 +126,15 @@ class Episode:
 
         If the agent is new, the policy mapping fn will be called to bind the
         agent to a policy for the duration of the entire episode (even if the
-        policy_mapping_fn is changed in the meantime!).
+        policy_mapping_fn is changed in the meantime).
 
         Args:
-            agent_id: The agent ID to lookup the policy ID for.
+            agent_id (AgentID): The agent ID to lookup the policy ID for.
 
         Returns:
-            The policy ID for the specified agent.
+            PolicyID: The policy ID for the specified agent.
         """
 
-        # Perform a new policy_mapping_fn lookup and bind AgentID for the
-        # duration of this episode to the returned PolicyID.
         if agent_id not in self._agent_to_policy:
             # Try new API: pass in agent_id and episode as named args.
             # New signature should be: (agent_id, episode, worker, **kwargs)
@@ -157,11 +153,8 @@ class Episode:
                         self.policy_mapping_fn(agent_id)
                 else:
                     raise e
-        # Use already determined PolicyID.
         else:
             policy_id = self._agent_to_policy[agent_id]
-
-        # PolicyID not found in policy map -> Error.
         if policy_id not in self.policy_map:
             raise KeyError("policy_mapping_fn returned invalid policy id "
                            f"'{policy_id}'!")
@@ -169,70 +162,33 @@ class Episode:
 
     @DeveloperAPI
     def last_observation_for(
-            self, agent_id: AgentID = _DUMMY_AGENT_ID) -> Optional[EnvObsType]:
-        """Returns the last observation for the specified AgentID.
-
-        Args:
-            agent_id: The agent's ID to get the last observation for.
-
-        Returns:
-            Last observation the specified AgentID has seen. None in case
-            the agent has never made any observations in the episode.
-        """
+            self, agent_id: AgentID = _DUMMY_AGENT_ID) -> EnvObsType:
+        """Returns the last observation for the specified agent."""
 
         return self._agent_to_last_obs.get(agent_id)
 
     @DeveloperAPI
-    def last_raw_obs_for(
-            self, agent_id: AgentID = _DUMMY_AGENT_ID) -> Optional[EnvObsType]:
-        """Returns the last un-preprocessed obs for the specified AgentID.
+    def last_raw_obs_for(self,
+                         agent_id: AgentID = _DUMMY_AGENT_ID) -> EnvObsType:
+        """Returns the last un-preprocessed obs for the specified agent."""
 
-        Args:
-            agent_id: The agent's ID to get the last un-preprocessed
-                observation for.
-
-        Returns:
-            Last un-preprocessed observation the specified AgentID has seen.
-            None in case the agent has never made any observations in the
-            episode.
-        """
         return self._agent_to_last_raw_obs.get(agent_id)
 
     @DeveloperAPI
-    def last_info_for(self, agent_id: AgentID = _DUMMY_AGENT_ID
-                      ) -> Optional[EnvInfoDict]:
-        """Returns the last info for the specified AgentID.
+    def last_info_for(self,
+                      agent_id: AgentID = _DUMMY_AGENT_ID) -> EnvInfoDict:
+        """Returns the last info for the specified agent."""
 
-        Args:
-            agent_id: The agent's ID to get the last info for.
-
-        Returns:
-            Last info dict the specified AgentID has seen.
-            None in case the agent has never made any observations in the
-            episode.
-        """
         return self._agent_to_last_info.get(agent_id)
 
     @DeveloperAPI
     def last_action_for(self,
                         agent_id: AgentID = _DUMMY_AGENT_ID) -> EnvActionType:
-        """Returns the last action for the specified AgentID, or zeros.
+        """Returns the last action for the specified agent, or zeros."""
 
-        The "last" action is the most recent one taken by the agent.
-
-        Args:
-            agent_id: The agent's ID to get the last action for.
-
-        Returns:
-            Last action the specified AgentID has executed.
-            Zeros in case the agent has never performed any actions in the
-            episode.
-        """
-        # Agent has already taken at least one action in the episode.
         if agent_id in self._agent_to_last_action:
             return flatten_to_single_ndarray(
                 self._agent_to_last_action[agent_id])
-        # Agent has not acted yet, return all zeros.
         else:
             policy_id = self.policy_for(agent_id)
             policy = self.policy_map[policy_id]
@@ -244,84 +200,29 @@ class Episode:
     @DeveloperAPI
     def prev_action_for(self,
                         agent_id: AgentID = _DUMMY_AGENT_ID) -> EnvActionType:
-        """Returns the previous action for the specified agent, or zeros.
+        """Returns the previous action for the specified agent."""
 
-        The "previous" action is the one taken one timestep before the
-        most recent action taken by the agent.
-
-        Args:
-            agent_id: The agent's ID to get the previous action for.
-
-        Returns:
-            Previous action the specified AgentID has executed.
-            Zero in case the agent has never performed any actions (or only
-            one) in the episode.
-        """
-        # We are at t > 1 -> There has been a previous action by this agent.
         if agent_id in self._agent_to_prev_action:
             return flatten_to_single_ndarray(
                 self._agent_to_prev_action[agent_id])
-        # We're at t <= 1, so return all zeros.
         else:
+            # We're at t=0, so return all zeros.
             return np.zeros_like(self.last_action_for(agent_id))
 
     @DeveloperAPI
-    def last_reward_for(self, agent_id: AgentID = _DUMMY_AGENT_ID) -> float:
-        """Returns the last reward for the specified agent, or zero.
-
-        The "last" reward is the one received most recently by the agent.
-
-        Args:
-            agent_id: The agent's ID to get the last reward for.
-
-        Returns:
-            Last reward for the the specified AgentID.
-            Zero in case the agent has never performed any actions
-            (and thus received rewards) in the episode.
-        """
-
-        history = self._agent_reward_history[agent_id]
-        # We are at t > 0 -> Return previously received reward.
-        if len(history) >= 1:
-            return history[-1]
-        # We're at t=0, so there is no previous reward, just return zero.
-        else:
-            return 0.0
-
-    @DeveloperAPI
     def prev_reward_for(self, agent_id: AgentID = _DUMMY_AGENT_ID) -> float:
-        """Returns the previous reward for the specified agent, or zero.
-
-        The "previous" reward is the one received one timestep before the
-        most recently received reward of the agent.
-
-        Args:
-            agent_id: The agent's ID to get the previous reward for.
-
-        Returns:
-            Previous reward for the the specified AgentID.
-            Zero in case the agent has never performed any actions (or only
-            one) in the episode.
-        """
+        """Returns the previous reward for the specified agent."""
 
         history = self._agent_reward_history[agent_id]
-        # We are at t > 1 -> Return reward prior to most recent (last) one.
         if len(history) >= 2:
             return history[-2]
-        # We're at t <= 1, so there is no previous reward, just return zero.
         else:
+            # We're at t=0, so there is no previous reward, just return zero.
             return 0.0
 
     @DeveloperAPI
     def rnn_state_for(self, agent_id: AgentID = _DUMMY_AGENT_ID) -> List[Any]:
-        """Returns the last RNN state for the specified agent.
-
-        Args:
-            agent_id: The agent's ID to get the most recent RNN state for.
-
-        Returns:
-            Most recent RNN state of the the specified AgentID.
-        """
+        """Returns the last RNN state for the specified agent."""
 
         if agent_id not in self._agent_to_rnn_state:
             policy_id = self.policy_for(agent_id)
@@ -331,44 +232,24 @@ class Episode:
 
     @DeveloperAPI
     def last_done_for(self, agent_id: AgentID = _DUMMY_AGENT_ID) -> bool:
-        """Returns the last done flag for the specified AgentID.
-
-        Args:
-            agent_id: The agent's ID to get the last done flag for.
-
-        Returns:
-            Last done flag for the specified AgentID.
-        """
+        """Returns the last done flag received for the specified agent."""
         if agent_id not in self._agent_to_last_done:
             self._agent_to_last_done[agent_id] = False
         return self._agent_to_last_done[agent_id]
 
     @DeveloperAPI
-    def last_extra_action_outs_for(
-            self,
-            agent_id: AgentID = _DUMMY_AGENT_ID,
-    ) -> dict:
-        """Returns the last extra-action outputs for the specified agent.
+    def last_pi_info_for(self, agent_id: AgentID = _DUMMY_AGENT_ID) -> dict:
+        """Returns the last info object for the specified agent."""
 
-        This data is returned by a call to
-        `Policy.compute_actions_from_input_dict` as the 3rd return value
-        (1st return value = action; 2nd return value = RNN state outs).
-
-        Args:
-            agent_id: The agent's ID to get the last extra-action outs for.
-
-        Returns:
-            The last extra-action outs for the specified AgentID.
-        """
-        return self._agent_to_last_extra_action_outs[agent_id]
+        return self._agent_to_last_pi_info[agent_id]
 
     @DeveloperAPI
     def get_agents(self) -> List[AgentID]:
         """Returns list of agent IDs that have appeared in this episode.
 
         Returns:
-            The list of all agent IDs that have appeared so far in this
-            episode.
+            List[AgentID]: The list of all agents that have appeared so
+                far in this episode.
         """
         return list(self._agent_to_index.keys())
 
@@ -401,31 +282,11 @@ class Episode:
                 self._agent_to_last_action[agent_id]
         self._agent_to_last_action[agent_id] = action
 
-    def _set_last_extra_action_outs(self, agent_id, pi_info):
-        self._agent_to_last_extra_action_outs[agent_id] = pi_info
+    def _set_last_pi_info(self, agent_id, pi_info):
+        self._agent_to_last_pi_info[agent_id] = pi_info
 
     def _agent_index(self, agent_id):
         if agent_id not in self._agent_to_index:
             self._agent_to_index[agent_id] = self._next_agent_index
             self._next_agent_index += 1
         return self._agent_to_index[agent_id]
-
-    @property
-    def _policy_mapping_fn(self):
-        deprecation_warning(
-            old="Episode._policy_mapping_fn",
-            new="Episode.policy_mapping_fn",
-            error=False,
-        )
-        return self.policy_mapping_fn
-
-    @Deprecated(new="Episode.last_extra_action_outs_for", error=False)
-    def last_pi_info_for(self, *args, **kwargs):
-        return self.last_extra_action_outs_for(*args, **kwargs)
-
-
-# Backward compatibility. The name Episode implies that there is
-# also a (single agent?) Episode.
-@Deprecated(new="ray.rllib.evaluation.episode.Episode", error=False)
-class MultiAgentEpisode(Episode):
-    pass

--- a/rllib/evaluation/metrics.py
+++ b/rllib/evaluation/metrics.py
@@ -1,13 +1,14 @@
-import collections
 import logging
 import numpy as np
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+import collections
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import ray
 from ray import ObjectRef
 from ray.actor import ActorHandle
-from ray.rllib.offline.off_policy_estimator import OffPolicyEstimate
+from ray.rllib.evaluation.rollout_metrics import RolloutMetrics
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
+from ray.rllib.offline.off_policy_estimator import OffPolicyEstimate
 from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.utils.metrics.learner_info import LEARNER_STATS_KEY
 from ray.rllib.utils.typing import GradInfoDict, LearnerStatsDict, ResultDict
@@ -16,17 +17,6 @@ if TYPE_CHECKING:
     from ray.rllib.evaluation.rollout_worker import RolloutWorker
 
 logger = logging.getLogger(__name__)
-
-RolloutMetrics = collections.namedtuple("RolloutMetrics", [
-    "episode_length",
-    "episode_reward",
-    "agent_rewards",
-    "custom_metrics",
-    "perf_stats",
-    "hist_data",
-    "media",
-])
-RolloutMetrics.__new__.__defaults__ = (0, 0, {}, {}, {}, {}, {})
 
 
 def extract_stats(stats: Dict, key: str) -> Dict[str, Any]:

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from ray.rllib.env import BaseEnv
 from ray.rllib.policy import Policy
-from ray.rllib.evaluation import Episode, RolloutWorker
+from ray.rllib.evaluation import MultiAgentEpisode, RolloutWorker
 from ray.rllib.utils.framework import TensorType
 from ray.rllib.utils.typing import AgentID, PolicyID
 
@@ -22,7 +22,7 @@ class ObservationFunction:
 
     def __call__(self, agent_obs: Dict[AgentID, TensorType],
                  worker: RolloutWorker, base_env: BaseEnv,
-                 policies: Dict[PolicyID, Policy], episode: Episode,
+                 policies: Dict[PolicyID, Policy], episode: MultiAgentEpisode,
                  **kw) -> Dict[AgentID, TensorType]:
         """Callback run on each environment step to observe the environment.
 
@@ -45,7 +45,7 @@ class ObservationFunction:
                 retrieved by calling `base_env.get_sub_environments()`.
             policies (dict): Mapping of policy id to policy objects. In single
                 agent mode there will only be a single "default" policy.
-            episode (Episode): Episode state object.
+            episode (MultiAgentEpisode): Episode state object.
             kwargs: Forward compatibility placeholder.
 
         Returns:

--- a/rllib/evaluation/postprocessing.py
+++ b/rllib/evaluation/postprocessing.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.signal
 from typing import Dict, Optional
 
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import DeveloperAPI
@@ -135,7 +135,7 @@ def compute_gae_for_sample_batch(
         policy: Policy,
         sample_batch: SampleBatch,
         other_agent_batches: Optional[Dict[AgentID, SampleBatch]] = None,
-        episode: Optional[Episode] = None) -> SampleBatch:
+        episode: Optional[MultiAgentEpisode] = None) -> SampleBatch:
     """Adds GAE (generalized advantage estimations) to a trajectory.
 
     The trajectory contains only data from one episode and from one agent.
@@ -153,7 +153,7 @@ def compute_gae_for_sample_batch(
         other_agent_batches (Optional[Dict[PolicyID, SampleBatch]]): Optional
             dict of AgentIDs mapping to other agents' trajectory data (from the
             same episode). NOTE: The other agents use the same policy.
-        episode (Optional[Episode]): Optional multi-agent episode
+        episode (Optional[MultiAgentEpisode]): Optional multi-agent episode
             object in which the agents operated.
 
     Returns:

--- a/rllib/evaluation/rollout_metrics.py
+++ b/rllib/evaluation/rollout_metrics.py
@@ -1,0 +1,13 @@
+import collections
+
+# Define this in its own file, see #5125
+RolloutMetrics = collections.namedtuple("RolloutMetrics", [
+    "episode_length",
+    "episode_reward",
+    "agent_rewards",
+    "custom_metrics",
+    "perf_stats",
+    "hist_data",
+    "media",
+])
+RolloutMetrics.__new__.__defaults__ = (0, 0, {}, {}, {}, {}, {})

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -18,7 +18,7 @@ from ray.rllib.env.utils import record_env_wrapper
 from ray.rllib.env.vector_env import VectorEnv
 from ray.rllib.env.wrappers.atari_wrappers import wrap_deepmind, is_atari
 from ray.rllib.evaluation.sampler import AsyncSampler, SyncSampler
-from ray.rllib.evaluation.metrics import RolloutMetrics
+from ray.rllib.evaluation.rollout_metrics import RolloutMetrics
 from ray.rllib.models import ModelCatalog
 from ray.rllib.models.preprocessors import Preprocessor
 from ray.rllib.offline import NoopOutput, IOContext, OutputWriter, InputReader
@@ -31,7 +31,7 @@ from ray.rllib.policy.policy import Policy, PolicySpec
 from ray.rllib.policy.policy_map import PolicyMap
 from ray.rllib.policy.torch_policy import TorchPolicy
 from ray.rllib.utils import force_list, merge_dicts
-from ray.rllib.utils.annotations import Deprecated, DeveloperAPI
+from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.utils.debug import summarize, update_global_seed_if_necessary
 from ray.rllib.utils.deprecation import deprecation_warning
 from ray.rllib.utils.error import EnvError, ERR_MSG_NO_GPUS, \
@@ -50,7 +50,7 @@ from ray.util.debug import log_once, disable_log_once_globally, \
 from ray.util.iter import ParallelIteratorWorker
 
 if TYPE_CHECKING:
-    from ray.rllib.evaluation.episode import Episode
+    from ray.rllib.evaluation.episode import MultiAgentEpisode
     from ray.rllib.evaluation.observation_function import ObservationFunction
     from ray.rllib.agents.callbacks import DefaultCallbacks  # noqa
 
@@ -149,27 +149,11 @@ class RolloutWorker(ParallelIteratorWorker):
     @DeveloperAPI
     @classmethod
     def as_remote(cls,
-                  num_cpus: Optional[int] = None,
-                  num_gpus: Optional[Union[int, float]] = None,
-                  memory: Optional[int] = None,
-                  object_store_memory: Optional[int] = None,
-                  resources: Optional[dict] = None) -> type:
-        """Returns RolloutWorker class as a `@ray.remote using given options`.
-
-        The returned class can then be used to instantiate ray actors.
-
-        Args:
-            num_cpus: The number of CPUs to allocate for the remote actor.
-            num_gpus: The number of GPUs to allocate for the remote actor.
-                This could be a fraction as well.
-            memory: The heap memory request for the remote actor.
-            object_store_memory: The object store memory for the remote actor.
-            resources: The default custom resources to allocate for the remote
-                actor.
-
-        Returns:
-            The `@ray.remote` decorated RolloutWorker class.
-        """
+                  num_cpus: int = None,
+                  num_gpus: int = None,
+                  memory: int = None,
+                  object_store_memory: int = None,
+                  resources: dict = None) -> type:
         return ray.remote(
             num_cpus=num_cpus,
             num_gpus=num_gpus,
@@ -186,8 +170,8 @@ class RolloutWorker(ParallelIteratorWorker):
                                             None]] = None,
             policy_spec: Optional[Union[type, Dict[PolicyID,
                                                    PolicySpec]]] = None,
-            policy_mapping_fn: Optional[Callable[[AgentID, "Episode"],
-                                                 PolicyID]] = None,
+            policy_mapping_fn: Optional[Callable[
+                [AgentID, "MultiAgentEpisode"], PolicyID]] = None,
             policies_to_train: Optional[List[PolicyID]] = None,
             tf_session_creator: Optional[Callable[[], "tf1.Session"]] = None,
             rollout_fragment_length: int = 100,
@@ -230,114 +214,127 @@ class RolloutWorker(ParallelIteratorWorker):
             policy=None,
             monitor_path=None,
     ):
-        """Initializes a RolloutWorker instance.
+        """Initialize a rollout worker.
 
         Args:
-            env_creator: Function that returns a gym.Env given an EnvContext
-                wrapped configuration.
-            validate_env: Optional callable to validate the generated
-                environment (only on worker=0).
-            policy_spec: The MultiAgentPolicyConfigDict mapping policy IDs
-                (str) to PolicySpec's or a single policy class to use.
+            env_creator (Callable[[EnvContext], EnvType]): Function that
+                returns a gym.Env given an EnvContext wrapped configuration.
+            validate_env (Optional[Callable[[EnvType, EnvContext], None]]):
+                Optional callable to validate the generated environment (only
+                on worker=0).
+            policy_spec (Optional[Union[Type[Policy],
+                MultiAgentPolicyConfigDict]]): The MultiAgentPolicyConfigDict
+                mapping policy IDs (str) to PolicySpec's or a single policy
+                class to use.
                 If a dict is specified, then we are in multi-agent mode and a
                 policy_mapping_fn can also be set (if not, will map all agents
                 to DEFAULT_POLICY_ID).
-            policy_mapping_fn: A callable that maps agent ids to policy ids in
+            policy_mapping_fn (Optional[Callable[[AgentID, MultiAgentEpisode],
+                PolicyID]]): A callable that maps agent ids to policy ids in
                 multi-agent mode. This function will be called each time a new
                 agent appears in an episode, to bind that agent to a policy
                 for the duration of the episode. If not provided, will map all
                 agents to DEFAULT_POLICY_ID.
-            policies_to_train: Optional list of policies to train, or None
-                for all policies.
-            tf_session_creator: A function that returns a TF session.
-                This is optional and only useful with TFPolicy.
-            rollout_fragment_length: The target number of steps
+            policies_to_train (Optional[List[PolicyID]]): Optional list of
+                policies to train, or None for all policies.
+            tf_session_creator (Optional[Callable[[], tf1.Session]]): A
+                function that returns a TF session. This is optional and only
+                useful with TFPolicy.
+            rollout_fragment_length (int): The target number of steps
                 (maesured in `count_steps_by`) to include in each sample
                 batch returned from this worker.
-            count_steps_by: The unit in which to count fragment
+            count_steps_by (str): The unit in which to count fragment
                 lengths. One of env_steps or agent_steps.
-            batch_mode: One of the following batch modes:
-                - "truncate_episodes": Each call to sample() will return a
-                batch of at most `rollout_fragment_length * num_envs` in size.
-                The batch will be exactly `rollout_fragment_length * num_envs`
-                in size if postprocessing does not change batch sizes. Episodes
-                may be truncated in order to meet this size requirement.
-                - "complete_episodes": Each call to sample() will return a
-                batch of at least `rollout_fragment_length * num_envs` in
-                size. Episodes will not be truncated, but multiple episodes
-                may be packed within one batch to meet the batch size. Note
-                that when `num_envs > 1`, episode steps will be buffered
-                until the episode completes, and hence batches may contain
-                significant amounts of off-policy data.
+            batch_mode (str): One of the following batch modes:
+                "truncate_episodes": Each call to sample() will return a batch
+                    of at most `rollout_fragment_length * num_envs` in size.
+                    The batch will be exactly
+                    `rollout_fragment_length * num_envs` in size if
+                    postprocessing does not change batch sizes. Episodes may be
+                    truncated in order to meet this size requirement.
+                "complete_episodes": Each call to sample() will return a batch
+                    of at least `rollout_fragment_length * num_envs` in size.
+                    Episodes will not be truncated, but multiple episodes may
+                    be packed within one batch to meet the batch size. Note
+                    that when `num_envs > 1`, episode steps will be buffered
+                    until the episode completes, and hence batches may contain
+                    significant amounts of off-policy data.
             episode_horizon: Horizon at which to stop episodes (even if the
                 environment itself has not retured a "done" signal).
-            preprocessor_pref: Whether to use RLlib preprocessors
+            preprocessor_pref (str): Whether to use RLlib preprocessors
                 ("rllib") or deepmind ("deepmind"), when applicable.
-            sample_async: Whether to compute samples asynchronously in
+            sample_async (bool): Whether to compute samples asynchronously in
                 the background, which improves throughput but can cause samples
                 to be slightly off-policy.
-            compress_observations: If true, compress the observations.
+            compress_observations (bool): If true, compress the observations.
                 They can be decompressed with rllib/utils/compression.
-            num_envs: If more than one, will create multiple envs
+            num_envs (int): If more than one, will create multiple envs
                 and vectorize the computation of actions. This has no effect if
                 if the env already implements VectorEnv.
-            observation_fn: Optional multi-agent observation function.
-            observation_filter: Name of observation filter to use.
-            clip_rewards: True for clipping rewards to [-1.0, 1.0] prior
-                to experience postprocessing. None: Clip for Atari only.
+            observation_fn (ObservationFunction): Optional multi-agent
+                observation function.
+            observation_filter (str): Name of observation filter to use.
+            clip_rewards (Optional[Union[bool, float]]): Whether to clip
+                rewards to [-1.0, 1.0] prior to experience postprocessing.
+                None: Clip for Atari only.
                 float: Clip to [-clip_rewards; +clip_rewards].
-            normalize_actions: Whether to normalize actions to the
+            normalize_actions (bool): Whether to normalize actions to the
                 action space's bounds.
-            clip_actions: Whether to clip action values to the range
+            clip_actions (bool): Whether to clip action values to the range
                 specified by the policy action space.
-            env_config: Config to pass to the env creator.
-            model_config: Config to use when creating the policy model.
+            env_config (EnvConfigDict): Config to pass to the env creator.
+            model_config (ModelConfigDict): Config to use when creating the
+                policy model.
             policy_config: Config to pass to the
                 policy. In the multi-agent case, this config will be merged
                 with the per-policy configs specified by `policy_spec`.
-            worker_index: For remote workers, this should be set to a
+            worker_index (int): For remote workers, this should be set to a
                 non-zero and unique value. This index is passed to created envs
                 through EnvContext so that envs can be configured per worker.
-            num_workers: For remote workers, how many workers altogether
+            num_workers (int): For remote workers, how many workers altogether
                 have been created?
-            record_env: Write out episode stats and videos
+            record_env (Union[bool, str]): Write out episode stats and videos
                 using gym.wrappers.Monitor to this directory if specified. If
                 True, use the default output dir in ~/ray_results/.... If
                 False, do not record anything.
-            log_dir: Directory where logs can be placed.
-            log_level: Set the root log level on creation.
-            callbacks: Custom sub-class of
+            log_dir (str): Directory where logs can be placed.
+            log_level (str): Set the root log level on creation.
+            callbacks (Type[DefaultCallbacks]): Custom sub-class of
                 DefaultCallbacks for training/policy/rollout-worker callbacks.
-            input_creator: Function that returns an InputReader object for
-                loading previous generated experiences.
-            input_evaluation: How to evaluate the policy
+            input_creator (Callable[[IOContext], InputReader]): Function that
+                returns an InputReader object for loading previous generated
+                experiences.
+            input_evaluation (List[str]): How to evaluate the policy
                 performance. This only makes sense to set when the input is
                 reading offline data. The possible values include:
-                - "is": the step-wise importance sampling estimator.
-                - "wis": the weighted step-wise is estimator.
-                - "simulation": run the environment in the background, but
-                use this data for evaluation only and never for learning.
-            output_creator: Function that returns an OutputWriter object for
-                saving generated experiences.
-            remote_worker_envs: If using num_envs_per_worker > 1,
+                  - "is": the step-wise importance sampling estimator.
+                  - "wis": the weighted step-wise is estimator.
+                  - "simulation": run the environment in the background, but
+                    use this data for evaluation only and never for learning.
+            output_creator (Callable[[IOContext], OutputWriter]): Function that
+                returns an OutputWriter object for saving generated
+                experiences.
+            remote_worker_envs (bool): If using num_envs_per_worker > 1,
                 whether to create those new envs in remote processes instead of
                 in the current process. This adds overheads, but can make sense
                 if your envs are expensive to step/reset (e.g., for StarCraft).
                 Use this cautiously, overheads are significant!
-            remote_env_batch_wait_ms: Timeout that remote workers
+            remote_env_batch_wait_ms (float): Timeout that remote workers
                 are waiting when polling environments. 0 (continue when at
                 least one env is ready) is a reasonable default, but optimal
                 value could be obtained by measuring your environment
                 step / reset and model inference perf.
-            soft_horizon: Calculate rewards but don't reset the
+            soft_horizon (bool): Calculate rewards but don't reset the
                 environment when the horizon is hit.
-            no_done_at_end: Ignore the done=True at the end of the
+            no_done_at_end (bool): Ignore the done=True at the end of the
                 episode and instead record done=False.
-            seed: Set the seed of both np and tf to this value to
+            seed (int): Set the seed of both np and tf to this value to
                 to ensure each remote worker has unique exploration behavior.
-            extra_python_environs: Extra python environments need to be set.
-            fake_sampler: Use a fake (inf speed) sampler for testing.
-            spaces: An optional space dict mapping policy IDs
+            extra_python_environs (dict): Extra python environments need to
+                be set.
+            fake_sampler (bool): Use a fake (inf speed) sampler for testing.
+            spaces (Optional[Dict[PolicyID, Tuple[gym.spaces.Space,
+                gym.spaces.Space]]]): An optional space dict mapping policy IDs
                 to (obs_space, action_space)-tuples. This is used in case no
                 Env is created on this RolloutWorker.
             policy: Obsoleted arg. Use `policy_spec` instead.
@@ -735,7 +732,7 @@ class RolloutWorker(ParallelIteratorWorker):
         This method must be implemented by subclasses.
 
         Returns:
-            A columnar batch of experiences (e.g., tensors).
+            SampleBatchType: A columnar batch of experiences (e.g., tensors).
 
         Examples:
             >>> print(worker.sample())
@@ -801,35 +798,142 @@ class RolloutWorker(ParallelIteratorWorker):
     @DeveloperAPI
     @ray.method(num_returns=2)
     def sample_with_count(self) -> Tuple[SampleBatchType, int]:
-        """Same as sample() but returns the count as a separate value.
-
-        Returns:
-            A columnar batch of experiences (e.g., tensors) and the
-                size of the collected batch.
-
-        Examples:
-            >>> print(worker.sample_with_count())
-            (SampleBatch({"obs": [1, 2, 3], "action": [0, 1, 0], ...}), 3)
-        """
+        """Same as sample() but returns the count as a separate future."""
         batch = self.sample()
         return batch, batch.count
 
     @DeveloperAPI
-    def learn_on_batch(self, samples: SampleBatchType) -> Dict:
+    def get_weights(
+            self,
+            policies: Optional[List[PolicyID]] = None,
+    ) -> Dict[PolicyID, ModelWeights]:
+        """Returns the model weights of this worker.
+
+        Args:
+            policies (Optional[List[PolicyID]]): List of PolicyIDs to get
+                the weights from. Use None for all policies.
+
+        Returns:
+            Dict[PolicyID, ModelWeights]: Mapping from PolicyIDs to weights
+                dicts.
+        """
+        if policies is None:
+            policies = list(self.policy_map.keys())
+        policies = force_list(policies)
+
+        return {
+            pid: policy.get_weights()
+            for pid, policy in self.policy_map.items() if pid in policies
+        }
+
+    @DeveloperAPI
+    def set_weights(self, weights: ModelWeights,
+                    global_vars: dict = None) -> None:
+        """Sets the model weights of this worker.
+
+        Examples:
+            >>> weights = worker.get_weights()
+            >>> worker.set_weights(weights)
+        """
+        for pid, w in weights.items():
+            self.policy_map[pid].set_weights(w)
+        if global_vars:
+            self.set_global_vars(global_vars)
+
+    @DeveloperAPI
+    def compute_gradients(
+            self, samples: SampleBatchType) -> Tuple[ModelGradients, dict]:
+        """Returns a gradient computed w.r.t the specified samples.
+
+        Returns:
+            (grads, info): A list of gradients that can be applied on a
+            compatible worker. In the multi-agent case, returns a dict
+            of gradients keyed by policy ids. An info dictionary of
+            extra metadata is also returned.
+
+        Examples:
+            >>> batch = worker.sample()
+            >>> grads, info = worker.compute_gradients(samples)
+        """
+        if log_once("compute_gradients"):
+            logger.info("Compute gradients on:\n\n{}\n".format(
+                summarize(samples)))
+        if isinstance(samples, MultiAgentBatch):
+            grad_out, info_out = {}, {}
+            if self.policy_config.get("framework") == "tf":
+                for pid, batch in samples.policy_batches.items():
+                    if pid not in self.policies_to_train:
+                        continue
+                    policy = self.policy_map[pid]
+                    builder = TFRunBuilder(policy.get_session(),
+                                           "compute_gradients")
+                    grad_out[pid], info_out[pid] = (
+                        policy._build_compute_gradients(builder, batch))
+                grad_out = {k: builder.get(v) for k, v in grad_out.items()}
+                info_out = {k: builder.get(v) for k, v in info_out.items()}
+            else:
+                for pid, batch in samples.policy_batches.items():
+                    if pid not in self.policies_to_train:
+                        continue
+                    grad_out[pid], info_out[pid] = (
+                        self.policy_map[pid].compute_gradients(batch))
+        else:
+            grad_out, info_out = (
+                self.policy_map[DEFAULT_POLICY_ID].compute_gradients(samples))
+        info_out["batch_count"] = samples.count
+        if log_once("grad_out"):
+            logger.info("Compute grad info:\n\n{}\n".format(
+                summarize(info_out)))
+        return grad_out, info_out
+
+    @DeveloperAPI
+    def apply_gradients(self, grads: ModelGradients) -> Dict[PolicyID, Any]:
+        """Applies the given gradients to this worker's weights.
+
+        Examples:
+            >>> samples = worker.sample()
+            >>> grads, info = worker.compute_gradients(samples)
+            >>> worker.apply_gradients(grads)
+        """
+        if log_once("apply_gradients"):
+            logger.info("Apply gradients:\n\n{}\n".format(summarize(grads)))
+        if isinstance(grads, dict):
+            if self.policy_config.get("framework") == "tf":
+                builders = {}
+                outputs = {}
+                for pid, grad in grads.items():
+                    if pid not in self.policies_to_train:
+                        continue
+                    policy = self.policy_map[pid]
+                    builders[pid] = TFRunBuilder(policy.get_session(),
+                                                 "apply_gradients")
+                    outputs[pid] = policy._build_apply_gradients(
+                        builders[pid], grad)
+                return {
+                    pid: builders[pid].get(op)
+                    for pid, op in outputs.items()
+                }
+            else:
+                return {
+                    pid: self.policy_map[pid].apply_gradients(g)
+                    for pid, g in grads.items()
+                }
+        else:
+            return self.policy_map[DEFAULT_POLICY_ID].apply_gradients(grads)
+
+    @DeveloperAPI
+    def learn_on_batch(self, samples: SampleBatchType) -> dict:
         """Update policies based on the given batch.
 
         This is the equivalent to apply_gradients(compute_gradients(samples)),
         but can be optimized to avoid pulling gradients into CPU memory.
 
-        Args:
-            samples: The SampleBatch or MultiAgentBatch to learn on.
-
         Returns:
-            Dictionary of extra metadata from compute_gradients().
+            info: dictionary of extra metadata from compute_gradients().
 
         Examples:
             >>> batch = worker.sample()
-            >>> info = worker.learn_on_batch(samples)
+            >>> worker.learn_on_batch(samples)
         """
         if log_once("learn_on_batch"):
             logger.info(
@@ -872,15 +976,14 @@ class RolloutWorker(ParallelIteratorWorker):
         This is typically used in combination with distributed allreduce.
 
         Args:
-            expected_batch_size: Expected number of samples to learn on.
-            num_sgd_iter: Number of SGD iterations.
-            sgd_minibatch_size: SGD minibatch size.
-            standardize_fields: List of sample fields to normalize.
+            expected_batch_size (int): Expected number of samples to learn on.
+            num_sgd_iter (int): Number of SGD iterations.
+            sgd_minibatch_size (int): SGD minibatch size.
+            standardize_fields (list): List of sample fields to normalize.
 
         Returns:
-            A tuple consisting of a dictionary of extra metadata returned from
-                the policies' `learn_on_batch()` and the number of samples
-                learned on.
+            info: dictionary of extra metadata from learn_on_batch().
+            count: number of samples learned on.
         """
         batch = self.sample()
         assert batch.count == expected_batch_size, \
@@ -894,105 +997,8 @@ class RolloutWorker(ParallelIteratorWorker):
         return info, batch.count
 
     @DeveloperAPI
-    def compute_gradients(
-            self, samples: SampleBatchType) -> Tuple[ModelGradients, dict]:
-        """Returns a gradient computed w.r.t the specified samples.
-
-        Uses the Policy's/ies' compute_gradients method(s) to perform the
-        calculations.
-
-        Args:
-            samples: The SampleBatch or MultiAgentBatch to compute gradients
-                for using this worker's policies.
-
-        Returns:
-            In the single-agent case, a tuple consisting of ModelGradients and
-            info dict of the worker's policy.
-            In the multi-agent case, a tuple consisting of a dict mapping
-            PolicyID to ModelGradients and a dict mapping PolicyID to extra
-            metadata info.
-            Note that the first return value (grads) can be applied as is to a
-            compatible worker using the worker's `apply_gradients()` method.
-
-        Examples:
-            >>> batch = worker.sample()
-            >>> grads, info = worker.compute_gradients(samples)
-        """
-        if log_once("compute_gradients"):
-            logger.info("Compute gradients on:\n\n{}\n".format(
-                summarize(samples)))
-        # MultiAgentBatch -> Calculate gradients for all policies.
-        if isinstance(samples, MultiAgentBatch):
-            grad_out, info_out = {}, {}
-            if self.policy_config.get("framework") == "tf":
-                for pid, batch in samples.policy_batches.items():
-                    if pid not in self.policies_to_train:
-                        continue
-                    policy = self.policy_map[pid]
-                    builder = TFRunBuilder(policy.get_session(),
-                                           "compute_gradients")
-                    grad_out[pid], info_out[pid] = (
-                        policy._build_compute_gradients(builder, batch))
-                grad_out = {k: builder.get(v) for k, v in grad_out.items()}
-                info_out = {k: builder.get(v) for k, v in info_out.items()}
-            else:
-                for pid, batch in samples.policy_batches.items():
-                    if pid not in self.policies_to_train:
-                        continue
-                    grad_out[pid], info_out[pid] = (
-                        self.policy_map[pid].compute_gradients(batch))
-        # SampleBatch -> Calculate gradients for the default policy.
-        else:
-            grad_out, info_out = (
-                self.policy_map[DEFAULT_POLICY_ID].compute_gradients(samples))
-
-        info_out["batch_count"] = samples.count
-        if log_once("grad_out"):
-            logger.info("Compute grad info:\n\n{}\n".format(
-                summarize(info_out)))
-
-        return grad_out, info_out
-
-    @DeveloperAPI
-    def apply_gradients(
-            self,
-            grads: Union[ModelGradients, Dict[PolicyID, ModelGradients]],
-    ) -> None:
-        """Applies the given gradients to this worker's models.
-
-        Uses the Policy's/ies' apply_gradients method(s) to perform the
-        operations.
-
-        Args:
-            grads: Single ModelGradients (single-agent case) or a dict
-                mapping PolicyIDs to the respective model gradients
-                structs.
-
-        Examples:
-            >>> samples = worker.sample()
-            >>> grads, info = worker.compute_gradients(samples)
-            >>> worker.apply_gradients(grads)
-        """
-        if log_once("apply_gradients"):
-            logger.info("Apply gradients:\n\n{}\n".format(summarize(grads)))
-        # Grads is a dict (mapping PolicyIDs to ModelGradients).
-        # Multi-agent case.
-        if isinstance(grads, dict):
-            for pid, g in grads.items():
-                if pid in self.policies_to_train:
-                    self.policy_map[pid].apply_gradients(g)
-        # Grads is a ModelGradients type. Single-agent case.
-        elif DEFAULT_POLICY_ID in self.policies_to_train:
-            self.policy_map[DEFAULT_POLICY_ID].apply_gradients(grads)
-
-    @DeveloperAPI
     def get_metrics(self) -> List[Union[RolloutMetrics, OffPolicyEstimate]]:
-        """Returns the thus-far collected metrics from this worker's rollouts.
-
-        Returns:
-             List of RolloutMetrics and/or OffPolicyEstimate objects
-             collected thus-far.
-        """
+        """Returns a list of new RolloutMetric objects from evaluation."""
 
         # Get metrics from sampler (if any).
         if self.sampler is not None:
@@ -1006,16 +1012,8 @@ class RolloutWorker(ParallelIteratorWorker):
         return out
 
     @DeveloperAPI
-    def foreach_env(self, func: Callable[[EnvType], T]) -> List[T]:
-        """Calls the given function with each sub-environment as arg.
-
-        Args:
-            func: The function to call for each underlying
-                sub-environment (as only arg).
-
-        Returns:
-             The list of return values of all calls to `func([env])`.
-        """
+    def foreach_env(self, func: Callable[[BaseEnv], T]) -> List[T]:
+        """Apply the given function to each sub-environment instance."""
 
         if self.async_env is None:
             return []
@@ -1031,15 +1029,8 @@ class RolloutWorker(ParallelIteratorWorker):
 
     @DeveloperAPI
     def foreach_env_with_context(
-            self, func: Callable[[EnvType, EnvContext], T]) -> List[T]:
-        """Calls given function with each sub-env plus env_ctx as args.
-
-        Args:
-            func: The function to call for each underlying
-                sub-environment and its EnvContext (as the args).
-
-        Returns:
-             The list of return values of all calls to `func([env, ctx])`.
+            self, func: Callable[[BaseEnv, EnvContext], T]) -> List[T]:
+        """Apply the given function to each underlying sub-environment.
         """
 
         if self.async_env is None:
@@ -1059,17 +1050,17 @@ class RolloutWorker(ParallelIteratorWorker):
             return ret
 
     @DeveloperAPI
-    def get_policy(self, policy_id: PolicyID = DEFAULT_POLICY_ID) -> \
-            Optional[Policy]:
+    def get_policy(self, policy_id: PolicyID = DEFAULT_POLICY_ID) -> Policy:
         """Return policy for the specified id, or None.
 
         Args:
-            policy_id: ID of the policy to return. None for DEFAULT_POLICY_ID
-                (in the single agent case).
+            policy_id (PolicyID): ID of the policy to return.
 
         Returns:
-            The policy under the given ID (or None if not found).
+            Optional[Policy]: The policy under the given ID (or None if not
+                found).
         """
+
         return self.policy_map.get(policy_id)
 
     @DeveloperAPI
@@ -1081,31 +1072,36 @@ class RolloutWorker(ParallelIteratorWorker):
             observation_space: Optional[gym.spaces.Space] = None,
             action_space: Optional[gym.spaces.Space] = None,
             config: Optional[PartialTrainerConfigDict] = None,
-            policy_mapping_fn: Optional[Callable[[AgentID, "Episode"],
-                                                 PolicyID]] = None,
+            policy_mapping_fn: Optional[Callable[
+                [AgentID, "MultiAgentEpisode"], PolicyID]] = None,
             policies_to_train: Optional[List[PolicyID]] = None,
     ) -> Policy:
         """Adds a new policy to this RolloutWorker.
 
         Args:
-            policy_id: ID of the policy to add.
-            policy_cls: The Policy class to use for constructing the new
-                Policy.
-            observation_space: The observation space of the policy to add.
-            action_space: The action space of the policy to add.
+            policy_id (Optional[PolicyID]): ID of the policy to add.
+            policy_cls (Type[Policy]): The Policy class to use for
+                constructing the new Policy.
+            observation_space (Optional[gym.spaces.Space]): The observation
+                space of the policy to add.
+            action_space (Optional[gym.spaces.Space]): The action space
+                of the policy to add.
             config: The config overrides for the policy to add.
             policy_config: The base config of the Trainer object owning this
                 RolloutWorker.
-            policy_mapping_fn: An optional (updated) policy mapping function
-                to use from here on. Note that already ongoing episodes will
-                not change their mapping but will use the old mapping till
-                the end of the episode.
-            policies_to_train: An optional list of policy IDs to be trained.
-                If None, will keep the existing list in place. Policies,
-                whose IDs are not in the list will not be updated.
+            policy_mapping_fn (Optional[Callable[[AgentID, MultiAgentEpisode],
+                PolicyID]]): An optional (updated) policy mapping function to
+                use from here on. Note that already ongoing episodes will not
+                change their mapping but will use the old mapping till the
+                end of the episode.
+            policies_to_train (Optional[List[PolicyID]]): An optional list of
+                policy IDs to be trained. If None, will keep the existing list
+                in place. Policies, whose IDs are not in the list will not be
+                updated.
 
         Returns:
-            The newly added policy.
+            Policy: The newly added policy (the copy that got added to the
+                local worker).
         """
         if policy_id in self.policy_map:
             raise ValueError(f"Policy ID '{policy_id}' already in policy map!")
@@ -1139,19 +1135,20 @@ class RolloutWorker(ParallelIteratorWorker):
             policy_id: PolicyID = DEFAULT_POLICY_ID,
             policy_mapping_fn: Optional[Callable[[AgentID], PolicyID]] = None,
             policies_to_train: Optional[List[PolicyID]] = None,
-    ) -> None:
+    ):
         """Removes a policy from this RolloutWorker.
 
         Args:
-            policy_id: ID of the policy to be removed. None for
-                DEFAULT_POLICY_ID.
-            policy_mapping_fn: An optional (updated) policy mapping function
-                to use from here on. Note that already ongoing episodes will
-                not change their mapping but will use the old mapping till
-                the end of the episode.
-            policies_to_train: An optional list of policy IDs to be trained.
-                If None, will keep the existing list in place. Policies,
-                whose IDs are not in the list will not be updated.
+            policy_id (Optional[PolicyID]): ID of the policy to be removed.
+            policy_mapping_fn (Optional[Callable[[AgentID], PolicyID]]): An
+                optional (updated) policy mapping function to use from here on.
+                Note that already ongoing episodes will not change their
+                mapping but will use the old mapping till the end of the
+                episode.
+            policies_to_train (Optional[List[PolicyID]]): An optional list of
+                policy IDs to be trained. If None, will keep the existing list
+                in place. Policies, whose IDs are not in the list will not be
+                updated.
         """
         if policy_id not in self.policy_map:
             raise ValueError(f"Policy ID '{policy_id}' not in policy map!")
@@ -1163,14 +1160,15 @@ class RolloutWorker(ParallelIteratorWorker):
     @DeveloperAPI
     def set_policy_mapping_fn(
             self,
-            policy_mapping_fn: Optional[Callable[[AgentID, "Episode"],
-                                                 PolicyID]] = None,
-    ) -> None:
+            policy_mapping_fn: Optional[Callable[
+                [AgentID, "MultiAgentEpisode"], PolicyID]] = None,
+    ):
         """Sets `self.policy_mapping_fn` to a new callable (if provided).
 
         Args:
-            policy_mapping_fn: The new mapping function to use. If None,
-                will keep the existing mapping function in place.
+            policy_mapping_fn (Optional[Callable[[AgentID], PolicyID]]): The
+                new mapping function to use. If None, will keep the existing
+                mapping function in place.
         """
         if policy_mapping_fn is not None:
             self.policy_mapping_fn = policy_mapping_fn
@@ -1179,78 +1177,50 @@ class RolloutWorker(ParallelIteratorWorker):
 
     @DeveloperAPI
     def set_policies_to_train(
-            self, policies_to_train: Optional[List[PolicyID]] = None) -> None:
+            self, policies_to_train: Optional[List[PolicyID]] = None):
         """Sets `self.policies_to_train` to a new list of PolicyIDs.
 
         Args:
-            policies_to_train: The new list of policy IDs to train with.
-                If None, will keep the existing list in place.
+            policies_to_train (Optional[List[PolicyID]]): The new
+                list of policy IDs to train with. If None, will keep the
+                existing list in place.
         """
         if policies_to_train is not None:
             self.policies_to_train = policies_to_train
 
     @DeveloperAPI
     def for_policy(self,
-                   func: Callable[[Policy, Optional[Any]], T],
+                   func: Callable[[Policy], T],
                    policy_id: Optional[PolicyID] = DEFAULT_POLICY_ID,
                    **kwargs) -> T:
-        """Calls the given function with the specified policy as first arg.
-
-        Args:
-            func: The function to call with the policy as first arg.
-            policy_id: The PolicyID of the policy to call the function with.
-
-        Keyword Args:
-            kwargs: Additional kwargs to be passed to the call.
-
-        Returns:
-            The return value of the function call.
-        """
+        """Apply the given function to the specified policy."""
 
         return func(self.policy_map[policy_id], **kwargs)
 
     @DeveloperAPI
-    def foreach_policy(self,
-                       func: Callable[[Policy, PolicyID, Optional[Any]], T],
+    def foreach_policy(self, func: Callable[[Policy, PolicyID], T],
                        **kwargs) -> List[T]:
-        """Calls the given function with each (policy, policy_id) tuple.
+        """Apply the given function to each (policy, policy_id) tuple."""
 
-        Args:
-            func: The function to call with each (policy, policy ID) tuple.
-
-        Keyword Args:
-            kwargs: Additional kwargs to be passed to the call.
-
-        Returns:
-             The list of return values of all calls to
-                `func([policy, pid, **kwargs])`.
-        """
         return [
             func(policy, pid, **kwargs)
             for pid, policy in self.policy_map.items()
         ]
 
     @DeveloperAPI
-    def foreach_trainable_policy(
-            self, func: Callable[[Policy, PolicyID, Optional[Any]], T],
-            **kwargs) -> List[T]:
+    def foreach_trainable_policy(self, func: Callable[[Policy, PolicyID], T],
+                                 **kwargs) -> List[T]:
         """
-        Calls the given function with each (policy, policy_id) tuple.
-
-
-        Only those policies/IDs will be called on, which can be found in
-        `self.policies_to_train`.
+        Applies the given function to each (policy, policy_id) tuple, which
+        can be found in `self.policies_to_train`.
 
         Args:
-            func: The function to call with each (policy, policy ID) tuple,
-                for only those policies that are in `self.policies_to_train`.
-
-        Keyword Args:
-            kwargs: Additional kwargs to be passed to the call.
+            func (callable): A function - taking a Policy and its ID - that is
+                called on all Policies within `self.policies_to_train`.
 
         Returns:
-            The list of return values of all calls to
-            `func([policy, pid, **kwargs])`.
+            List[any]: The list of n return values of all
+                `func([policy], [ID])`-calls.
         """
         return [
             func(policy, pid, **kwargs)
@@ -1263,21 +1233,21 @@ class RolloutWorker(ParallelIteratorWorker):
         """Changes self's filter to given and rebases any accumulated delta.
 
         Args:
-            new_filters: Filters with new state to update local copy.
+            new_filters (dict): Filters with new state to update local copy.
         """
         assert all(k in new_filters for k in self.filters)
         for k in self.filters:
             self.filters[k].sync(new_filters[k])
 
     @DeveloperAPI
-    def get_filters(self, flush_after: bool = False) -> Dict:
+    def get_filters(self, flush_after: bool = False) -> dict:
         """Returns a snapshot of filters.
 
         Args:
-            flush_after: Clears the filter buffer state.
+            flush_after (bool): Clears the filter buffer state.
 
         Returns:
-            Dict for serializable filters
+            return_filters (dict): Dict for serializable filters
         """
         return_filters = {}
         for k, f in self.filters.items():
@@ -1288,12 +1258,6 @@ class RolloutWorker(ParallelIteratorWorker):
 
     @DeveloperAPI
     def save(self) -> bytes:
-        """Serializes this RolloutWorker's current state and returns it.
-
-        Returns:
-            The current state of this RolloutWorker as a serialized, pickled
-            byte sequence.
-        """
         filters = self.get_filters(flush_after=True)
         state = {}
         policy_specs = {}
@@ -1308,16 +1272,6 @@ class RolloutWorker(ParallelIteratorWorker):
 
     @DeveloperAPI
     def restore(self, objs: bytes) -> None:
-        """Restores this RolloutWorker's state from a sequence of bytes.
-
-        Args:
-            objs: The byte sequence to restore this worker's state from.
-
-        Examples:
-            >>> state = worker.save()
-            >>> new_worker = RolloutWorker(...)
-            >>> new_worker.restore(state)
-        """
         objs = pickle.loads(objs)
         self.sync_filters(objs["filters"])
         for pid, state in objs["state"].items():
@@ -1341,109 +1295,99 @@ class RolloutWorker(ParallelIteratorWorker):
                 self.policy_map[pid].set_state(state)
 
     @DeveloperAPI
-    def get_weights(
-            self,
-            policies: Optional[List[PolicyID]] = None,
-    ) -> Dict[PolicyID, ModelWeights]:
-        """Returns each policies' model weights of this worker.
-
-        Args:
-            policies: List of PolicyIDs to get the weights from.
-                Use None for all policies.
-
-        Returns:
-            Dict mapping PolicyIDs to ModelWeights.
-
-        Examples:
-            >>> weights = worker.get_weights()
-            >>> print(weights)
-            {"default_policy": {"layer1": array(...), "layer2": ...}}
-        """
-        if policies is None:
-            policies = list(self.policy_map.keys())
-        policies = force_list(policies)
-
-        return {
-            pid: policy.get_weights()
-            for pid, policy in self.policy_map.items() if pid in policies
-        }
-
-    @DeveloperAPI
-    def set_weights(self,
-                    weights: Dict[PolicyID, ModelWeights],
-                    global_vars: Optional[Dict] = None) -> None:
-        """Sets each policies' model weights of this worker.
-
-        Args:
-            weights: Dict mapping PolicyIDs to the new weights to be used.
-            global_vars: An optional global vars dict to set this
-                worker to. If None, do not update the global_vars.
-
-        Examples:
-            >>> weights = worker.get_weights()
-            >>> # Set `global_vars` (timestep) as well.
-            >>> worker.set_weights(weights, {"timestep": 42})
-        """
-        for pid, w in weights.items():
-            self.policy_map[pid].set_weights(w)
-        if global_vars:
-            self.set_global_vars(global_vars)
-
-    @DeveloperAPI
-    def get_global_vars(self) -> dict:
-        """Returns the current global_vars dict of this worker.
-
-        Returns:
-            The current global_vars dict of this worker.
-
-        Examples:
-            >>> global_vars = worker.get_global_vars()
-            >>> print(global_vars)
-            {"timestep": 424242}
-        """
-        return self.global_vars
-
-    @DeveloperAPI
     def set_global_vars(self, global_vars: dict) -> None:
-        """Updates this worker's and all its policies' global vars.
-
-        Args:
-            global_vars: The new global_vars dict.
-
-        Examples:
-            >>> global_vars = worker.set_global_vars({"timestep": 4242})
-        """
         self.foreach_policy(lambda p, _: p.on_global_var_update(global_vars))
         self.global_vars = global_vars
 
     @DeveloperAPI
-    def stop(self) -> None:
-        """Releases all resources used by this RolloutWorker."""
-
-        # If we have an env -> Release its resources.
-        if self.env is not None:
-            self.async_env.stop()
-        # Close all policies' sessions (if tf static graph).
-        for policy in self.policy_map.values():
-            sess = policy.get_session()
-            # Closes the tf session, if any.
-            if sess is not None:
-                sess.close()
+    def get_global_vars(self) -> dict:
+        return self.global_vars
 
     @DeveloperAPI
-    def apply(self, func: Callable[["RolloutWorker", Optional[Any]], T],
-              *args) -> T:
-        """Calls the given function with this rollout worker instance.
+    def export_policy_model(self,
+                            export_dir: str,
+                            policy_id: PolicyID = DEFAULT_POLICY_ID,
+                            onnx: Optional[int] = None):
+        self.policy_map[policy_id].export_model(export_dir, onnx=onnx)
 
-        Args:
-            func: The function to call with this RolloutWorker as first
-                argument.
-            args: Optional additional args to pass to the function call.
+    @DeveloperAPI
+    def import_policy_model_from_h5(self,
+                                    import_file: str,
+                                    policy_id: PolicyID = DEFAULT_POLICY_ID):
+        self.policy_map[policy_id].import_model_from_h5(import_file)
 
-        Returns:
-            The return value of the function call.
-        """
+    @DeveloperAPI
+    def export_policy_checkpoint(self,
+                                 export_dir: str,
+                                 filename_prefix: str = "model",
+                                 policy_id: PolicyID = DEFAULT_POLICY_ID):
+        self.policy_map[policy_id].export_checkpoint(export_dir,
+                                                     filename_prefix)
+
+    @DeveloperAPI
+    def stop(self) -> None:
+        if self.env is not None:
+            self.async_env.stop()
+
+    @DeveloperAPI
+    def creation_args(self) -> dict:
+        """Returns the args used to create this worker."""
+        return self._original_kwargs
+
+    @DeveloperAPI
+    def get_host(self) -> str:
+        """Returns the hostname of the process running this evaluator."""
+
+        return platform.node()
+
+    @DeveloperAPI
+    def apply(self, func: Callable[["RolloutWorker"], T], *args) -> T:
+        """Apply the given function to this rollout worker instance."""
+
         return func(self, *args)
+
+    def _build_policy_map(
+            self,
+            policy_dict: MultiAgentPolicyConfigDict,
+            policy_config: PartialTrainerConfigDict,
+            session_creator: Optional[Callable[[], "tf1.Session"]] = None,
+            seed: Optional[int] = None,
+    ) -> Tuple[Dict[PolicyID, Policy], Dict[PolicyID, Preprocessor]]:
+
+        ma_config = policy_config.get("multiagent", {})
+
+        self.policy_map = self.policy_map or PolicyMap(
+            worker_index=self.worker_index,
+            num_workers=self.num_workers,
+            capacity=ma_config.get("policy_map_capacity"),
+            path=ma_config.get("policy_map_cache"),
+            policy_config=policy_config,
+            session_creator=session_creator,
+            seed=seed,
+        )
+        self.preprocessors = self.preprocessors or {}
+
+        for name, (orig_cls, obs_space, act_space,
+                   conf) in sorted(policy_dict.items()):
+            logger.debug("Creating policy for {}".format(name))
+            merged_conf = merge_dicts(policy_config, conf or {})
+            merged_conf["num_workers"] = self.num_workers
+            merged_conf["worker_index"] = self.worker_index
+            if self.preprocessing_enabled:
+                preprocessor = ModelCatalog.get_preprocessor_for_space(
+                    obs_space, merged_conf.get("model"))
+                self.preprocessors[name] = preprocessor
+                if preprocessor is not None:
+                    obs_space = preprocessor.observation_space
+            else:
+                self.preprocessors[name] = None
+
+            self.policy_map.create_policy(name, orig_cls, obs_space, act_space,
+                                          conf, merged_conf)
+
+        if self.worker_index == 0:
+            logger.info(f"Built policy map: {self.policy_map}")
+            logger.info(f"Built preprocessor map: {self.preprocessors}")
 
     def setup_torch_data_parallel(self, url: str, world_rank: int,
                                   world_size: int, backend: str) -> None:
@@ -1464,123 +1408,18 @@ class RolloutWorker(ParallelIteratorWorker):
                     "This policy does not support torch distributed", policy)
             policy.distributed_world_size = world_size
 
-    @DeveloperAPI
-    def creation_args(self) -> dict:
-        """Returns the kwargs dict used to create this worker."""
-        return self._original_kwargs
-
-    @DeveloperAPI
-    def get_host(self) -> str:
-        """Returns the hostname of the process running this evaluator."""
-        return platform.node()
-
-    @DeveloperAPI
     def get_node_ip(self) -> str:
-        """Returns the IP address of the node that this worker runs on."""
+        """Returns the IP address of the current node."""
         return ray.util.get_node_ip_address()
 
-    @DeveloperAPI
     def find_free_port(self) -> int:
-        """Finds a free port on the node that this worker runs on."""
+        """Finds a free port on the current node."""
         from ray.util.sgd import utils
         return utils.find_free_port()
 
     def __del__(self):
-        """If this worker is deleted, clears all resources used by it."""
-
-        # In case we have-an AsyncSampler, kill its sampling thread.
         if hasattr(self, "sampler") and isinstance(self.sampler, AsyncSampler):
             self.sampler.shutdown = True
-
-    def _build_policy_map(
-            self,
-            policy_dict: MultiAgentPolicyConfigDict,
-            policy_config: PartialTrainerConfigDict,
-            session_creator: Optional[Callable[[], "tf1.Session"]] = None,
-            seed: Optional[int] = None,
-    ) -> None:
-        """Adds the given policy_dict to `self.policy_map`.
-
-        Args:
-            policy_dict: The MultiAgentPolicyConfigDict to be added to this
-                worker's PolicyMap.
-            policy_config: The general policy config to use. May be updated
-                by individual policy condig overrides in the given
-                multi-agent `policy_dict`.
-            session_creator: A callable that creates a tf session
-                (if applicable).
-            seed: An optional random seed to pass to PolicyMap's
-                constructor.
-        """
-        ma_config = policy_config.get("multiagent", {})
-
-        # If our policy_map does not exist yet, create it here.
-        self.policy_map = self.policy_map or PolicyMap(
-            worker_index=self.worker_index,
-            num_workers=self.num_workers,
-            capacity=ma_config.get("policy_map_capacity"),
-            path=ma_config.get("policy_map_cache"),
-            policy_config=policy_config,
-            session_creator=session_creator,
-            seed=seed,
-        )
-        # If our preprocessors dict does not exist yet, create it here.
-        self.preprocessors = self.preprocessors or {}
-
-        # Loop through given policy-dict and add each entry to our map.
-        for name, (orig_cls, obs_space, act_space,
-                   conf) in sorted(policy_dict.items()):
-            logger.debug("Creating policy for {}".format(name))
-            # Update the general policy_config with the specific config
-            # for this particular policy.
-            merged_conf = merge_dicts(policy_config, conf or {})
-            # Update num_workers and worker_index.
-            merged_conf["num_workers"] = self.num_workers
-            merged_conf["worker_index"] = self.worker_index
-            # Preprocessors.
-            if self.preprocessing_enabled:
-                preprocessor = ModelCatalog.get_preprocessor_for_space(
-                    obs_space, merged_conf.get("model"))
-                self.preprocessors[name] = preprocessor
-                if preprocessor is not None:
-                    obs_space = preprocessor.observation_space
-            else:
-                self.preprocessors[name] = None
-            # Create the actual policy object.
-            self.policy_map.create_policy(name, orig_cls, obs_space, act_space,
-                                          conf, merged_conf)
-
-        if self.worker_index == 0:
-            logger.info(f"Built policy map: {self.policy_map}")
-            logger.info(f"Built preprocessor map: {self.preprocessors}")
-
-    @Deprecated(
-        new="Trainer.get_policy().export_model([export_dir], [onnx]?)",
-        error=False)
-    def export_policy_model(self,
-                            export_dir: str,
-                            policy_id: PolicyID = DEFAULT_POLICY_ID,
-                            onnx: Optional[int] = None):
-        self.policy_map[policy_id].export_model(export_dir, onnx=onnx)
-
-    @Deprecated(
-        new="Trainer.get_policy().import_model_from_h5([import_file])",
-        error=False)
-    def import_policy_model_from_h5(self,
-                                    import_file: str,
-                                    policy_id: PolicyID = DEFAULT_POLICY_ID):
-        self.policy_map[policy_id].import_model_from_h5(import_file)
-
-    @Deprecated(
-        new="Trainer.get_policy().export_checkpoint([export_dir], "
-        "[filename]?)",
-        error=False)
-    def export_policy_checkpoint(self,
-                                 export_dir: str,
-                                 filename_prefix: str = "model",
-                                 policy_id: PolicyID = DEFAULT_POLICY_ID):
-        self.policy_map[policy_id].export_checkpoint(export_dir,
-                                                     filename_prefix)
 
 
 def _determine_spaces_for_multi_agent_dict(

--- a/rllib/evaluation/sample_batch_builder.py
+++ b/rllib/evaluation/sample_batch_builder.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import List, Any, Dict, Optional, TYPE_CHECKING
 
 from ray.rllib.env.base_env import _DUMMY_AGENT_ID
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
 from ray.rllib.utils.annotations import Deprecated, DeveloperAPI
@@ -152,15 +152,15 @@ class MultiAgentSampleBatchBuilder:
 
         self.agent_builders[agent_id].add_values(**values)
 
-    def postprocess_batch_so_far(self,
-                                 episode: Optional[Episode] = None) -> None:
+    def postprocess_batch_so_far(
+            self, episode: Optional[MultiAgentEpisode] = None) -> None:
         """Apply policy postprocessors to any unprocessed rows.
 
         This pushes the postprocessed per-agent batches onto the per-policy
         builders, clearing per-agent state.
 
         Args:
-            episode (Optional[Episode]): The Episode object that
+            episode (Optional[MultiAgentEpisode]): The Episode object that
                 holds this MultiAgentBatchBuilder object.
         """
 
@@ -234,15 +234,15 @@ class MultiAgentSampleBatchBuilder:
                     "Alternatively, set no_done_at_end=True to allow this.")
 
     @DeveloperAPI
-    def build_and_reset(self,
-                        episode: Optional[Episode] = None) -> MultiAgentBatch:
+    def build_and_reset(self, episode: Optional[MultiAgentEpisode] = None
+                        ) -> MultiAgentBatch:
         """Returns the accumulated sample batches for each policy.
 
         Any unprocessed rows will be first postprocessed with a policy
         postprocessor. The internal state of this builder will be reset.
 
         Args:
-            episode (Optional[Episode]): The Episode object that
+            episode (Optional[MultiAgentEpisode]): The Episode object that
                 holds this MultiAgentBatchBuilder object or None.
 
         Returns:

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -14,8 +14,8 @@ from ray.rllib.evaluation.collectors.sample_collector import \
     SampleCollector
 from ray.rllib.evaluation.collectors.simple_list_collector import \
     SimpleListCollector
-from ray.rllib.evaluation.episode import Episode
-from ray.rllib.evaluation.metrics import RolloutMetrics
+from ray.rllib.evaluation.episode import MultiAgentEpisode
+from ray.rllib.evaluation.rollout_metrics import RolloutMetrics
 from ray.rllib.evaluation.sample_batch_builder import \
     MultiAgentSampleBatchBuilder
 from ray.rllib.env.base_env import BaseEnv, ASYNC_RESET_RETURN
@@ -110,45 +110,16 @@ class SamplerInput(InputReader, metaclass=ABCMeta):
     @abstractmethod
     @DeveloperAPI
     def get_data(self) -> SampleBatchType:
-        """Called by `self.next()` to return the next batch of data.
-
-        Override this in child classes.
-
-        Returns:
-            The next batch of data.
-        """
         raise NotImplementedError
 
     @abstractmethod
     @DeveloperAPI
     def get_metrics(self) -> List[RolloutMetrics]:
-        """Returns list of episode metrics since the last call to this method.
-
-        The list will contain one RolloutMetrics object per completed episode.
-
-        Returns:
-            List of RolloutMetrics objects, one per completed episode since
-            the last call to this method.
-        """
         raise NotImplementedError
 
     @abstractmethod
     @DeveloperAPI
     def get_extra_batches(self) -> List[SampleBatchType]:
-        """Returns list of extra batches since the last call to this method.
-
-        The list will contain all SampleBatches or
-        MultiAgentBatches that the user has provided thus-far. Users can
-        add these "extra batches" to an episode by calling the episode's
-        `add_extra_batch([SampleBatchType])` method. This can be done from
-        inside an overridden `Policy.compute_actions_from_input_dict(...,
-        episodes)` or from a custom callback's `on_episode_[start|step|end]()`
-        methods.
-
-        Returns:
-            List of SamplesBatches or MultiAgentBatches provided thus-far by
-            the user since the last call to this method.
-        """
         raise NotImplementedError
 
 
@@ -172,7 +143,7 @@ class SyncSampler(SamplerInput):
             clip_actions: bool = False,
             soft_horizon: bool = False,
             no_done_at_end: bool = False,
-            observation_fn: Optional["ObservationFunction"] = None,
+            observation_fn: "ObservationFunction" = None,
             sample_collector_class: Optional[Type[SampleCollector]] = None,
             render: bool = False,
             # Obsolete.
@@ -182,44 +153,41 @@ class SyncSampler(SamplerInput):
             obs_filters=None,
             tf_sess=None,
     ):
-        """Initializes a SyncSampler instance.
+        """Initializes a SyncSampler object.
 
         Args:
-            worker: The RolloutWorker that will use this Sampler for sampling.
-            env: Any Env object. Will be converted into an RLlib BaseEnv.
-            clip_rewards: True for +/-1.0 clipping,
+            worker (RolloutWorker): The RolloutWorker that will use this
+                Sampler for sampling.
+            env (Env): Any Env object. Will be converted into an RLlib BaseEnv.
+            clip_rewards (Union[bool, float]): True for +/-1.0 clipping,
                 actual float value for +/- value clipping. False for no
                 clipping.
-            rollout_fragment_length: The length of a fragment to collect
+            rollout_fragment_length (int): The length of a fragment to collect
                 before building a SampleBatch from the data and resetting
                 the SampleBatchBuilder object.
-            count_steps_by: One of "env_steps" (default) or "agent_steps".
-                Use "agent_steps", if you want rollout lengths to be counted
-                by individual agent steps. In a multi-agent env,
-                a single env_step contains one or more agent_steps, depending
-                on how many agents are present at any given time in the
-                ongoing episode.
-            callbacks: The Callbacks object to use when episode
+            callbacks (Callbacks): The Callbacks object to use when episode
                 events happen during rollout.
-            horizon: Hard-reset the Env after this many timesteps.
-            multiple_episodes_in_batch: Whether to pack multiple
+            horizon (Optional[int]): Hard-reset the Env
+            multiple_episodes_in_batch (bool): Whether to pack multiple
                 episodes into each batch. This guarantees batches will be
                 exactly `rollout_fragment_length` in size.
-            normalize_actions: Whether to normalize actions to the
+            normalize_actions (bool): Whether to normalize actions to the
                 action space's bounds.
-            clip_actions: Whether to clip actions according to the
+            clip_actions (bool): Whether to clip actions according to the
                 given action_space's bounds.
-            soft_horizon: If True, calculate bootstrapped values as if
+            soft_horizon (bool): If True, calculate bootstrapped values as if
                 episode had ended, but don't physically reset the environment
                 when the horizon is hit.
-            no_done_at_end: Ignore the done=True at the end of the
+            no_done_at_end (bool): Ignore the done=True at the end of the
                 episode and instead record done=False.
-            observation_fn: Optional multi-agent observation func to use for
-                preprocessing observations.
-            sample_collector_class: An optional Samplecollector sub-class to
-                use to collect, store, and retrieve environment-, model-,
-                and sampler data.
-            render: Whether to try to render the environment after each step.
+            observation_fn (Optional[ObservationFunction]): Optional
+                multi-agent observation func to use for preprocessing
+                observations.
+            sample_collector_class (Optional[Type[SampleCollector]]): An
+                optional Samplecollector sub-class to use to collect, store,
+                and retrieve environment-, model-, and sampler data.
+            render (bool): Whether to try to render the environment after each
+                step.
         """
         # All of the following arguments are deprecated. They will instead be
         # provided via the passed in `worker` arg, e.g. `worker.policy_map`.
@@ -294,9 +262,8 @@ class SyncSampler(SamplerInput):
 class AsyncSampler(threading.Thread, SamplerInput):
     """Async SamplerInput that collects experiences in thread and queues them.
 
-    Once started, experiences are continuously collected in the background
-    and put into a Queue, from where they can be unqueued by the caller
-    of `get_data()`.
+    Once started, experiences are continuously collected and put into a Queue,
+    from where they can be unqueued by the caller of `get_data()`.
     """
 
     def __init__(
@@ -312,12 +279,12 @@ class AsyncSampler(threading.Thread, SamplerInput):
             multiple_episodes_in_batch: bool = False,
             normalize_actions: bool = True,
             clip_actions: bool = False,
+            blackhole_outputs: bool = False,
             soft_horizon: bool = False,
             no_done_at_end: bool = False,
             observation_fn: Optional["ObservationFunction"] = None,
             sample_collector_class: Optional[Type[SampleCollector]] = None,
             render: bool = False,
-            blackhole_outputs: bool = False,
             # Obsolete.
             policies=None,
             policy_mapping_fn=None,
@@ -325,44 +292,45 @@ class AsyncSampler(threading.Thread, SamplerInput):
             obs_filters=None,
             tf_sess=None,
     ):
-        """Initializes an AsyncSampler instance.
+        """Initializes a AsyncSampler object.
 
         Args:
-            worker: The RolloutWorker that will use this Sampler for sampling.
-            env: Any Env object. Will be converted into an RLlib BaseEnv.
-            clip_rewards: True for +/-1.0 clipping,
+            worker (RolloutWorker): The RolloutWorker that will use this
+                Sampler for sampling.
+            env (Env): Any Env object. Will be converted into an RLlib BaseEnv.
+            clip_rewards (Union[bool, float]): True for +/-1.0 clipping,
                 actual float value for +/- value clipping. False for no
                 clipping.
-            rollout_fragment_length: The length of a fragment to collect
+            rollout_fragment_length (int): The length of a fragment to collect
                 before building a SampleBatch from the data and resetting
                 the SampleBatchBuilder object.
-            count_steps_by: One of "env_steps" (default) or "agent_steps".
-                Use "agent_steps", if you want rollout lengths to be counted
-                by individual agent steps. In a multi-agent env,
-                a single env_step contains one or more agent_steps, depending
-                on how many agents are present at any given time in the
-                ongoing episode.
+            count_steps_by (str): Either "env_steps" or "agent_steps".
+                Refers to the unit of `rollout_fragment_length`.
+            callbacks (Callbacks): The Callbacks object to use when episode
+                events happen during rollout.
             horizon: Hard-reset the Env after this many timesteps.
-            multiple_episodes_in_batch: Whether to pack multiple
+            multiple_episodes_in_batch (bool): Whether to pack multiple
                 episodes into each batch. This guarantees batches will be
                 exactly `rollout_fragment_length` in size.
-            normalize_actions: Whether to normalize actions to the
+            normalize_actions (bool): Whether to normalize actions to the
                 action space's bounds.
-            clip_actions: Whether to clip actions according to the
+            clip_actions (bool): Whether to clip actions according to the
                 given action_space's bounds.
-            blackhole_outputs: Whether to collect samples, but then
+            blackhole_outputs (bool): Whether to collect samples, but then
                 not further process or store them (throw away all samples).
-            soft_horizon: If True, calculate bootstrapped values as if
+            soft_horizon (bool): If True, calculate bootstrapped values as if
                 episode had ended, but don't physically reset the environment
                 when the horizon is hit.
-            no_done_at_end: Ignore the done=True at the end of the
+            no_done_at_end (bool): Ignore the done=True at the end of the
                 episode and instead record done=False.
-            observation_fn: Optional multi-agent observation func to use for
-                preprocessing observations.
-            sample_collector_class: An optional SampleCollector sub-class to
-                use to collect, store, and retrieve environment-, model-,
-                and sampler data.
-            render: Whether to try to render the environment after each step.
+            observation_fn (Optional[ObservationFunction]): Optional
+                multi-agent observation func to use for preprocessing
+                observations.
+            sample_collector_class (Optional[Type[SampleCollector]]): An
+                optional Samplecollector sub-class to use to collect, store,
+                and retrieve environment-, model-, and sampler data.
+            render (bool): Whether to try to render the environment after each
+                step.
         """
         # All of the following arguments are deprecated. They will instead be
         # provided via the passed in `worker` arg, e.g. `worker.policy_map`.
@@ -499,32 +467,32 @@ def _env_runner(
     """This implements the common experience collection logic.
 
     Args:
-        worker: Reference to the current rollout worker.
-        base_env: Env implementing BaseEnv.
-        extra_batch_callback: function to send extra batch data to.
+        worker (RolloutWorker): Reference to the current rollout worker.
+        base_env (BaseEnv): Env implementing BaseEnv.
+        extra_batch_callback (fn): function to send extra batch data to.
         horizon: Horizon of the episode.
-        multiple_episodes_in_batch: Whether to pack multiple
+        multiple_episodes_in_batch (bool): Whether to pack multiple
             episodes into each batch. This guarantees batches will be exactly
             `rollout_fragment_length` in size.
-        normalize_actions: Whether to normalize actions to the action
+        normalize_actions (bool): Whether to normalize actions to the action
             space's bounds.
-        clip_actions: Whether to clip actions to the space range.
-        callbacks: User callbacks to run on episode events.
-        perf_stats: Record perf stats into this object.
-        soft_horizon: Calculate rewards but don't reset the
+        clip_actions (bool): Whether to clip actions to the space range.
+        callbacks (DefaultCallbacks): User callbacks to run on episode events.
+        perf_stats (_PerfStats): Record perf stats into this object.
+        soft_horizon (bool): Calculate rewards but don't reset the
             environment when the horizon is hit.
-        no_done_at_end: Ignore the done=True at the end of the episode
+        no_done_at_end (bool): Ignore the done=True at the end of the episode
             and instead record done=False.
-        observation_fn: Optional multi-agent
+        observation_fn (ObservationFunction): Optional multi-agent
             observation func to use for preprocessing observations.
-        sample_collector: An optional
+        sample_collector (Optional[SampleCollector]): An optional
             SampleCollector object to use.
-        render: Whether to try to render the environment after each
+        render (bool): Whether to try to render the environment after each
             step.
 
     Yields:
-        Object containing state, action, reward, terminal condition,
-        and other fields as dictated by `policy`.
+        rollout (SampleBatch): Object containing state, action, reward,
+            terminal condition, and other fields as dictated by `policy`.
     """
 
     # May be populated with used for image rendering
@@ -578,7 +546,7 @@ def _env_runner(
             return None
 
     def new_episode(env_id):
-        episode = Episode(
+        episode = MultiAgentEpisode(
             worker.policy_map,
             worker.policy_mapping_fn,
             get_batch_builder,
@@ -608,7 +576,7 @@ def _env_runner(
         )
         return episode
 
-    active_episodes: Dict[EnvID, Episode] = \
+    active_episodes: Dict[EnvID, MultiAgentEpisode] = \
         NewEpisodeDefaultDict(new_episode)
 
     while True:
@@ -716,7 +684,7 @@ def _process_observations(
         *,
         worker: "RolloutWorker",
         base_env: BaseEnv,
-        active_episodes: Dict[EnvID, Episode],
+        active_episodes: Dict[EnvID, MultiAgentEpisode],
         unfiltered_obs: Dict[EnvID, Dict[AgentID, EnvObsType]],
         rewards: Dict[EnvID, Dict[AgentID, float]],
         dones: Dict[EnvID, Dict[AgentID, bool]],
@@ -733,37 +701,38 @@ def _process_observations(
     """Record new data from the environment and prepare for policy evaluation.
 
     Args:
-        worker: Reference to the current rollout worker.
-        base_env: Env implementing BaseEnv.
-        active_episodes: Mapping from
-            episode ID to currently ongoing Episode object.
-        unfiltered_obs: Doubly keyed dict of env-ids -> agent ids
+        worker (RolloutWorker): Reference to the current rollout worker.
+        base_env (BaseEnv): Env implementing BaseEnv.
+        active_episodes (Dict[EnvID, MultiAgentEpisode]): Mapping from
+            episode ID to currently ongoing MultiAgentEpisode object.
+        unfiltered_obs (dict): Doubly keyed dict of env-ids -> agent ids
             -> unfiltered observation tensor, returned by a `BaseEnv.poll()`
             call.
-        rewards: Doubly keyed dict of env-ids -> agent ids ->
+        rewards (dict): Doubly keyed dict of env-ids -> agent ids ->
             rewards tensor, returned by a `BaseEnv.poll()` call.
-        dones: Doubly keyed dict of env-ids -> agent ids ->
+        dones (dict): Doubly keyed dict of env-ids -> agent ids ->
             boolean done flags, returned by a `BaseEnv.poll()` call.
-        infos: Doubly keyed dict of env-ids -> agent ids ->
+        infos (dict): Doubly keyed dict of env-ids -> agent ids ->
             info dicts, returned by a `BaseEnv.poll()` call.
-        horizon: Horizon of the episode.
-        multiple_episodes_in_batch: Whether to pack multiple
+        horizon (int): Horizon of the episode.
+        multiple_episodes_in_batch (bool): Whether to pack multiple
             episodes into each batch. This guarantees batches will be exactly
             `rollout_fragment_length` in size.
-        callbacks: User callbacks to run on episode events.
-        soft_horizon: Calculate rewards but don't reset the
+        callbacks (DefaultCallbacks): User callbacks to run on episode events.
+        soft_horizon (bool): Calculate rewards but don't reset the
             environment when the horizon is hit.
-        no_done_at_end: Ignore the done=True at the end of the episode
+        no_done_at_end (bool): Ignore the done=True at the end of the episode
             and instead record done=False.
-        observation_fn: Optional multi-agent
+        observation_fn (ObservationFunction): Optional multi-agent
             observation func to use for preprocessing observations.
-        sample_collector: The SampleCollector object
+        sample_collector (SampleCollector): The SampleCollector object
             used to store and retrieve environment samples.
 
     Returns:
-        Tuple consisting of 1) active_envs: Set of non-terminated env ids.
-        2) to_eval: Map of policy_id to list of agent PolicyEvalData.
-        3) outputs: List of metrics and samples to return from the sampler.
+        Tuple:
+            - active_envs: Set of non-terminated env ids.
+            - to_eval: Map of policy_id to list of agent PolicyEvalData.
+            - outputs: List of metrics and samples to return from the sampler.
     """
 
     # Output objects.
@@ -775,7 +744,7 @@ def _process_observations(
     # types: EnvID, Dict[AgentID, EnvObsType]
     for env_id, all_agents_obs in unfiltered_obs.items():
         is_new_episode: bool = env_id not in active_episodes
-        episode: Episode = active_episodes[env_id]
+        episode: MultiAgentEpisode = active_episodes[env_id]
 
         if not is_new_episode:
             sample_collector.episode_step(episode)
@@ -885,11 +854,9 @@ def _process_observations(
                     # Next observation.
                     SampleBatch.NEXT_OBS: filtered_obs,
                 }
-                # Add extra-action-fetches (policy-inference infos) to
-                # collectors.
+                # Add extra-action-fetches to collectors.
                 pol = worker.policy_map[policy_id]
-                for key, value in episode.last_extra_action_outs_for(
-                        agent_id).items():
+                for key, value in episode.last_pi_info_for(agent_id).items():
                     if key in pol.view_requirements:
                         values_dict[key] = value
                 # Env infos for this agent.
@@ -980,7 +947,7 @@ def _process_observations(
             # Creates a new episode if this is not async return.
             # If reset is async, we will get its result in some future poll.
             elif resetted_obs != ASYNC_RESET_RETURN:
-                new_episode: Episode = active_episodes[env_id]
+                new_episode: MultiAgentEpisode = active_episodes[env_id]
                 if observation_fn:
                     resetted_obs: Dict[AgentID, EnvObsType] = observation_fn(
                         agent_obs=resetted_obs,
@@ -1028,20 +995,21 @@ def _do_policy_eval(
         to_eval: Dict[PolicyID, List[PolicyEvalData]],
         policies: PolicyMap,
         sample_collector,
-        active_episodes: Dict[EnvID, Episode],
+        active_episodes: Dict[EnvID, MultiAgentEpisode],
 ) -> Dict[PolicyID, Tuple[TensorStructType, StateBatch, dict]]:
     """Call compute_actions on collected episode/model data to get next action.
 
     Args:
-        to_eval: Mapping of policy IDs to lists of PolicyEvalData objects
-            (items in these lists will be the batch's items for the model
-            forward pass).
-        policies: Mapping from policy ID to Policy obj.
-        sample_collector: The SampleCollector object to use.
-        active_episodes: Mapping of EnvID to its currently active episode.
+        to_eval (Dict[PolicyID, List[PolicyEvalData]]): Mapping of policy
+            IDs to lists of PolicyEvalData objects (items in these lists will
+            be the batch's items for the model forward pass).
+        policies (Dict[PolicyID, Policy]): Mapping from policy ID to Policy
+            obj.
+        sample_collector (SampleCollector): The SampleCollector object to use.
+        active_episodes (Dict[EnvID, MultiAgentEpisode]): Mapping of
 
     Returns:
-        Dict mapping PolicyIDs to compute_actions_from_input_dict() outputs.
+        eval_results: dict of policy to compute_action() outputs.
     """
 
     eval_results: Dict[PolicyID, TensorStructType] = {}
@@ -1084,7 +1052,7 @@ def _process_policy_eval_results(
         to_eval: Dict[PolicyID, List[PolicyEvalData]],
         eval_results: Dict[PolicyID, Tuple[TensorStructType, StateBatch,
                                            dict]],
-        active_episodes: Dict[EnvID, Episode],
+        active_episodes: Dict[EnvID, MultiAgentEpisode],
         active_envs: Set[int],
         off_policy_actions: MultiEnvDict,
         policies: Dict[PolicyID, Policy],
@@ -1097,22 +1065,24 @@ def _process_policy_eval_results(
     returns replies to send back to agents in the env.
 
     Args:
-        to_eval: Mapping of policy IDs to lists of PolicyEvalData objects.
-        eval_results: Mapping of policy IDs to list of
+        to_eval (Dict[PolicyID, List[PolicyEvalData]]): Mapping of policy IDs
+            to lists of PolicyEvalData objects.
+        eval_results (Dict[PolicyID, List]): Mapping of policy IDs to list of
             actions, rnn-out states, extra-action-fetches dicts.
-        active_episodes: Mapping from episode ID to currently ongoing
-            Episode object.
-        active_envs: Set of non-terminated env ids.
-        off_policy_actions: Doubly keyed dict of env-ids -> agent ids ->
+        active_episodes (Dict[EnvID, MultiAgentEpisode]): Mapping from
+            episode ID to currently ongoing MultiAgentEpisode object.
+        active_envs (Set[int]): Set of non-terminated env ids.
+        off_policy_actions (dict): Doubly keyed dict of env-ids -> agent ids ->
             off-policy-action, returned by a `BaseEnv.poll()` call.
-        policies: Mapping from policy ID to Policy.
-        normalize_actions: Whether to normalize actions to the action
+        policies (Dict[PolicyID, Policy]): Mapping from policy ID to Policy.
+        normalize_actions (bool): Whether to normalize actions to the action
             space's bounds.
-        clip_actions: Whether to clip actions to the action space's bounds.
+        clip_actions (bool): Whether to clip actions to the action space's
+            bounds.
 
     Returns:
-        Nested dict of env id -> agent id -> actions to be sent to
-        Env (np.ndarrays).
+        actions_to_send: Nested dict of env id -> agent id -> actions to be
+            sent to Env (np.ndarrays).
     """
 
     actions_to_send: Dict[EnvID, Dict[AgentID, EnvActionType]] = \
@@ -1128,7 +1098,7 @@ def _process_policy_eval_results(
         actions = convert_to_numpy(actions)
 
         rnn_out_cols: StateBatch = eval_results[policy_id][1]
-        extra_action_out_cols: dict = eval_results[policy_id][2]
+        pi_info_cols: dict = eval_results[policy_id][2]
 
         # In case actions is a list (representing the 0th dim of a batch of
         # primitive actions), try converting it first.
@@ -1137,7 +1107,7 @@ def _process_policy_eval_results(
 
         # Store RNN state ins/outs and extra-action fetches to episode.
         for f_i, column in enumerate(rnn_out_cols):
-            extra_action_out_cols["state_out_{}".format(f_i)] = column
+            pi_info_cols["state_out_{}".format(f_i)] = column
 
         policy: Policy = _get_or_raise(policies, policy_id)
         # Split action-component batches into single action rows.
@@ -1157,11 +1127,11 @@ def _process_policy_eval_results(
 
             env_id: int = eval_data[i].env_id
             agent_id: AgentID = eval_data[i].agent_id
-            episode: Episode = active_episodes[env_id]
+            episode: MultiAgentEpisode = active_episodes[env_id]
             episode._set_rnn_state(agent_id, [c[i] for c in rnn_out_cols])
-            episode._set_last_extra_action_outs(
+            episode._set_last_pi_info(
                 agent_id, {k: v[i]
-                           for k, v in extra_action_out_cols.items()})
+                           for k, v in pi_info_cols.items()})
             if env_id in off_policy_actions and \
                     agent_id in off_policy_actions[env_id]:
                 episode._set_last_action(agent_id,

--- a/rllib/evaluation/tests/test_episode.py
+++ b/rllib/evaluation/tests/test_episode.py
@@ -81,7 +81,7 @@ class EchoPolicy(Policy):
         return obs_batch.argmax(axis=1), [], {}
 
 
-class EpisodeEnv(MultiAgentEnv):
+class MultiAgentEpisodeEnv(MultiAgentEnv):
     def __init__(self, episode_length, num):
         self.agents = [MockEnv3(episode_length) for _ in range(num)]
         self.dones = set()
@@ -123,9 +123,9 @@ class TestEpisodeLastValues(unittest.TestCase):
         ev.sample()
 
     def test_multiagent_env(self):
-        temp_env = EpisodeEnv(NUM_STEPS, NUM_AGENTS)
+        temp_env = MultiAgentEpisodeEnv(NUM_STEPS, NUM_AGENTS)
         ev = RolloutWorker(
-            env_creator=lambda _: EpisodeEnv(NUM_STEPS, NUM_AGENTS),
+            env_creator=lambda _: MultiAgentEpisodeEnv(NUM_STEPS, NUM_AGENTS),
             policy_spec={
                 str(agent_id): (EchoPolicy, temp_env.observation_space,
                                 temp_env.action_space, {})

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -13,7 +13,7 @@ import ray
 from ray import tune
 from ray.rllib.agents.callbacks import DefaultCallbacks
 from ray.rllib.env import BaseEnv
-from ray.rllib.evaluation import Episode, RolloutWorker
+from ray.rllib.evaluation import MultiAgentEpisode, RolloutWorker
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 
@@ -28,8 +28,8 @@ parser.add_argument("--stop-iters", type=int, default=2000)
 
 class MyCallbacks(DefaultCallbacks):
     def on_episode_start(self, *, worker: RolloutWorker, base_env: BaseEnv,
-                         policies: Dict[str, Policy], episode: Episode,
-                         env_index: int, **kwargs):
+                         policies: Dict[str, Policy],
+                         episode: MultiAgentEpisode, env_index: int, **kwargs):
         # Make sure this episode has just been started (only initial obs
         # logged so far).
         assert episode.length == 0, \
@@ -41,8 +41,8 @@ class MyCallbacks(DefaultCallbacks):
         episode.hist_data["pole_angles"] = []
 
     def on_episode_step(self, *, worker: RolloutWorker, base_env: BaseEnv,
-                        policies: Dict[str, Policy], episode: Episode,
-                        env_index: int, **kwargs):
+                        policies: Dict[str, Policy],
+                        episode: MultiAgentEpisode, env_index: int, **kwargs):
         # Make sure this episode is ongoing.
         assert episode.length > 0, \
             "ERROR: `on_episode_step()` callback should not be called right " \
@@ -53,7 +53,7 @@ class MyCallbacks(DefaultCallbacks):
         episode.user_data["pole_angles"].append(pole_angle)
 
     def on_episode_end(self, *, worker: RolloutWorker, base_env: BaseEnv,
-                       policies: Dict[str, Policy], episode: Episode,
+                       policies: Dict[str, Policy], episode: MultiAgentEpisode,
                        env_index: int, **kwargs):
         # Make sure this episode is really done.
         assert episode.batch_builder.policy_collectors[
@@ -84,8 +84,8 @@ class MyCallbacks(DefaultCallbacks):
             policy, result["sum_actions_in_train_batch"]))
 
     def on_postprocess_trajectory(
-            self, *, worker: RolloutWorker, episode: Episode, agent_id: str,
-            policy_id: str, policies: Dict[str, Policy],
+            self, *, worker: RolloutWorker, episode: MultiAgentEpisode,
+            agent_id: str, policy_id: str, policies: Dict[str, Policy],
             postprocessed_batch: SampleBatch,
             original_batches: Dict[str, SampleBatch], **kwargs):
         print("postprocessed {} steps".format(postprocessed_batch.count))

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -23,7 +23,7 @@ tf1, tf, tfv = try_import_tf()
 torch, _ = try_import_torch()
 
 if TYPE_CHECKING:
-    from ray.rllib.evaluation import Episode
+    from ray.rllib.evaluation import MultiAgentEpisode
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ class Policy(metaclass=ABCMeta):
             prev_reward: Optional[TensorStructType] = None,
             info: dict = None,
             input_dict: Optional[SampleBatch] = None,
-            episode: Optional["Episode"] = None,
+            episode: Optional["MultiAgentEpisode"] = None,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
             # Kwars placeholder for future compatibility.
@@ -238,7 +238,7 @@ class Policy(metaclass=ABCMeta):
             input_dict: Union[SampleBatch, Dict[str, TensorStructType]],
             explore: bool = None,
             timestep: Optional[int] = None,
-            episodes: Optional[List["Episode"]] = None,
+            episodes: Optional[List["MultiAgentEpisode"]] = None,
             **kwargs) -> \
             Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
         """Computes actions from collected samples (across multiple-agents).
@@ -300,7 +300,7 @@ class Policy(metaclass=ABCMeta):
             prev_reward_batch: Union[List[TensorStructType],
                                      TensorStructType] = None,
             info_batch: Optional[Dict[str, list]] = None,
-            episodes: Optional[List["Episode"]] = None,
+            episodes: Optional[List["MultiAgentEpisode"]] = None,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
             **kwargs) -> \
@@ -313,7 +313,7 @@ class Policy(metaclass=ABCMeta):
             prev_action_batch: Batch of previous action values.
             prev_reward_batch: Batch of previous rewards.
             info_batch: Batch of info objects.
-            episodes: List of Episode objects, one for each obs in
+            episodes: List of MultiAgentEpisodes, one for each obs in
                 obs_batch. This provides access to all of the internal
                 episode state, which may be useful for model-based or
                 multi-agent algorithms.
@@ -377,7 +377,7 @@ class Policy(metaclass=ABCMeta):
             sample_batch: SampleBatch,
             other_agent_batches: Optional[Dict[AgentID, Tuple[
                 "Policy", SampleBatch]]] = None,
-            episode: Optional["Episode"] = None) -> SampleBatch:
+            episode: Optional["MultiAgentEpisode"] = None) -> SampleBatch:
         """Implements algorithm-specific trajectory postprocessing.
 
         This will be called on each trajectory fragment computed during policy

--- a/rllib/policy/policy_template.py
+++ b/rllib/policy/policy_template.py
@@ -19,7 +19,7 @@ from ray.rllib.utils.typing import ModelGradients, TensorType, \
     TrainerConfigDict
 
 if TYPE_CHECKING:
-    from ray.rllib.evaluation.episode import Episode  # noqa
+    from ray.rllib.evaluation import MultiAgentEpisode  # noqa
 
 jax, _ = try_import_jax()
 torch, _ = try_import_torch()
@@ -39,7 +39,7 @@ def build_policy_class(
             str, TensorType]]] = None,
         postprocess_fn: Optional[Callable[[
             Policy, SampleBatch, Optional[Dict[Any, SampleBatch]], Optional[
-                "Episode"]
+                "MultiAgentEpisode"]
         ], SampleBatch]] = None,
         extra_action_out_fn: Optional[Callable[[
             Policy, Dict[str, TensorType], List[TensorType], ModelV2,
@@ -98,7 +98,7 @@ def build_policy_class(
             overrides. If None, uses only(!) the user-provided
             PartialTrainerConfigDict as dict for this Policy.
         postprocess_fn (Optional[Callable[[Policy, SampleBatch,
-            Optional[Dict[Any, SampleBatch]], Optional["Episode"]],
+            Optional[Dict[Any, SampleBatch]], Optional["MultiAgentEpisode"]],
             SampleBatch]]): Optional callable for post-processing experience
             batches (called after the super's `postprocess_trajectory` method).
         stats_fn (Optional[Callable[[Policy, SampleBatch],

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -28,7 +28,7 @@ from ray.rllib.utils.typing import LocalOptimizer, ModelGradients, \
     TensorType, TrainerConfigDict
 
 if TYPE_CHECKING:
-    from ray.rllib.evaluation import Episode
+    from ray.rllib.evaluation import MultiAgentEpisode
 
 tf1, tf, tfv = try_import_tf()
 logger = logging.getLogger(__name__)
@@ -277,7 +277,7 @@ class TFPolicy(Policy):
             input_dict: Union[SampleBatch, Dict[str, TensorType]],
             explore: bool = None,
             timestep: Optional[int] = None,
-            episodes: Optional[List["Episode"]] = None,
+            episodes: Optional[List["MultiAgentEpisode"]] = None,
             **kwargs) -> \
             Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
 
@@ -308,7 +308,7 @@ class TFPolicy(Policy):
             prev_action_batch: Union[List[TensorType], TensorType] = None,
             prev_reward_batch: Union[List[TensorType], TensorType] = None,
             info_batch: Optional[Dict[str, list]] = None,
-            episodes: Optional[List["Episode"]] = None,
+            episodes: Optional[List["MultiAgentEpisode"]] = None,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
             **kwargs):

--- a/rllib/policy/tf_policy_template.py
+++ b/rllib/policy/tf_policy_template.py
@@ -18,7 +18,7 @@ from ray.rllib.utils.typing import AgentID, ModelGradients, TensorType, \
     TrainerConfigDict
 
 if TYPE_CHECKING:
-    from ray.rllib.evaluation import Episode
+    from ray.rllib.evaluation import MultiAgentEpisode
 
 tf1, tf, tfv = try_import_tf()
 
@@ -34,7 +34,7 @@ def build_tf_policy(
                                               TrainerConfigDict]] = None,
         postprocess_fn: Optional[Callable[[
             Policy, SampleBatch, Optional[Dict[AgentID, SampleBatch]],
-            Optional["Episode"]
+            Optional["MultiAgentEpisode"]
         ], SampleBatch]] = None,
         stats_fn: Optional[Callable[[Policy, SampleBatch], Dict[
             str, TensorType]]] = None,
@@ -107,7 +107,7 @@ def build_tf_policy(
             overrides. If None, uses only(!) the user-provided
             PartialTrainerConfigDict as dict for this Policy.
         postprocess_fn (Optional[Callable[[Policy, SampleBatch,
-            Optional[Dict[AgentID, SampleBatch]], Episode], None]]):
+            Optional[Dict[AgentID, SampleBatch]], MultiAgentEpisode], None]]):
             Optional callable for post-processing experience batches (called
             after the parent class' `postprocess_trajectory` method).
         stats_fn (Optional[Callable[[Policy, SampleBatch],

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -31,7 +31,7 @@ from ray.rllib.utils.typing import ModelGradients, ModelWeights, TensorType, \
     TensorStructType, TrainerConfigDict
 
 if TYPE_CHECKING:
-    from ray.rllib.evaluation import Episode  # noqa
+    from ray.rllib.evaluation import MultiAgentEpisode  # noqa
 
 torch, nn = try_import_torch()
 
@@ -279,7 +279,7 @@ class TorchPolicy(Policy):
             prev_reward_batch: Union[List[TensorStructType],
                                      TensorStructType] = None,
             info_batch: Optional[Dict[str, list]] = None,
-            episodes: Optional[List["Episode"]] = None,
+            episodes: Optional[List["MultiAgentEpisode"]] = None,
             explore: Optional[bool] = None,
             timestep: Optional[int] = None,
             **kwargs) -> \

--- a/rllib/tests/test_multi_agent_env.py
+++ b/rllib/tests/test_multi_agent_env.py
@@ -7,7 +7,7 @@ import ray
 from ray.tune.registry import register_env
 from ray.rllib.agents.dqn.dqn_tf_policy import DQNTFPolicy
 from ray.rllib.agents.pg import PGTrainer
-from ray.rllib.evaluation.episode import Episode
+from ray.rllib.evaluation.episode import MultiAgentEpisode
 from ray.rllib.evaluation.rollout_worker import get_global_worker
 from ray.rllib.examples.policy.random_policy import RandomPolicy
 from ray.rllib.examples.env.multi_agent import MultiAgentCartPole, \
@@ -336,9 +336,9 @@ class TestMultiAgentEnv(unittest.TestCase):
                     # Pretend we did a model-based rollout and want to return
                     # the extra trajectory.
                     env_id = episodes[0].env_id
-                    fake_eps = Episode(episodes[0].policy_map,
-                                       episodes[0].policy_mapping_fn,
-                                       lambda: None, lambda x: None, env_id)
+                    fake_eps = MultiAgentEpisode(
+                        episodes[0].policy_map, episodes[0].policy_mapping_fn,
+                        lambda: None, lambda x: None, env_id)
                     builder = get_global_worker().sampler.sample_collector
                     agent_id = "extra_0"
                     policy_id = "p1"  # use p1 so we can easily check it


### PR DESCRIPTION
This reverts commit 9c73871da01493950f8e885136a6f8225216a50e.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<img width="811" alt="Screen Shot 2021-10-29 at 7 07 01 AM" src="https://user-images.githubusercontent.com/18510752/139449376-ccb2d159-c758-438c-89c0-2e5ca20d7a49.png">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
