### PR TITLE
[CI] Move Serve nightly tests to a separate suite

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -95,6 +95,19 @@ CORE_NIGHTLY_TESTS = {
     ],
 }
 
+SERVE_NIGHTLY_TESTS = {
+    "~/ray/release/long_running_tests/long_running_tests.yaml": [
+        SmokeTest("serve"),
+        SmokeTest("serve_failure"),
+    ],
+    "~/ray/release/serve_tests/serve_tests.yaml": [
+        "single_deployment_1k_noop_replica",
+        "multi_deployment_1k_noop_replica",
+        "serve_micro_benchmark",
+        "serve_cluster_fault_tolerance",
+    ],
+}
+
 NIGHTLY_TESTS = {
     # "~/ray/release/horovod_tests/horovod_tests.yaml": [
     #     SmokeTest("horovod_test"),
@@ -165,12 +178,6 @@ NIGHTLY_TESTS = {
         # We'll have these as per-PR tests soon.
         # "example_scripts_on_gpu_tests",
     ],
-    "~/ray/release/serve_tests/serve_tests.yaml": [
-        "single_deployment_1k_noop_replica",
-        "multi_deployment_1k_noop_replica",
-        "serve_micro_benchmark",
-        "serve_cluster_fault_tolerance",
-    ],
     "~/ray/release/runtime_env_tests/runtime_env_tests.yaml": [
         "rte_many_tasks_actors", "wheel_urls", "rte_ray_client"
     ],
@@ -219,13 +226,6 @@ WEEKLY_TESTS = {
     ],
 }
 
-MANUAL_TESTS = {
-    "~/ray/release/long_running_tests/long_running_tests.yaml": [
-        SmokeTest("serve"),
-        SmokeTest("serve_failure"),
-    ],
-}
-
 # This test suite holds "user" tests to test important user workflows
 # in a particular environment.
 # All workloads in this test suite should:
@@ -245,12 +245,12 @@ USER_TESTS = {
 
 SUITES = {
     "core-nightly": CORE_NIGHTLY_TESTS,
+    "serve-nightly": SERVE_NIGHTLY_TESTS,
     "nightly": {
         **NIGHTLY_TESTS,
         **USER_TESTS
     },
     "weekly": WEEKLY_TESTS,
-    "manual": MANUAL_TESTS,
 }
 
 DEFAULT_STEP_TEMPLATE = {


### PR DESCRIPTION
So we can run them via separate cronjobs

Current schedule:
- nightly tests `0 18 * * *` UTC: daily at 10AM PT
- core nightly tests `0 */12 * * *` UTC: daily at 4AM and 4PM PT.

I want to move Serve tests to `0 10 * * *` daily at 2AM PT.