### PR TITLE
[Datasets] Multi-aggregations [1/3]: Add basic support for groupby multi-aggregations.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -818,7 +818,7 @@ class Dataset(Generic[T]):
         from ray.data.grouped_dataset import GroupedDataset
         return GroupedDataset(self, key)
 
-    def aggregate(self, *aggs: Tuple[AggregateFn]) -> U:
+    def aggregate(self, *aggs: AggregateFn) -> U:
         """Aggregate the entire dataset as one group.
 
         This is a blocking operation.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -825,13 +825,13 @@ class Dataset(Generic[T]):
 
         Examples:
             >>> ray.data.range(100).aggregate(Max())
-            >>> ray.data.range_arrow(100).aggregate(Max("value"))
+            >>> ray.data.range_arrow(100).aggregate(
+                Max("value"), Mean("value"))
 
         Time complexity: O(dataset size / parallelism)
 
         Args:
             aggs: Aggregations to do.
-                Currently only single aggregation is supported.
 
         Returns:
             If the input dataset is a simple dataset then the output is

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -58,12 +58,12 @@ class GroupedDataset(Generic[T]):
 
         Returns:
             If the input dataset is simple dataset then the output is
-            a simple dataset of (k, v) pairs where k is the groupby key
-            and v is the corresponding aggregation result.
+            a simple dataset of (k, v_1, ..., v_n) tuples where k is the
+            groupby key and v_i is the result of the ith given aggregation.
             If the input dataset is Arrow dataset then the output is
-            an Arrow dataset of two columns where first column is
-            the groupby key and the second column is the corresponding
-            aggregation result.
+            an Arrow dataset of n + 1 columns where first column is
+            the groupby key and the second through n + 1 columns are the
+            results of the aggregations.
             If groupby key is None then the key part of return is omitted.
         """
 

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -341,18 +341,19 @@ class ArrowBlockAccessor(BlockAccessor):
         ret.append(_copy_table(table.slice(prev_i)))
         return ret
 
-    def combine(self, key: GroupKeyT, agg: AggregateFn) -> Block[ArrowRow]:
+    def combine(self, key: GroupKeyT, *aggs: AggregateFn) -> Block[ArrowRow]:
         """Combine rows with the same key into an accumulator.
 
         This assumes the block is already sorted by key in ascending order.
 
         Args:
             key: The column name of key or None for global aggregation.
-            agg: The aggregation to do.
+            aggs: The aggregations to do.
 
         Returns:
-            A sorted block of [k, v] columns where k is the groupby key
-            and v is the partially combined accumulator.
+            A sorted block of [k, v_1, ..., v_n] columns where k is the groupby
+            key and v_i is the partially combined accumulator for the ith given
+            aggregation.
             If key is None then the k column is omitted.
         """
         # TODO(jjyao) This can be implemented natively in Arrow
@@ -377,13 +378,24 @@ class ArrowBlockAccessor(BlockAccessor):
                             next_row = None
                             break
 
-                accumulator = agg.init(next_key)
+                accumulators = [agg.init(next_key) for agg in aggs]
                 for r in gen():
-                    accumulator = agg.accumulate(accumulator, r)
+                    for i in range(len(aggs)):
+                        accumulators[i] = aggs[i].accumulate(
+                            accumulators[i], r)
                 if key is None:
-                    builder.add({agg.name: accumulator})
+                    builder.add({
+                        agg.name: accumulator
+                        for agg, accumulator in zip(aggs, accumulators)
+                    })
                 else:
-                    builder.add({key: next_key, agg.name: accumulator})
+                    builder.add(
+                        dict({
+                            key: next_key
+                        }, **{
+                            agg.name: accumulator
+                            for agg, accumulator in zip(aggs, accumulators)
+                        }))
             except StopIteration:
                 break
         return builder.build()
@@ -404,7 +416,7 @@ class ArrowBlockAccessor(BlockAccessor):
     @staticmethod
     def aggregate_combined_blocks(
             blocks: List[Block[ArrowRow]], key: GroupKeyT,
-            agg: AggregateFn) -> Tuple[Block[ArrowRow], BlockMetadata]:
+            *aggs: AggregateFn) -> Tuple[Block[ArrowRow], BlockMetadata]:
         """Aggregate sorted, partially combined blocks with the same key range.
 
         This assumes blocks are already sorted by key in ascending order,
@@ -413,12 +425,12 @@ class ArrowBlockAccessor(BlockAccessor):
         Args:
             blocks: A list of partially combined and sorted blocks.
             key: The column name of key or None for global aggregation.
-            agg: The aggregation to do.
+            aggs: The aggregations to do.
 
         Returns:
-            A block of [k, v] columns and its metadata
-            where k is the groupby key
-            and v is the corresponding aggregation result.
+            A block of [k, v_1, ..., v_n] columns and its metadata where k is
+            the groupby key and v_i is the corresponding aggregation result for
+            the ith given aggregation.
             If key is None then the k column is omitted.
         """
 
