### PR TITLE
[scheduler] Update local object store usage

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -963,7 +963,8 @@ void ClusterResourceScheduler::FillResourceUsage(rpc::ResourcesData &resources_d
     auto &capacity =
         GetMutableLocalNodeResources()->predefined_resources[OBJECT_STORE_MEM];
     double used = get_used_object_store_memory_();
-    capacity.available = FixedPoint(capacity.total.Double() - used);
+    double total = capacity.total.Double();
+    capacity.available = FixedPoint(total >= used ? total - used : 0.0);
   }
 
   NodeResources resources;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -342,7 +342,7 @@ const NodeResources &ClusterResourceScheduler::GetLocalNodeResources() const {
 }
 
 NodeResources *ClusterResourceScheduler::GetMutableLocalNodeResources() {
-  const auto &node_it = nodes_.find(local_node_id_);
+  auto node_it = nodes_.find(local_node_id_);
   RAY_CHECK(node_it != nodes_.end());
   return node_it->second.GetMutableLocalView();
 }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -412,6 +412,9 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   bool SubtractRemoteNodeAvailableResources(int64_t node_id,
                                             const ResourceRequest &resource_request);
 
+  /// Get mutable local node resources.
+  NodeResources *GetMutableLocalNodeResources();
+
   /// The threshold at which to switch from packing to spreading.
   const float spread_threshold_;
   /// List of nodes in the clusters and their resources organized as a map.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -1073,6 +1073,14 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 750 * 1024 * 1024);
     ASSERT_EQ(total["object_store_memory"], 1000 * 1024 * 1024);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .available.Double(),
+              750 * 1024 * 1024);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .total.Double(),
+              1000 * 1024 * 1024);
   }
 
   used_object_store_memory = 450 * 1024 * 1024;
@@ -1082,6 +1090,14 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 550 * 1024 * 1024);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .available.Double(),
+              550 * 1024 * 1024);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .total.Double(),
+              1000 * 1024 * 1024);
   }
 
   used_object_store_memory = 0;
@@ -1091,6 +1107,14 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 1000 * 1024 * 1024);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .available.Double(),
+              1000 * 1024 * 1024);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .total.Double(),
+              1000 * 1024 * 1024);
   }
 
   used_object_store_memory = 9999999999;
@@ -1100,6 +1124,14 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 0);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .available.Double(),
+              -8951423999);
+    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
+                  .predefined_resources[OBJECT_STORE_MEM]
+                  .total.Double(),
+              1000 * 1024 * 1024);
   }
 }
 

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -1127,7 +1127,7 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
                   .predefined_resources[OBJECT_STORE_MEM]
                   .available.Double(),
-              -8951423999);
+              0);
     ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
                   .predefined_resources[OBJECT_STORE_MEM]
                   .total.Double(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We never update local object store usage so local raylet always sees zero utilization of it's object store mem. Although it does report its accurate usage to other raylets.

This PR fixes it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
