### PR TITLE
[Datasets] Multi-aggregations [3/3]: Add Pandas-like multi-aggregation API.

### DIFF
--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -8,7 +8,7 @@ AggregateOnT = Union[Callable[[T], Any], str]
 
 
 @PublicAPI(stability="beta")
-class Aggregation:
+class BoundAggregateFn:
     def __init__(self,
                  agg_fn: "AggregateFn",
                  on: Optional[Union[str, Callable]] = None,
@@ -181,6 +181,7 @@ class Std(AggregateFn):
             finalize=finalize)
 
 
+Aggregation = Union[str, AggregateFn]
 AGGS_TABLE = {"sum": Sum, "min": Min, "max": Max, "mean": Mean, "std": Std}
 
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     import pandas
     import pyarrow
     from ray.data.impl.block_builder import BlockBuilder
-    from ray.data.aggregate import AggregateFn
+    from ray.data.aggregate import Aggregation
     from ray.data.grouped_dataset import GroupKeyT
 
 from ray.types import ObjectRef
@@ -166,7 +166,7 @@ class BlockAccessor(Generic[T]):
         """Return a list of sorted partitions of this block."""
         raise NotImplementedError
 
-    def combine(self, key: "GroupKeyT", agg: "AggregateFn") -> Block[U]:
+    def combine(self, key: "GroupKeyT", agg: Tuple["Aggregation"]) -> Block[U]:
         """Combine rows with the same key into an accumulator."""
         raise NotImplementedError
 
@@ -180,6 +180,6 @@ class BlockAccessor(Generic[T]):
     @staticmethod
     def aggregate_combined_blocks(
             blocks: List[Block], key: "GroupKeyT",
-            agg: "AggregateFn") -> Tuple[Block[U], BlockMetadata]:
+            agg: Tuple["Aggregation"]) -> Tuple[Block[U], BlockMetadata]:
         """Aggregate partially combined and sorted blocks."""
         raise NotImplementedError

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -1,5 +1,5 @@
 from typing import TypeVar, List, Generic, Iterator, Tuple, Any, Union, \
-    Optional, TYPE_CHECKING
+    Sequence, Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     import pandas
     import pyarrow
     from ray.data.impl.block_builder import BlockBuilder
-    from ray.data.aggregate import Aggregation
+    from ray.data.aggregate import BoundAggregateFn
     from ray.data.grouped_dataset import GroupKeyT
 
 from ray.types import ObjectRef
@@ -166,7 +166,8 @@ class BlockAccessor(Generic[T]):
         """Return a list of sorted partitions of this block."""
         raise NotImplementedError
 
-    def combine(self, key: "GroupKeyT", agg: Tuple["Aggregation"]) -> Block[U]:
+    def combine(self, key: "GroupKeyT",
+                aggs: Sequence["BoundAggregateFn"]) -> Block[U]:
         """Combine rows with the same key into an accumulator."""
         raise NotImplementedError
 
@@ -178,8 +179,8 @@ class BlockAccessor(Generic[T]):
         raise NotImplementedError
 
     @staticmethod
