### PR TITLE
[dependencies] Use `redis[hiredis]` in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -264,7 +264,7 @@ if setup_spec.type == SetupType.RAY:
         "numpy >= 1.19.3; python_version >= '3.9'",
         "protobuf >= 3.15.3",
         "pyyaml",
-        "redis >= 3.5.0",
+        "redis[hiredis] >= 3.5.0",
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is recommended by `redis-py` and as a side effect gets rid of a current error in `test_output` for the minimal dependency test (e.g. https://buildkite.com/ray-project/ray-builders-branch/builds/4746#7444b5d0-87c3-4998-b722-1cbc2d9fe7e3)

cc @richardliaw @ericl 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
