### PR TITLE
[CI] [windows] Fix typo in skipped multinode test name

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -172,7 +172,7 @@ test_python() {
       -python/ray/tests:test_multi_node
       -python/ray/tests:test_multi_node_2
       -python/ray/tests:test_multi_node_3
-      -python/ray/tests:test_multi_node_failures_2
+      -python/ray/tests:test_multinode_failures_2
       -python/ray/tests:test_multiprocessing  # test_connect_to_ray() fails to connect to raylet
       -python/ray/tests:test_multiprocessing_client_mode  # timeout
       -python/ray/tests:test_node_manager


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The Windows CI build errors with

`
(20:25:31) ERROR: Skipping 'python/ray/tests:test_multi_node_failures_2': no such target '//python/ray/tests:test_multi_node_failures_2': target 'test_multi_node_failures_2' not declared in package 'python/ray/tests' (did you mean 'test_multinode_failures_2'?) defined by D:/a/ray/ray/python/ray/tests/BUILD
`

(example: https://github.com/ray-project/ray/runs/4143531461?check_suite_focus=true#step:8:533)

This PR fixes the typo in the test name.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
