### PR TITLE
Revert "[core] Fail objects when pull/reconstruction hangs (#19789)"

### DIFF
--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -1,7 +1,6 @@
 import os
 import signal
 import sys
-import time
 
 import numpy as np
 import pytest
@@ -680,47 +679,6 @@ def test_nondeterministic_output(ray_start_cluster, reconstruction_enabled):
             node_to_kill = cluster.add_node(
                 num_cpus=1, resources={"node1": 1}, object_store_memory=10**8)
             ray.get(x)
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_reconstruction_hangs(ray_start_cluster):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "max_direct_call_object_size": 100,
-        "task_retry_delay_ms": 100,
-        "object_timeout_milliseconds": 200,
-        "fetch_warn_timeout_milliseconds": 1000,
-    }
-    cluster = ray_start_cluster
-    # Head node with no resources.
-    cluster.add_node(
-        num_cpus=0, _system_config=config, enable_object_reconstruction=True)
-    ray.init(address=cluster.address)
-    # Node to place the initial object.
-    node_to_kill = cluster.add_node(
-        num_cpus=1, resources={"node1": 1}, object_store_memory=10**8)
-    cluster.add_node(num_cpus=1, object_store_memory=10**8)
-    cluster.wait_for_nodes()
-
-    @ray.remote
-    def sleep():
-        # Task takes longer than the reconstruction timeout.
-        time.sleep(3)
-        return np.zeros(10**5, dtype=np.uint8)
-
-    @ray.remote
-    def dependent_task(x):
-        return
-
-    obj = sleep.options(resources={"node1": 1}).remote()
-    for _ in range(3):
-        ray.get(dependent_task.remote(obj))
-        x = dependent_task.remote(obj)
-        cluster.remove_node(node_to_kill, allow_graceful=False)
-        node_to_kill = cluster.add_node(
-            num_cpus=1, resources={"node1": 1}, object_store_memory=10**8)
-        ray.get(x)
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -263,13 +263,9 @@ void ReferenceCounter::RemoveLocalReference(const ObjectID &object_id,
 }
 
 void ReferenceCounter::UpdateSubmittedTaskReferences(
-    const std::vector<ObjectID> return_ids,
     const std::vector<ObjectID> &argument_ids_to_add,
     const std::vector<ObjectID> &argument_ids_to_remove, std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &return_id : return_ids) {
-    UpdateObjectPendingCreation(return_id, true);
-  }
   for (const ObjectID &argument_id : argument_ids_to_add) {
     RAY_LOG(DEBUG) << "Increment ref count for submitted task argument " << argument_id;
     auto it = object_id_refs_.find(argument_id);
@@ -294,11 +290,8 @@ void ReferenceCounter::UpdateSubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateResubmittedTaskReferences(
-    const std::vector<ObjectID> return_ids, const std::vector<ObjectID> &argument_ids) {
+    const std::vector<ObjectID> &argument_ids) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &return_id : return_ids) {
-    UpdateObjectPendingCreation(return_id, true);
-  }
   for (const ObjectID &argument_id : argument_ids) {
     auto it = object_id_refs_.find(argument_id);
     RAY_CHECK(it != object_id_refs_.end());
@@ -311,13 +304,10 @@ void ReferenceCounter::UpdateResubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateFinishedTaskReferences(
-    const std::vector<ObjectID> return_ids, const std::vector<ObjectID> &argument_ids,
-    bool release_lineage, const rpc::Address &worker_addr,
-    const ReferenceTableProto &borrowed_refs, std::vector<ObjectID> *deleted) {
+    const std::vector<ObjectID> &argument_ids, bool release_lineage,
+    const rpc::Address &worker_addr, const ReferenceTableProto &borrowed_refs,
+    std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &return_id : return_ids) {
-    UpdateObjectPendingCreation(return_id, false);
-  }
   // Must merge the borrower refs before decrementing any ref counts. This is
   // to make sure that for serialized IDs, we increment the borrower count for
   // the inner ID before decrementing the submitted_task_ref_count for the
@@ -1043,19 +1033,6 @@ bool ReferenceCounter::RemoveObjectLocation(const ObjectID &object_id,
   return true;
 }
 
-void ReferenceCounter::UpdateObjectPendingCreation(const ObjectID &object_id,
-                                                   bool pending_creation) {
-  auto it = object_id_refs_.find(object_id);
-  bool push = false;
-  if (it != object_id_refs_.end()) {
-    push = (it->second.pending_creation != pending_creation);
-    it->second.pending_creation = pending_creation;
-  }
-  if (push) {
-    PushToLocationSubscribers(it);
-  }
-}
-
 absl::optional<absl::flat_hash_set<NodeID>> ReferenceCounter::GetObjectLocations(
     const ObjectID &object_id) {
   absl::MutexLock lock(&mutex_);
@@ -1196,15 +1173,6 @@ bool ReferenceCounter::IsObjectReconstructable(const ObjectID &object_id) const 
   return it->second.is_reconstructable;
 }
 
-bool ReferenceCounter::IsObjectPendingCreation(const ObjectID &object_id) const {
-  absl::MutexLock lock(&mutex_);
-  auto it = object_id_refs_.find(object_id);
-  if (it == object_id_refs_.end()) {
-    return false;
-  }
-  return it->second.pending_creation;
-}
-
 void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
   const auto &object_id = it->first;
   const auto &locations = it->second.locations;
@@ -1217,8 +1185,7 @@ void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
                  << " locations, spilled url: " << spilled_url
                  << ", spilled node ID: " << spilled_node_id
                  << ", and object size: " << object_size
-                 << ", and primary node ID: " << primary_node_id << ", pending creation? "
-                 << it->second.pending_creation;
+                 << ", and primary node ID: " << primary_node_id;
   rpc::PubMessage pub_message;
   pub_message.set_key_id(object_id.Binary());
   pub_message.set_channel_type(rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL);
@@ -1254,7 +1221,6 @@ void ReferenceCounter::FillObjectInformationInternal(
   object_info->set_spilled_node_id(it->second.spilled_node_id.Binary());
   auto primary_node_id = it->second.pinned_at_raylet_id.value_or(NodeID::Nil());
   object_info->set_primary_node_id(primary_node_id.Binary());
-  object_info->set_pending_creation(it->second.pending_creation);
 }
 
 void ReferenceCounter::PublishObjectLocationSnapshot(const ObjectID &object_id) {

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -112,7 +112,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[out] deleted Any objects that are newly out of scope after this
   /// function call.
   void UpdateSubmittedTaskReferences(
-      const std::vector<ObjectID> return_ids,
       const std::vector<ObjectID> &argument_ids_to_add,
       const std::vector<ObjectID> &argument_ids_to_remove = std::vector<ObjectID>(),
       std::vector<ObjectID> *deleted = nullptr) LOCKS_EXCLUDED(mutex_);
@@ -122,13 +121,13 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// have already incremented them when the task was first submitted.
   ///
   /// \param[in] argument_ids The arguments of the task to add references for.
-  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> return_ids,
-                                       const std::vector<ObjectID> &argument_ids)
+  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> &argument_ids)
       LOCKS_EXCLUDED(mutex_);
 
   /// Update object references that were given to a submitted task. The task
   /// may still be borrowing any object IDs that were contained in its