@@ -450,20 +462,29 @@ class ArrowBlockAccessor(BlockAccessor):
                             break
 
                 first = True
-                accumulator = None
+                accumulators = [None] * len(aggs)
                 for r in gen():
                     if first:
-                        accumulator = r[agg.name]
+                        for i in range(len(aggs)):
+                            accumulators[i] = r[aggs[i].name]
                         first = False
                     else:
-                        accumulator = agg.merge(accumulator, r[agg.name])
+                        for i in range(len(aggs)):
+                            accumulators[i] = aggs[i].merge(
+                                accumulators[i], r[aggs[i].name])
                 if key is None:
-                    builder.add({agg.name: agg.finalize(accumulator)})
-                else:
                     builder.add({
-                        next_key_name: next_key,
                         agg.name: agg.finalize(accumulator)
+                        for agg, accumulator in zip(aggs, accumulators)
                     })
+                else:
+                    builder.add(
+                        dict({
+                            next_key_name: next_key
+                        }, **{
+                            agg.name: agg.finalize(accumulator)
+                            for agg, accumulator in zip(aggs, accumulators)
+                        }))
             except StopIteration:
                 break
 

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -341,7 +341,8 @@ class ArrowBlockAccessor(BlockAccessor):
         ret.append(_copy_table(table.slice(prev_i)))
         return ret
 
-    def combine(self, key: GroupKeyT, *aggs: AggregateFn) -> Block[ArrowRow]:
+    def combine(self, key: GroupKeyT,
+                aggs: Tuple[AggregateFn]) -> Block[ArrowRow]:
         """Combine rows with the same key into an accumulator.
 
         This assumes the block is already sorted by key in ascending order.
@@ -416,7 +417,7 @@ class ArrowBlockAccessor(BlockAccessor):
     @staticmethod
     def aggregate_combined_blocks(
             blocks: List[Block[ArrowRow]], key: GroupKeyT,
-            *aggs: AggregateFn) -> Tuple[Block[ArrowRow], BlockMetadata]:
+            aggs: Tuple[AggregateFn]) -> Tuple[Block[ArrowRow], BlockMetadata]:
         """Aggregate sorted, partially combined blocks with the same key range.
 
         This assumes blocks are already sorted by key in ascending order,

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -149,7 +149,7 @@ class SimpleBlockAccessor(BlockAccessor):
         return ret
 
     def combine(self, key: GroupKeyT,
-                *aggs: AggregateFn) -> Block[Tuple[KeyType, AggType]]:
+                aggs: Tuple[AggregateFn]) -> Block[Tuple[KeyType, AggType]]:
         """Combine rows with the same key into an accumulator.
 
         This assumes the block is already sorted by key in ascending order.
@@ -218,7 +218,7 @@ class SimpleBlockAccessor(BlockAccessor):
     @staticmethod
     def aggregate_combined_blocks(
             blocks: List[Block[Tuple[KeyType, AggType]]], key: GroupKeyT,
-            *aggs: AggregateFn
+            aggs: Tuple[AggregateFn]
     ) -> Tuple[Block[Tuple[KeyType, U]], BlockMetadata]:
         """Aggregate sorted, partially combined blocks with the same key range.
 

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -149,7 +149,7 @@ class SimpleBlockAccessor(BlockAccessor):
         return ret
 
     def combine(self, key: GroupKeyT,
-                agg: AggregateFn) -> Block[Tuple[KeyType, AggType]]:
+                *aggs: AggregateFn) -> Block[Tuple[KeyType, AggType]]:
         """Combine rows with the same key into an accumulator.
 
         This assumes the block is already sorted by key in ascending order.
@@ -157,11 +157,12 @@ class SimpleBlockAccessor(BlockAccessor):
         Args:
             key: The key function that returns the key from the row
                 or None for global aggregation.
-            agg: The aggregation to do.
+            agg: The aggregations to do.
 
         Returns:
-            A sorted block of (k, v) tuples where k is the groupby
-            key and v is the partially combined accumulator.
+            A sorted block of (k, v_1, ..., v_n) tuples where k is the groupby
+            key and v_i is the partially combined accumulator for the ith given
+            aggregation.
             If key is None then the k element of tuple is omitted.
         """
         key_fn = key if key else lambda r: None
