### PR TITLE
[CI] avoid installing latest setuptools

### DIFF
--- a/python/build-wheel-macos-arm64.sh
+++ b/python/build-wheel-macos-arm64.sh
@@ -67,7 +67,8 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
 
   pushd python
     # Setuptools on CentOS is too old to install arrow 0.9.0, therefore we upgrade.
-    $PIP_CMD install --upgrade setuptools
+    # TODO: Unpin after https://github.com/pypa/setuptools/issues/2849 is fixed.
+    $PIP_CMD install --upgrade setuptools==58.4
     $PIP_CMD install -q cython==0.29.15
     # Install wheel to avoid the error "invalid command 'bdist_wheel'".
     $PIP_CMD install -q wheel

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -82,7 +82,8 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
 
   pushd python
     # Setuptools on CentOS is too old to install arrow 0.9.0, therefore we upgrade.
-    $PIP_CMD install --upgrade setuptools
+    # TODO: Unpin after https://github.com/pypa/setuptools/issues/2849 is fixed.
+    $PIP_CMD install --upgrade setuptools==58.4
     # Install setuptools_scm because otherwise when building the wheel for
     # Python 3.6, we see an error.
     $PIP_CMD install -q setuptools_scm==3.1.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The latest version of setuptools breaks package installations, e.g. https://buildkite.com/ray-project/ray-builders-branch/builds/4474#23fe9c86-d8d8-4642-b3d0-668e66147e35/6-11145

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
