### PR TITLE
[Docs] Streaming MapReduce: Remove breaking city

### DIFF
--- a/doc/examples/streaming/articles.txt
+++ b/doc/examples/streaming/articles.txt
@@ -1,4 +1,3 @@
-New York City
 Berlin
 London
 Paris


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The Streaming MapReduce Tutorial does not run on Windows as its currently written. One city in the `articles.txt` file causes an error (New York City). The traceback is viewable in #19788

This PR removes the city. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #19788 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
