### PR TITLE
Revert "Revert "Revert "[core] Fail objects when pull/reconstruction …

### DIFF
--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -1,7 +1,6 @@
 import os
 import signal
 import sys
-import time
 
 import numpy as np
 import pytest
@@ -681,47 +680,6 @@ def test_nondeterministic_output(ray_start_cluster, reconstruction_enabled):
             node_to_kill = cluster.add_node(
                 num_cpus=1, resources={"node1": 1}, object_store_memory=10**8)
             ray.get(x)
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_reconstruction_hangs(ray_start_cluster):
-    config = {
-        "num_heartbeats_timeout": 10,
-        "raylet_heartbeat_period_milliseconds": 100,
-        "max_direct_call_object_size": 100,
-        "task_retry_delay_ms": 100,
-        "object_timeout_milliseconds": 200,
-        "fetch_warn_timeout_milliseconds": 1000,
-    }
-    cluster = ray_start_cluster
-    # Head node with no resources.
-    cluster.add_node(
-        num_cpus=0, _system_config=config, enable_object_reconstruction=True)
-    ray.init(address=cluster.address)
-    # Node to place the initial object.
-    node_to_kill = cluster.add_node(
-        num_cpus=1, resources={"node1": 1}, object_store_memory=10**8)
-    cluster.add_node(num_cpus=1, object_store_memory=10**8)
-    cluster.wait_for_nodes()
-
-    @ray.remote
-    def sleep():
-        # Task takes longer than the reconstruction timeout.
-        time.sleep(3)
-        return np.zeros(10**5, dtype=np.uint8)
-
-    @ray.remote
-    def dependent_task(x):
-        return
-
-    obj = sleep.options(resources={"node1": 1}).remote()
-    for _ in range(3):
-        ray.get(dependent_task.remote(obj))
-        x = dependent_task.remote(obj)
-        cluster.remove_node(node_to_kill, allow_graceful=False)
-        node_to_kill = cluster.add_node(
-            num_cpus=1, resources={"node1": 1}, object_store_memory=10**8)
-        ray.get(x)
 
 
 def test_lineage_evicted(ray_start_cluster):

--- a/src/ray/core_worker/gcs_server_address_updater.cc
+++ b/src/ray/core_worker/gcs_server_address_updater.cc
@@ -51,6 +51,7 @@ GcsServerAddressUpdater::~GcsServerAddressUpdater() {
 }
 
 void GcsServerAddressUpdater::UpdateGcsServerAddress() {
+  RAY_LOG(DEBUG) << "Getting gcs server address from raylet.";
   raylet_client_->GetGcsServerAddress([this](const Status &status,
                                              const rpc::GetGcsServerAddressReply &reply) {
     if (!status.ok()) {

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -298,13 +298,9 @@ void ReferenceCounter::RemoveLocalReferenceInternal(const ObjectID &object_id,
 }
 
 void ReferenceCounter::UpdateSubmittedTaskReferences(
-    const std::vector<ObjectID> return_ids,
     const std::vector<ObjectID> &argument_ids_to_add,
     const std::vector<ObjectID> &argument_ids_to_remove, std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &return_id : return_ids) {
-    UpdateObjectPendingCreation(return_id, true);
-  }
   for (const ObjectID &argument_id : argument_ids_to_add) {
     RAY_LOG(DEBUG) << "Increment ref count for submitted task argument " << argument_id;
     auto it = object_id_refs_.find(argument_id);
@@ -329,11 +325,8 @@ void ReferenceCounter::UpdateSubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateResubmittedTaskReferences(
-    const std::vector<ObjectID> return_ids, const std::vector<ObjectID> &argument_ids) {
+    const std::vector<ObjectID> &argument_ids) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &return_id : return_ids) {
-    UpdateObjectPendingCreation(return_id, true);
-  }
   for (const ObjectID &argument_id : argument_ids) {
     auto it = object_id_refs_.find(argument_id);
     RAY_CHECK(it != object_id_refs_.end());
@@ -346,13 +339,10 @@ void ReferenceCounter::UpdateResubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateFinishedTaskReferences(
-    const std::vector<ObjectID> return_ids, const std::vector<ObjectID> &argument_ids,
-    bool release_lineage, const rpc::Address &worker_addr,
-    const ReferenceTableProto &borrowed_refs, std::vector<ObjectID> *deleted) {
+    const std::vector<ObjectID> &argument_ids, bool release_lineage,
+    const rpc::Address &worker_addr, const ReferenceTableProto &borrowed_refs,
+    std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &return_id : return_ids) {
-    UpdateObjectPendingCreation(return_id, false);
-  }
   // Must merge the borrower refs before decrementing any ref counts. This is
   // to make sure that for serialized IDs, we increment the borrower count for
   // the inner ID before decrementing the submitted_task_ref_count for the
@@ -1122,19 +1112,6 @@ bool ReferenceCounter::RemoveObjectLocation(const ObjectID &object_id,
   return true;
 }
 
-void ReferenceCounter::UpdateObjectPendingCreation(const ObjectID &object_id,
-                                                   bool pending_creation) {
-  auto it = object_id_refs_.find(object_id);
-  bool push = false;
-  if (it != object_id_refs_.end()) {
-    push = (it->second.pending_creation != pending_creation);
-    it->second.pending_creation = pending_creation;
-  }
-  if (push) {
-    PushToLocationSubscribers(it);
-  }
-}
-
 absl::optional<absl::flat_hash_set<NodeID>> ReferenceCounter::GetObjectLocations(
     const ObjectID &object_id) {
   absl::MutexLock lock(&mutex_);
@@ -1278,15 +1255,6 @@ bool ReferenceCounter::IsObjectReconstructable(const ObjectID &object_id,
   return it->second.is_reconstructable;
 }
 
-bool ReferenceCounter::IsObjectPendingCreation(const ObjectID &object_id) const {
-  absl::MutexLock lock(&mutex_);
-  auto it = object_id_refs_.find(object_id);
-  if (it == object_id_refs_.end()) {
-    return false;
-  }
-  return it->second.pending_creation;
-}
-
 void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
   const auto &object_id = it->first;
   const auto &locations = it->second.locations;
@@ -1299,8 +1267,7 @@ void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
                  << " locations, spilled url: [" << spilled_url
                  << "], spilled node ID: " << spilled_node_id
                  << ", and object size: " << object_size
-                 << ", and primary node ID: " << primary_node_id << ", pending creation? "
-                 << it->second.pending_creation;
+                 << ", and primary node ID: " << primary_node_id;
   rpc::PubMessage pub_message;
   pub_message.set_key_id(object_id.Binary());
   pub_message.set_channel_type(rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL);
@@ -1336,7 +1303,6 @@ void ReferenceCounter::FillObjectInformationInternal(
   object_info->set_spilled_node_id(it->second.spilled_node_id.Binary());
   auto primary_node_id = it->second.pinned_at_raylet_id.value_or(NodeID::Nil());
   object_info->set_primary_node_id(primary_node_id.Binary());
-  object_info->set_pending_creation(it->second.pending_creation);
 }
 
 void ReferenceCounter::PublishObjectLocationSnapshot(const ObjectID &object_id) {

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -236,16 +236,14 @@ class MockDistributedPublisher : public pubsub::PublisherInterface {
   void Publish(const rpc::PubMessage &pub_message) {
     auto maybe_subscribers = directory_->GetSubscriberIdsByKeyId(pub_message.key_id());
     const auto oid = ObjectID::FromBinary(pub_message.key_id());
-    if (maybe_subscribers.has_value()) {
-      for (const auto &subscriber_id : maybe_subscribers.value().get()) {
-        const auto id = GenerateID(publisher_id_, subscriber_id);
-        const auto it = subscription_callback_map_->find(id);
-        if (it != subscription_callback_map_->end()) {
-          const auto callback_it = it->second.find(oid);
-          RAY_CHECK(callback_it != it->second.end());
-          callback_it->second(pub_message);
-        }
-      }
+    RAY_CHECK(maybe_subscribers.has_value());
+    for (const auto &subscriber_id : maybe_subscribers.value().get()) {
+      const auto id = GenerateID(publisher_id_, subscriber_id);
+      const auto it = subscription_callback_map_->find(id);
+      RAY_CHECK(it != subscription_callback_map_->end());
+      const auto callback_it = it->second.find(oid);
+      RAY_CHECK(callback_it != it->second.end());
+      callback_it->second(pub_message);
     }
   }
 
@@ -366,10 +364,10 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
   }
 
   ObjectID SubmitTaskWithArg(const ObjectID &arg_id) {
-    ObjectID return_id = ObjectID::FromRandom();
     if (!arg_id.IsNil()) {
-      rc_.UpdateSubmittedTaskReferences({return_id}, {arg_id});
+      rc_.UpdateSubmittedTaskReferences({arg_id});
     }
+    ObjectID return_id = ObjectID::FromRandom();
     rc_.AddOwnedObject(return_id, {}, address_, "", 0, false);
     // Add a sentinel reference to keep all nested object IDs in scope.
     rc_.AddLocalReference(return_id, "");
@@ -393,7 +391,7 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
   }
 
   void HandleSubmittedTaskFinished(
-      const ObjectID &return_id, const ObjectID &arg_id,
+      const ObjectID &arg_id,
       const std::unordered_map<ObjectID, std::vector<ObjectID>> &nested_return_ids = {},
       const rpc::Address &borrower_address = empty_borrower,
       const ReferenceCounter::ReferenceTableProto &borrower_refs = empty_refs) {
@@ -405,8 +403,8 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
     if (!arg_id.IsNil()) {
       arguments.push_back(arg_id);
     }
-    rc_.UpdateFinishedTaskReferences({return_id}, arguments, false, borrower_address,
-                                     borrower_refs, nullptr);
+    rc_.UpdateFinishedTaskReferences(arguments, false, borrower_address, borrower_refs,
+                                     nullptr);
   }
 
   WorkerID GetID() const { return WorkerID::FromBinary(address_.worker_id()); }
@@ -445,8 +443,6 @@ TEST_F(ReferenceCountTest, TestBasic) {
 
   ObjectID id1 = ObjectID::FromRandom();
   ObjectID id2 = ObjectID::FromRandom();
-  ObjectID return_id1 = ObjectID::FromRandom();
-  ObjectID return_id2 = ObjectID::FromRandom();
 
   // Local references.
   rc->AddLocalReference(id1, "");
@@ -465,48 +461,32 @@ TEST_F(ReferenceCountTest, TestBasic) {
   out.clear();
 
   // Submitted task references.
-  rc->AddLocalReference(return_id1, "");
-  rc->AddLocalReference(return_id2, "");
-  ASSERT_FALSE(rc->IsObjectPendingCreation(return_id1));
-  ASSERT_FALSE(rc->IsObjectPendingCreation(return_id2));
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id1});
-  rc->UpdateSubmittedTaskReferences({return_id2}, {id1, id2});
-  ASSERT_TRUE(rc->IsObjectPendingCreation(return_id1));
-  ASSERT_TRUE(rc->IsObjectPendingCreation(return_id2));
-
-  ASSERT_EQ(rc->NumObjectIDsInScope(), 4);
-  rc->UpdateFinishedTaskReferences({return_id1}, {id1}, false, empty_borrower, empty_refs,
-                                   &out);
-  ASSERT_EQ(rc->NumObjectIDsInScope(), 4);
+  rc->UpdateSubmittedTaskReferences({id1});
+  rc->UpdateSubmittedTaskReferences({id1, id2});
+  ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
+  rc->UpdateFinishedTaskReferences({id1}, false, empty_borrower, empty_refs, &out);
+  ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
   ASSERT_EQ(out.size(), 0);
-  rc->UpdateFinishedTaskReferences({return_id2}, {id2}, false, empty_borrower, empty_refs,
-                                   &out);
-  ASSERT_EQ(rc->NumObjectIDsInScope(), 3);
+  rc->UpdateFinishedTaskReferences({id2}, false, empty_borrower, empty_refs, &out);
+  ASSERT_EQ(rc->NumObjectIDsInScope(), 1);
   ASSERT_EQ(out.size(), 1);
-  rc->UpdateFinishedTaskReferences({return_id2}, {id1}, false, empty_borrower, empty_refs,
-                                   &out);
-  ASSERT_EQ(out.size(), 2);
-  ASSERT_FALSE(rc->IsObjectPendingCreation(return_id1));
-  ASSERT_FALSE(rc->IsObjectPendingCreation(return_id2));
-  rc->RemoveLocalReference(return_id1, &out);
-  rc->RemoveLocalReference(return_id2, &out);
+  rc->UpdateFinishedTaskReferences({id1}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 0);
+  ASSERT_EQ(out.size(), 2);
   out.clear();
 
   // Local & submitted task references.
   rc->AddLocalReference(id1, "");
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id1, id2});
+  rc->UpdateSubmittedTaskReferences({id1, id2});
   rc->AddLocalReference(id2, "");
   ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
   rc->RemoveLocalReference(id1, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
   ASSERT_EQ(out.size(), 0);
-  rc->UpdateFinishedTaskReferences({return_id1}, {id2}, false, empty_borrower, empty_refs,
-                                   &out);
+  rc->UpdateFinishedTaskReferences({id2}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
   ASSERT_EQ(out.size(), 0);
-  rc->UpdateFinishedTaskReferences({return_id1}, {id1}, false, empty_borrower, empty_refs,
-                                   &out);
+  rc->UpdateFinishedTaskReferences({id1}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 1);
   ASSERT_EQ(out.size(), 1);
   rc->RemoveLocalReference(id2, &out);
@@ -515,11 +495,11 @@ TEST_F(ReferenceCountTest, TestBasic) {
   out.clear();
 
   // Submitted task with inlined references.
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id1});
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id2}, {id1}, &out);
+  rc->UpdateSubmittedTaskReferences({id1});
+  rc->UpdateSubmittedTaskReferences({id2}, {id1}, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 1);
   ASSERT_EQ(out.size(), 1);
-  rc->UpdateSubmittedTaskReferences({return_id1}, {}, {id2}, &out);
+  rc->UpdateSubmittedTaskReferences({}, {id2}, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 0);
   ASSERT_EQ(out.size(), 2);
   out.clear();
@@ -550,9 +530,9 @@ TEST_F(ReferenceCountTest, TestUnreconstructableObjectOutOfScope) {
   ASSERT_FALSE(rc->SetDeleteCallback(id, callback));
   rc->AddOwnedObject(id, {}, address, "", 0, false);
   ASSERT_TRUE(rc->SetDeleteCallback(id, callback));
-  rc->UpdateSubmittedTaskReferences({}, {id});
+  rc->UpdateSubmittedTaskReferences({id});
   ASSERT_FALSE(*out_of_scope);
-  rc->UpdateFinishedTaskReferences({}, {id}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
   ASSERT_TRUE(*out_of_scope);
 }
 
@@ -746,7 +726,7 @@ TEST(DistributedReferenceCountTest, TestNoBorrow) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to inner_id.
-  auto return_id1 = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(inner_id, nullptr);
@@ -757,12 +737,12 @@ TEST(DistributedReferenceCountTest, TestNoBorrow) {
   // The borrower is given a reference to the inner object.
   borrower->ExecuteTaskWithArg(outer_id, inner_id, owner->address_);
   // The borrower submits a task that depends on the inner object.
-  auto return_id2 = borrower->SubmitTaskWithArg(inner_id);
+  borrower->SubmitTaskWithArg(inner_id);
   borrower->rc_.RemoveLocalReference(inner_id, nullptr);
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
 
   // The borrower waits for the task to finish before returning to the owner.
-  borrower->HandleSubmittedTaskFinished(return_id2, inner_id);
+  borrower->HandleSubmittedTaskFinished(inner_id);
   auto borrower_refs = borrower->FinishExecutingTask(outer_id, ObjectID::Nil());
   // Check that the borrower's ref count is now 0 for all objects.
   ASSERT_FALSE(borrower->rc_.HasReference(inner_id));
@@ -770,8 +750,7 @@ TEST(DistributedReferenceCountTest, TestNoBorrow) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id1, outer_id, {}, borrower->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs);
   borrower->FlushBorrowerCallbacks();
   // Check that owner's ref count is now 0 for all objects.
   ASSERT_FALSE(owner->rc_.HasReference(inner_id));
@@ -802,8 +781,8 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrower) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to inner_id.
-  auto return_id1 =
-      owner->SubmitTaskWithArg(outer_id);  // The owner's references go out of scope.
+  owner->SubmitTaskWithArg(outer_id);
+  // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(inner_id, nullptr);
   // The owner's ref count > 0 for both objects.
@@ -813,7 +792,7 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrower) {
   // The borrower is given a reference to the inner object.
   borrower->ExecuteTaskWithArg(outer_id, inner_id, owner->address_);
   // The borrower submits a task that depends on the inner object.
-  auto return_id2 = borrower->SubmitTaskWithArg(inner_id);
+  borrower->SubmitTaskWithArg(inner_id);
   borrower->rc_.RemoveLocalReference(inner_id, nullptr);
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
 
@@ -827,8 +806,7 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrower) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id1, outer_id, {}, borrower->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs);
   borrower->FlushBorrowerCallbacks();
   // Check that owner now has borrower in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -838,7 +816,7 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrower) {
 
   // The task submitted by the borrower returns. Everyone's ref count should go
   // to 0.
-  borrower->HandleSubmittedTaskFinished(return_id2, inner_id);
+  borrower->HandleSubmittedTaskFinished(inner_id);
   ASSERT_FALSE(borrower->rc_.HasReference(inner_id));
   ASSERT_FALSE(borrower->rc_.HasReference(outer_id));
   ASSERT_FALSE(owner->rc_.HasReference(inner_id));
@@ -873,7 +851,7 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrowerFailure) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to inner_id.
-  auto return_id1 = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(inner_id, nullptr);
@@ -898,8 +876,7 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrowerFailure) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id1, outer_id, {}, borrower->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs);
   borrower->FlushBorrowerCallbacks();
   // Check that owner now has borrower in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -938,7 +915,7 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrowerReferenceRemoved) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to inner_id.