@@ -193,13 +194,15 @@ class SimpleBlockAccessor(BlockAccessor):
                             next_row = None
                             break
 
-                accumulator = agg.init(next_key)
+                accumulators = [agg.init(next_key) for agg in aggs]
                 for r in gen():
-                    accumulator = agg.accumulate(accumulator, r)
+                    for i in range(len(aggs)):
+                        accumulators[i] = aggs[i].accumulate(
+                            accumulators[i], r)
                 if key is None:
-                    ret.append((accumulator, ))
+                    ret.append(tuple(accumulators))
                 else:
-                    ret.append((next_key, accumulator))
+                    ret.append((next_key, ) + tuple(accumulators))
             except StopIteration:
                 break
         return ret
@@ -215,7 +218,7 @@ class SimpleBlockAccessor(BlockAccessor):
     @staticmethod
     def aggregate_combined_blocks(
             blocks: List[Block[Tuple[KeyType, AggType]]], key: GroupKeyT,
-            agg: AggregateFn
+            *aggs: AggregateFn
     ) -> Tuple[Block[Tuple[KeyType, U]], BlockMetadata]:
         """Aggregate sorted, partially combined blocks with the same key range.
 
@@ -226,11 +229,12 @@ class SimpleBlockAccessor(BlockAccessor):
             blocks: A list of partially combined and sorted blocks.
             key: The key function that returns the key from the row
                 or None for global aggregation.
-            agg: The aggregation to do.
+            aggs: The aggregations to do.
 
         Returns:
-            A block of (k, v) tuples and its metadata where k is the groupby
-            key and v is the corresponding aggregation result.
+            A block of (k, v_1, ..., v_n) tuples and its metadata where k is
+            the groupby key and v_i is the corresponding aggregation result for
+            the ith given aggregation.
             If key is None then the k element of tuple is omitted.
         """
 
@@ -259,18 +263,25 @@ class SimpleBlockAccessor(BlockAccessor):
                             break
 
                 first = True
-                accumulator = None
+                accumulators = [None] * len(aggs)
                 for r in gen():
                     if first:
-                        accumulator = r[1] if key else r[0]
+                        for i in range(len(aggs)):
+                            accumulators[i] = r[i + 1] if key else r[i]
                         first = False
                     else:
-                        accumulator = agg.merge(accumulator, r[1]
-                                                if key else r[0])
+                        for i in range(len(aggs)):
+                            accumulators[i] = aggs[i].merge(
+                                accumulators[i], r[i + 1] if key else r[i])
                 if key is None:
-                    ret.append((agg.finalize(accumulator), ))
+                    ret.append(
+                        tuple(
+                            agg.finalize(accumulator)
+                            for agg, accumulator in zip(aggs, accumulators)))
                 else:
-                    ret.append((next_key, agg.finalize(accumulator)))
+                    ret.append((next_key, ) + tuple(
+                        agg.finalize(accumulator)
+                        for agg, accumulator in zip(aggs, accumulators)))
             except StopIteration:
                 break
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3052,7 +3052,10 @@ def test_groupby_arrow_multi_agg(ray_start_regular_shared):
     for agg in ["sum", "min", "max", "mean", "std"]:
         result = result_row[f"{agg}(A)"]
         expected = getattr(df["A"], agg)()
-        assert math.isclose(result, expected)
+        if agg == "std":
+            assert math.isclose(result, expected)
+        else:
+            assert result == expected
 
 
 def test_groupby_simple(ray_start_regular_shared):
@@ -3268,7 +3271,10 @@ def test_groupby_simple_multi_agg(ray_start_regular_shared):
     for idx, agg in enumerate(["sum", "min", "max", "mean", "std"]):
         result = result_row[idx]
         expected = getattr(series, agg)()
