### PR TITLE
Fix unused import warning in streaming.proto

### DIFF
--- a/streaming/BUILD.bazel
+++ b/streaming/BUILD.bazel
@@ -9,9 +9,6 @@ proto_library(
     srcs = ["src/protobuf/streaming.proto"],
     strip_import_prefix = "src",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_google_protobuf//:any_proto",
-    ],
 )
 
 proto_library(

--- a/streaming/src/protobuf/streaming.proto
+++ b/streaming/src/protobuf/streaming.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package ray.streaming.proto;
 
-import "google/protobuf/any.proto";
-
 option java_package = "io.ray.streaming.runtime.generated";
 
 enum Language {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This generates a warning when calling `protoc` on the proto.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
