### PR TITLE
[workflow] fix s3 storage path

### DIFF
--- a/python/ray/workflow/storage/__init__.py
+++ b/python/ray/workflow/storage/__init__.py
@@ -36,7 +36,7 @@ def create_storage(storage_url: str) -> Storage:
     elif parsed_url.scheme == "s3":
         from ray.workflow.storage.s3 import S3StorageImpl
         bucket = parsed_url.netloc
-        s3_path = parsed_url.path
+        s3_path = parsed_url.path.lstrip("/")
         if not s3_path:
             raise ValueError(f"Invalid s3 path: {s3_path}")
         params = dict(parse.parse_qsl(parsed_url.query))

--- a/python/ray/workflow/storage/filesystem.py
+++ b/python/ray/workflow/storage/filesystem.py
@@ -1,5 +1,5 @@
+import os
 import contextlib
-import itertools
 import json
 import shutil
 import pathlib
@@ -131,7 +131,7 @@ class FilesystemStorageImpl(Storage):
             self._workflow_root_dir.mkdir(parents=True)
 
     def make_key(self, *names: str) -> str:
-        return "/".join(itertools.chain([str(self._workflow_root_dir)], names))
+        return os.path.join(str(self._workflow_root_dir), *names)
 
     async def put(self, key: str, data: Any, is_json: bool = False) -> None:
         if is_json:

--- a/python/ray/workflow/storage/s3.py
+++ b/python/ray/workflow/storage/s3.py
@@ -1,9 +1,9 @@
+import os
 import tempfile
 import json
 import urllib.parse as parse
 from botocore.exceptions import ClientError
 import aioboto3
-import itertools
 import ray
 from typing import Any, List
 from ray.workflow.storage.base import Storage, KeyNotFoundError
@@ -45,7 +45,7 @@ class S3StorageImpl(Storage):
         self._config = config
 
     def make_key(self, *names: str) -> str:
-        return "/".join(itertools.chain([self._s3_path], names))
+        return os.path.join(self._s3_path, *names)
 
     async def put(self, key: str, data: Any, is_json: bool = False) -> None:
         with tempfile.SpooledTemporaryFile(

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -150,8 +150,7 @@ def test_workflow_storage(workflow_start_regular):
         "output_step_id": "a12423",
         "dynamic_output_step_id": "b1234"
     }
-    root_output_metadata = {
-        "output_step_id": "c123"}
+    root_output_metadata = {"output_step_id": "c123"}
     flattened_args = [
         signature.DUMMY_TYPE, 1, signature.DUMMY_TYPE, "2", "k", b"543"
     ]

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -197,87 +197,87 @@ def test_workflow_storage(workflow_start_regular):
                 "workflow/test_workflow_storage/steps/outputs.json",
                 True)) == root_output_metadata
 