-  auto return_id = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(inner_id, nullptr);
@@ -957,8 +934,7 @@ TEST(DistributedReferenceCountTest, TestSimpleBorrowerReferenceRemoved) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id, outer_id, {}, borrower->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs);
   // Check that owner now has borrower in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
   // Check that owner's ref count for outer == 0 since the borrower task
@@ -1011,7 +987,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerTree) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to inner_id.
-  auto return_id1 = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(inner_id, nullptr);
@@ -1024,7 +1000,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerTree) {
   // The borrower submits a task that depends on the inner object.
   auto outer_id2 = ObjectID::FromRandom();
   borrower1->PutWrappedId(outer_id2, inner_id);
-  auto return_id2 = borrower1->SubmitTaskWithArg(outer_id2);
+  borrower1->SubmitTaskWithArg(outer_id2);
   borrower1->rc_.RemoveLocalReference(inner_id, nullptr);
   borrower1->rc_.RemoveLocalReference(outer_id2, nullptr);
   ASSERT_TRUE(borrower1->rc_.HasReference(inner_id));
@@ -1039,8 +1015,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerTree) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id1, outer_id, {}, borrower1->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower1->address_, borrower_refs);
   borrower1->FlushBorrowerCallbacks();
   // Check that owner now has borrower in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -1058,7 +1033,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerTree) {
   ASSERT_FALSE(borrower2->rc_.HasReference(outer_id2));
   ASSERT_FALSE(borrower2->rc_.HasReference(outer_id));
 
-  borrower1->HandleSubmittedTaskFinished(return_id2, outer_id2, {}, borrower2->address_,
+  borrower1->HandleSubmittedTaskFinished(outer_id2, {}, borrower2->address_,
                                          borrower_refs);
   borrower2->FlushBorrowerCallbacks();
   // Borrower 1 no longer has a reference to any objects.
@@ -1099,7 +1074,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectNoBorrow) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to mid_id.
-  auto return_id = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(mid_id, nullptr);
@@ -1129,8 +1104,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectNoBorrow) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id, outer_id, {}, borrower->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs);
   // Check that owner now has nothing in scope.
   ASSERT_FALSE(owner->rc_.HasReference(outer_id));
   ASSERT_FALSE(owner->rc_.HasReference(mid_id));
@@ -1165,7 +1139,7 @@ TEST(DistributedReferenceCountTest, TestNestedObject) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to mid_id.
-  auto return_id = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(mid_id, nullptr);
@@ -1193,8 +1167,7 @@ TEST(DistributedReferenceCountTest, TestNestedObject) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id, outer_id, {}, borrower->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs);
   // Check that owner now has borrower in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
   // Check that owner's ref count for outer and mid are 0 since the borrower
@@ -1254,7 +1227,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to owner_id2.
-  auto return_id2 = owner->SubmitTaskWithArg(owner_id3);
+  owner->SubmitTaskWithArg(owner_id3);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(owner_id1, nullptr);
   owner->rc_.RemoveLocalReference(owner_id2, nullptr);
