### PR TITLE
[Serve] Fix HTTP error handling behavior and add tests

### DIFF
--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 import requests
 from fastapi import FastAPI, Request
@@ -5,7 +7,6 @@ from starlette.responses import RedirectResponse
 
 import ray
 from ray import serve
-from ray._private.test_utils import SignalActor
 
 
 def test_path_validation(serve_instance):
@@ -222,7 +223,7 @@ def test_default_error_handling(serve_instance):
         1 / 0
 
     f.deploy()
-    r = requests.get(f"http://localhost:8000/f")
+    r = requests.get("http://localhost:8000/f")
     assert r.status_code == 500
     assert "ZeroDivisionError" in r.text, r.text
 
@@ -234,9 +235,10 @@ def test_default_error_handling(serve_instance):
     def h():
         ray.get(
             intentional_kill.remote(ray.get_runtime_context().current_actor))
+        time.sleep(100)  # Don't return here to leave time for actor exit.
 
     h.deploy()
-    r = requests.get(f"http://localhost:8000/h")
+    r = requests.get("http://localhost:8000/h")
     assert r.status_code == 500
     assert "retries" in r.text, r.text
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Looks like the code path for handling RayTaskError stopped working this PR fixes that. Additionally, I changed the exponential backoff scaling factor. Lastly, added tests for both features.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #19713
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
