### PR TITLE
[Core][actor out-of-order execution 5/n] implement out-of-order scheduling queue

### DIFF
--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
@@ -1,0 +1,120 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/transport/out_of_order_actor_scheduling_queue.h"
+
+namespace ray {
+namespace core {
+
+OutOfOrderActorSchedulingQueue::OutOfOrderActorSchedulingQueue(
+    instrumented_io_context &main_io_service, DependencyWaiter &waiter,
+    std::shared_ptr<PoolManager> pool_manager, bool is_asyncio, int fiber_max_concurrency,
+    const std::vector<ConcurrencyGroup> &concurrency_groups)
+    : main_thread_id_(boost::this_thread::get_id()),
+      waiter_(waiter),
+      pool_manager_(pool_manager),
+      is_asyncio_(is_asyncio) {
+  if (is_asyncio_) {
+    std::stringstream ss;
+    ss << "Setting actor as asyncio with max_concurrency=" << fiber_max_concurrency
+       << ", and defined concurrency groups are:" << std::endl;
+    for (const auto &concurrency_group : concurrency_groups) {
+      ss << "\t" << concurrency_group.name << " : " << concurrency_group.max_concurrency;
+    }
+    RAY_LOG(INFO) << ss.str();
+    fiber_state_manager_ =
+        std::make_unique<FiberStateManager>(concurrency_groups, fiber_max_concurrency);
+  }
+}
+
+void OutOfOrderActorSchedulingQueue::Stop() {
+  if (pool_manager_) {
+    pool_manager_->Stop();
+  }
+}
+
+bool OutOfOrderActorSchedulingQueue::TaskQueueEmpty() const {
+  RAY_CHECK(false) << "TaskQueueEmpty() not implemented for actor queues";
+  return false;
+}
+
+size_t OutOfOrderActorSchedulingQueue::Size() const {
+  RAY_CHECK(false) << "Size() not implemented for actor queues";
+  return 0;
+}
+
+void OutOfOrderActorSchedulingQueue::Add(
+    int64_t seq_no, int64_t client_processed_up_to,
+    std::function<void(rpc::SendReplyCallback)> accept_request,
+    std::function<void(rpc::SendReplyCallback)> reject_request,
+    rpc::SendReplyCallback send_reply_callback, const std::string &concurrency_group_name,
+    const ray::FunctionDescriptor &function_descriptor,
+    std::function<void(rpc::SendReplyCallback)> steal_request, TaskID task_id,
+    const std::vector<rpc::ObjectReference> &dependencies) {
+  RAY_CHECK(boost::this_thread::get_id() == main_thread_id_);
+  auto request = InboundRequest(std::move(accept_request), std::move(reject_request),
+                                std::move(steal_request), std::move(send_reply_callback),
+                                task_id, dependencies.size() > 0, concurrency_group_name,
+                                function_descriptor);
+
+  if (dependencies.size() > 0) {
+    waiter_.Wait(dependencies, [this, request = std::move(request)]() mutable {
+      RAY_CHECK(boost::this_thread::get_id() == main_thread_id_);
+      request.MarkDependenciesSatisfied();
+      pending_actor_tasks_.push_back(std::move(request));
+      ScheduleRequests();
+    });
+  } else {
+    request.MarkDependenciesSatisfied();
+    pending_actor_tasks_.push_back(std::move(request));
+    ScheduleRequests();
+  }
+}
+
+size_t OutOfOrderActorSchedulingQueue::Steal(rpc::StealTasksReply *reply) {
+  RAY_CHECK(false) << "Cannot steal actor tasks";
+  return 0;
+}
+
+bool OutOfOrderActorSchedulingQueue::CancelTaskIfFound(TaskID task_id) {
+  RAY_CHECK(false) << "Cannot cancel actor tasks";
+  return false;
+}
+
+/// Schedules as many requests as possible in sequence.
+void OutOfOrderActorSchedulingQueue::ScheduleRequests() {
+  while (!pending_actor_tasks_.empty()) {
+    auto request = pending_actor_tasks_.front();
+    if (is_asyncio_) {
+      // Process async actor task.
+      auto fiber = fiber_state_manager_->GetFiber(request.ConcurrencyGroupName(),
+                                                  request.FunctionDescriptor());
+      fiber->EnqueueFiber([request]() mutable { request.Accept(); });
+    } else {
+      // Process actor tasks.
+      RAY_CHECK(pool_manager_ != nullptr);
+      auto pool = pool_manager_->GetPool(request.ConcurrencyGroupName(),
+                                         request.FunctionDescriptor());
+      if (pool == nullptr) {
+        request.Accept();
+      } else {
+        pool->PostBlocking([request]() mutable { request.Accept(); });
+      }
+    }
+    pending_actor_tasks_.pop_front();
+  }
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
@@ -1,0 +1,90 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/synchronization/mutex.h"
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/core_worker/transport/actor_scheduling_util.h"
+#include "ray/core_worker/transport/fiber_state_manager.h"
+#include "ray/core_worker/transport/scheduling_queue.h"
+#include "ray/core_worker/transport/thread_pool_manager.h"
+#include "ray/raylet_client/raylet_client.h"
+#include "ray/rpc/server_call.h"
+#include "src/ray/protobuf/core_worker.pb.h"
+
+namespace ray {
+namespace core {
+
+/// This queue schedule the actor tasks as soon as the dependency is resolved,
+/// and ignores the ordering (sequence_no) by the submitting client.
+class OutOfOrderActorSchedulingQueue : public SchedulingQueue {
+ public:
+  OutOfOrderActorSchedulingQueue(
+      instrumented_io_context &main_io_service, DependencyWaiter &waiter,
+      std::shared_ptr<PoolManager> pool_manager = std::make_shared<PoolManager>(),
+      bool is_asyncio = false, int fiber_max_concurrency = 1,
+      const std::vector<ConcurrencyGroup> &concurrency_groups = {});
+
+  void Stop() override;
+
+  bool TaskQueueEmpty() const override;
+
+  size_t Size() const override;
+
+  /// Add a new actor task's callbacks to the worker queue.
+  void Add(int64_t seq_no, int64_t client_processed_up_to,
+           std::function<void(rpc::SendReplyCallback)> accept_request,
+           std::function<void(rpc::SendReplyCallback)> reject_request,
+           rpc::SendReplyCallback send_reply_callback,
+           const std::string &concurrency_group_name,
+           const ray::FunctionDescriptor &function_descriptor,
+           std::function<void(rpc::SendReplyCallback)> steal_request = nullptr,
+           TaskID task_id = TaskID::Nil(),
+           const std::vector<rpc::ObjectReference> &dependencies = {}) override;
+
+  size_t Steal(rpc::StealTasksReply *reply) override;
+
+  // We don't allow the cancellation of actor tasks, so invoking CancelTaskIfFound
+  // results in a fatal error.
+  bool CancelTaskIfFound(TaskID task_id) override;
+
+  /// Schedules as many requests as possible in sequence.
+  void ScheduleRequests() override;
+
+ private:
+  /// The queue stores all the pending tasks.
+  std::deque<InboundRequest> pending_actor_tasks_;
+  /// The id of the thread that constructed this scheduling queue.
+  boost::thread::id main_thread_id_;
+  /// Reference to the waiter owned by the task receiver.
+  DependencyWaiter &waiter_;
+  /// If concurrent calls are allowed, holds the pools for executing these tasks.
+  std::shared_ptr<PoolManager> pool_manager_;
+  /// Whether we should enqueue requests into asyncio pool. Setting this to true
+  /// will instantiate all tasks as fibers that can be yielded.
+  bool is_asyncio_ = false;
+  /// Manage the running fiber states of actors in this worker. It works with
+  /// python asyncio if this is an asyncio actor.
+  std::unique_ptr<FiberStateManager> fiber_state_manager_;
+
+  friend class SchedulingQueueTest;
+};
+
+}  // namespace core
+}  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This PR belongs to the stack that enables out of order execution. Previous PR: #20160, Next PR: #20177

In this PR specifically, we implemented a simple  out_of_order_scheduling queue which queues the task for execution as soon as the dependency is ready.

TBD: 
- [ ] add unit tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
