### PR TITLE
[Core][actor out-of-order execution 6/n] plumbing work to make it work e2e

### DIFF
--- a/doc/source/fault-tolerance.rst
+++ b/doc/source/fault-tolerance.rst
@@ -165,9 +165,9 @@ checkpoint.
 
 .. note::
     For :ref:`async or threaded actors <async-actors>`, the tasks might
-    be completed out of order. Upon actor restart, the system will only retry
-    *incomplete* task, in their initial submission order. Previously completed
-    tasks will not be re-executed.
+    be executed out of order. Upon actor restart, the system will only retry
+    *incomplete* tasks. Previously completed tasks will not be
+    re-executed.
 
 .. _object-reconstruction:
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1523,7 +1523,10 @@ cdef class CoreWorker:
                         placement_group_capture_child_tasks,
                         serialized_runtime_env,
                         c_runtime_env_uris,
-                        c_concurrency_groups),
+                        c_concurrency_groups,
+                        # execute out of order for
+                        # async or threaded actors.
+                        is_asyncio or max_concurrency > 1),
                     extension_data,
                     &c_actor_id))
 

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -256,7 +256,8 @@ cdef extern from "ray/core_worker/common.h" nogil:
             c_bool placement_group_capture_child_tasks,
             c_string serialized_runtime_env,
             c_vector[c_string] runtime_env_uris,
-            const c_vector[CConcurrencyGroup] &concurrency_groups)
+            const c_vector[CConcurrencyGroup] &concurrency_groups,
+            c_bool execute_out_of_order)
 
     cdef cppclass CPlacementGroupCreationOptions \
             "ray::core::PlacementGroupCreationOptions":

--- a/python/ray/tests/test_actor_out_of_order.py
+++ b/python/ray/tests/test_actor_out_of_order.py
@@ -1,0 +1,55 @@
+import sys
+
+import ray
+import ray.cluster_utils
+from ray._private.test_utils import SignalActor
+
+
+def test_threaded_actor_execute_out_of_order(shutdown_only):
+    ray.init()
+
+    @ray.remote
+    class A:
+        def echo(self, inp):
+            print(inp)
+            return inp
+
+    actor = SignalActor.remote()
+
+    inp_ref_1 = actor.wait.remote()
+    inp_ref_2 = ray.put(2)
+
+    a = A.options(max_concurrency=2).remote()
+
+    a.echo.remote(inp_ref_1)
+    out_ref_2 = a.echo.remote(inp_ref_2)
+
+    assert ray.get(out_ref_2, timeout=5) == 2
+
+
+def test_async_actor_execute_out_of_order(shutdown_only):
+    ray.init()
+
+    @ray.remote
+    class A:
+        async def echo(self, inp):
+            print(inp)
+            return inp
+
+    actor = SignalActor.remote()
+
+    inp_ref_1 = actor.wait.remote()
+    inp_ref_2 = ray.put(2)
+
+    a = A.options(max_concurrency=2).remote()
+
+    a.echo.remote(inp_ref_1)
+    out_ref_2 = a.echo.remote(inp_ref_2)
+
+    assert ray.get(out_ref_2, timeout=5) == 2
+
+
+if __name__ == "__main__":
+    import pytest
+    # Test suite is timing out. Disable on windows for now.
+    sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -338,6 +338,11 @@ std::string TaskSpecification::ConcurrencyGroupName() const {
   return message_->concurrency_group_name();
 }
 
