### PR TITLE
WINDOWS: disable multi-node (cluster) mode on windows

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1333,6 +1333,8 @@ cdef class CoreWorker:
                         CRayObject(data, metadata, contained_object_refs),
                         contained_object_ids, c_object_id))
             else:
+                if os.name == "nt":
+                    raise RuntimeError("multi-node not supported on windows")
                 c_owner_address = move(self._convert_python_address(
                     owner_address))
                 with nogil:

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -160,6 +160,8 @@ def create_or_update_cluster(
     # no_monitor_on_head is an internal flag used by the Ray K8s operator.
     # If True, prevents autoscaling config sync to the Ray head during cluster
     # creation. See https://github.com/ray-project/ray/pull/13720.
+    if os.name == 'nt':
+        raise RuntimeError('cannot currently use multi-node on windows')
     set_using_login_shells(use_login_shells)
     if not use_login_shells:
         cmd_output_util.set_allow_interactive(False)

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -160,8 +160,8 @@ def create_or_update_cluster(
     # no_monitor_on_head is an internal flag used by the Ray K8s operator.
     # If True, prevents autoscaling config sync to the Ray head during cluster
     # creation. See https://github.com/ray-project/ray/pull/13720.
-    if os.name == 'nt':
-        raise RuntimeError('cannot currently use multi-node on windows')
+    if os.name == "nt":
+        raise RuntimeError("cannot currently use multi-node on windows")
     set_using_login_shells(use_login_shells)
     if not use_login_shells:
         cmd_output_util.set_allow_interactive(False)

--- a/python/ray/autoscaler/_private/local/node_provider.py
+++ b/python/ray/autoscaler/_private/local/node_provider.py
@@ -166,8 +166,8 @@ class LocalNodeProvider(NodeProvider):
 
     def __init__(self, provider_config, cluster_name):
 
-        if os.name == 'nt':
-            raise RuntimeError('cannot currently use multi-node on windows')
+        if os.name == "nt":
+            raise RuntimeError("cannot currently use multi-node on windows")
 
         NodeProvider.__init__(self, provider_config, cluster_name)
 

--- a/python/ray/autoscaler/_private/local/node_provider.py
+++ b/python/ray/autoscaler/_private/local/node_provider.py
@@ -165,6 +165,10 @@ class LocalNodeProvider(NodeProvider):
     """
 
     def __init__(self, provider_config, cluster_name):
+
+        if os.name == 'nt':
+            raise RuntimeError('cannot currently use multi-node on windows')
+
         NodeProvider.__init__(self, provider_config, cluster_name)
 
         if cluster_name:

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -96,6 +96,8 @@ class Cluster:
             shutdown_at_exit (bool): If True, registers an exit hook
                 for shutting down all started processes.
         """
+        if os.name == 'nt':
+            raise RuntimeError('cannot currently use clusters on windows')
         self.head_node = None
         self.worker_nodes = set()
         self.redis_address = None

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -96,8 +96,8 @@ class Cluster:
             shutdown_at_exit (bool): If True, registers an exit hook
                 for shutting down all started processes.
         """
-        if os.name == 'nt':
-            raise RuntimeError('cannot currently use clusters on windows')
+        if os.name == "nt":
+            raise RuntimeError("cannot currently use clusters on windows")
         self.head_node = None
         self.worker_nodes = set()
         self.redis_address = None

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -105,6 +105,15 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_autoscaler_fake_multinode.py",  # Temporarily owned by core.
+  ],
+  size = "medium",
+  extra_srcs = SRCS,
+  tags = ["exclusive", "team:core"],
+  deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+  files = [
     "test_args.py",
     "test_asyncio_cluster.py",
     "test_asyncio.py",

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -101,7 +101,7 @@ def ray_start_regular_shared(request):
     }])
 def ray_start_shared_local_modes(request):
     param = getattr(request, "param", {})
-    if params["local_mode"] is False and os.name == "nt":
+    if param["local_mode"] is False and os.name == "nt":
         pytest.skip("multi-node not supported on windows")
     with _ray_start(**param) as res:
         yield res

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -121,6 +121,8 @@ def ray_start_10_cpus(request):
 
 @contextmanager
 def _ray_start_cluster(**kwargs):
+    if os.name == 'nt':
+        pytest.skip('multi-node not supported on windows')
     init_kwargs = get_default_fixture_ray_kwargs()
     num_nodes = 0
     do_init = False
@@ -273,6 +275,8 @@ def two_node_cluster():
         "object_timeout_milliseconds": 200,
         "num_heartbeats_timeout": 10,
     }
+    if os.name == 'nt':
+        pytest.skip('multi-node not supported on windows')
     cluster = ray.cluster_utils.Cluster(
         head_node_args={"_system_config": system_config})
     for _ in range(2):

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -101,6 +101,8 @@ def ray_start_regular_shared(request):
     }])
 def ray_start_shared_local_modes(request):
     param = getattr(request, "param", {})
+    if params["local_mode"] is False and os.name == "nt":
+        pytest.skip("multi-node not supported on windows")
     with _ray_start(**param) as res:
         yield res
 
@@ -121,8 +123,8 @@ def ray_start_10_cpus(request):
 
 @contextmanager
 def _ray_start_cluster(**kwargs):
-    if os.name == 'nt':
-        pytest.skip('multi-node not supported on windows')
+    if os.name == "nt":
+        pytest.skip("multi-node not supported on windows")
     init_kwargs = get_default_fixture_ray_kwargs()
     num_nodes = 0
     do_init = False
@@ -275,8 +277,8 @@ def two_node_cluster():
         "object_timeout_milliseconds": 200,
         "num_heartbeats_timeout": 10,
     }
-    if os.name == 'nt':
-        pytest.skip('multi-node not supported on windows')
+    if os.name == "nt":
+        pytest.skip("multi-node not supported on windows")
     cluster = ray.cluster_utils.Cluster(
         head_node_args={"_system_config": system_config})
     for _ in range(2):

--- a/python/ray/tests/test_asyncio_cluster.py
+++ b/python/ray/tests/test_asyncio_cluster.py
@@ -8,7 +8,10 @@ import numpy as np
 import ray
 from ray.cluster_utils import Cluster
 
+avoid_multi_node = (sys.platform == 'win32')
 
+
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 @pytest.mark.asyncio
 async def test_asyncio_cluster_wait():
     cluster = Cluster()

--- a/python/ray/tests/test_asyncio_cluster.py
+++ b/python/ray/tests/test_asyncio_cluster.py
@@ -8,7 +8,7 @@ import numpy as np
 import ray
 from ray.cluster_utils import Cluster
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -4,7 +4,7 @@ import sys
 import ray
 from ray.cluster_utils import AutoscalingCluster
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -1,12 +1,13 @@
 import pytest
-import platform
+import sys
 
 import ray
 from ray.cluster_utils import AutoscalingCluster
 
+avoid_multi_node = (sys.platform == 'win32')
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
+
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_fake_autoscaler_basic_e2e(shutdown_only):
     # __example_begin__
     cluster = AutoscalingCluster(

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -81,6 +81,8 @@ boto3_list = [{
     }
 }]
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 @pytest.fixture
 def configure_lang():
@@ -494,6 +496,7 @@ def test_ray_status():
     ray.shutdown()
 
 
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_ray_status_multinode():
     from ray.cluster_utils import Cluster
     cluster = Cluster()

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -81,7 +81,7 @@ boto3_list = [{
     }
 }]
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.fixture

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -13,6 +13,8 @@ from ray._private.test_utils import run_string_as_driver_nonblocking,\
 
 from ray.cluster_utils import Cluster
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 @pytest.mark.parametrize("address", [
     "localhost:1234", "localhost:1234/url?params",
@@ -45,7 +47,7 @@ def test_client(address):
         assert builder.address == address.replace("ray://", "")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_namespace():
     """
     Most of the "checks" in this test case rely on the fact that

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -13,7 +13,7 @@ from ray._private.test_utils import run_string_as_driver_nonblocking,\
 
 from ray.cluster_utils import Cluster
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.mark.parametrize("address", [

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -43,8 +43,8 @@ class C:
 
 @pytest.fixture
 def init_and_serve_lazy():
-    if os.name == 'nt':
-        pytest.skip('multi-node not supported on windows')
+    if os.name == "nt":
+        pytest.skip("multi-node not supported on windows")
     cluster = ray.cluster_utils.Cluster()
     cluster.add_node(num_cpus=1, num_gpus=0)
     cluster.wait_for_nodes(1)

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -1,4 +1,5 @@
 """Client tests that run their own init (as with init_and_serve) live here"""
+import os
 import pytest
 
 import time
@@ -42,6 +43,8 @@ class C:
 
 @pytest.fixture
 def init_and_serve_lazy():
+    if os.name == 'nt':
+        pytest.skip('multi-node not supported on windows')
     cluster = ray.cluster_utils.Cluster()
     cluster.add_node(num_cpus=1, num_gpus=0)
     cluster.wait_for_nodes(1)

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -19,8 +19,8 @@ SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 @pytest.fixture(params=[(1, 4), (4, 4)])
 def ray_start_workers_separate_multinode(request):
-    if os.name == 'nt':
-        pytest.skip('multi-node not supported on windows')
+    if os.name == "nt":
+        pytest.skip("multi-node not supported on windows")
     num_nodes = request.param[0]
     num_initial_workers = request.param[1]
     # Start the Ray processes.

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -19,6 +19,8 @@ SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 @pytest.fixture(params=[(1, 4), (4, 4)])
 def ray_start_workers_separate_multinode(request):
+    if os.name == 'nt':
+        pytest.skip('multi-node not supported on windows')
     num_nodes = request.param[0]
     num_initial_workers = request.param[1]
     # Start the Ray processes.

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -22,6 +22,8 @@ import pytest
 
 class OnPremCoordinatorServerTest(unittest.TestCase):
     def setUp(self):
+        if os.name == 'nt':
+            pytest.skip('multi-node not supported on windows')
         self.list_of_node_ips = ["0.0.0.0:1", "0.0.0.0:2"]
         self.host, self.port = socket.gethostbyname(socket.gethostname()), 1234
         self.server = OnPremCoordinatorServer(

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -22,8 +22,8 @@ import pytest
 
 class OnPremCoordinatorServerTest(unittest.TestCase):
     def setUp(self):
-        if os.name == 'nt':
-            pytest.skip('multi-node not supported on windows')
+        if os.name == "nt":
+            pytest.skip("multi-node not supported on windows")
         self.list_of_node_ips = ["0.0.0.0:1", "0.0.0.0:2"]
         self.host, self.port = socket.gethostbyname(socket.gethostname()), 1234
         self.server = OnPremCoordinatorServer(

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -17,7 +17,7 @@ from ray.core.generated import gcs_service_pb2_grpc
 from ray._private.test_utils import (init_error_pubsub, get_error_message,
                                      run_string_as_driver, wait_for_condition)
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 def search_raylet(cluster):

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -17,6 +17,8 @@ from ray.core.generated import gcs_service_pb2_grpc
 from ray._private.test_utils import (init_error_pubsub, get_error_message,
                                      run_string_as_driver, wait_for_condition)
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 def search_raylet(cluster):
     """Return the number of running processes."""
@@ -94,6 +96,7 @@ def test_retry_application_level_error(ray_start_regular):
         ray.get(r3)
 
 
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_connect_with_disconnected_node(shutdown_only):
     config = {
         "num_heartbeats_timeout": 50,
@@ -178,7 +181,6 @@ if __name__ == "__main__":
     assert x == 42
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("debug_enabled", [False, True])
 def test_object_lost_error(ray_start_cluster, debug_enabled):
     cluster = ray_start_cluster
@@ -245,7 +247,6 @@ def test_object_lost_error(ray_start_cluster, debug_enabled):
         assert ("test_object_lost_error" in error) == debug_enabled
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [{
         "num_cpus": 0,
@@ -338,7 +339,6 @@ def test_raylet_graceful_shutdown_through_rpc(ray_start_cluster_head,
     ray.get(f.options(num_cpus=0).remote())
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
     "ray_start_cluster_head", [{
         "num_cpus": 0,

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -14,7 +14,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.internal.internal_api import global_gc
 
 logger = logging.getLogger(__name__)
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 def test_auto_local_gc(shutdown_only):

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import gc
 import logging
+import sys
 import weakref
 
 import numpy as np
@@ -13,6 +14,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.internal.internal_api import global_gc
 
 logger = logging.getLogger(__name__)
+avoid_multi_node = (sys.platform == 'win32')
 
 
 def test_auto_local_gc(shutdown_only):
@@ -58,6 +60,7 @@ def test_auto_local_gc(shutdown_only):
         gc.enable()
 
 
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_global_gc(shutdown_only):
     cluster = ray.cluster_utils.Cluster()
     cluster.add_node(
@@ -108,6 +111,7 @@ def test_global_gc(shutdown_only):
         gc.enable()
 
 
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_global_gc_when_full(shutdown_only):
     cluster = ray.cluster_utils.Cluster()
     for _ in range(2):

--- a/python/ray/tests/test_k8s_cluster_launcher.py
+++ b/python/ray/tests/test_k8s_cluster_launcher.py
@@ -13,6 +13,8 @@ from ray.autoscaler import sdk
 
 IMAGE_ENV = "KUBERNETES_CLUSTER_LAUNCHER_TEST_IMAGE"
 
+avoid_multi_node = (os.name == 'nt')
+
 
 def fill_image_field(pod_config):
     image = os.getenv(IMAGE_ENV, "rayproject/ray:nightly")
@@ -35,6 +37,8 @@ def get_config():
 
 
 class KubernetesTest(unittest.TestCase):
+    @pytest.mark.xfail("avoid_multi_node",
+                       reason="cluster requires multi-node")
     def test_up_and_down(self):
         """(1) Runs 'ray up' with a Kubernetes config that specifies
         min_workers=1.

--- a/python/ray/tests/test_k8s_cluster_launcher.py
+++ b/python/ray/tests/test_k8s_cluster_launcher.py
@@ -13,7 +13,7 @@ from ray.autoscaler import sdk
 
 IMAGE_ENV = "KUBERNETES_CLUSTER_LAUNCHER_TEST_IMAGE"
 
-avoid_multi_node = (os.name == 'nt')
+avoid_multi_node = (os.name == "nt")
 
 
 def fill_image_field(pod_config):

--- a/python/ray/tests/test_k8s_cluster_launcher.py
+++ b/python/ray/tests/test_k8s_cluster_launcher.py
@@ -37,8 +37,8 @@ def get_config():
 
 
 class KubernetesTest(unittest.TestCase):
-    @pytest.mark.xfail("avoid_multi_node",
-                       reason="cluster requires multi-node")
+    @pytest.mark.xfail(
+        "avoid_multi_node", reason="cluster requires multi-node")
     def test_up_and_down(self):
         """(1) Runs 'ray up' with a Kubernetes config that specifies
         min_workers=1.

--- a/python/ray/tests/test_k8s_operator_unit_tests.py
+++ b/python/ray/tests/test_k8s_operator_unit_tests.py
@@ -35,6 +35,8 @@ file mounts.
 START = "start"
 JOIN = "join"
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 def mock_start(self):
     # Detects any file mounts passed in NodeUpdaterThread.__init__()
@@ -134,6 +136,8 @@ def custom_resources():
 
 
 class OperatorTest(unittest.TestCase):
+    @pytest.mark.xfail("avoid_multi_node",
+                       reason="cluster requires multi-node")
     def test_no_file_mounts_k8s_operator_cluster_launch(self):
         with patch.object(NodeUpdaterThread, START, mock_start),\
                 patch.object(NodeUpdaterThread, JOIN, mock_join),\

--- a/python/ray/tests/test_k8s_operator_unit_tests.py
+++ b/python/ray/tests/test_k8s_operator_unit_tests.py
@@ -136,8 +136,8 @@ def custom_resources():
 
 
 class OperatorTest(unittest.TestCase):
-    @pytest.mark.xfail("avoid_multi_node",
-                       reason="cluster requires multi-node")
+    @pytest.mark.xfail(
+        "avoid_multi_node", reason="cluster requires multi-node")
     def test_no_file_mounts_k8s_operator_cluster_launch(self):
         with patch.object(NodeUpdaterThread, START, mock_start),\
                 patch.object(NodeUpdaterThread, JOIN, mock_join),\

--- a/python/ray/tests/test_k8s_operator_unit_tests.py
+++ b/python/ray/tests/test_k8s_operator_unit_tests.py
@@ -35,7 +35,7 @@ file mounts.
 START = "start"
 JOIN = "join"
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 def mock_start(self):

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -37,6 +37,8 @@ PID = "pid"
 OBJECT_SIZE = "object size"
 REFERENCE_TYPE = "reference type"
 
+avoid_multi_node = (os.name == 'nt')
+
 
 def data_lines(memory_str):
     for line in memory_str.split("\n"):
@@ -233,6 +235,7 @@ def test_pinned_object_call_site(ray_start_regular):
     assert num_objects(info) == 0, info
 
 
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_multi_node_stats(shutdown_only):
     # NOTE(mwtian): using env var only enables the feature on workers, while
     # using head_node_args={"_system_config": ray_config} only enables the

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -37,7 +37,7 @@ PID = "pid"
 OBJECT_SIZE = "object size"
 REFERENCE_TYPE = "reference type"
 
-avoid_multi_node = (os.name == 'nt')
+avoid_multi_node = (os.name == "nt")
 
 
 def data_lines(memory_str):

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import sys
 import time
 
 import ray
@@ -13,7 +14,10 @@ from ray._private.test_utils import (generate_system_config_map,
 
 logger = logging.getLogger(__name__)
 
+avoid_multi_node = (sys.platform == 'win32')
 
+
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_cluster():
     """Basic test for adding and removing nodes in cluster."""
     g = Cluster(initialize_head=False)
@@ -26,6 +30,7 @@ def test_cluster():
     assert not any(n.any_processes_alive() for n in [node, node2])
 
 
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_shutdown():
     g = Cluster(initialize_head=False)
     node = g.add_node()

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -14,7 +14,7 @@ from ray._private.test_utils import (generate_system_config_map,
 
 logger = logging.getLogger(__name__)
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")

--- a/python/ray/tests/test_multinode_failures.py
+++ b/python/ray/tests/test_multinode_failures.py
@@ -15,8 +15,8 @@ SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 @pytest.fixture(params=[(1, 4), (4, 4)])
 def ray_start_workers_separate_multinode(request):
-    if os.name == 'nt':
-        pytest.skip('multi-node not supported on windows')
+    if os.name == "nt":
+        pytest.skip("multi-node not supported on windows")
     num_nodes = request.param[0]
     num_initial_workers = request.param[1]
     # Start the Ray processes.

--- a/python/ray/tests/test_multinode_failures.py
+++ b/python/ray/tests/test_multinode_failures.py
@@ -15,6 +15,8 @@ SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 @pytest.fixture(params=[(1, 4), (4, 4)])
 def ray_start_workers_separate_multinode(request):
+    if os.name == 'nt':
+        pytest.skip('multi-node not supported on windows')
     num_nodes = request.param[0]
     num_initial_workers = request.param[1]
     # Start the Ray processes.

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -8,6 +8,8 @@ from ray._private.test_utils import get_error_message, init_error_pubsub, \
     run_string_as_driver
 from ray.cluster_utils import Cluster
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 def test_isolation(shutdown_only):
     info = ray.init(namespace="namespace")
@@ -184,6 +186,7 @@ def test_detached_warning(shutdown_only):
     assert error.type == ray_constants.DETACHED_ACTOR_ANONYMOUS_NAMESPACE_ERROR
 
 
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_namespace_client():
     cluster = Cluster()
     cluster.add_node(num_cpus=4, ray_client_server_port=8080)

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -8,7 +8,7 @@ from ray._private.test_utils import get_error_message, init_error_pubsub, \
     run_string_as_driver
 from ray.cluster_utils import Cluster
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 def test_isolation(shutdown_only):

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -14,7 +14,7 @@ if (multiprocessing.cpu_count() < 40
         or ray._private.utils.get_system_memory() < 50 * 10**9):
     warnings.warn("This test must be run on large machines.")
 
-avoid_multi_node = (os.name == 'nt')
+avoid_multi_node = (os.name == "nt")
 
 
 def create_cluster(num_nodes):

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -29,7 +29,7 @@ def create_cluster(num_nodes):
 @pytest.fixture()
 def ray_start_cluster_with_resource():
     if avoid_multi_node:
-        pytest.skip('multi-node not supported')
+        pytest.skip("multi-node not supported")
     num_nodes = 5
     cluster = create_cluster(num_nodes)
     yield cluster, num_nodes

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -18,7 +18,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.cluster_utils import Cluster
 from ray.internal.internal_api import memory_summary
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 def run_basic_workload():

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -18,6 +18,8 @@ from ray._private.test_utils import wait_for_condition
 from ray.cluster_utils import Cluster
 from ray.internal.internal_api import memory_summary
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 def run_basic_workload():
     """Run the workload that requires spilling."""
@@ -126,8 +128,6 @@ def test_default_config(shutdown_only):
     assert config["type"] == "mock_distributed_fs"
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
 def test_default_config_cluster(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=0)
@@ -480,8 +480,6 @@ def test_spill_deadlock(object_spilling_config, shutdown_only):
     assert_no_thrashing(address["redis_address"])
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
 def test_partial_retval_allocation(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(object_store_memory=100 * 1024 * 1024)
@@ -497,8 +495,6 @@ def test_partial_retval_allocation(ray_start_cluster):
         print(obj.size)
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
 def test_pull_spilled_object(ray_start_cluster,
                              multi_node_object_spilling_config, shutdown_only):
     cluster = ray_start_cluster
@@ -601,8 +597,7 @@ def test_pull_spilled_object_failure(object_spilling_config,
     assert hash_value == hash_value1
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows.")
+@pytest.mark.xfail("avoid_multi_node", reason="cluster requires multi-node")
 def test_spill_dir_cleanup_on_raylet_start(object_spilling_config):
     object_spilling_config, temp_folder = object_spilling_config
     cluster = Cluster()

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -15,6 +15,8 @@ from ray._raylet import ClientObjectRef
 from ray.util.client.worker import Worker
 import grpc
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 @pytest.fixture
 def password():
@@ -70,6 +72,8 @@ class TestRedisPassword:
             host=redis_ip, port=redis_port, password=password)
         assert redis_client.ping()
 
+    @pytest.mark.xfail("avoid_multi_node",
+                       reason="cluster requires multi-node")
     def test_redis_password_cluster(self, password, shutdown_only):
         @ray.remote
         def f():

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -15,7 +15,7 @@ from ray._raylet import ClientObjectRef
 from ray.util.client.worker import Worker
 import grpc
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.fixture

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -72,8 +72,8 @@ class TestRedisPassword:
             host=redis_ip, port=redis_port, password=password)
         assert redis_client.ping()
 
-    @pytest.mark.xfail("avoid_multi_node",
-                       reason="cluster requires multi-node")
+    @pytest.mark.xfail(
+        "avoid_multi_node", reason="cluster requires multi-node")
     def test_redis_password_cluster(self, password, shutdown_only):
         @ray.remote
         def f():

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -20,7 +20,7 @@ from ray._private.test_utils import (wait_for_condition, new_scheduler_enabled,
 
 logger = logging.getLogger(__name__)
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 def attempt_to_load_balance(remote_function,

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -1,9 +1,12 @@
 import numpy as np
 import pytest
+import sys
 import time
 
 import ray
 from ray.cluster_utils import Cluster
+
+avoid_multi_node = (sys.platform == 'win32')
 
 
 @pytest.fixture(params=[(1, 4), (4, 4)])
@@ -11,6 +14,8 @@ def ray_start_combination(request):
     num_nodes = request.param[0]
     num_workers_per_scheduler = request.param[1]
     # Start the Ray processes.
+    if avoid_multi_node:
+        pytest.skip('multi-node not supported')
     cluster = Cluster(
         initialize_head=True,
         head_node_args={

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -6,7 +6,7 @@ import time
 import ray
 from ray.cluster_utils import Cluster
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.fixture(params=[(1, 4), (4, 4)])
@@ -15,7 +15,7 @@ def ray_start_combination(request):
     num_workers_per_scheduler = request.param[1]
     # Start the Ray processes.
     if avoid_multi_node:
-        pytest.skip('multi-node not supported')
+        pytest.skip("multi-node not supported")
     cluster = Cluster(
         initialize_head=True,
         head_node_args={

--- a/python/ray/tests/test_stress_failure.py
+++ b/python/ray/tests/test_stress_failure.py
@@ -8,7 +8,7 @@ from ray.cluster_utils import Cluster
 import ray.ray_constants as ray_constants
 from ray._private.test_utils import get_error_message
 
-avoid_multi_node = (sys.platform == 'win32')
+avoid_multi_node = (sys.platform == "win32")
 
 
 @pytest.fixture(params=[1, 4])
@@ -18,7 +18,7 @@ def ray_start_reconstruction(request):
     plasma_store_memory = int(0.5 * 10**9)
 
     if avoid_multi_node:
-        pytest.skip('multi-node not supported')
+        pytest.skip("multi-node not supported")
     cluster = Cluster(
         initialize_head=True,
         head_node_args={

--- a/python/ray/tests/test_stress_failure.py
+++ b/python/ray/tests/test_stress_failure.py
@@ -8,6 +8,8 @@ from ray.cluster_utils import Cluster
 import ray.ray_constants as ray_constants
 from ray._private.test_utils import get_error_message
 
+avoid_multi_node = (sys.platform == 'win32')
+
 
 @pytest.fixture(params=[1, 4])
 def ray_start_reconstruction(request):
@@ -15,6 +17,8 @@ def ray_start_reconstruction(request):
 
     plasma_store_memory = int(0.5 * 10**9)
 
+    if avoid_multi_node:
+        pytest.skip('multi-node not supported')
     cluster = Cluster(
         initialize_head=True,
         head_node_args={


### PR DESCRIPTION
## Why are these changes needed?

Multi-node mode (clusters) are broken on windows. This PR raises an error if `Cluster()` is called. It also xfails the appropriate tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
