### PR TITLE
[scheduler] Fix dynamically increasing resources

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -567,6 +567,13 @@ std::string ClusterResourceScheduler::DebugString(void) const {
   return buffer.str();
 }
 
+uint64_t ClusterResourceScheduler::GetNumCpus(void) const {
+  auto it = nodes_.find(local_node_id_);
+  RAY_CHECK(it != nodes_.end());
+  return static_cast<uint64_t>(
+      it->second.GetLocalView().predefined_resources[CPU].total.Double());
+}
+
 void ClusterResourceScheduler::InitResourceInstances(
     FixedPoint total, bool unit_instances, ResourceInstanceCapacities *instance_list) {
   if (unit_instances) {
@@ -784,10 +791,13 @@ void ClusterResourceScheduler::UpdateLocalAvailableResourcesFromResourceInstance
   auto local_view = it_local_node->second.GetMutableLocalView();
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     local_view->predefined_resources[i].available = 0;
+    local_view->predefined_resources[i].total = 0;
     for (size_t j = 0; j < local_resources_.predefined_resources[i].available.size();
          j++) {
       local_view->predefined_resources[i].available +=
           local_resources_.predefined_resources[i].available[j];
+      local_view->predefined_resources[i].total +=
+          local_resources_.predefined_resources[i].total[j];
     }
   }
 

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -567,13 +567,6 @@ std::string ClusterResourceScheduler::DebugString(void) const {
   return buffer.str();
 }
 
-uint64_t ClusterResourceScheduler::GetNumCpus(void) const {
-  auto it = nodes_.find(local_node_id_);
-  RAY_CHECK(it != nodes_.end());
-  return static_cast<uint64_t>(
-      it->second.GetLocalView().predefined_resources[CPU].total.Double());
-}
-
 void ClusterResourceScheduler::InitResourceInstances(
     FixedPoint total, bool unit_instances, ResourceInstanceCapacities *instance_list) {
   if (unit_instances) {

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -390,6 +390,9 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// Return human-readable string for this scheduler state.
   std::string DebugString() const;
 
+  /// Get the number of cpus on this node.
+  uint64_t GetNumCpus() const;
+
   /// Check whether a task request is schedulable on a the local node. A node is
   /// schedulable if it has the available resources needed to execute the task.
   ///

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -442,6 +442,7 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   // Specify custom resources that consists of unit-size instances.
   std::unordered_set<int64_t> custom_unit_instance_resources_{};
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingResourceRequestTest);
+  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest);
 };
 
 }  // end namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -390,9 +390,6 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// Return human-readable string for this scheduler state.
   std::string DebugString() const;
 
-  /// Get the number of cpus on this node.
-  uint64_t GetNumCpus() const;
-
   /// Check whether a task request is schedulable on a the local node. A node is
   /// schedulable if it has the available resources needed to execute the task.
   ///

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -369,6 +369,22 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
   }
 }
 
+TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest) {
+  absl::flat_hash_map<std::string, double> initial_resources = {{ray::kCPU_ResourceLabel, 1}, {"custom", 1}};
+  ClusterResourceScheduler resource_scheduler(NodeID::FromRandom().Binary(), initial_resources, *gcs_client_, nullptr, nullptr);
+
+  resource_scheduler.AddLocalResourceInstances(ray::kCPU_ResourceLabel, {0, 1, 1});
+  resource_scheduler.AddLocalResourceInstances("custom", {0, 1, 1});
+
+  const auto &predefined_resources = resource_scheduler.GetLocalNodeResources().predefined_resources;
+  ASSERT_EQ(predefined_resources[CPU].total.Double(), 3);
+
+  const auto &custom_resources = resource_scheduler.GetLocalNodeResources().custom_resources;
+  auto resource_id = resource_scheduler.string_to_int_map_.Get("custom");
+  ASSERT_EQ(custom_resources.find(resource_id)->second.total.Double(), 3);
+
+}
+
 TEST_F(ClusterResourceSchedulerTest, SchedulingAddOrUpdateNodeTest) {
   ClusterResourceScheduler resource_scheduler;
   NodeResources nr, nr_out;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -370,19 +370,22 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
 }
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest) {
-  absl::flat_hash_map<std::string, double> initial_resources = {{ray::kCPU_ResourceLabel, 1}, {"custom", 1}};
-  ClusterResourceScheduler resource_scheduler(NodeID::FromRandom().Binary(), initial_resources, *gcs_client_, nullptr, nullptr);
+  absl::flat_hash_map<std::string, double> initial_resources = {
+      {ray::kCPU_ResourceLabel, 1}, {"custom", 1}};
+  ClusterResourceScheduler resource_scheduler(
+      NodeID::FromRandom().Binary(), initial_resources, *gcs_client_, nullptr, nullptr);
 
   resource_scheduler.AddLocalResourceInstances(ray::kCPU_ResourceLabel, {0, 1, 1});
   resource_scheduler.AddLocalResourceInstances("custom", {0, 1, 1});
 
-  const auto &predefined_resources = resource_scheduler.GetLocalNodeResources().predefined_resources;
+  const auto &predefined_resources =
+      resource_scheduler.GetLocalNodeResources().predefined_resources;
   ASSERT_EQ(predefined_resources[CPU].total.Double(), 3);
 
-  const auto &custom_resources = resource_scheduler.GetLocalNodeResources().custom_resources;
+  const auto &custom_resources =
+      resource_scheduler.GetLocalNodeResources().custom_resources;
   auto resource_id = resource_scheduler.string_to_int_map_.Get("custom");
   ASSERT_EQ(custom_resources.find(resource_id)->second.total.Double(), 3);
-
 }
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingAddOrUpdateNodeTest) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a scheduler bug in which we increased the total resource instances, but don't update the total capacity in the non-instance view.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
