### PR TITLE
[data] Skip tests locally if moto server is not installed

### DIFF
--- a/python/ray/data/tests/mock_server.py
+++ b/python/ray/data/tests/mock_server.py
@@ -15,6 +15,8 @@ _proxy_bypass = {
 
 def start_service(service_name, host, port):
     moto_svr_path = shutil.which("moto_server")
+    if not moto_svr_path:
+        pytest.skip("moto not installed")
     args = [moto_svr_path, service_name, "-H", host, "-p", str(port)]
     # For debugging
     # args = '{0} {1} -H {2} -p {3} 2>&1 | \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

(this speeds up tests a lot since moto start is quite slow)