### PR TITLE
[CI] Pin `shortuuid` to fix CI

### DIFF
--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -30,6 +30,7 @@ optuna==2.9.1
 pytest-remotedata==0.3.2
 lightning-bolts==0.4.0
 pytorch-lightning==1.4.9
+shortuuid==1.0.1
 scikit-learn==0.24.2
 scikit-optimize==0.8.1
 sigopt==7.5.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

`shortuuid` is a subdependency of `wandb`. New `shortuuid` releases don't work on Python 3.7 and have caused CI failures. We pin the version to fix CI.

https://github.com/skorokithakis/shortuuid/issues/60

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