-  /// arguments. This should be called when the task finishes.
+  /// arguments. This should be called when inlined dependencies are inlined or
+  /// when the task finishes for plasma dependencies.
   ///
   /// \param[in] object_ids The object IDs to remove references for.
   /// \param[in] release_lineage Whether to decrement the arguments' lineage
@@ -140,8 +139,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// arguments. Some references in this table may still be borrowed by the
   /// worker and/or a task that the worker submitted.
   /// \param[out] deleted The object IDs whos reference counts reached zero.
-  void UpdateFinishedTaskReferences(const std::vector<ObjectID> return_ids,
-                                    const std::vector<ObjectID> &argument_ids,
+  void UpdateFinishedTaskReferences(const std::vector<ObjectID> &argument_ids,
                                     bool release_lineage, const rpc::Address &worker_addr,
                                     const ReferenceTableProto &borrowed_refs,
                                     std::vector<ObjectID> *deleted)
@@ -472,10 +470,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   bool IsObjectReconstructable(const ObjectID &object_id) const;
 
-  /// Whether the object is pending creation (the task that creates it is
-  /// scheduled/executing).
-  bool IsObjectPendingCreation(const ObjectID &object_id) const;
-
  private:
   struct Reference {
     /// Constructor for a reference whose origin is unknown.
@@ -629,8 +623,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// This will be Nil if the object has not been spilled or if it is spilled
     /// distributed external storage.
     NodeID spilled_node_id = NodeID::Nil();
-    /// Whether the task that creates this object is scheduled/executing.
-    bool pending_creation = false;
     /// Callback that will be called when this ObjectID no longer has
     /// references.
     std::function<void(const ObjectID &)> on_delete;
@@ -763,9 +755,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[in] it The reference iterator for the object.
   /// \param[in] node_id The new object location to be added.
   void AddObjectLocationInternal(ReferenceTable::iterator it, const NodeID &node_id)
-      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
-
-  void UpdateObjectPendingCreation(const ObjectID &object_id, bool pending_creation)
       EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Publish object locations to all subscribers.

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -54,6 +54,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
     task_deps.push_back(actor_creation_return_id);
   }
+  reference_counter_->UpdateSubmittedTaskReferences(task_deps);
 
   // Add new owned objects for the return values of the task.
   size_t num_returns = spec.NumReturns();
@@ -61,9 +62,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     num_returns--;
   }
   std::vector<rpc::ObjectReference> returned_refs;
-  std::vector<ObjectID> return_ids;
   for (size_t i = 0; i < num_returns; i++) {
-    auto return_id = spec.ReturnId(i);
     if (!spec.IsActorCreationTask()) {
       bool is_reconstructable = max_retries != 0;
       // We pass an empty vector for inner IDs because we do not know the return
@@ -71,20 +70,17 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
       // publish the WaitForRefRemoved message that we are now a borrower for
       // the inner IDs. Note that this message can be received *before* the
       // PushTaskReply.
-      reference_counter_->AddOwnedObject(return_id,
+      reference_counter_->AddOwnedObject(spec.ReturnId(i),
                                          /*inner_ids=*/{}, caller_address, call_site, -1,
                                          /*is_reconstructable=*/is_reconstructable);
     }
 
-    return_ids.push_back(return_id);
     rpc::ObjectReference ref;
     ref.set_object_id(spec.ReturnId(i).Binary());
     ref.mutable_owner_address()->CopyFrom(caller_address);
     ref.set_call_site(call_site);
     returned_refs.push_back(std::move(ref));
   }
-
-  reference_counter_->UpdateSubmittedTaskReferences(return_ids, task_deps);
 
   {
     absl::MutexLock lock(&mu_);
@@ -101,7 +97,6 @@ Status TaskManager::ResubmitTask(const TaskID &task_id,
                                  std::vector<ObjectID> *task_deps) {
   TaskSpecification spec;
   bool resubmit = false;
-  std::vector<ObjectID> return_ids;
   {
     absl::MutexLock lock(&mu_);
     auto it = submissible_tasks_.find(task_id);
@@ -118,32 +113,30 @@ Status TaskManager::ResubmitTask(const TaskID &task_id,
         RAY_CHECK(it->second.num_retries_left == -1);
       }
       spec = it->second.spec;
+    }
+  }
 
-      for (const auto &return_id : it->second.reconstructable_return_ids) {
-        return_ids.push_back(return_id);
+  for (size_t i = 0; i < spec.NumArgs(); i++) {
+    if (spec.ArgByRef(i)) {
+      task_deps->push_back(spec.ArgId(i));
+    } else {
+      const auto &inlined_refs = spec.ArgInlinedRefs(i);
+      for (const auto &inlined_ref : inlined_refs) {
+        task_deps->push_back(ObjectID::FromBinary(inlined_ref.object_id()));
       }
     }
   }
 
+  if (!task_deps->empty()) {
+    reference_counter_->UpdateResubmittedTaskReferences(*task_deps);
+  }
+
+  if (spec.IsActorTask()) {
+    const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
+    reference_counter_->UpdateResubmittedTaskReferences({actor_creation_return_id});
+  }
+
   if (resubmit) {
-    for (size_t i = 0; i < spec.NumArgs(); i++) {
-      if (spec.ArgByRef(i)) {
-        task_deps->push_back(spec.ArgId(i));
-      } else {
-        const auto &inlined_refs = spec.ArgInlinedRefs(i);
-        for (const auto &inlined_ref : inlined_refs) {
-          task_deps->push_back(ObjectID::FromBinary(inlined_ref.object_id()));
-        }
-      }
-    }
-
-    reference_counter_->UpdateResubmittedTaskReferences(return_ids, *task_deps);
-    if (spec.IsActorTask()) {
-      const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
-      reference_counter_->UpdateResubmittedTaskReferences(return_ids,
-                                                          {actor_creation_return_id});
-    }
-
     retry_task_callback_(spec, /*delay=*/false);
   }
 
@@ -437,7 +430,6 @@ void TaskManager::OnTaskDependenciesInlined(
     const std::vector<ObjectID> &contained_ids) {
   std::vector<ObjectID> deleted;
   reference_counter_->UpdateSubmittedTaskReferences(
-      /*return_ids=*/{},
       /*argument_ids_to_add=*/contained_ids,
       /*argument_ids_to_remove=*/inlined_dependency_ids, &deleted);
   in_memory_store_->Delete(deleted);
@@ -462,19 +454,9 @@ void TaskManager::RemoveFinishedTaskReferences(
     plasma_dependencies.push_back(actor_creation_return_id);
   }
 
-  std::vector<ObjectID> return_ids;
-  size_t num_returns = spec.NumReturns();
-  if (spec.IsActorTask()) {
-    num_returns--;
-  }
-  for (size_t i = 0; i < num_returns; i++) {
-    return_ids.push_back(spec.ReturnId(i));
-  }
-
   std::vector<ObjectID> deleted;
-  reference_counter_->UpdateFinishedTaskReferences(return_ids, plasma_dependencies,
-                                                   release_lineage, borrower_addr,
-                                                   borrowed_refs, &deleted);
+  reference_counter_->UpdateFinishedTaskReferences(
+      plasma_dependencies, release_lineage, borrower_addr, borrowed_refs, &deleted);
   in_memory_store_->Delete(deleted);
 }
 

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -90,7 +90,6 @@ TEST_F(TaskManagerTest, TestTaskSuccess) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
   auto return_id = spec.ReturnId(0);
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   rpc::PushTaskReply reply;
   auto return_object = reply.add_return_objects();
@@ -101,7 +100,6 @@ TEST_F(TaskManagerTest, TestTaskSuccess) {
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));
   // Only the return object reference should remain.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
   RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, false, &results));
