### PR TITLE
[Core][Pubsub] handle subscriber client-side connection issues with sequence numbers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -361,7 +361,7 @@
       --test_tag_filters=-kubernetes,medium_size_python_tests_a_to_j,-flaky
       --test_env=RAY_gcs_grpc_based_pubsub=true
       -- //python/ray/tests/...
-      -//python/ray/tests:test_client_multi -//python/ray/tests:test_component_failures_3
+      -//python/ray/tests:test_component_failures_3
       -//python/ray/tests:test_healthcheck -//python/ray/tests:test_gcs_fault_tolerance
       -//python/ray/tests:test_client
 - label: ":redis: HA GCS (Medium K-Z)"
@@ -374,7 +374,6 @@
       -- //python/ray/tests/...
       -//python/ray/tests:test_multinode_failures_2 -//python/ray/tests:test_ray_debugger
       -//python/ray/tests:test_placement_group_2 -//python/ray/tests:test_placement_group_3
-      -//python/ray/tests:test_multi_node
 
 - label: ":brain: RLlib: Learning discr. actions TF2-static-graph (from rllib/tuned_examples/*.yaml)"
   conditions: ["RAY_CI_RLLIB_AFFECTED"]

--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -1,5 +1,10 @@
+import asyncio
+import random
 import sys
+import threading
+import time
 
+import grpc
 import ray
 import ray._private.gcs_utils as gcs_utils
 from ray._private.gcs_pubsub import GcsPublisher, GcsSubscriber, \
@@ -67,6 +72,90 @@ async def test_aio_publish_and_subscribe_error_info(ray_start_regular):
     assert await subscriber.poll_error() == (b"bbb_id", err2)
 
     await subscriber.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ray_start_regular", [{
+        "_system_config": {
+            "gcs_grpc_based_pubsub": True
+        }
+    }],
+    indirect=True)
+async def test_subscribe_with_client_rpc_failures(ray_start_regular):
+    # This test uses short client RPC deadlines to simulate the subscriber
+    # client encountering connection issues, and publisher receiving multiple
+    # outstanding polling requests from a subscriber. These cases should be
+    # handled with no message loss, with sequence numbers.
+
+    address_info = ray_start_regular
+    redis = ray._private.services.create_redis_client(
+        address_info["redis_address"],
+        password=ray.ray_constants.REDIS_DEFAULT_PASSWORD)
+
+    gcs_server_addr = gcs_utils.get_gcs_address_from_redis(redis)
+
+    num_messages = 200
+
+    messages = []
+
+    def receive_messages():
+        subscriber = GcsSubscriber(address=gcs_server_addr)
+        subscriber.subscribe_error()
+        while len(messages) < num_messages:
+            try:
+                _, msg = subscriber.poll_error(timeout=random.uniform(0, 0.1))
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+                    continue
+                raise
+            messages.append(msg)
+
+    async_messages = []
+
+    async def async_receive_messages():
+        subscriber = GcsAioSubscriber(address=gcs_server_addr)
+        await subscriber.subscribe_error()
+        while len(async_messages) < num_messages:
+            try:
+                _, msg = await subscriber.poll_error(
+                    timeout=random.uniform(0, 0.1))
+            except grpc.RpcError as e:
+                if e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+                    continue
+                raise
+            async_messages.append(msg)
+
+    def run_async_receive_messages():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(async_receive_messages())
+        loop.close()
+
+    t1 = threading.Thread(target=receive_messages)
+    t1.start()
+
+    t2 = threading.Thread(target=run_async_receive_messages)
+    t2.start()
+
+    publisher = GcsPublisher(address=gcs_server_addr)
+    for i in range(0, num_messages):
+        time.sleep(random.uniform(0, 0.2))
+        publisher.publish_error(
+            b"msg_id", ErrorTableData(error_message=f"error {i}"))
+
+    t1.join(timeout=1)
+    assert not t1.is_alive()
+    assert len(messages) == num_messages
+
+    t2.join(timeout=1)
+    assert not t2.is_alive()
+    assert len(async_messages) == num_messages
+
+    for i in range(0, num_messages):
+        err = ErrorTableData(error_message=f"error {i}")
+        assert messages[i] == err
+        assert async_messages[i] == err
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2809,7 +2809,7 @@ void CoreWorker::HandlePubsubLongPolling(const rpc::PubsubLongPollingRequest &re
                                          rpc::SendReplyCallback send_reply_callback) {
   const auto subscriber_id = NodeID::FromBinary(request.subscriber_id());
   RAY_LOG(DEBUG) << "Got a long polling request from a node " << subscriber_id;
-  object_info_publisher_->ConnectToSubscriber(subscriber_id, reply,
+  object_info_publisher_->ConnectToSubscriber(request, reply,
                                               std::move(send_reply_callback));
 }
 

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -53,11 +53,14 @@ void GcsSubscriberClient::PubsubLongPolling(
     const rpc::ClientCallback<rpc::PubsubLongPollingReply> &callback) {
   rpc::GcsSubscriberPollRequest req;
   req.set_subscriber_id(request.subscriber_id());
+  req.set_processed_seq(request.processed_seq());
   rpc_client_->GcsSubscriberPoll(
       req,
       [callback](const Status &status, const rpc::GcsSubscriberPollReply &poll_reply) {
         rpc::PubsubLongPollingReply reply;
         *reply.mutable_pub_messages() = poll_reply.pub_messages();
+        reply.set_seq(poll_reply.seq());
+        reply.set_reset_seq(poll_reply.reset_seq());
         callback(status, reply);
       });
 }

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -60,7 +60,7 @@ void GcsSubscriberClient::PubsubLongPolling(
         rpc::PubsubLongPollingReply reply;
         *reply.mutable_pub_messages() = poll_reply.pub_messages();
         reply.set_seq(poll_reply.seq());
-        reply.set_reset_seq(poll_reply.reset_seq());
+        reply.set_type(poll_reply.type());
         callback(status, reply);
       });
 }

