### PR TITLE
[Serve] [Serve Autoscaler] fix flaky initial_num_replicas test on Windows

### DIFF
--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -170,7 +170,7 @@ def test_initial_num_replicas(mock, serve_instance):
     A.deploy()
 
     controller = serve_instance._controller
-    wait_for_condition(lambda: get_num_running_replicas(controller, A) == 2)
+    assert get_num_running_replicas(controller, A) == 2
 
 
 class MockTimer:

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -148,6 +148,7 @@ def test_e2e_basic_scale_up_down(serve_instance):
 
 
 @mock.patch.object(ServeController, "autoscale")
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_initial_num_replicas(mock, serve_instance):
     """ assert that the inital amount of replicas a deployment is launched with
     respects the bounds set by autoscaling_config.

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -170,7 +170,6 @@ def test_initial_num_replicas(mock, serve_instance):
 
     controller = serve_instance._controller
     wait_for_condition(lambda: get_num_running_replicas(controller, A) == 2)
-    
 
 
 class MockTimer:

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -169,7 +169,8 @@ def test_initial_num_replicas(mock, serve_instance):
     A.deploy()
 
     controller = serve_instance._controller
-    assert get_num_running_replicas(controller, A) == 2
+    wait_for_condition(lambda: get_num_running_replicas(controller, A) == 2)
+    
 
 
 class MockTimer:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #19889 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
