### PR TITLE
[serve] Add Google Cloud Storage as a backend

### DIFF
--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -248,9 +248,10 @@ The checkpoint path argument accepts the following format:
 
 - ``file://local_file_path``
 - ``s3://bucket/path``
+- ``gcs://bucket/path``
 - ``custom://importable.custom_python.Class/path``
 
-While we have native support for on disk and AWS S3 storage, there is no reason we cannot support more. 
+While we have native support for on disk, AWS S3, and Google Cloud Storage (GCS), there is no reason we cannot support more.
 
 In Kubernetes environment, we recommend using `Persistent Volumes`_ to create a disk and mount it into the Ray head node.
 For example, you can provision Azure Disk, AWS Elastic Block Store, or GCP Persistent Disk using the K8s `Persistent Volumes`_ API.

--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -248,7 +248,7 @@ The checkpoint path argument accepts the following format:
 
 - ``file://local_file_path``
 - ``s3://bucket/path``
-- ``gcs://bucket/path``
+- ``gs://bucket/path``
 - ``custom://importable.custom_python.Class/path``
 
 While we have native support for on disk, AWS S3, and Google Cloud Storage (GCS), there is no reason we cannot support more.

--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -221,8 +221,8 @@ Ray cluster and re-deploys all Serve deployments into that cluster.
   the long term roadmap and being actively worked on.
 
 Ray Serve added an experimental feature to help recovering the state.
-This features enables Serve to write all your deployment configuration and code into a storage location. 
-Upon Ray cluster failure and restarts, you can simply call Serve to reconstruct the state. 
+This features enables Serve to write all your deployment configuration and code into a storage location.
+Upon Ray cluster failure and restarts, you can simply call Serve to reconstruct the state.
 
 Here is how to use it:
 
@@ -237,7 +237,7 @@ You can use both the start argument and the CLI to specify it:
 
     serve.start(_checkpoint_path=...)
 
-or 
+or
 
 .. code-block:: shell
 

--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -21,7 +21,7 @@ def make_kv_store(checkpoint_path, namespace):
         if parsed_url.scheme not in {"gcs", "s3", "file", "custom"}:
             raise ValueError(
                 f"Checkpoint must be one of `{DEFAULT_CHECKPOINT_PATH}`, "
-                "`file://path...`, `s3://path...` or "
+                "`file://path...`, `gcs://path...`, `s3://path...`, or "
                 "`custom://my_module.ClassName?arg1=val1`. But it is "
                 f"{checkpoint_path}")
 

--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -21,7 +21,7 @@ def make_kv_store(checkpoint_path, namespace):
         if parsed_url.scheme not in {"gcs", "s3", "file", "custom"}:
             raise ValueError(
                 f"Checkpoint must be one of `{DEFAULT_CHECKPOINT_PATH}`, "
-                "`file://path...`, `gcs://path...`, `s3://path...`, or "
+                "`file://path...`, `gs://path...`, `s3://path...`, or "
                 "`custom://my_module.ClassName?arg1=val1`. But it is "
                 f"{checkpoint_path}")
 
@@ -31,10 +31,10 @@ def make_kv_store(checkpoint_path, namespace):
                         f"checkpoint and recovery: path={db_path}")
             return RayLocalKVStore(namespace, db_path)
 
-        if parsed_url.scheme == "gcs":
+        if parsed_url.scheme == "gs":
             bucket = parsed_url.netloc
             # We need to strip leading "/" in path as right key to use in
