### PR TITLE
[GCP] Filter GCP TPUs by cluster name, matching behavior for GCP compute nodes.

### DIFF
--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -527,8 +527,8 @@ class GCPTPU(GCPResource):
 
         # same logic as in GCPCompute.list_instances
         label_filters = label_filters or {}
-
         label_filters[TAG_RAY_CLUSTER_NAME] = self.cluster_name
+
         def filter_instance(instance: GCPTPUNode) -> bool:
             if instance.is_terminated():
                 return False

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -526,6 +526,9 @@ class GCPTPU(GCPResource):
         # so we need to filter the results ourselves
 
         # same logic as in GCPCompute.list_instances
+        if not label_filters:
+            label_filters = {}
+        label_filters[TAG_RAY_CLUSTER_NAME] = self.cluster_name
         def filter_instance(instance: GCPTPUNode) -> bool:
             if instance.is_terminated():
                 return False

--- a/python/ray/autoscaler/_private/gcp/node.py
+++ b/python/ray/autoscaler/_private/gcp/node.py
@@ -526,8 +526,8 @@ class GCPTPU(GCPResource):
         # so we need to filter the results ourselves
 
         # same logic as in GCPCompute.list_instances
-        if not label_filters:
-            label_filters = {}
+        label_filters = label_filters or {}
+
         label_filters[TAG_RAY_CLUSTER_NAME] = self.cluster_name
         def filter_instance(instance: GCPTPUNode) -> bool:
             if instance.is_terminated():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray currently does not filter GCP TPU nodes based on the cluster name, resulting in conflicts when multiple ray clusters are running on the same GCP account.

This change updates the TPU behavior to match the GCP compute node behavior, i.e. filtering to TPU nodes for the current cluster.

## Related issue number

https://github.com/ray-project/ray/issues/20286

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
