### PR TITLE
[core][bugfix] fix print ref count for an erased iterator

### DIFF
--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -271,7 +271,6 @@ void ReferenceCounter::RemoveLocalReference(const ObjectID &object_id,
   if (it->second.RefCount() == 0) {
     DeleteReferenceInternal(it, deleted);
   }
-  PRINT_REF_COUNT(it);
 }
 
 void ReferenceCounter::UpdateSubmittedTaskReferences(

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -270,6 +270,8 @@ void ReferenceCounter::RemoveLocalReference(const ObjectID &object_id,
   PRINT_REF_COUNT(it);
   if (it->second.RefCount() == 0) {
     DeleteReferenceInternal(it, deleted);
+  } else {
+    PRINT_REF_COUNT(it);
   }
 }
 


### PR DESCRIPTION

## Why are these changes needed?

The`it` can be erased by `DeleteReferenceInternal ` in line 272. But we always print ref count in line 274. Sometime we can get an crash like:
![image](https://user-images.githubusercontent.com/26714159/140692526-1af59dc3-2779-421b-ae35-bc0502ebf912.png)
