### PR TITLE
[Core][actor out-of-order execution 2/n] create abstraction for the queuing logic on the client/actor submission.

### DIFF
--- a/src/ray/core_worker/transport/actor_submit_queue.h
+++ b/src/ray/core_worker/transport/actor_submit_queue.h
@@ -1,0 +1,47 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <utility>
+
+#include "absl/types/optional.h"
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
+
+namespace ray {
+namespace core {
+
+/**
+ * IActorSubmitQueue is responsible for queuing per actor requests on the client.
+ * TODO(scv119): add more details.
+ */
+class IActorSubmitQueue {
+ public:
+  virtual ~IActorSubmitQueue() = default;
+  virtual bool Emplace(uint64_t sequence_no, TaskSpecification spec) = 0;
+  virtual bool Contains(uint64_t sequence_no) const = 0;
+  virtual const std::pair<TaskSpecification, bool> &Get(uint64_t sequence_no) const = 0;
+  virtual void MarkDependencyFailed(uint64_t sequence_no) = 0;
+  virtual void MarkDependencyResolved(uint64_t sequence_no) = 0;
+  virtual std::vector<TaskID> ClearAllTasks() = 0;
+  virtual absl::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() = 0;
+  virtual std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() = 0;
+  virtual void OnClientConnected() = 0;
+  virtual uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const = 0;
+  virtual void MarkTaskCompleted(uint64_t sequence_no, TaskSpecification task_spec) = 0;
+};
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/transport/actor_submit_queue.h
+++ b/src/ray/core_worker/transport/actor_submit_queue.h
@@ -26,21 +26,54 @@ namespace core {
 
 /**
  * IActorSubmitQueue is responsible for queuing per actor requests on the client.
- * TODO(scv119): add more details.
+ * To use ActorSubmitQueue, user should Emplace a task with a monotincally increasing
+ * (and unique) sequence_no.
+ * The task is not ready until it's being marked as
+ * MarkDependencyResolved; and being removed from the queue if it's beking marked as
+ * MarkDependencyFailed.
+ * The caller should call PopNextTaskToSend to find next task to send; and once the
+ * task is known to send, MarkTaskCompleted is expected to be called to remove
+ * the task from sending queue.
+ * This queue is also aware of client connection/reconnection, so it needs to
+ * call OnClientConnected whenever client is connected, and use GetSequenceNumber
+ * to know the actual sequence_no to send over the network.
+ * For some of the implementation (such as SequentialActorSubmitQueue), it guarantees
+ * the sequential order between client and server and works with retry/actor restart,
+ * so PopAllOutOfOrderCompletedTasks is called during actor restart.
+ *
+ * This class is not thread safe.
+ * TODO(scv119): the protocol could be improved.
  */
 class IActorSubmitQueue {
  public:
   virtual ~IActorSubmitQueue() = default;
-  virtual bool Emplace(uint64_t sequence_no, TaskSpecification spec) = 0;
+  /// Add a task into the queue. Returns false if a task with the same sequence_no has
+  /// already been inserted.
+  virtual bool Emplace(uint64_t sequence_no, TaskSpecification task) = 0;
+  /// If a task exists.
   virtual bool Contains(uint64_t sequence_no) const = 0;
+  /// Get a task.
   virtual const std::pair<TaskSpecification, bool> &Get(uint64_t sequence_no) const = 0;
+  /// Make a task's dependency is resolved thus ready to send.
   virtual void MarkDependencyFailed(uint64_t sequence_no) = 0;
+  /// Make a task's dependency resolvation failed thus remove from the queue.
   virtual void MarkDependencyResolved(uint64_t sequence_no) = 0;
+  /// Clear the queue.
   virtual std::vector<TaskID> ClearAllTasks() = 0;
+  /// Find next task to send.
+  /// \return
+  ///   - nullopt if no task read to send
+  ///   - a pair of task and bool represents the task to be send and if the receiver
+  ///     should SKIP THE SCHEDULING QUEUE while executing it.
   virtual absl::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() = 0;
+  /// On client connect/reconnect, find all the TASK that's known to be
+  /// executed out of order. This is specific to SequentialActorSubmitQueue.
   virtual std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() = 0;
+  /// On client is connected.
   virtual void OnClientConnected() = 0;
+  /// Get the sequence number to send.
   virtual uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const = 0;
+  /// Mark a task has been executed on the receiver side.
   virtual void MarkTaskCompleted(uint64_t sequence_no, TaskSpecification task_spec) = 0;
 };
 }  // namespace core

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.cc
@@ -28,7 +28,7 @@ void CoreWorkerDirectActorTaskSubmitter::AddActorQueueIfNotExists(
   absl::MutexLock lock(&mu_);
   // No need to check whether the insert was successful, since it is possible
   // for this worker to have multiple references to the same actor.
-  client_queues_.emplace(actor_id, ClientQueue());
+  client_queues_.emplace(actor_id, ClientQueue(actor_id));
 }
 
 void CoreWorkerDirectActorTaskSubmitter::KillActor(const ActorID &actor_id,
@@ -77,9 +77,7 @@ Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(TaskSpecification task_spe
       // backpressure. The receiving actor will execute the tasks according to
       // this sequence number.
       send_pos = task_spec.ActorCounter();
-      auto inserted =
-          queue->second.requests.emplace(send_pos, std::make_pair(task_spec, false));
-      RAY_CHECK(inserted.second);
+      RAY_CHECK(queue->second.actor_submit_queue->Emplace(send_pos, task_spec));
       task_queued = true;
     }
   }
@@ -91,16 +89,16 @@ Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(TaskSpecification task_spe
       absl::MutexLock lock(&mu_);
       auto queue = client_queues_.find(actor_id);
       RAY_CHECK(queue != client_queues_.end());
-      auto it = queue->second.requests.find(send_pos);
+      auto &actor_submit_queue = queue->second.actor_submit_queue;
       // Only dispatch tasks if the submitted task is still queued. The task
       // may have been dequeued if the actor has since failed.
-      if (it != queue->second.requests.end()) {
+      if (actor_submit_queue->Contains(send_pos)) {
         if (status.ok()) {
-          it->second.second = true;
+          actor_submit_queue->MarkDependencyResolved(send_pos);
           SendPendingTasks(actor_id);
         } else {
-          auto task_id = it->second.first.TaskId();
-          queue->second.requests.erase(it);
+          auto task_id = actor_submit_queue->Get(send_pos).first.TaskId();
+          actor_submit_queue->MarkDependencyFailed(send_pos);
           task_finisher_.PendingTaskFailed(
               task_id, rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status);
         }
@@ -196,13 +194,7 @@ void CoreWorkerDirectActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
     queue->second.worker_id = address.worker_id();
     // Create a new connection to the actor.
     queue->second.rpc_client = core_worker_client_pool_.GetOrConnect(address);
-    // This assumes that all replies from the previous incarnation
-    // of the actor have been received. This assumption should be OK
-    // because we fail all inflight tasks in `DisconnectRpcClient`.
-    RAY_LOG(DEBUG) << "Resetting caller starts at for actor " << actor_id << " from "
-                   << queue->second.caller_starts_at << " to "
-                   << queue->second.next_task_reply_position;
-    queue->second.caller_starts_at = queue->second.next_task_reply_position;
+    queue->second.actor_submit_queue->OnClientConnected();
 
     RAY_LOG(INFO) << "Connecting to actor " << actor_id << " at worker "
                   << WorkerID::FromBinary(address.worker_id());
@@ -251,19 +243,16 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(
       // If there are pending requests, treat the pending tasks as failed.
       RAY_LOG(INFO) << "Failing pending tasks for actor " << actor_id
                     << " because the actor is already dead.";
-      auto &requests = queue->second.requests;
-      auto head = requests.begin();
 
       auto status = Status::IOError("cancelling all pending tasks of dead actor");
-      while (head != requests.end()) {
-        const auto &task_spec = head->second.first;
-        task_finisher_.MarkTaskCanceled(task_spec.TaskId());
+      auto task_ids = queue->second.actor_submit_queue->ClearAllTasks();
+
+      for (auto &task_id : task_ids) {
+        task_finisher_.MarkTaskCanceled(task_id);
         // No need to increment the number of completed tasks since the actor is
         // dead.
-        RAY_UNUSED(!task_finisher_.PendingTaskFailed(task_spec.TaskId(),
-                                                     rpc::ErrorType::ACTOR_DIED, &status,
-                                                     creation_task_exception));
-        head = requests.erase(head);
+        RAY_UNUSED(!task_finisher_.PendingTaskFailed(task_id, rpc::ErrorType::ACTOR_DIED,
+                                                     &status, creation_task_exception));
       }
 
       auto &wait_for_death_info_tasks = queue->second.wait_for_death_info_tasks;
@@ -322,21 +311,16 @@ void CoreWorkerDirectActorTaskSubmitter::SendPendingTasks(const ActorID &actor_i
     client_queue.pending_force_kill.reset();
   }
 
-  // Submit all pending requests.
-  auto &requests = client_queue.requests;
-  auto head = requests.begin();
-  while (head != requests.end() &&
-         (/*seqno*/ head->first <= client_queue.next_send_position) &&
-         (/*dependencies_resolved*/ head->second.second)) {
-    // If the task has been sent before, skip the other tasks in the send
-    // queue.
-    bool skip_queue = head->first < client_queue.next_send_position;
-    auto task_spec = std::move(head->second.first);
-    head = requests.erase(head);
+  // Submit all pending actor_submit_queue->
+  auto &actor_submit_queue = client_queue.actor_submit_queue;
 
+  while (true) {
+    auto task = actor_submit_queue->PopNextTaskToSend();
+    if (!task.has_value()) {
+      break;
+    }
     RAY_CHECK(!client_queue.worker_id.empty());
-    PushActorTask(client_queue, task_spec, skip_queue);
-    client_queue.next_send_position++;
+    PushActorTask(client_queue, task.value().first, task.value().second);
   }
 }
 
@@ -348,15 +332,15 @@ void CoreWorkerDirectActorTaskSubmitter::ResendOutOfOrderTasks(const ActorID &ac
   }
   auto &client_queue = it->second;
   RAY_CHECK(!client_queue.worker_id.empty());
-
-  for (const auto &completed_task : client_queue.out_of_order_completed_tasks) {
+  auto out_of_order_completed_tasks =
+      client_queue.actor_submit_queue->PopAllOutOfOrderCompletedTasks();
+  for (const auto &completed_task : out_of_order_completed_tasks) {
     // Making a copy here because we are flipping a flag and the original value is
     // const.
     auto task_spec = completed_task.second;
     task_spec.GetMutableMessage().set_skip_execution(true);
     PushActorTask(client_queue, task_spec, /*skip_queue=*/true);
   }
-  client_queue.out_of_order_completed_tasks.clear();
 }
 
 void CoreWorkerDirectActorTaskSubmitter::PushActorTask(ClientQueue &queue,
@@ -369,9 +353,7 @@ void CoreWorkerDirectActorTaskSubmitter::PushActorTask(ClientQueue &queue,
   request->mutable_task_spec()->CopyFrom(task_spec.GetMessage());
 
   request->set_intended_worker_id(queue.worker_id);
-  RAY_CHECK(task_spec.ActorCounter() >= queue.caller_starts_at)
-      << "actor counter " << task_spec.ActorCounter() << " " << queue.caller_starts_at;
-  request->set_sequence_number(task_spec.ActorCounter() - queue.caller_starts_at);
+  request->set_sequence_number(queue.actor_submit_queue->GetSequenceNumber(task_spec));
 
   const auto task_id = task_spec.TaskId();
   const auto actor_id = task_spec.ActorId();
@@ -435,29 +417,7 @@ void CoreWorkerDirectActorTaskSubmitter::PushActorTask(ClientQueue &queue,
           auto queue_pair = client_queues_.find(actor_id);
           RAY_CHECK(queue_pair != client_queues_.end());
           auto &queue = queue_pair->second;
-
-          // Try to increment queue.next_task_reply_position consecutively until we
-          // cannot. In the case of tasks not received in order, the following block
-          // ensure queue.next_task_reply_position are incremented to the max possible
-          // value.
-          queue.out_of_order_completed_tasks.insert({actor_counter, task_spec});
-          auto min_completed_task = queue.out_of_order_completed_tasks.begin();
-          while (min_completed_task != queue.out_of_order_completed_tasks.end()) {
-            if (min_completed_task->first == queue.next_task_reply_position) {
-              queue.next_task_reply_position++;
-              // increment the iterator and erase the old value
-              queue.out_of_order_completed_tasks.erase(min_completed_task++);
-            } else {
-              break;
-            }
-          }
-
-          RAY_LOG(DEBUG) << "Got PushTaskReply for actor " << actor_id
-                         << " with actor_counter " << actor_counter
-                         << " new queue.next_task_reply_position is "
-                         << queue.next_task_reply_position
-                         << " and size of out_of_order_tasks set is "
-                         << queue.out_of_order_completed_tasks.size();
+          queue.actor_submit_queue->MarkTaskCompleted(actor_counter, task_spec);
         }
       };
 
@@ -491,6 +451,5 @@ bool CoreWorkerDirectActorTaskSubmitter::IsActorAlive(const ActorID &actor_id) c
   auto iter = client_queues_.find(actor_id);
   return (iter != client_queues_.end() && iter->second.rpc_client);
 }
-
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.h
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.h
@@ -30,7 +30,9 @@
 #include "ray/core_worker/actor_creator.h"
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
+#include "ray/core_worker/transport/actor_submit_queue.h"
 #include "ray/core_worker/transport/dependency_resolver.h"
+#include "ray/core_worker/transport/sequential_actor_submit_queue.h"
 #include "ray/rpc/worker/core_worker_client.h"
 
 namespace ray {
@@ -127,6 +129,9 @@ class CoreWorkerDirectActorTaskSubmitter
 
  private:
   struct ClientQueue {
+    ClientQueue(ActorID actor_id)
+        : actor_submit_queue(std::make_unique<SequentialActorSubmitQueue>(actor_id)) {}
+
     /// The current state of the actor. If this is ALIVE, then we should have
     /// an RPC client to the actor. If this is DEAD, then all tasks in the
     /// queue will be marked failed and all other ClientQueue state is ignored.
@@ -143,66 +148,8 @@ class CoreWorkerDirectActorTaskSubmitter
     /// The intended worker ID of the actor.
     std::string worker_id = "";
 
-    /// The actor's pending requests, ordered by the task number (see below
-    /// diagram) in the request. The bool indicates whether the dependencies
-    /// for that task have been resolved yet. A task will be sent after its
-    /// dependencies have been resolved and its task number matches
-    /// next_send_position.
-    std::map<uint64_t, std::pair<TaskSpecification, bool>> requests;
-
-    /// Diagram of the sequence numbers assigned to actor tasks during actor
-    /// crash and restart:
-    ///
-    /// The actor starts, and 10 tasks are submitted. We have sent 6 tasks
-    /// (0-5) so far, and have received a successful reply for 4 tasks (0-3).
-    /// 0 1 2 3 4 5 6 7 8 9
-    ///             ^ next_send_position
-    ///         ^ next_task_reply_position
-    /// ^ caller_starts_at
-    ///
-    /// Suppose the actor crashes and recovers. Then, caller_starts_at is reset
-    /// to the current next_task_reply_position. caller_starts_at is then subtracted
-    /// from each task's counter, so the recovered actor will receive the
-    /// sequence numbers 0, 1, 2 (and so on) for tasks 4, 5, 6, respectively.
-    /// Therefore, the recovered actor will restart execution from task 4.
-    /// 0 1 2 3 4 5 6 7 8 9
-    ///             ^ next_send_position
-    ///         ^ next_task_reply_position
-    ///         ^ caller_starts_at
-    ///
-    /// New actor tasks will continue to be sent even while tasks are being
-    /// resubmitted, but the receiving worker will only execute them after the
-    /// resent tasks. For example, this diagram shows what happens if task 6 is
-    /// sent for the first time, tasks 4 and 5 have been resent, and we have
-    /// received a successful reply for task 4.
-    /// 0 1 2 3 4 5 6 7 8 9
-    ///               ^ next_send_position
-    ///           ^ next_task_reply_position
-    ///         ^ caller_starts_at
-    ///
-    /// The send position of the next task to send to this actor. This sequence
-    /// number increases monotonically.
-    uint64_t next_send_position = 0;
-    /// The offset at which the the actor should start its counter for this
-    /// caller. This is used for actors that can be restarted, so that the new
-    /// instance of the actor knows from which task to start executing.
-    uint64_t caller_starts_at = 0;
-    /// Out of the tasks sent by this worker to the actor, the number of tasks
-    /// that we will never send to the actor again. This is used to reset
-    /// caller_starts_at if the actor dies and is restarted. We only include
-    /// tasks that will not be sent again, to support automatic task retry on
-    /// actor failure. This value only tracks consecutive tasks that are completed.
-    /// Tasks completed out of order will be cached in out_of_completed_tasks first.
-    uint64_t next_task_reply_position = 0;
-
-    /// The temporary container for tasks completed out of order. It can happen in
-    /// async or threaded actor mode. This map is used to store the seqno and task
-    /// spec for (1) increment next_task_reply_position later when the in order tasks are
-    /// returned (2) resend the tasks to restarted actor so retried tasks can maintain
-    /// ordering.
-    // NOTE(simon): consider absl::btree_set for performance, but it requires updating
-    // abseil.
-    std::map<uint64_t, TaskSpecification> out_of_order_completed_tasks;
+    /// The queue that orders actor requests.
+    std::unique_ptr<IActorSubmitQueue> actor_submit_queue;
 
     /// Tasks that can't be sent because 1) the callee actor is dead. 2) network error.
     /// For 1) the task will wait for the DEAD state notification, then mark task as

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -39,6 +39,7 @@
 #include "ray/core_worker/transport/normal_scheduling_queue.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/worker/core_worker_client.h"
+#include "ray/core_worker/transport/direct_actor_task_submitter.h"
 
 namespace ray {
 namespace core {

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -39,7 +39,6 @@
 #include "ray/core_worker/transport/normal_scheduling_queue.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/worker/core_worker_client.h"
-#include "ray/core_worker/transport/direct_actor_task_submitter.h"
 
 namespace ray {
 namespace core {

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
@@ -1,0 +1,122 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/transport/sequential_actor_submit_queue.h"
+
+namespace ray {
+namespace core {
+SequentialActorSubmitQueue::SequentialActorSubmitQueue(ActorID actor_id)
+    : actor_id(actor_id) {}
+
+bool SequentialActorSubmitQueue::Emplace(uint64_t sequence_no, TaskSpecification spec) {
+  return requests
+      .emplace(sequence_no, std::make_pair(spec, /*dependency_resolved*/ false))
+      .second;
+}
+
+bool SequentialActorSubmitQueue::Contains(uint64_t sequence_no) const {
+  return requests.find(sequence_no) != requests.end();
+}
+
+const std::pair<TaskSpecification, bool> &SequentialActorSubmitQueue::Get(
+    uint64_t sequence_no) const {
+  auto it = requests.find(sequence_no);
+  RAY_CHECK(it != requests.end());
+  return it->second;
+}
+
+void SequentialActorSubmitQueue::MarkDependencyFailed(uint64_t sequence_no) {
+  requests.erase(sequence_no);
+}
+
+void SequentialActorSubmitQueue::MarkDependencyResolved(uint64_t sequence_no) {
+  auto it = requests.find(sequence_no);
+  RAY_CHECK(it != requests.end());
+  it->second.second = true;
+}
+
+std::vector<TaskID> SequentialActorSubmitQueue::ClearAllTasks() {
+  std::vector<TaskID> task_ids;
+  for (auto &[pos, spec] : requests) {
+    task_ids.push_back(spec.first.TaskId());
+  }
+  requests.clear();
+  return task_ids;
+}
+
+absl::optional<std::pair<TaskSpecification, bool>>
+SequentialActorSubmitQueue::PopNextTaskToSend() {
+  auto head = requests.begin();
+  if (head != requests.end() && (/*seqno*/ head->first <= next_send_position) &&
+      (/*dependencies_resolved*/ head->second.second)) {
+    // If the task has been sent before, skip the other tasks in the send
+    // queue.
+    bool skip_queue = head->first < next_send_position;
+    auto task_spec = std::move(head->second.first);
+    head = requests.erase(head);
+    next_send_position++;
+    return std::make_pair(std::move(task_spec), skip_queue);
+  }
+  return absl::nullopt;
+}
+
+std::map<uint64_t, TaskSpecification>
+SequentialActorSubmitQueue::PopAllOutOfOrderCompletedTasks() {
+  auto result = std::move(out_of_order_completed_tasks);
+  out_of_order_completed_tasks.clear();
+  return result;
+}
+
+void SequentialActorSubmitQueue::OnClientConnected() {
+  // This assumes that all replies from the previous incarnation
+  // of the actor have been received. This assumption should be OK
+  // because we fail all inflight tasks in `DisconnectRpcClient`.
+  RAY_LOG(DEBUG) << "Resetting caller starts at for actor " << actor_id << " from "
+                 << caller_starts_at << " to " << next_task_reply_position;
+  caller_starts_at = next_task_reply_position;
+}
+
+uint64_t SequentialActorSubmitQueue::GetSequenceNumber(
+    const TaskSpecification &task_spec) const {
+  RAY_CHECK(task_spec.ActorCounter() >= caller_starts_at)
+      << "actor counter " << task_spec.ActorCounter() << " " << caller_starts_at;
+  return task_spec.ActorCounter() - caller_starts_at;
+}
+
+void SequentialActorSubmitQueue::MarkTaskCompleted(uint64_t sequence_no,
+                                                   TaskSpecification task_spec) {
+  // Try to increment queue.next_task_reply_position consecutively until we
+  // cannot. In the case of tasks not received in order, the following block
+  // ensure queue.next_task_reply_position are incremented to the max possible
+  // value.
+  out_of_order_completed_tasks.insert({sequence_no, task_spec});
+  auto min_completed_task = out_of_order_completed_tasks.begin();
+  while (min_completed_task != out_of_order_completed_tasks.end()) {
+    if (min_completed_task->first == next_task_reply_position) {
+      next_task_reply_position++;
+      // increment the iterator and erase the old value
+      out_of_order_completed_tasks.erase(min_completed_task++);
+    } else {
+      break;
+    }
+  }
+
+  RAY_LOG(DEBUG) << "Got PushTaskReply for actor " << actor_id << " with actor_counter "
+                 << sequence_no << " new queue.next_task_reply_position is "
+                 << next_task_reply_position << " and size of out_of_order_tasks set is "
+                 << out_of_order_completed_tasks.size();
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.h
@@ -1,0 +1,196 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <utility>
+
+#include "absl/types/optional.h"
+#include "ray/common/id.h"
+#include "ray/core_worker/transport/actor_submit_queue.h"
+
+namespace ray {
+namespace core {
+
+/**
+ * SequentialActorSumitQueue ensures actor are send in the sequence_no.
+ * TODO(scv119): failures/reconnection.
+ */
+class SequentialActorSubmitQueue : public IActorSubmitQueue {
+ public:
+  SequentialActorSubmitQueue(ActorID actor_id) : actor_id(actor_id) {}
+
+  bool Emplace(uint64_t sequence_no, TaskSpecification spec) override {
+    return requests
+        .emplace(sequence_no, std::make_pair(spec, /*dependency_resolved*/ false))
+        .second;
+  }
+
+  bool Contains(uint64_t sequence_no) const override {
+    return requests.find(sequence_no) != requests.end();
+  }
+
+  const std::pair<TaskSpecification, bool> &Get(uint64_t sequence_no) const override {
+    auto it = requests.find(sequence_no);
+    RAY_CHECK(it != requests.end());
+    return it->second;
+  }
+
+  void MarkDependencyFailed(uint64_t sequence_no) override {
+    requests.erase(sequence_no);
+  }
+
+  void MarkDependencyResolved(uint64_t sequence_no) override {
+    auto it = requests.find(sequence_no);
+    RAY_CHECK(it != requests.end());
+    it->second.second = true;
+  }
+
+  std::vector<TaskID> ClearAllTasks() override {
+    std::vector<TaskID> task_ids;
+    for (auto &[pos, spec] : requests) {
+      task_ids.push_back(spec.first.TaskId());
+    }
+    requests.clear();
+    return task_ids;
+  }
+
+  absl::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() override {
+    auto head = requests.begin();
+    if (head != requests.end() && (/*seqno*/ head->first <= next_send_position) &&
+        (/*dependencies_resolved*/ head->second.second)) {
+      // If the task has been sent before, skip the other tasks in the send
+      // queue.
+      bool skip_queue = head->first < next_send_position;
+      auto task_spec = std::move(head->second.first);
+      head = requests.erase(head);
+      next_send_position++;
+      return std::make_pair(std::move(task_spec), skip_queue);
+    }
+    return absl::nullopt;
+  }
+
+  std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override {
+    auto result = std::move(out_of_order_completed_tasks);
+    out_of_order_completed_tasks.clear();
+    return result;
+  }
+
+  void OnClientConnected() override {
+    // This assumes that all replies from the previous incarnation
+    // of the actor have been received. This assumption should be OK
+    // because we fail all inflight tasks in `DisconnectRpcClient`.
+    RAY_LOG(DEBUG) << "Resetting caller starts at for actor " << actor_id << " from "
+                   << caller_starts_at << " to " << next_task_reply_position;
+    caller_starts_at = next_task_reply_position;
+  }
+
+  uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const override {
+    RAY_CHECK(task_spec.ActorCounter() >= caller_starts_at)
+        << "actor counter " << task_spec.ActorCounter() << " " << caller_starts_at;
+    return task_spec.ActorCounter() - caller_starts_at;
+  }
+
+  void MarkTaskCompleted(uint64_t sequence_no, TaskSpecification task_spec) override {
+    // Try to increment queue.next_task_reply_position consecutively until we
+    // cannot. In the case of tasks not received in order, the following block
+    // ensure queue.next_task_reply_position are incremented to the max possible
+    // value.
+    out_of_order_completed_tasks.insert({sequence_no, task_spec});
+    auto min_completed_task = out_of_order_completed_tasks.begin();
+    while (min_completed_task != out_of_order_completed_tasks.end()) {
+      if (min_completed_task->first == next_task_reply_position) {
+        next_task_reply_position++;
+        // increment the iterator and erase the old value
+        out_of_order_completed_tasks.erase(min_completed_task++);
+      } else {
+        break;
+      }
+    }
+
+    RAY_LOG(DEBUG) << "Got PushTaskReply for actor " << actor_id << " with actor_counter "
+                   << sequence_no << " new queue.next_task_reply_position is "
+                   << next_task_reply_position
+                   << " and size of out_of_order_tasks set is "
+                   << out_of_order_completed_tasks.size();
+  }
+
+ private:
+  /// The ID of the actor.
+  ActorID actor_id;
+
+  /// The actor's pending requests, ordered by the task number (see below
+  /// diagram) in the request. The bool indicates whether the dependencies
+  /// for that task have been resolved yet. A task will be sent after its
+  /// dependencies have been resolved and its task number matches
+  /// next_send_position.
+  std::map<uint64_t, std::pair<TaskSpecification, bool>> requests;
+
+  /// Diagram of the sequence numbers assigned to actor tasks during actor
+  /// crash and restart:
+  ///
+  /// The actor starts, and 10 tasks are submitted. We have sent 6 tasks
+  /// (0-5) so far, and have received a successful reply for 4 tasks (0-3).
+  /// 0 1 2 3 4 5 6 7 8 9
+  ///             ^ next_send_position
+  ///         ^ next_task_reply_position
+  /// ^ caller_starts_at
+  ///
+  /// Suppose the actor crashes and recovers. Then, caller_starts_at is reset
+  /// to the current next_task_reply_position. caller_starts_at is then subtracted
+  /// from each task's counter, so the recovered actor will receive the
+  /// sequence numbers 0, 1, 2 (and so on) for tasks 4, 5, 6, respectively.
+  /// Therefore, the recovered actor will restart execution from task 4.
+  /// 0 1 2 3 4 5 6 7 8 9
+  ///             ^ next_send_position
+  ///         ^ next_task_reply_position
+  ///         ^ caller_starts_at
+  ///
+  /// New actor tasks will continue to be sent even while tasks are being
+  /// resubmitted, but the receiving worker will only execute them after the
+  /// resent tasks. For example, this diagram shows what happens if task 6 is
+  /// sent for the first time, tasks 4 and 5 have been resent, and we have
+  /// received a successful reply for task 4.
+  /// 0 1 2 3 4 5 6 7 8 9
+  ///               ^ next_send_position
+  ///           ^ next_task_reply_position
+  ///         ^ caller_starts_at
+  ///
+  /// The send position of the next task to send to this actor. This sequence
+  /// number increases monotonically.
+  uint64_t next_send_position = 0;
+  /// The offset at which the the actor should start its counter for this
+  /// caller. This is used for actors that can be restarted, so that the new
+  /// instance of the actor knows from which task to start executing.
+  uint64_t caller_starts_at = 0;
+  /// Out of the tasks sent by this worker to the actor, the number of tasks
+  /// that we will never send to the actor again. This is used to reset
+  /// caller_starts_at if the actor dies and is restarted. We only include
+  /// tasks that will not be sent again, to support automatic task retry on
+  /// actor failure. This value only tracks consecutive tasks that are completed.
+  /// Tasks completed out of order will be cached in out_of_completed_tasks first.
+  uint64_t next_task_reply_position = 0;
+
+  /// The temporary container for tasks completed out of order. It can happen in
+  /// async or threaded actor mode. This map is used to store the seqno and task
+  /// spec for (1) increment next_task_reply_position later when the in order tasks are
+  /// returned (2) resend the tasks to restarted actor so retried tasks can maintain
+  /// ordering.
+  // NOTE(simon): consider absl::btree_set for performance, but it requires updating
+  // abseil.
+  std::map<uint64_t, TaskSpecification> out_of_order_completed_tasks;
+};
+}  // namespace core
+}  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This second PR in the stack that supports out or order execution for threaded/async actors. Previous PR #20148 Next PR #20150
At a high level, threaded actor/async actor already don't guarantee execution order, and the current "sequential" order implementation has caused some confusion and inconvenience. Please refer to #19822 for detailed discussion.

This PR we further separate out the logic for ordering actor requests on the client side. In the next PR, we will implement a different type of queue that supports out of order execution.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
