### PR TITLE
[serve] Fix actor resources error in failure test

### DIFF
--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -472,14 +472,16 @@ class DeploymentReplica(VersionedReplica):
         """
         return self._actor.check_health()
 
-    def resource_requirements(
-            self) -> Tuple[Dict[str, float], Dict[str, float]]:
+    def resource_requirements(self) -> Tuple[str, str]:
         """Returns required and currently available resources.
 
         Only resources with nonzero requirements will be included in the
         required dict and only resources in the required dict will be
         included in the available dict (filtered for relevance).
         """
+        if not self._actor:
+            return "UNKNOWN", "UNKNOWN"
+
         required = {
             k: v
             for k, v in self._actor.actor_resources.items() if v > 0
@@ -489,7 +491,7 @@ class DeploymentReplica(VersionedReplica):
             for k, v in self._actor.available_resources.items()
             if k in required
         }
-        return required, available
+        return str(required), str(available)
 
 
 class ReplicaStateContainer:

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -279,7 +279,7 @@ class ActorReplicaWrapper:
         return ReplicaStartupStatus.SUCCEEDED, version
 
     @property
-    def actor_resources(self) -> Dict[str, float]:
+    def actor_resources(self) -> Optional[Dict[str, float]]:
         return self._actor_resources
 
     @property
@@ -479,7 +479,8 @@ class DeploymentReplica(VersionedReplica):
         required dict and only resources in the required dict will be
         included in the available dict (filtered for relevance).
         """
-        if not self._actor:
+        # NOTE(edoakes):
+        if self._actor.actor_resources is None:
             return "UNKNOWN", "UNKNOWN"
 
         required = {

--- a/python/ray/serve/tests/test_deployment_state.py
+++ b/python/ray/serve/tests/test_deployment_state.py
@@ -115,10 +115,13 @@ class MockReplicaActorWrapper:
             self.version = self.starting_version
         return ready, self.version
 
-    def resource_requirements(
-            self) -> Tuple[Dict[str, float], Dict[str, float]]:
+    def resource_requirements(self) -> Tuple[str, str]:
         assert self.started
-        return {"REQUIRED_RESOURCE": 1.0}, {"AVAILABLE_RESOURCE": 1.0}
+        return str({
+            "REQUIRED_RESOURCE": 1.0
+        }), str({
+            "AVAILABLE_RESOURCE": 1.0
+        })
 
     @property
     def actor_resources(self) -> Dict[str, float]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Replicas may not have actor_resources yet if they're in `RECOVERING` state.

## Related issue number

Closes https://github.com/ray-project/ray/issues/20384

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
