### PR TITLE
[RLlib] Add a comment in the doc string of `on_learn_on_batch` callback function.

### DIFF
--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -178,6 +178,12 @@ class DefaultCallbacks:
         Note: This is called before 0-padding via
         `pad_batch_to_sequences_of_same_size`.
 
+        Also note, SampleBatch.INFOS column will not be available on
+        train_batch within this callback if framework is tf1, due to
+        the fact that tf1 static graph would mistake it as part of the
+        input dict if present.
+        It is available though, for tf2 and torch frameworks.
+
         Args:
             policy: Reference to the current Policy object.
             train_batch: SampleBatch to be trained on. You can


### PR DESCRIPTION
To clarify the fact that info dict is not available for tf1 framework.

## Why are these changes needed?

Doc improvement.

## Related issue number

Closes #19993

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
