### PR TITLE
[test] Fix test_output broken in the master

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,6 +24,7 @@ py-spy >= 0.2.0
 pydantic >= 1.8
 pyyaml
 redis >= 3.5.0
+hiredis >= 0.1.4
 requests
 
 ## setup.py extras

--- a/python/setup.py
+++ b/python/setup.py
@@ -265,6 +265,7 @@ if setup_spec.type == SetupType.RAY:
         "protobuf >= 3.15.3",
         "pyyaml",
         "redis >= 3.5.0",
+        "hiredis >= 0.1.4",
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like redis-py is complaining the hiredis version. I verified the required version of redis we have `redis >= 3.5.0` all have the same hi-redis version requirement (>=0.1.4). This fixes the issue by adding hiredis as a requirement.

```
E           AssertionError: ['/opt/miniconda/lib/python3.7/site-packages/redis/connection.py:77: UserWarning: redis-py works best with hiredis. Please consider installing', '  warnings.warn(msg)', '']
```

I am not sure exactly why this happens now, but my guess is it was downloaded transitively, and that was somehow removed.

I verified this works locally, but let's wait for CI

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
