### PR TITLE
[Train] Propagate env vars to `BackendExecutor`

### DIFF
--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -361,6 +361,7 @@ class BackendExecutor:
                 training function via ``train.load_checkpoint()``. If this
                 is ``None`` then no checkpoint will be loaded.
         """
+        import pdb; pdb.set_trace()
         use_detailed_autofilled_metrics = env_integer(
             ENABLE_DETAILED_AUTOFILLED_METRICS_ENV, 0)
 

--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -361,7 +361,6 @@ class BackendExecutor:
                 training function via ``train.load_checkpoint()``. If this
                 is ``None`` then no checkpoint will be loaded.
         """
-        import pdb; pdb.set_trace()
         use_detailed_autofilled_metrics = env_integer(
             ENABLE_DETAILED_AUTOFILLED_METRICS_ENV, 0)
 

--- a/python/ray/train/constants.py
+++ b/python/ray/train/constants.py
@@ -19,10 +19,6 @@ NODE_IP = "_node_ip"
 PID = "_pid"
 TIME_TOTAL_S = "_time_total_s"
 
-# Env var name
-ENABLE_DETAILED_AUTOFILLED_METRICS_ENV = (
-    "TRAIN_RESULT_ENABLE_DETAILED_AUTOFILLED_METRICS")
-
 # Will not be reported unless ENABLE_DETAILED_AUTOFILLED_METRICS_ENV
 # env var is not 0
 DETAILED_AUTOFILLED_KEYS = {DATE, HOSTNAME, NODE_IP, PID, TIME_TOTAL_S}
@@ -44,6 +40,10 @@ TUNE_CHECKPOINT_FILE_NAME = "checkpoint"
 # This needs to be added to the checkpoint dictionary so if the Tune trial
 # is restarted, the checkpoint_id can continue to increment.
 TUNE_CHECKPOINT_ID = "_current_checkpoint_id"
+
+# Env var name
+ENABLE_DETAILED_AUTOFILLED_METRICS_ENV = (
+    "TRAIN_RESULT_ENABLE_DETAILED_AUTOFILLED_METRICS")
 
 # Integer value which if set will override the value of
 # Backend.share_cuda_visible_devices. 1 for True, 0 for False.

--- a/python/ray/train/tests/test_callbacks.py
+++ b/python/ray/train/tests/test_callbacks.py
@@ -55,9 +55,14 @@ class TestBackend(Backend):
         pass
 
 
-@pytest.mark.parametrize("workers_to_log", [0])
-@pytest.mark.parametrize("detailed", [True, False])
-@pytest.mark.parametrize("filename", [None])
+# The ordering of these parametrize decorators matters.
+# `detailed` has to be the last one, and False has to come before True.
+# This is because of the bug with runtime envs:
+# https://github.com/ray-project/ray/issues/20587.
+# TODO(amogkam): Remove the above comment once the above issue is closed.
+@pytest.mark.parametrize("workers_to_log", [0, None, [0, 1]])
+@pytest.mark.parametrize("filename", [None, "my_own_filename.json"])
+@pytest.mark.parametrize("detailed", [False, True])
 def test_json(ray_start_4_cpus, make_temp_dir, workers_to_log, detailed,
               filename):
     if detailed:
@@ -87,7 +92,8 @@ def test_json(ray_start_4_cpus, make_temp_dir, workers_to_log, detailed,
         # if None, use default value
         callback = JsonLoggerCallback(workers_to_log=workers_to_log)
     else:
-        callback = JsonLoggerCallback(filename=filename, workers_to_log=workers_to_log)
+        callback = JsonLoggerCallback(
+            filename=filename, workers_to_log=workers_to_log)
     trainer = Trainer(config, num_workers=num_workers, logdir=make_temp_dir)
     trainer.start()
     trainer.run(train_func, callbacks=[callback])
@@ -119,8 +125,6 @@ def test_json(ray_start_4_cpus, make_temp_dir, workers_to_log, detailed,
         assert all(
             all(not any(key in worker for key in DETAILED_AUTOFILLED_KEYS)
                 for worker in element) for element in log)
-
-
 
 
 def _validate_tbx_result(events_dir):

--- a/python/ray/train/tests/test_callbacks.py
+++ b/python/ray/train/tests/test_callbacks.py
@@ -157,3 +157,10 @@ def test_TBX(ray_start_4_cpus, make_temp_dir):
     trainer.run(train_func, callbacks=[callback])
 
     _validate_tbx_result(temp_dir)
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -160,6 +160,7 @@ class Trainer:
             }
         }
 
