### PR TITLE
[Serve] Add serve failure test to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -222,8 +222,8 @@
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-post_wheel_build
       python/ray/serve/...
-    - bazel test --config=ci $(./scripts/bazel_export_options) \
-      --test_tag_filters=team:serve \
+    - bazel test --config=ci $(./scripts/bazel_export_options)
+      --test_tag_filters=team:serve
       release/...
 
 - label: ":python: Minimal install"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -222,6 +222,9 @@
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-post_wheel_build
       python/ray/serve/...
+    - bazel test --config=ci $(./scripts/bazel_export_options) \
+      --test_tag_filters=team:serve \
+      release/...
 
 - label: ":python: Minimal install"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]

--- a/release/BUILD
+++ b/release/BUILD
@@ -1,0 +1,21 @@
+load("@rules_python//python:defs.bzl", "py_test")
+
+test_srcs = glob(["**/*.py"])
+
+py_test(
+    name = "serve_failure_smoke_test",
+    size = "medium",
+    srcs = test_srcs,
+    env = {
+        "IS_SMOKE_TEST": "1",
+    },
+    main = "serve_failure.py",
+    tags = [
+        "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        "//:ray_lib",
+        "//python/ray/serve:serve_lib",
+    ],
+)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
While debugging #20384, I realized the failure test has some bug (i.e. start killing even before we have full deployment setup), this PR fixes that and add it to smoke test running in CI. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
