### PR TITLE
Fix flaky `train_small` being 2X slow 

### DIFF
--- a/release/lightgbm_tests/workloads/train_small.py
+++ b/release/lightgbm_tests/workloads/train_small.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
     start = time.time()
 
-    @ray.remote
+    @ray.remote(num_cpus=0)
     def train():
         os.environ["TEST_OUTPUT_JSON"] = output
         os.environ["TEST_STATE_JSON"] = state

--- a/release/xgboost_tests/workloads/train_small.py
+++ b/release/xgboost_tests/workloads/train_small.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
     start = time.time()
 
-    @ray.remote
+    @ray.remote(num_cpus=0)
     def train():
         os.environ["TEST_OUTPUT_JSON"] = output
         os.environ["TEST_STATE_JSON"] = state


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

TL;DR: This was due to the Ray core issue, but it won't be fixed in this PR. This PR makes tests pass consistently by "avoiding" scenarios where Ray core has a bug. Core bug will be fixed by me in next 2 weeks.

The issue was that the cluster has 16 CPUs, and the placement group requires 16 CPUs. But we are also requesting 1 CPU for invoking a remote function `train`. 

This happened to work due to Ray's "CPU borrowance" feature. Basically, when `ray.get(pg.ready())` was called, it made 1 CPU available which makes pg able to be scheduled. Look below for more details.

### Step 1
Original cluster
{CPU: 4}
{CPU: 4}
{CPU: 4}
{CPU: 4}

### Step 2
`train` remote function scheduled
{CPU: 4}
{CPU: 4}
{CPU: 4}
{CPU: 3} # 1 CPU used by train

### Step 3
PG is created and pending since it requires 16 CPUs.

### Step 4
`ray.get(pg.ready()` is called (from the Xgboost on Ray I believe), and 1 CPU is temporarily available (Ray releases CPU temporarily when blocking API is called to avoid deadlock). So, pg is scheduled since 16 CPUs are available.

{CPU: 0} # 4 CPUs Used by pg
{CPU: 0} # 4 CPUs Used by pg
{CPU: 0} # 4 CPUs Used by pg
{CPU: -1} # 4 CPUs Used by pg + 1 CPU used by `train`

Here, the Ray core has a bug where in this scenario, the resource is incorrectly propagated, which made tests slow. The PR **didn't fix that issue yet**, but it will make `train_small` at least pass consistently by removing CPU request for `train`. I will fix the issue where the resource propagation is done incorrectly within next 2 weeks. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/19305. I will open a separate issue

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
