### PR TITLE
[added local_dir argument since the quickstart's next step is to try t…

### DIFF
--- a/python/ray/tune/tests/example.py
+++ b/python/ray/tune/tests/example.py
@@ -30,6 +30,7 @@ def training_function(config):
 
 analysis = tune.run(
     training_function,
+    local_dir="./ray_results",  # log results for tensorboard
     config={
         "alpha": tune.grid_search([0.001, 0.01, 0.1]),
         "beta": tune.choice([1, 2, 3])


### PR DESCRIPTION
…ensorboard --logdir ./ray_results

Signed-off-by: Jules S.Damji <jules@anyscale.com>

## Why are these changes needed?

The quick start suggests inspecting results using `tensorboard --logdir ./ray_results`. I have added a local_dir parameter

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
