### PR TITLE
[Core] Fix Used Memory Calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,6 @@ test_state.json
 
 # workflow storage
 workflow_data/
+
+# vscode java extention generated
+.factorypath

--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -129,9 +129,8 @@ class MemoryMonitor:
         total_gb = psutil_mem.total / (1024**3)
         used_gb = total_gb - psutil_mem.available / (1024**3)
 
-        # Linux, BSD has cached memory, which should
-        # also be considered as unused memory
-        if hasattr(psutil_mem, "cached"):
+        # Linux's cached memory should also be considered as unused memory
+        if platform.system() == "Linux":
             used_gb -= psutil_mem.cached / (1024**3)
 
         if self.cgroup_memory_limit_gb < total_gb:

--- a/python/ray/_private/memory_monitor.py
+++ b/python/ray/_private/memory_monitor.py
@@ -127,11 +127,7 @@ class MemoryMonitor:
     def get_memory_usage(self):
         psutil_mem = psutil.virtual_memory()
         total_gb = psutil_mem.total / (1024**3)
-        used_gb = total_gb - psutil_mem.available / (1024**3)
-
-        # Linux's cached memory should also be considered as unused memory
-        if platform.system() == "Linux":
-            used_gb -= psutil_mem.cached / (1024**3)
+        used_gb = psutil_mem.used / (1024**3)
 
         if self.cgroup_memory_limit_gb < total_gb:
             total_gb = self.cgroup_memory_limit_gb


### PR DESCRIPTION
## Why are these changes needed?

`total=used+free+buffers+cache`. And `available` is not related to them all. It’s an estimation of how much memory is available for use without swapping. 

We shouldn't calculate used memory as `total-avail`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