+bool TaskSpecification::ExecuteOutOfOrder() const {
+  return IsActorCreationTask() &&
+         message_->actor_creation_task_spec().execute_out_of_order();
+}
+
 bool TaskSpecification::IsAsyncioActor() const {
   RAY_CHECK(IsActorCreationTask());
   return message_->actor_creation_task_spec().is_asyncio();

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -304,6 +304,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   std::string ConcurrencyGroupName() const;
 
+  bool ExecuteOutOfOrder() const;
+
  private:
   void ComputeResources();
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -181,7 +181,7 @@ class TaskSpecBuilder {
       int max_concurrency = 1, bool is_detached = false, std::string name = "",
       std::string ray_namespace = "", bool is_asyncio = false,
       const std::vector<ConcurrencyGroup> &concurrency_groups = {},
-      const std::string &extension_data = "") {
+      const std::string &extension_data = "", bool execute_out_of_order = false) {
     message_->set_type(TaskType::ACTOR_CREATION_TASK);
     auto actor_creation_spec = message_->mutable_actor_creation_task_spec();
     actor_creation_spec->set_actor_id(actor_id.Binary());
@@ -207,6 +207,7 @@ class TaskSpecBuilder {
         *fd = item->GetMessage();
       }
     }
+    actor_creation_spec->set_execute_out_of_order(execute_out_of_order);
     return *this;
   }
 

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -18,14 +18,14 @@
 
 namespace ray {
 namespace core {
-
+namespace {
 rpc::ActorHandle CreateInnerActorHandle(
     const class ActorID &actor_id, const TaskID &owner_id,
     const rpc::Address &owner_address, const class JobID &job_id,
     const ObjectID &initial_cursor, const Language actor_language,
     const FunctionDescriptor &actor_creation_task_function_descriptor,
     const std::string &extension_data, int64_t max_task_retries, const std::string &name,
-    const std::string &ray_namespace) {
+    const std::string &ray_namespace, bool execute_out_of_order) {
   rpc::ActorHandle inner;
   inner.set_actor_id(actor_id.Data(), actor_id.Size());
   inner.set_owner_id(owner_id.Binary());
@@ -39,6 +39,7 @@ rpc::ActorHandle CreateInnerActorHandle(
   inner.set_max_task_retries(max_task_retries);
   inner.set_name(name);
   inner.set_ray_namespace(ray_namespace);
+  inner.set_execute_out_of_order(execute_out_of_order);
   return inner;
 }
 
@@ -67,8 +68,11 @@ rpc::ActorHandle CreateInnerActorHandleFromActorTableData(
   inner.set_name(actor_table_data.task_spec().actor_creation_task_spec().name());
   inner.set_ray_namespace(
       actor_table_data.task_spec().actor_creation_task_spec().ray_namespace());
+  inner.set_execute_out_of_order(
+      actor_table_data.task_spec().actor_creation_task_spec().execute_out_of_order());
   return inner;
 }
+}  // namespace
 
 ActorHandle::ActorHandle(
     const class ActorID &actor_id, const TaskID &owner_id,
@@ -76,11 +80,11 @@ ActorHandle::ActorHandle(
     const ObjectID &initial_cursor, const Language actor_language,
     const FunctionDescriptor &actor_creation_task_function_descriptor,
     const std::string &extension_data, int64_t max_task_retries, const std::string &name,
-    const std::string &ray_namespace)
+    const std::string &ray_namespace, bool execute_out_of_order)
     : ActorHandle(CreateInnerActorHandle(
           actor_id, owner_id, owner_address, job_id, initial_cursor, actor_language,
           actor_creation_task_function_descriptor, extension_data, max_task_retries, name,
-          ray_namespace)) {}
+          ray_namespace, execute_out_of_order)) {}
 
 ActorHandle::ActorHandle(const std::string &serialized)
     : ActorHandle(CreateInnerActorHandleFromString(serialized)) {}

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -37,7 +37,8 @@ class ActorHandle {
               const ObjectID &initial_cursor, const Language actor_language,
               const FunctionDescriptor &actor_creation_task_function_descriptor,
               const std::string &extension_data, int64_t max_task_retries,
-              const std::string &name, const std::string &ray_namespace);
+              const std::string &name, const std::string &ray_namespace,
+              bool execute_out_of_order = false);
 
   /// Constructs an ActorHandle from a serialized string.
   explicit ActorHandle(const std::string &serialized);
