### PR TITLE
[Datasets] Add standard deviation aggregation.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -28,7 +28,8 @@ from ray.data.block import Block, BlockAccessor, BlockMetadata, T, U, \
 from ray.data.datasource import (
     Datasource, CSVDatasource, JSONDatasource, NumpyDatasource,
     ParquetDatasource, BlockWritePathProvider, DefaultBlockWritePathProvider)
-from ray.data.aggregate import AggregateOnT, AggregateFn, Sum, Max, Min, Mean
+from ray.data.aggregate import AggregateOnT, AggregateFn, Sum, Max, Min, \
+    Mean, Std
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.batcher import Batcher
 from ray.data.impl.compute import get_compute, cache_wrapper, \
@@ -921,6 +922,28 @@ class Dataset(Generic[T]):
         ret = self.aggregate(Mean(on))
         if ret is None:
             raise ValueError("Cannot compute mean on an empty dataset")
+        else:
+            return ret[0]
+
+    def std(self, on: AggregateOnT = None, ddof: int = 1) -> U:
+        """Compute standard deviation over entire dataset.
+
+        Examples:
+            >>> ray.data.range(100).std()
+            >>> ray.data.range_arrow(100).std("value")
+
+        Args:
+            on: The data on which to compute the standard deviation.
+                It can be the column name for Arrow dataset.
+            ddof: Delta Degrees of Freedom. The divisor used in calculations
+                is N - ddof, where N represents the number of elements.
+
+        Returns:
+            The standard deviation result.
+        """
+        ret = self.aggregate(Std(on, ddof))
+        if ret is None:
+            raise ValueError("Cannot compute std on an empty dataset")
         else:
             return ret[0]
 

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -5,7 +5,7 @@ from ray.util.annotations import PublicAPI
 from ray.data.dataset import Dataset
 from ray.data.impl import sort
 from ray.data.aggregate import AggregateFn, Count, Sum, Max, Min, \
-    Mean, AggregateOnT
+    Mean, Std, AggregateOnT
 from ray.data.impl.block_list import BlockList
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.progress_bar import ProgressBar
@@ -231,6 +231,32 @@ class GroupedDataset(Generic[T]):
             If groupby key is None then the key part of return is omitted.
         """
         return self.aggregate(Mean(on))
+
+    def std(self, on: AggregateOnT = None, ddof: int = 1) -> Dataset[U]:
+        """Compute standard deviation aggregation.
+
+        This is a blocking operation.
+
+        Examples:
+            >>> ray.data.range(100).groupby(lambda x: x % 3).std()
+            >>> ray.data.from_items([
+            ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
+            ...     "A").std("B")
+
+        Args:
+            on: The data on which to compute the standard deviation.
+                It can be the column name for Arrow dataset.
+            ddof: Delta Degrees of Freedom. The divisor used in calculations
+                is N - ddof, where N represents the number of elements.
+
+        Returns:
+            A simple dataset of (k, v) pairs or
+            an Arrow dataset of [k, v] columns
+            where k is the groupby key and
+            v is the standard deviation result.
+            If groupby key is None then the key part of return is omitted.
+        """
+        return self.aggregate(Std(on, ddof))
 
 
 def _partition_and_combine_block(block: Block[T], boundaries: List[KeyType],

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2883,6 +2883,8 @@ def test_groupby_arrow(ray_start_regular_shared):
         lambda r: r["value"] > 10).groupby("value").count()
     assert agg_ds.count() == 0
 
+
+def test_groupby_arrow_count(ray_start_regular_shared):
     # Test built-in count aggregation
     xs = list(range(100))
     random.shuffle(xs)
@@ -2895,6 +2897,8 @@ def test_groupby_arrow(ray_start_regular_shared):
         [{"A": 0, "count()": 34}, {"A": 1, "count()": 33},
          {"A": 2, "count()": 33}]
 
+
+def test_groupby_arrow_sum(ray_start_regular_shared):
     # Test built-in sum aggregation
     xs = list(range(100))
     random.shuffle(xs)
@@ -2911,6 +2915,8 @@ def test_groupby_arrow(ray_start_regular_shared):
     assert ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).sum(
         "value") == 0
 
+
+def test_groupby_arrow_min(ray_start_regular_shared):
     # Test built-in min aggregation
     xs = list(range(100))
     random.shuffle(xs)
@@ -2927,6 +2933,8 @@ def test_groupby_arrow(ray_start_regular_shared):
     with pytest.raises(ValueError):
         ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).min("value")
 
+
+def test_groupby_arrow_max(ray_start_regular_shared):
     # Test built-in max aggregation
     xs = list(range(100))
     random.shuffle(xs)
@@ -2943,6 +2951,8 @@ def test_groupby_arrow(ray_start_regular_shared):
     with pytest.raises(ValueError):
         ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).max("value")
 
+
+def test_groupby_arrow_mean(ray_start_regular_shared):
     # Test built-in mean aggregation
     xs = list(range(100))
     random.shuffle(xs)
@@ -2959,6 +2969,24 @@ def test_groupby_arrow(ray_start_regular_shared):
     with pytest.raises(ValueError):
         ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).mean(
             "value")
+
+
+def test_groupby_arrow_std(ray_start_regular_shared):
+    # Test built-in std aggregation
+    xs = list(range(100))
+    random.shuffle(xs)
+    df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
+    agg_ds = ray.data.from_pandas(df).groupby("A").std("B")
+    assert agg_ds.count() == 3
+    expected = df.groupby("A")["B"].std()
+    assert agg_ds.to_pandas()["std(B)"].equals(expected)
+    # Test built-in global std aggregation
+    df = pd.DataFrame({"A": xs})
+    ray.data.from_pandas(df).std("A") == df["A"].std()
+    with pytest.raises(ValueError):
+        ray.data.from_pandas(pd.DataFrame({"A": []})).std("A")
+    # Test edge cases
+    assert ray.data.from_pandas(pd.DataFrame({"A": [3]})).std("A") == 0
 
 
 def test_groupby_simple(ray_start_regular_shared):


### PR DESCRIPTION
Adds standard deviation groupby + global aggregation. We use an accumulator-style implementation of [Welford's method](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for the sake of numerical stability and it being computable in a single pass.

**NOTE:** I noticed that, although the `on` parameter is optional for the aggregation functions, `on` must be given for Arrow Datasets, otherwise the aggregation functions will fail with an opaque error (trying to add a float and a dict). I was going to raise a more informative error as a driveby in this PR, but I'll be adding multi-aggregation next which will add support for no `on` parameter when aggregating on Arrow Datasets, so I decided to leave it as-is.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
