### PR TITLE
[runtime env] Revert reference counting for per-actor URIs

### DIFF
--- a/python/ray/tests/test_runtime_env_conda.py
+++ b/python/ray/tests/test_runtime_env_conda.py
@@ -123,7 +123,8 @@ def test_detached_actor_gc(start_cluster, field, spec_format, tmp_path):
 
     wait_for_condition(lambda: check_local_files_gced(cluster), timeout=30)
 
-
+# TODO(architkulkarni): fix bug #19602 and enable test.
+@pytest.mark.skip("Currently failing")
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="Requires PR wheels built in CI, so only run on linux CI machines.")

--- a/python/ray/tests/test_runtime_env_conda.py
+++ b/python/ray/tests/test_runtime_env_conda.py
@@ -123,6 +123,7 @@ def test_detached_actor_gc(start_cluster, field, spec_format, tmp_path):
 
     wait_for_condition(lambda: check_local_files_gced(cluster), timeout=30)
 
+
 # TODO(architkulkarni): fix bug #19602 and enable test.
 @pytest.mark.skip("Currently failing")
 @pytest.mark.skipif(

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -317,6 +317,7 @@ def test_job_level_gc(start_cluster, option: str, source: str):
     wait_for_condition(check_internal_kv_gced)
     wait_for_condition(lambda: check_local_files_gced(cluster))
 
+
 # TODO(architkulkarni): fix bug #19602 and enable test.
 @pytest.mark.skip("Currently failing.")
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -317,7 +317,8 @@ def test_job_level_gc(start_cluster, option: str, source: str):
     wait_for_condition(check_internal_kv_gced)
     wait_for_condition(lambda: check_local_files_gced(cluster))
 
-
+# TODO(architkulkarni): fix bug #19602 and enable test.
+@pytest.mark.skip("Currently failing.")
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 def test_actor_level_gc(start_cluster, option: str):

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -397,10 +397,11 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
     // This actor is owned. Send a long polling request to the actor's
     // owner to determine when the actor should be removed.
     PollOwnerForActorOutOfScope(actor);
+  } else {
+    // If it's a detached actor, we need to register the runtime env it used to GC.
+    runtime_env_manager_.AddURIReference(actor->GetActorID().Hex(),
+                                         request.task_spec().runtime_env());
   }
-
-  runtime_env_manager_.AddURIReference(actor->GetActorID().Hex(),
-                                       request.task_spec().runtime_env());
 
   // The backend storage is supposed to be reliable, so the status must be ok.
   RAY_CHECK_OK(gcs_table_storage_->ActorTable().Put(
@@ -627,12 +628,10 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id) {
   // Clean up the client to the actor's owner, if necessary.
   if (!actor->IsDetached()) {
     RemoveActorFromOwner(actor);
+  } else {
+    runtime_env_manager_.RemoveURIReference(actor->GetActorID().Hex());
   }
-
-  runtime_env_manager_.RemoveURIReference(actor->GetActorID().Hex());
-
   RemoveActorNameFromRegistry(actor);
-
   // The actor is already dead, most likely due to process or node failure.
   if (actor->GetState() == rpc::ActorTableData::DEAD) {
     RAY_LOG(DEBUG) << "Actor " << actor->GetActorID() << "has been dead,"

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1256,7 +1256,9 @@ void NodeManager::DisconnectClient(
         cluster_task_manager_->TaskFinished(worker, &task);
       }
 
-      runtime_env_manager_.RemoveURIReference(actor_id.Hex());
+      if (worker->IsDetachedActor()) {
+        runtime_env_manager_.RemoveURIReference(actor_id.Hex());
+      }
 
       if (disconnect_type == rpc::WorkerExitType::SYSTEM_ERROR_EXIT) {
         // Push the error to driver.
@@ -1948,10 +1950,9 @@ void NodeManager::FinishAssignedActorCreationTask(WorkerInterface &worker,
     auto job_id = task.GetTaskSpecification().JobId();
     auto job_config = worker_pool_.GetJobConfig(job_id);
     RAY_CHECK(job_config);
+    runtime_env_manager_.AddURIReference(actor_id.Hex(),
+                                         task.GetTaskSpecification().RuntimeEnv());
   }
-
-  runtime_env_manager_.AddURIReference(actor_id.Hex(),
-                                       task.GetTaskSpecification().RuntimeEnv());
 }
 
 void NodeManager::HandleObjectLocal(const ObjectInfo &object_info) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Reverts https://github.com/ray-project/ray/pull/20165 which couldn't be automatically reverted.  That PR broke the release test `rte_many_tasks_actors`, bisection details here: https://buildkite.com/ray-project/periodic-ci/builds/1601#_

The root cause is probably the following:

- Tasks are run with certain runtime envs, requiring new workers to be started, and some of the workers with those environments stick around after the tasks are finished. (There's some delay in pruning the extra workers that go above the soft cap.)
- Later, an actor is run with an runtime env.  When the actor exits, we delete the conda environment for this runtime env (the refcount is zero because we don't count references for workers or tasks).  
- Finally, a child task of a different actor gets scheduled on an old worker whose conda environment was unknowingly deleted when the actor exited.  This causes the `ModuleNotFoundError`.

The way to do the GC properly for actors and tasks is probably to reference count based on workers, not based on actors or tasks.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