@@ -131,14 +129,12 @@ TEST_F(TaskManagerTest, TestTaskFailure) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
   auto return_id = spec.ReturnId(0);
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   auto error = rpc::ErrorType::WORKER_DIED;
   manager_.PendingTaskFailed(spec.TaskId(), error);
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));
   // Only the return object reference should remain.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
   RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, false, &results));
@@ -194,14 +190,12 @@ TEST_F(TaskManagerTest, TestTaskReconstruction) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
   auto return_id = spec.ReturnId(0);
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   auto error = rpc::ErrorType::WORKER_DIED;
   for (int i = 0; i < num_retries; i++) {
     RAY_LOG(INFO) << "Retry " << i;
     manager_.PendingTaskFailed(spec.TaskId(), error);
     ASSERT_TRUE(manager_.IsTaskPending(spec.TaskId()));
-    ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
     ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
     std::vector<std::shared_ptr<RayObject>> results;
     ASSERT_FALSE(store_->Get({return_id}, 1, 0, ctx, false, &results).ok());
@@ -212,7 +206,6 @@ TEST_F(TaskManagerTest, TestTaskReconstruction) {
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));
   // Only the return object reference should remain.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
   RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
@@ -488,7 +481,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ObjectID dep1 = ObjectID::FromRandom();
   ObjectID dep2 = ObjectID::FromRandom();
   auto spec = CreateTaskHelper(1, {dep1, dep2});
-  auto return_id = spec.ReturnId(0);
   int num_retries = 3;
 
   // Cannot resubmit a task whose spec we do not have.
@@ -496,16 +488,15 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_FALSE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps).ok());
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 0);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   manager_.AddPendingTask(caller_address, spec, "", num_retries);
   // A task that is already pending does not get resubmitted.
   ASSERT_TRUE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps).ok());
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 0);
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The task completes.
+  auto return_id = spec.ReturnId(0);
   reference_counter_->AddLocalReference(return_id, "");
   rpc::PushTaskReply reply;
   auto return_object = reply.add_return_objects();
@@ -514,7 +505,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   return_object->set_data(data->Data(), data->Size());
   return_object->set_in_plasma(true);
   manager_.CompletePendingTask(spec.TaskId(), reply, rpc::Address());
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The task finished, its return ID is still in scope, and the return object
   // was stored in plasma. It is okay to resubmit it now.
@@ -522,7 +512,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_EQ(resubmitted_task_deps, spec.GetDependencyIds());
   ASSERT_EQ(num_retries_, 1);
   resubmitted_task_deps.clear();
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The return ID goes out of scope.
   reference_counter_->RemoveLocalReference(return_id, nullptr);
@@ -532,8 +521,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_TRUE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps).ok());
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 1);
-  // Object is out of scope, so no longer pending creation.
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The resubmitted task finishes.
   manager_.CompletePendingTask(spec.TaskId(), reply, rpc::Address());
@@ -542,7 +529,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_FALSE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps).ok());
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 1);
-  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
 }
 
 // Test resubmission for a task that was successfully executed once and stored

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -44,7 +44,7 @@ struct RemoteConnectionInfo {
 /// Callback for object location notifications.
 using OnLocationsFound = std::function<void(
     const ray::ObjectID &object_id, const std::unordered_set<ray::NodeID> &,
-    const std::string &, const NodeID &, bool pending_creation, size_t object_size)>;
+    const std::string &, const NodeID &, size_t object_size)>;
 
 class IObjectDirectory {
  public:

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -56,8 +56,7 @@ ObjectManager::ObjectManager(
     SpillObjectsCallback spill_objects_callback,
     std::function<void()> object_store_full_callback,
     AddObjectCallback add_object_callback, DeleteObjectCallback delete_object_callback,
-    std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
-    const std::function<void(const ObjectID &)> fail_pull_request)
+    std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object)
     : main_service_(&main_service),
       self_node_id_(self_node_id),
       config_(config),
