### PR TITLE
[autoscaler] AWS Autoscaler CloudWatch Dashboard support

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -361,7 +361,7 @@ class AWSNodeProvider(NodeProvider):
                 "Value": v,
             })
         if CloudwatchHelper.cloudwatch_config_exists(self.provider_config,
-                                                     "config"):
+                                                     "agent"):
             cwa_installed = self._check_ami_cwa_installation(node_config)
             if cwa_installed:
                 tag_pairs.extend([{

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -307,7 +307,7 @@ class NodeUpdater:
             from ray.autoscaler._private.aws.cloudwatch.cloudwatch_helper \
                 import CloudwatchHelper
             CloudwatchHelper(self.provider.provider_config,
-                             [self.node_id], self.provider.cluster_name). \
+                             self.node_id, self.provider.cluster_name). \
                 update_from_config(self.is_head_node)
 
         if node_tags.get(TAG_RAY_RUNTIME_CONFIG) == self.runtime_hash:

--- a/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
+++ b/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
@@ -3,10 +3,6 @@
       "metrics_collection_interval":60,
       "run_as_user":"root"
    },
-   "csm":{
-      "memory_limit_in_mb":20,
-      "port":31000
-   },
    "logs":{
       "metrics_collected": {
         "prometheus": {
@@ -116,60 +112,72 @@
          }
       }
    },
-   "metrics":{
-      "append_dimensions":{
-         "AutoScalingGroupName":"${aws:AutoScalingGroupName}",
-         "InstanceId":"${aws:InstanceId}"
-      },
-      "metrics_collected":{
-         "collectd":{
-            "metrics_aggregation_interval":60
-         },
-         "cpu":{
-            "measurement":[
-               "usage_active",
-               "usage_system",
-               "usage_user",
-               "usage_idle",
-               "time_active",
-               "time_system",
-               "time_user",
-               "time_idle"
-            ]
-         },
-         "processes":{
-            "measurement":[
-               "processes_running",
-               "processes_sleeping",
-               "processes_zombies",
-               "processes_dead",
-               "processes_total"
-            ],
-            "metrics_collection_interval":60,
-            "resources":[
-               "*"
-            ]
-         },
-         "disk":{
-            "measurement":[
-               "disk_used_percent"
-            ],
-            "metrics_collection_interval":60,
-            "resources":[
-               "*"
-            ]
-         },
-         "mem":{
-            "measurement":[
-               "mem_used_percent"
-            ],
-            "metrics_collection_interval":60
-         },
-         "statsd":{
-            "metrics_aggregation_interval":60,
-            "metrics_collection_interval":10,
-            "service_address":":8125"
-         }
-      }
+   "metrics": {
+     "namespace": "{cluster_name}-ray-CWAgent",
+     "aggregation_dimensions": [
+       [
+         "InstanceId"
+       ]
+     ],
+     "append_dimensions": {
+       "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+       "InstanceId": "${aws:InstanceId}"
+     },
+     "metrics_collected": {
+       "collectd": {
+         "metrics_aggregation_interval": 60
+       },
+       "cpu": {
+         "measurement": [
+           "usage_active",
+           "usage_system",
+           "usage_user",
+           "usage_idle",
+           "time_active",
+           "time_system",
+           "time_user",
+           "time_idle"
+         ],
+         "resources": [
+           "*"
+         ]
+       },
+       "processes": {
+         "measurement": [
+           "processes_running",
+           "processes_sleeping",
+           "processes_zombies",
+           "processes_dead",
+           "processes_total"
+         ],
+         "metrics_collection_interval": 60,
+         "resources": [
+           "*"
+         ]
+       },
+       "disk": {
+         "measurement": [
+           "disk_used_percent"
+         ],
+         "metrics_collection_interval": 60,
+         "resources": [
+           "/"
+         ]
+       },
+       "mem": {
+         "measurement": [
+           "mem_used_percent"
+         ],
+         "metrics_collection_interval": 60,
+         "resources": [
+           "*"
+         ]
+       },
+       "statsd": {
+         "metrics_aggregation_interval": 60,
+         "metrics_collection_interval": 10,
+         "service_address": ":8125"
+       }
+     }
    }
 }

--- a/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-dashboard-config.json
+++ b/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-dashboard-config.json
@@ -1,0 +1,238 @@
+[
+   {
+      "type":"explorer",
+      "x":12,
+      "y":18,
+      "width":12,
+      "height":6,
+      "properties": {
+        "metrics": [
+           {
+              "metricName": "CPUUtilization",
+              "resourceType": "AWS::EC2::Instance",
+              "stat": "Average"
+           }
+        ],
+        "aggregateBy": {
+                    "key": "*",
+                    "func": "SUM"
+        },
+        "labels": [
+            {
+                "key": "cloudwatch-agent-installed",
+                "value": "True"
+            },
+            {
+                "key": "ray-cluster-name",
+                "value": "{cluster_name}"
+            }
+        ],
+        "widgetOptions": {
+            "legend": {
+                "position": "bottom"
+            },
+            "view": "timeSeries",
+            "stacked": false,
+            "rowsPerPage": 1,
+            "widgetsPerRow": 1
+        },
+        "title":"Cluster CPU Utilization"
+      }
+   },
+   {
+      "type":"explorer",
+      "x":0,
+      "y":18,
+      "width":12,
+      "height":6,
+      "properties": {
+        "metrics": [
+           {
+              "metricName": "CPUUtilization",
+              "resourceType": "AWS::EC2::Instance",
+              "stat": "Average"
+           }
+        ],
+        "aggregateBy": {
+              "key": "*",
+              "func": "AVG"
+        },
+        "labels": [
+            {
+                "key": "cloudwatch-agent-installed",
+                "value": "True"
+            },
+            {
+                "key": "ray-cluster-name",
+                "value": "{cluster_name}"
+            }
+        ],
+        "widgetOptions": {
+            "legend": {
+                "position": "bottom"
+            },
+            "view": "timeSeries",
+            "stacked": false,
+            "rowsPerPage": 1,
+            "widgetsPerRow": 1
+        },
+        "title":"Single Node CPU Utilization (Avg and Max)"
+      }
+   },
+   {
+      "type":"metric",
+      "x":12,
+      "y":6,
+      "width":12,
+      "height":6,
+      "properties":{
+         "view":"timeSeries",
+         "metrics":[
+            [ { "expression": "SUM(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} processes_running', 'Average', 300))", "label": "cluster running process sum", "id": "e1" } ],
+            [ { "expression": "SUM(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} processes_sleeping', 'Average', 300))", "label": "cluster sleeping process sum", "id": "e2" } ]
+         ],
+         "region":"{region}",
+         "stat":"Average",
+         "period":60,
+         "title":"Cluster Processes"
+      }
+   },
+   {
+      "type":"metric",
+      "x":0,
+      "y":6,
+      "width":12,
+      "height":6,
+      "properties":{
+         "view":"timeSeries",
+         "metrics":[
+            [ { "expression": "AVG(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} processes_running', 'Average', 300))", "label": "cluster running process average", "id": "e3" } ],
+            [ { "expression": "AVG(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} processes_sleeping', 'Average', 300))", "label": "cluster sleeping process average", "id": "e4" } ],
+            [ { "expression": "MAX(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} processes_running', 'Average', 300))", "label": "cluster running process maximum", "id": "e5" } ],
+            [ { "expression": "MAX(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} processes_sleeping', 'Average', 300))", "label": "cluster sleeping process maximum", "id": "e6" } ]
+         ],
+         "region":"{region}",
+         "stat":"Average",
+         "period":60,
+         "title":"Single Node Processes (Avg and Max)"
+      }
+   },
+   {
+      "type":"metric",
+      "x":12,
+      "y":12,
+      "width":12,
+      "height":6,
+      "properties":{
+         "view":"timeSeries",
+         "stacked":false,
+         "metrics":[
+            [ { "expression": "SUM(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} disk_used_percent', 'Average', 300))", "label": "cluster disk used percent sum", "id": "e7", "period": 300 } ]
+
+         ],
+         "region":"{region}",
+         "title":"Cluster Disk Usage"
+      }
+   },
+   {
+      "type":"metric",
+      "x":0,
+      "y":12,
+      "width":12,
+      "height":6,
+      "properties":{
+         "view":"timeSeries",
+         "stacked":false,
+         "metrics":[
+            [ { "expression": "AVG(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} disk_used_percent', 'Average', 300))", "id": "e8", "label": "cluster disk used percent average", "period": 300 } ],
+            [ { "expression": "MAX(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} disk_used_percent', 'Maximum', 300))", "id": "e9", "label": "cluster disk used percent maximum", "period": 300 } ]
+
+         ],
+         "region":"{region}",
+         "title":"Single Node Disk Usage (Avg and Max)"
+      }
+   },
+   {
+      "type":"metric",
+      "x":12,
+      "y":18,
+      "width":12,
+      "height":6,
+      "properties": {
+          "metrics": [
+              [ { "expression": "SUM(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} mem_used_percent', 'Average', 300))", "id": "e10", "label": "cluster mem used percent sum", "period": 300 } ]
+
+          ],
+          "view": "timeSeries",
+          "stacked": false,
+          "region": "{region}",
+          "stat": "Maximum",
+          "period": 300,
+          "start": "-PT2H",
+          "end": "P0D",
+          "title": "Cluster Memory Usage"
+      }
+   },
+   {
+      "type":"metric",
+      "x":0,
+      "y":18,
+      "width":12,
+      "height":6,
+      "properties": {
+          "metrics": [
+              [ { "expression": "AVG(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} mem_used_percent', 'Average', 300))", "id": "e11", "label": "cluster mem used percent average", "period": 300 } ],
+              [ { "expression": "MAX(SEARCH('{{cluster_name}-ray-CWAgent,InstanceId} mem_used_percent', 'Maximum', 300))", "id": "e12", "label": "cluster mem used percent maximum", "period": 300 } ]
+          ],
+          "view": "timeSeries",
+          "stacked": false,
+          "region": "{region}",
+          "stat": "Maximum",
+          "period": 300,
+          "start": "-PT2H",
+          "end": "P0D",
+          "title": "Single Node Memory Usage (Avg and Max)"
+      }
+   },
+   {
+      "height": 6,
+      "width": 12,
+      "y": 0,
+      "x": 0,
+      "type": "metric",
+      "properties": {
+          "metrics": [
+              [ { "expression": "SUM(SEARCH('{{cluster_name}-ray-prometheus,instance} ray_node_cpu_count', 'Maximum', 300))", "label": "cluster cpu sum", "id": "e13" } ]
+          ],
+          "view": "timeSeries",
+          "stacked": false,
+          "region": "{region}",
+          "stat": "Maximum",
+          "period": 300,
+          "start": "-PT2H",
+          "end": "P0D",
+          "title": "Cluster CPUs"
+      }
+   },
+   {
+      "height": 6,
+      "width": 12,
+      "y": 0,
+      "x": 12,
+      "type": "metric",
+      "properties": {
+          "metrics": [
+              [ { "expression": "SUM(SEARCH('{{cluster_name}-ray-prometheus,instance} object_store_available_memory', 'Average', 300))", "label": "cluster object store available memory sum", "id": "e14" } ]
+          ],
+          "view": "timeSeries",
+          "stacked": false,
+          "region": "{region}",
+          "stat": "Maximum",
+          "period": 300,
+          "start": "-PT2H",
+          "end": "P0D",
+          "title": "Cluster Object Store Available Memory"
+      }
+   }
+]
+

--- a/python/ray/autoscaler/aws/example-cloudwatch.yaml
+++ b/python/ray/autoscaler/aws/example-cloudwatch.yaml
@@ -14,8 +14,9 @@ provider:
         # We depend on AWS Systems Manager (SSM) to deploy CloudWatch configuration updates to your cluster,
         # with relevant configuration created or updated in the SSM Parameter Store during `ray up`.
 
-        # The `AmazonCloudWatch-ray_agent_config_{cluster_name}` SSM Parameter Store Config Key is used to
-        # store a remote cache of the last Unified CloudWatch Agent config applied.
+        # We support two CloudWatch related config type under this cloudwatch section: agent and dashboard.
+        # The `AmazonCloudWatch-ray_{config_type}_config_{cluster_name}` SSM Parameter Store Config Key is used to
+        # store a remote cache of the last Unified CloudWatch config applied.
 
         # Every time you run `ray up` to update your cluster, we compare your local CloudWatch config file contents
         # to the SSM Parameter Store's contents for that config and, if they differ, then the associated CloudWatch
@@ -39,6 +40,17 @@ provider:
                 max_attempts: 120
                 # Seconds to wait between each Unified CloudWatch Agent SSM config update attempt.
                 delay_seconds: 30
+        # For CloudWatch Dashboard config files, we will also replace references to
+        # `{region}` with your cluster's region name, and `{cluster_name}` with your cluster name.
+        dashboard:
+            # CloudWatch Dashboard name
+            # Per-cluster level dashboard is created and dashboard name will be
+            # `{your_cluster_name}-example-dashboard-name` as default
+            name: "example-dashboard-name"
+            # The CloudWatch Dashboard is defined via the config file described
+            # at https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html.
+            # Path to the CloudWatch Dashboard config file
+            config: "cloudwatch/example-cloudwatch-dashboard-config.json"
 
 # How Ray will authenticate with newly launched nodes.
 auth:

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -201,6 +201,16 @@
                                 "description": "Seconds to wait between each Unified CloudWatch Agent installation attempt."
                             }
                         }
+                    },
+                    "dashboard": {
+                        "name": {
+                            "type": ["string", "null"],
+                            "description": "User defined CloudWatch Dashboard name."
+                        },
+                        "config": {
+                            "type": ["string", "null"],
+                            "description": "Path to CloudWatch Dashboard config file. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html for additional details."
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes add a set of improvements to enable automatic creation and update of CloudWatch dashboards when provisioning AWS Autoscaling clusters. Successful implementation of these improvements will allow AWS Autoscaler users to:

1. Get rapid insights into their cluster state via CloudWatch dashboards.
2. Allow users to update their CloudWatch dashboard JSON configuration files during Ray up execution time.

Notes:
1.  This PR is a follow-up PR for #18619, adds dashboard support.

## Related issue number

Closes ##9644 #8967

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
