### PR TITLE
[Docs] Fix typo in C++ Placement Group example

### DIFF
--- a/doc/source/placement-group.rst
+++ b/doc/source/placement-group.rst
@@ -133,7 +133,7 @@ Placement groups are atomically created - meaning that if there exists a bundle 
     .. code-block:: c++
 
       // Wait for the placement group to be ready within the specified time(unit is seconds).
-      boll ready = pg.Wait(60);
+      bool ready = pg.Wait(60);
       assert(ready);
 
       // You can look at placement group states using this API.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a typo in C++ example code for placement group creation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
