### PR TITLE
[Java] Add timeout parameter for `Ray.get()` API.

### DIFF
--- a/doc/source/walkthrough.rst
+++ b/doc/source/walkthrough.rst
@@ -486,6 +486,8 @@ If the current node's object store does not contain the object, the object is do
       // Get the value of one object ref.
       ObjectRef<Integer> objRef = Ray.put(1);
       Assert.assertTrue(objRef.get() == 1);
+      // You can also set a timeout(ms) to return early from a ``get`` that's blocking for too long.
+      Assert.assertTrue(objRef.get(1000) == 1);
 
       // Get the values of multiple object refs in parallel.
       List<ObjectRef<Integer>> objectRefs = new ArrayList<>();
@@ -494,6 +496,16 @@ If the current node's object store does not contain the object, the object is do
       }
       List<Integer> results = Ray.get(objectRefs);
       Assert.assertEquals(results, ImmutableList.of(0, 1, 2));
+
+      // Ray.get timeout example: Ray.get will throw an RayTimeoutException if time out.
+      public class MyRayApp {
+        public static int slowFunction() throws InterruptedException {
+          TimeUnit.SECONDS.sleep(10);
+          return 1;
+        }
+      }
+      Assert.assertThrows(RayTimeoutException.class, 
+        () -> Ray.get(Ray.task(MyRayApp::slowFunction).remote(), 3000));
 
   .. group-tab:: C++
 

--- a/java/api/src/main/java/io/ray/api/ObjectRef.java
+++ b/java/api/src/main/java/io/ray/api/ObjectRef.java
@@ -12,4 +12,12 @@ public interface ObjectRef<T> {
    * available.
    */
   T get();
+
+  /**
+   * Fetch the object from the object store, this method will block until the object is locally
+   * available.
+   *
+   * @param timeoutMs The maximum amount of time in miliseconds to wait before returning.
+   */
+  T get(long timeoutMs);
 }

