### PR TITLE
[serve] Remove 10s halt from controller startup

### DIFF
--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -22,11 +22,6 @@ ASYNC_CONCURRENCY = int(1e6)
 # How often to call the control loop on the controller.
 CONTROL_LOOP_PERIOD_S = 0.1
 
-# Upon controller failure and recovery with running actor names,
-# we will update replica handles that halt all traffic to the cluster.
-# This constant indicates grace period to avoid controller thrashing.
-CONTROLLER_STARTUP_GRACE_PERIOD_S = 5
-
 #: Max time to wait for HTTP proxy in `serve.start()`.
 HTTP_PROXY_TIMEOUT = 60
 

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -720,11 +720,10 @@ class DeploymentState:
                 f"RECOVERING replica: {new_deployment_replica.replica_tag}, "
                 f"deployment: {self._name}.")
 
-        # Blocking grace period to avoid controller thrashing when cover
-        # from replica actor names
-        time.sleep(CONTROLLER_STARTUP_GRACE_PERIOD_S)
-        # This halts all traffic in cluster.
-        self._notify_running_replicas_changed()
+        # TODO(jiaodong): this currently halts all traffic in the cluster
+        # briefly because we will broadcast a replica update with everything in
+        # RECOVERING. We should have a grace period where we recover the state
+        # of the replicas before doing this update.
 
     @property
     def target_info(self) -> DeploymentInfo:

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -13,9 +13,9 @@ from ray.serve.async_goal_manager import AsyncGoalManager
 from ray.serve.common import (DeploymentInfo, Duration, GoalId, ReplicaTag,
                               ReplicaName, RunningReplicaInfo)
 from ray.serve.config import DeploymentConfig
-from ray.serve.constants import (
-    CONTROLLER_STARTUP_GRACE_PERIOD_S, SERVE_CONTROLLER_NAME, SERVE_PROXY_NAME,
-    MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT, MAX_NUM_DELETED_DEPLOYMENTS)
+from ray.serve.constants import (SERVE_CONTROLLER_NAME, SERVE_PROXY_NAME,
+                                 MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT,
+                                 MAX_NUM_DELETED_DEPLOYMENTS)
 from ray.serve.storage.kv_store import KVStoreBase
 from ray.serve.long_poll import LongPollHost, LongPollNamespace
 from ray.serve.utils import format_actor_name, get_random_letters, logger

--- a/python/ray/serve/tests/test_deployment_state.py
+++ b/python/ray/serve/tests/test_deployment_state.py
@@ -1773,10 +1773,8 @@ def mock_deployment_state_manager(
     with patch(
             "ray.serve.deployment_state.ActorReplicaWrapper",
             new=MockReplicaActorWrapper), patch(
-                "ray.serve.deployment_state.CONTROLLER_STARTUP_GRACE_PERIOD_S",
-                0), patch(
-                    "time.time", new=timer.time), patch(
-                        "ray.serve.long_poll.LongPollHost") as mock_long_poll:
+                "time.time", new=timer.time), patch(
+                    "ray.serve.long_poll.LongPollHost") as mock_long_poll:
 
         kv_store = RayLocalKVStore("TEST_DB", "test_kv_store.db")
         goal_manager = AsyncGoalManager()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is doing nothing but blocking the controller on recovery.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