@@ -123,10 +122,10 @@ ObjectManager::ObjectManager(
   if (available_memory < 0) {
     available_memory = 0;
   }
-  pull_manager_.reset(new PullManager(
-      self_node_id_, object_is_local, send_pull_request, cancel_pull_request,
-      fail_pull_request, restore_spilled_object_, get_time, config.pull_timeout_ms,
-      available_memory, pin_object, get_spilled_object_url));
+  pull_manager_.reset(new PullManager(self_node_id_, object_is_local, send_pull_request,
+                                      cancel_pull_request, restore_spilled_object_,
+                                      get_time, config.pull_timeout_ms, available_memory,
+                                      pin_object, get_spilled_object_url));
   // Start object manager rpc server and send & receive request threads
   StartRpcService();
 }
@@ -209,13 +208,13 @@ uint64_t ObjectManager::Pull(const std::vector<rpc::ObjectReference> &object_ref
   std::vector<rpc::ObjectReference> objects_to_locate;
   auto request_id = pull_manager_->Pull(object_refs, prio, &objects_to_locate);
 
-  const auto &callback =
-      [this](const ObjectID &object_id, const std::unordered_set<NodeID> &client_ids,
-             const std::string &spilled_url, const NodeID &spilled_node_id,
-             bool pending_creation, size_t object_size) {
-        pull_manager_->OnLocationChange(object_id, client_ids, spilled_url,
-                                        spilled_node_id, pending_creation, object_size);
-      };
+  const auto &callback = [this](const ObjectID &object_id,
+                                const std::unordered_set<NodeID> &client_ids,
+                                const std::string &spilled_url,
+                                const NodeID &spilled_node_id, size_t object_size) {
+    pull_manager_->OnLocationChange(object_id, client_ids, spilled_url, spilled_node_id,
+                                    object_size);
+  };
 
   for (const auto &ref : objects_to_locate) {
     // Subscribe to object notifications. A notification will be received every
@@ -568,7 +567,7 @@ ray::Status ObjectManager::LookupRemainingWaitObjects(const UniqueID &wait_id) {
           [this, wait_id](const ObjectID &lookup_object_id,
                           const std::unordered_set<NodeID> &node_ids,
                           const std::string &spilled_url, const NodeID &spilled_node_id,
-                          bool pending_creation, size_t object_size) {
+                          size_t object_size) {
             auto &wait_state = active_wait_requests_.find(wait_id)->second;
             // Note that the object is guaranteed to be added to local_objects_ before
             // the notification is triggered.
@@ -610,7 +609,7 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
           [this, wait_id](const ObjectID &subscribe_object_id,
                           const std::unordered_set<NodeID> &node_ids,
                           const std::string &spilled_url, const NodeID &spilled_node_id,
-                          bool pending_creation, size_t object_size) {
+                          size_t object_size) {
             auto object_id_wait_state = active_wait_requests_.find(wait_id);
             if (object_id_wait_state == active_wait_requests_.end()) {
               // Depending on the timing of calls to the object directory, we

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -170,8 +170,7 @@ class ObjectManager : public ObjectManagerInterface,
       SpillObjectsCallback spill_objects_callback,
       std::function<void()> object_store_full_callback,
       AddObjectCallback add_object_callback, DeleteObjectCallback delete_object_callback,
-      std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
-      const std::function<void(const ObjectID &)> fail_pull_request);
+      std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object);
 
   ~ObjectManager();
 

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -49,8 +49,7 @@ void FilterRemovedNodes(std::shared_ptr<gcs::GcsClient> gcs_client,
 bool UpdateObjectLocations(const rpc::WorkerObjectLocationsPubMessage &location_info,
                            std::shared_ptr<gcs::GcsClient> gcs_client,
                            std::unordered_set<NodeID> *node_ids, std::string *spilled_url,
-                           NodeID *spilled_node_id, bool *pending_creation,
-                           size_t *object_size) {
+                           NodeID *spilled_node_id, size_t *object_size) {
   bool is_updated = false;
   std::unordered_set<NodeID> new_node_ids;
   // The size can be 0 if the update was a deletion. This assumes that an
@@ -82,10 +81,6 @@ bool UpdateObjectLocations(const rpc::WorkerObjectLocationsPubMessage &location_
       *spilled_url = new_spilled_url;
       *spilled_node_id = new_spilled_node_id;
     }
-    is_updated = true;
-  }
-  if (location_info.pending_creation() != *pending_creation) {
-    *pending_creation = location_info.pending_creation();
     is_updated = true;
   }
 
@@ -235,8 +230,7 @@ void OwnershipBasedObjectDirectory::ObjectLocationSubscriptionCallback(
   }
   auto location_updated = UpdateObjectLocations(
       location_info, gcs_client_, &it->second.current_object_locations,
-      &it->second.spilled_url, &it->second.spilled_node_id, &it->second.pending_creation,
-      &it->second.object_size);
+      &it->second.spilled_url, &it->second.spilled_node_id, &it->second.object_size);
 
   // If the lookup has failed, that means the object is lost. Trigger the callback in this
   // case to handle failure properly.
@@ -262,7 +256,7 @@ void OwnershipBasedObjectDirectory::ObjectLocationSubscriptionCallback(
       // See https://github.com/ray-project/ray/issues/2959.
       callback_pair.second(object_id, it->second.current_object_locations,
                            it->second.spilled_url, it->second.spilled_node_id,
-                           it->second.pending_creation, it->second.object_size);
+                           it->second.object_size);
     }
   }
 }
@@ -325,7 +319,6 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     auto &locations = listener_state.current_object_locations;
     auto &spilled_url = listener_state.spilled_url;
     auto &spilled_node_id = listener_state.spilled_node_id;
-    bool pending_creation = listener_state.pending_creation;
     auto object_size = listener_state.object_size;
     RAY_LOG(DEBUG) << "Already subscribed to object's locations, pushing location "
                       "updates to subscribers for object "
@@ -337,10 +330,8 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     // structures shared with the caller and potentially invalidating caller
     // iterators. See https://github.com/ray-project/ray/issues/2959.
     io_service_.post(
-        [callback, locations, spilled_url, spilled_node_id, pending_creation, object_size,
-         object_id]() {
-          callback(object_id, locations, spilled_url, spilled_node_id, pending_creation,
-                   object_size);
+        [callback, locations, spilled_url, spilled_node_id, object_size, object_id]() {
+          callback(object_id, locations, spilled_url, spilled_node_id, object_size);
         },
         "ObjectDirectory.SubscribeObjectLocations");
   }
@@ -378,16 +369,13 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
     auto &locations = it->second.current_object_locations;
     auto &spilled_url = it->second.spilled_url;
     auto &spilled_node_id = it->second.spilled_node_id;
-    bool pending_creation = it->second.pending_creation;
     auto object_size = it->second.object_size;
     // We post the callback to the event loop in order to avoid mutating data
     // structures shared with the caller and potentially invalidating caller
     // iterators. See https://github.com/ray-project/ray/issues/2959.
     io_service_.post(
-        [callback, object_id, locations, spilled_url, spilled_node_id, pending_creation,
-         object_size]() {
-          callback(object_id, locations, spilled_url, spilled_node_id, pending_creation,
-                   object_size);
+        [callback, object_id, locations, spilled_url, spilled_node_id, object_size]() {
+          callback(object_id, locations, spilled_url, spilled_node_id, object_size);
         },
         "ObjectDirectory.LookupLocations");
   } else {
@@ -401,8 +389,7 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
       // See https://github.com/ray-project/ray/issues/2959.
       io_service_.post(
           [callback, object_id]() {
-            callback(object_id, std::unordered_set<NodeID>(), "", NodeID::Nil(),
-                     /*pending_creation=*/false, 0);
+            callback(object_id, std::unordered_set<NodeID>(), "", NodeID::Nil(), 0);
           },
           "ObjectDirectory.LookupLocations");
       return Status::OK();
@@ -420,7 +407,6 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
           std::string spilled_url;
           NodeID spilled_node_id;
           size_t object_size = 0;
-          bool pending_creation = false;
 
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Worker " << worker_id << " failed to get the location for "
@@ -434,8 +420,7 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
             mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
           } else {
             UpdateObjectLocations(reply.object_location_info(), gcs_client_, &node_ids,
-                                  &spilled_url, &spilled_node_id, &pending_creation,
-                                  &object_size);
+                                  &spilled_url, &spilled_node_id, &object_size);
           }
           RAY_LOG(DEBUG) << "Looked up locations for " << object_id
                          << ", returning: " << node_ids.size()
