### PR TITLE
[RLlib; Documentation] Added atari pip installs to Pong-v0 example.

### DIFF
--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -399,6 +399,14 @@ Similar to accessing policy state, you may want to get a reference to the underl
 
 **Example: Preprocessing observations for feeding into a model**
 
+First, install the dependencies:
+
+.. code-block:: python
+
+    pip install "ray[rllib]" tensorflow torch "gym[atari]" "gym[accept-rom-license]" atari_py
+
+Then for the code:
+
 .. code-block:: python
 
     >>> import gym

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -403,7 +403,7 @@ First, install the dependencies:
 
 .. code-block:: python
 
-    # the "Pong-v0" environment requires a few special versions of gym
+    # The "Pong-v0" Atari environment requires a few additional gym installs:
     pip install "ray[rllib]" tensorflow torch "gym[atari]" "gym[accept-rom-license]" atari_py
 
 Then for the code:

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -403,6 +403,7 @@ First, install the dependencies:
 
 .. code-block:: python
 
+    # the "Pong-v0" environment requires a few special versions of gym
     pip install "ray[rllib]" tensorflow torch "gym[atari]" "gym[accept-rom-license]" atari_py
 
 Then for the code:


### PR DESCRIPTION
Fixes documentation where Pongv0 example did not work

Fixes https://github.com/ray-project/ray/issues/20002
