### PR TITLE
[workflow][docs] Fix api comparison formatting

### DIFF
--- a/doc/source/workflows/comparison.rst
+++ b/doc/source/workflows/comparison.rst
@@ -5,17 +5,17 @@ Comparison between Ray Core APIs and Workflows
 ----------------------------------------------
 Workflows is built on top of Ray, and offers a mostly consistent subset of its API while providing durability. This section highlights some of the differences:
 
-`func.remote` vs `func.step`
+``func.remote`` vs ``func.step``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 With Ray tasks, ``func.remote`` will submit a remote task to run. In Ray workflows, ``func.step`` is used to create a ``Workflow`` object. Execution of the workflow is deferred until ``.run(workflow_id="id")`` or ``.run_async(workflow_id="id")`` is called on the ``Workflow``. Specifying the workflow id allows for resuming of the workflow by its id in case of cluster failure.
 
 
-`Actor.remote` vs `Actor.get_or_create`
+``Actor.remote`` vs ``Actor.get_or_create``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With Ray actors, ``Actor.remote`` will submit an actor creation task and create an actor process in the cluster. In Ray workflows, virtual actors are created by ``Actor.get_or_create``. The actor state is tracked as a dynamic workflow (durably logged) instead of in a running process. This means that the actor uses no resources when inactive, and can be used even after cluster restarts.
 
-`actor.func.remote` vs `actor.func.run`
+``actor.func.remote`` vs ``actor.func.run``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With Ray actors, ``actor.func.remote`` will submit a remote task to run which is similar as ``func.remote``. On the other hand ``actor.func.run`` on a virtual actor will read the actor state from storage, execute a step, and then write the new state back to storage. If the ``actor.func`` is decorated with ``workflow.virtual_actor.readonly``, its result will not be logged.

--- a/doc/source/workflows/comparison.rst
+++ b/doc/source/workflows/comparison.rst
@@ -6,17 +6,17 @@ Comparison between Ray Core APIs and Workflows
 Workflows is built on top of Ray, and offers a mostly consistent subset of its API while providing durability. This section highlights some of the differences:
 
 ``func.remote`` vs ``func.step``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 With Ray tasks, ``func.remote`` will submit a remote task to run. In Ray workflows, ``func.step`` is used to create a ``Workflow`` object. Execution of the workflow is deferred until ``.run(workflow_id="id")`` or ``.run_async(workflow_id="id")`` is called on the ``Workflow``. Specifying the workflow id allows for resuming of the workflow by its id in case of cluster failure.
 
 
 ``Actor.remote`` vs ``Actor.get_or_create``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With Ray actors, ``Actor.remote`` will submit an actor creation task and create an actor process in the cluster. In Ray workflows, virtual actors are created by ``Actor.get_or_create``. The actor state is tracked as a dynamic workflow (durably logged) instead of in a running process. This means that the actor uses no resources when inactive, and can be used even after cluster restarts.
 
 ``actor.func.remote`` vs ``actor.func.run``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With Ray actors, ``actor.func.remote`` will submit a remote task to run which is similar as ``func.remote``. On the other hand ``actor.func.run`` on a virtual actor will read the actor state from storage, execute a step, and then write the new state back to storage. If the ``actor.func`` is decorated with ``workflow.virtual_actor.readonly``, its result will not be logged.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The API comparison formatting uses \`code\` which is rendered as italicization not code. This PR puts the code in code blocks instead of italics. 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