@@ -446,8 +431,7 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
           // caller iterators since this is already running in the core worker
           // client's lookup callback stack.
           // See https://github.com/ray-project/ray/issues/2959.
-          callback(object_id, node_ids, spilled_url, spilled_node_id, pending_creation,
-                   object_size);
+          callback(object_id, node_ids, spilled_url, spilled_node_id, object_size);
         });
   }
   return Status::OK();
@@ -496,7 +480,6 @@ void OwnershipBasedObjectDirectory::HandleNodeRemoved(const NodeID &node_id) {
         // in the subscription callback stack.
         callback_pair.second(object_id, listener.second.current_object_locations,
                              listener.second.spilled_url, listener.second.spilled_node_id,
-                             listener.second.pending_creation,
                              listener.second.object_size);
       }
     }

--- a/src/ray/object_manager/ownership_based_object_directory.h
+++ b/src/ray/object_manager/ownership_based_object_directory.h
@@ -95,7 +95,6 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
     // The node id that spills the object to the disk.
     // It will be Nil if it uses a distributed external storage.
     NodeID spilled_node_id = NodeID::Nil();
-    bool pending_creation = false;
     /// The size of the object.
     size_t object_size = 0;
     /// This flag will get set to true if received any notification of the object.

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -22,9 +22,8 @@ PullManager::PullManager(
     NodeID &self_node_id, const std::function<bool(const ObjectID &)> object_is_local,
     const std::function<void(const ObjectID &, const NodeID &)> send_pull_request,
     const std::function<void(const ObjectID &)> cancel_pull_request,
-    const std::function<void(const ObjectID &)> fail_pull_request,
     const RestoreSpilledObjectCallback restore_spilled_object,
-    const std::function<double()> get_time_seconds, int pull_timeout_ms,
+    const std::function<double()> get_time, int pull_timeout_ms,
     int64_t num_bytes_available,
     std::function<std::unique_ptr<RayObject>(const ObjectID &)> pin_object,
     std::function<std::string(const ObjectID &)> get_locally_spilled_object_url)
