### PR TITLE
[Release] Increase Placement Group timeout

### DIFF
--- a/release/ml_user_tests/horovod/horovod_user_test.py
+++ b/release/ml_user_tests/horovod/horovod_user_test.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     main(
         num_workers=6,
         use_gpu=True,
-        placement_group_timeout_s=900,
+        placement_group_timeout_s=2000,
         kwargs={"num_epochs": 20})
 
     taken = time.time() - start

--- a/release/ml_user_tests/train/app_config.yaml
+++ b/release/ml_user_tests/train/app_config.yaml
@@ -1,5 +1,7 @@
 base_image: "anyscale/ray-ml:pinned-nightly-py37-gpu"
-env_vars: { }
+env_vars:
+    TRAIN_PLACEMENT_GROUP_TIMEOUT_S: 2000
+
 debian_packages:
     - curl
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Some of our release tests that use an autoscaling cluster are failing due to placement group creation timeout. This makes sure that we set the timeout to a high enough value so that there is enough time for all the nodes to join the cluster.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