@@ -1272,7 +1245,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners) {
 
   // Borrower 1 submits a task that depends on the wrapped object. The task
   // will be given a reference to owner_id2.
-  auto return_id1 = borrower1->SubmitTaskWithArg(borrower_id);
+  borrower1->SubmitTaskWithArg(borrower_id);
   borrower1->rc_.RemoveLocalReference(borrower_id, nullptr);
   borrower2->ExecuteTaskWithArg(borrower_id, owner_id2, owner->address_);
 
@@ -1285,7 +1258,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners) {
 
   // Borrower 1 should now know that borrower 2 is borrowing the inner object
   // ID.
-  borrower1->HandleSubmittedTaskFinished(return_id1, borrower_id, {}, borrower2->address_,
+  borrower1->HandleSubmittedTaskFinished(borrower_id, {}, borrower2->address_,
                                          borrower_refs);
   ASSERT_TRUE(borrower1->rc_.HasReference(owner_id1));
 
@@ -1299,8 +1272,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id2, owner_id3, {}, borrower1->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(owner_id3, {}, borrower1->address_, borrower_refs);
   // Check that owner now has borrower2 in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(owner_id1));
   ASSERT_FALSE(owner->rc_.HasReference(owner_id2));
@@ -1353,7 +1325,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners2) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to owner_id2.
-  auto return_id2 = owner->SubmitTaskWithArg(owner_id3);
+  owner->SubmitTaskWithArg(owner_id3);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(owner_id1, nullptr);
   owner->rc_.RemoveLocalReference(owner_id2, nullptr);
@@ -1371,7 +1343,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners2) {
 
   // Borrower 1 submits a task that depends on the wrapped object. The task
   // will be given a reference to owner_id2.
-  auto return_id1 = borrower1->SubmitTaskWithArg(borrower_id);
+  borrower1->SubmitTaskWithArg(borrower_id);
   borrower2->ExecuteTaskWithArg(borrower_id, owner_id2, owner->address_);
 
   // The nested task returns while still using owner_id1.
@@ -1383,7 +1355,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners2) {
 
   // Borrower 1 should now know that borrower 2 is borrowing the inner object
   // ID.
-  borrower1->HandleSubmittedTaskFinished(return_id1, borrower_id, {}, borrower2->address_,
+  borrower1->HandleSubmittedTaskFinished(borrower_id, {}, borrower2->address_,
                                          borrower_refs);
   ASSERT_TRUE(borrower1->rc_.HasReference(owner_id1));
   ASSERT_TRUE(borrower1->rc_.HasReference(owner_id2));
@@ -1395,8 +1367,7 @@ TEST(DistributedReferenceCountTest, TestNestedObjectDifferentOwners2) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id2, owner_id3, {}, borrower1->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(owner_id3, {}, borrower1->address_, borrower_refs);
   // Check that owner now has borrower2 in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(owner_id1));
   ASSERT_TRUE(owner->rc_.HasReference(owner_id2));
@@ -1448,7 +1419,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerPingPong) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to inner_id.
-  auto return_id1 = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   owner->rc_.RemoveLocalReference(inner_id, nullptr);
@@ -1458,7 +1429,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerPingPong) {
   // The borrower submits a task that depends on the inner object.
   auto outer_id2 = ObjectID::FromRandom();
   borrower->PutWrappedId(outer_id2, inner_id);
-  auto return_id2 = borrower->SubmitTaskWithArg(outer_id2);
+  borrower->SubmitTaskWithArg(outer_id2);
   borrower->rc_.RemoveLocalReference(inner_id, nullptr);
   borrower->rc_.RemoveLocalReference(outer_id2, nullptr);
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
@@ -1473,8 +1444,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerPingPong) {
 
   // The owner receives the borrower's reply and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id1, outer_id, {}, borrower->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs);
   borrower->FlushBorrowerCallbacks();
   // Check that owner now has a borrower for inner.
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -1490,8 +1460,7 @@ TEST(DistributedReferenceCountTest, TestBorrowerPingPong) {
   borrower_refs = owner->FinishExecutingTask(outer_id2, ObjectID::Nil());
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
 
-  borrower->HandleSubmittedTaskFinished(return_id2, outer_id2, {}, owner->address_,
-                                        borrower_refs);
+  borrower->HandleSubmittedTaskFinished(outer_id2, {}, owner->address_, borrower_refs);
   borrower->FlushBorrowerCallbacks();
   // Borrower no longer has a reference to any objects.
   ASSERT_FALSE(borrower->rc_.HasReference(inner_id));
@@ -1531,7 +1500,7 @@ TEST(DistributedReferenceCountTest, TestDuplicateBorrower) {
 
   // The owner submits a task that depends on the outer object. The task will
   // be given a reference to inner_id.
-  auto return_id1 = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   // The owner's references go out of scope.
   owner->rc_.RemoveLocalReference(inner_id, nullptr);
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -1539,7 +1508,7 @@ TEST(DistributedReferenceCountTest, TestDuplicateBorrower) {
   // The borrower is given a reference to the inner object.
   borrower->ExecuteTaskWithArg(outer_id, inner_id, owner->address_);
   // The borrower submits a task that depends on the inner object.
-  auto return_id2 = borrower->SubmitTaskWithArg(inner_id);
+  borrower->SubmitTaskWithArg(inner_id);
   borrower->rc_.RemoveLocalReference(inner_id, nullptr);
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
 
@@ -1551,17 +1520,15 @@ TEST(DistributedReferenceCountTest, TestDuplicateBorrower) {
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
 
   // The borrower is given a 2nd reference to the inner object.
-  auto return_id3 = owner->SubmitTaskWithArg(outer_id);
+  owner->SubmitTaskWithArg(outer_id);
   owner->rc_.RemoveLocalReference(outer_id, nullptr);
   borrower->ExecuteTaskWithArg(outer_id, inner_id, owner->address_);
   auto borrower_refs2 = borrower->FinishExecutingTask(outer_id, ObjectID::Nil());
 
   // The owner receives the borrower's replies and merges the borrower's ref
   // count into its own.
-  owner->HandleSubmittedTaskFinished(return_id1, outer_id, {}, borrower->address_,
-                                     borrower_refs1);
-  owner->HandleSubmittedTaskFinished(return_id3, outer_id, {}, borrower->address_,
-                                     borrower_refs2);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs1);
+  owner->HandleSubmittedTaskFinished(outer_id, {}, borrower->address_, borrower_refs2);
   borrower->FlushBorrowerCallbacks();
   // Check that owner now has borrower in inner's borrowers list.
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -1571,7 +1538,7 @@ TEST(DistributedReferenceCountTest, TestDuplicateBorrower) {
 
   // The task submitted by the borrower returns and its second reference goes
   // out of scope. Everyone's ref count should go to 0.
-  borrower->HandleSubmittedTaskFinished(return_id2, inner_id);
+  borrower->HandleSubmittedTaskFinished(inner_id);
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
   borrower->rc_.RemoveLocalReference(inner_id, nullptr);
   ASSERT_FALSE(owner->rc_.HasReference(inner_id));
@@ -1627,8 +1594,7 @@ TEST(DistributedReferenceCountTest, TestForeignOwner) {
   ASSERT_FALSE(caller->rc_.HasReference(inner_id));
   // Caller receives the owner's message, but inner_id is still in scope
   // because caller has a reference to return_id.
-  caller->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                      {{return_id, {inner_id}}});
+  caller->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
   ASSERT_TRUE(caller->rc_.HasReference(inner_id));
 
   //
@@ -1644,7 +1610,7 @@ TEST(DistributedReferenceCountTest, TestForeignOwner) {
   owner->ExecuteTaskWithArg(return_id, inner_id, caller->address_);
   auto refs2 = owner->FinishExecutingTask(return_id, return_id2);
   // owner merges ref count into the caller.
-  caller->HandleSubmittedTaskFinished(return_id2, return_id, {}, owner->address_, refs2);
+  caller->HandleSubmittedTaskFinished(return_id, {}, owner->address_, refs2);
   ASSERT_FALSE(caller->rc_.HasReference(inner_id));
   ASSERT_FALSE(owner->rc_.HasReference(return_id));
   ASSERT_FALSE(caller->rc_.HasReference(return_id));
@@ -1697,8 +1663,8 @@ TEST(DistributedReferenceCountTest, TestDuplicateNestedObject) {
   owner->PutWrappedId(owner_id2, owner_id1);
   owner->PutWrappedId(owner_id3, owner_id2);
 
-  auto return_id1 = owner->SubmitTaskWithArg(owner_id3);
-  auto return_id2 = owner->SubmitTaskWithArg(owner_id2);
+  owner->SubmitTaskWithArg(owner_id3);
+  owner->SubmitTaskWithArg(owner_id2);
   owner->rc_.RemoveLocalReference(owner_id1, nullptr);
   owner->rc_.RemoveLocalReference(owner_id2, nullptr);
   owner->rc_.RemoveLocalReference(owner_id3, nullptr);
@@ -1708,8 +1674,7 @@ TEST(DistributedReferenceCountTest, TestDuplicateNestedObject) {
   borrower2->rc_.RemoveLocalReference(owner_id2, nullptr);
   // The nested task returns while still using owner_id1.
   auto borrower_refs = borrower2->FinishExecutingTask(owner_id3, ObjectID::Nil());
-  owner->HandleSubmittedTaskFinished(return_id1, owner_id3, {}, borrower2->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(owner_id3, {}, borrower2->address_, borrower_refs);
   ASSERT_TRUE(borrower2->FlushBorrowerCallbacks());
 
   // The owner submits a task that is given a reference to owner_id1.
@@ -1720,14 +1685,14 @@ TEST(DistributedReferenceCountTest, TestDuplicateNestedObject) {
   borrower1->rc_.RemoveLocalReference(owner_id1, nullptr);
   // Borrower 1 submits a task that depends on the wrapped object. The task
   // will be given a reference to owner_id1.
-  auto return_id3 = borrower1->SubmitTaskWithArg(borrower_id);
+  borrower1->SubmitTaskWithArg(borrower_id);
   borrower1->rc_.RemoveLocalReference(borrower_id, nullptr);
   borrower2->ExecuteTaskWithArg(borrower_id, owner_id1, owner->address_);
   // The nested task returns while still using owner_id1.
   // It should now have 2 local references to owner_id1, one from the owner and
   // one from the borrower.
   borrower_refs = borrower2->FinishExecutingTask(borrower_id, ObjectID::Nil());
-  borrower1->HandleSubmittedTaskFinished(return_id3, borrower_id, {}, borrower2->address_,
+  borrower1->HandleSubmittedTaskFinished(borrower_id, {}, borrower2->address_,
                                          borrower_refs);
 
   // Borrower 1 finishes. It should not have any references now because all
@@ -1739,8 +1704,7 @@ TEST(DistributedReferenceCountTest, TestDuplicateNestedObject) {
   ASSERT_FALSE(borrower1->rc_.HasReference(borrower_id));
   // Borrower 1 should not have merge any refs into the owner because borrower 2's ref was
   // already merged into the owner.
-  owner->HandleSubmittedTaskFinished(return_id2, owner_id2, {}, borrower1->address_,
-                                     borrower_refs);
+  owner->HandleSubmittedTaskFinished(owner_id2, {}, borrower1->address_, borrower_refs);
 
   // The borrower receives the owner's wait message.
   borrower2->FlushBorrowerCallbacks();
@@ -1782,8 +1746,7 @@ TEST(DistributedReferenceCountTest, TestReturnObjectIdNoBorrow) {
 
   // Caller's ref to the task's return ID goes out of scope before it hears
   // from the owner of inner_id.
-  caller->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                      {{return_id, {inner_id}}});
+  caller->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
   caller->rc_.RemoveLocalReference(return_id, nullptr);
   ASSERT_FALSE(caller->rc_.HasReference(return_id));
   ASSERT_FALSE(caller->rc_.HasReference(inner_id));
@@ -1823,8 +1786,7 @@ TEST(DistributedReferenceCountTest, TestReturnObjectIdBorrow) {
 
   // Caller receives the owner's message, but inner_id is still in scope
   // because caller has a reference to return_id.
-  caller->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                      {{return_id, {inner_id}}});
+  caller->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
   ASSERT_TRUE(caller->FlushBorrowerCallbacks());
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
 
@@ -1872,9 +1834,8 @@ TEST(DistributedReferenceCountTest, TestReturnObjectIdBorrowChain) {
 
   // Caller receives the owner's message, but inner_id is still in scope
   // because caller has a reference to return_id.
-  caller->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                      {{return_id, {inner_id}}});
-  auto return_id2 = caller->SubmitTaskWithArg(return_id);
+  caller->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
+  caller->SubmitTaskWithArg(return_id);
   caller->rc_.RemoveLocalReference(return_id, nullptr);
   ASSERT_TRUE(caller->FlushBorrowerCallbacks());
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -1887,8 +1848,7 @@ TEST(DistributedReferenceCountTest, TestReturnObjectIdBorrowChain) {
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
 
   // Borrower merges ref count into the caller.
-  caller->HandleSubmittedTaskFinished(return_id2, return_id, {}, borrower->address_,
-                                      borrower_refs);
+  caller->HandleSubmittedTaskFinished(return_id, {}, borrower->address_, borrower_refs);
   // The caller should not have a ref count anymore because it was merged into
   // the owner.
   ASSERT_FALSE(caller->rc_.HasReference(return_id));
@@ -1944,8 +1904,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedId) {
 
   // Caller receives the owner's message, but inner_id is still in scope
   // because caller has a reference to return_id.
-  caller->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                      {{return_id, {inner_id}}});
+  caller->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
   auto borrower_return_id = caller->SubmitTaskWithArg(return_id);
   caller->rc_.RemoveLocalReference(return_id, nullptr);
   ASSERT_TRUE(caller->FlushBorrowerCallbacks());
@@ -1960,8 +1919,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedId) {
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
 
   // Borrower merges ref count into the caller.
-  caller->HandleSubmittedTaskFinished(borrower_return_id, return_id,
-                                      {{borrower_return_id, {inner_id}}},
+  caller->HandleSubmittedTaskFinished(return_id, {{borrower_return_id, {inner_id}}},
                                       borrower->address_, borrower_refs);
   // The caller should still have a ref count because it has a reference to
   // borrower_return_id.
@@ -2030,8 +1988,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedIdDeserialize) {
 
   // Caller receives the owner's message, but inner_id is still in scope
   // because caller has a reference to return_id.
-  caller->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                      {{return_id, {inner_id}}});
+  caller->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
   auto borrower_return_id = caller->SubmitTaskWithArg(return_id);
   caller->rc_.RemoveLocalReference(return_id, nullptr);
   ASSERT_TRUE(owner->rc_.HasReference(inner_id));
@@ -2045,8 +2002,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedIdDeserialize) {
   ASSERT_TRUE(borrower->rc_.HasReference(inner_id));
 
   // Borrower merges ref count into the caller.
-  caller->HandleSubmittedTaskFinished(borrower_return_id, return_id,
-                                      {{borrower_return_id, {inner_id}}},
+  caller->HandleSubmittedTaskFinished(return_id, {{borrower_return_id, {inner_id}}},
                                       borrower->address_, borrower_refs);
   // The caller should still have a ref count because it has a reference to
   // borrower_return_id.
@@ -2120,10 +2076,8 @@ TEST(DistributedReferenceCountTest, TestReturnIdChain) {
   ASSERT_TRUE(nested_worker->rc_.HasReference(inner_id));
 
   // All task execution replies are received.
-  root->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                    {{return_id, {nested_return_id}}});
-  worker->HandleSubmittedTaskFinished(nested_return_id, ObjectID::Nil(),
-                                      {{nested_return_id, {inner_id}}});
+  root->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {nested_return_id}}});
+  worker->HandleSubmittedTaskFinished(ObjectID::Nil(), {{nested_return_id, {inner_id}}});
   root->FlushBorrowerCallbacks();
   worker->FlushBorrowerCallbacks();
 
@@ -2182,8 +2136,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedIdChain) {
   ASSERT_TRUE(nested_worker->rc_.HasReference(inner_id));
 
   // Worker receives the reply from the nested task.
-  worker->HandleSubmittedTaskFinished(nested_return_id, ObjectID::Nil(),
-                                      {{nested_return_id, {inner_id}}});
+  worker->HandleSubmittedTaskFinished(ObjectID::Nil(), {{nested_return_id, {inner_id}}});
   worker->FlushBorrowerCallbacks();
   // Worker deserializes the inner_id and returns it.
   worker->GetSerializedObjectId(nested_return_id, inner_id, nested_worker->address_);
@@ -2199,8 +2152,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedIdChain) {
 
   // Root receives worker's reply, then the WaitForRefRemovedRequest from
   // nested_worker.
-  root->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                    {{return_id, {inner_id}}});
+  root->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
   root->FlushBorrowerCallbacks();
   // Object is still in scope because root now knows that return_id contains
   // inner_id.
@@ -2262,8 +2214,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedIdChainOutOfOrder) {
   ASSERT_TRUE(nested_worker->rc_.HasReference(inner_id));
 
   // Worker receives the reply from the nested task.
-  worker->HandleSubmittedTaskFinished(nested_return_id, ObjectID::Nil(),
-                                      {{nested_return_id, {inner_id}}});
+  worker->HandleSubmittedTaskFinished(ObjectID::Nil(), {{nested_return_id, {inner_id}}});
   worker->FlushBorrowerCallbacks();
   // Worker deserializes the inner_id and returns it.
   worker->GetSerializedObjectId(nested_return_id, inner_id, nested_worker->address_);
@@ -2282,8 +2233,7 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedIdChainOutOfOrder) {
   root->FlushBorrowerCallbacks();
   ASSERT_TRUE(nested_worker->rc_.HasReference(inner_id));
 
-  root->HandleSubmittedTaskFinished(return_id, ObjectID::Nil(),
-                                    {{return_id, {inner_id}}});
+  root->HandleSubmittedTaskFinished(ObjectID::Nil(), {{return_id, {inner_id}}});
   root->rc_.RemoveLocalReference(return_id, nullptr);
   ASSERT_FALSE(root->rc_.HasReference(return_id));
   ASSERT_FALSE(root->rc_.HasReference(inner_id));
@@ -2294,7 +2244,6 @@ TEST(DistributedReferenceCountTest, TestReturnBorrowedIdChainOutOfOrder) {
 
 TEST_F(ReferenceCountLineageEnabledTest, TestUnreconstructableObjectOutOfScope) {
   ObjectID id = ObjectID::FromRandom();
-  ObjectID return_id = ObjectID::FromRandom();
   rpc::Address address;
   address.set_ip_address("1234");
 
@@ -2312,29 +2261,21 @@ TEST_F(ReferenceCountLineageEnabledTest, TestUnreconstructableObjectOutOfScope) 
   rc->RemoveLocalReference(id, &out);
   ASSERT_TRUE(*out_of_scope);
 
-  rc->AddLocalReference(return_id, "");
-
   // Unreconstructable objects stay in scope if they have a nonzero lineage ref
   // count.
   *out_of_scope = false;
   ASSERT_FALSE(rc->SetDeleteCallback(id, callback));
   rc->AddOwnedObject(id, {}, address, "", 0, false);
   ASSERT_TRUE(rc->SetDeleteCallback(id, callback));
-  rc->UpdateSubmittedTaskReferences({return_id}, {id});
-  ASSERT_TRUE(rc->IsObjectPendingCreation(return_id));
+  rc->UpdateSubmittedTaskReferences({id});
   ASSERT_FALSE(*out_of_scope);
-  rc->UpdateFinishedTaskReferences({return_id}, {id}, false, empty_borrower, empty_refs,
-                                   &out);
-  ASSERT_FALSE(rc->IsObjectPendingCreation(return_id));
+  rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
   ASSERT_FALSE(*out_of_scope);
 
   // Unreconstructable objects go out of scope once their lineage ref count
   // reaches 0.
-  rc->UpdateResubmittedTaskReferences({return_id}, {id});
-  ASSERT_TRUE(rc->IsObjectPendingCreation(return_id));
-  rc->UpdateFinishedTaskReferences({return_id}, {id}, true, empty_borrower, empty_refs,
-                                   &out);
-  ASSERT_FALSE(rc->IsObjectPendingCreation(return_id));
+  rc->UpdateResubmittedTaskReferences({id});
+  rc->UpdateFinishedTaskReferences({id}, true, empty_borrower, empty_refs, &out);
   ASSERT_TRUE(*out_of_scope);
 }
 
@@ -2402,11 +2343,11 @@ TEST_F(ReferenceCountLineageEnabledTest, TestPinLineageRecursive) {
     // Submit a dependent task on id.
     rc->AddLocalReference(id, "");
     ASSERT_TRUE(rc->HasReference(id));
-    rc->UpdateSubmittedTaskReferences({}, {id});
+    rc->UpdateSubmittedTaskReferences({id});
     rc->RemoveLocalReference(id, nullptr);
 
     // The task finishes but is retryable.
-    rc->UpdateFinishedTaskReferences({}, {id}, false, empty_borrower, empty_refs, &out);
+    rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
     // We should fail to set the deletion callback because the object has
     // already gone out of scope.
     ASSERT_FALSE(rc->SetDeleteCallback(
@@ -2447,9 +2388,9 @@ TEST_F(ReferenceCountLineageEnabledTest, TestEvictLineage) {
       });
 
   // ID1 depends on ID0.
-  rc->UpdateSubmittedTaskReferences({ids[1]}, {ids[0]});
-  rc->UpdateFinishedTaskReferences({ids[1]}, {ids[0]}, /*release_lineage=*/false,
-                                   empty_borrower, empty_refs, nullptr);
+  rc->UpdateSubmittedTaskReferences({ids[0]});
+  rc->UpdateFinishedTaskReferences({ids[0]}, /*release_lineage=*/false, empty_borrower,
+                                   empty_refs, nullptr);
   rc->AddLocalReference(ids[1], "");
   rc->AddLocalReference(ids[2], "");
 
@@ -2492,22 +2433,22 @@ TEST_F(ReferenceCountLineageEnabledTest, TestResubmittedTask) {
   ASSERT_TRUE(rc->HasReference(id));
 
   // Submit 2 dependent tasks.
-  rc->UpdateSubmittedTaskReferences({}, {id});
-  rc->UpdateSubmittedTaskReferences({}, {id});
+  rc->UpdateSubmittedTaskReferences({id});
+  rc->UpdateSubmittedTaskReferences({id});
   rc->RemoveLocalReference(id, nullptr);
   ASSERT_TRUE(rc->HasReference(id));
 
   // Both tasks finish, 1 is retryable.
-  rc->UpdateFinishedTaskReferences({}, {id}, true, empty_borrower, empty_refs, &out);
-  rc->UpdateFinishedTaskReferences({}, {id}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, true, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
   // The dependency is no longer in scope, but we still keep a reference to it
   // because it is in the lineage of the retryable task.
   ASSERT_EQ(out.size(), 1);
   ASSERT_TRUE(rc->HasReference(id));
 
   // Simulate retrying the task.
-  rc->UpdateResubmittedTaskReferences({}, {id});
-  rc->UpdateFinishedTaskReferences({}, {id}, true, empty_borrower, empty_refs, &out);
+  rc->UpdateResubmittedTaskReferences({id});
+  rc->UpdateFinishedTaskReferences({id}, true, empty_borrower, empty_refs, &out);
   ASSERT_FALSE(rc->HasReference(id));
   ASSERT_EQ(lineage_deleted.size(), 1);
 }
@@ -2756,14 +2697,14 @@ TEST_F(ReferenceCountTest, TestForwardNestedRefs) {
   // Borrower 1 forwards the ObjectRef to borrower 2 via task submission.
   borrower1->rc_.AddLocalReference(outer_id, "");
   borrower1->rc_.AddBorrowedObject(outer_id, ObjectID::Nil(), owner->address_);
-  auto return_id = borrower1->SubmitTaskWithArg(outer_id);
+  borrower1->SubmitTaskWithArg(outer_id);
 
   // Borrower 2 executes the task, keeps ref to inner ref.
   borrower2->ExecuteTaskWithArg(outer_id, middle_id, owner->address_);
   borrower2->GetSerializedObjectId(middle_id, inner_id, owner->address_);
   borrower2->rc_.RemoveLocalReference(middle_id, nullptr);
   auto borrower_refs = borrower2->FinishExecutingTask(outer_id, ObjectID::Nil());
-  borrower1->HandleSubmittedTaskFinished(return_id, outer_id, {}, borrower2->address_,
+  borrower1->HandleSubmittedTaskFinished(outer_id, {}, borrower2->address_,
                                          borrower_refs);
   borrower1->rc_.RemoveLocalReference(outer_id, nullptr);
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -54,6 +54,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
     task_deps.push_back(actor_creation_return_id);
   }
+  reference_counter_->UpdateSubmittedTaskReferences(task_deps);
 
   // Add new owned objects for the return values of the task.
   size_t num_returns = spec.NumReturns();
@@ -61,9 +62,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     num_returns--;
   }
   std::vector<rpc::ObjectReference> returned_refs;
-  std::vector<ObjectID> return_ids;
   for (size_t i = 0; i < num_returns; i++) {
-    auto return_id = spec.ReturnId(i);
     if (!spec.IsActorCreationTask()) {
       bool is_reconstructable = max_retries != 0;
       // We pass an empty vector for inner IDs because we do not know the return
@@ -71,20 +70,17 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
       // publish the WaitForRefRemoved message that we are now a borrower for
       // the inner IDs. Note that this message can be received *before* the
       // PushTaskReply.
-      reference_counter_->AddOwnedObject(return_id,
+      reference_counter_->AddOwnedObject(spec.ReturnId(i),
                                          /*inner_ids=*/{}, caller_address, call_site, -1,
                                          /*is_reconstructable=*/is_reconstructable);
     }
 
-    return_ids.push_back(return_id);
     rpc::ObjectReference ref;
     ref.set_object_id(spec.ReturnId(i).Binary());
     ref.mutable_owner_address()->CopyFrom(caller_address);
     ref.set_call_site(call_site);
     returned_refs.push_back(std::move(ref));
   }
-
-  reference_counter_->UpdateSubmittedTaskReferences(return_ids, task_deps);
 
   {
     absl::MutexLock lock(&mu_);
@@ -100,7 +96,6 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
 bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *task_deps) {
   TaskSpecification spec;
   bool resubmit = false;
-  std::vector<ObjectID> return_ids;
   {
     absl::MutexLock lock(&mu_);
     auto it = submissible_tasks_.find(task_id);
@@ -127,32 +122,30 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
         RAY_CHECK(it->second.num_retries_left == -1);
       }
       spec = it->second.spec;
+    }
+  }
 
-      for (const auto &return_id : it->second.reconstructable_return_ids) {
-        return_ids.push_back(return_id);
+  for (size_t i = 0; i < spec.NumArgs(); i++) {
+    if (spec.ArgByRef(i)) {
+      task_deps->push_back(spec.ArgId(i));
+    } else {
+      const auto &inlined_refs = spec.ArgInlinedRefs(i);
+      for (const auto &inlined_ref : inlined_refs) {
+        task_deps->push_back(ObjectID::FromBinary(inlined_ref.object_id()));
       }
     }
   }
 
+  if (!task_deps->empty()) {
+    reference_counter_->UpdateResubmittedTaskReferences(*task_deps);
+  }
+
+  if (spec.IsActorTask()) {
+    const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
+    reference_counter_->UpdateResubmittedTaskReferences({actor_creation_return_id});
+  }
+
   if (resubmit) {
-    for (size_t i = 0; i < spec.NumArgs(); i++) {
-      if (spec.ArgByRef(i)) {
-        task_deps->push_back(spec.ArgId(i));
-      } else {
-        const auto &inlined_refs = spec.ArgInlinedRefs(i);
-        for (const auto &inlined_ref : inlined_refs) {
-          task_deps->push_back(ObjectID::FromBinary(inlined_ref.object_id()));
-        }
-      }
-    }
-
-    reference_counter_->UpdateResubmittedTaskReferences(return_ids, *task_deps);
-    if (spec.IsActorTask()) {
-      const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
-      reference_counter_->UpdateResubmittedTaskReferences(return_ids,
-                                                          {actor_creation_return_id});
-    }
-
     retry_task_callback_(spec, /*delay=*/false);
   }
 
@@ -461,7 +454,6 @@ void TaskManager::OnTaskDependenciesInlined(
     const std::vector<ObjectID> &contained_ids) {
   std::vector<ObjectID> deleted;
   reference_counter_->UpdateSubmittedTaskReferences(
-      /*return_ids=*/{},
       /*argument_ids_to_add=*/contained_ids,
       /*argument_ids_to_remove=*/inlined_dependency_ids, &deleted);
   in_memory_store_->Delete(deleted);
@@ -486,19 +478,9 @@ void TaskManager::RemoveFinishedTaskReferences(
     plasma_dependencies.push_back(actor_creation_return_id);
   }
 
-  std::vector<ObjectID> return_ids;
-  size_t num_returns = spec.NumReturns();
-  if (spec.IsActorTask()) {
-    num_returns--;
-  }
-  for (size_t i = 0; i < num_returns; i++) {
-    return_ids.push_back(spec.ReturnId(i));
-  }
-
   std::vector<ObjectID> deleted;
-  reference_counter_->UpdateFinishedTaskReferences(return_ids, plasma_dependencies,
-                                                   release_lineage, borrower_addr,
-                                                   borrowed_refs, &deleted);
+  reference_counter_->UpdateFinishedTaskReferences(
+      plasma_dependencies, release_lineage, borrower_addr, borrowed_refs, &deleted);
   in_memory_store_->Delete(deleted);
 }
 

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -101,7 +101,6 @@ TEST_F(TaskManagerTest, TestTaskSuccess) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
   auto return_id = spec.ReturnId(0);
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   rpc::PushTaskReply reply;
   auto return_object = reply.add_return_objects();
@@ -112,7 +111,6 @@ TEST_F(TaskManagerTest, TestTaskSuccess) {
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));
   // Only the return object reference should remain.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
   RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, false, &results));
@@ -142,14 +140,12 @@ TEST_F(TaskManagerTest, TestTaskFailure) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
   auto return_id = spec.ReturnId(0);
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   auto error = rpc::ErrorType::WORKER_DIED;
   manager_.PendingTaskFailed(spec.TaskId(), error);
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));
   // Only the return object reference should remain.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
   RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, false, &results));
@@ -205,14 +201,12 @@ TEST_F(TaskManagerTest, TestTaskReconstruction) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
   auto return_id = spec.ReturnId(0);
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   auto error = rpc::ErrorType::WORKER_DIED;
   for (int i = 0; i < num_retries; i++) {
     RAY_LOG(INFO) << "Retry " << i;
     manager_.PendingTaskFailed(spec.TaskId(), error);
     ASSERT_TRUE(manager_.IsTaskPending(spec.TaskId()));
-    ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
     ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
     std::vector<std::shared_ptr<RayObject>> results;
     ASSERT_FALSE(store_->Get({return_id}, 1, 0, ctx, false, &results).ok());
@@ -223,7 +217,6 @@ TEST_F(TaskManagerTest, TestTaskReconstruction) {
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));
   // Only the return object reference should remain.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
   RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
@@ -499,7 +492,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ObjectID dep1 = ObjectID::FromRandom();
   ObjectID dep2 = ObjectID::FromRandom();
   auto spec = CreateTaskHelper(1, {dep1, dep2});
-  auto return_id = spec.ReturnId(0);
   int num_retries = 3;
 
   // Cannot resubmit a task whose spec we do not have.
@@ -507,16 +499,15 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_FALSE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps));
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 0);
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   manager_.AddPendingTask(caller_address, spec, "", num_retries);
   // A task that is already pending does not get resubmitted.
   ASSERT_TRUE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps));
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 0);
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The task completes.
+  auto return_id = spec.ReturnId(0);
   reference_counter_->AddLocalReference(return_id, "");
   rpc::PushTaskReply reply;
   auto return_object = reply.add_return_objects();
@@ -525,7 +516,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   return_object->set_data(data->Data(), data->Size());
   return_object->set_in_plasma(true);
   manager_.CompletePendingTask(spec.TaskId(), reply, rpc::Address());
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The task finished, its return ID is still in scope, and the return object
   // was stored in plasma. It is okay to resubmit it now.
@@ -533,7 +523,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_EQ(resubmitted_task_deps, spec.GetDependencyIds());
   ASSERT_EQ(num_retries_, 1);
   resubmitted_task_deps.clear();
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The return ID goes out of scope.
   reference_counter_->RemoveLocalReference(return_id, nullptr);
@@ -543,8 +532,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_TRUE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps));
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 1);
-  // Object is out of scope, so no longer pending creation.
-  ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The resubmitted task finishes.
   manager_.CompletePendingTask(spec.TaskId(), reply, rpc::Address());
