### PR TITLE
[runtime env] Always print package pushing logs regardless of size

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -15,9 +15,6 @@ from ray._private.thirdparty.pathspec import PathSpec
 
 default_logger = logging.getLogger(__name__)
 
-# If the working_dir is beyond this size, print a progress message to prevent
-# the appearance of hanging.
-SILENT_UPLOAD_SIZE_THRESHOLD = 1 * 1024 * 1024  # 1MiB
 # If an individual file is beyond this size, print a warning.
 FILE_SIZE_WARNING = 10 * 1024 * 1024  # 10MiB
 # NOTE(edoakes): we should be able to support up to 512 MiB based on the GCS'
@@ -181,12 +178,10 @@ def _store_package_in_gcs(
             f"{_mib_string(GCS_STORAGE_MAX_SIZE)}. You can exclude large "
             "files using the 'excludes' option to the runtime_env.")
 
-    if file_size > SILENT_UPLOAD_SIZE_THRESHOLD:
-        logger.info(f"Pushing file package '{pkg_uri}' ({size_str}) to "
-                    "Ray cluster...")
+    logger.info(f"Pushing file package '{pkg_uri}' ({size_str}) to "
+                "Ray cluster...")
     _internal_kv_put(pkg_uri, data)
-    if file_size > SILENT_UPLOAD_SIZE_THRESHOLD:
-        logger.info(f"Successfully pushed file package '{pkg_uri}'.")
+    logger.info(f"Successfully pushed file package '{pkg_uri}'.")
     return len(data)
 
 

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -823,7 +823,7 @@ import ray
 ray.init("{address}", runtime_env={{"py_modules": ["{tmp_dir}"]}})
 """
 
-        with open(filepath, "wb") as f:
+        with open(filepath, "w") as f:
             f.write("Hi")
 
         output = run_string_as_driver(driver_script)

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -13,8 +13,7 @@ import ray
 import ray.experimental.internal_kv as kv
 from ray._private.test_utils import wait_for_condition
 from ray._private.runtime_env import RAY_WORKER_DEV_EXCLUDES
-from ray._private.runtime_env.packaging import (GCS_STORAGE_MAX_SIZE,
-                                                SILENT_UPLOAD_SIZE_THRESHOLD)
+from ray._private.runtime_env.packaging import GCS_STORAGE_MAX_SIZE
 
 # This package contains a subdirectory called `test_module`.
 # Calling `test_module.one()` should return `2`.
@@ -824,21 +823,16 @@ import ray
 ray.init("{address}", runtime_env={{"py_modules": ["{tmp_dir}"]}})
 """
 
-        size = SILENT_UPLOAD_SIZE_THRESHOLD - 1024
         with open(filepath, "wb") as f:
-            f.write(os.urandom(size))
+            f.write("Hi")
 
-        output = run_string_as_driver(driver_script)
-        assert "Pushing file package" not in output
 
-        size = SILENT_UPLOAD_SIZE_THRESHOLD + 1
-        with open(filepath, "wb") as f:
-            f.write(os.urandom(size))
+
 
         output = run_string_as_driver(driver_script)
         assert "Pushing file package" in output
         assert "Successfully pushed file package" in output
-
+        assert "warning" not in output.lower()
 
 @pytest.mark.skipif(
     sys.platform != "darwin", reason="Package exceeds max size.")

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -826,13 +826,11 @@ ray.init("{address}", runtime_env={{"py_modules": ["{tmp_dir}"]}})
         with open(filepath, "wb") as f:
             f.write("Hi")
 
-
-
-
         output = run_string_as_driver(driver_script)
         assert "Pushing file package" in output
         assert "Successfully pushed file package" in output
         assert "warning" not in output.lower()
+
 
 @pytest.mark.skipif(
     sys.platform != "darwin", reason="Package exceeds max size.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Addresses followup comments in https://github.com/ray-project/ray/pull/18893/.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
