### PR TITLE
[Tune] Revert "remove pg caching"

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -304,7 +304,7 @@ py_test(
 
 py_test(
     name = "test_trial_scheduler_pbt",
-    size = "large",
+    size = "medium",
     srcs = ["tests/test_trial_scheduler_pbt.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive", "flaky", "tests_dir_T"],
@@ -397,7 +397,7 @@ py_test(
 
 py_test(
     name = "blendsearch_example",
-    size = "medium",
+    size = "small",
     srcs = ["examples/blendsearch_example.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive", "example"],

--- a/python/ray/tune/examples/xgboost_dynamic_resources_example.py
+++ b/python/ray/tune/examples/xgboost_dynamic_resources_example.py
@@ -220,7 +220,7 @@ def tune_xgboost(use_class_trainable=True):
             total_available_cpus // len(trial_runner.get_live_trials()))
 
         # Assign new CPUs to the trial in a PlacementGroupFactory
-        return PlacementGroupFactory([{"CPU": cpu_to_use, "GPU": 0}])
+        return PlacementGroupFactory([{"CPU": cpu_to_use}])
 
     # You can either define your own resources_allocation_function, or
     # use the default one - evenly_distribute_cpus_gpus

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -503,12 +503,20 @@ class RayTrialExecutor(TrialExecutor):
                         logger.exception(
                             "Trial %s: updating resources timed out.", trial)
 
-    def _stop_trial(self, trial: Trial, error=False, error_msg=None):
+    def _stop_trial(self,
+                    trial: Trial,
+                    error=False,
+                    error_msg=None,
+                    destroy_pg_if_cannot_replace=True):
         """Stops this trial.
 
         Stops this trial, releasing all allocating resources. If stopping the
         trial fails, the run will be marked as terminated in error, but no
         exception will be thrown.
+
+        If the placement group will be used right away
+        (destroy_pg_if_cannot_replace=False), we do not remove its placement
+        group (or a surrogate placement group).
 
         Args:
             error (bool): Whether to mark this trial as terminated in error.
@@ -548,7 +556,8 @@ class RayTrialExecutor(TrialExecutor):
                     logger.debug("Trial %s: Destroying actor.", trial)
 
                     # Try to return the placement group for other trials to use
-                    self._pg_manager.return_pg(trial)
+                    self._pg_manager.return_pg(trial,
+                                               destroy_pg_if_cannot_replace)
 
                     with self._change_working_directory(trial):
                         self._trial_cleanup.add(trial, actor=trial.runner)
@@ -606,9 +615,18 @@ class RayTrialExecutor(TrialExecutor):
     def stop_trial(self,
                    trial: Trial,
                    error: bool = False,
-                   error_msg: Optional[str] = None) -> None:
+                   error_msg: Optional[str] = None,
+                   destroy_pg_if_cannot_replace: bool = True) -> None:
+        """Only returns resources if resources allocated.
+
+        If destroy_pg_if_cannot_replace is False, the Trial placement group
+        will not be removed if it can't replace any staging ones."""
         prior_status = trial.status
-        self._stop_trial(trial, error=error, error_msg=error_msg)
+        self._stop_trial(
+            trial,
+            error=error,
+            error_msg=error_msg,
+            destroy_pg_if_cannot_replace=destroy_pg_if_cannot_replace)
         if prior_status == Trial.RUNNING:
             logger.debug("Trial %s: Returning resources.", trial)
             out = self._find_item(self._running, trial)

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -590,7 +590,8 @@ class PopulationBasedTraining(FIFOScheduler):
             else:
                 # Stop trial, but do not free resources (so we can use them
                 # again right away)
-                trial_executor.stop_trial(trial)
+                trial_executor.stop_trial(
+                    trial, destroy_pg_if_cannot_replace=False)
                 trial.set_experiment_tag(new_tag)
                 trial.set_config(new_config)
 
@@ -820,7 +821,8 @@ class PopulationBasedTrainingReplay(FIFOScheduler):
         if reset_successful:
             trial_executor.restore(trial, checkpoint, block=True)
         else:
-            trial_executor.stop_trial(trial)
+            trial_executor.stop_trial(
+                trial, destroy_pg_if_cannot_replace=False)
             trial.set_experiment_tag(new_tag)
             trial.set_config(new_config)
             trial_executor.start_trial(trial, checkpoint, train=False)

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -313,6 +313,7 @@ def test_trial_migration(start_connected_emptyhead_cluster, trainable_id):
     with pytest.raises(TuneError):
         runner.step()
 
+
 # TODO(xwjiang): Uncomment this when pg caching is removed.
 # @pytest.mark.parametrize("trainable_id", ["__fake", "__fake_durable"])
 # def test_trial_requeue(start_connected_emptyhead_cluster, trainable_id):

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -313,49 +313,49 @@ def test_trial_migration(start_connected_emptyhead_cluster, trainable_id):
     with pytest.raises(TuneError):
         runner.step()
 
-
-@pytest.mark.parametrize("trainable_id", ["__fake", "__fake_durable"])
-def test_trial_requeue(start_connected_emptyhead_cluster, trainable_id):
-    """Removing a node in full cluster causes Trial to be requeued."""
-    os.environ["TUNE_MAX_PENDING_TRIALS_PG"] = "1"
-
-    cluster = start_connected_emptyhead_cluster
-    node = cluster.add_node(num_cpus=1)
-    cluster.wait_for_nodes()
-
-    syncer_callback = _PerTrialSyncerCallback(
-        lambda trial: trial.trainable_name == "__fake")
-    runner = TrialRunner(
-        BasicVariantGenerator(), callbacks=[syncer_callback])  # noqa
-    kwargs = {
-        "stopping_criterion": {
-            "training_iteration": 5
-        },
-        "checkpoint_freq": 1,
-        "max_failures": 1,
-    }
-
-    if trainable_id == "__fake_durable":
-        kwargs["remote_checkpoint_dir"] = MOCK_REMOTE_DIR
-
-    trials = [Trial(trainable_id, **kwargs), Trial(trainable_id, **kwargs)]
-    for t in trials:
-        runner.add_trial(t)
-
-    runner.step()  # Start trial
-    runner.step()  # Process result, dispatch save
-    runner.step()  # Process save
-
-    running_trials = _get_running_trials(runner)
-    assert len(running_trials) == 1
-    assert _check_trial_running(running_trials[0])
-    cluster.remove_node(node)
-    cluster.wait_for_nodes()
-    time.sleep(0.1)  # Sleep so that next step() refreshes cluster resources
-    runner.step()  # Process result, dispatch save
-    runner.step()  # Process save (detect error), requeue trial
-    assert all(
-        t.status == Trial.PENDING for t in trials), runner.debug_string()
+# TODO(xwjiang): Uncomment this when pg caching is removed.
+# @pytest.mark.parametrize("trainable_id", ["__fake", "__fake_durable"])
+# def test_trial_requeue(start_connected_emptyhead_cluster, trainable_id):
+#     """Removing a node in full cluster causes Trial to be requeued."""
+#     os.environ["TUNE_MAX_PENDING_TRIALS_PG"] = "1"
+#
+#     cluster = start_connected_emptyhead_cluster
+#     node = cluster.add_node(num_cpus=1)
+#     cluster.wait_for_nodes()
+#
+#     syncer_callback = _PerTrialSyncerCallback(
+#         lambda trial: trial.trainable_name == "__fake")
+#     runner = TrialRunner(
+#         BasicVariantGenerator(), callbacks=[syncer_callback])  # noqa
+#     kwargs = {
+#         "stopping_criterion": {
+#             "training_iteration": 5
+#         },
+#         "checkpoint_freq": 1,
+#         "max_failures": 1,
+#     }
+#
+#     if trainable_id == "__fake_durable":
+#         kwargs["remote_checkpoint_dir"] = MOCK_REMOTE_DIR
+#
+#     trials = [Trial(trainable_id, **kwargs), Trial(trainable_id, **kwargs)]
+#     for t in trials:
+#         runner.add_trial(t)
+#
+#     runner.step()  # Start trial
+#     runner.step()  # Process result, dispatch save
+#     runner.step()  # Process save
+#
+#     running_trials = _get_running_trials(runner)
+#     assert len(running_trials) == 1
+#     assert _check_trial_running(running_trials[0])
+#     cluster.remove_node(node)
+#     cluster.wait_for_nodes()
+#     time.sleep(0.1)  # Sleep so that next step() refreshes cluster resources
+#     runner.step()  # Process result, dispatch save
+#     runner.step()  # Process save (detect error), requeue trial
+#     assert all(
+#         t.status == Trial.PENDING for t in trials), runner.debug_string()
 
 
 @pytest.mark.parametrize("trainable_id", ["__fake_remote", "__fake_durable"])

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -225,7 +225,11 @@ class _MockTrialExecutor(TrialExecutor):
         trial.status = Trial.RUNNING
         return True
 
-    def stop_trial(self, trial, error=False, error_msg=None):
+    def stop_trial(self,
+                   trial,
+                   error=False,
+                   error_msg=None,
+                   destroy_pg_if_cannot_replace=True):
         trial.status = Trial.ERROR if error else Trial.TERMINATED
 
     def restore(self, trial, checkpoint=None, block=False):
@@ -1875,9 +1879,6 @@ class E2EPopulationBasedTestingSuite(unittest.TestCase):
                     f.write("OK")
                 return checkpoint
 
-            def reset_config(self, config):
-                return True
-
         trial_hyperparams = {
             "float_factor": 2.0,
             "const_factor": 3,
@@ -1912,9 +1913,6 @@ class E2EPopulationBasedTestingSuite(unittest.TestCase):
 
             def load_checkpoint(self, state):
                 self.state = state
-
-            def reset_config(self, config):
-                return True
 
         trial_hyperparams = {
             "float_factor": 2.0,

--- a/python/ray/tune/tests/test_trial_scheduler_pbt.py
+++ b/python/ray/tune/tests/test_trial_scheduler_pbt.py
@@ -64,10 +64,6 @@ class PopulationBasedTrainingMemoryTest(unittest.TestCase):
                 with open(path, "rb") as fp:
                     self.large_object, self.iter, self.a = pickle.load(fp)
 
-            def reset_config(self, new_config):
-                self.a = new_config["a"]
-                return True
-
         class CustomExecutor(RayTrialExecutor):
             def save(self, *args, **kwargs):
                 checkpoint = super(CustomExecutor, self).save(*args, **kwargs)
@@ -126,10 +122,6 @@ class PopulationBasedTrainingFileDescriptorTest(unittest.TestCase):
                 with open(path, "rb") as fp:
                     self.iter, self.a = pickle.load(fp)
 
-            def reset_config(self, new_config):
-                self.a = new_config["a"]
-                return True
-
         from ray.tune.callback import Callback
 
         class FileCheck(Callback):
@@ -182,6 +174,7 @@ class PopulationBasedTrainingFileDescriptorTest(unittest.TestCase):
 class PopulationBasedTrainingSynchTest(unittest.TestCase):
     def setUp(self):
         os.environ["TUNE_TRIAL_STARTUP_GRACE_PERIOD"] = "0"
+        os.environ["TUNE_TRIAL_RESULT_WAIT_TIME_S"] = "99999"
         ray.init(num_cpus=2)
 
         def MockTrainingFuncSync(config, checkpoint_dir=None):
@@ -217,7 +210,7 @@ class PopulationBasedTrainingSynchTest(unittest.TestCase):
 
     def synchSetup(self, synch, param=None):
         if param is None:
-            param = [10, 20, 40]
+            param = [10, 20, 30]
 
         scheduler = PopulationBasedTraining(
             time_attr="training_iteration",
@@ -251,14 +244,14 @@ class PopulationBasedTrainingSynchTest(unittest.TestCase):
         self.assertTrue(
             any(
                 analysis.dataframe(metric="mean_accuracy", mode="max")
-                ["mean_accuracy"] != 43))
+                ["mean_accuracy"] != 33))
 
     def testSynchPass(self):
         analysis = self.synchSetup(True)
         self.assertTrue(
             all(
                 analysis.dataframe(metric="mean_accuracy", mode="max")[
-                    "mean_accuracy"] == 43))
+                    "mean_accuracy"] == 33))
 
     def testSynchPassLast(self):
         analysis = self.synchSetup(True, param=[30, 20, 10])
@@ -348,12 +341,6 @@ class PopulationBasedTrainingResumeTest(unittest.TestCase):
                                                "model.mock")
                 with open(checkpoint_path, "rb") as fp:
                     self.a, self.b, self.iter = pickle.load(fp)
-
-            def reset_config(self, new_config):
-                self.a = new_config["a"]
-                self.b = new_config["b"]
-                self.c = new_config["c"]
-                return True
 
         scheduler = PopulationBasedTraining(
             time_attr="training_iteration",

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -205,7 +205,8 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
     def stop_trial(self,
                    trial: Trial,
                    error: bool = False,
-                   error_msg: Optional[str] = None) -> None:
+                   error_msg: Optional[str] = None,
+                   destroy_pg_if_cannot_replace: bool = True) -> None:
         """Stops the trial.
 
         Stops this trial, releasing all allocating resources.
@@ -215,6 +216,8 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         Args:
             error (bool): Whether to mark this trial as terminated in error.
             error_msg (str): Optional error message.
+            destroy_pg_if_cannot_replace (bool): Whether the trial's placement
+            group should be destroyed if it cannot replace any staged ones.
 
         """
         pass

--- a/python/ray/tune/utils/placement_groups.py
+++ b/python/ray/tune/utils/placement_groups.py
@@ -596,17 +596,37 @@ class PlacementGroupManager:
         self._ready[pgf].add(pg)
         return True
 
-    def return_pg(self, trial: "Trial"):
-        """Return pg back to Core scheduling.
+    def return_pg(self,
+                  trial: "Trial",
+                  destroy_pg_if_cannot_replace: bool = True):
+        """Return pg, making it available for other trials to use.
+
+        If destroy_pg_if_cannot_replace is True, this will only return
+        a placement group if a staged placement group can be replaced
+        by it. If not, it will destroy the placement group.
 
         Args:
             trial (Trial): Return placement group of this trial.
-        """
 
+        Returns:
+            Boolean indicating if the placement group was returned.
+        """
+        pgf = trial.placement_group_factory
         pg = self._in_use_trials.pop(trial)
         self._in_use_pgs.pop(pg)
 
-        self.remove_pg(pg)
+        if destroy_pg_if_cannot_replace:
+            staged_pg = self._unstage_unused_pg(pgf)
+
+            # Could not replace
+            if not staged_pg:
+                self.remove_pg(pg)
+                return False
+
+            self.remove_pg(staged_pg)
+        self._ready[pgf].add(pg)
+
+        return True
 
     def _unstage_unused_pg(
             self, pgf: PlacementGroupFactory) -> Optional[PlacementGroup]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some pbt workflow relies on a trial to be stopped and then started again with new config in *one tune loop*. If that doesn't happen, tuning will fail. This was ok with pg caching. Without pg caching, this becomes problematic as new pg is not staged at the time when new trial is supposed to start. 

See Kai's comment (sorry I didn't quite get it at that time): https://github.com/ray-project/ray/pull/19515#discussion_r748096554

The plan is:
1. revert the offending change. 
2. scope out an incremental step towards "pending trial queue" abstraction that we talked about in this [doc](https://docs.google.com/document/d/13vKXZ7bZVnMOMFqjsF555zrZjC8og4JSHSLcOx8t8nI/edit) to unblock "remove pg caching". Also as Kai mentioned one time, we should avoid PbtScheduler talking to Executor directly but rather it should go through the runner API.
3. re-land the PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/20304
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
