### PR TITLE
[hotfix] Fix stress_test_many_tasks cluster environment

### DIFF
--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -1,5 +1,6 @@
 base_image: "anyscale/ray:nightly-py37"
 env_vars: {}
+
 debian_packages:
   - curl
   - unzip
@@ -18,6 +19,8 @@ post_build_cmds:
   - pip3 install numpy || true
   - pip3 install pytest || true
   - pip3 install -U ray[all] gym[atari] autorom[accept-rom-license]
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install ray[all]
+  # TODO (Alex): Ideally we would install all the dependencies from the new
+  # version too, but pip won't be able to find the new version of ray-cpp.
+  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This should fix the long running release tests that are failing to build their app configs.

It seems like `pip install ray[all]` now downgrades the ray version. It's unclear why, but most likely, a dependency has pinned the ray version now. This PR explicitely install the version of Ray that we want after the `pip install ray[all]` to fix the problem. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #20503


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
