### PR TITLE
Revert "[Java] Skip javadoc when deploying. (#19428)"

### DIFF
--- a/java/build-jar-multiplatform.sh
+++ b/java/build-jar-multiplatform.sh
@@ -181,9 +181,7 @@ deploy_jars() {
     )
     (
       cd "$WORKSPACE_DIR/streaming/java"
-      # We now skip the javadoc plugin to avoid the issue https://github.com/ray-project/ray/issues/18199
-      # We should enable it once the issue gets addressed.
-      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip="${GPG_SKIP:-true}" -Dmaven.javadoc.skip=true
+      mvn -T16 deploy -Dmaven.test.skip=true -Dcheckstyle.skip -Prelease -Dgpg.skip="${GPG_SKIP:-true}"
     )
     echo "Finished deploying jars"
   else


### PR DESCRIPTION
This reverts commit 1047914ee0ec27d0e7b8fc3599f8a0a573ba2dd7.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
