### PR TITLE
[runtime env] [test] Enable runtime env nightly test with working_dir reconnection

### DIFF
--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -73,17 +73,24 @@ def test_lazy_reads(start_cluster, tmp_working_dir, option: str):
     """
     cluster, address = start_cluster
 
-    if option == "failure":
-        # Don't pass the files at all, so it should fail!
-        ray.init(address)
-    elif option == "working_dir":
-        ray.init(address, runtime_env={"working_dir": tmp_working_dir})
-    elif option == "py_modules":
-        ray.init(
-            address,
-            runtime_env={
-                "py_modules": [str(Path(tmp_working_dir) / "test_module")]
-            })
+    def call_ray_init():
+        if option == "failure":
+            # Don't pass the files at all, so it should fail!
+            ray.init(address)
+        elif option == "working_dir":
+            ray.init(address, runtime_env={"working_dir": tmp_working_dir})
+        elif option == "py_modules":
+            ray.init(
+                address,
+                runtime_env={
+                    "py_modules": [str(Path(tmp_working_dir) / "test_module")]
+                })
+
+    call_ray_init()
+
+    def reinit():
+        ray.shutdown()
+        call_ray_init()
 
     @ray.remote
     def test_import():
@@ -96,6 +103,8 @@ def test_lazy_reads(start_cluster, tmp_working_dir, option: str):
     else:
         assert ray.get(test_import.remote()) == 1
 
+    reinit()
+
     @ray.remote
     def test_read():
         return open("hello").read()
@@ -105,6 +114,8 @@ def test_lazy_reads(start_cluster, tmp_working_dir, option: str):
             ray.get(test_read.remote())
     elif option == "working_dir":
         assert ray.get(test_read.remote()) == "world"
+
+    reinit()
 
     @ray.remote
     class Actor:
@@ -136,17 +147,26 @@ def test_captured_import(start_cluster, tmp_working_dir, option: str):
     """
     cluster, address = start_cluster
 
-    if option == "failure":
-        # Don't pass the files at all, so it should fail!
-        ray.init(address)
-    elif option == "working_dir":
-        ray.init(address, runtime_env={"working_dir": tmp_working_dir})
-    elif option == "py_modules":
-        ray.init(
-            address,
-            runtime_env={
-                "py_modules": [os.path.join(tmp_working_dir, "test_module")]
-            })
+    def call_ray_init():
+        if option == "failure":
+            # Don't pass the files at all, so it should fail!
+            ray.init(address)
+        elif option == "working_dir":
+            ray.init(address, runtime_env={"working_dir": tmp_working_dir})
+        elif option == "py_modules":
+            ray.init(
+                address,
+                runtime_env={
+                    "py_modules": [
+                        os.path.join(tmp_working_dir, "test_module")
+                    ]
+                })
+
+    call_ray_init()
+
+    def reinit():
+        ray.shutdown()
+        call_ray_init()
 
     # Import in the driver.
     sys.path.insert(0, tmp_working_dir)
@@ -161,6 +181,8 @@ def test_captured_import(start_cluster, tmp_working_dir, option: str):
             ray.get(test_import.remote())
     else:
         assert ray.get(test_import.remote()) == 1
+
+    reinit()
 
     @ray.remote
     class Actor:
@@ -198,6 +220,9 @@ def test_empty_working_dir(start_cluster):
         a = A.remote()
         assert len(ray.get(a.listdir.remote())) == 0
 
+        # Test that we can reconnect with no errors
+        ray.shutdown()
+        ray.init(address, runtime_env={"working_dir": working_dir})
 
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -224,6 +224,7 @@ def test_empty_working_dir(start_cluster):
         ray.shutdown()
         ray.init(address, runtime_env={"working_dir": working_dir})
 
+
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_input_validation(start_cluster, option: str):

