### PR TITLE
[pg] Fix the test case which hangs because of scheduling dead lock

### DIFF
--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -659,6 +659,12 @@ def test_placement_group_local_resource_view(monkeypatch, ray_start_cluster):
 
         cluster.add_node(num_cpus=16, object_store_memory=1e9)
         cluster.wait_for_nodes()
+        # We need to init here so that we can make sure it's connecting to
+        # the raylet where it only has cpu resources.
+        # This is a hacky way to prevent scheduling hanging which will
+        # schedule <CPU:1> job to the node with GPU and for <GPU:1, CPU:1> task
+        # there is no node has this resource.
+        ray.init(address="auto")
         cluster.add_node(num_cpus=16, num_gpus=1)
         cluster.wait_for_nodes()
         NUM_CPU_BUNDLES = 30
@@ -681,7 +687,6 @@ def test_placement_group_local_resource_view(monkeypatch, ray_start_cluster):
                 time.sleep(0.2)
                 print("train ", self.i)
 
-        ray.init(address="auto")
         bundles = [{"CPU": 1, "GPU": 1}]
         bundles += [{"CPU": 1} for _ in range(NUM_CPU_BUNDLES)]
         pg = placement_group(bundles, strategy="PACK")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In this test case, the following case could happen:

1. actor creation first uses all resource in local node which is a GPU node
2. the actor need GPU will not be able to be scheduled since we only have one GPU node

The fixing is just a short term fix and only tries to connect to the head node with CPU resources.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#19438 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
