### PR TITLE
Revert "[dependencies] Use `redis[hiredis]` in setup.py"

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -264,7 +264,7 @@ if setup_spec.type == SetupType.RAY:
         "numpy >= 1.19.3; python_version >= '3.9'",
         "protobuf >= 3.15.3",
         "pyyaml",
-        "redis[hiredis] >= 3.5.0",
+        "redis >= 3.5.0",
     ]
 
 


### PR DESCRIPTION
Reverts ray-project/ray#20423

`hiredis` will break our M1 support right now. 