### PR TITLE
[Nightly test] Do not import pytest in test util

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -15,7 +15,6 @@ from typing import Optional, Any, List, Dict
 from contextlib import redirect_stdout, redirect_stderr
 import yaml
 import logging
-import pytest
 import tempfile
 import grpc
 
@@ -855,6 +854,7 @@ def monitor_memory_usage(print_interval_s: int = 30,
 
 def setup_tls():
     """Sets up required environment variables for tls"""
+    import pytest
     if sys.platform == "darwin":
         pytest.skip("Cryptography doesn't install in Mac build pipeline")
     cert, key = generate_self_signed_tls_certs()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some nightly tests that use test_utils occasionally failed with `pytest` issue because test util imports pytest, and it is not included in ray[default] dep.

We resolved the issue by not importing pytest for the test_util module unless it is necessary. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