@@ -553,7 +540,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_FALSE(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps));
   ASSERT_TRUE(resubmitted_task_deps.empty());
   ASSERT_EQ(num_retries_, 1);
-  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
 }
 
 // Test resubmission for a task that was successfully executed once and stored

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -44,7 +44,7 @@ struct RemoteConnectionInfo {
 /// Callback for object location notifications.
 using OnLocationsFound = std::function<void(
     const ray::ObjectID &object_id, const std::unordered_set<ray::NodeID> &,
-    const std::string &, const NodeID &, bool pending_creation, size_t object_size)>;
+    const std::string &, const NodeID &, size_t object_size)>;
 
 class IObjectDirectory {
  public:

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -56,8 +56,7 @@ ObjectManager::ObjectManager(
     SpillObjectsCallback spill_objects_callback,
     std::function<void()> object_store_full_callback,
     AddObjectCallback add_object_callback, DeleteObjectCallback delete_object_callback,
-    std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
-    const std::function<void(const ObjectID &)> fail_pull_request)
+    std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object)
     : main_service_(&main_service),
       self_node_id_(self_node_id),
       config_(config),
@@ -123,10 +122,10 @@ ObjectManager::ObjectManager(
   if (available_memory < 0) {
     available_memory = 0;
   }
-  pull_manager_.reset(new PullManager(
-      self_node_id_, object_is_local, send_pull_request, cancel_pull_request,
-      fail_pull_request, restore_spilled_object_, get_time, config.pull_timeout_ms,
-      available_memory, pin_object, get_spilled_object_url));
+  pull_manager_.reset(new PullManager(self_node_id_, object_is_local, send_pull_request,
+                                      cancel_pull_request, restore_spilled_object_,
+                                      get_time, config.pull_timeout_ms, available_memory,
+                                      pin_object, get_spilled_object_url));
   // Start object manager rpc server and send & receive request threads
   StartRpcService();
 }