+        import pdb; pdb.set_trace()
         remote_executor = ray.remote(num_cpus=0)(BackendExecutor)
 
         self._backend_executor_actor = remote_executor.options(

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -160,7 +160,6 @@ class Trainer:
             }
         }
 
-        import pdb; pdb.set_trace()
         remote_executor = ray.remote(num_cpus=0)(BackendExecutor)
 
         self._backend_executor_actor = remote_executor.options(

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -16,7 +16,9 @@ from ray.train.utils import RayDataset
 from ray.train.checkpoint import CheckpointStrategy, TuneCheckpointManager, \
     CheckpointManager
 from ray.train.constants import TUNE_INSTALLED, DEFAULT_RESULTS_DIR, \
-    TUNE_CHECKPOINT_FILE_NAME
+    TUNE_CHECKPOINT_FILE_NAME, ENABLE_DETAILED_AUTOFILLED_METRICS_ENV, \
+    ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV, \
+    TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV, TRAIN_ENABLE_WORKER_SPREAD_ENV
 
 # Ray Train should be usable even if Tune is not installed.
 from ray.train.utils import construct_path
@@ -46,6 +48,12 @@ BACKEND_NAME_TO_CONFIG_CLS_NAME = {
     "horovod": "HorovodConfig",
     "tensorflow": "TensorflowConfig",
     "torch": "TorchConfig"
+}
+
+BACKEND_ENV_VARS = {
+    ENABLE_DETAILED_AUTOFILLED_METRICS_ENV,
+    ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV, TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV,
+    TRAIN_ENABLE_WORKER_SPREAD_ENV
 }
 
 
@@ -143,15 +151,23 @@ class Trainer:
                     "request a positive number of `GPU` in "
                     "`resources_per_worker.")
 
+        runtime_env = {
+            "env_vars": {
+                var_name: os.environ.get(var_name, "")
+                for var_name in BACKEND_ENV_VARS
+            }
+        }
+
         remote_executor = ray.remote(num_cpus=0)(BackendExecutor)
 
-        self._backend_executor_actor = remote_executor.remote(
-            backend_config=self._backend_config,
-            num_workers=num_workers,
-            num_cpus_per_worker=num_cpus,
-            num_gpus_per_worker=num_gpus,
-            additional_resources_per_worker=resources_per_worker,
-            max_retries=max_retries)
+        self._backend_executor_actor = remote_executor.options(
+            runtime_env=runtime_env).remote(
+                backend_config=self._backend_config,
+                num_workers=num_workers,
+                num_cpus_per_worker=num_cpus,
+                num_gpus_per_worker=num_gpus,
+                additional_resources_per_worker=resources_per_worker,
+                max_retries=max_retries)
 
         if self._is_tune_enabled():
             self.checkpoint_manager = TuneCheckpointManager()

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -50,6 +50,8 @@ BACKEND_NAME_TO_CONFIG_CLS_NAME = {
     "torch": "TorchConfig"
 }
 
+# The environment variables that need to be propagated from the driver to the
+# `BackendExecutor` actor via runtime env.
 BACKEND_ENV_VARS = {
     ENABLE_DETAILED_AUTOFILLED_METRICS_ENV,
     ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV, TRAIN_PLACEMENT_GROUP_TIMEOUT_S_ENV,
@@ -153,8 +155,8 @@ class Trainer:
 
         runtime_env = {
             "env_vars": {
-                var_name: os.environ.get(var_name, "")
-                for var_name in BACKEND_ENV_VARS
+                var_name: os.environ[var_name]
+                for var_name in BACKEND_ENV_VARS if var_name in os.environ
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Propagates environment variables to `BackendExecutor` actor using runtime envs.

Also actually run `test_callbacks` in CI.

Note that there is an issue with runtime envs: https://github.com/ray-project/ray/issues/20587. But this only happens if you shutdown Ray and start a new session again. 

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
