### PR TITLE
[RLlib] Minor fix on json encoding during worker sampling

### DIFF
--- a/python/ray/util/ml_utils/json.py
+++ b/python/ray/util/ml_utils/json.py
@@ -10,12 +10,15 @@ class SafeFallbackEncoder(json.JSONEncoder):
 
     def default(self, value):
         try:
-            if np.isnan(value):
-                return self.nan_str
-
             if (type(value).__module__ == np.__name__
                     and isinstance(value, np.ndarray)):
                 return value.tolist()
+
+            if isinstance(value, np.bool_):
+                return bool(value)
+            
+            if np.isnan(value):
+                return self.nan_str
 
             if issubclass(type(value), numbers.Integral):
                 return int(value)

--- a/python/ray/util/ml_utils/json.py
+++ b/python/ray/util/ml_utils/json.py
@@ -16,7 +16,7 @@ class SafeFallbackEncoder(json.JSONEncoder):
 
             if isinstance(value, np.bool_):
                 return bool(value)
-            
+
             if np.isnan(value):
                 return self.nan_str
 

--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -17,6 +17,7 @@ from ray.rllib.offline.output_writer import OutputWriter
 from ray.rllib.utils.annotations import override, PublicAPI
 from ray.rllib.utils.compression import pack, compression_supported
 from ray.rllib.utils.typing import FileType, SampleBatchType
+from ray.util.ml_utils.json import SafeFallbackEncoder
 from typing import Any, List
 
 logger = logging.getLogger(__name__)
@@ -121,4 +122,4 @@ def _to_json(batch: SampleBatchType, compress_columns: List[str]) -> str:
         out["type"] = "SampleBatch"
         for k, v in batch.items():
             out[k] = _to_jsonable(v, compress=k in compress_columns)
-    return json.dumps(out)
+    return json.dumps(out, cls=SafeFallbackEncoder)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a minor bug on json encoding during worker sampling (specifically when output_writer write batch).
Currently, when output_writer write batch, it first transforms data into json file.
If data contains type that is not json serializable, error occurs while dumping.
In rllib, this usually happens in custom env with custom infos.
Luckly, similar issues have been reported before (https://github.com/ray-project/ray/issues/2243) and SafeFallbackEncoder has been implemented.

This PR contributes in two way
1. Import and pass SafeFallbackEncoder to json.dumps
2. Improving SafeFallbackEncoder 

Regarding the improvement of SafeFallbackEncoder, order of nan checking and np.ndarray type check has been changed.
This is because return of np.isnan(ndarray object) is not boolean but array of boolean.
``
if np.isnan(np.array([1,1])): -> throws error
``
Therefore, ndarray type check has to be checked before checking nan
Also, type check of np.bool_ is added.

Using implemented SafeFallbackEncoder, 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

"Resolves #5785 "
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