-            # gcs. Ex: gcs://bucket/folder/file.zip -> key = "folder/file.zip"
+            # gcs. Ex: gs://bucket/folder/file.zip -> key = "folder/file.zip"
             prefix = parsed_url.path.lstrip("/")
             logger.info("Using Ray GCS KVStore for controller checkpoint and"
                         " recovery: "

--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -36,10 +36,9 @@ def make_kv_store(checkpoint_path, namespace):
             # We need to strip leading "/" in path as right key to use in
             # gcs. Ex: gcs://bucket/folder/file.zip -> key = "folder/file.zip"
             prefix = parsed_url.path.lstrip("/")
-            logger.info(
-                "Using Ray GCS KVStore for controller checkpoint and"
-                " recovery: "
-                f"bucket={bucket} checkpoint_path={checkpoint_path}")
+            logger.info("Using Ray GCS KVStore for controller checkpoint and"
+                        " recovery: "
+                        f"bucket={bucket} checkpoint_path={checkpoint_path}")
             return RayGcsKVStore(
                 namespace,
                 bucket=bucket,

--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -5,6 +5,7 @@ from ray.serve.constants import DEFAULT_CHECKPOINT_PATH
 from ray.serve.storage.kv_store import (RayInternalKVStore, RayLocalKVStore,
                                         RayS3KVStore)
 from ray.serve.storage.kv_store_base import KVStoreBase
+from ray.serve.storage.ray_gcs_kv_store import RayGcsKVStore
 from ray._private.utils import import_attr
 
 
@@ -17,7 +18,7 @@ def make_kv_store(checkpoint_path, namespace):
         return RayInternalKVStore(namespace)
     else:
         parsed_url = urlparse(checkpoint_path)
-        if parsed_url.scheme not in {"s3", "file", "custom"}:
+        if parsed_url.scheme not in {"gcs", "s3", "file", "custom"}:
             raise ValueError(
                 f"Checkpoint must be one of `{DEFAULT_CHECKPOINT_PATH}`, "
                 "`file://path...`, `s3://path...` or "
@@ -29,6 +30,21 @@ def make_kv_store(checkpoint_path, namespace):
             logger.info("Using RayLocalKVStore for controller "
                         f"checkpoint and recovery: path={db_path}")
             return RayLocalKVStore(namespace, db_path)
+
+        if parsed_url.scheme == "gcs":
+            bucket = parsed_url.netloc
+            # We need to strip leading "/" in path as right key to use in
+            # gcs. Ex: gcs://bucket/folder/file.zip -> key = "folder/file.zip"
+            prefix = parsed_url.path.lstrip("/")
+            logger.info(
+                "Using Ray GCS KVStore for controller checkpoint and"
+                " recovery: "
+                f"bucket={bucket} checkpoint_path={checkpoint_path}")
+            return RayGcsKVStore(
+                namespace,
+                bucket=bucket,
+                prefix=prefix,
+            )
 
         if parsed_url.scheme == "s3":
             bucket = parsed_url.netloc

--- a/python/ray/serve/storage/checkpoint_path.py
+++ b/python/ray/serve/storage/checkpoint_path.py
@@ -18,7 +18,7 @@ def make_kv_store(checkpoint_path, namespace):
         return RayInternalKVStore(namespace)
     else:
         parsed_url = urlparse(checkpoint_path)
-        if parsed_url.scheme not in {"gcs", "s3", "file", "custom"}:
+        if parsed_url.scheme not in {"gs", "s3", "file", "custom"}:
             raise ValueError(
                 f"Checkpoint must be one of `{DEFAULT_CHECKPOINT_PATH}`, "
                 "`file://path...`, `gs://path...`, `s3://path...`, or "

--- a/python/ray/serve/storage/ray_gcs_kv_store.py
+++ b/python/ray/serve/storage/ray_gcs_kv_store.py
@@ -1,0 +1,96 @@
+try:
+    from google.cloud import storage
+    from google.cloud.exceptions import NotFound
+except ImportError:
+    storage = None
+import io
+from typing import Optional
+
+from ray.serve.storage.kv_store_base import KVStoreBase
+from ray.serve.utils import logger
+
+
+class RayGcsKVStore(KVStoreBase):
+    """Persistent version of KVStoreBase for cluster fault
+    tolerance. Writes to GCS bucket with provided path and credentials.
+
+    Supports only string type for key and bytes type for value,
+    caller must handle serialization.
+    """
+
+    def __init__(
+            self,
+            namespace: str,
+            bucket="",
+            prefix="",
+    ):
+        self._namespace = namespace
+        self._bucket = bucket
+        self._prefix = prefix + "/" if prefix else ""
+        if not storage:
+            raise ImportError(
+                "You tried to use RayGcsKVStore client without google-cloud-storage installed."
+                "Please run `pip install google-cloud-storage`")
+        self._gcs = storage.Client()
+        self._bucket = self._gcs.bucket(bucket)
+
+    def get_storage_key(self, key: str) -> str:
+        return f"{self._prefix}{self._namespace}-{key}"
+
+    def put(self, key: str, val: bytes) -> bool:
+        """Put the key-value pair into the store.
+
+        Args:
+            key (str)
+            val (bytes)
+        """
+        if not isinstance(key, str):
+            raise TypeError("key must be a string, got: {}.".format(type(key)))
+        if not isinstance(val, bytes):
+            raise TypeError("val must be bytes, got: {}.".format(type(val)))
+
+        try:
+            blob = self._bucket.blob(blob_name=self.get_storage_key(key))
+            f = io.BytesIO(val)
+            blob.upload_from_file(f, num_retries=5)
+        except Exception as e:
+            message = str(e)
+            logger.error(f"Encountered ClientError while calling put() "
+                         f"in RayExternalKVStore: {message}")
+            raise e
+
+    def get(self, key: str) -> Optional[bytes]:
+        """Get the value associated with the given key from the store.
+
+        Args:
+            key (str)
+
+        Returns:
+            The bytes value. If the key wasn't found, returns None.
+        """
+        if not isinstance(key, str):
+            raise TypeError("key must be a string, got: {}.".format(type(key)))
+
+        try:
+            blob = self._bucket.blob(blob_name=self.get_storage_key(key))
+            return blob.download_as_bytes()
+        except NotFound:
+                logger.warning(f"No such key in GCS for key = {key}")
+                return None
+
+    def delete(self, key: str):
+        """Delete the value associated with the given key from the store.
+
+        Args:
+            key (str)
+        """
+
+        if not isinstance(key, str):
+            raise TypeError("key must be a string, got: {}.".format(type(key)))
+
+        try:
+            blob = self._bucket.blob(blob_name=self.get_storage_key(key))
+            blob.delete()
+        except NotFound:
+            logger.error(f"Encountered ClientError while calling delete() "
+                         f"in RayExternalKVStore - Blob was not found!")

--- a/python/ray/serve/storage/ray_gcs_kv_store.py
+++ b/python/ray/serve/storage/ray_gcs_kv_store.py
@@ -28,9 +28,9 @@ class RayGcsKVStore(KVStoreBase):
         self._bucket = bucket
         self._prefix = prefix + "/" if prefix else ""
         if not storage:
-            raise ImportError(
-                "You tried to use RayGcsKVStore client without google-cloud-storage installed."
-                "Please run `pip install google-cloud-storage`")
+            raise ImportError("You tried to use RayGcsKVStore client without"
+                              "google-cloud-storage installed."
+                              "Please run `pip install google-cloud-storage`")
         self._gcs = storage.Client()
         self._bucket = self._gcs.bucket(bucket)
 
@@ -75,8 +75,8 @@ class RayGcsKVStore(KVStoreBase):
             blob = self._bucket.blob(blob_name=self.get_storage_key(key))
             return blob.download_as_bytes()
         except NotFound:
-                logger.warning(f"No such key in GCS for key = {key}")
-                return None
+            logger.warning(f"No such key in GCS for key = {key}")
+            return None
 
     def delete(self, key: str):
         """Delete the value associated with the given key from the store.
@@ -89,8 +89,10 @@ class RayGcsKVStore(KVStoreBase):
             raise TypeError("key must be a string, got: {}.".format(type(key)))
 
         try:
-            blob = self._bucket.blob(blob_name=self.get_storage_key(key))
+            blob_name = self.get_storage_key(key)
+            blob = self._bucket.blob(blob_name=blob_name)
             blob.delete()
         except NotFound:
             logger.error(f"Encountered ClientError while calling delete() "
-                         f"in RayExternalKVStore - Blob was not found!")
+                         f"in RayExternalKVStore - "
+                         f"Blob {blob_name} was not found!")

--- a/python/ray/serve/tests/storage_tests/test_kv_store.py
+++ b/python/ray/serve/tests/storage_tests/test_kv_store.py
@@ -7,8 +7,9 @@ import pytest
 from ray.serve.constants import DEFAULT_CHECKPOINT_PATH
 from ray.serve.storage.checkpoint_path import make_kv_store
 from ray.serve.storage.kv_store import (RayInternalKVStore, RayLocalKVStore,
-                                        RayS3KVStore, RayGcsKVStore)
+                                        RayS3KVStore)
 from ray.serve.storage.kv_store_base import KVStoreBase
+from ray.serve.storage.ray_gcs_kv_store import RayGcsKVStore
 
 
 def test_ray_internal_kv(serve_instance):  # noqa: F811

--- a/python/ray/serve/tests/storage_tests/test_kv_store.py
+++ b/python/ray/serve/tests/storage_tests/test_kv_store.py
@@ -7,7 +7,7 @@ import pytest
 from ray.serve.constants import DEFAULT_CHECKPOINT_PATH
 from ray.serve.storage.checkpoint_path import make_kv_store
 from ray.serve.storage.kv_store import (RayInternalKVStore, RayLocalKVStore,
-                                        RayS3KVStore)
+                                        RayS3KVStore, RayGcsKVStore)
 from ray.serve.storage.kv_store_base import KVStoreBase
 
 
@@ -89,6 +89,17 @@ def test_external_kv_aws_s3():
         aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", None),
         aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", None),
         aws_session_token=os.environ.get("AWS_SESSION_TOKEN", None),
+    )
+
+    _test_operations(kv_store)
+
+
+@pytest.mark.skip(reason="Need to figure out credentials for testing")
+def test_external_kv_gcs():
+    kv_store = RayGcsKVStore(
+        "namespace",
+        bucket="jiao-test",
+        prefix="/checkpoint",
     )
 
     _test_operations(kv_store)

--- a/python/ray/serve/tests/storage_tests/test_kv_store.py
+++ b/python/ray/serve/tests/storage_tests/test_kv_store.py
@@ -1,6 +1,6 @@
 import os
-import tempfile
 import sys
+import tempfile
 from typing import Optional
 
 import pytest
@@ -155,11 +155,13 @@ def test_make_kv_store(serve_instance):
 
     store = make_kv_store(
         f"custom://{module_name}.MyCustomStorageCls?arg1=val1&arg2=val2",
-        namespace=namespace)
+        namespace=namespace,
+    )
     assert store.namespace == namespace
     assert store.kwargs == {"arg1": "val1", "arg2": "val2"}
 
 
 if __name__ == "__main__":
     import sys
+
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -52,6 +52,7 @@ cython >= 0.29.15
 dataclasses; python_version < '3.7'
 feather-format
 google-api-python-client
+google-cloud-storage
 gym-minigrid
 kubernetes
 lxml

--- a/release/serve_tests/workloads/serve_cluster_fault_tolerance_gcs.py
+++ b/release/serve_tests/workloads/serve_cluster_fault_tolerance_gcs.py
@@ -1,0 +1,119 @@
+"""
+Test that a serve deployment can recover from cluster failures by resuming
+from checkpoints of external source, such as Google Cloud Storage (GCS).
+
+For product testing, we skip the part of actually starting new cluster as
+it's Job Manager's responsibility, and only re-deploy to the same cluster
+with remote checkpoint.
+"""
+
+import os
+import time
+import uuid
+
+import click
+import requests
+from ray.serve.utils import logger
+from serve_test_cluster_utils import setup_local_single_node_cluster
+from serve_test_utils import save_test_results
+
+import ray
+from ray import serve
+
+# Deployment configs
+DEFAULT_NUM_REPLICAS = 4
+DEFAULT_MAX_BATCH_SIZE = 16
+
+
+def request_with_retries(endpoint, timeout=3):
+    start = time.time()
+    while True:
+        try:
+            return requests.get(
+                "http://127.0.0.1:8000" + endpoint, timeout=timeout)
+        except requests.RequestException:
+            if time.time() - start > timeout:
+                raise TimeoutError
+            time.sleep(0.1)
+
+
+@click.command()
+def main():
+    # Setup local cluster, note this cluster setup is the same for both
+    # local and product ray cluster env.
+    # Each test uses different ray namespace, thus kv storage key for each
+    # checkpoint is different to avoid collision.
+    namespace = uuid.uuid4().hex
+
+    # IS_SMOKE_TEST is set by args of releaser's e2e.py
+    smoke_test = os.environ.get("IS_SMOKE_TEST", "1")
+    if smoke_test == "1":
+        checkpoint_path = "file://checkpoint.db"
+    else:
+        checkpoint_path = "gs://kazi_test/fault-tolerant-test-checkpoint"  # noqa: E501
+
+    _, cluster = setup_local_single_node_cluster(
+        1, checkpoint_path=checkpoint_path, namespace=namespace)
+
+    # Deploy for the first time
+    @serve.deployment(name="echo", num_replicas=DEFAULT_NUM_REPLICAS)
+    class Echo:
+        def __init__(self):
+            return True
+
+        def __call__(self, request):
+            return "hii"
+
+    Echo.deploy()
+
+    # Ensure endpoint is working
+    for _ in range(5):
+        response = request_with_retries("/echo/", timeout=3)
+        assert response.text == "hii"
+
+    logger.info("Initial deployment successful with working endpoint.")
+
+    # Kill current cluster, recover from remote checkpoint and ensure endpoint
+    # is still available with expected results
+
+    ray.kill(serve.api._global_client._controller, no_restart=True)
+    ray.shutdown()
+    cluster.shutdown()
+    serve.api._set_global_client(None)
+
+    # Start another ray cluster with same namespace to resume from previous
+    # checkpoints with no new deploy() call.
+    setup_local_single_node_cluster(
+        1, checkpoint_path=checkpoint_path, namespace=namespace)
+
+    for _ in range(5):
+        response = request_with_retries("/echo/", timeout=3)
+        assert response.text == "hii"
+
+    logger.info("Deployment recovery from Google Cloud Storage checkpoint "
+                "is successful with working endpoint.")
+
+    # Delete dangling checkpoints. If script failed before this step, it's up
+    # to the TTL policy on GCS to clean up, but won't lead to collision with
+    # subsequent tests since each test run in different uuid namespace.
+    serve.shutdown()
+    ray.shutdown()
+    cluster.shutdown()
+
+    # Checkpoints in GCS bucket are moved after 7 days with explicit lifecycle
+    # rules. Each checkpoint is ~260 Bytes in size from this test.
+
+    # Save results
+    save_test_results(
+        {
+            "result": "success"
+        },
+        default_output_file="/tmp/serve_cluster_fault_tolerance.json")
+
+
+if __name__ == "__main__":
+    main()
+    import sys
+
+    import pytest
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/release/serve_tests/workloads/serve_cluster_fault_tolerance_gcs.py
+++ b/release/serve_tests/workloads/serve_cluster_fault_tolerance_gcs.py
@@ -50,7 +50,7 @@ def main():
     if smoke_test == "1":
         checkpoint_path = "file://checkpoint.db"
     else:
-        checkpoint_path = "gs://kazi_test/fault-tolerant-test-checkpoint"  # noqa: E501
+        checkpoint_path = "gs://kazi_test/test/fault-tolerant-test-checkpoint"  # noqa: E501
 
     _, cluster = setup_local_single_node_cluster(
         1, checkpoint_path=checkpoint_path, namespace=namespace)


### PR DESCRIPTION
## Why are these changes needed?

Ray serve currently provides the ability to restore from a checkpoint in S3, this PR adds the possibility to use Google Cloud Storage (GCS) as a backend
## Related issue number


## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [X] Release tests
