### PR TITLE
Revert "[scheduler] Update local object store usage (#20026)"

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -341,12 +341,6 @@ const NodeResources &ClusterResourceScheduler::GetLocalNodeResources() const {
   return node_it->second.GetLocalView();
 }
 
-NodeResources *ClusterResourceScheduler::GetMutableLocalNodeResources() {
-  auto node_it = nodes_.find(local_node_id_);
-  RAY_CHECK(node_it != nodes_.end());
-  return node_it->second.GetMutableLocalView();
-}
-
 int64_t ClusterResourceScheduler::NumNodes() const { return nodes_.size(); }
 
 const StringIdMap &ClusterResourceScheduler::GetStringIdMap() const {
@@ -961,15 +955,6 @@ void ClusterResourceScheduler::UpdateLastResourceUsage(
 }
 
 void ClusterResourceScheduler::FillResourceUsage(rpc::ResourcesData &resources_data) {
-  // Update local object store usage and report to other raylets.
-  if (get_used_object_store_memory_ != nullptr) {
-    auto &capacity =
-        GetMutableLocalNodeResources()->predefined_resources[OBJECT_STORE_MEM];
-    double used = get_used_object_store_memory_();
-    double total = capacity.total.Double();
-    capacity.available = FixedPoint(total >= used ? total - used : 0.0);
-  }
-
   NodeResources resources;
 
   RAY_CHECK(GetNodeResources(local_node_id_, &resources))
@@ -991,6 +976,15 @@ void ClusterResourceScheduler::FillResourceUsage(rpc::ResourcesData &resources_d
     if (node.first != local_node_id_) {
       node.second.ResetLocalView();
     }
+  }
+
+  // Automatically report object store usage.
+  // XXX: this MUTATES the resources field, which is needed since we are storing
+  // it in last_report_resources_.
+  if (get_used_object_store_memory_ != nullptr) {
+    auto &capacity = resources.predefined_resources[OBJECT_STORE_MEM];
+    double used = get_used_object_store_memory_();
+    capacity.available = FixedPoint(capacity.total.Double() - used);
   }
 
   for (int i = 0; i < PredefinedResources_MAX; i++) {

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -412,9 +412,6 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   bool SubtractRemoteNodeAvailableResources(int64_t node_id,
                                             const ResourceRequest &resource_request);
 
-  /// Get mutable local node resources.
-  NodeResources *GetMutableLocalNodeResources();
-
   /// The threshold at which to switch from packing to spreading.
   const float spread_threshold_;
   /// List of nodes in the clusters and their resources organized as a map.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -1092,14 +1092,6 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 750 * 1024 * 1024);
     ASSERT_EQ(total["object_store_memory"], 1000 * 1024 * 1024);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .available.Double(),
-              750 * 1024 * 1024);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .total.Double(),
-              1000 * 1024 * 1024);
   }
 
   used_object_store_memory = 450 * 1024 * 1024;
@@ -1109,14 +1101,6 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 550 * 1024 * 1024);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .available.Double(),
-              550 * 1024 * 1024);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .total.Double(),
-              1000 * 1024 * 1024);
   }
 
   used_object_store_memory = 0;
@@ -1126,14 +1110,6 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 1000 * 1024 * 1024);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .available.Double(),
-              1000 * 1024 * 1024);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .total.Double(),
-              1000 * 1024 * 1024);
   }
 
   used_object_store_memory = 9999999999;
@@ -1143,14 +1119,6 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 0);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .available.Double(),
-              0);
-    ASSERT_EQ(resource_scheduler.GetLocalNodeResources()
-                  .predefined_resources[OBJECT_STORE_MEM]
-                  .total.Double(),
-              1000 * 1024 * 1024);
   }
 }
 


### PR DESCRIPTION
This reverts commit 7e013366ace676e1f8defad61ac4dc465f19348e.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR might have broken Dask on ray 1TB shuffle and autoscaling shuffle.

Not 100% sure, but let's try reverting it and re-merge if it doesn't fix the issue.

@jjyao can you create a re-revert PR?

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
