### PR TITLE
[Core] Fix the named actor get or create race condition

### DIFF
--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1331,6 +1331,87 @@ def test_get_actor_after_killed(shutdown_only):
     #     ray.get_actor("actor_2", namespace="namespace")
 
 
+def test_get_actor_race_condition(shutdown_only):
+    @ray.remote
+    class Actor:
+        def ping(self):
+            return "ok"
+
+    @ray.remote
+    def getter(name):
+        try:
+            try:
+                actor = ray.get_actor(name)
+            except Exception:
+                print("Get failed, trying to create", name)
+                actor = Actor.options(name=name).remote()
+        except Exception:
+            print("Someone else created it, trying to get", name)
+            actor = ray.get_actor(name)
+        return ray.get(actor.ping.remote())
+
+    def do_run(name, concurrency=4):
+        name = "actor_" + str(name)
+        tasks = [getter.remote(name) for _ in range(concurrency)]
+        result = ray.get(tasks)
+        try:
+            ray.kill(ray.get_actor(name))  # Cleanup
+        except Exception:
+            pass
+        return result
+
+    for i in range(50):
+        # TODO(sang): Currently increasing concurrency
+        # to 8 will make test flaky due to this issue
+        # https://github.com/ray-project/ray/issues/20129
+        CONCURRENCY = 4
+        results = do_run(i, concurrency=CONCURRENCY)
+        assert ["ok"] * CONCURRENCY == results
+
+
+def test_get_actor_in_remote_workers(ray_start_cluster):
+    """Make sure we can get and create actors without
+        race condition in a remote worker.
+
+        Check https://github.com/ray-project/ray/issues/20092. # noqa
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0)
+    cluster.add_node(num_cpus=1)
+    ray.init(address=cluster.address, namespace="xxx")
+
+    @ray.remote(num_cpus=0)
+    class RemoteProc:
+        def __init__(self):
+            pass
+
+        def procTask(self, a, b):
+            print("[%s]-> %s" % (a, b))
+            return a, b
+
+    @ray.remote
+    def submit_named_actors():
+        RemoteProc.options(
+            name="test",
+            lifetime="detached",
+            max_concurrency=10,
+            namespace="xxx").remote()
+        proc = ray.get_actor("test", namespace="xxx")
+        ray.get(proc.procTask.remote(1, 2))
+        # Should be able to create an actor with the same name
+        # immediately after killing it.
+        ray.kill(proc)
+        RemoteProc.options(
+            name="test",
+            lifetime="detached",
+            max_concurrency=10,
+            namespace="xxx").remote()
+        proc = ray.get_actor("test", namespace="xxx")
+        return ray.get(proc.procTask.remote(1, 2))
+
+    assert (1, 2) == ray.get(submit_named_actors.remote())
+
+
 if __name__ == "__main__":
     import pytest
     # Test suite is timing out. Disable on windows for now.

--- a/src/mock/ray/core_worker/actor_creator.h
+++ b/src/mock/ray/core_worker/actor_creator.h
@@ -19,7 +19,8 @@ namespace core {
 
 class MockActorCreatorInterface : public ActorCreatorInterface {
  public:
-  MOCK_METHOD(Status, RegisterActor, (const TaskSpecification &task_spec), (override));
+  MOCK_METHOD(Status, RegisterActor, (const TaskSpecification &task_spec),
+              (const, override));
   MOCK_METHOD(Status, AsyncRegisterActor,
               (const TaskSpecification &task_spec, gcs::StatusCallback callback),
               (override));
@@ -40,7 +41,8 @@ namespace core {
 
 class MockDefaultActorCreator : public DefaultActorCreator {
  public:
-  MOCK_METHOD(Status, RegisterActor, (const TaskSpecification &task_spec), (override));
+  MOCK_METHOD(Status, RegisterActor, (const TaskSpecification &task_spec),
+              (const, override));
   MOCK_METHOD(Status, AsyncRegisterActor,
               (const TaskSpecification &task_spec, gcs::StatusCallback callback),
               (override));

--- a/src/ray/core_worker/actor_creator.h
+++ b/src/ray/core_worker/actor_creator.h
@@ -28,7 +28,7 @@ class ActorCreatorInterface {
   ///
   /// \param task_spec The specification for the actor creation task.
   /// \return Status
-  virtual Status RegisterActor(const TaskSpecification &task_spec) = 0;
+  virtual Status RegisterActor(const TaskSpecification &task_spec) const = 0;
 
   /// Asynchronously request GCS to register the actor.
   /// \param task_spec The specification for the actor creation task.
@@ -67,20 +67,20 @@ class DefaultActorCreator : public ActorCreatorInterface {
   explicit DefaultActorCreator(std::shared_ptr<gcs::GcsClient> gcs_client)
       : gcs_client_(std::move(gcs_client)) {}
 
-  Status RegisterActor(const TaskSpecification &task_spec) override {
-    auto promise = std::make_shared<std::promise<void>>();
-    auto status = gcs_client_->Actors().AsyncRegisterActor(
-        task_spec, [promise](const Status &status) { promise->set_value(); });
-    if (status.ok() &&
-        promise->get_future().wait_for(std::chrono::seconds(
+  Status RegisterActor(const TaskSpecification &task_spec) const override {
+    auto promise = std::make_shared<std::promise<Status>>();
+    RAY_UNUSED(gcs_client_->Actors().AsyncRegisterActor(
+        task_spec, [promise](const Status &status) { promise->set_value(status); }));
+    auto future = promise->get_future();
+    if (future.wait_for(std::chrono::seconds(
             ::RayConfig::instance().gcs_server_request_timeout_seconds())) !=
-            std::future_status::ready) {
+        std::future_status::ready) {
       std::ostringstream stream;
       stream << "There was timeout in registering an actor. It is probably "
                 "because GCS server is dead or there's a high load there.";
       return Status::TimedOut(stream.str());
     }
-    return status;
+    return future.get();
   }
 
   Status AsyncRegisterActor(const TaskSpecification &task_spec,

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -96,9 +96,8 @@ std::pair<std::shared_ptr<const ActorHandle>, Status> ActorManager::GetNamedActo
     std::ostringstream stream;
     stream << "Failed to look up actor with name '" << name << "'. This could "
            << "because 1. You are trying to look up a named actor you "
-           << "didn't create. 2. The named actor died. 3. The actor hasn't "
-           << "been created because named actor creation is asynchronous. "
-           << "4. You did not use a namespace matching the namespace of the "
+           << "didn't create. 2. The named actor died. "
+           << "3. You did not use a namespace matching the namespace of the "
            << "actor.";
     auto error_msg = stream.str();
     RAY_LOG(WARNING) << error_msg;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1856,7 +1856,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       // For named actor, we still go through the sync way because for
       // functions like list actors these actors need to be there, especially
       // for local driver. But the current code all go through the gcs right now.
-      const auto status = actor_creator_->RegisterActor(task_spec);
+      auto status = actor_creator_->RegisterActor(task_spec);
       if (!status.ok()) {
         return status;
       }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1856,7 +1856,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       // For named actor, we still go through the sync way because for
       // functions like list actors these actors need to be there, especially
       // for local driver. But the current code all go through the gcs right now.
-      auto status = actor_creator_->RegisterActor(task_spec);
+      const auto status = actor_creator_->RegisterActor(task_spec);
       if (!status.ok()) {
         return status;
       }

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -264,7 +264,7 @@ class MockActorCreator : public ActorCreatorInterface {
  public:
   MockActorCreator() {}
 
-  Status RegisterActor(const TaskSpecification &task_spec) override {
+  Status RegisterActor(const TaskSpecification &task_spec) const override {
     return Status::OK();
   };
 

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -25,7 +25,7 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
 
   resolver_.ResolveDependencies(task_spec, [this, task_spec](Status status) {
     if (!status.ok()) {
-      RAY_LOG(ERROR) << "Resolving task dependencies failed " << status.ToString();
+      RAY_LOG(WARNING) << "Resolving task dependencies failed " << status.ToString();
       RAY_UNUSED(task_finisher_->PendingTaskFailed(
           task_spec.TaskId(), rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status));
       return;
@@ -38,7 +38,7 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
       // https://docs.google.com/document/d/1EAWide-jy05akJp6OMtDn58XOK7bUyruWMia4E-fV28/edit?usp=sharing
       auto actor_id = task_spec.ActorCreationId();
       auto task_id = task_spec.TaskId();
-      RAY_LOG(INFO) << "Creating actor via GCS actor id = : " << actor_id;
+      RAY_LOG(DEBUG) << "Creating actor via GCS actor id = : " << actor_id;
       RAY_CHECK_OK(actor_creator_->AsyncCreateActor(
           task_spec,
           [this, actor_id, task_id](Status status, const rpc::CreateActorReply &reply) {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -264,6 +264,11 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   ActorID GetActorIDByName(const std::string &name,
                            const std::string &ray_namespace) const;
 
+  /// Remove the actor name from the name registry if actor has the name.
+  /// If the actor doesn't have the name, it is no-op.
+  /// \param actor The actor to remove name from the entry.
+  void RemoveActorNameFromRegistry(const std::shared_ptr<GcsActor> &actor);
+
   /// Get names of named actors.
   //
   /// \param[in] all_namespaces Whether to include actors from all Ray namespaces.

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -562,7 +562,7 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*detached=*/true, /*name=*/"actor2");
   status = gcs_actor_manager_->RegisterActor(request3,
                                              [](std::shared_ptr<gcs::GcsActor> actor) {});
-  ASSERT_TRUE(status.IsInvalid());
+  ASSERT_TRUE(status.IsNotFound());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor2", "").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
 
@@ -571,7 +571,7 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*detached=*/true, /*name=*/"actor2");
   status = gcs_actor_manager_->RegisterActor(request4,
                                              [](std::shared_ptr<gcs::GcsActor> actor) {});
-  ASSERT_TRUE(status.IsInvalid());
+  ASSERT_TRUE(status.IsNotFound());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor2", "").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
 }
@@ -713,7 +713,7 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNotHappendWhenReconstructed) {
                                                   /*detached=*/true, /*name=*/"actor");
   status = gcs_actor_manager_->RegisterActor(request2,
                                              [](std::shared_ptr<gcs::GcsActor> actor) {});
-  ASSERT_TRUE(status.IsInvalid());
+  ASSERT_TRUE(status.IsNotFound());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "").Binary(),
             request1.task_spec().actor_creation_task_spec().actor_id());
 }
@@ -948,7 +948,7 @@ TEST_F(GcsActorManagerTest, TestRayNamespace) {
   {  // Actors from different jobs, in the same namespace should still collide.
     Status status = gcs_actor_manager_->RegisterActor(
         request3, [](std::shared_ptr<gcs::GcsActor> actor) {});
-    ASSERT_TRUE(status.IsInvalid());
+    ASSERT_TRUE(status.IsNotFound());
     ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "").Binary(),
               request1.task_spec().actor_creation_task_spec().actor_id());
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

## NOTE
https://github.com/ray-project/ray/pull/20126 -> This issue actually wasn’t a regression. Repro had a mistake, and for some reasons with that mistake, it was broken from 1.8. The issue itself existed for a long time. cc @iycheng 

## Description

Currently, "RegisterActor" RPC is synchronous, so theoretically, we shouldn't have any race condition in creating same named actors. The problem was that `RegisterActor` RPC response status was not properly propagated to the caller, and it was always set to `Status::OK()`, which is a bug. 

I verified this fixes the issue https://github.com/ray-project/ray/issues/19896. I am adding more unit tests now. 

We can also close this as I verified it was working with the fix (check the test https://github.com/ray-project/ray/issues/20092)

Also, while I was working on this issue, I found https://github.com/ray-project/ray/issues/20129. I will probably work on it after this PR is merged.

**TODO**
 - [x] Add unit tests
 - [ ] Fix cpp unit tests

## Related issue number

Closes https://github.com/ray-project/ray/issues/19896
Closes https://github.com/ray-project/ray/issues/20092

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
