### PR TITLE
[RLlib; Docs] Added fixes to CartPole example.

### DIFF
--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -21,11 +21,12 @@ The following is a whirlwind overview of RLlib. For a more in-depth guide, see a
 Running RLlib
 ~~~~~~~~~~~~~
 
-RLlib has extra dependencies on top of ``ray``. First, you'll need to install either `PyTorch <http://pytorch.org/>`__ or `TensorFlow <https://www.tensorflow.org>`__. Then, install the RLlib module:
+RLlib has extra dependencies on top of ``ray``. You'll need to install either `PyTorch <http://pytorch.org/>`__ or `TensorFlow <https://www.tensorflow.org>`__ as well as a couple of other dependencies:
 
 .. code-block:: bash
 
-  pip install "ray[rllib]"
+  # if you want to use PyTorch or TF, only need one of the last two
+  pip install "ray[rllib]" pandas tensorflow torch
 
 Then, you can try out training in the following equivalent ways:
 
@@ -42,6 +43,16 @@ Then, you can try out training in the following equivalent ways:
   tune.run(PPOTrainer, config={"env": "CartPole-v0"})  # "log_level": "INFO" for verbose,
                                                        # "framework": "tfe"/"tf2" for eager,
                                                        # "framework": "torch" for PyTorch
+
+If you run into issues, be sure to check you're using the correct RLlib executable with ``which rllib``.
+
+Finally, if you'd like to pause the ``CartPole-v0`` example and restart some other time, you can do so with ``CTRL+C``, and you'll see something like the following:
+
+.. code-block:: bash
+
+  2021-10-27 17:40:20,804 WARNING tune.py:622 -- Experiment has been interrupted, but the most recent state was saved.You can continue running this experiment by passing `resume=True` to `tune.run()`
+
+You can read more here about RLlib's deep integration with Ray Tune, and how this allows you to save model checkpoints as you train so your progress is never lost.
 
 Next, we'll cover three key concepts in RLlib: Policies, Samples, and Trainers.
 

--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -25,7 +25,7 @@ RLlib has extra dependencies on top of ``ray``. You'll need to install either `P
 
 .. code-block:: bash
 
-  # if you want to use PyTorch or TF, only need one of the last two
+  # Note: You will only need either `torch` or `tensorflow`, but feel free to install both:
   pip install "ray[rllib]" pandas tensorflow torch
 
 Then, you can try out training in the following equivalent ways:


### PR DESCRIPTION
This updates the initial Rllib example to not break and just run "as is"!

Part of the Q4 audit of examples.

TODO: needs linking to Tune + checkpointing docs.