### PR TITLE
[RLlib; Docs] Updated RLlib training example page

### DIFF
--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -15,10 +15,11 @@ be trained, checkpointed, or an action computed. In multi-agent training, the tr
 
 .. image:: rllib-api.svg
 
-You can train a simple DQN trainer with the following command:
+You can train a simple DQN trainer with the following commands:
 
 .. code-block:: bash
 
+    pip install "ray[rllib]" tensorflow
     rllib train --run DQN --env CartPole-v0  # --config '{"framework": "tf2", "eager_tracing": true}' for eager execution
 
 By default, the results will be logged to a subdirectory of ``~/ray_results``.
@@ -56,6 +57,7 @@ An example of evaluating a previously trained DQN policy is as follows:
 
 .. code-block:: bash
 
+    pip install gym
     rllib rollout \
         ~/ray_results/default/DQN_CartPole-v0_0upjmdgr0/checkpoint_1/checkpoint-1 \
         --run DQN --env CartPole-v0 --steps 10000

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -57,7 +57,6 @@ An example of evaluating a previously trained DQN policy is as follows:
 
 .. code-block:: bash
 
-    pip install gym
     rllib rollout \
         ~/ray_results/default/DQN_CartPole-v0_0upjmdgr0/checkpoint_1/checkpoint-1 \
         --run DQN --env CartPole-v0 --steps 10000


### PR DESCRIPTION
This updates the RLlib training docs page to stop users from running into errors when running examples.

Added some `pip install ...` to help. Still running into this error, though:

```
% rllib train --env=PongDeterministic-v4 --run=A2C --config '{"num_workers": 8}'
Traceback (most recent call last):
  File "/Users/will/opt/anaconda3/envs/ray-docs/bin/rllib", line 5, in <module>
    from ray.rllib.scripts import cli
  File "/Users/will/opt/anaconda3/envs/ray-docs/lib/python3.7/site-packages/ray/rllib/__init__.py", line 5, in <module>
    from ray.rllib.env.base_env import BaseEnv
  File "/Users/will/opt/anaconda3/envs/ray-docs/lib/python3.7/site-packages/ray/rllib/env/__init__.py", line 1, in <module>
    from ray.rllib.env.base_env import BaseEnv
  File "/Users/will/opt/anaconda3/envs/ray-docs/lib/python3.7/site-packages/ray/rllib/env/base_env.py", line 3, in <module>
    from ray.rllib.env.external_env import ExternalEnv
  File "/Users/will/opt/anaconda3/envs/ray-docs/lib/python3.7/site-packages/ray/rllib/env/external_env.py", line 7, in <module>
    from ray.rllib.utils.annotations import PublicAPI
  File "/Users/will/opt/anaconda3/envs/ray-docs/lib/python3.7/site-packages/ray/rllib/utils/__init__.py", line 10, in <module>
    from ray.rllib.utils.numpy import sigmoid, softmax, relu, one_hot, fc, lstm, \
  File "/Users/will/opt/anaconda3/envs/ray-docs/lib/python3.7/site-packages/ray/rllib/utils/numpy.py", line 2, in <module>
    import tree
ModuleNotFoundError: No module named 'tree'
```

