### PR TITLE
[RFC] Add tsan build mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,7 +96,7 @@ build:tsan --copt -DTHREAD_SANITIZER
 build:tsan --copt -O2
 build:tsan --copt -g
 build:tsan --copt -fno-omit-frame-pointer
-build:tsan --copt -Wno-maybe-uninitialized
+build:tsan --copt -Wno-uninitialized
 build:tsan --linkopt -fsanitize=thread
 # This config is only for running TSAN with LLVM toolchain on Linux.
 build:tsan-clang --config=tsan

--- a/.bazelrc
+++ b/.bazelrc
@@ -96,6 +96,7 @@ build:tsan --copt -DTHREAD_SANITIZER
 build:tsan --copt -O2
 build:tsan --copt -g
 build:tsan --copt -fno-omit-frame-pointer
+build:tsan --copt -Wno-maybe-uninitialized
 build:tsan --linkopt -fsanitize=thread
 # This config is only for running TSAN with LLVM toolchain on Linux.
 build:tsan-clang --config=tsan

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,6 +69,7 @@ class BuildType(Enum):
     DEFAULT = 1
     DEBUG = 2
     ASAN = 3
+    TSAN = 4
 
 
 class SetupSpec:
@@ -102,6 +103,8 @@ if build_type == "debug":
     BUILD_TYPE = BuildType.DEBUG
 elif build_type == "asan":
     BUILD_TYPE = BuildType.ASAN
+elif build_type == "tsan":
+    BUILD_TYPE = BuildType.TSAN
 else:
     BUILD_TYPE = BuildType.DEFAULT
 
@@ -509,6 +512,8 @@ def build(build_python, build_java, build_cpp):
         bazel_flags.extend(["--config", "debug"])
     if setup_spec.build_type == BuildType.ASAN:
         bazel_flags.extend(["--config=asan-build"])
+    if setup_spec.build_type == BuildType.TSAN:
+        bazel_flags.extend(["--config=tsan"])
 
     return bazel_invoke(
         subprocess.check_call,

--- a/python/setup.py
+++ b/python/setup.py
@@ -83,6 +83,8 @@ class SetupSpec:
             self.version: str = f"{version}+dbg"
         elif build_type == BuildType.ASAN:
             self.version: str = f"{version}+asan"
+        elif build_type == BuildType.TSAN:
+            self.version: str = f"{version}+tsan"
         else:
             self.version = version
         self.description: str = description


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This allows you to build Ray with tsan via `RAY_DEBUG_BUILD=tsan pip install -e . --verbose`.

After building, you can `LD_PRELOAD=/lib/x86_64-linux-gnu/libtsan.so.0 python` to run Ray with tsan enabled. Here's an example tsan log of a simple ray task execution (seems we have some non-thread safe stats usage): https://gist.github.com/ericl/f062fc614731b2b2ccb15189db73aeb0