--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -189,9 +189,7 @@ NIGHTLY_TESTS = {
         "serve_cluster_fault_tolerance",
     ],
     "~/ray/release/runtime_env_tests/runtime_env_tests.yaml": [
-        "rte_many_tasks_actors",
-        "wheel_urls",
-        "rte_ray_client"
+        "rte_many_tasks_actors", "wheel_urls", "rte_ray_client"
     ],
 }
 

--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -191,6 +191,7 @@ NIGHTLY_TESTS = {
     "~/ray/release/runtime_env_tests/runtime_env_tests.yaml": [
         "rte_many_tasks_actors",
         "wheel_urls",
+        "rte_ray_client"
     ],
 }
 

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -367,9 +367,17 @@ def wheel_url(ray_version, git_branch, git_commit):
            f"ray-{ray_version}-cp37-cp37m-manylinux2014_x86_64.whl"
 
 
+def mac_wheel_url(ray_version, git_branch, git_commit):
+    return f"https://s3-us-west-2.amazonaws.com/ray-wheels/" \
+           f"{git_branch}/{git_commit}/" \
+           f"ray-{ray_version}-cp37-cp37m-macosx_10_15_intel.whl"
+
+
 def wheel_exists(ray_version, git_branch, git_commit):
     url = wheel_url(ray_version, git_branch, git_commit)
-    return requests.head(url).status_code == 200
+    mac_url = mac_wheel_url(ray_version, git_branch, git_commit)
+    return requests.head(url).status_code == 200 and requests.head(
+        mac_url).status_code == 200
 
 
 def commit_or_url(commit_or_url: str) -> str:

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -367,17 +367,9 @@ def wheel_url(ray_version, git_branch, git_commit):
            f"ray-{ray_version}-cp37-cp37m-manylinux2014_x86_64.whl"
 
 
-def mac_wheel_url(ray_version, git_branch, git_commit):
-    return f"https://s3-us-west-2.amazonaws.com/ray-wheels/" \
-           f"{git_branch}/{git_commit}/" \
-           f"ray-{ray_version}-cp37-cp37m-macosx_10_15_intel.whl"
-
-
 def wheel_exists(ray_version, git_branch, git_commit):
     url = wheel_url(ray_version, git_branch, git_commit)
-    mac_url = mac_wheel_url(ray_version, git_branch, git_commit)
-    return requests.head(url).status_code == 200 and requests.head(
-        mac_url).status_code == 200
+    return requests.head(url).status_code == 200
 
 
 def commit_or_url(commit_or_url: str) -> str:

--- a/release/runtime_env_tests/workloads/rte_ray_client.py
+++ b/release/runtime_env_tests/workloads/rte_ray_client.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
 
     addr = os.environ.get("RAY_ADDRESS")
     job_name = os.environ.get("RAY_JOB_NAME", "rte_ray_client")
+    # Test reconnecting to the same cluster multiple times.
     for use_working_dir in [True, True, False, False]:
         with tempfile.TemporaryDirectory() as tmpdir:
             runtime_env = {"working_dir": tmpdir} if use_working_dir else None

--- a/release/runtime_env_tests/workloads/rte_ray_client.py
+++ b/release/runtime_env_tests/workloads/rte_ray_client.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
     addr = os.environ.get("RAY_ADDRESS")
     job_name = os.environ.get("RAY_JOB_NAME", "rte_ray_client")
-    for use_working_dir in [True, False]:
+    for use_working_dir in [True, True, False, False]:
         with tempfile.TemporaryDirectory() as tmpdir:
             runtime_env = {"working_dir": tmpdir} if use_working_dir else None
             print("Testing with use_working_dir=" + str(use_working_dir))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds a test which reconnects to the working_dir with the same working_dir (there used to be a bug in this case, originally reported in https://github.com/ray-project/ray/issues/19792#issuecomment-953331809, which was later fixed, but a unit test hadn't been added yet.). 

This PR also adds the reconnection scenario to the release test, and enables the release test in CI.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
