### PR TITLE
[core] Turn worker cap feature flag off by default

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -113,7 +113,7 @@ RAY_CONFIG(bool, preallocate_plasma_memory, false)
 /// exponentially. The soft cap is needed to prevent deadlock in the case where
 /// a task begins to execute and tries to `ray.get` another task of the same
 /// class.
-RAY_CONFIG(int64_t, worker_cap_initial_backoff_delay_ms, 1000)
+RAY_CONFIG(int64_t, worker_cap_initial_backoff_delay_ms, 0)
 
 /// After reaching the worker cap, the backoff delay will grow exponentially,
 /// until it hits a maximum delay.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The worker cap/rate limit seems to be causing a few CI tests to become flakey. This PR disables it until we understand the flakiness. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
