### PR TITLE
[Rllib/release] Disable throughput check

### DIFF
--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -749,8 +749,8 @@ def run_learning_tests_from_yaml(
 
                 # TODO(jungong) : track trainer and env throughput separately.
                 throughput = timesteps_total / (total_time_s or 1.0)
-                # TODO(jungong) : enable throughput check again after TD3_HalfCheetahBulletEnv
-                # is fixed and verified.
+                # TODO(jungong) : enable throughput check again after
+                #   TD3_HalfCheetahBulletEnv is fixed and verified.
                 # desired_throughput = checks[experiment]["min_throughput"]
                 desired_throughput = None
 

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -749,7 +749,10 @@ def run_learning_tests_from_yaml(
 
                 # TODO(jungong) : track trainer and env throughput separately.
                 throughput = timesteps_total / (total_time_s or 1.0)
-                desired_throughput = checks[experiment]["min_throughput"]
+                # TODO(jungong) : enable throughput check again after TD3_HalfCheetahBulletEnv
+                # is fixed and verified.
+                # desired_throughput = checks[experiment]["min_throughput"]
+                desired_throughput = None
 
                 # Record performance.
                 stats[experiment] = {


### PR DESCRIPTION
Throughput check was enabled by d8a61f801f6b2c044088002e914a3d9d2c29dea6 prematurely.
E.g., see state before the commit:
https://github.com/ray-project/ray/blob/a931076f59a993fc8c5c69d336650e253f087cc4/rllib/utils/test_utils.py#L740-L741

## Why are these changes needed?

Disable throughput check that was accidentally enabled.
Good to know which Test still has significant performance gap though :)

## Related issue number

Closes #20385

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
