### PR TITLE
[docs] Add pyarrow as a dependency to docs

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -12,6 +12,7 @@ scikit-image
 pandas
 pickle5
 pillow
+pyarrow
 pydantic
 pygments
 pyyaml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes
```
WARNING: autodoc: failed to import class 'extensions.tensor_extension.TensorDtype' from module 'ray.data'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'extensions.tensor_extension.TensorArray' from module 'ray.data'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'extensions.tensor_extension.ArrowTensorType' from module 'ray.data'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'extensions.tensor_extension.ArrowTensorArray' from module 'ray.data'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayParams' from module 'lightgbm_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayDMatrix' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import function 'train' from module 'lightgbm_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import function 'predict' from module 'lightgbm_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayLGBMClassifier' from module 'lightgbm_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayLGBMRegressor' from module 'lightgbm_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayParams' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayDMatrix' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import function 'train' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import function 'predict' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayXGBClassifier' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayXGBRegressor' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayXGBRFClassifier' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
WARNING: autodoc: failed to import class 'RayXGBRFRegressor' from module 'xgboost_ray'; the following exception was raised:
No module named 'pyarrow'
looking for now-outdated files... none found
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