@@ -209,13 +208,13 @@ uint64_t ObjectManager::Pull(const std::vector<rpc::ObjectReference> &object_ref
   std::vector<rpc::ObjectReference> objects_to_locate;
   auto request_id = pull_manager_->Pull(object_refs, prio, &objects_to_locate);
 
-  const auto &callback =
-      [this](const ObjectID &object_id, const std::unordered_set<NodeID> &client_ids,
-             const std::string &spilled_url, const NodeID &spilled_node_id,
-             bool pending_creation, size_t object_size) {
-        pull_manager_->OnLocationChange(object_id, client_ids, spilled_url,
-                                        spilled_node_id, pending_creation, object_size);
-      };
+  const auto &callback = [this](const ObjectID &object_id,
+                                const std::unordered_set<NodeID> &client_ids,
+                                const std::string &spilled_url,
+                                const NodeID &spilled_node_id, size_t object_size) {
+    pull_manager_->OnLocationChange(object_id, client_ids, spilled_url, spilled_node_id,
+                                    object_size);
+  };
 
   for (const auto &ref : objects_to_locate) {
     // Subscribe to object notifications. A notification will be received every
@@ -568,7 +567,7 @@ ray::Status ObjectManager::LookupRemainingWaitObjects(const UniqueID &wait_id) {
           [this, wait_id](const ObjectID &lookup_object_id,
                           const std::unordered_set<NodeID> &node_ids,
                           const std::string &spilled_url, const NodeID &spilled_node_id,
-                          bool pending_creation, size_t object_size) {
+                          size_t object_size) {
             auto &wait_state = active_wait_requests_.find(wait_id)->second;
             // Note that the object is guaranteed to be added to local_objects_ before
             // the notification is triggered.
@@ -610,7 +609,7 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
           [this, wait_id](const ObjectID &subscribe_object_id,
                           const std::unordered_set<NodeID> &node_ids,
                           const std::string &spilled_url, const NodeID &spilled_node_id,
-                          bool pending_creation, size_t object_size) {
+                          size_t object_size) {
             auto object_id_wait_state = active_wait_requests_.find(wait_id);
             if (object_id_wait_state == active_wait_requests_.end()) {
               // Depending on the timing of calls to the object directory, we

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -170,8 +170,7 @@ class ObjectManager : public ObjectManagerInterface,
       SpillObjectsCallback spill_objects_callback,
       std::function<void()> object_store_full_callback,
       AddObjectCallback add_object_callback, DeleteObjectCallback delete_object_callback,
-      std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
-      const std::function<void(const ObjectID &)> fail_pull_request);
+      std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object);
 
   ~ObjectManager();
 

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -49,15 +49,14 @@ void FilterRemovedNodes(std::shared_ptr<gcs::GcsClient> gcs_client,
 bool UpdateObjectLocations(const rpc::WorkerObjectLocationsPubMessage &location_info,
                            std::shared_ptr<gcs::GcsClient> gcs_client,
                            std::unordered_set<NodeID> *node_ids, std::string *spilled_url,
-                           NodeID *spilled_node_id, bool *pending_creation,
-                           size_t *object_size) {
+                           NodeID *spilled_node_id, size_t *object_size) {
   bool is_updated = false;
   std::unordered_set<NodeID> new_node_ids;
   // The size can be 0 if the update was a deletion. This assumes that an
   // object's size is always greater than 0.
   // TODO(swang): If that's not the case, we should use a flag to check
   // whether the size is set instead.
-  if (location_info.object_size() > 0 && location_info.object_size() != *object_size) {
+  if (location_info.object_size() > 0) {
     *object_size = location_info.object_size();
     is_updated = true;
   }
@@ -82,10 +81,6 @@ bool UpdateObjectLocations(const rpc::WorkerObjectLocationsPubMessage &location_
       *spilled_url = new_spilled_url;
       *spilled_node_id = new_spilled_node_id;
     }
-    is_updated = true;
-  }
-  if (location_info.pending_creation() != *pending_creation) {
-    *pending_creation = location_info.pending_creation();
     is_updated = true;
   }
 
@@ -231,12 +226,11 @@ void OwnershipBasedObjectDirectory::ObjectLocationSubscriptionCallback(
   for (auto const &node_id_binary : location_info.node_ids()) {
     const auto node_id = NodeID::FromBinary(node_id_binary);
     RAY_LOG(DEBUG) << "Object " << object_id << " is on node " << node_id << " alive? "
-                   << !gcs_client_->Nodes().IsRemoved(node_id);
+                   << gcs_client_->Nodes().IsRemoved(node_id);
   }
   auto location_updated = UpdateObjectLocations(
       location_info, gcs_client_, &it->second.current_object_locations,
-      &it->second.spilled_url, &it->second.spilled_node_id, &it->second.pending_creation,
-      &it->second.object_size);
+      &it->second.spilled_url, &it->second.spilled_node_id, &it->second.object_size);
 
   // If the lookup has failed, that means the object is lost. Trigger the callback in this
   // case to handle failure properly.
@@ -262,7 +256,7 @@ void OwnershipBasedObjectDirectory::ObjectLocationSubscriptionCallback(
       // See https://github.com/ray-project/ray/issues/2959.
       callback_pair.second(object_id, it->second.current_object_locations,
                            it->second.spilled_url, it->second.spilled_node_id,
-                           it->second.pending_creation, it->second.object_size);
+                           it->second.object_size);
     }
   }
 }
@@ -326,7 +320,6 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     auto &locations = listener_state.current_object_locations;
     auto &spilled_url = listener_state.spilled_url;
     auto &spilled_node_id = listener_state.spilled_node_id;
-    bool pending_creation = listener_state.pending_creation;
     auto object_size = listener_state.object_size;
     RAY_LOG(DEBUG) << "Already subscribed to object's locations, pushing location "
                       "updates to subscribers for object "
@@ -338,10 +331,8 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     // structures shared with the caller and potentially invalidating caller
     // iterators. See https://github.com/ray-project/ray/issues/2959.
     io_service_.post(
-        [callback, locations, spilled_url, spilled_node_id, pending_creation, object_size,
-         object_id]() {
-          callback(object_id, locations, spilled_url, spilled_node_id, pending_creation,
-                   object_size);
+        [callback, locations, spilled_url, spilled_node_id, object_size, object_id]() {
+          callback(object_id, locations, spilled_url, spilled_node_id, object_size);
         },
         "ObjectDirectory.SubscribeObjectLocations");
   }
@@ -379,16 +370,13 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
     auto &locations = it->second.current_object_locations;
     auto &spilled_url = it->second.spilled_url;
     auto &spilled_node_id = it->second.spilled_node_id;
-    bool pending_creation = it->second.pending_creation;
     auto object_size = it->second.object_size;
     // We post the callback to the event loop in order to avoid mutating data
     // structures shared with the caller and potentially invalidating caller
     // iterators. See https://github.com/ray-project/ray/issues/2959.
     io_service_.post(
-        [callback, object_id, locations, spilled_url, spilled_node_id, pending_creation,
-         object_size]() {
-          callback(object_id, locations, spilled_url, spilled_node_id, pending_creation,
-                   object_size);
+        [callback, object_id, locations, spilled_url, spilled_node_id, object_size]() {
+          callback(object_id, locations, spilled_url, spilled_node_id, object_size);
         },
         "ObjectDirectory.LookupLocations");
   } else {
@@ -402,8 +390,7 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
       // See https://github.com/ray-project/ray/issues/2959.
       io_service_.post(
           [callback, object_id]() {
-            callback(object_id, std::unordered_set<NodeID>(), "", NodeID::Nil(),
-                     /*pending_creation=*/false, 0);
+            callback(object_id, std::unordered_set<NodeID>(), "", NodeID::Nil(), 0);
           },
           "ObjectDirectory.LookupLocations");
       return Status::OK();
@@ -421,7 +408,6 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
           std::string spilled_url;
           NodeID spilled_node_id;
           size_t object_size = 0;
-          bool pending_creation = false;
 
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Worker " << worker_id << " failed to get the location for "
@@ -435,8 +421,7 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
             mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
           } else {
             UpdateObjectLocations(reply.object_location_info(), gcs_client_, &node_ids,
-                                  &spilled_url, &spilled_node_id, &pending_creation,
-                                  &object_size);
+                                  &spilled_url, &spilled_node_id, &object_size);
           }
           RAY_LOG(DEBUG) << "Looked up locations for " << object_id
                          << ", returning: " << node_ids.size()
@@ -447,8 +432,7 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
           // caller iterators since this is already running in the core worker
           // client's lookup callback stack.
           // See https://github.com/ray-project/ray/issues/2959.
-          callback(object_id, node_ids, spilled_url, spilled_node_id, pending_creation,
-                   object_size);
+          callback(object_id, node_ids, spilled_url, spilled_node_id, object_size);
         });
   }
   return Status::OK();
