### PR TITLE
[Test] Fix newly added nightly tests, threaded actor + chaos testing

### DIFF
--- a/release/nightly_tests/chaos_test/test_chaos_basic.py
+++ b/release/nightly_tests/chaos_test/test_chaos_basic.py
@@ -48,7 +48,8 @@ def run_task_workload(total_num_cpus, smoke):
     wait_for_condition(
         lambda: (
             ray.cluster_resources().get("CPU", 0)
-            == ray.available_resources().get("CPU", 0)))
+            == ray.available_resources().get("CPU", 0)),
+        timeout=60)
 
 
 def run_actor_workload(total_num_cpus, smoke):
@@ -112,7 +113,8 @@ def run_actor_workload(total_num_cpus, smoke):
     wait_for_condition(
         lambda: (
             ray.cluster_resources().get("CPU", 0)
-            == ray.available_resources().get("CPU", 0)))
+            == ray.available_resources().get("CPU", 0)),
+        timeout=60)
     letter_set = set()
     for db_actor in db_actors:
         letter_set.update(ray.get(db_actor.get.remote()))

--- a/release/nightly_tests/stress_tests/test_threaded_actors.py
+++ b/release/nightly_tests/stress_tests/test_threaded_actors.py
@@ -69,10 +69,11 @@ class PiCalculator:
         return result
 
 
-def start_actors(num_actors, num_nodes):
+def start_actors(total_num_actors, num_nodes):
     """Create actors and run the computation loop.
     """
-    num_actors = int(num_actors)
+    total_num_actors = int(total_num_actors)
+    actors_per_node = int(total_num_actors / num_nodes)
     start = time.time()
     nodes = []
     # Place an actor per node in round-robin.
@@ -88,10 +89,10 @@ def start_actors(num_actors, num_nodes):
             n: 0.01
         }, max_concurrency=10).remote({
             "meta": 1
-        }) for n in nodes for _ in range(num_actors)
+        }) for n in nodes for _ in range(actors_per_node)
     ]
     ray.get([actor.ready.remote() for actor in pi_actors])
-    print(f"Took {time.time() - start} to create {num_actors} actors")
+    print(f"Took {time.time() - start} to create {actors_per_node} actors")
     # Start the computation loop.
     for actor in pi_actors:
         actor.run_compute.remote()

--- a/release/nightly_tests/stress_tests/test_threaded_actors.py
+++ b/release/nightly_tests/stress_tests/test_threaded_actors.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 PiResult = namedtuple("PiResult", ["samples", "pi"])
 
 
-@ray.remote(num_cpus=1)
+@ray.remote(num_cpus=0)
 class PiCalculator:
     def __init__(self, metadata):
         # -- Read only variables --
@@ -101,7 +101,7 @@ def start_actors(num_actors, num_nodes):
 def parse_script_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--kill-interval_s", type=float, default=60)
-    parser.add_argument("--test-runtime", type=float, default=3600)
+    parser.add_argument("--test-runtime", type=float, default=3000)
     return parser.parse_known_args()
 
 

--- a/release/nightly_tests/stress_tests/test_threaded_actors.py
+++ b/release/nightly_tests/stress_tests/test_threaded_actors.py
@@ -92,7 +92,7 @@ def start_actors(total_num_actors, num_nodes):
         }) for n in nodes for _ in range(actors_per_node)
     ]
     ray.get([actor.ready.remote() for actor in pi_actors])
-    print(f"Took {time.time() - start} to create {actors_per_node} actors")
+    print(f"Took {time.time() - start} to create {total_num_actors} actors")
     # Start the computation loop.
     for actor in pi_actors:
         actor.run_compute.remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Both seems flaky.

- chaos testing: It seems like it takes more than 10 seconds until all resources are recovered. Increase the timeout
- threaded actor: It shouldn't require 1 CPU 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
