### PR TITLE
[Ray Dataset] Update raydp test dependency

### DIFF
--- a/doc/source/ray-libraries.rst
+++ b/doc/source/ray-libraries.rst
@@ -120,7 +120,7 @@ RayDP |raydp|
 
 RayDP ("Spark on Ray") enables you to easily use Spark inside a Ray program. You can use Spark to read the input data, process the data using SQL, Spark DataFrame, or Pandas (via Koalas) API, extract and transform features using Spark MLLib, and use RayDP Estimator API for distributed training on the preprocessed dataset.
 
-GitHub: `https://github.com/Intel-bigdata/oap-raydp <https://github.com/Intel-bigdata/oap-raydp>`_
+GitHub: `https://github.com/oap-project/raydp <https://github.com/oap-project/raydp>`_
 
 Scikit Learn |scikit|
 ---------------------

--- a/python/ray/data/tests/test_raydp_dataset.py
+++ b/python/ray/data/tests/test_raydp_dataset.py
@@ -16,10 +16,6 @@ def spark_on_ray_small(request):
     return spark
 
 
-@pytest.mark.skip(
-    reason=(
-        "raydp.spark.spark_dataframe_to_ray_dataset needs to be updated to "
-        "use ray.data.from_arrow_refs."))
 def test_raydp_roundtrip(spark_on_ray_small):
     spark = spark_on_ray_small
     spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")],

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -68,7 +68,7 @@ opentelemetry-exporter-otlp==1.1.0
 pexpect
 Pillow; platform_system != "Windows"
 pygments
-pyspark==3.1.2
+pyspark==3.2.0
 pytest==5.4.3
 pytest-asyncio
 pytest-rerunfailures

--- a/python/requirements/data_processing/requirements.txt
+++ b/python/requirements/data_processing/requirements.txt
@@ -7,4 +7,4 @@ s3fs
 modin>=0.8.3;  python_version < '3.7'
 modin>=0.11.0; python_version >= '3.7'
 pytest-repeat
-raydp-nightly
+raydp


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently raydp test is disabled because `from_arrow` changes to `from_arrow_refs`. This PR re-enables it. In addition, the test currently depends on raydp-nightly, which is not stable. This PR changes the dependency to raydp.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