@@ -497,7 +481,6 @@ void OwnershipBasedObjectDirectory::HandleNodeRemoved(const NodeID &node_id) {
         // in the subscription callback stack.
         callback_pair.second(object_id, listener.second.current_object_locations,
                              listener.second.spilled_url, listener.second.spilled_node_id,
-                             listener.second.pending_creation,
                              listener.second.object_size);
       }
     }

--- a/src/ray/object_manager/ownership_based_object_directory.h
+++ b/src/ray/object_manager/ownership_based_object_directory.h
@@ -95,7 +95,6 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
     // The node id that spills the object to the disk.
     // It will be Nil if it uses a distributed external storage.
     NodeID spilled_node_id = NodeID::Nil();
-    bool pending_creation = true;
     /// The size of the object.
     size_t object_size = 0;
     /// This flag will get set to true if received any notification of the object.
@@ -169,8 +168,6 @@ class OwnershipBasedObjectDirectory : public IObjectDirectory {
   double metrics_num_object_location_updates_per_second_;
 
   uint64_t cum_metrics_num_object_location_updates_;
-
-  friend class OwnershipBasedObjectDirectoryTest;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -22,9 +22,8 @@ PullManager::PullManager(
     NodeID &self_node_id, const std::function<bool(const ObjectID &)> object_is_local,
     const std::function<void(const ObjectID &, const NodeID &)> send_pull_request,
     const std::function<void(const ObjectID &)> cancel_pull_request,
-    const std::function<void(const ObjectID &)> fail_pull_request,
     const RestoreSpilledObjectCallback restore_spilled_object,
-    const std::function<double()> get_time_seconds, int pull_timeout_ms,
+    const std::function<double()> get_time, int pull_timeout_ms,
     int64_t num_bytes_available,
     std::function<std::unique_ptr<RayObject>(const ObjectID &)> pin_object,
     std::function<std::string(const ObjectID &)> get_locally_spilled_object_url)
@@ -33,12 +32,11 @@ PullManager::PullManager(
       send_pull_request_(send_pull_request),
       cancel_pull_request_(cancel_pull_request),
       restore_spilled_object_(restore_spilled_object),
-      get_time_seconds_(get_time_seconds),
+      get_time_(get_time),
       pull_timeout_ms_(pull_timeout_ms),
       num_bytes_available_(num_bytes_available),
       pin_object_(pin_object),
       get_locally_spilled_object_url_(get_locally_spilled_object_url),
-      fail_pull_request_(fail_pull_request),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_bundle,
@@ -81,7 +79,7 @@ uint64_t PullManager::Pull(const std::vector<rpc::ObjectReference> &object_ref_b
       // The first pull request doesn't need to be special case. Instead we can just let
       // the retry timer fire immediately.
       it = object_pull_requests_
-               .emplace(obj_id, ObjectPullRequest(/*next_pull_time=*/get_time_seconds_()))
+               .emplace(obj_id, ObjectPullRequest(/*next_pull_time=*/get_time_()))
                .first;
     } else {
       if (it->second.object_size_set) {
@@ -388,8 +386,7 @@ std::vector<ObjectID> PullManager::CancelPull(uint64_t request_id) {
 void PullManager::OnLocationChange(const ObjectID &object_id,
                                    const std::unordered_set<NodeID> &client_ids,
                                    const std::string &spilled_url,
-                                   const NodeID &spilled_node_id, bool pending_creation,
-                                   size_t object_size) {
+                                   const NodeID &spilled_node_id, size_t object_size) {
   // Exit if the Pull request has already been fulfilled or canceled.
   auto it = object_pull_requests_.find(object_id);
   if (it == object_pull_requests_.end()) {
@@ -402,15 +399,7 @@ void PullManager::OnLocationChange(const ObjectID &object_id,
   it->second.client_locations = std::vector<NodeID>(client_ids.begin(), client_ids.end());
   it->second.spilled_url = spilled_url;
   it->second.spilled_node_id = spilled_node_id;
-  it->second.pending_object_creation = pending_creation;
   if (!it->second.object_size_set) {
-    // TODO(swang): This assumes that the object size will be set correctly on
-    // the first location update and that locations will soon appear after the
-    // object size has been set. This can block later requests whose metadata
-    // has already arrived. Instead, we should keep track of which pull
-    // requests are still waiting for object metadata and queue requests in the
-    // order that their metadata appears.
-    // See https://github.com/ray-project/ray/issues/13689.
     it->second.object_size = object_size;
     it->second.object_size_set = true;
     for (auto &bundle_request_id : it->second.bundle_request_ids) {
@@ -459,7 +448,7 @@ void PullManager::TryToMakeObjectLocal(const ObjectID &object_id) {
   auto it = object_pull_requests_.find(object_id);
   RAY_CHECK(it != object_pull_requests_.end());
   auto &request = it->second;
-  if (request.next_pull_time > get_time_seconds_()) {
+  if (request.next_pull_time > get_time_()) {
     return;
   }
 
@@ -492,24 +481,9 @@ void PullManager::TryToMakeObjectLocal(const ObjectID &object_id) {
     return;
   }
 
-  if (request.expiration_time_seconds == 0) {
-    RAY_LOG(WARNING) << "Object neither in memory nor external storage "
-                     << object_id.Hex();
-    request.expiration_time_seconds =
-        get_time_seconds_() +
-        RayConfig::instance().fetch_warn_timeout_milliseconds() / 1e3;
-  } else if (request.pending_object_creation) {
-    // Object is pending creation, wait for the task that creates the object to
-    // finish.
-    RAY_LOG(INFO) << "Object pending creation " << object_id.Hex();
-    request.expiration_time_seconds =
-        get_time_seconds_() +
-        RayConfig::instance().fetch_warn_timeout_milliseconds() / 1e3;
-  } else if (get_time_seconds_() > request.expiration_time_seconds) {
-    // Object has no locations and is not being reconstructed by its owner.
-    fail_pull_request_(object_id);
-    request.expiration_time_seconds = 0;
-  }
+  // TODO(swang): Store an error if this times out and the object is not
+  // pending reconstruction.
+  RAY_LOG(WARNING) << "Object neither in memory nor external storage " << object_id.Hex();
 }
 
 bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
@@ -572,14 +546,14 @@ bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
 void PullManager::ResetRetryTimer(const ObjectID &object_id) {
   auto it = object_pull_requests_.find(object_id);
   if (it != object_pull_requests_.end()) {
-    it->second.next_pull_time = get_time_seconds_();
+    it->second.next_pull_time = get_time_();
     it->second.num_retries = 0;
   }
 }
 
 void PullManager::UpdateRetryTimer(ObjectPullRequest &request,
                                    const ObjectID &object_id) {
-  const auto time = get_time_seconds_();
+  const auto time = get_time_();
   auto retry_timeout_len = (pull_timeout_ms_ / 1000.) * (1UL << request.num_retries);
   request.next_pull_time = time + retry_timeout_len;
   if (retry_timeout_len > max_timeout_) {

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -63,9 +63,8 @@ class PullManager {
       NodeID &self_node_id, const std::function<bool(const ObjectID &)> object_is_local,
       const std::function<void(const ObjectID &, const NodeID &)> send_pull_request,
       const std::function<void(const ObjectID &)> cancel_pull_request,
-      const std::function<void(const ObjectID &)> fail_pull_request,
       const RestoreSpilledObjectCallback restore_spilled_object,
-      const std::function<double()> get_time_seconds, int pull_timeout_ms,
+      const std::function<double()> get_time, int pull_timeout_ms,
       int64_t num_bytes_available,
       std::function<std::unique_ptr<RayObject>(const ObjectID &object_id)> pin_object,
       std::function<std::string(const ObjectID &)> get_locally_spilled_object_url);
@@ -105,14 +104,10 @@ class PullManager {
   /// non-empty, the object may no longer be on any node.
   /// \param spilled_node_id The node id of the object if it was spilled. If Nil, the
   /// object may no longer be on any node.
-  /// \param pending_creation Whether this object is pending creation. This is
-  /// used to time out objects that have had no locations for too long.
-  /// \param object_size The size of the object. Used to compute how many
-  /// objects we can safely pull.
   void OnLocationChange(const ObjectID &object_id,
                         const std::unordered_set<NodeID> &client_ids,
                         const std::string &spilled_url, const NodeID &spilled_node_id,
-                        bool pending_creation, size_t object_size);
+                        size_t object_size);
 
   /// Cancel an existing pull request.
   ///
@@ -175,11 +170,7 @@ class PullManager {
     std::vector<NodeID> client_locations;
     std::string spilled_url;
     NodeID spilled_node_id;
-    bool pending_object_creation = false;
     double next_pull_time;
-    // The pull will timeout at this time if there are still no locations for
-    // the object.
-    double expiration_time_seconds = 0;
     uint8_t num_retries;
     bool object_size_set = false;
     size_t object_size = 0;
@@ -288,7 +279,7 @@ class PullManager {
   const std::function<void(const ObjectID &, const NodeID &)> send_pull_request_;
   const std::function<void(const ObjectID &)> cancel_pull_request_;
   const RestoreSpilledObjectCallback restore_spilled_object_;
-  const std::function<double()> get_time_seconds_;
+  const std::function<double()> get_time_;
   uint64_t pull_timeout_ms_;
 
   /// The next ID to assign to a bundle pull request, so that the caller can
@@ -371,9 +362,6 @@ class PullManager {
   // A callback to get the spilled object URL if the object is spilled locally.
   // It will return an empty string otherwise.
   std::function<std::string(const ObjectID &)> get_locally_spilled_object_url_;
-
-  // A callback to fail a hung pull request.
-  std::function<void(const ObjectID &)> fail_pull_request_;
 
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;

--- a/src/ray/object_manager/test/ownership_based_object_directory_test.cc
+++ b/src/ray/object_manager/test/ownership_based_object_directory_test.cc
@@ -28,9 +28,6 @@
 
 namespace ray {
 
-using ::testing::_;
-using ::testing::Return;
-
 class MockWorkerClient : public rpc::CoreWorkerClientInterface {
  public:
   void UpdateObjectLocationBatch(
@@ -163,13 +160,6 @@ class OwnershipBasedObjectDirectoryTest : public ::testing::Test {
     auto dummy_info = CreateNewObjectInfo(owner_id);
     obod_.ReportObjectAdded(dummy_info.object_id, current_node_id, dummy_info);
     RAY_LOG(INFO) << "First batch sent.";
-  }
-
-  void HandleMessage(const rpc::WorkerObjectLocationsPubMessage &location_info,
-                     const ObjectID &object_id, bool location_lookup_failed = false) {
-    // Mock for receiving a message from the pubsub layer.
-    obod_.ObjectLocationSubscriptionCallback(location_info, object_id,
-                                             location_lookup_failed);
   }
 
   int64_t max_batch_size = 20;
@@ -383,69 +373,6 @@ TEST_F(OwnershipBasedObjectDirectoryTest, TestOwnerFailed) {
   ASSERT_TRUE(owner_client->ReplyUpdateObjectLocationBatch(ray::Status::Invalid("")));
   // Requests are not sent anymore.
   ASSERT_EQ(NumBatchRequestSent(), 2);
-  // Make sure metadata is cleaned up properly.
-  AssertNoLeak();
-}
-
-TEST_F(OwnershipBasedObjectDirectoryTest, TestNotifyOnUpdate) {
-  UniqueID callback_id = UniqueID::FromRandom();
-  ObjectID obj_id = ObjectID::FromRandom();
-  int num_callbacks = 0;
-  EXPECT_CALL(*subscriber_, Subscribe(_, _, _, _, _, _, _)).WillOnce(Return(true));
-  ASSERT_TRUE(
-      obod_
-          .SubscribeObjectLocations(
-              callback_id, obj_id, rpc::Address(),
-              [&](const ObjectID &object_id, const std::unordered_set<NodeID> &client_ids,
-                  const std::string &spilled_url, const NodeID &spilled_node_id,
-                  bool pending_creation, size_t object_size) { num_callbacks++; })
-          .ok());
-  ASSERT_EQ(num_callbacks, 0);
-
-  // Object pending, no other metadata. This is the same as the initial state,
-  // so no callbacks triggered.
-  rpc::WorkerObjectLocationsPubMessage location_info;
-  location_info.set_pending_creation(true);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 0);
-
-  // Setting object size triggers callback once.
-  location_info.set_object_size(100);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 1);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 1);
-
-  // Adding object location triggers callback once.
-  location_info.add_node_ids(NodeID::FromRandom().Binary());
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 2);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 2);
-
-  // Removing object location triggers callback once.
-  location_info.mutable_node_ids()->Clear();
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 3);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 3);
-
-  // Adding spilled location triggers callback once.
-  location_info.set_spilled_url("1234");
-  location_info.set_spilled_node_id(NodeID::FromRandom().Binary());
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 4);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 4);
-
-  // Setting pending creation back to false (happens during reconstruction)
-  // triggers callback.
-  location_info.set_pending_creation(false);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 5);
-  HandleMessage(location_info, obj_id);
-  ASSERT_EQ(num_callbacks, 5);
-
   // Make sure metadata is cleaned up properly.
   AssertNoLeak();
 }

--- a/src/ray/object_manager/test/pull_manager_test.cc
+++ b/src/ray/object_manager/test/pull_manager_test.cc
@@ -37,7 +37,6 @@ class PullManagerTestWithCapacity {
               num_send_pull_request_calls_++;
             },
             [this](const ObjectID &object_id) { num_abort_calls_[object_id]++; },
-            [this](const ObjectID &object_id) { timed_out_objects_.insert(object_id); },
             [this](const ObjectID &, const std::string &,
                    std::function<void(const ray::Status &)> callback) {
               num_restore_spilled_object_calls_++;
@@ -62,8 +61,6 @@ class PullManagerTestWithCapacity {
     ASSERT_TRUE(pull_manager_.active_object_pull_requests_.empty());
     ASSERT_TRUE(pull_manager_.pinned_objects_.empty());
     ASSERT_EQ(pull_manager_.pinned_objects_size_, 0);
-    // Most tests should not timeout any pull requests.
-    ASSERT_TRUE(timed_out_objects_.empty());
   }
 
   int NumPinnedObjects() { return pull_manager_.pinned_objects_.size(); }
@@ -90,7 +87,6 @@ class PullManagerTestWithCapacity {
   PullManager pull_manager_;
   std::unordered_map<ObjectID, int> num_abort_calls_;
   std::unordered_map<ObjectID, std::string> spilled_url_;
-  std::unordered_set<ObjectID> timed_out_objects_;
 };
 
 class PullManagerTest : public PullManagerTestWithCapacity,
@@ -150,7 +146,7 @@ TEST_P(PullManagerTest, TestStaleSubscription) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), 0);
   AssertNumActiveRequestsEquals(1);
 
   // There are no client ids to pull from.
@@ -167,7 +163,7 @@ TEST_P(PullManagerTest, TestStaleSubscription) {
   AssertNumActiveRequestsEquals(0);
 
   client_ids.insert(NodeID::FromRandom());
-  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), 0);
 
   // Now we're getting a notification about an object that was already cancelled.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -191,7 +187,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -201,7 +197,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 node_that_object_spilled, false, 0);
+                                 node_that_object_spilled, 0);
 
   // We request a remote pull to restore the object.
   ASSERT_EQ(num_send_pull_request_calls_, 1);
@@ -210,7 +206,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   // No retry yet.
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 node_that_object_spilled, false, 0);
+                                 node_that_object_spilled, 0);
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
@@ -219,7 +215,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 node_that_object_spilled, false, 0);
+                                 node_that_object_spilled, 0);
   ASSERT_EQ(num_send_pull_request_calls_, 2);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
@@ -227,7 +223,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectRemote) {
   object_is_local_ = true;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 NodeID::FromRandom(), false, 0);
+                                 NodeID::FromRandom(), 0);
   ASSERT_EQ(num_send_pull_request_calls_, 2);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
 
