### PR TITLE
[Core] Raise an exception on Ray version mismatch

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -803,7 +803,10 @@ def check_version_info(redis_client):
                          " was started with:" + "\n"
                          "    Ray: " + version_info[0] + "\n"
                          "    Python: " + version_info[1] + "\n")
-        raise RuntimeError(error_message)
+        if version_info[:2] != true_version_info[:2]:
+            raise RuntimeError(error_message)
+        else:
+            logger.warning(error_message)
 
 
 def start_reaper(fate_share=None):

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -803,10 +803,7 @@ def check_version_info(redis_client):
                          " was started with:" + "\n"
                          "    Ray: " + version_info[0] + "\n"
                          "    Python: " + version_info[1] + "\n")
-        if version_info[:2] != true_version_info[:2]:
-            raise RuntimeError(error_message)
-        else:
-            logger.warning(error_message)
+        raise RuntimeError(error_message)
 
 
 def start_reaper(fate_share=None):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -448,21 +448,20 @@ def test_put_error2(ray_start_object_store_memory):
     # get_error_message(ray_constants.PUT_RECONSTRUCTION_PUSH_ERROR, 1)
 
 
-@pytest.mark.skip("Publish happeds before we subscribe it")
-def test_version_mismatch(error_pubsub, shutdown_only):
+def test_version_mismatch(ray_start_cluster):
     ray_version = ray.__version__
-    ray.__version__ = "fake ray version"
+    try:
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=1)
 
-    ray.init(num_cpus=1)
-    p = error_pubsub
+        # Test the driver.
+        ray.__version__ = "fake ray version"
+        with pytest.raises(RuntimeError):
+            ray.init(address="auto")
 
-    errors = get_error_message(p, 1, ray_constants.VERSION_MISMATCH_PUSH_ERROR)
-    assert False, errors
-    assert len(errors) == 1
-    assert errors[0].type == ray_constants.VERSION_MISMATCH_PUSH_ERROR
-
-    # Reset the version.
-    ray.__version__ = ray_version
+    finally:
+        # Reset the version.
+        ray.__version__ = ray_version
 
 
 def test_export_large_objects(ray_start_regular, error_pubsub):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Mismatching Ray versions will most likely cause issues because we don't have stable API behaviors across internal APIs (inbetween Ray components).

That says, we should better raising an exception rather than making it work. 

TODO
- [x] Unit tests

## Related issue number

https://github.com/ray-project/ray/issues/20166

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