-    def aggregate_combined_blocks(
-            blocks: List[Block], key: "GroupKeyT",
-            agg: Tuple["Aggregation"]) -> Tuple[Block[U], BlockMetadata]:
+    def aggregate_combined_blocks(blocks: List[Block], key: "GroupKeyT",
+                                  aggs: Sequence["BoundAggregateFn"]
+                                  ) -> Tuple[Block[U], BlockMetadata]:
         """Aggregate partially combined and sorted blocks."""
         raise NotImplementedError

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -849,47 +849,61 @@ class Dataset(Generic[T]):
                               Dict[str, Union[str, AggregateFn]]]):
         """Aggregate using one or more operations over the specified columns.
 
+        This is a blocking operation.
+
         Examples:
             >>> ray.data.range(100).agg("sum")
             >>> ray.data.range(100).agg(["sum", Std(ddof=0)])
             >>> ray.data.from_items([
-                        {"A": x, "B": x**2} for x in range(100)]) \
-                    .agg({
-                        "A": ["mean", Std(ddof=0)],
-                        "B": ["min", "max"],
-                    })
+            ...         {"A": x, "B": x**2} for x in range(100)]) \
+            ...     .agg({
+            ...         "A": ["mean", Std(ddof=0)],
+            ...         "B": ["min", "max"],
+            ...     })
 
         Args:
             aggs: Aggregations to compute. This can be:
 
-                - Union[str, AggregateFn]: The (name of an) aggregation that we
-                    want to apply to all columns.
-                - List[Union[str, AggregateFn]]: A list of the (names of)
-                    aggregations that we want to apply to all columns.
-                - Dict[str, Union[str, AggregateFn]]: A map from column names
-                    to the (names of the) aggregations that we wish to apply to
-                    those specific columns. This can only be applied to Arrow
-                    Datasets.
+                - ``Union[str, AggregateFn]``: The (name of an) aggregation
+                  that we want to apply to all columns.
+                - ``List[Union[str, AggregateFn]]``: A list of the (names of)
+                  aggregations that we want to apply to all columns.
+                - ``Dict[str, Union[str, AggregateFn]]``: A map from column
+                  names to the (names of the) aggregations that we wish to
+                  apply to those specific columns. This can only be applied to
+                  Arrow Datasets.
 
         Returns:
             If the input dataset is a simple dataset then the output is
-            a tuple of (agg1, agg2, ...) where each tuple element is
+            a tuple of ``(agg1, agg2, ...)`` where each tuple element is
             the corresponding aggregation result.
+
             If the input dataset is an Arrow dataset then the output is
-            an ArrowRow where each column is the corresponding
+            an ``ArrowRow`` where each column is the corresponding
             aggregation result.
-            When `aggs` is given as a list, the aggregation columns are ordered
-            in accordance with the aggregation list ordering (aggs, cols):
+
+            When ``aggs`` is given as a list, the aggregation columns are
+            ordered in accordance with the aggregation list ordering
+            (aggs, cols)::
+
                 [agg1, agg2]
-            on a dataset with columns col1 and col2 would yield aggregation
-            columns:
+
+            on a dataset with columns ``col1`` and ``col2`` would yield
+            aggregation columns::
+
                 col1_agg1, col2_agg1, col1_agg2, col2_agg2
-            When `aggs` is given as a dict, the aggregation columns are ordered
-            in accordance with the depth-first dict ordering (cols, aggs):
+
+            When ``aggs`` is given as a dict, the aggregation columns are
+            ordered in accordance with the depth-first dict ordering
+            (cols, aggs)::
+
                 {col1: [agg1, agg2], col2: [agg2, agg1]}
-            would yield aggregation columns:
+
+            would yield aggregation columns::
+
                 col1_agg1, col1_agg2, col2_agg2, col2_agg1
-            If the dataset is empty, return None.
+
+            If the dataset is empty, return ``None``.
         """
         aggs_ = self._build_multi_agg(aggs)
         return self.apply_aggregations(*aggs_)
@@ -964,9 +978,11 @@ class Dataset(Generic[T]):
             If the input dataset is a simple dataset then the output is
             a tuple of ``(agg1, agg2, ...)`` where each tuple element is
             the corresponding aggregation result.
+
             If the input dataset is an Arrow dataset then the output is
             an ``ArrowRow`` where each column is the corresponding
             aggregation result.