-    # # test "inspect_step"
-    # inspect_result = wf_storage.inspect_step(step_id)
-    # assert inspect_result == workflow_storage.StepInspectResult(
-    #     output_object_valid=True)
-    # assert inspect_result.is_recoverable()
-    #
-    # step_id = "some_step2"
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_input_metadata(step_id), input_metadata,
-    #         True))
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_function_body(step_id), some_func))
-    # asyncio_run(wf_storage._put(wf_storage._key_step_args(step_id), args))
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_output_metadata(step_id), output_metadata,
-    #         True))
-    #
-    # inspect_result = wf_storage.inspect_step(step_id)
-    # assert inspect_result == workflow_storage.StepInspectResult(
-    #     output_step_id=output_metadata["dynamic_output_step_id"])
-    # assert inspect_result.is_recoverable()
-    #
-    # step_id = "some_step3"
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_input_metadata(step_id), input_metadata,
-    #         True))
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_function_body(step_id), some_func))
-    # asyncio_run(wf_storage._put(wf_storage._key_step_args(step_id), args))
-    # inspect_result = wf_storage.inspect_step(step_id)
-    # step_options = WorkflowStepRuntimeOptions(
-    #     step_type=StepType.FUNCTION,
-    #     catch_exceptions=False,
-    #     max_retries=1,
-    #     ray_options={})
-    # assert inspect_result == workflow_storage.StepInspectResult(
-    #     args_valid=True,
-    #     func_body_valid=True,
-    #     workflows=input_metadata["workflows"],
-    #     workflow_refs=input_metadata["workflow_refs"],
-    #     step_options=step_options)
-    # assert inspect_result.is_recoverable()
-    #
-    # step_id = "some_step4"
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_input_metadata(step_id), input_metadata,
-    #         True))
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_function_body(step_id), some_func))
-    # inspect_result = wf_storage.inspect_step(step_id)
-    # assert inspect_result == workflow_storage.StepInspectResult(
-    #     func_body_valid=True,
-    #     workflows=input_metadata["workflows"],
-    #     workflow_refs=input_metadata["workflow_refs"],
-    #     step_options=step_options)
-    # assert not inspect_result.is_recoverable()
-    #
-    # step_id = "some_step5"
-    # asyncio_run(
-    #     wf_storage._put(
-    #         wf_storage._key_step_input_metadata(step_id), input_metadata,
-    #         True))
-    # inspect_result = wf_storage.inspect_step(step_id)
-    # assert inspect_result == workflow_storage.StepInspectResult(
-    #     workflows=input_metadata["workflows"],
-    #     workflow_refs=input_metadata["workflow_refs"],
-    #     step_options=step_options)
-    # assert not inspect_result.is_recoverable()
-    #
-    # step_id = "some_step6"
-    # inspect_result = wf_storage.inspect_step(step_id)
-    # print(inspect_result)
-    # assert inspect_result == workflow_storage.StepInspectResult()
-    # assert not inspect_result.is_recoverable()
+    # test "inspect_step"
+    inspect_result = wf_storage.inspect_step(step_id)
+    assert inspect_result == workflow_storage.StepInspectResult(
+        output_object_valid=True)
+    assert inspect_result.is_recoverable()
+
+    step_id = "some_step2"
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_input_metadata(step_id), input_metadata,
+            True))
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_function_body(step_id), some_func))
+    asyncio_run(wf_storage._put(wf_storage._key_step_args(step_id), args))
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_output_metadata(step_id), output_metadata,
+            True))
+
+    inspect_result = wf_storage.inspect_step(step_id)
+    assert inspect_result == workflow_storage.StepInspectResult(
+        output_step_id=output_metadata["dynamic_output_step_id"])
+    assert inspect_result.is_recoverable()
+
+    step_id = "some_step3"
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_input_metadata(step_id), input_metadata,
+            True))
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_function_body(step_id), some_func))
+    asyncio_run(wf_storage._put(wf_storage._key_step_args(step_id), args))
+    inspect_result = wf_storage.inspect_step(step_id)
+    step_options = WorkflowStepRuntimeOptions(
+        step_type=StepType.FUNCTION,
+        catch_exceptions=False,
+        max_retries=1,
+        ray_options={})
+    assert inspect_result == workflow_storage.StepInspectResult(
+        args_valid=True,
+        func_body_valid=True,
+        workflows=input_metadata["workflows"],
+        workflow_refs=input_metadata["workflow_refs"],
+        step_options=step_options)
+    assert inspect_result.is_recoverable()
+
+    step_id = "some_step4"
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_input_metadata(step_id), input_metadata,
+            True))
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_function_body(step_id), some_func))
+    inspect_result = wf_storage.inspect_step(step_id)
+    assert inspect_result == workflow_storage.StepInspectResult(
+        func_body_valid=True,
+        workflows=input_metadata["workflows"],
+        workflow_refs=input_metadata["workflow_refs"],
+        step_options=step_options)
+    assert not inspect_result.is_recoverable()
+
+    step_id = "some_step5"
+    asyncio_run(
+        wf_storage._put(
+            wf_storage._key_step_input_metadata(step_id), input_metadata,
+            True))
+    inspect_result = wf_storage.inspect_step(step_id)
+    assert inspect_result == workflow_storage.StepInspectResult(
+        workflows=input_metadata["workflows"],
+        workflow_refs=input_metadata["workflow_refs"],
+        step_options=step_options)
+    assert not inspect_result.is_recoverable()
+
+    step_id = "some_step6"
+    inspect_result = wf_storage.inspect_step(step_id)
+    print(inspect_result)
+    assert inspect_result == workflow_storage.StepInspectResult()
+    assert not inspect_result.is_recoverable()
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -282,5 +282,4 @@ def test_workflow_storage(workflow_start_regular):
 
 if __name__ == "__main__":
     import sys
-
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To fix two path related issues when s3 is used as storage backend:
1.  a leading slash will be added to the path due to the behavior of `parse.urlparse`.
2. When `step_id=""`, double slashes will be added in the path.

Details are explained in https://github.com/ray-project/ray/issues/20114

## Related issue number

https://github.com/ray-project/ray/issues/20114
https://github.com/ray-project/ray/issues/19027

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
