### PR TITLE
[Core][ConcurrencyGroup] Fix blocking task in default group block tasks in other group.

### DIFF
--- a/java/test/src/main/java/io/ray/test/ConcurrencyGroupTest.java
+++ b/java/test/src/main/java/io/ray/test/ConcurrencyGroupTest.java
@@ -161,7 +161,7 @@ public class ConcurrencyGroupTest extends BaseTest {
     Assert.assertTrue(ret8.get());
   }
 
-  class ConcurrencyActor2 {
+  private static class ConcurrencyActor2 {
 
     public String f1() throws InterruptedException {
       TimeUnit.MINUTES.sleep(100);

--- a/java/test/src/main/java/io/ray/test/ConcurrencyGroupTest.java
+++ b/java/test/src/main/java/io/ray/test/ConcurrencyGroupTest.java
@@ -6,6 +6,7 @@ import io.ray.api.Ray;
 import io.ray.api.concurrencygroup.ConcurrencyGroup;
 import io.ray.api.concurrencygroup.ConcurrencyGroupBuilder;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -158,5 +159,33 @@ public class ConcurrencyGroupTest extends BaseTest {
     ObjectRef<Boolean> ret8 = myActor.task(CountDownActor::f5).remote();
     Assert.assertTrue(ret7.get());
     Assert.assertTrue(ret8.get());
+  }
+
+  class ConcurrencyActor2 {
+
+    public String f1() throws InterruptedException {
+      TimeUnit.MINUTES.sleep(100);
+      return "never returned";
+    }
+
+    public String f2() {
+      return "ok";
+    }
+  }
+
+  /// This case tests that blocking task in default group will block other groups.
+  /// See https://github.com/ray-project/ray/issues/20475
+  public void testDefaultCgDoNotBlockOthers() {
+    ConcurrencyGroup group =
+        new ConcurrencyGroupBuilder<ConcurrencyActor2>()
+            .setName("group")
+            .setMaxConcurrency(1)
+            .addMethod(ConcurrencyActor2::f2)
+            .build();
+
+    ActorHandle<ConcurrencyActor2> myActor =
+        Ray.actor(ConcurrencyActor2::new).setConcurrencyGroups(group).remote();
+    myActor.task(ConcurrencyActor2::f1).remote();
+    Assert.assertEquals(myActor.task(ConcurrencyActor2::f2).remote().get(), "ok");
   }
 }

--- a/java/test/src/main/java/io/ray/test/ConcurrencyGroupTest.java
+++ b/java/test/src/main/java/io/ray/test/ConcurrencyGroupTest.java
@@ -175,6 +175,7 @@ public class ConcurrencyGroupTest extends BaseTest {
 
   /// This case tests that blocking task in default group will block other groups.
   /// See https://github.com/ray-project/ray/issues/20475
+  @Test(groups = {"cluster"})
   public void testDefaultCgDoNotBlockOthers() {
     ConcurrencyGroup group =
         new ConcurrencyGroupBuilder<ConcurrencyActor2>()

--- a/src/ray/core_worker/transport/thread_pool_manager.cc
+++ b/src/ray/core_worker/transport/thread_pool_manager.cc
@@ -56,8 +56,10 @@ PoolManager::PoolManager(const std::vector<ConcurrencyGroup> &concurrency_groups
     }
     name_to_thread_pool_index_[name] = pool;
   }
-  // If max concurrency of default group is 1, the tasks of default group
-  // will be performed in main thread instead of any executor pool.
+  // If max concurrency of default group is 1 and there is no other concurrency group of
+  // this actor, the tasks of default group will be performed in main thread instead of
+  // any executor pool, otherwise tasks in any concurrency group should be performed in
+  // the thread pools instead of main thread.
   if (default_group_max_concurrency > 1 || !concurrency_groups.empty()) {
     /// The concurrency group is enabled.
     default_thread_pool_ =

--- a/src/ray/core_worker/transport/thread_pool_manager.cc
+++ b/src/ray/core_worker/transport/thread_pool_manager.cc
@@ -58,7 +58,8 @@ PoolManager::PoolManager(const std::vector<ConcurrencyGroup> &concurrency_groups
   }
   // If max concurrency of default group is 1, the tasks of default group
   // will be performed in main thread instead of any executor pool.
-  if (default_group_max_concurrency > 1) {
+  if (default_group_max_concurrency > 1 || !concurrency_groups.empty()) {
+    /// The concurrency group is enabled.
     default_thread_pool_ =
         std::make_shared<BoundedExecutor>(default_group_max_concurrency);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If max concurrency is 1 in default group, a blocking task executing in default group will block the following tasks in different group. See  reproduction script in #20475

The issue is due to tasks executing in the default concurrent group run in the main task execution thread, and tasks in other concurrent groups will be blocked if the main task execution thread is blocked.

This PR only changes concurrent actor behavior that default group will not block other groups.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Fix https://github.com/ray-project/ray/issues/20475
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
