### PR TITLE
[train] fix Train/Tune integration on Client

### DIFF
--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -22,8 +22,7 @@ from ray.train.constants import TUNE_INSTALLED, DEFAULT_RESULTS_DIR, \
 # Ray Train should be usable even if Tune is not installed.
 from ray.train.utils import construct_path
 from ray.train.worker_group import WorkerGroup
-from ray.util.ml_utils.node import force_on_current_node, \
-    get_current_node_resource_key
+from ray.util.ml_utils.node import force_on_current_node
 
 if TUNE_INSTALLED:
     from ray import tune
@@ -150,8 +149,11 @@ class Trainer:
 
         if not ray.is_initialized():
             ray.init()
-        # Assign BackendExecutor to head node.
-        remote_executor = force_on_current_node(remote_executor)
+        if not self._is_tune_enabled():
+            # Assign BackendExecutor to head node.
+            # This is needed for Ray Client mode to support fault tolerance.
+            # This is not needed in Tune as the Trial will be on the cluster.
+            remote_executor = force_on_current_node(remote_executor)
 
         self._backend_executor_actor = remote_executor.remote(
             backend_config=backend_config,
@@ -161,7 +163,7 @@ class Trainer:
             additional_resources_per_worker=resources_per_worker,
             max_retries=max_retries)
 
-        if tune is not None and tune.is_session_enabled():
+        if self._is_tune_enabled():
             self.checkpoint_manager = TuneCheckpointManager()
         else:
             self.checkpoint_manager = CheckpointManager()
@@ -206,6 +208,10 @@ class Trainer:
             return get_backend_config_cls(backend)()
         else:
             raise TypeError(f"Invalid type for backend: {type(backend)}.")
+
+    def _is_tune_enabled(self):
+        """Whether or not this Trainer is part of a Tune session."""
+        return tune is not None and tune.is_session_enabled()
 
     def start(self, initialization_hook: Optional[Callable[[], None]] = None):
         """Starts the training execution service.
@@ -786,9 +792,7 @@ def _create_tune_trainable(train_func, dataset, backend, num_workers, use_gpu,
         @classmethod
         def default_resource_request(cls,
                                      config: Dict) -> PlacementGroupFactory:
-            node_resource_key = get_current_node_resource_key()
             trainer_bundle = [{"CPU": 1}]
-            backend_executor_bundle = [{node_resource_key: 0.01}]
             worker_resources = {"CPU": 1, "GPU": int(use_gpu)}
             worker_resources_extra = {} if resources_per_worker is None else \
                 resources_per_worker
@@ -796,7 +800,7 @@ def _create_tune_trainable(train_func, dataset, backend, num_workers, use_gpu,
                 **worker_resources,
                 **worker_resources_extra
             } for _ in range(num_workers)]
-            bundles = trainer_bundle + backend_executor_bundle + worker_bundles
+            bundles = trainer_bundle + worker_bundles
             return PlacementGroupFactory(bundles, strategy="PACK")
 
     return TrainTrainable

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -22,7 +22,6 @@ from ray.train.constants import TUNE_INSTALLED, DEFAULT_RESULTS_DIR, \
 # Ray Train should be usable even if Tune is not installed.
 from ray.train.utils import construct_path
 from ray.train.worker_group import WorkerGroup
-from ray.util.ml_utils.node import force_on_current_node
 
 if TUNE_INSTALLED:
     from ray import tune
@@ -146,14 +145,6 @@ class Trainer:
                     "`resources_per_worker.")
 
         remote_executor = ray.remote(num_cpus=0)(BackendExecutor)
-
-        if not ray.is_initialized():
-            ray.init()
-        if not self._is_tune_enabled():
-            # Assign BackendExecutor to head node.
-            # This is needed for Ray Client mode to support fault tolerance.
-            # This is not needed in Tune as the Trial will be on the cluster.
-            remote_executor = force_on_current_node(remote_executor)
 
         self._backend_executor_actor = remote_executor.remote(
             backend_config=backend_config,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Follow-up to https://github.com/ray-project/ray/pull/20123.

Train uses `force_on_current_node` to support Ray Client by ensuring that the `BackendExecutor` is scheduled on the head node. 

~With Tune integration, this causes some scheduling issues because the `PlacementGroupFactory` constructed for Tune will try to place the `BackendExecutor` on Tune's head node, and not the node the Trial is assigned to.~

~To solve this, we only call `force_on_current_node` if Train is not in a Tune session. This will cause the implementation between Train and Train+Tune to diverge slightly. **Note:** I'm not sure what the strategy is for scheduling a 0 resource Actor in a placement group is - if it schedules to the first bundle (with the `Trainer`) then the resulting behavior is the same.~

`force_on_current_node` is unnecessary to begin with since the scheduling algorithm should place the 0 CPU `BackendExecutor` on the head node. This PR removes the `force_on_current_node` logic. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #20348

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