@@ -33,12 +32,11 @@ PullManager::PullManager(
       send_pull_request_(send_pull_request),
       cancel_pull_request_(cancel_pull_request),
       restore_spilled_object_(restore_spilled_object),
-      get_time_seconds_(get_time_seconds),
+      get_time_(get_time),
       pull_timeout_ms_(pull_timeout_ms),
       num_bytes_available_(num_bytes_available),
       pin_object_(pin_object),
       get_locally_spilled_object_url_(get_locally_spilled_object_url),
-      fail_pull_request_(fail_pull_request),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
@@ -81,7 +79,7 @@ uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_b
       // The first pull request doesn't need to be special case. Instead we can just let
       // the retry timer fire immediately.
       it = object_pull_requests_
-               .emplace(obj_id, ObjectPullRequest(/*next_pull_time=*/get_time_seconds_()))
+               .emplace(obj_id, ObjectPullRequest(/*next_pull_time=*/get_time_()))
                .first;
     } else {
       if (it->second.object_size_set) {
@@ -388,8 +386,7 @@ std::vector<ObjectID> PullManager::CancelPull(uint64_t request_id) {
 void PullManager::OnLocationChange(const ObjectID &object_id,
                                    const std::unordered_set<NodeID> &client_ids,
                                    const std::string &spilled_url,
-                                   const NodeID &spilled_node_id, bool pending_creation,
-                                   size_t object_size) {
+                                   const NodeID &spilled_node_id, size_t object_size) {
   // Exit if the Pull request has already been fulfilled or canceled.
   auto it = object_pull_requests_.find(object_id);
   if (it == object_pull_requests_.end()) {
@@ -402,7 +399,6 @@ void PullManager::OnLocationChange(const ObjectID &object_id,
   it->second.client_locations = std::vector<NodeID>(client_ids.begin(), client_ids.end());
   it->second.spilled_url = spilled_url;
   it->second.spilled_node_id = spilled_node_id;
-  it->second.pending_object_creation = pending_creation;
   if (!it->second.object_size_set) {
     it->second.object_size = object_size;
     it->second.object_size_set = true;
@@ -452,7 +448,7 @@ void PullManager::TryToMakeObjectLocal(const ObjectID &object_id) {
   auto it = object_pull_requests_.find(object_id);
   RAY_CHECK(it != object_pull_requests_.end());
   auto &request = it->second;
-  if (request.next_pull_time > get_time_seconds_()) {
+  if (request.next_pull_time > get_time_()) {
     return;
   }
 
@@ -485,24 +481,9 @@ void PullManager::TryToMakeObjectLocal(const ObjectID &object_id) {
     return;
   }
 
-  if (request.expiration_time_seconds == 0) {
-    RAY_LOG(WARNING) << "Object neither in memory nor external storage "
-                     << object_id.Hex();
-    request.expiration_time_seconds =
-        get_time_seconds_() +
-        RayConfig::instance().fetch_warn_timeout_milliseconds() / 1e3;
-  } else if (request.pending_object_creation) {
-    // Object is pending creation, wait for the task that creates the object to
-    // finish.
-    RAY_LOG(INFO) << "Object pending creation " << object_id.Hex();
-    request.expiration_time_seconds =
-        get_time_seconds_() +
-        RayConfig::instance().fetch_warn_timeout_milliseconds() / 1e3;
-  } else if (get_time_seconds_() > request.expiration_time_seconds) {
-    // Object has no locations and is not being reconstructed by its owner.
-    fail_pull_request_(object_id);
-    request.expiration_time_seconds = 0;
-  }
+  // TODO(swang): Store an error if this times out and the object is not
+  // pending reconstruction.
+  RAY_LOG(WARNING) << "Object neither in memory nor external storage " << object_id.Hex();
 }
 
 bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
@@ -565,14 +546,14 @@ bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
 void PullManager::ResetRetryTimer(const ObjectID &object_id) {
   auto it = object_pull_requests_.find(object_id);
   if (it != object_pull_requests_.end()) {
-    it->second.next_pull_time = get_time_seconds_();
+    it->second.next_pull_time = get_time_();
     it->second.num_retries = 0;
   }
 }
 
 void PullManager::UpdateRetryTimer(ObjectPullRequest &request,
                                    const ObjectID &object_id) {
-  const auto time = get_time_seconds_();
+  const auto time = get_time_();
   auto retry_timeout_len = (pull_timeout_ms_ / 1000.) * (1UL << request.num_retries);
   request.next_pull_time = time + retry_timeout_len;
   if (retry_timeout_len > max_timeout_) {

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -63,9 +63,8 @@ class PullManager {
       NodeID &self_node_id, const std::function<bool(const ObjectID &)> object_is_local,
       const std::function<void(const ObjectID &, const NodeID &)> send_pull_request,
       const std::function<void(const ObjectID &)> cancel_pull_request,
-      const std::function<void(const ObjectID &)> fail_pull_request,
       const RestoreSpilledObjectCallback restore_spilled_object,
-      const std::function<double()> get_time_seconds, int pull_timeout_ms,
+      const std::function<double()> get_time, int pull_timeout_ms,
       int64_t num_bytes_available,
       std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
       std::function<std::string(const ObjectID &)> get_locally_spilled_object_url);
@@ -108,7 +107,7 @@ class PullManager {
   void OnLocationChange(const ObjectID &object_id,
                         const std::unordered_set<NodeID> &client_ids,
                         const std::string &spilled_url, const NodeID &spilled_node_id,
-                        bool pending_creation, size_t object_size);
+                        size_t object_size);
 
   /// Cancel an existing pull request.
   ///
@@ -171,11 +170,7 @@ class PullManager {
     std::vector<NodeID> client_locations;
     std::string spilled_url;
     NodeID spilled_node_id;
-    bool pending_object_creation = false;
     double next_pull_time;
-    // The pull will timeout at this time if there are still no locations for
-    // the object.
-    double expiration_time_seconds = 0;
     uint8_t num_retries;
     bool object_size_set = false;
     size_t object_size = 0;
@@ -284,7 +279,7 @@ class PullManager {
   const std::function<void(const ObjectID &, const NodeID &)> send_pull_request_;
   const std::function<void(const ObjectID &)> cancel_pull_request_;
   const RestoreSpilledObjectCallback restore_spilled_object_;
-  const std::function<double()> get_time_seconds_;
+  const std::function<double()> get_time_;
   uint64_t pull_timeout_ms_;
 
   /// The next ID to assign to a bundle pull request, so that the caller can
@@ -367,9 +362,6 @@ class PullManager {
   // A callback to get the spilled object URL if the object is spilled locally.
   // It will return an empty string otherwise.
   std::function<std::string(const ObjectID &)> get_locally_spilled_object_url_;
-
-  // A callback to fail a hung pull request.
-  std::function<void(const ObjectID &)> fail_pull_request_;
 
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -37,7 +37,6 @@ class PullManagerTestWithCapacity {
               num_send_pull_request_calls_++;
             },
             [this](const ObjectID &object_id) { num_abort_calls_[object_id]++; },
-            [this](const ObjectID &object_id) { timed_out_objects_.insert(object_id); },
             [this](const ObjectID &, const std::string &,
                    std::function<void(const ray::Status &)> callback) {
               num_restore_spilled_object_calls_++;
@@ -62,8 +61,6 @@ class PullManagerTestWithCapacity {
     ASSERT_TRUE(pull_manager_.active_object_pull_requests_.empty());
     ASSERT_TRUE(pull_manager_.pinned_objects_.empty());
     ASSERT_EQ(pull_manager_.pinned_objects_size_, 0);
-    // Most tests should not timeout any pull requests.
-    ASSERT_TRUE(timed_out_objects_.empty());
   }
 
   int NumPinnedObjects() { return pull_manager_.pinned_objects_.size(); }
@@ -90,7 +87,6 @@ class PullManagerTestWithCapacity {
   PullManager pull_manager_;
   std::unordered_map<ObjectID, int> num_abort_calls_;
   std::unordered_map<ObjectID, std::string> spilled_url_;
-  std::unordered_set<ObjectID> timed_out_objects_;
 };
 
 class PullManagerTest : public PullManagerTestWithCapacity,
@@ -150,7 +146,7 @@ TEST_P(PullManagerTest, TestStaleSubscription) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), 0);
   AssertNumActiveRequestsEquals(1);
 
   // There are no client ids to pull from.
@@ -167,7 +163,7 @@ TEST_P(PullManagerTest, TestStaleSubscription) {
   AssertNumActiveRequestsEquals(0);
 
   client_ids.insert(NodeID::FromRandom());
-  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), 0);
 
   // Now we're getting a notification about an object that was already cancelled.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -191,7 +187,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -201,7 +197,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 node_that_object_spilled, false, 0);
+                                 node_that_object_spilled, 0);
 
   // We request a remote pull to restore the object.
   ASSERT_EQ(num_send_pull_request_calls_, 1);
@@ -210,7 +206,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   // No retry yet.
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 node_that_object_spilled, false, 0);
+                                 node_that_object_spilled, 0);
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
@@ -219,7 +215,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 node_that_object_spilled, false, 0);
+                                 node_that_object_spilled, 0);
   ASSERT_EQ(num_send_pull_request_calls_, 2);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
@@ -227,7 +223,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   object_is_local_ = true;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 NodeID::FromRandom(), false, 0);
+                                 NodeID::FromRandom(), 0);
   ASSERT_EQ(num_send_pull_request_calls_, 2);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
@@ -254,7 +250,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -263,7 +259,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -272,7 +268,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   // No retry yet.
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 1);
 
@@ -280,7 +276,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 2);
 
@@ -308,7 +304,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnLocalStorage) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -318,7 +314,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnLocalStorage) {
   // Objects are spilled locally, but the remote object directory doesn't have the
   // information. It should still restore objects.
   ObjectSpilled(obj1, "remote_url/foo/bar");
-  pull_manager_.OnLocationChange(obj1, client_ids, "", self_node_id_, false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", self_node_id_, 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -328,7 +324,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnLocalStorage) {
   // updated now.
   fake_time_ += 10.;
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 2);
 
@@ -356,7 +352,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -368,7 +364,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
   // If objects are spilled to external storages, the node id should be Nil().
   // So this shouldn't invoke restoration.
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -376,7 +372,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
 
   // Now Nil ID is properly updated.
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", NodeID::Nil(),
-                                 false, 0);
+                                 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -385,7 +381,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
   // The call can be retried after a delay.
   fake_time_ += 10.;
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", NodeID::Nil(),
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 2);
 
