### PR TITLE
Fix aiohttp 3.8.0 breaking changes (and unpin from 3.7)

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.7
+aiohttp
 aiosignal
 blist
 boto3

--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -7,6 +7,7 @@ dataclasses; python_version < '3.7'
 dm-tree==0.1.5
 feather-format
 flask
+frozenlist
 grpcio
 gym
 kubernetes

--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.7
+aiosignal
 blist
 boto3
 cython==0.29.0

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -76,7 +76,7 @@ if [[ "$platform" == "linux" ]]; then
     "$PYTHON_EXE" -u -c "import ray; print(ray.__commit__)" | grep "$TRAVIS_COMMIT" || (echo "ray.__commit__ not set properly!" && exit 1)
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp==3.7 aiosignal frozenlist grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
@@ -117,7 +117,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp==3.7 aiosignal frozenlist grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -76,7 +76,7 @@ if [[ "$platform" == "linux" ]]; then
     "$PYTHON_EXE" -u -c "import ray; print(ray.__commit__)" | grep "$TRAVIS_COMMIT" || (echo "ray.__commit__ not set properly!" && exit 1)
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp==3.7 grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp==3.7 aiosignal grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
@@ -117,7 +117,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp==3.7 grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp==3.7 aiosignal grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -76,7 +76,7 @@ if [[ "$platform" == "linux" ]]; then
     "$PYTHON_EXE" -u -c "import ray; print(ray.__commit__)" | grep "$TRAVIS_COMMIT" || (echo "ray.__commit__ not set properly!" && exit 1)
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp==3.7 aiosignal grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp==3.7 aiosignal frozenlist grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
@@ -117,7 +117,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp==3.7 aiosignal grpcio pytest==5.4.3 requests
+    "$PIP_CMD" install -q aiohttp==3.7 aiosignal frozenlist grpcio pytest==5.4.3 requests
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do

--- a/dashboard/optional_deps.py
+++ b/dashboard/optional_deps.py
@@ -5,7 +5,7 @@ import opencensus  # noqa: F401
 import prometheus_client  # noqa: F401
 
 import aiohttp  # noqa: F401
-import aiohttp.signals
+import aiosignal  # noqa: F401
 import aiohttp.web  # noqa: F401
 import aiohttp_cors  # noqa: F401
 from aiohttp import hdrs  # noqa: F401

--- a/dashboard/optional_deps.py
+++ b/dashboard/optional_deps.py
@@ -9,7 +9,7 @@ import aiosignal  # noqa: F401
 import aiohttp.web  # noqa: F401
 import aiohttp_cors  # noqa: F401
 from aiohttp import hdrs  # noqa: F401
-from aiohttp.frozenlist import FrozenList  # noqa: F401
+from frozenlist import FrozenList  # noqa: F401
 from aiohttp.typedefs import PathLike  # noqa: F401
 from aiohttp.web import RouteDef  # noqa: F401
 

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -26,8 +26,8 @@ from ray._private.utils import binary_to_hex
 # All third-party dependencies that are not included in the minimal Ray
 # installation must be included in this file. This allows us to determine if
 # the agent has the necessary dependencies to be started.
-from ray.dashboard.optional_deps import (aiohttp, aioredis, hdrs, FrozenList,
-                                         PathLike, RouteDef)
+from ray.dashboard.optional_deps import (aiohttp, aiosignal, aioredis, hdrs,
+                                         FrozenList, PathLike, RouteDef)
 
 try:
     create_task = asyncio.create_task
@@ -401,7 +401,7 @@ class SignalManager:
             sig.freeze()
 
 
-class Signal(aiohttp.signals.Signal):
+class Signal(aiosignal.Signal):
     __slots__ = ()
 
     def __init__(self, owner):

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,6 +11,7 @@ aiosignal
 click >= 7.0
 cloudpickle
 filelock
+frozenlist
 gpustat >= 1.0.0b1
 grpcio >= 1.28.1
 jsonschema

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,6 +7,7 @@
 # setup.py install_requires
 aiohttp>=3.7
 aioredis < 2
+aiosignal
 click >= 7.0
 cloudpickle
 filelock

--- a/python/requirements/requirements_default.txt
+++ b/python/requirements/requirements_default.txt
@@ -3,5 +3,6 @@ aiosignal
 aiohttp_cors
 aioredis<2
 colorful
+frozenlist
 opencensus
 prometheus_client>=0.7.1

--- a/python/requirements/requirements_default.txt
+++ b/python/requirements/requirements_default.txt
@@ -1,4 +1,5 @@
 aiohttp==3.7
+aiosignal
 aiohttp_cors
 aioredis<2
 colorful

--- a/python/requirements/requirements_default.txt
+++ b/python/requirements/requirements_default.txt
@@ -1,4 +1,4 @@
-aiohttp==3.7
+aiohttp>=3.7
 aiosignal
 aiohttp_cors
 aioredis<2

--- a/python/setup.py
+++ b/python/setup.py
@@ -203,6 +203,7 @@ if setup_spec.type == SetupType.RAY:
             "aiohttp_cors",
             "aioredis < 2",
             "colorful",
+            "frozenlist",
             "py-spy >= 0.2.0",
             "requests",
             "gpustat >= 1.0.0b1",  # for windows

--- a/python/setup.py
+++ b/python/setup.py
@@ -198,7 +198,7 @@ if setup_spec.type == SetupType.RAY:
             "fsspec",
         ],
         "default": [
-            "aiohttp == 3.7",
+            "aiohttp >= 3.7",
             "aiosignal",
             "aiohttp_cors",
             "aioredis < 2",

--- a/python/setup.py
+++ b/python/setup.py
@@ -199,6 +199,7 @@ if setup_spec.type == SetupType.RAY:
         ],
         "default": [
             "aiohttp == 3.7",
+            "aiosignal",
             "aiohttp_cors",
             "aioredis < 2",
             "colorful",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

**Fixes compatibility with aiohttp >= 3.8**


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

As of [version 3.8.0,](https://docs.aiohttp.org/en/v3.8.0/changes.html#id1) aiohttp uses external frozenlist & aiosignal dependencies and no longer provides users internal variants.
- see: aio-libs/aiohttp#5293

While #19948 temporarily fixes this, this PR resolves the longer-term issue (viz. #19951) of aiohttp compatibility.

## Related issue number

<!-- For example: "Closes #1234" -->

- Closes #19951

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
