### PR TITLE
[Release] Commit sanity check when a url is provided

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -379,7 +379,7 @@ def commit_or_url(commit_or_url: str) -> str:
         if url is not None:
             # Extract commit from url so that we can do the
             # commit sanity check later.
-            p = re.compile('/([a-f0-9]{40})/')
+            p = re.compile("/([a-f0-9]{40})/")
             m = p.search(url)
             if m is not None:
                 os.environ["RAY_COMMIT"] = m.group(1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I realized that sometimes the installed ray commit is different from the provided url: https://beta.anyscale.com/o/anyscale-internal/projects/prj_JS35jSrv5JFxMqSZmQG7Yif7/app-config-details/bld_eNUBFhMhBTwMjkUB9Su9fShE.  I still don't know why but at least we should add sanity check to catch these issues.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
