### PR TITLE
[Core][Core-worker] de-escalate the error message when worker is accessed after shutdown.

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -188,7 +188,7 @@ void CoreWorkerProcess::EnsureInitialized(bool quick_exit) {
   }
 
   if (quick_exit) {
-    RAY_LOG(ERROR) << "The core worker process is not initialized yet or already "
+    RAY_LOG(WARNING) << "The core worker process is not initialized yet or already "
                    << "shutdown.";
     QuickExit();
   } else {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -189,7 +189,7 @@ void CoreWorkerProcess::EnsureInitialized(bool quick_exit) {
 
   if (quick_exit) {
     RAY_LOG(WARNING) << "The core worker process is not initialized yet or already "
-                   << "shutdown.";
+                     << "shutdown.";
     QuickExit();
   } else {
     RAY_CHECK(core_worker_process)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This error is not actionable; change it to warning for better usability.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
