### PR TITLE
[Doc] Example docs minor wording fixes

### DIFF
--- a/doc/examples/placement-group.rst
+++ b/doc/examples/placement-group.rst
@@ -19,7 +19,7 @@ Here are possible system overheads when your tasks and actors are located in a d
 - **Object transfer cost**: When A accesses an object created by B (O), the O is not immediately available to A. Here, Ray fetches the O from NB to NA. That says, there will be a network cost to transfer the object and latency overhead to wait for the object to be fetched. The overhead linearly grows to the object size that needs to be transferred.
 - **Network cost**: When A and B communicate with each other, there is additional networking overhead since A and B are located in a different node.
 
-In some cases, this type of overhead can have a significant impact on your application's performance. For example, imagine you'd like to read 
+In some cases, this type of overhead can have a significant impact on your application's performance. For example, imagine you'd like to read a 
 large size dataset using S3 and distribute it to multiple tasks or actors. 
 
 You can minimize the overhead using the placement group's `STRICT_PACK` strategy. `STRICT_PACK` guarantees that all the tasks and actors are located in the same node.

--- a/doc/examples/plot_parameter_server.py
+++ b/doc/examples/plot_parameter_server.py
@@ -284,6 +284,6 @@ print("Final accuracy is {:.1f}.".format(accuracy))
 # parameter servers and to modify the behavior of the parameter server.
 #
 # For example, sharding the parameter server, changing the update rule,
-# switch between asynchronous and synchronous updates, ignoring
+# switching between asynchronous and synchronous updates, ignoring
 # straggler workers, or any number of other customizations,
 # will only require a few extra lines of code.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are a few minor wording fixes in the example docs for [Parameter Server](https://docs.ray.io/en/latest/auto_examples/plot_parameter_server.html) and [Placement Group](https://docs.ray.io/en/latest/auto_examples/placement-group.html) examples.

## Related issue number

None

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
- [x] I've ensured that the docs build and look good. 