### PR TITLE
[CI] Pin aiohttp version to fix master branch

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp==3.7
 blist
 boto3
 cython==0.29.0

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -76,7 +76,7 @@ if [[ "$platform" == "linux" ]]; then
     "$PYTHON_EXE" -u -c "import ray; print(ray.__commit__)" | grep "$TRAVIS_COMMIT" || (echo "ray.__commit__ not set properly!" && exit 1)
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp==3.7 grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
@@ -117,7 +117,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp==3.7 grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do

--- a/python/requirements/requirements_default.txt
+++ b/python/requirements/requirements_default.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.7
+aiohttp==3.7
 aiohttp_cors
 aioredis<2
 colorful

--- a/python/setup.py
+++ b/python/setup.py
@@ -191,7 +191,7 @@ if setup_spec.type == SetupType.RAY:
             "fsspec",
         ],
         "default": [
-            "aiohttp >= 3.7",
+            "aiohttp == 3.7",
             "aiohttp_cors",
             "aioredis < 2",
             "colorful",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
aiohttp 3.8.0 release broke our tests.
```
Traceback (most recent call last):
  File "/ray/python/ray/_private/services.py", line 1262, in start_dashboard
    import ray.dashboard.optional_deps  # noqa: F401
  File "/ray/python/ray/dashboard/optional_deps.py", line 8, in <module>
    import aiohttp.signals
ModuleNotFoundError: No module named 'aiohttp.signals'
```

ping for now, going to fix it soon.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