@@ -87,6 +88,8 @@ class ActorHandle {
   std::string GetName() const;
 
   std::string GetNamespace() const;
+
+  bool ExecuteOutOfOrder() const { return inner_.execute_out_of_order(); }
 
  private:
   // Protobuf-defined persistent state of the actor handle.

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -148,7 +148,8 @@ bool ActorManager::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
                                   const ObjectID &actor_creation_return_id,
                                   bool is_self) {
   reference_counter_->AddLocalReference(actor_creation_return_id, call_site);
-  direct_actor_submitter_->AddActorQueueIfNotExists(actor_id);
+  direct_actor_submitter_->AddActorQueueIfNotExists(actor_id,
+                                                    actor_handle->ExecuteOutOfOrder());
   bool inserted;
   {
     absl::MutexLock lock(&mutex_);

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -95,7 +95,8 @@ struct ActorCreationOptions {
       bool placement_group_capture_child_tasks = true,
       const std::string &serialized_runtime_env = "{}",
       const std::vector<std::string> &runtime_env_uris = {},
-      const std::vector<ConcurrencyGroup> &concurrency_groups = {})
+      const std::vector<ConcurrencyGroup> &concurrency_groups = {},
+      bool execute_out_of_order = false)
       : max_restarts(max_restarts),
         max_task_retries(max_task_retries),
         max_concurrency(max_concurrency),
@@ -110,7 +111,8 @@ struct ActorCreationOptions {
         placement_group_capture_child_tasks(placement_group_capture_child_tasks),
         serialized_runtime_env(serialized_runtime_env),
         runtime_env_uris(runtime_env_uris),
-        concurrency_groups(concurrency_groups.begin(), concurrency_groups.end()){};
+        concurrency_groups(concurrency_groups.begin(), concurrency_groups.end()),
+        execute_out_of_order(execute_out_of_order){};
 
   /// Maximum number of times that the actor should be restarted if it dies
   /// unexpectedly. A value of -1 indicates infinite restarts. If it's 0, the
@@ -156,6 +158,8 @@ struct ActorCreationOptions {
   /// The actor concurrency groups to indicate how this actor perform its
   /// methods concurrently.
   const std::vector<ConcurrencyGroup> concurrency_groups;
+  /// Wether the actor execute tasks out of order.
+  const bool execute_out_of_order = false;
 };
 
 using PlacementStrategy = rpc::PlacementStrategy;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1807,7 +1807,8 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       actor_id, GetCallerId(), rpc_address_, job_id,
       /*actor_cursor=*/ObjectID::FromIndex(actor_creation_task_id, 1),
       function.GetLanguage(), function.GetFunctionDescriptor(), extension_data,
-      actor_creation_options.max_task_retries, actor_name, ray_namespace);
+      actor_creation_options.max_task_retries, actor_name, ray_namespace,
+      actor_creation_options.execute_out_of_order);
   std::string serialized_actor_handle;
   actor_handle->Serialize(&serialized_actor_handle);
   builder.SetActorCreationTaskSpec(
@@ -1816,7 +1817,8 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       actor_creation_options.dynamic_worker_options,
       actor_creation_options.max_concurrency, actor_creation_options.is_detached,
       actor_name, ray_namespace, actor_creation_options.is_asyncio,
-      actor_creation_options.concurrency_groups, extension_data);
+      actor_creation_options.concurrency_groups, extension_data,
+      actor_creation_options.execute_out_of_order);
   // Add the actor handle before we submit the actor creation task, since the
   // actor handle must be in scope by the time the GCS sends the
   // WaitForActorOutOfScopeRequest.