@@ -254,7 +250,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -263,7 +259,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -272,7 +268,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   // No retry yet.
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 1);
 
@@ -280,7 +276,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectLocal) {
   fake_time_ += 10.;
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 2);
 
@@ -308,7 +304,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnLocalStorage) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -318,7 +314,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnLocalStorage) {
   // Objects are spilled locally, but the remote object directory doesn't have the
   // information. It should still restore objects.
   ObjectSpilled(obj1, "remote_url/foo/bar");
-  pull_manager_.OnLocationChange(obj1, client_ids, "", self_node_id_, false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", self_node_id_, 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -328,7 +324,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnLocalStorage) {
   // updated now.
   fake_time_ += 10.;
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 2);
 
@@ -356,7 +352,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
   ASSERT_EQ(ObjectRefsToIds(objects_to_locate), ObjectRefsToIds(refs));
 
   std::unordered_set<NodeID> client_ids;
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
 
   // client_ids is empty here, so there's nowhere to pull from.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -368,7 +364,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
   // If objects are spilled to external storages, the node id should be Nil().
   // So this shouldn't invoke restoration.
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", self_node_id_,
-                                 false, 0);
+                                 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -376,7 +372,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
 
   // Now Nil ID is properly updated.
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", NodeID::Nil(),
-                                 false, 0);
+                                 0);
 
   // We request a local restore.
   ASSERT_EQ(num_send_pull_request_calls_, 0);
@@ -385,7 +381,7 @@ TEST_P(PullManagerTest, TestRestoreSpilledObjectOnExternalStorage) {
   // The call can be retried after a delay.
   fake_time_ += 10.;
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar", NodeID::Nil(),
-                                 false, 0);
+                                 0);
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_EQ(num_restore_spilled_object_calls_, 2);
 