+
             If the dataset is empty, return ``None``.
         """
         ret = self.groupby(None).apply_aggregations(*aggs).take(1)

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -55,43 +55,55 @@ class GroupedDataset(Generic[T]):
             >>> grouped_ds.agg("sum")
             >>> grouped_ds.agg(["sum", Std(ddof=0)])
             >>> grouped_ds.agg({
-                    "A": ["mean", Std(ddof=0)],
-                    "B": ["min", "max"]})
+            ...     "A": ["mean", Std(ddof=0)],
+            ...     "B": ["min", "max"]})
 
         Args:
             aggs: Aggregations to compute. This can be:
 
-                - Union[str, AggregateFn]: The (name of an) aggregation that we
-                    want to apply to all columns (other than the groupby key
-                    column).
-                - List[Union[str, AggregateFn]]: A list of the (names of)
-                    aggregations that we want to apply to all columns (other
-                    than the groupby key column).
-                - Dict[str, Union[str, AggregateFn]]: A map from column names
-                    to the (names of the) aggregations that we wish to apply to
-                    those specific columns. This can only be applied to Arrow
-                    Datasets.
+                - ``Union[str, AggregateFn]:`` The (name of an) aggregation
+                  that we want to apply to all columns (other than the groupby
+                  key column).
+                - ``List[Union[str, AggregateFn]]``: A list of the (names of)
+                  aggregations that we want to apply to all columns (other
+                  than the groupby key column).
+                - ``Dict[str, Union[str, AggregateFn]]``: A map from column
+                  names to the (names of the) aggregations that we wish to
+                  apply to those specific columns. This can only be applied to
+                  Arrow Datasets.
 
         Returns:
-            If the input dataset is simple dataset then the output is
-            a simple dataset of (k, v_1, ..., v_n) tuples where k is the
-            groupby key and v_i is the result of the ith given aggregation.
-            If the input dataset is Arrow dataset then the output is
-            an Arrow dataset of n + 1 columns where first column is
-            the groupby key and the second through n + 1 columns are the
-            results of the aggregations.
-            When `aggs` is given as a list, the aggregation columns are ordered
-            in accordance with the aggregation list ordering (aggs, cols):
+            If the input dataset is simple dataset then the output is a simple
+            dataset of ``(k, v_1, ..., v_n)`` tuples where ``k`` is the groupby
+            key and ``v_i`` is the result of the ith given aggregation.
+
+            If the input dataset is Arrow dataset then the output is an Arrow
+            dataset of ``n + 1`` columns where first column is the groupby key
+            and the second through ``n + 1`` columns are the results of the
+            aggregations.
+
+            When ``aggs`` is given as a list, the aggregation columns are
+            ordered in accordance with the aggregation list ordering
+            (aggs, cols)::
+
                 [agg1, agg2]
-            on a dataset with columns col1 and col2 would yield aggregation
-            columns:
+
+            on a dataset with columns ``col1`` and ``col2`` would yield
+            aggregation columns::
+
                 col1_agg1, col2_agg1, col1_agg2, col2_agg2
-            When `aggs` is given as a dict, the aggregation columns are ordered
-            in accordance with the depth-first dict ordering (cols, aggs):
+
+            When ``aggs`` is given as a dict, the aggregation columns are
+            ordered in accordance with the depth-first dict ordering
+            (cols, aggs)::
+
                 {col1: [agg1, agg2], col2: [agg2, agg1]}
-            would yield aggregation columns:
+
+            would yield aggregation columns::
+
                 col1_agg1, col1_agg2, col2_agg2, col2_agg1
-            If the dataset is empty, return None.
+
+            If the dataset is empty, return ``None`.
         """
         aggs_ = self._dataset._build_multi_agg(aggs, skip_cols=self._key)
         return self.apply_aggregations(*aggs_)
@@ -116,10 +128,12 @@ class GroupedDataset(Generic[T]):
             If the input dataset is simple dataset then the output is a simple
             dataset of ``(k, v_1, ..., v_n)`` tuples where ``k`` is the groupby
             key and ``v_i`` is the result of the ith given aggregation.
+
             If the input dataset is an Arrow dataset then the output is an
             Arrow dataset of ``n + 1`` columns where the first column is the
             groupby key and the second through ``n + 1`` columns are the
             results of the aggregations.