--- a/src/ray/core_worker/test/actor_manager_test.cc
+++ b/src/ray/core_worker/test/actor_manager_test.cc
@@ -72,8 +72,12 @@ class MockGcsClient : public gcs::GcsClient {
 class MockDirectActorSubmitter : public CoreWorkerDirectActorTaskSubmitterInterface {
  public:
   MockDirectActorSubmitter() : CoreWorkerDirectActorTaskSubmitterInterface() {}
-
-  MOCK_METHOD1(AddActorQueueIfNotExists, void(const ActorID &actor_id));
+  void AddActorQueueIfNotExists(const ActorID &actor_id,
+                                bool execute_out_of_order = false) override {
+    AddActorQueueIfNotExists_(actor_id, execute_out_of_order);
+  }
+  MOCK_METHOD2(AddActorQueueIfNotExists_,
+               void(const ActorID &actor_id, bool execute_out_of_order));
   MOCK_METHOD3(ConnectActor, void(const ActorID &actor_id, const rpc::Address &address,
                                   int64_t num_restarts));
   MOCK_METHOD4(DisconnectActor, void(const ActorID &actor_id, int64_t num_restarts,
@@ -142,7 +146,7 @@ class ActorManagerTest : public ::testing::Test {
 
     auto actor_handle = absl::make_unique<ActorHandle>(
         actor_id, TaskID::Nil(), rpc::Address(), job_id, ObjectID::FromRandom(),
-        function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "");
+        function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "", false);
     EXPECT_CALL(*reference_counter_, SetDeleteCallback(_, _))
         .WillRepeatedly(testing::Return(true));
     actor_manager_->AddNewActorHandle(move(actor_handle), call_site, caller_address,
@@ -168,7 +172,7 @@ TEST_F(ActorManagerTest, TestAddAndGetActorHandleEndToEnd) {
                        FunctionDescriptorBuilder::BuildPython("", "", "", ""));
   auto actor_handle = absl::make_unique<ActorHandle>(
       actor_id, TaskID::Nil(), rpc::Address(), job_id, ObjectID::FromRandom(),
-      function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "");
+      function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "", false);
   EXPECT_CALL(*reference_counter_, SetDeleteCallback(_, _))
       .WillRepeatedly(testing::Return(true));
 
@@ -181,7 +185,7 @@ TEST_F(ActorManagerTest, TestAddAndGetActorHandleEndToEnd) {
 
   auto actor_handle2 = absl::make_unique<ActorHandle>(
       actor_id, TaskID::Nil(), rpc::Address(), job_id, ObjectID::FromRandom(),
-      function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "");
+      function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "", false);
   // Make sure the same actor id adding will return false.
   ASSERT_FALSE(actor_manager_->AddNewActorHandle(move(actor_handle2), call_site,
                                                  caller_address, false));
@@ -221,7 +225,7 @@ TEST_F(ActorManagerTest, RegisterActorHandles) {
                        FunctionDescriptorBuilder::BuildPython("", "", "", ""));
   auto actor_handle = absl::make_unique<ActorHandle>(
       actor_id, TaskID::Nil(), rpc::Address(), job_id, ObjectID::FromRandom(),
-      function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "");
+      function.GetLanguage(), function.GetFunctionDescriptor(), "", 0, "", "", false);
   EXPECT_CALL(*reference_counter_, SetDeleteCallback(_, _))
       .WillRepeatedly(testing::Return(true));
   ObjectID outer_object_id = ObjectID::Nil();

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.cc
@@ -26,11 +26,11 @@ namespace ray {
 namespace core {
 
 void CoreWorkerDirectActorTaskSubmitter::AddActorQueueIfNotExists(
-    const ActorID &actor_id) {
+    const ActorID &actor_id, bool execute_out_of_order) {
   absl::MutexLock lock(&mu_);
   // No need to check whether the insert was successful, since it is possible
   // for this worker to have multiple references to the same actor.
-  client_queues_.emplace(actor_id, ClientQueue(actor_id));
+  client_queues_.emplace(actor_id, ClientQueue(actor_id, execute_out_of_order));
 }
 
 void CoreWorkerDirectActorTaskSubmitter::KillActor(const ActorID &actor_id,

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -56,7 +56,8 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
 
   if (task_spec.IsActorCreationTask()) {
     worker_context_.SetCurrentActorId(task_spec.ActorCreationId());
-    SetMaxActorConcurrency(task_spec.IsAsyncioActor(), task_spec.MaxActorConcurrency());
+    SetupActor(task_spec.IsAsyncioActor(), task_spec.MaxActorConcurrency(),
+               task_spec.ExecuteOutOfOrder());
   }
 
   // Only assign resources for non-actor tasks. Actor tasks inherit the resources
@@ -173,12 +174,22 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
     if (it == actor_scheduling_queues_.end()) {
       auto cg_it = concurrency_groups_cache_.find(task_spec.ActorId());
       RAY_CHECK(cg_it != concurrency_groups_cache_.end());
-      auto result = actor_scheduling_queues_.emplace(
-          task_spec.CallerWorkerId(),
-          std::unique_ptr<SchedulingQueue>(new ActorSchedulingQueue(
-              task_main_io_service_, *waiter_, pool_manager_, is_asyncio_,
-              fiber_max_concurrency_, cg_it->second)));
-      it = result.first;
+      if (execute_out_of_order_) {
+        it = actor_scheduling_queues_
+                 .emplace(
+                     task_spec.CallerWorkerId(),
+                     std::unique_ptr<SchedulingQueue>(new OutOfOrderActorSchedulingQueue(
+                         task_main_io_service_, *waiter_, pool_manager_, is_asyncio_,
+                         fiber_max_concurrency_, cg_it->second)))
+                 .first;
+      } else {
+        it = actor_scheduling_queues_
+                 .emplace(task_spec.CallerWorkerId(),
+                          std::unique_ptr<SchedulingQueue>(new ActorSchedulingQueue(
+                              task_main_io_service_, *waiter_, pool_manager_, is_asyncio_,
+                              fiber_max_concurrency_, cg_it->second)))
+                 .first;
+      }
     }
 
     it->second->Add(request.sequence_number(), request.client_processed_up_to(),
@@ -223,12 +234,13 @@ bool CoreWorkerDirectTaskReceiver::CancelQueuedNormalTask(TaskID task_id) {
 }
 
 /// Note that this method is only used for asyncio actor.
-void CoreWorkerDirectTaskReceiver::SetMaxActorConcurrency(bool is_asyncio,
-                                                          int fiber_max_concurrency) {
+void CoreWorkerDirectTaskReceiver::SetupActor(bool is_asyncio, int fiber_max_concurrency,
+                                              bool execute_out_of_order) {
   RAY_CHECK(fiber_max_concurrency_ == 0)
-      << "SetMaxActorConcurrency should only be called at most once.";
+      << "SetupActor should only be called at most once.";
   is_asyncio_ = is_asyncio;
   fiber_max_concurrency_ = fiber_max_concurrency;
+  execute_out_of_order_ = execute_out_of_order;
 }
 
 void CoreWorkerDirectTaskReceiver::Stop() {

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -37,6 +37,7 @@
 #include "ray/core_worker/transport/dependency_resolver.h"
 #include "ray/core_worker/transport/direct_actor_task_submitter.h"
 #include "ray/core_worker/transport/normal_scheduling_queue.h"
+#include "ray/core_worker/transport/out_of_order_actor_scheduling_queue.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/worker/core_worker_client.h"
 
@@ -94,6 +95,11 @@ class CoreWorkerDirectTaskReceiver {
 
   void Stop();
 
+ private:
+  /// Set up the configs for an actor.
+  /// This should be called once for the actor creation task.
+  void SetupActor(bool is_asyncio, int fiber_max_concurrency, bool execute_out_of_order);
+
  protected:
   /// Cache the concurrency groups of actors.
   absl::flat_hash_map<ActorID, std::vector<ConcurrencyGroup>> concurrency_groups_cache_;
@@ -122,15 +128,12 @@ class CoreWorkerDirectTaskReceiver {
   /// The max number of concurrent calls to allow for fiber mode.
   /// 0 indicates that the value is not set yet.
   int fiber_max_concurrency_ = 0;
-
   /// If concurrent calls are allowed, holds the pools for executing these tasks.
   std::shared_ptr<PoolManager> pool_manager_;
   /// Whether this actor use asyncio for concurrency.
   bool is_asyncio_ = false;
-
-  /// Set the max concurrency for fiber actor.
-  /// This should be called once for the actor creation task.
-  void SetMaxActorConcurrency(bool is_asyncio, int fiber_max_concurrency);
+  /// Whether this actor execute our of order.
+  bool execute_out_of_order_ = false;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -132,7 +132,8 @@ class CoreWorkerDirectTaskReceiver {
   std::shared_ptr<PoolManager> pool_manager_;
   /// Whether this actor use asyncio for concurrency.
   bool is_asyncio_ = false;
-  /// Whether this actor executes tasks out of order with respect to client submission order.
+  /// Whether this actor executes tasks out of order with respect to client submission
+  /// order.
   bool execute_out_of_order_ = false;
 };
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -132,7 +132,7 @@ class CoreWorkerDirectTaskReceiver {
   std::shared_ptr<PoolManager> pool_manager_;
   /// Whether this actor use asyncio for concurrency.
   bool is_asyncio_ = false;
-  /// Whether this actor execute our of order.
+  /// Whether this actor executes tasks out of order with respect to client submission order.
   bool execute_out_of_order_ = false;
 };
 

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -347,6 +347,8 @@ message ActorCreationTaskSpec {
   bytes serialized_actor_handle = 12;
   // The concurrency groups of this actor.
   repeated ConcurrencyGroup concurrency_groups = 13;
+  // Support out of order execution.
+  bool execute_out_of_order = 14;
 }
 
 // Task spec of an actor task.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -347,7 +347,7 @@ message ActorCreationTaskSpec {
   bytes serialized_actor_handle = 12;
   // The concurrency groups of this actor.
   repeated ConcurrencyGroup concurrency_groups = 13;
-  // Support out of order execution.
+  // Whether to enable out of order execution.
   bool execute_out_of_order = 14;
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -62,7 +62,7 @@ message ActorHandle {
   // The namespace that this actor belongs to.
   string ray_namespace = 11;
 
-  // Does the actor support execute out of order.
+  // Whether the actor supports out of order execution.
   bool execute_out_of_order = 12;
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -61,6 +61,9 @@ message ActorHandle {
 
   // The namespace that this actor belongs to.
   string ray_namespace = 11;
+
+  // Does the actor support execute out of order.
+  bool execute_out_of_order = 12;
 }
 
 message ReturnObject {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This PR is the last PR that enables out of order execution. Previous PR: #20176

In this PR specifically, we added an `execute_out_of_order` option to `.options` call, which creates the actor with both out_of_order_submit_queue and out_of_order_scheduling queue.

this PR also added @simon-mo original case for testing.

- [x] add more tests.
- [x] update the doc.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