@@ -423,7 +419,7 @@ TEST_P(PullManagerTest, TestLoadBalancingRestorationRequest) {
   client_ids.insert(copy_node2);
   ObjectSpilled(obj1, "remote_url/foo/bar");
   pull_manager_.OnLocationChange(obj1, client_ids, "remote_url/foo/bar",
-                                 remote_node_that_spilled_object, false, 0);
+                                 remote_node_that_spilled_object, 0);
 
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   // Make sure the restore request wasn't sent since there are nodes that have a copied
@@ -449,7 +445,7 @@ TEST_P(PullManagerTest, TestManyUpdates) {
   client_ids.insert(NodeID::FromRandom());
 
   for (int i = 0; i < 100; i++) {
-    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
     AssertNumActiveRequestsEquals(1);
   }
 
@@ -484,7 +480,7 @@ TEST_P(PullManagerTest, TestRetryTimer) {
 
   // We need to call OnLocationChange at least once, to population the list of nodes with
   // the object.
-  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
   AssertNumActiveRequestsEquals(1);
   ASSERT_EQ(num_send_pull_request_calls_, 1);
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
@@ -495,7 +491,7 @@ TEST_P(PullManagerTest, TestRetryTimer) {
 
   // Location changes can trigger reset timer.
   for (; fake_time_ <= 120 * 10; fake_time_ += 1.) {
-    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(obj1, client_ids, "", NodeID::Nil(), 0);
   }
 
   // We should make a pull request every tick (even if it's a duplicate to a node we're
@@ -537,7 +533,7 @@ TEST_P(PullManagerTest, TestBasic) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_TRUE(pull_manager_.IsObjectActive(oids[i]));
@@ -552,7 +548,7 @@ TEST_P(PullManagerTest, TestBasic) {
   num_send_pull_request_calls_ = 0;
   fake_time_ += 10;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
 
@@ -572,7 +568,7 @@ TEST_P(PullManagerTest, TestBasic) {
   num_send_pull_request_calls_ = 0;
   fake_time_ += 10;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
   ASSERT_FALSE(pull_manager_.HasPullsQueued());
@@ -596,7 +592,7 @@ TEST_P(PullManagerTest, TestPinActiveObjects) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 1);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 1);
   }
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_TRUE(pull_manager_.IsObjectActive(oids[i]));
@@ -624,7 +620,7 @@ TEST_P(PullManagerTest, TestPinActiveObjects) {
   auto req_id2 = pull_manager_.Pull(refs2, BundlePriority::TASK_ARGS, &objects_to_locate);
   for (size_t i = 0; i < oids2.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids2[i]));
-    pull_manager_.OnLocationChange(oids2[i], client_ids, "", NodeID::Nil(), false, 1000);
+    pull_manager_.OnLocationChange(oids2[i], client_ids, "", NodeID::Nil(), 1000);
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids2[i]));
   }
   pull_manager_.UpdatePullsBasedOnAvailableMemory(4);
@@ -660,7 +656,7 @@ TEST_P(PullManagerTest, TestDeduplicateBundles) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, oids.size());
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
@@ -676,8 +672,8 @@ TEST_P(PullManagerTest, TestDeduplicateBundles) {
   fake_time_ += 10;
   num_send_pull_request_calls_ = 0;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
     ASSERT_EQ(num_send_pull_request_calls_, i + 1);
     ASSERT_EQ(num_restore_spilled_object_calls_, 0);
     ASSERT_TRUE(pull_manager_.IsObjectActive(oids[i]));
@@ -698,7 +694,7 @@ TEST_P(PullManagerTest, TestDeduplicateBundles) {
   object_is_local_ = false;
   num_send_pull_request_calls_ = 0;
   for (size_t i = 0; i < oids.size(); i++) {
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false, 0);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), 0);
   }
   ASSERT_EQ(num_send_pull_request_calls_, 0);
 
@@ -749,7 +745,7 @@ TEST_P(PullManagerTest, TestDuplicateObjectsAreActivatedAndCleanedUp) {
 
   std::unordered_set<NodeID> client_ids;
   client_ids.insert(NodeID::FromRandom());
-  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), false, 0);
+  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), 0);
   AssertNumActiveRequestsEquals(1);
 
   auto objects_to_cancel = pull_manager_.CancelPull(req_id);
@@ -779,8 +775,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestBasic) {
   client_ids.insert(NodeID::FromRandom());
   for (size_t i = 0; i < oids.size(); i++) {
     ASSERT_FALSE(pull_manager_.IsObjectActive(oids[i]));
-    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), object_size);
   }
   ASSERT_EQ(num_send_pull_request_calls_, oids.size());
   ASSERT_EQ(num_restore_spilled_object_calls_, 0);
@@ -847,8 +842,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestQueue) {
   client_ids.insert(NodeID::FromRandom());
   for (auto &oids : bundles) {
     for (size_t i = 0; i < oids.size(); i++) {
-      pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), false,
-                                     object_size);
+      pull_manager_.OnLocationChange(oids[i], client_ids, "", NodeID::Nil(), object_size);
     }
   }
 
@@ -908,8 +902,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestCancel) {
       req_ids.push_back(req_id);
     }
     for (size_t i = 0; i < object_sizes.size(); i++) {
-      pull_manager_.OnLocationChange(oids[i], {}, "", NodeID::Nil(), false,
-                                     object_sizes[i]);
+      pull_manager_.OnLocationChange(oids[i], {}, "", NodeID::Nil(), object_sizes[i]);
     }
     AssertNumActiveRequestsEquals(num_active_requests_expected_before);
     pull_manager_.CancelPull(req_ids[cancel_idx]);
@@ -917,7 +910,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestCancel) {
 
     // Request is really canceled.
     pull_manager_.OnLocationChange(oids[cancel_idx], {NodeID::FromRandom()}, "",
-                                   NodeID::Nil(), false, object_sizes[cancel_idx]);
+                                   NodeID::Nil(), object_sizes[cancel_idx]);
     ASSERT_EQ(num_send_pull_request_calls_, 0);
 
     // The expected number of requests at the head of the queue are pulled.
@@ -925,7 +918,7 @@ TEST_P(PullManagerWithAdmissionControlTest, TestCancel) {
     for (size_t i = 0; i < refs.size() && num_active < num_active_requests_expected_after;
          i++) {
       pull_manager_.OnLocationChange(oids[i], {NodeID::FromRandom()}, "", NodeID::Nil(),
-                                     false, object_sizes[i]);
+                                     object_sizes[i]);
       if (i != cancel_idx) {
         num_active++;
       }
@@ -981,8 +974,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   std::unordered_set<NodeID> client_ids;
   client_ids.insert(NodeID::FromRandom());
   for (auto &oid : task_oids) {
-    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), object_size);
   }
 
   // Two requests can be pulled at a time.
@@ -996,7 +988,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   auto wait_req_id =
       pull_manager_.Pull(refs, BundlePriority::WAIT_REQUEST, &objects_to_locate);
   wait_oids.push_back(ObjectRefsToIds(refs)[0]);
-  pull_manager_.OnLocationChange(wait_oids[0], client_ids, "", NodeID::Nil(), false,
+  pull_manager_.OnLocationChange(wait_oids[0], client_ids, "", NodeID::Nil(),
                                  object_size);
   AssertNumActiveRequestsEquals(2);
   ASSERT_TRUE(pull_manager_.IsObjectActive(wait_oids[0]));
@@ -1017,8 +1009,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   // Worker request takes priority over the wait and task requests once its size is
   // available.
   for (auto &oid : get_oids) {
-    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), object_size);
   }
   AssertNumActiveRequestsEquals(2);
   ASSERT_TRUE(pull_manager_.IsObjectActive(get_oids[0]));
@@ -1038,8 +1029,7 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   ASSERT_FALSE(pull_manager_.IsObjectActive(task_oids[0]));
   ASSERT_FALSE(pull_manager_.IsObjectActive(task_oids[1]));
   for (auto &oid : get_oids) {
-    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), false,
-                                   object_size);
+    pull_manager_.OnLocationChange(oid, client_ids, "", NodeID::Nil(), object_size);
   }
   AssertNumActiveRequestsEquals(2);
   ASSERT_TRUE(pull_manager_.IsObjectActive(get_oids[0]));
@@ -1085,55 +1075,6 @@ TEST_F(PullManagerWithAdmissionControlTest, TestPrioritizeWorkerRequests) {
   ASSERT_TRUE(pull_manager_.IsObjectActive(task_oids[1]));
 
   pull_manager_.CancelPull(task_req_id2);
-  AssertNoLeaks();
-}
-
-TEST_P(PullManagerTest, TestTimeOut) {
-  auto prio = BundlePriority::TASK_ARGS;
-  if (GetParam()) {
-    prio = BundlePriority::GET_REQUEST;
-  }
-  auto refs = CreateObjectRefs(1);
-  auto oids = ObjectRefsToIds(refs);
-  std::vector<rpc::ObjectReference> objects_to_locate;
-  auto req_id = pull_manager_.Pull(refs, prio, &objects_to_locate);
-  ASSERT_EQ(ObjectRefsToIds(objects_to_locate), oids);
-  ASSERT_TRUE(pull_manager_.HasPullsQueued());
-
-  std::unordered_set<NodeID> client_ids;
-  client_ids.insert(NodeID::FromRandom());
-  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), false, 0);
-  ASSERT_TRUE(pull_manager_.IsObjectActive(oids[0]));
-  ASSERT_EQ(num_send_pull_request_calls_, 1);
-
-  // Object has no locations now.
-  fake_time_ += 10;
-  pull_manager_.OnLocationChange(oids[0], {}, "", NodeID::Nil(), false, 0);
-  ASSERT_FALSE(timed_out_objects_.count(oids[0]));
-  fake_time_ += 61;
-  pull_manager_.Tick();
-  ASSERT_TRUE(timed_out_objects_.count(oids[0]));
-  timed_out_objects_.clear();
-  RAY_UNUSED(pull_manager_.CancelPull(req_id));
-
-  req_id = pull_manager_.Pull(refs, prio, &objects_to_locate);
-  pull_manager_.OnLocationChange(oids[0], client_ids, "", NodeID::Nil(), false, 0);
-  ASSERT_TRUE(pull_manager_.IsObjectActive(oids[0]));
-  // Object has no locations now but it is pending execution.
-  fake_time_ += 10;
-  pull_manager_.OnLocationChange(oids[0], {}, "", NodeID::Nil(), true, 0);
-  ASSERT_FALSE(timed_out_objects_.count(oids[0]));
-  fake_time_ += 61;
-  pull_manager_.Tick();
-  ASSERT_FALSE(timed_out_objects_.count(oids[0]));
-  // Object has no locations now and is no longer pending execution.
-  pull_manager_.OnLocationChange(oids[0], {}, "", NodeID::Nil(), false, 0);
-  fake_time_ += 61;
-  pull_manager_.Tick();
-  ASSERT_TRUE(timed_out_objects_.count(oids[0]));
-  timed_out_objects_.clear();
-  RAY_UNUSED(pull_manager_.CancelPull(req_id));
-
   AssertNoLeaks();
 }
 

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -101,10 +101,6 @@ message WorkerObjectLocationsPubMessage {
   // counting protocol that causes the object to be released while there are
   // still references.
   bool ref_removed = 7;
-  // If this is set, the task that creates the object is pending execution. If
-  // there are no locations and this is set, the subscriber should wait for the
-  // new location to appear.
-  bool pending_creation = 8;
 }
 
 /// Indicating the subscriber needs to handle failure callback.

--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -125,6 +125,8 @@ void SubscriberChannel::HandlePublishedMessage(const rpc::Address &publisher_add
   RAY_CHECK(channel_type == channel_type_)
       << "Message from " << rpc::ChannelType_Name(channel_type) << ", this channel is "
       << rpc::ChannelType_Name(channel_type_);
+  RAY_LOG(DEBUG) << "key id " << key_id << " information was published from "
+                 << publisher_id;
 
   auto maybe_subscription_callback =
       GetSubscriptionItemCallback(publisher_address, key_id);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -253,12 +253,6 @@ NodeManager::NodeManager(instrumented_io_context &io_service, const NodeID &self
               result = std::move(results[0]);
             }
             return result;
-          },
-          /*fail_pull_request=*/
-          [this](const ObjectID &object_id) {
-            rpc::ObjectReference ref;
-            ref.set_object_id(object_id.Binary());
-            MarkObjectsAsFailed(rpc::ErrorType::OBJECT_LOST, {ref}, JobID::Nil());
           }),
       periodical_runner_(io_service),
       report_resources_period_ms_(config.report_resources_period_ms),

--- a/src/ray/stats/metric_exporter_client.cc
+++ b/src/ray/stats/metric_exporter_client.cc
@@ -22,7 +22,9 @@ namespace stats {
 ///
 /// Stdout Exporter
 ///
-void StdoutExporterClient::ReportMetrics(const std::vector<MetricPoint> &points) {}
+void StdoutExporterClient::ReportMetrics(const std::vector<MetricPoint> &points) {
+  RAY_LOG(DEBUG) << "Metric point size : " << points.size();
+}
 
 ///
 /// Metrics Exporter Decorator


### PR DESCRIPTION
…hangs (#19789)" (#19904)" (#20120)"

This reverts commit 0f57a9a105d593b57509d2f48346238259a2d942.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Causing failure on dask-on-ray 1TB sort.

Closes #20391.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