+
             If groupby key is ``None`` then the key part of return is omitted.
         """
 
@@ -194,6 +208,7 @@ class GroupedDataset(Generic[T]):
             A simple dataset of ``(k, v)`` pairs or an Arrow dataset of
             ``[k, v]`` columns where ``k`` is the groupby key and ``v`` is the
             number of rows with that key.
+
             If groupby key is ``None`` then the key part of return is omitted.
         """
         return self.apply_aggregations(Aggregation(Count()))

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -53,8 +53,7 @@ class GroupedDataset(Generic[T]):
 
         Common aggregations can be given as strings (``"sum"``, ``"min"``,
         ``"max"``, ``"mean"``, ``"std"``) while custom/customized aggregations
-        can be given as instances of
-        :class:`~.aggregate.AggregateFn`. If providing a
+        can be given as instances of :class:`~.AggregateFn`. If providing a
         dictionary of data subsets --> aggregations, the data subset keys can
         be column name strings for table (Arrow) datasets, and can be
         row --> data subset callables for both table (Arrow) datasets and
@@ -63,31 +62,20 @@ class GroupedDataset(Generic[T]):
         This is a blocking operation.
 
         Examples:
-            >>> simple_grouped_ds.agg("sum")
-            >>> simple_grouped_ds.agg(["sum", Std(ddof=0)])
             >>> simple_grouped_ds.agg({
             ...     lambda x: x % 3: ["min", "max"],
             ...     lambda x: x % 2: ["mean", "std"],
             ... })
-            >>> arrow_grouped_ds.agg(["mean", "std"])
             >>> arrow_grouped_ds.agg({
             ...     "A": ["mean", Std(ddof=0)],
             ...     "B": ["min", "max"],
             ... })
 
         Args:
-            aggs: Aggregations to compute. This can be:
-
-                - ``Union[Aggregation, List[Aggregation]]``: The (name of the)
-                  aggregation(s) that we want to apply to: each column for an
-                  Arrow dataset (other than the groupby key column);
-                  the entire row for a simple dataset.
-                - ``Dict[AggregateOnT, List[Aggregation]``: A map from a data
-                  subsetter (column name or callable) to the (names of the)
-                  aggregations that we wish to apply to that data subset.
-
-                Here, ``Aggregation = Union[str, AggregateFn]`` and
-                ``AggregateOnT = Union[str, Callable[[T], Any]]``.
+            aggs: Aggregations to compute as a map from a data subsetter
+                (column name for Arrow dataset or callable for any dataset) to
+                the (names of the) aggregations that we wish to apply to that
+                data subset.
 
         Returns:
             If the input dataset is simple dataset then the output is a simple
@@ -99,20 +87,8 @@ class GroupedDataset(Generic[T]):
             and the second through ``n + 1`` columns are the results of the
             aggregations.
 
-            When ``aggs`` is given as a list, the aggregation columns are
-            ordered in accordance with the aggregation list ordering
-            (aggs, cols)::
-
-                [agg1, agg2]
-
-            on a dataset with columns ``col1`` and ``col2`` would yield
-            aggregation columns::
-
-                col1_agg1, col2_agg1, col1_agg2, col2_agg2
-
-            When ``aggs`` is given as a dict, the aggregation columns are
-            ordered in accordance with the depth-first dict ordering
-            (cols, aggs)::
+            The aggregation columns are ordered in accordance with the
+            depth-first dict ordering (cols, aggs)::
 
                 {col1: [agg1, agg2], col2: [agg2, agg1]}
 

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -2,7 +2,7 @@ import collections
 import random
 import heapq
 from typing import Iterator, List, Union, Tuple, Any, TypeVar, Optional, \
-    TYPE_CHECKING
+    Sequence, TYPE_CHECKING
 
 import numpy as np
 
@@ -14,7 +14,7 @@ except ImportError:
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.impl.block_builder import BlockBuilder
 from ray.data.impl.simple_block import SimpleBlockBuilder
-from ray.data.aggregate import Aggregation
+from ray.data.aggregate import BoundAggregateFn
 from ray.data.impl.size_estimator import SizeEstimator
 
 if TYPE_CHECKING:
@@ -345,7 +345,7 @@ class ArrowBlockAccessor(BlockAccessor):
         return ret
 
     def combine(self, key: GroupKeyT,
-                aggs: Tuple[Aggregation]) -> Block[ArrowRow]:
+                aggs: Sequence[BoundAggregateFn]) -> Block[ArrowRow]:
         """Combine rows with the same key into an accumulator.
 
         This assumes the block is already sorted by key in ascending order.
@@ -426,9 +426,10 @@ class ArrowBlockAccessor(BlockAccessor):
         return ret, ArrowBlockAccessor(ret).get_metadata(None)
 
     @staticmethod
-    def aggregate_combined_blocks(
-            blocks: List[Block[ArrowRow]], key: GroupKeyT,
-            aggs: Tuple[Aggregation]) -> Tuple[Block[ArrowRow], BlockMetadata]:
+    def aggregate_combined_blocks(blocks: List[Block[ArrowRow]],
+                                  key: GroupKeyT,
+                                  aggs: Sequence[BoundAggregateFn]
+                                  ) -> Tuple[Block[ArrowRow], BlockMetadata]:
         """Aggregate sorted, partially combined blocks with the same key range.
 
         This assumes blocks are already sorted by key in ascending order,

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -2,7 +2,7 @@ import random
 import sys
 import heapq
 from typing import Callable, Iterator, List, Tuple, Union, Any, Optional, \
