### PR TITLE
[Serve] Don't create placement group for deployments without resources allocated

### DIFF
--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -167,12 +167,17 @@ class ActorReplicaWrapper:
         """
         Start a new actor for current DeploymentReplica instance.
         """
-        self._actor_resources = deployment_info.replica_config.resource_dict
         self._max_concurrent_queries = (
             deployment_info.deployment_config.max_concurrent_queries)
         self._graceful_shutdown_timeout_s = (
             deployment_info.deployment_config.graceful_shutdown_timeout_s)
-        if USE_PLACEMENT_GROUP:
+
+        self._actor_resources = deployment_info.replica_config.resource_dict
+        # it is currently not possiible to create a placement group
+        # with no resources (https://github.com/ray-project/ray/issues/20401)
+        has_resources_assigned = all(
+            (r > 0 for r in self._actor_resources.values()))
+        if USE_PLACEMENT_GROUP and has_resources_assigned:
             self._placement_group = self.create_placement_group(
                 self._placement_group_name, self._actor_resources)
 

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -1098,6 +1098,17 @@ def test_deploy_change_route_prefix(serve_instance):
     wait_for_condition(check_switched)
 
 
+@pytest.mark.timeout(10, method="thread")
+def test_deploy_empty_bundle(serve_instance):
+    @serve.deployment(ray_actor_options={"num_cpus": 0})
+    class D:
+        def hello(self, _):
+            return "hello"
+
+    # This should succesfully terminate within the provided time-frame.
+    D.deploy()
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
It's currently not possible to create a resource group without resources allocated, resulting in an error when creating a deployment with empty resource requirements. This PR does not create a resource group for such deployments as a temporary fix.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #19771

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