@@ -423,7 +419,7 @@ TEST_P(PullManagerTest, TestLoadBalancingRestorationRequest) {
   client_ids.insert(copy_node2);
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 remote_node_that_spilled_object, false, 0);
+                                 remote_node_that_spilled_object, 0);
 
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   // Make sure the restore request wasn't sent since there are nodes that have a copied
@@ -449,7 +445,7 @@ TEST_P(PullManagerTest, TestManyUpdates) {
   client_ids.insert(NodeID::FromRandom());
 
   for (int i = 0; i < 100; i++) {
-    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
     AssertNumActiveRequestsEquals(1);
   }
 
@@ -484,7 +480,7 @@ TEST_P(PullManagerTest, TestRetryTimer) {
 
   // We need to call OnLocationChange at least once, to population the list of nodes with
   // the object.
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
   AssertNumActiveRequestsEquals(1);
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
@@ -495,7 +491,7 @@ TEST_P(PullManagerTest, TestRetryTimer) {
 
   // Location changes can trigger reset timer.
   for (; fake_time_ <= 120 * 10; fake_time_ += 1.) {
-    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
   }
 
   // We should make a pull request every tick (even if it's a duplicate to a node we're
@@ -537,7 +533,7 @@ TEST_P(PullManagerTest, TestBasic) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_TRUE(pull_manager_.IsObjectActive(oids[i]));
@@ -552,7 +548,7 @@ TEST_P(PullManagerTest, TestBasic) {
   num_send_pull_request_calls_ = 0;
   fake_time_ += 10;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
 
@@ -572,7 +568,7 @@ TEST_P(PullManagerTest, TestBasic) {
   num_send_pull_request_calls_ = 0;
   fake_time_ += 10;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_FALSE(pull_manager_.HasPullsQueued());
@@ -596,7 +592,7 @@ TEST_P(PullManagerTest, TestPinActiveObjects) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 1);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 1);
   }
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_TRUE(pull_manager_.IsObjectActive(oids[i]));
@@ -624,7 +620,7 @@ TEST_P(PullManagerTest, TestPinActiveObjects) {
   auto req_id2 = pull_manager_.Pull(refs2, BundlePriority::TASK_ARGS, &objects_to_locate);
   for (size_t i = 0; i < oids2.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids2[i]));
-    pull_manager_.OnLocationChange(oids2[i], client_ids, "", NodeID::Nil(), false, 1000);
+    pull_manager_.OnLocationChange(oids2[i], client_ids, "", NodeID::Nil(), 1000);
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids2[i]));
   }
   pull_manager_.UpdatePullsBasedOnAvailableMemory(4);
@@ -660,7 +656,7 @@ TEST_P(PullManagerTest, TestDeduplicateBundles) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, oids.size());
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
@@ -676,8 +672,8 @@ TEST_P(PullManagerTest, TestDeduplicateBundles) {
   fake_time_ += 10;
   num_send_pull_request_calls_ = 0;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
     ASSERT_EQ(num_send_pull_request_calls_, i + 1);
     ASSERT_EQ(num_restore_spilled_object_calls_, 0);
     ASSERT_TRUE(pull_manager_.IsObjectActive(oids[i]));
@@ -698,7 +694,7 @@ TEST_P(PullManagerTest, TestDeduplicateBundles) {
   object_is_local_ = false;
   num_send_pull_request_calls_ = 0;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
 
@@ -749,7 +745,7 @@ TEST_P(PullManagerTest, TestDuplicateObjectsAreActivatedAndCleanedUp) {
 
   std::unordered_set<NodeID> client_ids;
   client_ids.insert(NodeID::FromRandom());
-  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), 0);
   AssertNumActiveRequestsEquals(1);
 
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
@@ -779,8 +775,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestBasic) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), object_size);
   }
   ASSERT_EQ(num_send_pull_request_calls_, oids.size());
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
@@ -847,8 +842,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestQueue) {
   client_ids.insert(NodeID::FromRandom());
   for (auto &oids : bundles) {
     for (size_t i = 0; i < oids.size(); i++) {
-      pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false,
-                                     object_size);
+      pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), object_size);
     }
   }
 
@@ -908,8 +902,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestCancel) {
       req_ids.push_back(req_id);
     }
     for (size_t i = 0; i < object_sizes.size(); i++) {
-      pull_manager_.OnLocationChange(oids[i], {}, "", NodeID::Nil(), false,
-                                     object_sizes[i]);
+      pull_manager_.OnLocationChange(oids[i], {}, "", NodeID::Nil(), object_sizes[i]);
     }
     AssertNumActiveRequestsEquals(num_active_requests_expected_before);
     pull_manager_.CancelPull(req_ids[cancel_idx]);