--- a/java/api/src/main/java/io/ray/api/Ray.java
+++ b/java/api/src/main/java/io/ray/api/Ray.java
@@ -81,10 +81,32 @@ public final class Ray extends RayCall {
    * Get an object by `ObjectRef` from the object store.
    *
    * @param objectRef The reference of the object to get.
+   * @param timeoutMs The maximum amount of time in miliseconds to wait before returning.
+   * @return The Java object.
+   */
+  public static <T> T get(ObjectRef<T> objectRef, long timeoutMs) {
+    return internal().get(objectRef, timeoutMs);
+  }
+
+  /**
+   * Get an object by `ObjectRef` from the object store.
+   *
+   * @param objectRef The reference of the object to get.
    * @return The Java object.
    */
   public static <T> T get(ObjectRef<T> objectRef) {
     return internal().get(objectRef);
+  }
+
+  /**
+   * Get a list of objects by `ObjectRef`s from the object store.
+   *
+   * @param objectList A list of object references.
+   * @param timeoutMs The maximum amount of time in miliseconds to wait before returning.
+   * @return A list of Java objects.
+   */
+  public static <T> List<T> get(List<ObjectRef<T>> objectList, long timeoutMs) {
+    return internal().get(objectList, timeoutMs);
   }
 
   /**

--- a/java/api/src/main/java/io/ray/api/runtime/RayRuntime.java
+++ b/java/api/src/main/java/io/ray/api/runtime/RayRuntime.java
@@ -67,6 +67,24 @@ public interface RayRuntime {
   <T> List<T> get(List<ObjectRef<T>> objectRefs);
 
   /**
+   * Get an object from the object store.
+   *
+   * @param objectRef The reference of the object to get.
+   * @param timeoutMs The maximum amount of time in millseconds to wait before returning.
+   * @return The Java object.
+   */
+  <T> T get(ObjectRef<T> objectRef, long timeoutMs);
+
+  /**
+   * Get a list of objects from the object store.
+   *
+   * @param objectRefs The list of object references.
+   * @param timeoutMs The maximum amount of time in millseconds to wait before returning.
+   * @return A list of Java objects.
+   */
+  <T> List<T> get(List<ObjectRef<T>> objectRefs, long timeoutMs);
+
+  /**
    * Wait for a list of RayObjects to be available, until specified number of objects are ready, or
    * specified timeout has passed.
    *

--- a/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
@@ -93,12 +93,22 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
 
   @Override
   public <T> T get(ObjectRef<T> objectRef) throws RuntimeException {
-    List<T> ret = get(ImmutableList.of(objectRef));
+    return get(objectRef, -1);
+  }
+
+  @Override
+  public <T> T get(ObjectRef<T> objectRef, long timeoutMs) throws RuntimeException {
+    List<T> ret = get(ImmutableList.of(objectRef), timeoutMs);
     return ret.get(0);
   }
 
   @Override
   public <T> List<T> get(List<ObjectRef<T>> objectRefs) {
+    return get(objectRefs, -1);
+  }
+
+  @Override
+  public <T> List<T> get(List<ObjectRef<T>> objectRefs, long timeoutMs) {
     List<ObjectId> objectIds = new ArrayList<>();
     Class<T> objectType = null;
     for (ObjectRef<T> o : objectRefs) {
@@ -107,7 +117,7 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
       objectType = objectRefImpl.getType();
     }
     LOGGER.debug("Getting Objects {}.", objectIds);
-    return objectStore.get(objectIds, objectType);
+    return objectStore.get(objectIds, objectType, timeoutMs);
   }
 
   @Override

--- a/java/runtime/src/main/java/io/ray/runtime/exception/RayTimeoutException.java
+++ b/java/runtime/src/main/java/io/ray/runtime/exception/RayTimeoutException.java
@@ -1,0 +1,12 @@
+package io.ray.runtime.exception;
+
+/** Indicate that there are some thing have timed out, including `Ray.get()` or others. */
+public class RayTimeoutException extends RayException {
+  public RayTimeoutException(String message) {
+    super(message);
+  }
+
+  public RayTimeoutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/runtime/src/main/java/io/ray/runtime/object/LocalModeObjectStore.java
+++ b/java/runtime/src/main/java/io/ray/runtime/object/LocalModeObjectStore.java
@@ -5,6 +5,7 @@ import io.ray.api.id.ActorId;
 import io.ray.api.id.ObjectId;
 import io.ray.api.id.UniqueId;
 import io.ray.runtime.context.WorkerContext;
+import io.ray.runtime.exception.RayTimeoutException;
 import io.ray.runtime.generated.Common.Address;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,6 +64,9 @@ public class LocalModeObjectStore extends ObjectStore {
   @Override
   public List<NativeRayObject> getRaw(List<ObjectId> objectIds, long timeoutMs) {
     waitInternal(objectIds, objectIds.size(), timeoutMs);
+    if (timeoutMs >= 0 && objectIds.stream().filter(pool::containsKey).count() < objectIds.size()) {
+      throw new RayTimeoutException("Get timed out: some object(s) not ready.");
+    }
     return objectIds.stream().map(pool::get).collect(Collectors.toList());
   }
 

--- a/java/runtime/src/main/java/io/ray/runtime/object/ObjectRefImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/object/ObjectRefImpl.java
@@ -45,6 +45,11 @@ public final class ObjectRefImpl<T> implements ObjectRef<T>, Externalizable {
     return Ray.get(this);
   }
 
+  @Override
+  public synchronized T get(long timeoutMs) {
+    return Ray.get(this, timeoutMs);
+  }
+
   public ObjectId getId() {
     return id;
   }

--- a/java/runtime/src/main/java/io/ray/runtime/object/ObjectStore.java
+++ b/java/runtime/src/main/java/io/ray/runtime/object/ObjectStore.java
@@ -114,8 +114,20 @@ public abstract class ObjectStore {
    */
   @SuppressWarnings("unchecked")
   public <T> List<T> get(List<ObjectId> ids, Class<?> elementType) {
-    // Pass -1 as timeout to wait until all objects are available in object store.
-    List<NativeRayObject> dataAndMetaList = getRaw(ids, -1);
+    return get(ids, elementType, -1);
+  }
+
+  /**
+   * Get a list of objects from the object store.
+   *
+   * @param ids List of the object ids.
+   * @param <T> Type of these objects.
+   * @param timeoutMs The maximum amount of time in seconds to wait before returning.
+   * @return A list of GetResult objects.
+   */
+  @SuppressWarnings("unchecked")
+  public <T> List<T> get(List<ObjectId> ids, Class<?> elementType, long timeoutMs) {
+    List<NativeRayObject> dataAndMetaList = getRaw(ids, timeoutMs);
 
     List<T> results = new ArrayList<>();
     for (int i = 0; i < dataAndMetaList.size(); i++) {

--- a/java/test/src/main/java/io/ray/test/GetTimeoutTest.java
+++ b/java/test/src/main/java/io/ray/test/GetTimeoutTest.java
@@ -1,0 +1,80 @@
+package io.ray.test;
+
+import io.ray.api.ActorHandle;
+import io.ray.api.ObjectRef;
+import io.ray.api.Ray;
+import io.ray.runtime.exception.RayTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class GetTimeoutTest extends BaseTest {
+
+  public static int squareDelay(int x) {
+    try {
+      Thread.sleep(5 * 1000);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return x * x;
+  }
+
+  public static class Counter {
+
+    private int value;
+
+    public Counter(int initValue) {
+      this.value = initValue;
+    }
+
+    public int getValueDelay() {
+      try {
+        Thread.sleep(5 * 1000);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      return value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
+
+  public void testActorTaskGetTimeout() {
+    ActorHandle<Counter> actor = Ray.actor(Counter::new, 1).remote();
+    Assert.assertEquals(Integer.valueOf(1), actor.task(Counter::getValueDelay).remote().get());
+    Assert.assertEquals(Integer.valueOf(1), actor.task(Counter::getValueDelay).remote().get(10000));
+
+    long startTime = System.currentTimeMillis();
+    long timeout = 2000;
+    Assert.assertThrows(
+        RayTimeoutException.class,
+        () -> Ray.get(actor.task(Counter::getValueDelay).remote(), timeout));
+    long waitTime = System.currentTimeMillis() - startTime;
+    Assert.assertTrue(Math.abs(waitTime - timeout) < 1500);
+  }
+
+  public void testNormalTaskGetTimeout() {
+    List<ObjectRef<Integer>> objectRefList = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      objectRefList.add(Ray.task(GetTimeoutTest::squareDelay, i).remote());
+    }
+    long startTime = System.currentTimeMillis();
+    long timeout = 2000;
+    Assert.assertThrows(RayTimeoutException.class, () -> Ray.get(objectRefList, timeout));
+    long waitTime = System.currentTimeMillis() - startTime;
+    Assert.assertTrue(Math.abs(waitTime - timeout) < 1500);
+    Assert.assertEquals(Ray.get(objectRefList, 10000).toArray(), new int[] {0, 1, 4, 9});
+    Assert.assertEquals(Ray.get(objectRefList).toArray(), new int[] {0, 1, 4, 9});
+  }
+
+  public void testObjectGetTimeout() {
+    int y = 1;
+    ObjectRef<Integer> objectRef = Ray.put(y);
+    Assert.assertTrue(Ray.get(objectRef) == 1);
+    Assert.assertTrue(Ray.get(objectRef, 2000) == 1);
+  }
+}

--- a/src/ray/core_worker/lib/java/jni_init.cc
+++ b/src/ray/core_worker/lib/java/jni_init.cc
@@ -59,6 +59,7 @@ jmethodID java_system_gc;
 
 jclass java_ray_exception_class;
 jclass java_ray_intentional_system_exit_exception_class;
+jclass java_ray_timeout_exception_class;
 
 jclass java_ray_actor_exception_class;
 jmethodID java_ray_exception_to_bytes;
@@ -210,6 +211,9 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
   java_ray_exception_class = LoadClass(env, "io/ray/runtime/exception/RayException");
   java_ray_intentional_system_exit_exception_class =
       LoadClass(env, "io/ray/runtime/exception/RayIntentionalSystemExitException");
+
+  java_ray_timeout_exception_class =
+      LoadClass(env, "io/ray/runtime/exception/RayTimeoutException");
 
   java_ray_actor_exception_class =
       LoadClass(env, "io/ray/runtime/exception/RayActorException");
@@ -363,6 +367,7 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
   env->DeleteGlobalRef(java_system_class);
   env->DeleteGlobalRef(java_ray_exception_class);
   env->DeleteGlobalRef(java_ray_intentional_system_exit_exception_class);
+  env->DeleteGlobalRef(java_ray_timeout_exception_class);
   env->DeleteGlobalRef(java_ray_actor_exception_class);
   env->DeleteGlobalRef(java_jni_exception_util_class);
   env->DeleteGlobalRef(java_base_id_class);

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -110,6 +110,9 @@ extern jclass java_ray_intentional_system_exit_exception_class;
 /// RayActorCreationTaskException class
 extern jclass java_ray_actor_exception_class;
 
+/// RayTimeoutException class
+extern jclass java_ray_timeout_exception_class;
+
 /// toBytes method of RayException
 extern jmethodID java_ray_exception_to_bytes;
 
@@ -251,12 +254,16 @@ extern jmethodID java_resource_value_init;
 extern JavaVM *jvm;
 
 /// Throws a Java RayException if the status is not OK.
-#define THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, ret)               \
-  {                                                                          \
-    if (!(status).ok()) {                                                    \
-      (env)->ThrowNew(java_ray_exception_class, (status).message().c_str()); \
-      return (ret);                                                          \
-    }                                                                        \
+#define THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, ret)                         \
+  {                                                                                    \
+    if (!(status).ok()) {                                                              \
+      if (status.IsTimedOut()) {                                                       \
+        (env)->ThrowNew(java_ray_timeout_exception_class, (status).message().c_str()); \
+      } else {                                                                         \
+        (env)->ThrowNew(java_ray_exception_class, (status).message().c_str());         \
+      }                                                                                \
+      return (ret);                                                                    \
+    }                                                                                  \
   }
 
 #define RAY_CHECK_JAVA_EXCEPTION(env)                                                 \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

add timeout(ms) param for Java ray.get. The API changes have been updated to doc ([Ray Core Walkthrough]->[Fetching Results]).
eg:
```
ObjectRef<Integer> objRef = Ray.put(1);
objRef.get(1000) 
Ray.get(Ray.task(MyRayApp::slowFunction).remote(), 3000)
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
[Ray java api] Java api Ray.get support timeout param #20247 


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