-    TYPE_CHECKING
+    Sequence, TYPE_CHECKING
 
 import numpy as np
 
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     import pyarrow
 
 from ray.data.impl.block_builder import BlockBuilder
-from ray.data.aggregate import Aggregation
+from ray.data.aggregate import BoundAggregateFn
 from ray.data.impl.size_estimator import SizeEstimator
 from ray.data.block import Block, BlockAccessor, BlockMetadata, \
     T, U, KeyType, AggType
@@ -148,8 +148,8 @@ class SimpleBlockAccessor(BlockAccessor):
         ret.append(items[prev_i:])
         return ret
 
-    def combine(self, key: GroupKeyT,
-                aggs: Tuple[Aggregation]) -> Block[Tuple[KeyType, AggType]]:
+    def combine(self, key: GroupKeyT, aggs: Sequence[BoundAggregateFn]
+                ) -> Block[Tuple[KeyType, AggType]]:
         """Combine rows with the same key into an accumulator.
 
         This assumes the block is already sorted by key in ascending order.
@@ -218,7 +218,7 @@ class SimpleBlockAccessor(BlockAccessor):
     @staticmethod
     def aggregate_combined_blocks(
             blocks: List[Block[Tuple[KeyType, AggType]]], key: GroupKeyT,
-            aggs: Tuple[Aggregation]
+            aggs: Sequence[BoundAggregateFn]
     ) -> Tuple[Block[Tuple[KeyType, U]], BlockMetadata]:
         """Aggregate sorted, partially combined blocks with the same key range.
 


### PR DESCRIPTION
As a stacked follow-up to #20074 (only the last commit contains incremental changes from the last PR), this PR adds a [Pandas-like multi-aggregation API](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.agg.html), making it much easier to express "do this set of aggregations for this column, and a different set of aggregations for this other column".

### Mean + Std with custom ddof on one column, Sum + Min + Max on another - old API
```python
from ray.data.aggregate import Mean, Std, Sum, Min, Max

ds.aggregate(Mean("A"), Std("A", ddof=0), Sum("B"), Min("B"), Max("B"))
```

### Mean + Std with custom ddof on one column, Sum + Min + Max on another - new API
```python
ds.agg({"A": ["mean", Std(ddof=0)], "B": ["sum", "min", "max"]})
```

## TODOs

1. [Future PR] Add examples to docs. This is saved for a future PR, which will also expand the last-mile preprocessing content in the docs.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
