### PR TITLE
[workflow] Fix workflow event doc typo

### DIFF
--- a/doc/source/workflows/events.rst
+++ b/doc/source/workflows/events.rst
@@ -94,7 +94,7 @@ After the workflow finishes checkpointing the event, the event listener will be 
             message = await self.consumer.poll()
             return message
 
-        async def after_checkpoint(self, event: KafkaEventType) -> None:
+        async def event_checkpointed(self, event: KafkaEventType) -> None:
              self.consuemr.commit(event, asynchronous=False)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the example, it says `after_checkpoint`, but this should be `event_checkpointed`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
