### PR TITLE
[Datasets] Multi-aggregations [2/3]: Add groupby multi-column/multi-lambda aggregation

### DIFF
--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -4,7 +4,8 @@ from typing import Callable, Optional, Union, Any, List
 from ray.util.annotations import PublicAPI
 from ray.data.block import T, U, KeyType, AggType
 
-AggregateOnT = Union[None, Callable[[T], Any], str]
+AggregateOnTBase = Union[Callable[[T], Any], str]
+AggregateOnT = Optional[Union[AggregateOnTBase, List[AggregateOnTBase]]]
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -4,8 +4,7 @@ from typing import Callable, Optional, Union, Any, List
 from ray.util.annotations import PublicAPI
 from ray.data.block import T, U, KeyType, AggType
 
-AggregateOnTBase = Union[Callable[[T], Any], str]
-AggregateOnT = Optional[Union[AggregateOnTBase, List[AggregateOnTBase]]]
+AggregateOnT = Union[Callable[[T], Any], str]
 
 
 @PublicAPI(stability="beta")
@@ -58,7 +57,7 @@ class Count(AggregateFn):
 class Sum(AggregateFn):
     """Defines sum aggregation."""
 
-    def __init__(self, on: AggregateOnT = None):
+    def __init__(self, on: Optional[AggregateOnT] = None):
         on_fn = _to_on_fn(on)
         super().__init__(
             init=lambda k: 0,
@@ -70,7 +69,7 @@ class Sum(AggregateFn):
 class Min(AggregateFn):
     """Defines min aggregation."""
 
-    def __init__(self, on: AggregateOnT = None):
+    def __init__(self, on: Optional[AggregateOnT] = None):
         on_fn = _to_on_fn(on)
         super().__init__(
             init=lambda k: None,
@@ -83,7 +82,7 @@ class Min(AggregateFn):
 class Max(AggregateFn):
     """Defines max aggregation."""
 
-    def __init__(self, on: AggregateOnT = None):
+    def __init__(self, on: Optional[AggregateOnT] = None):
         on_fn = _to_on_fn(on)
         super().__init__(
             init=lambda k: None,
@@ -96,7 +95,7 @@ class Max(AggregateFn):
 class Mean(AggregateFn):
     """Defines mean aggregation."""
 
-    def __init__(self, on: AggregateOnT = None):
+    def __init__(self, on: Optional[AggregateOnT] = None):
         on_fn = _to_on_fn(on)
         super().__init__(
             init=lambda k: [0, 0],
@@ -118,7 +117,7 @@ class Std(AggregateFn):
     https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
     """
 
-    def __init__(self, on: AggregateOnT = None, ddof: int = 1):
+    def __init__(self, on: Optional[AggregateOnT] = None, ddof: int = 1):
         on_fn = _to_on_fn(on)
 
         def accumulate(a: List[float], r: float):
@@ -169,7 +168,7 @@ class Std(AggregateFn):
             name=(f"std({str(on)})"))
 
 
-def _to_on_fn(on: AggregateOnT):
+def _to_on_fn(on: Optional[AggregateOnT]):
     if on is None:
         return lambda r: r
     elif isinstance(on, str):

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -352,7 +352,6 @@ class Dataset(Generic[T]):
 
         # Compute the (n-1) indices needed for an equal split of the data.
         count = self.count()
-        num_blocks = min(num_blocks, count)
         indices = []
         cur_idx = 0
         for _ in range(num_blocks - 1):

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -352,6 +352,7 @@ class Dataset(Generic[T]):
 
         # Compute the (n-1) indices needed for an equal split of the data.
         count = self.count()
+        num_blocks = min(num_blocks, count)
         indices = []
         cur_idx = 0
         for _ in range(num_blocks - 1):

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -119,10 +119,8 @@ class GroupedDataset(Generic[T]):
         multi-aggregation on all columns for an Arrow Dataset, and a single
         aggregation on the entire row for a simple Dataset.
         """
-        on = self._dataset._check_and_normalize_agg_on(on, self._key)
-        if not isinstance(on, list):
-            on = [on]
-        aggs = [agg_cls(on_, *args, **kwargs) for on_ in on]
+        aggs = self._dataset._build_multicolumn_aggs(
+            agg_cls, on, *args, skip_cols=self._key, **kwargs)
         return self.aggregate(*aggs)
 
     def count(self) -> Dataset[U]:

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -42,7 +42,7 @@ class GroupedDataset(Generic[T]):
             self._key = key
 
     def aggregate(self, *aggs: AggregateFn) -> Dataset[U]:
-        """Implements the accumulator-based aggregation.
+        """Implements an accumulator-based aggregation.
 
         This is a blocking operation.
 
@@ -58,14 +58,14 @@ class GroupedDataset(Generic[T]):
             aggs: Aggregations to do.
 
         Returns:
-            If the input dataset is simple dataset then the output is
-            a simple dataset of (k, v_1, ..., v_n) tuples where k is the
-            groupby key and v_i is the result of the ith given aggregation.
-            If the input dataset is Arrow dataset then the output is
-            an Arrow dataset of n + 1 columns where first column is
-            the groupby key and the second through n + 1 columns are the
+            If the input dataset is simple dataset then the output is a simple
+            dataset of ``(k, v_1, ..., v_n)`` tuples where ``k`` is the groupby
+            key and ``v_i`` is the result of the ith given aggregation.
+            If the input dataset is an Arrow dataset then the output is an
+            Arrow dataset of ``n + 1`` columns where the first column is the
+            groupby key and the second through ``n + 1`` columns are the
             results of the aggregations.
-            If groupby key is None then the key part of return is omitted.
+            If groupby key is ``None`` then the key part of return is omitted.
         """
 
         if len(aggs) == 0:
@@ -114,6 +114,7 @@ class GroupedDataset(Generic[T]):
 
     def _aggregate_on(self, agg_cls: type, on: AggregateOnT, *args, **kwargs):
         """Helper for aggregating on a particular subset of the dataset.
+
         This validates the `on` argument, and converts a list of column names
         or lambdas to a multi-aggregation. A null `on` results in a
         multi-aggregation on all columns for an Arrow Dataset, and a single
@@ -135,120 +136,244 @@ class GroupedDataset(Generic[T]):
             ...     "A").count()
 
         Returns:
-            A simple dataset of (k, v) pairs or
-            an Arrow dataset of [k, v] columns
-            where k is the groupby key and
-            v is the number of rows with that key.
-            If groupby key is None then the key part of return is omitted.
+            A simple dataset of ``(k, v)`` pairs or an Arrow dataset of
+            ``[k, v]`` columns where ``k`` is the groupby key and ``v`` is the
+            number of rows with that key.
+            If groupby key is ``None`` then the key part of return is omitted.
         """
         return self.aggregate(Count())
 
     def sum(self, on: AggregateOnT = None) -> Dataset[U]:
-        """Compute sum aggregation.
+        """Compute grouped sum aggregation.
 
         This is a blocking operation.
 
         Examples:
             >>> ray.data.range(100).groupby(lambda x: x % 3).sum()
             >>> ray.data.from_items([
-            ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
-            ...     "A").sum("B")
+            ...     (i % 3, i, i**2)
+            ...     for i in range(100)]) \
+            ...     .groupby(lambda x: x[0] % 3) \
+            ...     .sum(lambda x: x[2])
+            >>> ray.data.range_arrow(100).groupby("value").sum()
+            >>> ray.data.from_items([
+            ...     {"A": i % 3, "B": i, "C": i**2}
+            ...     for i in range(100)]) \
+            ...     .groupby("A") \
+            ...     .sum(["B", "C"])
 
         Args:
-            on: The data to sum on.
-                It can be the column name for Arrow dataset.
+            on: The data subset on which to compute the sum.
+
+                - For a simple dataset: it can be a callable or a list thereof,
+                  and the default is to take a sum of all rows.
+                - For an Arrow dataset: it can be a column name or a list
+                  thereof, and the default is to do a column-wise sum of all
+                  columns.
 
         Returns:
-            A simple dataset of (k, v) pairs or
-            an Arrow dataset of [k, v] columns
-            where k is the groupby key and
-            v is the sum result.
-            If groupby key is None then the key part of return is omitted.
+            The sum result.
+
+            For a simple dataset, the output is:
+
+            - ``on=None``: a simple dataset of ``(k, sum)`` tuples where ``k``
+              is the groupby key and ``sum`` is sum of all rows in that group.
+            - ``on=[callable_1, ..., callable_n]``: a simple dataset of
+              ``(k, sum_1, ..., sum_n)`` tuples where ``k`` is the groupby key
+              and ``sum_i`` is sum of the outputs of the ith callable called on
+              each row in that group.
+
+            For an Arrow dataset, the output is:
+
+            - ``on=None``: an Arrow dataset containing a groupby key column,
+              ``"k"``, and a column-wise sum column for each original column
+              in the dataset.
+            - ``on=["col_1", ..., "col_n"]``: an Arrow dataset of ``n + 1``
+              columns where the first column is the groupby key and the second
+              through ``n + 1`` columns are the results of the aggregations.
+
+            If groupby key is ``None`` then the key part of return is omitted.
         """
         return self._aggregate_on(Sum, on)
 
     def min(self, on: AggregateOnT = None) -> Dataset[U]:
-        """Compute min aggregation.
+        """Compute grouped min aggregation.
 
         This is a blocking operation.
 
         Examples:
             >>> ray.data.range(100).groupby(lambda x: x % 3).min()
             >>> ray.data.from_items([
-            ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
-            ...     "A").min("B")
+            ...     (i % 3, i, i**2)
+            ...     for i in range(100)]) \
+            ...     .groupby(lambda x: x[0] % 3) \
+            ...     .min(lambda x: x[2])
+            >>> ray.data.range_arrow(100).groupby("value").min()
+            >>> ray.data.from_items([
+            ...     {"A": i % 3, "B": i, "C": i**2}
+            ...     for i in range(100)]) \
+            ...     .groupby("A") \
+            ...     .min(["B", "C"])
 
         Args:
-            on: The data to min on.
-                It can be the column name for Arrow dataset.
+            on: The data subset on which to compute the min.
+
+                - For a simple dataset: it can be a callable or a list thereof,
+                  and the default is to take a min of all rows.
+                - For an Arrow dataset: it can be a column name or a list
+                  thereof, and the default is to do a column-wise min of all
+                  columns.
 
         Returns:
-            A simple dataset of (k, v) pairs or
-            an Arrow dataset of [k, v] columns
-            where k is the groupby key and
-            v is the min result.
-            If groupby key is None then the key part of return is omitted.
+            The min result.
+
+            For a simple dataset, the output is:
+
+            - ``on=None``: a simple dataset of ``(k, min)`` tuples where ``k``
+              is the groupby key and min is min of all rows in that group.
+            - ``on=[callable_1, ..., callable_n]``: a simple dataset of
+              ``(k, min_1, ..., min_n)`` tuples where ``k`` is the groupby key
+              and ``min_i`` is min of the outputs of the ith callable called on
+              each row in that group.
+
+            For an Arrow dataset, the output is:
+
+            - ``on=None``: an Arrow dataset containing a groupby key column,
+              ``"k"``, and a column-wise min column for each original column in
+              the dataset.
+            - ``on=["col_1", ..., "col_n"]``: an Arrow dataset of ``n + 1``
+              columns where the first column is the groupby key and the second
+              through ``n + 1`` columns are the results of the aggregations.
+
+            If groupby key is ``None`` then the key part of return is omitted.
         """
         return self._aggregate_on(Min, on)
 
     def max(self, on: AggregateOnT = None) -> Dataset[U]:
-        """Compute max aggregation.
+        """Compute grouped max aggregation.
 
         This is a blocking operation.
 
         Examples:
             >>> ray.data.range(100).groupby(lambda x: x % 3).max()
             >>> ray.data.from_items([
-            ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
-            ...     "A").max("B")
+            ...     (i % 3, i, i**2)
+            ...     for i in range(100)]) \
+            ...     .groupby(lambda x: x[0] % 3) \
+            ...     .max(lambda x: x[2])
+            >>> ray.data.range_arrow(100).groupby("value").max()
+            >>> ray.data.from_items([
+            ...     {"A": i % 3, "B": i, "C": i**2}
+            ...     for i in range(100)]) \
+            ...     .groupby("A") \
+            ...     .max(["B", "C"])
 
         Args:
-            on: The data to max on.
-                It can be the column name for Arrow dataset.
+            on: The data subset on which to compute the max.
+
+                - For a simple dataset: it can be a callable or a list thereof,
+                  and the default is to take a max of all rows.
+                - For an Arrow dataset: it can be a column name or a list
+                  thereof, and the default is to do a column-wise max of all
+                  columns.
 
         Returns:
-            A simple dataset of (k, v) pairs or
-            an Arrow dataset of [k, v] columns
-            where k is the groupby key and
-            v is the max result.
-            If groupby key is None then the key part of return is omitted.
+            The max result.
+
+            For a simple dataset, the output is:
+
+            - ``on=None``: a simple dataset of ``(k, max)`` tuples where ``k``
+              is the groupby key and ``max`` is max of all rows in that group.
+            - ``on=[callable_1, ..., callable_n]``: a simple dataset of
+              ``(k, max_1, ..., max_n)`` tuples where ``k`` is the groupby key
+              and ``max_i`` is max of the outputs of the ith callable called on
+              each row in that group.
+
+            For an Arrow dataset, the output is:
+
+            - ``on=None``: an Arrow dataset containing a groupby key column,
+              ``"k"``, and a column-wise max column for each original column in
+              the dataset.
+            - ``on=["col_1", ..., "col_n"]``: an Arrow dataset of ``n + 1``
+              columns where the first column is the groupby key and the second
+              through ``n + 1`` columns are the results of the aggregations.
+
+            If groupby key is ``None`` then the key part of return is omitted.
         """
         return self._aggregate_on(Max, on)
 
     def mean(self, on: AggregateOnT = None) -> Dataset[U]:
-        """Compute mean aggregation.
+        """Compute grouped mean aggregation.
 
         This is a blocking operation.
 
         Examples:
             >>> ray.data.range(100).groupby(lambda x: x % 3).mean()
             >>> ray.data.from_items([
-            ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
-            ...     "A").mean("B")
+            ...     (i % 3, i, i**2)
+            ...     for i in range(100)]) \
+            ...     .groupby(lambda x: x[0] % 3) \
+            ...     .mean(lambda x: x[2])
+            >>> ray.data.range_arrow(100).groupby("value").mean()
+            >>> ray.data.from_items([
+            ...     {"A": i % 3, "B": i, "C": i**2}
+            ...     for i in range(100)]) \
+            ...     .groupby("A") \
+            ...     .mean(["B", "C"])
 
         Args:
-            on: The data to mean on.
-                It can be the column name for Arrow dataset.
+            on: The data subset on which to compute the mean.
+
+                - For a simple dataset: it can be a callable or a list thereof,
+                  and the default is to take a mean of all rows.
+                - For an Arrow dataset: it can be a column name or a list
+                  thereof, and the default is to do a column-wise mean of all
+                  columns.
 
         Returns:
-            A simple dataset of (k, v) pairs or
-            an Arrow dataset of [k, v] columns
-            where k is the groupby key and
-            v is the mean result.
-            If groupby key is None then the key part of return is omitted.
+            The mean result.
+
+            For a simple dataset, the output is:
+
+            - ``on=None``: a simple dataset of ``(k, mean)`` tuples where ``k``
+              is the groupby key and ``mean`` is mean of all rows in that
+              group.
+            - ``on=[callable_1, ..., callable_n]``: a simple dataset of
+              ``(k, mean_1, ..., mean_n)`` tuples where ``k`` is the groupby
+              key and ``mean_i`` is mean of the outputs of the ith callable
+              called on each row in that group.
+
+            For an Arrow dataset, the output is:
+
+            - ``on=None``: an Arrow dataset containing a groupby key column,
+              ``"k"``, and a column-wise mean column for each original column
+              in the dataset.
+            - ``on=["col_1", ..., "col_n"]``: an Arrow dataset of ``n + 1``
+              columns where the first column is the groupby key and the second
+              through ``n + 1`` columns are the results of the aggregations.
+
+            If groupby key is ``None`` then the key part of return is omitted.
         """
         return self._aggregate_on(Mean, on)
 
     def std(self, on: AggregateOnT = None, ddof: int = 1) -> Dataset[U]:
-        """Compute standard deviation aggregation.
+        """Compute grouped standard deviation aggregation.
 
         This is a blocking operation.
 
         Examples:
             >>> ray.data.range(100).groupby(lambda x: x % 3).std()
             >>> ray.data.from_items([
-            ...     {"A": x % 3, "B": x} for x in range(100)]).groupby(
-            ...     "A").std("B")
+            ...     (i % 3, i, i**2)
+            ...     for i in range(100)]) \
+            ...     .groupby(lambda x: x[0] % 3) \
+            ...     .std(lambda x: x[2])
+            >>> ray.data.range_arrow(100).groupby("value").std(ddof=0)
+            >>> ray.data.from_items([
+            ...     {"A": i % 3, "B": i, "C": i**2}
+            ...     for i in range(100)]) \
+            ...     .groupby("A") \
+            ...     .std(["B", "C"])
 
         NOTE: This uses Welford's online method for an accumulator-style
         computation of the standard deviation. This method was chosen due to
@@ -259,17 +384,38 @@ class GroupedDataset(Generic[T]):
         https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
 
         Args:
-            on: The data on which to compute the standard deviation.
-                It can be the column name for Arrow dataset.
+            on: The data subset on which to compute the std.
+
+                - For a simple dataset: it can be a callable or a list thereof,
+                  and the default is to take a std of all rows.
+                - For an Arrow dataset: it can be a column name or a list
+                  thereof, and the default is to do a column-wise std of all
+                  columns.
             ddof: Delta Degrees of Freedom. The divisor used in calculations
-                is N - ddof, where N represents the number of elements.
+                is ``N - ddof``, where ``N`` represents the number of elements.
 
         Returns:
-            A simple dataset of (k, v) pairs or
-            an Arrow dataset of [k, v] columns
-            where k is the groupby key and
-            v is the standard deviation result.
-            If groupby key is None then the key part of return is omitted.
+            The standard deviation result.
+
+            For a simple dataset, the output is:
+
+            - ``on=None``: a simple dataset of ``(k, std)`` tuples where ``k``
+              is the groupby key and ``std`` is std of all rows in that group.
+            - ``on=[callable_1, ..., callable_n]``: a simple dataset of
+              ``(k, std_1, ..., std_n)`` tuples where ``k`` is the groupby key
+              and ``std_i`` is std of the outputs of the ith callable called on
+              each row in that group.
+
+            For an Arrow dataset, the output is:
+
+            - ``on=None``: an Arrow dataset containing a groupby key column,
+              ``"k"``, and a column-wise std column for each original column in
+              the dataset.
+            - ``on=["col_1", ..., "col_n"]``: an Arrow dataset of ``n + 1``
+              columns where the first column is the groupby key and the second
+              through ``n + 1`` columns are the results of the aggregations.
+
+            If groupby key is ``None`` then the key part of return is omitted.
         """
         return self._aggregate_on(Std, on, ddof=ddof)
 

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -15,6 +15,8 @@ from ray.data.block import Block, BlockAccessor, BlockMetadata, \
 GroupKeyBaseT = Union[Callable[[T], KeyType], str]
 GroupKeyT = Optional[Union[GroupKeyBaseT, List[GroupKeyBaseT]]]
 
+AggregateOnTs = Union[AggregateOnT, List[AggregateOnT]]
+
 
 @PublicAPI(stability="beta")
 class GroupedDataset(Generic[T]):
@@ -112,7 +114,8 @@ class GroupedDataset(Generic[T]):
         metadata = ray.get(metadata)
         return Dataset(BlockList(blocks, metadata), self._dataset._epoch)
 
-    def _aggregate_on(self, agg_cls: type, on: AggregateOnT, *args, **kwargs):
+    def _aggregate_on(self, agg_cls: type, on: Optional[AggregateOnTs], *args,
+                      **kwargs):
         """Helper for aggregating on a particular subset of the dataset.
 
         This validates the `on` argument, and converts a list of column names
@@ -143,7 +146,7 @@ class GroupedDataset(Generic[T]):
         """
         return self.aggregate(Count())
 
-    def sum(self, on: AggregateOnT = None) -> Dataset[U]:
+    def sum(self, on: Optional[AggregateOnTs] = None) -> Dataset[U]:
         """Compute grouped sum aggregation.
 
         This is a blocking operation.
@@ -196,7 +199,7 @@ class GroupedDataset(Generic[T]):
         """
         return self._aggregate_on(Sum, on)
 
-    def min(self, on: AggregateOnT = None) -> Dataset[U]:
+    def min(self, on: Optional[AggregateOnTs] = None) -> Dataset[U]:
         """Compute grouped min aggregation.
 
         This is a blocking operation.
@@ -249,7 +252,7 @@ class GroupedDataset(Generic[T]):
         """
         return self._aggregate_on(Min, on)
 
-    def max(self, on: AggregateOnT = None) -> Dataset[U]:
+    def max(self, on: Optional[AggregateOnTs] = None) -> Dataset[U]:
         """Compute grouped max aggregation.
 
         This is a blocking operation.
@@ -302,7 +305,7 @@ class GroupedDataset(Generic[T]):
         """
         return self._aggregate_on(Max, on)
 
-    def mean(self, on: AggregateOnT = None) -> Dataset[U]:
+    def mean(self, on: Optional[AggregateOnTs] = None) -> Dataset[U]:
         """Compute grouped mean aggregation.
 
         This is a blocking operation.
@@ -356,7 +359,8 @@ class GroupedDataset(Generic[T]):
         """
         return self._aggregate_on(Mean, on)
 
-    def std(self, on: AggregateOnT = None, ddof: int = 1) -> Dataset[U]:
+    def std(self, on: Optional[AggregateOnTs] = None,
+            ddof: int = 1) -> Dataset[U]:
         """Compute grouped standard deviation aggregation.
 
         This is a blocking operation.

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -70,6 +70,9 @@ class ArrowRow:
     def __repr__(self):
         return str(self)
 
+    def __len__(self):
+        return self._row.num_columns
+
 
 class DelegatingArrowBlockBuilder(BlockBuilder[T]):
     def __init__(self):

--- a/python/ray/data/impl/block_list.py
+++ b/python/ray/data/impl/block_list.py
@@ -128,10 +128,13 @@ class BlockList:
 
         Returns None if the block list is empty.
         """
-        if not self._blocks:
-            return None
         get_schema = cached_remote_fn(_get_schema)
-        schema = ray.get(get_schema.remote(next(self.iter_blocks())))
+        try:
+            block = next(self.iter_blocks())
+        except (StopIteration, ValueError):
+            # Dataset is empty (no blocks) or was manually cleared.
+            return None
+        schema = ray.get(get_schema.remote(block))
         # Set the schema.
         self._metadata[0].schema = schema
         return schema

--- a/python/ray/data/impl/block_list.py
+++ b/python/ray/data/impl/block_list.py
@@ -125,6 +125,7 @@ class BlockList:
     def ensure_schema_for_first_block(
             self) -> Optional[Union["pyarrow.Schema", type]]:
         """Ensure that the schema is set for the first block.
+
         Returns None if the block list is empty.
         """
         if not self._blocks:

--- a/python/ray/data/impl/block_list.py
+++ b/python/ray/data/impl/block_list.py
@@ -1,11 +1,15 @@
 import math
-from typing import List, Iterator, Tuple
+from typing import List, Iterator, Tuple, Any, Union, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow
 
 import numpy as np
 
 import ray
 from ray.types import ObjectRef
-from ray.data.block import Block, BlockMetadata
+from ray.data.block import Block, BlockMetadata, BlockAccessor
+from ray.data.impl.remote_fn import cached_remote_fn
 
 
 class BlockList:
@@ -28,7 +32,7 @@ class BlockList:
         self._metadata[i] = metadata
 
     def get_metadata(self) -> List[BlockMetadata]:
-        """Get the metadata for a given block."""
+        """Get the metadata for all blocks."""
         return self._metadata.copy()
 
     def copy(self) -> "BlockList":
@@ -117,3 +121,20 @@ class BlockList:
         doesn't know how many blocks will be produced until tasks finish.
         """
         return len(list(self.iter_blocks()))
+
+    def ensure_schema_for_first_block(
+            self) -> Optional[Union["pyarrow.Schema", type]]:
+        """Ensure that the schema is set for the first block.
+        Returns None if the block list is empty.
+        """
+        if not self._blocks:
+            return None
+        get_schema = cached_remote_fn(_get_schema)
+        schema = ray.get(get_schema.remote(next(self.iter_blocks())))
+        # Set the schema.
+        self._metadata[0].schema = schema
+        return schema
+
+
+def _get_schema(block: Block) -> Any:
+    return BlockAccessor.for_block(block).schema()

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1210,26 +1210,6 @@ def test_to_numpy(ray_start_regular_shared):
     np.testing.assert_equal(arr, np.arange(0, 10))
 
 
-def test_to_arrow(ray_start_regular_shared):
-    n = 5
-
-    # Zero-copy.
-    df = pd.DataFrame({"value": list(range(n))})
-    ds = ray.data.range_arrow(n)
-    dfds = pd.concat(
-        [t.to_pandas() for t in ray.get(ds.to_arrow_refs())],
-        ignore_index=True)
-    assert df.equals(dfds)
-
-    # Conversion.
-    df = pd.DataFrame({0: list(range(n))})
-    ds = ray.data.range(n)
-    dfds = pd.concat(
-        [t.to_pandas() for t in ray.get(ds.to_arrow_refs())],
-        ignore_index=True)
-    assert df.equals(dfds)
-
-
 def test_to_arrow_refs(ray_start_regular_shared):
     n = 5
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1119,14 +1119,12 @@ def test_from_pandas_refs(ray_start_regular_shared):
 
 
 def test_from_numpy(ray_start_regular_shared):
-    arr1 = np.expand_dims(np.arange(0, 4), 1)
-    arr2 = np.expand_dims(np.arange(4, 8), 1)
+    arr1 = np.expand_dims(np.arange(0, 4), axis=1)
+    arr2 = np.expand_dims(np.arange(4, 8), axis=1)
     ds = ray.data.from_numpy([ray.put(arr1), ray.put(arr2)])
     values = np.array(ds.take(8))
-    for i in range(4):
-        assert values[i]["value"] == arr1[i]
-    for i in range(4, 8):
-        assert values[i]["value"] == arr2[i - 4]
+    np.testing.assert_array_equal(
+        values, np.expand_dims(np.concatenate((arr1, arr2)), axis=1))
 
 
 def test_from_arrow(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1058,9 +1058,17 @@ def test_repartition_noshuffle(ray_start_regular_shared):
     assert ds3.sum() == 190
     assert ds3._block_sizes() == [1] * 20
 
-    ds4 = ray.data.range(22).repartition(4)
-    assert ds4.num_blocks() == 4
-    assert ds4._block_sizes() == [5, 6, 5, 6]
+    # Test num_partitions > num_rows
+    ds4 = ds.repartition(40, shuffle=False)
+    assert ds4.num_blocks() == 40
+    blocks = ray.get(ds4.get_internal_block_refs())
+    assert all(isinstance(block, list) for block in blocks), blocks
+    assert ds4.sum() == 190
+    assert ds4._block_sizes() == ([1] * 20) + ([0] * 20)
+
+    ds5 = ray.data.range(22).repartition(4)
+    assert ds5.num_blocks() == 4
+    assert ds5._block_sizes() == [5, 6, 5, 6]
 
     large = ray.data.range(10000, parallelism=10)
     large = large.repartition(20)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2862,13 +2862,14 @@ def test_groupby_arrow(ray_start_regular_shared):
     assert agg_ds.count() == 0
 
 
-def test_groupby_agg_name_conflict(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_agg_name_conflict(ray_start_regular_shared, num_parts):
     # Test aggregation name conflict.
     xs = list(range(100))
     grouped_ds = ray.data.from_items([{
         "A": (x % 3),
         "B": x
-    } for x in xs]).groupby("A")
+    } for x in xs]).repartition(num_parts).groupby("A")
     agg_ds = grouped_ds.aggregate(
         AggregateFn(
             init=lambda k: [0, 0],
@@ -2889,7 +2890,8 @@ def test_groupby_agg_name_conflict(ray_start_regular_shared):
          {"A": 2, "foo": 50.0, "foo_2": 50.0}]
 
 
-def test_groupby_arrow_count(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_count(ray_start_regular_shared, num_parts):
     # Test built-in count aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_count with: {seed}")
@@ -2899,14 +2901,15 @@ def test_groupby_arrow_count(ray_start_regular_shared):
     agg_ds = ray.data.from_items([{
         "A": (x % 3),
         "B": x
-    } for x in xs]).groupby("A").count()
+    } for x in xs]).repartition(num_parts).groupby("A").count()
     assert agg_ds.count() == 3
     assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == \
         [{"A": 0, "count()": 34}, {"A": 1, "count()": 33},
          {"A": 2, "count()": 33}]
 
 
-def test_groupby_arrow_sum(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_sum(ray_start_regular_shared, num_parts):
     # Test built-in sum aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_sum with: {seed}")
@@ -2916,18 +2919,21 @@ def test_groupby_arrow_sum(ray_start_regular_shared):
     agg_ds = ray.data.from_items([{
         "A": (x % 3),
         "B": x
-    } for x in xs]).groupby("A").sum("B")
+    } for x in xs]).repartition(num_parts).groupby("A").sum("B")
     assert agg_ds.count() == 3
     assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == \
         [{"A": 0, "sum(B)": 1683}, {"A": 1, "sum(B)": 1617},
          {"A": 2, "sum(B)": 1650}]
     # Test built-in global sum aggregation
-    assert ray.data.from_items([{"A": x} for x in xs]).sum("A") == 4950
+    assert ray.data.from_items([{
+        "A": x
+    } for x in xs]).repartition(num_parts).sum("A") == 4950
     assert ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).sum(
         "value") == 0
 
 
-def test_groupby_arrow_min(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_min(ray_start_regular_shared, num_parts):
     # Test built-in min aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_min with: {seed}")
@@ -2937,18 +2943,21 @@ def test_groupby_arrow_min(ray_start_regular_shared):
     agg_ds = ray.data.from_items([{
         "A": (x % 3),
         "B": x
-    } for x in xs]).groupby("A").min("B")
+    } for x in xs]).repartition(num_parts).groupby("A").min("B")
     assert agg_ds.count() == 3
     assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == \
         [{"A": 0, "min(B)": 0}, {"A": 1, "min(B)": 1},
          {"A": 2, "min(B)": 2}]
     # Test built-in global min aggregation
-    assert ray.data.from_items([{"A": x} for x in xs]).min("A") == 0
+    assert ray.data.from_items([{
+        "A": x
+    } for x in xs]).repartition(num_parts).min("A") == 0
     with pytest.raises(ValueError):
         ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).min("value")
 
 
-def test_groupby_arrow_max(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_max(ray_start_regular_shared, num_parts):
     # Test built-in max aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_max with: {seed}")
@@ -2958,18 +2967,21 @@ def test_groupby_arrow_max(ray_start_regular_shared):
     agg_ds = ray.data.from_items([{
         "A": (x % 3),
         "B": x
-    } for x in xs]).groupby("A").max("B")
+    } for x in xs]).repartition(num_parts).groupby("A").max("B")
     assert agg_ds.count() == 3
     assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == \
         [{"A": 0, "max(B)": 99}, {"A": 1, "max(B)": 97},
          {"A": 2, "max(B)": 98}]
     # Test built-in global max aggregation
-    assert ray.data.from_items([{"A": x} for x in xs]).max("A") == 99
+    assert ray.data.from_items([{
+        "A": x
+    } for x in xs]).repartition(num_parts).max("A") == 99
     with pytest.raises(ValueError):
         ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).max("value")
 
 
-def test_groupby_arrow_mean(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_mean(ray_start_regular_shared, num_parts):
     # Test built-in mean aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_mean with: {seed}")
@@ -2979,19 +2991,22 @@ def test_groupby_arrow_mean(ray_start_regular_shared):
     agg_ds = ray.data.from_items([{
         "A": (x % 3),
         "B": x
-    } for x in xs]).groupby("A").mean("B")
+    } for x in xs]).repartition(num_parts).groupby("A").mean("B")
     assert agg_ds.count() == 3
     assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == \
         [{"A": 0, "mean(B)": 49.5}, {"A": 1, "mean(B)": 49.0},
          {"A": 2, "mean(B)": 50.0}]
     # Test built-in global mean aggregation
-    assert ray.data.from_items([{"A": x} for x in xs]).mean("A") == 49.5
+    assert ray.data.from_items([{
+        "A": x
+    } for x in xs]).repartition(num_parts).mean("A") == 49.5
     with pytest.raises(ValueError):
         ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).mean(
             "value")
 
 
-def test_groupby_arrow_std(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_std(ray_start_regular_shared, num_parts):
     # Test built-in std aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_std with: {seed}")
@@ -2999,30 +3014,36 @@ def test_groupby_arrow_std(ray_start_regular_shared):
     xs = list(range(100))
     random.shuffle(xs)
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
-    agg_ds = ray.data.from_pandas(df).groupby("A").std("B")
+    agg_ds = ray.data.from_pandas(df).repartition(num_parts).groupby("A").std(
+        "B")
     assert agg_ds.count() == 3
     result = agg_ds.to_pandas()["std(B)"].to_numpy()
     expected = df.groupby("A")["B"].std().to_numpy()
-    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_array_almost_equal(result, expected)
     # ddof of 0
-    agg_ds = ray.data.from_pandas(df).groupby("A").std("B", ddof=0)
+    agg_ds = ray.data.from_pandas(df).repartition(num_parts).groupby("A").std(
+        "B", ddof=0)
     assert agg_ds.count() == 3
     result = agg_ds.to_pandas()["std(B)"].to_numpy()
     expected = df.groupby("A")["B"].std(ddof=0).to_numpy()
-    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_array_almost_equal(result, expected)
     # Test built-in global std aggregation
     df = pd.DataFrame({"A": xs})
-    assert math.isclose(ray.data.from_pandas(df).std("A"), df["A"].std())
+    assert math.isclose(
+        ray.data.from_pandas(df).repartition(num_parts).std("A"),
+        df["A"].std())
     # ddof of 0
     assert math.isclose(
-        ray.data.from_pandas(df).std("A", ddof=0), df["A"].std(ddof=0))
+        ray.data.from_pandas(df).repartition(num_parts).std("A", ddof=0),
+        df["A"].std(ddof=0))
     with pytest.raises(ValueError):
         ray.data.from_pandas(pd.DataFrame({"A": []})).std("A")
     # Test edge cases
     assert ray.data.from_pandas(pd.DataFrame({"A": [3]})).std("A") == 0
 
 
-def test_groupby_arrow_multicolumn(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_multicolumn(ray_start_regular_shared, num_parts):
     # Test built-in mean aggregation on multiple columns
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_multicolumn with: {seed}")
@@ -3034,7 +3055,8 @@ def test_groupby_arrow_multicolumn(ray_start_regular_shared):
         "B": xs,
         "C": [2 * x for x in xs]
     })
-    agg_ds = ray.data.from_pandas(df).groupby("A").mean(["B", "C"])
+    agg_ds = ray.data.from_pandas(df).repartition(num_parts).groupby("A").mean(
+        ["B", "C"])
     assert agg_ds.count() == 3
     assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == \
         [{"A": 0, "mean(B)": 49.5, "mean(C)": 99.0},
@@ -3042,7 +3064,8 @@ def test_groupby_arrow_multicolumn(ray_start_regular_shared):
          {"A": 2, "mean(B)": 50.0, "mean(C)": 100.0}]
     # Test that unspecified agg column ==> agg on all columns except for
     # groupby keys.
-    agg_ds = ray.data.from_pandas(df).groupby("A").mean()
+    agg_ds = ray.data.from_pandas(df).repartition(num_parts).groupby(
+        "A").mean()
     assert agg_ds.count() == 3
     assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == \
         [{"A": 0, "mean(B)": 49.5, "mean(C)": 99.0},
@@ -3050,7 +3073,8 @@ def test_groupby_arrow_multicolumn(ray_start_regular_shared):
          {"A": 2, "mean(B)": 50.0, "mean(C)": 100.0}]
     # Test built-in global mean aggregation
     df = pd.DataFrame({"A": xs, "B": [2 * x for x in xs]})
-    result_row = ray.data.from_pandas(df).mean(["A", "B"])
+    result_row = ray.data.from_pandas(df).repartition(num_parts).mean(
+        ["A", "B"])
     assert result_row["mean(A)"] == df["A"].mean()
     assert result_row["mean(B)"] == df["B"].mean()
 
@@ -3099,21 +3123,23 @@ def test_groupby_agg_bad_on(ray_start_regular_shared):
         ray.data.from_items(xs).mean("A")
 
 
-def test_groupby_arrow_multi_agg(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_arrow_multi_agg(ray_start_regular_shared, num_parts):
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_multi_agg with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
-    agg_ds = ray.data.from_pandas(df).groupby("A").aggregate(
-        Count(),
-        Sum("B"),
-        Min("B"),
-        Max("B"),
-        Mean("B"),
-        Std("B"),
-    )
+    agg_ds = ray.data.from_pandas(df).repartition(num_parts).groupby(
+        "A").aggregate(
+            Count(),
+            Sum("B"),
+            Min("B"),
+            Max("B"),
+            Mean("B"),
+            Std("B"),
+        )
     assert agg_ds.count() == 3
     agg_df = agg_ds.to_pandas()
     expected_grouped = df.groupby("A")["B"]
@@ -3124,7 +3150,7 @@ def test_groupby_arrow_multi_agg(ray_start_regular_shared):
         np.testing.assert_array_equal(result, expected)
     # Test built-in global std aggregation
     df = pd.DataFrame({"A": xs})
-    result_row = ray.data.from_pandas(df).aggregate(
+    result_row = ray.data.from_pandas(df).repartition(num_parts).aggregate(
         Sum("A"),
         Min("A"),
         Max("A"),
@@ -3190,93 +3216,105 @@ def test_groupby_simple(ray_start_regular_shared):
     assert agg_ds.count() == 0
 
 
-def test_groupby_simple_count(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_count(ray_start_regular_shared, num_parts):
     # Test built-in count aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_count with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).count()
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).count()
     assert agg_ds.count() == 3
     assert agg_ds.sort(key=lambda r: r[0]).take(3) == [(0, 34), (1, 33), (2,
                                                                           33)]
 
 
-def test_groupby_simple_sum(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_sum(ray_start_regular_shared, num_parts):
     # Test built-in sum aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_sum with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).sum()
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).sum()
     assert agg_ds.count() == 3
     assert agg_ds.sort(key=lambda r: r[0]).take(3) == [(0, 1683), (1, 1617),
                                                        (2, 1650)]
     # Test built-in global sum aggregation
-    assert ray.data.from_items(xs).sum() == 4950
+    assert ray.data.from_items(xs).repartition(num_parts).sum() == 4950
     assert ray.data.range(10).filter(lambda r: r > 10).sum() == 0
 
 
-def test_groupby_simple_min(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_min(ray_start_regular_shared, num_parts):
     # Test built-in min aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_min with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).min()
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).min()
     assert agg_ds.count() == 3
     assert agg_ds.sort(key=lambda r: r[0]).take(3) == [(0, 0), (1, 1), (2, 2)]
     # Test built-in global min aggregation
-    assert ray.data.from_items(xs).min() == 0
+    assert ray.data.from_items(xs).repartition(num_parts).min() == 0
     with pytest.raises(ValueError):
         ray.data.range(10).filter(lambda r: r > 10).min()
 
 
-def test_groupby_simple_max(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_max(ray_start_regular_shared, num_parts):
     # Test built-in max aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_max with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).max()
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).max()
     assert agg_ds.count() == 3
     assert agg_ds.sort(key=lambda r: r[0]).take(3) == [(0, 99), (1, 97), (2,
                                                                           98)]
     # Test built-in global max aggregation
-    assert ray.data.from_items(xs).max() == 99
+    assert ray.data.from_items(xs).repartition(num_parts).max() == 99
     with pytest.raises(ValueError):
         ray.data.range(10).filter(lambda r: r > 10).max()
 
 
-def test_groupby_simple_mean(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_mean(ray_start_regular_shared, num_parts):
     # Test built-in mean aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_mean with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).mean()
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).mean()
     assert agg_ds.count() == 3
     assert agg_ds.sort(key=lambda r: r[0]).take(3) == [(0, 49.5), (1, 49.0),
                                                        (2, 50.0)]
     # Test built-in global mean aggregation
-    assert ray.data.from_items(xs).mean() == 49.5
+    assert ray.data.from_items(xs).repartition(num_parts).mean() == 49.5
     with pytest.raises(ValueError):
         ray.data.range(10).filter(lambda r: r > 10).mean()
 
 
-def test_groupby_simple_std(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_std(ray_start_regular_shared, num_parts):
     # Test built-in std aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_std with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).std()
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).std()
     assert agg_ds.count() == 3
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
     expected = df.groupby("A")["B"].std()
@@ -3286,7 +3324,8 @@ def test_groupby_simple_std(ray_start_regular_shared):
     result_df = result_df.set_index("A")
     pd.testing.assert_series_equal(result_df["B"], expected)
     # ddof of 0
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).std(ddof=0)
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).std(ddof=0)
     assert agg_ds.count() == 3
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
     expected = df.groupby("A")["B"].std(ddof=0)
@@ -3296,17 +3335,21 @@ def test_groupby_simple_std(ray_start_regular_shared):
     result_df = result_df.set_index("A")
     pd.testing.assert_series_equal(result_df["B"], expected)
     # Test built-in global std aggregation
-    assert math.isclose(ray.data.from_items(xs).std(), pd.Series(xs).std())
+    assert math.isclose(
+        ray.data.from_items(xs).repartition(num_parts).std(),
+        pd.Series(xs).std())
     # ddof of 0
     assert math.isclose(
-        ray.data.from_items(xs).std(ddof=0), pd.Series(xs).std(ddof=0))
+        ray.data.from_items(xs).repartition(num_parts).std(ddof=0),
+        pd.Series(xs).std(ddof=0))
     with pytest.raises(ValueError):
         ray.data.from_items([]).std()
     # Test edge cases
     assert ray.data.from_items([3]).std() == 0
 
 
-def test_groupby_simple_multilambda(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_multilambda(ray_start_regular_shared, num_parts):
     # Test built-in mean aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_multilambda with: {seed}")
@@ -3314,6 +3357,7 @@ def test_groupby_simple_multilambda(ray_start_regular_shared):
     xs = list(range(100))
     random.shuffle(xs)
     agg_ds = ray.data.from_items([[x, 2*x] for x in xs]) \
+        .repartition(num_parts) \
         .groupby(lambda x: x[0] % 3) \
         .mean([lambda x: x[0], lambda x: x[1]])
     assert agg_ds.count() == 3
@@ -3321,29 +3365,32 @@ def test_groupby_simple_multilambda(ray_start_regular_shared):
                                                         99.0), (1, 49.0, 98.0),
                                                        (2, 50.0, 100.0)]
     # Test built-in global mean aggregation
-    assert ray.data.from_items([[x, 2 * x] for x in xs]).mean(
-        [lambda x: x[0], lambda x: x[1]]) == (49.5, 99.0)
+    assert ray.data.from_items(
+        [[x, 2 * x] for x in xs]).repartition(num_parts).mean(
+            [lambda x: x[0], lambda x: x[1]]) == (49.5, 99.0)
     with pytest.raises(ValueError):
         ray.data.from_items([[x, 2*x] for x in range(10)]) \
             .filter(lambda r: r[0] > 10) \
             .mean([lambda x: x[0], lambda x: x[1]])
 
 
-def test_groupby_simple_multi_agg(ray_start_regular_shared):
+@pytest.mark.parametrize("num_parts", [1, 10, 100])
+def test_groupby_simple_multi_agg(ray_start_regular_shared, num_parts):
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_simple_multi_agg with: {seed}")
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
-    agg_ds = ray.data.from_items(xs).groupby(lambda x: x % 3).aggregate(
-        Count(),
-        Sum(),
-        Min(),
-        Max(),
-        Mean(),
-        Std(),
-    )
+    agg_ds = ray.data.from_items(xs).repartition(num_parts).groupby(
+        lambda x: x % 3).aggregate(
+            Count(),
+            Sum(),
+            Min(),
+            Max(),
+            Mean(),
+            Std(),
+        )
     assert agg_ds.count() == 3
     result = agg_ds.sort(key=lambda r: r[0]).take(3)
     groups, counts, sums, mins, maxs, means, stds = zip(*result)
@@ -3365,7 +3412,7 @@ def test_groupby_simple_multi_agg(ray_start_regular_shared):
         expected = getattr(expected_grouped, agg)().to_numpy()
         np.testing.assert_array_almost_equal(result, expected)
     # Test built-in global multi-aggregation
-    result_row = ray.data.from_items(xs).aggregate(
+    result_row = ray.data.from_items(xs).repartition(num_parts).aggregate(
         Sum(),
         Min(),
         Max(),

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3147,7 +3147,10 @@ def test_groupby_arrow_multi_agg(ray_start_regular_shared, num_parts):
     for agg in ["sum", "min", "max", "mean", "std"]:
         result = agg_df[f"{agg}(B)"].to_numpy()
         expected = getattr(expected_grouped, agg)().to_numpy()
-        np.testing.assert_array_equal(result, expected)
+        if agg == "std":
+            np.testing.assert_array_almost_equal(result, expected)
+        else:
+            np.testing.assert_array_equal(result, expected)
     # Test built-in global std aggregation
     df = pd.DataFrame({"A": xs})
     result_row = ray.data.from_pandas(df).repartition(num_parts).aggregate(
@@ -3410,7 +3413,10 @@ def test_groupby_simple_multi_agg(ray_start_regular_shared, num_parts):
     for agg in ["sum", "min", "max", "mean", "std"]:
         result = agg_df[agg].to_numpy()
         expected = getattr(expected_grouped, agg)().to_numpy()
-        np.testing.assert_array_almost_equal(result, expected)
+        if agg == "std":
+            np.testing.assert_array_almost_equal(result, expected)
+        else:
+            np.testing.assert_array_equal(result, expected)
     # Test built-in global multi-aggregation
     result_row = ray.data.from_items(xs).repartition(num_parts).aggregate(
         Sum(),


### PR DESCRIPTION
As a stacked follow-up to #20044 (only the last commit contains incremental changes from original PR), this PR adds multi-column/multi-lambda aggregations, making it much easier to express "do some aggregation on multiple columns".

### Mean on 3 columns - old API
```python
from ray.data.aggregate import Mean

ds.aggregate(Mean("A"), Mean("B"), Mean("C"))
```

### Mean on 3 columns - new API
```python
ds.mean(["A", "B", "C"])
```

This PR also adds thorough checking of the `on` aggregation argument.

## Drivebys

1. `.repartition()` wasn't properly handling the `num_partitions > num_rows` case: for a simple `Dataset` with simple blocks, the generated empty blocks were Arrow blocks instead of simple blocks, which causes most downstream operations to break. We [explicitly handle](https://github.com/ray-project/ray/pull/20074/commits/1246bf5f65a8d28ddd12b3223b881f5ffb1154cd) the empty block case in `.repartition()`. We should find a way to fix this in general, so I opened an [issue](https://github.com/ray-project/ray/issues/20290) for that effort.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
