### PR TITLE
[DOC] Fixed a broken code snippet with a missing method

### DIFF
--- a/doc/source/actors.rst
+++ b/doc/source/actors.rst
@@ -652,9 +652,17 @@ Actor Pool
 
       from ray.util import ActorPool
 
+      @ray.remote
+      class Actor
+        def double(self, n):
+            return n * 2
+
       a1, a2 = Actor.remote(), Actor.remote()
       pool = ActorPool([a1, a2])
-      print(pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4]))
+
+      # pool.map(..) returns a Python generator object ActorPool.map
+      gen = pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4]))
+      print([v for v in gen])
       # [2, 4, 6, 8]
 
     See the `package reference <package-ref.html#ray.util.ActorPool>`_ for more information.


### PR DESCRIPTION
Signed-off-by: Jules S.Damji <jules@anyscale.com>

## Why are these changes needed?

The code snippet to demonstrate how to use ActorPool is broken because a) Actor method `double()` is missing and b) ActoorPool.map returns a generator. To print the values you have to iterate over. 

This PR fixes it and makes it work. Having code snippets that demonstrably work is a good practice as part of developer docs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.