@@ -917,7 +910,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestCancel) {
 
     // Request is really canceled.
     pull_manager_.OnLocationChange(oids[cancel_idx], {NodeID::FromRandom()}, "",
-                                   NodeID::Nil(), false, object_sizes[cancel_idx]);
+                                   NodeID::Nil(), object_sizes[cancel_idx]);
     ASSERT_EQ(num_send_pull_request_calls_, 0);
 
     // The expected number of requests at the head of the queue are pulled.
@@ -925,7 +918,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestCancel) {
     for (size_t i = 0; i < refs.size() && num_active < num_active_requests_expected_after;
          i++) {
       pull_manager_.OnLocationChange(oids[i], {NodeID::FromRandom()}, "", NodeID::Nil(),
-                                     false, object_sizes[i]);
+                                     object_sizes[i]);
       if (i != cancel_idx) {
         num_active++;
       }
@@ -981,8 +974,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   std::unordered_set<NodeID> client_ids;
   client_ids.insert(NodeID::FromRandom());
   for (auto &oid : task_oids) {
-    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), object_size);
   }
 
   // Two requests can be pulled at a time.
@@ -996,7 +988,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   auto wait_req_id =
       pull_manager_.Pull(refs, BundlePriority::WAIT_REQUEST, &objects_to_locate);
   wait_oids.push_back(ObjectRefsToIds(refs)[0]);
-  pull_manager_.OnLocationChange(wait_oids[0], client_ids, "", NodeID::Nil(), false,
+  pull_manager_.OnLocationChange(wait_oids[0], client_ids, "", NodeID::Nil(),
                                  object_size);
   AssertNumActiveRequestsEquals(2);
   ASSERT_TRUE(pull_manager_.IsObjectActive(wait_oids[0]));
@@ -1017,8 +1009,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   // Worker request takes priority over the wait and task requests once its size is
   // available.
   for (auto &oid : get_oids) {
-    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), object_size);
   }
   AssertNumActiveRequestsEquals(2);
   ASSERT_TRUE(pull_manager_.IsObjectActive(get_oids[0]));
@@ -1038,8 +1029,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   ASSERT_FALSE(pull_manager_.IsObjectActive(task_oids[0]));
   ASSERT_FALSE(pull_manager_.IsObjectActive(task_oids[1]));
   for (auto &oid : get_oids) {
-    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), object_size);
   }
   AssertNumActiveRequestsEquals(2);
   ASSERT_TRUE(pull_manager_.IsObjectActive(get_oids[0]));
@@ -1085,55 +1075,6 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   ASSERT_TRUE(pull_manager_.IsObjectActive(task_oids[1]));
 
   pull_manager_.CancelPull(task_req_id2);
-  AssertNoLeaks();
-}
-
-TEST_P(PullManagerTest, TestTimeOut) {
-  auto prio = BundlePriority::TASK_ARGS;
-  if (GetParam()) {
-    prio = BundlePriority::GET_REQUEST;
-  }
-  auto refs = CreateObjectRefs(1);
-  auto oids = ObjectRefsToIds(refs);
-  std::vector<rpc::ObjectReference> objects_to_locate;
-  auto req_id = pull_manager_.Pull(refs, prio, &objects_to_locate);
-  ASSERT_EQ(ObjectRefsToIds(objects_to_locate), oids);
-  ASSERT_TRUE(pull_manager_.HasPullsQueued());
-
-  std::unordered_set<NodeID> client_ids;
-  client_ids.insert(NodeID::FromRandom());
-  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), false, 0);
-  ASSERT_TRUE(pull_manager_.IsObjectActive(oids[0]));
-  ASSERT_EQ(num_send_pull_request_calls_, 1);
-
-  // Object has no locations now.
-  fake_time_ += 10;
-  pull_manager_.OnLocationChange(oids[0], {}, "", NodeID::Nil(), false, 0);
-  ASSERT_FALSE(timed_out_objects_.count(oids[0]));
-  fake_time_ += 61;
-  pull_manager_.Tick();
-  ASSERT_TRUE(timed_out_objects_.count(oids[0]));
-  timed_out_objects_.clear();
-  RAY_UNUSED(pull_manager_.CancelPull(req_id));
-
-  req_id = pull_manager_.Pull(refs, prio, &objects_to_locate);
-  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), false, 0);
-  ASSERT_TRUE(pull_manager_.IsObjectActive(oids[0]));
-  // Object has no locations now but it is pending execution.
-  fake_time_ += 10;
-  pull_manager_.OnLocationChange(oids[0], {}, "", NodeID::Nil(), true, 0);
-  ASSERT_FALSE(timed_out_objects_.count(oids[0]));
-  fake_time_ += 61;
-  pull_manager_.Tick();
-  ASSERT_FALSE(timed_out_objects_.count(oids[0]));
-  // Object has no locations now and is no longer pending execution.
-  pull_manager_.OnLocationChange(oids[0], {}, "", NodeID::Nil(), false, 0);
-  fake_time_ += 61;
-  pull_manager_.Tick();
-  ASSERT_TRUE(timed_out_objects_.count(oids[0]));
-  timed_out_objects_.clear();
-  RAY_UNUSED(pull_manager_.CancelPull(req_id));
-
   AssertNoLeaks();
 }
 

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -94,10 +94,6 @@ message WorkerObjectLocationsPubMessage {
   // counting protocol that causes the object to be released while there are
   // still references.
   bool ref_removed = 7;
-  // If this is set, the task that creates the object is pending execution. If
-  // there are no locations and this is set, the subscriber should wait for the
-  // new location to appear.
-  bool pending_creation = 8;
 }
 
 /// Indicating the subscriber needs to handle failure callback.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -253,12 +253,6 @@ NodeManager::NodeManager(instrumented_io_context &io_service, const NodeID &self
               result = std::move(results[0]);
             }
             return result;
-          },
-          /*fail_pull_request=*/
-          [this](const ObjectID &object_id) {
-            rpc::ObjectReference ref;
-            ref.set_object_id(object_id.Binary());
-            MarkObjectsAsFailed(rpc::ErrorType::OBJECT_LOST, {ref}, JobID::Nil());
           }),
       periodical_runner_(io_service),
       report_resources_period_ms_(config.report_resources_period_ms),


### PR DESCRIPTION
This reverts commit e6d60d737694dcf67e2a4c1d4caf4ceef7d80d8b.

This may have caused #19894.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
