### PR TITLE
[Collective] Allow send/recv partial tensors in Send/Recv primitives

### DIFF
--- a/python/ray/util/collective/collective.py
+++ b/python/ray/util/collective/collective.py
@@ -571,7 +571,8 @@ def send_multigpu(tensor,
         raise RuntimeError("The dst_rank '{}' is self. Considering "
                            "doing GPU to GPU memcpy instead?".format(dst_rank))
     if n_elements < 0:
-        raise RuntimeError("The n_elements '{}' should >= 0.".format(n_elements))
+        raise RuntimeError(
+            "The n_elements '{}' should >= 0.".format(n_elements))
     opts = types.SendOptions()
     opts.dst_rank = dst_rank
     opts.dst_gpu_index = dst_gpu_index
@@ -629,7 +630,8 @@ def recv_multigpu(tensor,
         raise RuntimeError("The dst_rank '{}' is self. Considering "
                            "doing GPU to GPU memcpy instead?".format(src_rank))
     if n_elements < 0:
-        raise RuntimeError("The n_elements '{}' should be >= 0.".format(n_elements))
+        raise RuntimeError(
+            "The n_elements '{}' should be >= 0.".format(n_elements))
     opts = types.RecvOptions()
     opts.src_rank = src_rank
     opts.src_gpu_index = src_gpu_index

--- a/python/ray/util/collective/collective.py
+++ b/python/ray/util/collective/collective.py
@@ -544,7 +544,8 @@ def send(tensor, dst_rank: int, group_name: str = "default"):
 def send_multigpu(tensor,
                   dst_rank: int,
                   dst_gpu_index: int,
-                  group_name: str = "default"):
+                  group_name: str = "default",
+                  n_elements: int = 0):
     """Send a tensor to a remote GPU synchronously.
 
     The function asssume each process owns >1 GPUs, and the sender
@@ -555,6 +556,8 @@ def send_multigpu(tensor,
         dst_rank (int): the rank of the destination process.
         dst_gpu_index (int): the destination gpu index.
         group_name (str): the name of the collective group.
+        n_elements (int): if specified, send the next n elements
+            from the starting address of tensor.
 
     Returns:
         None
@@ -567,9 +570,12 @@ def send_multigpu(tensor,
     if dst_rank == g.rank:
         raise RuntimeError("The dst_rank '{}' is self. Considering "
                            "doing GPU to GPU memcpy instead?".format(dst_rank))
+    if n_elements < 0:
+        raise RuntimeError("The n_elements '{}' should >= 0.".format(n_elements))
     opts = types.SendOptions()
     opts.dst_rank = dst_rank
     opts.dst_gpu_index = dst_gpu_index
+    opts.n_elements = n_elements
     g.send([tensor], opts)
 
 
@@ -598,7 +604,8 @@ def recv(tensor, src_rank: int, group_name: str = "default"):
 def recv_multigpu(tensor,
                   src_rank: int,
                   src_gpu_index: int,
-                  group_name: str = "default"):
+                  group_name: str = "default",
+                  n_elements: int = 0):
     """Receive a tensor from a remote GPU synchronously.
 
     The function asssume each process owns >1 GPUs, and the sender
@@ -621,9 +628,12 @@ def recv_multigpu(tensor,
     if src_rank == g.rank:
         raise RuntimeError("The dst_rank '{}' is self. Considering "
                            "doing GPU to GPU memcpy instead?".format(src_rank))
+    if n_elements < 0:
+        raise RuntimeError("The n_elements '{}' should be >= 0.".format(n_elements))
     opts = types.RecvOptions()
     opts.src_rank = src_rank
     opts.src_gpu_index = src_gpu_index
+    opts.n_elements = n_elements
     g.recv([tensor], opts)
 
 

--- a/python/ray/util/collective/collective_group/nccl_collective_group.py
+++ b/python/ray/util/collective/collective_group/nccl_collective_group.py
@@ -349,7 +349,8 @@ class NCCLGroup(BaseGroup):
         def p2p_fn(tensor, comm, stream, peer):
             comm.send(
                 nccl_util.get_tensor_ptr(tensor),
-                nccl_util.get_tensor_n_elements(tensor),
+                send_options.n_elements if send_options.n_elements > 0
+                else nccl_util.get_tensor_n_elements(tensor),
                 nccl_util.get_nccl_tensor_dtype(tensor), peer, stream.ptr)
 
         self._point2point(tensors, p2p_fn, send_options.dst_rank,
@@ -369,7 +370,8 @@ class NCCLGroup(BaseGroup):
         def p2p_fn(tensor, comm, stream, peer):
             comm.recv(
                 nccl_util.get_tensor_ptr(tensor),
-                nccl_util.get_tensor_n_elements(tensor),
+                recv_options.n_elements if recv_options.n_elements > 0
+                else nccl_util.get_tensor_n_elements(tensor),
                 nccl_util.get_nccl_tensor_dtype(tensor), peer, stream.ptr)
 
         self._point2point(tensors, p2p_fn, recv_options.src_rank,

--- a/python/ray/util/collective/collective_group/nccl_collective_group.py
+++ b/python/ray/util/collective/collective_group/nccl_collective_group.py
@@ -348,9 +348,9 @@ class NCCLGroup(BaseGroup):
 
         def p2p_fn(tensor, comm, stream, peer):
             comm.send(
-                nccl_util.get_tensor_ptr(tensor),
-                send_options.n_elements if send_options.n_elements > 0
-                else nccl_util.get_tensor_n_elements(tensor),
+                nccl_util.get_tensor_ptr(tensor), send_options.n_elements
+                if send_options.n_elements > 0 else
+                nccl_util.get_tensor_n_elements(tensor),
                 nccl_util.get_nccl_tensor_dtype(tensor), peer, stream.ptr)
 
         self._point2point(tensors, p2p_fn, send_options.dst_rank,
@@ -369,9 +369,9 @@ class NCCLGroup(BaseGroup):
 
         def p2p_fn(tensor, comm, stream, peer):
             comm.recv(
-                nccl_util.get_tensor_ptr(tensor),
-                recv_options.n_elements if recv_options.n_elements > 0
-                else nccl_util.get_tensor_n_elements(tensor),
+                nccl_util.get_tensor_ptr(tensor), recv_options.n_elements
+                if recv_options.n_elements > 0 else
+                nccl_util.get_tensor_n_elements(tensor),
                 nccl_util.get_nccl_tensor_dtype(tensor), peer, stream.ptr)
 
         self._point2point(tensors, p2p_fn, recv_options.src_rank,

--- a/python/ray/util/collective/types.py
+++ b/python/ray/util/collective/types.py
@@ -101,6 +101,7 @@ class ReduceScatterOptions:
 class SendOptions:
     dst_rank = 0
     dst_gpu_index = 0
+    n_elements = 0
     timeout_ms = unset_timeout_ms
 
 
@@ -108,4 +109,5 @@ class SendOptions:
 class RecvOptions:
     src_rank = 0
     src_gpu_index = 0
+    n_elements = 0
     unset_timeout_ms = unset_timeout_ms


### PR DESCRIPTION
## Why are these changes needed?
In some cases, a user does not want to communicate a full tensor, but just a continuous subset of it.
We slightly extend the API of p2p primitive send/recv to allow this.  A RISELab ongoing project has several use cases depending on this.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
