### PR TITLE
[Datasets] Fix empty Dataset.iter_batches() when trying to prefetch more blocks than exist in the dataset

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1838,6 +1838,9 @@ class Dataset(Generic[T]):
             element on the base iterator (iterable) isn't consumed until the
             first sliding window containing that element is reached.
 
+            If n > len(iterable), then a single len(iterable) window is
+            returned.
+
             Args:
                 iterable: The iterable on which the sliding window will be
                     created.
@@ -1845,12 +1848,16 @@ class Dataset(Generic[T]):
 
             Returns:
                 An iterator of n-width windows over iterable.
+                If n > len(iterable), then a single len(iterable) window is
+                returned.
             """
-            iters = itertools.tee(iter(iterable), n)
-            for i in range(1, n):
-                for it in iters[i:]:
-                    next(it, None)
-            return zip(*iters)
+            it = iter(iterable)
+            window = collections.deque(itertools.islice(it, n), maxlen=n)
+            if len(window) > 0:
+                yield tuple(window)
+            for elem in it:
+                window.append(elem)
+                yield tuple(window)
 
         def format_batch(batch: Block, format: str) -> BatchType:
             if batch_format == "native":

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1830,8 +1830,9 @@ def test_iter_batches_basic(ray_start_regular_shared):
         batches, ignore_index=True).equals(pd.concat(dfs, ignore_index=True))
 
     # Prefetch.
-    for batch, df in zip(
-            ds.iter_batches(prefetch_blocks=1, batch_format="pandas"), dfs):
+    batches = list(ds.iter_batches(prefetch_blocks=1, batch_format="pandas"))
+    assert len(batches) == len(dfs)
+    for batch, df in zip(batches, dfs):
         assert isinstance(batch, pd.DataFrame)
         assert batch.equals(df)
 
@@ -1844,6 +1845,14 @@ def test_iter_batches_basic(ray_start_regular_shared):
         (len(df1) + len(df2) + len(df3) + len(df4)) / batch_size))
     assert pd.concat(
         batches, ignore_index=True).equals(pd.concat(dfs, ignore_index=True))
+
+    # Prefetch more than number of blocks.
+    batches = list(
+        ds.iter_batches(prefetch_blocks=len(dfs), batch_format="pandas"))
+    assert len(batches) == len(dfs)
+    for batch, df in zip(batches, dfs):
+        assert isinstance(batch, pd.DataFrame)
+        assert batch.equals(df)
 
 
 def test_iter_batches_grid(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -17,7 +17,7 @@ from pytest_lazyfixture import lazy_fixture
 import ray
 
 from ray.tests.conftest import *  # noqa
-from ray.data.dataset import Dataset
+from ray.data.dataset import Dataset, _sliding_window
 from ray.data.datasource import DummyOutputDatasource
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockAccessor
@@ -1760,6 +1760,25 @@ def test_read_binary_files_s3(ray_start_regular_shared):
         "https://anyscale-data.s3.us-west-2.amazonaws.com/small-files/0.dat"
     ).content
     assert item == expected
+
+
+def test_sliding_window():
+    arr = list(range(10))
+
+    # Test all windows over this iterable.
+    window_sizes = list(range(1, len(arr) + 1))
+    for window_size in window_sizes:
+        windows = list(_sliding_window(arr, window_size))
+        assert len(windows) == len(arr) - window_size + 1
+        assert all(len(window) == window_size for window in windows)
+        assert all(
+            list(window) == arr[i:i + window_size]
+            for i, window in enumerate(windows))
+
+    # Test window size larger than iterable length.
+    windows = list(_sliding_window(arr, 15))
+    assert len(windows) == 1
+    assert list(windows[0]) == arr
 
 
 def test_iter_batches_basic(ray_start_regular_shared):


### PR DESCRIPTION
Before this PR, `ds.iter_batches()` would yield no batches if `prefetch_blocks > ds.num_blocks()` was given, since the sliding window semantics were to return no windows if `window_size > len(iterable)`. This PR tweaks the sliding window implementation to always return at least one window, even if the one window is smaller than the given window size.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
