### PR TITLE
Pin Redis version to < 4.0.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -23,7 +23,7 @@ protobuf >= 3.8.0
 py-spy >= 0.2.0
 pydantic >= 1.8
 pyyaml
-redis >= 3.5.0
+redis >= 3.5.0, < 4.0.0
 requests
 
 ## setup.py extras

--- a/python/setup.py
+++ b/python/setup.py
@@ -260,7 +260,7 @@ if setup_spec.type == SetupType.RAY:
         "numpy >= 1.19.3; python_version >= '3.9'",
         "protobuf >= 3.15.3",
         "pyyaml",
-        "redis >= 3.5.0",
+        "redis >= 3.5.0, < 4.0.0",
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This pin is needed to fix `test_output` on master, which broke when 4.0.0 was released. 

It may also fix the windows build (unsure). 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