--- a/src/ray/gcs/gcs_server/pubsub_handler.cc
+++ b/src/ray/gcs/gcs_server/pubsub_handler.cc
@@ -59,7 +59,7 @@ void InternalPubSubHandler::HandleGcsSubscriberPoll(
                                                std::function<void()> failure_cb) {
         reply->mutable_pub_messages()->Swap(pubsub_reply->mutable_pub_messages());
         reply->set_seq(pubsub_reply->seq());
-        reply->set_reset_seq(pubsub_reply->reset_seq());
+        reply->set_type(pubsub_reply->type());
         reply_cb(std::move(status), std::move(success_cb), std::move(failure_cb));
       });
 }

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -585,9 +585,8 @@ message GcsSubscriberPollReply {
   repeated PubMessage pub_messages = 1;
   /// Sequence number of this polling reply.
   int64 seq = 2;
-  /// Whether the subscriber should reset its sequence number based on this reply,
-  /// e.g. when the subscriber makes an initial connection, or is reconnecting.
-  bool reset_seq = 3;
+  /// Type of this reply. See PubsubLongPollingReply.Type for details.
+  PubsubLongPollingReply.Type type = 3;
   // Not populated.
   GcsStatus status = 100;
 }

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -576,11 +576,18 @@ message GcsPublishReply {
 message GcsSubscriberPollRequest {
   /// The id of the subscriber.
   bytes subscriber_id = 1;
+  /// Highest processed sequence number by this subscriber. -1 for the initial connection.
+  int64 processed_seq = 2;
 }
 
 message GcsSubscriberPollReply {
   /// The messages that are published.
   repeated PubMessage pub_messages = 1;
+  /// Sequence number of this polling reply.
+  int64 seq = 2;
+  /// Whether the subscriber should reset its sequence number based on this reply,
+  /// e.g. when the subscriber makes an initial connection, or is reconnecting.
+  bool reset_seq = 3;
   // Not populated.
   GcsStatus status = 100;
 }

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -187,13 +187,26 @@ message PubsubLongPollingRequest {
 }
 
 message PubsubLongPollingReply {
-  /// The messages that are published.
+  // The messages that are published.
   repeated PubMessage pub_messages = 1;
-  /// Sequence number of this polling reply.
+
+  // Sequence number of this polling reply.
   int64 seq = 2;
-  /// Whether the subscriber should reset its sequence number based on this reply,
-  /// e.g. when the subscriber makes an initial connection, or is likely re-connecting.
-  bool reset_seq = 3;
+
+  // Type of this polling reply.
+  enum Type {
+    // Default message type. Subscriber expects to receive a message with seq number one more than the current
+    // processed seq number. Otherwise the message is dropped, or subscriber warns about inconsistent state.
+    DEFAULT = 0;
+
+    // This reply is a no-op. It is only sent for flushing / gc of inactive polls.
+    NO_OP = 1;
+
+    // The subscriber should reset its sequence number based on this reply,
+    // e.g. subscriber making an initial connection, or re-connecting after publisher gc'ed the subscriber's state.
+    RESET = 2;
+  }
+  Type type = 3;
 }
 
 message PubsubCommandBatchRequest {

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -182,11 +182,18 @@ message WorkerObjectLocationsSubMessage {
 message PubsubLongPollingRequest {
   /// The id of the subscriber.
   bytes subscriber_id = 1;
+  /// Highest processed sequence number by this subscriber. -1 for the initial connection.
+  int64 processed_seq = 2;
 }
 
 message PubsubLongPollingReply {
   /// The messages that are published.
   repeated PubMessage pub_messages = 1;
+  /// Sequence number of this polling reply.
+  int64 seq = 2;
+  /// Whether the subscriber should reset its sequence number based on this reply,
+  /// e.g. when the subscriber makes an initial connection, or is likely re-connecting.
+  bool reset_seq = 3;
 }
 
 message PubsubCommandBatchRequest {

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -143,26 +143,35 @@ bool SubscriptionIndex::CheckNoLeaks() const {
   return key_id_to_subscribers_.size() == 0 && subscribers_to_key_id_.size() == 0;
 }
 
-bool Subscriber::ConnectToSubscriber(rpc::PubsubLongPollingReply *reply,
-                                     rpc::SendReplyCallback send_reply_callback) {
+bool SubscriberState::ConnectToSubscriber(const rpc::PubsubLongPollingRequest &request,
+                                          rpc::PubsubLongPollingReply *reply,
+                                          rpc::SendReplyCallback send_reply_callback) {
+  // Delete messages that are already processed by the subscriber.
+  while (!mailbox_.empty() && mailbox_.front()->seq() <= request.processed_seq()) {
+    mailbox_.pop();
+  }
   if (long_polling_connection_) {
-    // Flush the current subscriber poll with an empty reply.
+    // Because of the new long polling request, flush the current polling request with an
+    // empty reply.
     PublishIfPossible(/*force_noop=*/true);
   }
-  if (!long_polling_connection_) {
-    RAY_CHECK(reply != nullptr);
-    RAY_CHECK(send_reply_callback != nullptr);
-    long_polling_connection_ =
-        std::make_unique<LongPollConnection>(reply, std::move(send_reply_callback));
-    last_connection_update_time_ms_ = get_time_ms_();
-    return true;
-  }
-  return false;
+  RAY_CHECK(!long_polling_connection_);
+  RAY_CHECK(reply != nullptr);
+  RAY_CHECK(send_reply_callback != nullptr);
+  long_polling_connection_ =
+      std::make_unique<LongPollConnection>(reply, std::move(send_reply_callback));
+  last_connection_update_time_ms_ = get_time_ms_();
+  PublishIfPossible();
+  return true;
 }
 
-void Subscriber::QueueMessage(const rpc::PubMessage &pub_message, bool try_publish) {
-  if (mailbox_.empty() || mailbox_.back()->pub_messages_size() >= publish_batch_size_) {
-    mailbox_.push(absl::make_unique<rpc::PubsubLongPollingReply>());
+void SubscriberState::QueueMessage(const rpc::PubMessage &pub_message, bool try_publish) {
+  if (mailbox_.empty() || mailbox_.back()->pub_messages_size() >= publish_batch_size_ ||
+      // When existing batches have been replied to the subscriber, do not modify them.
+      // New messages should be added to a new batch.
+      mailbox_.back()->seq() == replied_seq_) {
+    mailbox_.push(std::make_unique<rpc::PubsubLongPollingReply>());
+    mailbox_.back()->set_seq(next_seq_++);
   }
 
   // Update the long polling reply.
@@ -175,7 +184,7 @@ void Subscriber::QueueMessage(const rpc::PubMessage &pub_message, bool try_publi
   }
 }
 
-bool Subscriber::PublishIfPossible(bool force_noop) {
+bool SubscriberState::PublishIfPossible(bool force_noop) {
   if (!long_polling_connection_) {
     return false;
   }
@@ -183,10 +192,20 @@ bool Subscriber::PublishIfPossible(bool force_noop) {
     return false;
   }
 
-  if (!force_noop) {
-    // Reply to the long polling subscriber. Swap the reply here to avoid extra copy.
-    long_polling_connection_->reply->Swap(mailbox_.front().get());
-    mailbox_.pop();
+  // No message should have been added to the reply.
+  RAY_CHECK(long_polling_connection_->reply->pub_messages().empty());
+  if (force_noop) {
+    // Use -1 sequence number to mark a no-op message.
+    long_polling_connection_->reply->set_seq(-1);
+  } else {
+    // Mailbox must not be empty here.
+    RAY_CHECK(!mailbox_.empty() && !mailbox_.front()->pub_messages().empty());
+    // Reply to the long polling subscriber. Reply will be deleted later, after being
+    // acknowledged.
+    long_polling_connection_->reply->CopyFrom(*mailbox_.front());
+    if (replied_seq_ < mailbox_.front()->seq()) {
+      replied_seq_ = mailbox_.front()->seq();
+    }
   }
   long_polling_connection_->send_reply_callback(Status::OK(), nullptr, nullptr);
 
@@ -196,44 +215,47 @@ bool Subscriber::PublishIfPossible(bool force_noop) {
   return true;
 }
 
-bool Subscriber::CheckNoLeaks() const {
-  return !long_polling_connection_ && mailbox_.size() == 0;
-}
-
-bool Subscriber::IsDisconnected() const {
+bool SubscriberState::CheckNoLeaks() const {
+  // If all message in the mailbox has been replied, consider there is no leak.
   return !long_polling_connection_ &&
-         get_time_ms_() - last_connection_update_time_ms_ >= connection_timeout_ms_;
+         (mailbox_.empty() || mailbox_.back()->seq() == replied_seq_);
 }
 
-bool Subscriber::IsActiveConnectionTimedOut() const {
-  return long_polling_connection_ &&
-         get_time_ms_() - last_connection_update_time_ms_ >= connection_timeout_ms_;
+bool SubscriberState::ConnectionExists() const {
+  return long_polling_connection_ != nullptr;
+}
+
+bool SubscriberState::IsActive() const {
+  return get_time_ms_() - last_connection_update_time_ms_ < connection_timeout_ms_;
 }
 
 }  // namespace pub_internal
 
-void Publisher::ConnectToSubscriber(const SubscriberID &subscriber_id,
+void Publisher::ConnectToSubscriber(const rpc::PubsubLongPollingRequest &request,
                                     rpc::PubsubLongPollingReply *reply,
                                     rpc::SendReplyCallback send_reply_callback) {
   RAY_CHECK(reply != nullptr);
   RAY_CHECK(send_reply_callback != nullptr);
-  RAY_LOG(DEBUG) << "Long polling connection initiated by " << subscriber_id;
 
+  const auto subscriber_id = SubscriberID::FromBinary(request.subscriber_id());
+  RAY_LOG(DEBUG) << "Long polling connection initiated by " << subscriber_id.Hex();
   absl::MutexLock lock(&mutex_);
   auto it = subscribers_.find(subscriber_id);
   if (it == subscribers_.end()) {
     it = subscribers_
-             .emplace(subscriber_id,
-                      std::make_shared<pub_internal::Subscriber>(
-                          get_time_ms_, subscriber_timeout_ms_, publish_batch_size_))
+             .emplace(subscriber_id, std::make_shared<pub_internal::SubscriberState>(
+                                         subscriber_id, get_time_ms_,
+                                         subscriber_timeout_ms_, publish_batch_size_))
              .first;
+    // Subscription is created along with this poll request. So this is either a new
+    // subscription or a reconnection. Ask the subscriber to reset their sequence number.
+    reply->set_reset_seq(true);
   }
   auto &subscriber = it->second;
 
-  // Since the long polling connection is synchronous between the client and
-  // coordinator, when it connects, the connection shouldn't have existed.
-  RAY_CHECK(subscriber->ConnectToSubscriber(reply, std::move(send_reply_callback)));
-  subscriber->PublishIfPossible();
+  // May flush the current long poll with an empty message, if a poll request exists.
+  RAY_CHECK(
+      subscriber->ConnectToSubscriber(request, reply, std::move(send_reply_callback)));
 }
 
 bool Publisher::RegisterSubscription(const rpc::ChannelType channel_type,
@@ -241,9 +263,9 @@ bool Publisher::RegisterSubscription(const rpc::ChannelType channel_type,
                                      const std::optional<std::string> &key_id) {
   absl::MutexLock lock(&mutex_);
   if (!subscribers_.contains(subscriber_id)) {
-    subscribers_.emplace(subscriber_id,
-                         std::make_shared<pub_internal::Subscriber>(
-                             get_time_ms_, subscriber_timeout_ms_, publish_batch_size_));
+    subscribers_.emplace(subscriber_id, std::make_shared<pub_internal::SubscriberState>(
+                                            subscriber_id, get_time_ms_,
+                                            subscriber_timeout_ms_, publish_batch_size_));
   }
   auto subscription_index_it = subscription_index_map_.find(channel_type);
   RAY_CHECK(subscription_index_it != subscription_index_map_.end());
@@ -309,7 +331,7 @@ int Publisher::UnregisterSubscriberInternal(const SubscriberID &subscriber_id) {
     return erased;
   }
   auto &subscriber = it->second;
-  // Remove the long polling connection because otherwise, there's memory leak.
+  // Flush the long polling connection because otherwise the reply could be leaked.
   subscriber->PublishIfPossible(/*force_noop=*/true);
   subscribers_.erase(it);
   return erased;
@@ -321,16 +343,17 @@ void Publisher::CheckDeadSubscribers() {
 
   for (const auto &it : subscribers_) {
     const auto &subscriber = it.second;
-
-    auto disconnected = subscriber->IsDisconnected();
-    auto active_connection_timed_out = subscriber->IsActiveConnectionTimedOut();
-    RAY_CHECK(!(disconnected && active_connection_timed_out));
-
-    if (disconnected) {
-      dead_subscribers.push_back(it.first);
-    } else if (active_connection_timed_out) {
-      // Refresh the long polling connection. The subscriber will poll again.
+    if (subscriber->IsActive()) {
+      continue;
+    }
+    // Subscriber has no activity for a while. It is considered timed out now.
+    if (subscriber->ConnectionExists()) {
+      // Release the long polling connection with a noop. The subscriber will poll again
+      // if it is still alive. This also refreshes the last active time.
       subscriber->PublishIfPossible(/*force_noop*/ true);
+    } else {
+      // Subscriber state can be deleted since it does not have any active connection.
+      dead_subscribers.push_back(it.first);
     }
   }
 

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -249,7 +249,7 @@ void Publisher::ConnectToSubscriber(const rpc::PubsubLongPollingRequest &request
              .first;
     // Subscription is created along with this poll request. So this is either a new
     // subscription or a reconnection. Ask the subscriber to reset their sequence number.
-    reply->set_reset_seq(true);
+    reply->set_type(rpc::PubsubLongPollingReply::RESET);
   }
   auto &subscriber = it->second;
 

--- a/src/ray/pubsub/publisher.h
+++ b/src/ray/pubsub/publisher.h
@@ -93,17 +93,18 @@ struct LongPollConnection {
   rpc::SendReplyCallback send_reply_callback;
 };
 
-/// Abstraction to each subscriber.
-class Subscriber {
+/// Keeps the state of each connected subscriber.
+class SubscriberState {
  public:
-  Subscriber(std::function<double()> get_time_ms, uint64_t connection_timeout_ms,
-             const int publish_batch_size)
-      : get_time_ms_(std::move(get_time_ms)),
+  SubscriberState(SubscriberID subscriber_id, std::function<double()> get_time_ms,
+                  uint64_t connection_timeout_ms, const int publish_batch_size)
+      : subscriber_id_(subscriber_id),
+        get_time_ms_(std::move(get_time_ms)),
         connection_timeout_ms_(connection_timeout_ms),
         publish_batch_size_(publish_batch_size),
         last_connection_update_time_ms_(get_time_ms_()) {}
 
-  ~Subscriber() = default;
+  ~SubscriberState() = default;
 
   /// Connect to the subscriber. Currently, it means we cache the long polling request to
   /// memory. Once the bidirectional gRPC streaming is enabled, we should replace it.
@@ -111,14 +112,15 @@ class Subscriber {
   /// \param reply pubsub long polling reply.
   /// \param send_reply_callback A callback to reply to the long polling subscriber.
   /// \return True if connection is new. False if there were already connections cached.
-  bool ConnectToSubscriber(rpc::PubsubLongPollingReply *reply,
+  bool ConnectToSubscriber(const rpc::PubsubLongPollingRequest &request,
+                           rpc::PubsubLongPollingReply *reply,
                            rpc::SendReplyCallback send_reply_callback);
 
   /// Queue the pubsub message to publish to the subscriber.
   ///
   /// \param pub_message A message to publish.
-  /// \param try_publish If true, it try publishing the object id if there is a
-  /// connection.
+  /// \param try_publish If true, try publishing the object id if there is a connection.
+  ///     Currently only set to false in tests.
   void QueueMessage(const rpc::PubMessage &pub_message, bool try_publish = true);
 
   /// Publish all queued messages if possible.
@@ -132,18 +134,17 @@ class Subscriber {
   /// Testing only. Return true if there's no metadata remained in the private attribute.
   bool CheckNoLeaks() const;
 
-  /// Return true if the subscriber is disconnected (if the subscriber is dead).
-  /// The subscriber is considered to be dead if there was no long polling connection for
-  /// the timeout.
-  bool IsDisconnected() const;
+  /// Returns true if there is a long polling connection.
+  bool ConnectionExists() const;
 
-  /// Return true if there was no new long polling connection for a long time.
-  bool IsActiveConnectionTimedOut() const;
+  /// Returns true if there are recent activities (requests or replies) between the
+  /// subscriber and publisher.
+  bool IsActive() const;
 
  private:
-  /// Cached long polling reply callback.
-  /// It is cached whenever new long polling is coming from the subscriber.
-  /// It becomes a nullptr whenever the long polling request is replied.
+  /// Subscriber ID, for logging and debugging.
+  const SubscriberID subscriber_id_;
+  /// Inflight long polling reply callback, for replying to the subscriber.
   std::unique_ptr<LongPollConnection> long_polling_connection_;
   /// Queued messages to publish.
   std::queue<std::unique_ptr<rpc::PubsubLongPollingReply>> mailbox_;
@@ -155,6 +156,10 @@ class Subscriber {
   const int publish_batch_size_;
   /// The last time long polling was connected in milliseconds.
   double last_connection_update_time_ms_;
+  /// Next sequence number to use.
+  int64_t next_seq_ = 0;
+  /// Highest replied sequence number.
+  int64_t replied_seq_ = -1;
 };
 
 }  // namespace pub_internal
@@ -247,12 +252,12 @@ class Publisher : public PublisherInterface {
 
   ~Publisher() override = default;
 
-  /// Cache the subscriber's long polling request's information.
+  /// Handle a long poll request from `subscriber_id`.
   ///
   /// TODO(sang): Currently, we need to pass the callback for connection because we are
   /// using long polling internally. This should be changed once the bidirectional grpc
   /// streaming is supported.
-  void ConnectToSubscriber(const SubscriberID &subscriber_id,
+  void ConnectToSubscriber(const rpc::PubsubLongPollingRequest &request,
                            rpc::PubsubLongPollingReply *reply,
                            rpc::SendReplyCallback send_reply_callback);
 
@@ -360,7 +365,7 @@ class Publisher : public PublisherInterface {
   mutable absl::Mutex mutex_;
 
   /// Mapping of node id -> subscribers.
-  absl::flat_hash_map<SubscriberID, std::shared_ptr<pub_internal::Subscriber>>
+  absl::flat_hash_map<SubscriberID, std::shared_ptr<pub_internal::SubscriberState>>
       subscribers_ GUARDED_BY(mutex_);
 
   /// Index that stores the mapping of messages <-> subscribers.

--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -362,13 +362,13 @@ void Subscriber::HandleLongPollingResponse(const rpc::Address &publisher_address
     }
     // Empty the command queue because we cannot send commands anymore.
     commands_.erase(publisher_id);
-  } else if (processed_seq < reply.seq() || reply.reset_seq()) {
+  } else if (processed_seq < reply.seq() || reply.type() == rpc::PubsubLongPollingReply::RESET) {
     if (processed_seq + 1 < reply.seq()) {
       RAY_LOG(WARNING) << "Missing sequence numbers for subscriber "
                        << subscriber_id_.Hex()
                        << ", local processed_seq=" << processed_seq
                        << ", remote reply seq=" << reply.seq();
-    } else if (reply.reset_seq()) {
+    } else if (reply.type() == rpc::PubsubLongPollingReply::RESET) {
       RAY_LOG(WARNING) << "Publisher resets sequence number for subscriber "
                        << subscriber_id_.Hex()
                        << ", local processed_seq=" << processed_seq

--- a/src/ray/pubsub/test/publisher_test.cc
+++ b/src/ray/pubsub/test/publisher_test.cc
@@ -32,16 +32,21 @@ class PublisherTest : public ::testing::Test {
   ~PublisherTest() {}
 
   void SetUp() {
-    object_status_publisher_ = std::make_shared<Publisher>(
-        /*channels=*/std::vector<
-            rpc::ChannelType>{rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                              rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL,
-                              rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL},
+    publisher_ = std::make_shared<Publisher>(
+        /*channels=*/
+        std::vector<rpc::ChannelType>{
+            rpc::ChannelType::WORKER_OBJECT_EVICTION,
+            rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL,
+            rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL,
+            rpc::ChannelType::RAY_ERROR_INFO_CHANNEL,
+        },
         /*periodic_runner=*/periodic_runner_.get(),
         /*get_time_ms=*/[this]() { return current_time_; },
         /*subscriber_timeout_ms=*/subscriber_timeout_ms_,
         /*batch_size*/ 100);
     current_time_ = 0;
+    request_.set_subscriber_id(subscriber_id_.Binary());
+    request_.set_processed_seq(-1);
   }
 
   void TearDown() { subscribers_map_.clear(); }
@@ -55,12 +60,24 @@ class PublisherTest : public ::testing::Test {
     return pub_message;
   }
 
+  const rpc::PubMessage GenerateErrorInfoMessage(const std::string &id,
+                                                 const std::string &text) {
+    rpc::PubMessage pub_message;
+    auto *error_msg = pub_message.mutable_error_info_message();
+    error_msg->set_error_message(text);
+    pub_message.set_key_id(id);
+    pub_message.set_channel_type(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
+    return pub_message;
+  }
+
   instrumented_io_context io_service_;
   std::shared_ptr<PeriodicalRunner> periodic_runner_;
-  std::shared_ptr<Publisher> object_status_publisher_;
-  std::unordered_map<ObjectID, std::unordered_set<NodeID>> subscribers_map_;
+  std::shared_ptr<Publisher> publisher_;
+  std::unordered_map<ObjectID, absl::flat_hash_set<NodeID>> subscribers_map_;
   const uint64_t subscriber_timeout_ms_ = 30000;
   double current_time_;
+  const SubscriberID subscriber_id_ = SubscriberID::FromRandom();
+  rpc::PubsubLongPollingRequest request_;
 };
 
 TEST_F(PublisherTest, TestSubscriptionIndexSingeNodeSingleObject) {
@@ -89,7 +106,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexMultiNodeSingleObject) {
   /// oid1 -> [nid1~nid5]
   SubscriptionIndex subscription_index;
   const auto oid = ObjectID::FromRandom();
-  std::unordered_set<NodeID> empty_set;
+  absl::flat_hash_set<NodeID> empty_set;
   subscribers_map_.emplace(oid, empty_set);
 
   for (int i = 0; i < 5; i++) {
@@ -139,7 +156,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexErase) {
   int total_entries = 6;
   int entries_to_delete_at_each_time = 3;
   auto oid = ObjectID::FromRandom();
-  std::unordered_set<NodeID> empty_set;
+  absl::flat_hash_set<NodeID> empty_set;
   subscribers_map_.emplace(oid, empty_set);
 
   // Add entries.
@@ -186,7 +203,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexEraseMultiSubscribers) {
   SubscriptionIndex subscription_index;
   auto oid = ObjectID::FromRandom();
   auto oid2 = ObjectID::FromRandom();
-  std::unordered_set<NodeID> empty_set;
+  absl::flat_hash_set<NodeID> empty_set;
   subscribers_map_.emplace(oid, empty_set);
   subscribers_map_.emplace(oid2, empty_set);
 
@@ -265,11 +282,15 @@ TEST_F(PublisherTest, TestSubscriptionIndexIdempotency) {
 }
 
 TEST_F(PublisherTest, TestSubscriber) {
-  std::unordered_set<ObjectID> object_ids_published;
+  absl::flat_hash_set<ObjectID> object_ids_published;
   rpc::PubsubLongPollingReply reply;
   rpc::SendReplyCallback send_reply_callback =
-      [&reply, &object_ids_published](Status status, std::function<void()> success,
-                                      std::function<void()> failure) {
+      [this, &object_ids_published, &reply](Status status, std::function<void()> success,
+                                            std::function<void()> failure) {
+        if (request_.processed_seq() >= reply.seq()) {
+          return;
+        }
+        request_.set_processed_seq(reply.seq());
         for (int i = 0; i < reply.pub_messages_size(); i++) {
           const auto &msg = reply.pub_messages(i);
           const auto oid =
@@ -279,25 +300,27 @@ TEST_F(PublisherTest, TestSubscriber) {
         reply = rpc::PubsubLongPollingReply();
       };
 
-  std::shared_ptr<Subscriber> subscriber = std::make_shared<Subscriber>(
-      [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
+  auto subscriber = std::make_shared<SubscriberState>(
+      subscriber_id_, [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
   // If there's no connection, it will return false.
   ASSERT_FALSE(subscriber->PublishIfPossible());
   // Try connecting it. Should return true.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
-  // Polling when there is already an inflight polling request should still work.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
-  // Since there's no published objects, it should return false.
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
+  // Reconnection should still succeed.
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
+  // No result should have been returned.
+  ASSERT_TRUE(object_ids_published.empty());
+  // Since there's no objects pending to be published, it should return false.
   ASSERT_FALSE(subscriber->PublishIfPossible());
 
-  std::unordered_set<ObjectID> published_objects;
+  absl::flat_hash_set<ObjectID> published_objects;
   // Make sure publishing one object works as expected.
   auto oid = ObjectID::FromRandom();
   subscriber->QueueMessage(GeneratePubMessage(oid), /*try_publish=*/false);
   published_objects.emplace(oid);
   ASSERT_TRUE(subscriber->PublishIfPossible());
-  ASSERT_TRUE(object_ids_published.count(oid) > 0);
-  // Since the object is published, and there's no connection, it should return false.
+  ASSERT_TRUE(object_ids_published.contains(oid));
+  // No object is pending to be published, and there's no connection.
   ASSERT_FALSE(subscriber->PublishIfPossible());
 
   // Add 3 oids and see if it works properly.
@@ -309,20 +332,23 @@ TEST_F(PublisherTest, TestSubscriber) {
   }
   // Since there's no connection, objects won't be published.
   ASSERT_FALSE(subscriber->PublishIfPossible());
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
-  ASSERT_TRUE(subscriber->PublishIfPossible());
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
   for (auto oid : published_objects) {
-    ASSERT_TRUE(object_ids_published.count(oid) > 0);
+    ASSERT_TRUE(object_ids_published.contains(oid));
   }
   ASSERT_TRUE(subscriber->CheckNoLeaks());
 }
 
 TEST_F(PublisherTest, TestSubscriberBatchSize) {
-  std::unordered_set<ObjectID> object_ids_published;
+  absl::flat_hash_set<ObjectID> object_ids_published;
   rpc::PubsubLongPollingReply reply;
   rpc::SendReplyCallback send_reply_callback =
-      [&reply, &object_ids_published](Status status, std::function<void()> success,
-                                      std::function<void()> failure) {
+      [this, &object_ids_published, &reply](Status status, std::function<void()> success,
+                                            std::function<void()> failure) {
+        if (request_.processed_seq() >= reply.seq()) {
+          return;
+        }
+        request_.set_processed_seq(reply.seq());
         for (int i = 0; i < reply.pub_messages_size(); i++) {
           const auto &msg = reply.pub_messages(i);
           const auto oid =
@@ -333,11 +359,12 @@ TEST_F(PublisherTest, TestSubscriberBatchSize) {
       };
 
   auto max_publish_size = 5;
-  std::shared_ptr<Subscriber> subscriber = std::make_shared<Subscriber>(
-      [this]() { return current_time_; }, subscriber_timeout_ms_, max_publish_size);
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
+  auto subscriber = std::make_shared<SubscriberState>(
+      subscriber_id_, [this]() { return current_time_; }, subscriber_timeout_ms_,
+      max_publish_size);
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
 
-  std::unordered_set<ObjectID> published_objects;
+  absl::flat_hash_set<ObjectID> published_objects;
   std::vector<ObjectID> oids;
   for (int i = 0; i < 10; i++) {
     auto oid = ObjectID::FromRandom();
@@ -351,17 +378,16 @@ TEST_F(PublisherTest, TestSubscriberBatchSize) {
   ASSERT_TRUE(subscriber->PublishIfPossible());
 
   for (int i = 0; i < max_publish_size; i++) {
-    ASSERT_TRUE(object_ids_published.count(oids[i]) > 0);
+    ASSERT_TRUE(object_ids_published.contains(oids[i]));
   }
   for (int i = max_publish_size; i < 10; i++) {
-    ASSERT_FALSE(object_ids_published.count(oids[i]) > 0);
+    ASSERT_FALSE(object_ids_published.contains(oids[i]));
   }
 
-  // Remainings are published.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
-  ASSERT_TRUE(subscriber->PublishIfPossible());
+  // Remaining messages are published upon polling.
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
   for (int i = 0; i < 10; i++) {
-    ASSERT_TRUE(object_ids_published.count(oids[i]) > 0);
+    ASSERT_TRUE(object_ids_published.contains(oids[i]));
   }
 }
 
@@ -373,54 +399,60 @@ TEST_F(PublisherTest, TestSubscriberActiveTimeout) {
   auto reply_cnt = 0;
   rpc::PubsubLongPollingReply reply;
   rpc::SendReplyCallback send_reply_callback =
-      [&reply_cnt](Status status, std::function<void()> success,
-                   std::function<void()> failure) { reply_cnt++; };
+      [this, &reply, &reply_cnt](Status status, std::function<void()> success,
+                                 std::function<void()> failure) {
+        reply_cnt++;
+        if (request_.processed_seq() >= reply.seq()) {
+          return;
+        }
+        request_.set_processed_seq(reply.seq());
+      };
 
-  std::shared_ptr<Subscriber> subscriber = std::make_shared<Subscriber>(
-      [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
+  auto subscriber = std::make_shared<SubscriberState>(
+      subscriber_id_, [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
 
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
 
   // Connection is not timed out yet.
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_TRUE(subscriber->ConnectionExists());
 
   // Some time has passed, but it is not timed out yet.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_TRUE(subscriber->ConnectionExists());
 
   // Timeout is reached, and the long polling connection should've been refreshed.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_TRUE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_FALSE(subscriber->IsActive());
+  ASSERT_TRUE(subscriber->ConnectionExists());
 
   // Refresh the connection.
-  subscriber->PublishIfPossible(/*force*/ true);
+  subscriber->PublishIfPossible(/*force_noop=*/true);
   ASSERT_EQ(reply_cnt, 1);
 
   // New connection is established.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_TRUE(subscriber->ConnectionExists());
 
   // Some time has passed, but it is not timed out yet.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_TRUE(subscriber->ConnectionExists());
 
   // A message is published, so the connection is refreshed.
   auto oid = ObjectID::FromRandom();
   subscriber->QueueMessage(GeneratePubMessage(oid));
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
   ASSERT_EQ(reply_cnt, 2);
 
   // Although time has passed, since the connection was refreshed, timeout shouldn't
   // happen.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   ASSERT_TRUE(subscriber->CheckNoLeaks());
 }
@@ -433,53 +465,59 @@ TEST_F(PublisherTest, TestSubscriberDisconnected) {
   auto reply_cnt = 0;
   rpc::PubsubLongPollingReply reply;
   rpc::SendReplyCallback send_reply_callback =
-      [&reply_cnt](Status status, std::function<void()> success,
-                   std::function<void()> failure) { reply_cnt++; };
+      [this, &reply_cnt, &reply](Status status, std::function<void()> success,
+                                 std::function<void()> failure) {
+        reply_cnt++;
+        if (request_.processed_seq() >= reply.seq()) {
+          return;
+        }
+        request_.set_processed_seq(reply.seq());
+      };
 
-  std::shared_ptr<Subscriber> subscriber = std::make_shared<Subscriber>(
-      [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
+  auto subscriber = std::make_shared<SubscriberState>(
+      subscriber_id_, [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
 
   // Suppose the new connection is removed.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
   subscriber->PublishIfPossible(/*force*/ true);
   ASSERT_EQ(reply_cnt, 1);
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   // Some time has passed, but it is not timed out yet.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   // Timeout is reached. Since there was no new long polling connection, it is considered
   // as disconnected.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_TRUE(subscriber->IsDisconnected());
+  ASSERT_FALSE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   // New connection is coming in.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
   subscriber->PublishIfPossible(/*force*/ true);
   ASSERT_EQ(reply_cnt, 2);
 
   // Some time has passed, but it is not timed out yet.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   // Another connection is made, so it shouldn't timeout until the next timeout is
   // reached.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
   subscriber->PublishIfPossible(/*force*/ true);
   ASSERT_EQ(reply_cnt, 3);
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   // IF there's no new connection for a long time it should eventually timeout.
   current_time_ += subscriber_timeout_ms_ / 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_TRUE(subscriber->IsDisconnected());
+  ASSERT_FALSE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   ASSERT_TRUE(subscriber->CheckNoLeaks());
 }
@@ -495,37 +533,37 @@ TEST_F(PublisherTest, TestSubscriberTimeoutComplicated) {
       [&reply_cnt](Status status, std::function<void()> success,
                    std::function<void()> failure) { reply_cnt++; };
 
-  std::shared_ptr<Subscriber> subscriber = std::make_shared<Subscriber>(
-      [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
+  auto subscriber = std::make_shared<SubscriberState>(
+      subscriber_id_, [this]() { return current_time_; }, subscriber_timeout_ms_, 10);
 
   // Suppose the new connection is removed.
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
   subscriber->PublishIfPossible(/*force*/ true);
   ASSERT_EQ(reply_cnt, 1);
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   // Some time has passed, and the connection is removed.
   current_time_ += subscriber_timeout_ms_ - 1;
-  ASSERT_TRUE(subscriber->ConnectToSubscriber(&reply, send_reply_callback));
+  ASSERT_TRUE(subscriber->ConnectToSubscriber(request_, &reply, send_reply_callback));
   current_time_ += 2;
   // Timeout shouldn't happen because the connection has been refreshed.
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_TRUE(subscriber->ConnectionExists());
 
   // Right before the timeout, connection is removed. In this case, timeout shouldn't also
   // happen.
   current_time_ += subscriber_timeout_ms_ - 1;
   subscriber->PublishIfPossible(/*force*/ true);
   current_time_ += 2;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_FALSE(subscriber->IsDisconnected());
+  ASSERT_TRUE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   // Timeout is reached. Since there was no connection, it should be considered
   // disconnected.
   current_time_ += subscriber_timeout_ms_;
-  ASSERT_FALSE(subscriber->IsActiveConnectionTimedOut());
-  ASSERT_TRUE(subscriber->IsDisconnected());
+  ASSERT_FALSE(subscriber->IsActive());
+  ASSERT_FALSE(subscriber->ConnectionExists());
 
   ASSERT_TRUE(subscriber->CheckNoLeaks());
 }
@@ -545,14 +583,12 @@ TEST_F(PublisherTest, TestBasicSingleSubscriber) {
         reply = rpc::PubsubLongPollingReply();
       };
 
-  const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
 
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
-  object_status_publisher_->Publish(GeneratePubMessage(oid));
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
+  publisher_->Publish(GeneratePubMessage(oid));
   ASSERT_EQ(batched_ids[0], oid);
 }
 
@@ -571,16 +607,14 @@ TEST_F(PublisherTest, TestNoConnectionWhenRegistered) {
         reply = rpc::PubsubLongPollingReply();
       };
 
-  const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
 
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
-  object_status_publisher_->Publish(GeneratePubMessage(oid));
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
+  publisher_->Publish(GeneratePubMessage(oid));
   // Nothing has been published because there's no connection.
   ASSERT_EQ(batched_ids.size(), 0);
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
   // When the connection is coming, it should be published.
   ASSERT_EQ(batched_ids[0], oid);
 }
@@ -600,21 +634,19 @@ TEST_F(PublisherTest, TestMultiObjectsFromSingleNode) {
         reply = rpc::PubsubLongPollingReply();
       };
 
-  const auto subscriber_node_id = NodeID::FromRandom();
   std::vector<ObjectID> oids;
   int num_oids = 5;
   for (int i = 0; i < num_oids; i++) {
     const auto oid = ObjectID::FromRandom();
     oids.push_back(oid);
-    object_status_publisher_->RegisterSubscription(
-        rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary());
-    object_status_publisher_->Publish(GeneratePubMessage(oid));
+    publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                     subscriber_id_, oid.Binary());
+    publisher_->Publish(GeneratePubMessage(oid));
   }
   ASSERT_EQ(batched_ids.size(), 0);
 
   // Now connection is initiated, and all oids are published.
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
   for (int i = 0; i < num_oids; i++) {
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
@@ -648,18 +680,15 @@ TEST_F(PublisherTest, TestMultiObjectsFromMultiNodes) {
   // There will be one object per node.
   for (int i = 0; i < num_nodes; i++) {
     const auto oid = oids[i];
-    const auto subscriber_node_id = subscribers[i];
-    object_status_publisher_->RegisterSubscription(
-        rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary());
-    object_status_publisher_->Publish(GeneratePubMessage(oid));
+    publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                     subscriber_id_, oid.Binary());
+    publisher_->Publish(GeneratePubMessage(oid));
   }
   ASSERT_EQ(batched_ids.size(), 0);
 
   // Check all of nodes are publishing objects properly.
   for (int i = 0; i < num_nodes; i++) {
-    const auto subscriber_node_id = subscribers[i];
-    object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                  send_reply_callback);
+    publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
     ASSERT_EQ(oid_test, published_oid);
@@ -667,7 +696,7 @@ TEST_F(PublisherTest, TestMultiObjectsFromMultiNodes) {
 }
 
 TEST_F(PublisherTest, TestMultiSubscribers) {
-  std::unordered_set<ObjectID> batched_ids;
+  absl::flat_hash_set<ObjectID> batched_ids;
   rpc::PubsubLongPollingReply reply;
   int reply_invoked = 0;
   rpc::SendReplyCallback send_reply_callback =
@@ -692,19 +721,16 @@ TEST_F(PublisherTest, TestMultiSubscribers) {
 
   // There will be one object per node.
   for (int i = 0; i < num_nodes; i++) {
-    const auto subscriber_node_id = subscribers[i];
-    object_status_publisher_->RegisterSubscription(
-        rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary());
+    publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                     subscriber_id_, oid.Binary());
   }
   ASSERT_EQ(batched_ids.size(), 0);
 
   // Check all of nodes are publishing objects properly.
   for (int i = 0; i < num_nodes; i++) {
-    const auto subscriber_node_id = subscribers[i];
-    object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                  send_reply_callback);
+    publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
   }
-  object_status_publisher_->Publish(GeneratePubMessage(oid));
+  publisher_->Publish(GeneratePubMessage(oid));
   ASSERT_EQ(batched_ids.size(), 1);
   ASSERT_EQ(reply_invoked, 5);
 }
@@ -714,8 +740,12 @@ TEST_F(PublisherTest, TestBatch) {
   std::vector<ObjectID> batched_ids;
   rpc::PubsubLongPollingReply reply;
   rpc::SendReplyCallback send_reply_callback =
-      [&reply, &batched_ids](Status status, std::function<void()> success,
-                             std::function<void()> failure) {
+      [this, &reply, &batched_ids](Status status, std::function<void()> success,
+                                   std::function<void()> failure) {
+        if (request_.processed_seq() >= reply.seq()) {
+          return;
+        }
+        request_.set_processed_seq(reply.seq());
         for (int i = 0; i < reply.pub_messages_size(); i++) {
           const auto &msg = reply.pub_messages(i);
           const auto oid =
@@ -725,21 +755,19 @@ TEST_F(PublisherTest, TestBatch) {
         reply = rpc::PubsubLongPollingReply();
       };
 
-  const auto subscriber_node_id = NodeID::FromRandom();
   std::vector<ObjectID> oids;
   int num_oids = 5;
   for (int i = 0; i < num_oids; i++) {
     const auto oid = ObjectID::FromRandom();
     oids.push_back(oid);
-    object_status_publisher_->RegisterSubscription(
-        rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary());
-    object_status_publisher_->Publish(GeneratePubMessage(oid));
+    publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                     subscriber_id_, oid.Binary());
+    publisher_->Publish(GeneratePubMessage(oid));
   }
   ASSERT_EQ(batched_ids.size(), 0);
 
   // Now connection is initiated, and all oids are published.
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
   for (int i = 0; i < num_oids; i++) {
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
@@ -752,12 +780,11 @@ TEST_F(PublisherTest, TestBatch) {
   for (int i = 0; i < num_oids; i++) {
     const auto oid = ObjectID::FromRandom();
     oids.push_back(oid);
-    object_status_publisher_->RegisterSubscription(
-        rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary());
-    object_status_publisher_->Publish(GeneratePubMessage(oid));
+    publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                     subscriber_id_, oid.Binary());
+    publisher_->Publish(GeneratePubMessage(oid));
   }
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
   for (int i = 0; i < num_oids; i++) {
     const auto oid_test = oids[i];
     const auto published_oid = batched_ids[i];
@@ -774,39 +801,37 @@ TEST_F(PublisherTest, TestNodeFailureWhenConnectionExisted) {
         long_polling_connection_replied = true;
       };
 
-  const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
   // This information should be cleaned up as the subscriber is dead.
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
   // Timeout is reached. The connection should've been refreshed. Since the subscriber is
   // dead, no new connection is made.
   current_time_ += subscriber_timeout_ms_;
-  object_status_publisher_->CheckDeadSubscribers();
+  publisher_->CheckDeadSubscribers();
   ASSERT_EQ(long_polling_connection_replied, true);
 
   // More time has passed, and since there was no new long polling connection, this
   // subscriber is considered as dead.
   current_time_ += subscriber_timeout_ms_;
-  object_status_publisher_->CheckDeadSubscribers();
+  publisher_->CheckDeadSubscribers();
 
   // Connection should be replied (removed) when the subscriber is unregistered.
-  int erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
+  int erased = publisher_->UnregisterSubscriber(subscriber_id_);
   ASSERT_EQ(erased, 0);
-  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->CheckNoLeaks());
 
   // New subscriber is registsered for some reason. Since there's no new long polling
   // connection for the timeout, it should be removed.
   long_polling_connection_replied = false;
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
   current_time_ += subscriber_timeout_ms_;
-  object_status_publisher_->CheckDeadSubscribers();
-  erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
+  publisher_->CheckDeadSubscribers();
+  erased = publisher_->UnregisterSubscriber(subscriber_id_);
   ASSERT_EQ(erased, 0);
-  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->CheckNoLeaks());
 }
 
 TEST_F(PublisherTest, TestNodeFailureWhenConnectionDoesntExist) {
@@ -821,39 +846,37 @@ TEST_F(PublisherTest, TestNodeFailureWhenConnectionDoesntExist) {
   ///
   /// Test the case where there was a registration, but no connection.
   ///
-  auto subscriber_node_id = NodeID::FromRandom();
   auto oid = ObjectID::FromRandom();
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
-  object_status_publisher_->Publish(GeneratePubMessage(oid));
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
+  publisher_->Publish(GeneratePubMessage(oid));
   // There was no long polling connection yet.
   ASSERT_EQ(long_polling_connection_replied, false);
 
   // Connect should be removed eventually to avoid having a memory leak.
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
   ASSERT_EQ(long_polling_connection_replied, true);
   // Nothing happens at first.
-  object_status_publisher_->CheckDeadSubscribers();
+  publisher_->CheckDeadSubscribers();
 
   // After the timeout, the subscriber should be considered as dead because there was no
   // new long polling connection.
   current_time_ += subscriber_timeout_ms_;
-  object_status_publisher_->CheckDeadSubscribers();
+  publisher_->CheckDeadSubscribers();
   // Make sure the registration is cleaned up.
-  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->CheckNoLeaks());
 
   /// Test the case where there's no connection coming at all when there was a
   /// registration.
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
-  object_status_publisher_->Publish(GeneratePubMessage(oid));
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
+  publisher_->Publish(GeneratePubMessage(oid));
 
   // No new long polling connection was made until timeout.
   current_time_ += subscriber_timeout_ms_;
-  object_status_publisher_->CheckDeadSubscribers();
+  publisher_->CheckDeadSubscribers();
   // Make sure the registration is cleaned up.
-  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->CheckNoLeaks());
 }
 
 // Unregistration an entry.
@@ -866,37 +889,34 @@ TEST_F(PublisherTest, TestUnregisterSubscription) {
         long_polling_connection_replied = true;
       };
 
-  const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
   ASSERT_EQ(long_polling_connection_replied, false);
 
   // Connection should be replied (removed) when the subscriber is unregistered.
-  int erased = object_status_publisher_->UnregisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary());
+  int erased = publisher_->UnregisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_id_, oid.Binary());
   ASSERT_EQ(erased, 1);
   ASSERT_EQ(long_polling_connection_replied, false);
 
   // Make sure when the entries don't exist, it doesn't delete anything.
-  ASSERT_EQ(object_status_publisher_->UnregisterSubscription(
-                rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id,
-                ObjectID::FromRandom().Binary()),
-            0);
   ASSERT_EQ(
-      object_status_publisher_->UnregisterSubscription(
-          rpc::ChannelType::WORKER_OBJECT_EVICTION, NodeID::FromRandom(), oid.Binary()),
+      publisher_->UnregisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                         subscriber_id_, ObjectID::FromRandom().Binary()),
       0);
-  ASSERT_EQ(object_status_publisher_->UnregisterSubscription(
-                rpc::ChannelType::WORKER_OBJECT_EVICTION, NodeID::FromRandom(),
-                ObjectID::FromRandom().Binary()),
+  ASSERT_EQ(publisher_->UnregisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                               NodeID::FromRandom(), oid.Binary()),
+            0);
+  ASSERT_EQ(publisher_->UnregisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                               NodeID::FromRandom(),
+                                               ObjectID::FromRandom().Binary()),
             0);
   ASSERT_EQ(long_polling_connection_replied, false);
   // Metadata won't be removed until we unregsiter the subscriber.
-  object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
-  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
+  publisher_->UnregisterSubscriber(subscriber_id_);
+  ASSERT_TRUE(publisher_->CheckNoLeaks());
 }
 
 // Unregistration a subscriber.
@@ -910,59 +930,55 @@ TEST_F(PublisherTest, TestUnregisterSubscriber) {
       };
 
   // Test basic.
-  const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
   ASSERT_EQ(long_polling_connection_replied, false);
-  int erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
+  int erased = publisher_->UnregisterSubscriber(subscriber_id_);
   ASSERT_TRUE(erased);
   // Make sure the long polling request is replied to avoid memory leak.
   ASSERT_EQ(long_polling_connection_replied, true);
 
   // Test when registration wasn't done.
   long_polling_connection_replied = false;
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
-  erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
+  erased = publisher_->UnregisterSubscriber(subscriber_id_);
   ASSERT_FALSE(erased);
   ASSERT_EQ(long_polling_connection_replied, true);
 
   // Test when connect wasn't done.
   long_polling_connection_replied = false;
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
-  erased = object_status_publisher_->UnregisterSubscriber(subscriber_node_id);
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
+  erased = publisher_->UnregisterSubscriber(subscriber_id_);
   ASSERT_TRUE(erased);
   ASSERT_EQ(long_polling_connection_replied, false);
-  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->CheckNoLeaks());
 }
 
 // Test if registration / unregistration is idempotent.
 TEST_F(PublisherTest, TestRegistrationIdempotency) {
-  const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
-  ASSERT_TRUE(object_status_publisher_->RegisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
-  ASSERT_FALSE(object_status_publisher_->RegisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
-  ASSERT_FALSE(object_status_publisher_->RegisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
-  ASSERT_FALSE(object_status_publisher_->RegisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
-  ASSERT_FALSE(object_status_publisher_->CheckNoLeaks());
-  ASSERT_TRUE(object_status_publisher_->UnregisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
-  ASSERT_FALSE(object_status_publisher_->UnregisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
-  ASSERT_TRUE(object_status_publisher_->CheckNoLeaks());
-  ASSERT_TRUE(object_status_publisher_->RegisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
-  ASSERT_FALSE(object_status_publisher_->CheckNoLeaks());
-  ASSERT_TRUE(object_status_publisher_->UnregisterSubscription(
-      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_node_id, oid.Binary()));
+  ASSERT_TRUE(publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                               subscriber_id_, oid.Binary()));
+  ASSERT_FALSE(publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                                subscriber_id_, oid.Binary()));
+  ASSERT_FALSE(publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                                subscriber_id_, oid.Binary()));
+  ASSERT_FALSE(publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                                subscriber_id_, oid.Binary()));
+  ASSERT_FALSE(publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->UnregisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                                 subscriber_id_, oid.Binary()));
+  ASSERT_FALSE(publisher_->UnregisterSubscription(
+      rpc::ChannelType::WORKER_OBJECT_EVICTION, subscriber_id_, oid.Binary()));
+  ASSERT_TRUE(publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                               subscriber_id_, oid.Binary()));
+  ASSERT_FALSE(publisher_->CheckNoLeaks());
+  ASSERT_TRUE(publisher_->UnregisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                                 subscriber_id_, oid.Binary()));
 }
 
 TEST_F(PublisherTest, TestPublishFailure) {
@@ -985,16 +1001,35 @@ TEST_F(PublisherTest, TestPublishFailure) {
         reply = rpc::PubsubLongPollingReply();
       };
 
-  const auto subscriber_node_id = NodeID::FromRandom();
   const auto oid = ObjectID::FromRandom();
 
-  object_status_publisher_->ConnectToSubscriber(subscriber_node_id, &reply,
-                                                send_reply_callback);
-  object_status_publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                                 subscriber_node_id, oid.Binary());
-  object_status_publisher_->PublishFailure(rpc::ChannelType::WORKER_OBJECT_EVICTION,
-                                           oid.Binary());
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
+  publisher_->RegisterSubscription(rpc::ChannelType::WORKER_OBJECT_EVICTION,
+                                   subscriber_id_, oid.Binary());
+  publisher_->PublishFailure(rpc::ChannelType::WORKER_OBJECT_EVICTION, oid.Binary());
   ASSERT_EQ(failed_ids[0], oid);
+}
+
+TEST_F(PublisherTest, TestSequenceNumber) {
+  ///
+  /// Test the sequence number API.
+  ///
+  rpc::PubsubLongPollingReply reply;
+  rpc::SendReplyCallback send_reply_callback =
+      [](Status status, std::function<void()> success, std::function<void()> failure) {};
+
+  std::vector<rpc::PubMessage> messages;
+  for (int i = 0; i < 10; ++i) {
+    messages.push_back(
+        GenerateErrorInfoMessage(absl::StrCat("id ", i), absl::StrCat("message ", i)));
+  }
+
+  publisher_->RegisterSubscription(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL,
+                                   subscriber_id_, std::nullopt);
+  publisher_->Publish(messages[0]);
+  publisher_->Publish(messages[1]);
+  publisher_->Publish(messages[2]);
+  publisher_->ConnectToSubscriber(request_, &reply, send_reply_callback);
 }
 
 }  // namespace pubsub

--- a/src/ray/pubsub/test/subscriber_test.cc
+++ b/src/ray/pubsub/test/subscriber_test.cc
@@ -59,7 +59,7 @@ class MockWorkerClient : public pubsub::SubscriberClientInterface {
     }
     auto callback = long_polling_callbacks.front();
     auto reply = rpc::PubsubLongPollingReply();
-
+    reply.set_seq(next_seq_++);
     for (const auto &object_id : object_ids) {
       auto *new_pub_message = reply.add_pub_messages();
       new_pub_message->set_key_id(object_id.Binary());
@@ -78,6 +78,7 @@ class MockWorkerClient : public pubsub::SubscriberClientInterface {
 
     auto callback = long_polling_callbacks.front();
     auto reply = rpc::PubsubLongPollingReply();
+    reply.set_seq(next_seq_++);
 
     for (const auto &object_id : object_ids) {
       auto new_pub_message = reply.add_pub_messages();
@@ -94,6 +95,7 @@ class MockWorkerClient : public pubsub::SubscriberClientInterface {
 
   ~MockWorkerClient(){};
 
+  int64_t next_seq_ = 0;
   std::deque<rpc::ClientCallback<rpc::PubsubLongPollingReply>> long_polling_callbacks;
   std::deque<rpc::ClientCallback<rpc::PubsubCommandBatchReply>> command_batch_callbacks;
   std::queue<rpc::PubsubCommandBatchRequest> requests_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently when a publisher replies to a subscriber long poll request, there is no acknowledgement of subscriber receiving the data. Also publisher immediately deletes the replied messages, regardless of whether they actually are received by the subscriber. This PR adds a sequence number to the long poll request and response, so publisher sends not-yet-received messages to the subscriber, and deletes messages already processed at the subscriber. This allows re-enabling two CI tests, and helps supporting reconnection to GCS later.

This does not fix all cases where a message can be dropped. For example, the reply from publisher could be dropped, while the subscriber does not detect connection issue or make another polling request. Then the subscriber state with sequence number can time out at the publisher (e.g. after 30s). This can be addressed in future with client timeout / deadline on polling requests.

This affects existing Ray pubsub usages. It should probably merge at least after 1.9 branch cut.

An integration test exercising publisher and subscriber together will be added when reconnection tests are fixed. They can be added in this PR too if desired.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