-        assert math.isclose(result, expected)
+        if agg == "std":
+            assert math.isclose(result, expected)
+        else:
+            assert result == expected
 
 
 def test_sort_simple(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -22,7 +22,7 @@ from ray.data.datasource import DummyOutputDatasource
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockAccessor
 from ray.data.impl.block_list import BlockList
-from ray.data.aggregate import AggregateFn
+from ray.data.aggregate import AggregateFn, Count, Sum, Min, Max, Mean, Std
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import (
     PARALLELIZE_META_FETCH_THRESHOLD)
@@ -3017,6 +3017,44 @@ def test_groupby_arrow_std(ray_start_regular_shared):
     assert ray.data.from_pandas(pd.DataFrame({"A": [3]})).std("A") == 0
 
 
+def test_groupby_arrow_multi_agg(ray_start_regular_shared):
+    seed = int(time.time())
+    print(f"Seeding RNG for test_groupby_arrow_multi_agg with: {seed}")
+    random.seed(seed)
+    xs = list(range(100))
+    random.shuffle(xs)
+    df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
+    agg_ds = ray.data.from_pandas(df).groupby("A").aggregate(
+        Count(),
+        Sum("B"),
+        Min("B"),
+        Max("B"),
+        Mean("B"),
+        Std("B"),
+    )
+    assert agg_ds.count() == 3
+    agg_df = agg_ds.to_pandas()
+    expected_grouped = df.groupby("A")["B"]
+    np.testing.assert_array_equal(agg_df["count()"].to_numpy(), [34, 33, 33])
+    for agg in ["sum", "min", "max", "mean", "std"]:
+        result = agg_df[f"{agg}(B)"].to_numpy()
+        expected = getattr(expected_grouped, agg)().to_numpy()
+        np.testing.assert_array_equal(result, expected)
+    # Test built-in global std aggregation
+    df = pd.DataFrame({"A": xs})
+    result_row = ray.data.from_pandas(df).aggregate(
+        Sum("A"),
+        Min("A"),
+        Max("A"),
+        Mean("A"),
+        Std("A"),
+    )
+    for agg in ["sum", "min", "max", "mean", "std"]:
+        result = result_row[f"{agg}(A)"]
+        expected = getattr(df["A"], agg)()
+        assert math.isclose(result, expected)
+
+
 def test_groupby_simple(ray_start_regular_shared):
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple with: {seed}")
@@ -3181,6 +3219,56 @@ def test_groupby_simple_std(ray_start_regular_shared):
         ray.data.from_items([]).std()
     # Test edge cases
     assert ray.data.from_items([3]).std() == 0
+
+
+def test_groupby_simple_multi_agg(ray_start_regular_shared):
+    seed = int(time.time())
+    print(f"Seeding RNG for test_groupby_simple_multi_agg with: {seed}")
+    random.seed(seed)
+    xs = list(range(100))
+    random.shuffle(xs)
+    df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
+    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).aggregate(
+        Count(),
+        Sum(),
+        Min(),
+        Max(),
+        Mean(),
+        Std(),
+    )
+    assert agg_ds.count() == 3
+    result = agg_ds.sort(key=lambda r: r[0]).take(3)
+    groups, counts, sums, mins, maxs, means, stds = zip(*result)
+    agg_df = pd.DataFrame({
+        "groups": list(groups),
+        "count": list(counts),
+        "sum": list(sums),
+        "min": list(mins),
+        "max": list(maxs),
+        "mean": list(means),
+        "std": list(stds),
+    })
+    agg_df = agg_df.set_index("groups")
+    df = pd.DataFrame({"groups": [x % 3 for x in xs], "B": xs})
+    expected_grouped = df.groupby("groups")["B"]
+    np.testing.assert_array_equal(agg_df["count"].to_numpy(), [34, 33, 33])
+    for agg in ["sum", "min", "max", "mean", "std"]:
+        result = agg_df[agg].to_numpy()
+        expected = getattr(expected_grouped, agg)().to_numpy()
+        np.testing.assert_array_almost_equal(result, expected)
+    # Test built-in global multi-aggregation
+    result_row = ray.data.from_items(xs).aggregate(
+        Sum(),
+        Min(),
+        Max(),
+        Mean(),
+        Std(),
+    )
+    series = pd.Series(xs)
+    for idx, agg in enumerate(["sum", "min", "max", "mean", "std"]):
+        result = result_row[idx]
+        expected = getattr(series, agg)()
+        assert math.isclose(result, expected)
 
 
 def test_sort_simple(ray_start_regular_shared):


### PR DESCRIPTION
This PR adds basic support for groupby multi-aggregations.

## TODOs (for future PRs)

1. (In review, [PR](https://github.com/ray-project/ray/pull/20074)) Translate `ds.mean(["col1", "col2"])` to `ds.aggregate(Mean("col1"), Mean("col2"))` (and likewise for groupby aggregations). I've implemented a proof-of-concept for this locally, but I'm going to add it as a follow-up PR.
2. (In review, [PR](https://github.com/ray-project/ray/pull/20090)) Expose a nicer multi-aggregation API, similar to [the Pandas API](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.aggregate.html):
```python
ds.agg(["mean", "min", "max"])
ds.agg({"col1": ["mean", "max"], "col2": ["std", "min"]})
```

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
