### PR TITLE
Pin redis<4.0 on M1 Macs

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -267,12 +267,11 @@ if setup_spec.type == SetupType.RAY:
         "pyyaml",
     ]
 
-if platform.system() == "Darwin" and platform.machine() == "arm64":
+if platform.system() == "Windows" or (platform.system() == "Darwin"
+                                      and platform.machine() == "arm64"):
     # TODO (Alex): `hiredis` doesn't have prebuilt M1 mac wheels yet. We can
     # remove this, either when they add support, we remove redis, or we vendor
     # redis/hiredis ourselves.
-    setup_spec.install_requires.append("redis >= 3.5.0")
-elif platform.system() == "Windows":
     # TODO (Alex): Ray is not compatible with redis >= 4.0.0. We ened to either
     # investigate why, or remove the redis dependency.
     setup_spec.install_requires.append("redis >= 3.5.0, < 4.0")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR pins redis on M1 macs. Redis 4.0+ adds extra warning messages if `hiredis` is not installed, but `hiredis` doesn't provide m1 mac wheels, which makes it difficult to install. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
