### PR TITLE
[RLlib] report total_train_steps correctly for offline agents like CQL

### DIFF
--- a/rllib/agents/cql/cql.py
+++ b/rllib/agents/cql/cql.py
@@ -117,7 +117,7 @@ def execution_plan(workers, config, **kwargs):
             _fake_gpus=config["_fake_gpus"],
             framework=config.get("framework"))
 
-    replay_op = Replay(local_buffer=local_replay_buffer) \
+    train_op = Replay(local_buffer=local_replay_buffer) \
         .for_each(lambda x: post_fn(x, workers, config)) \
         .for_each(train_step_op) \
         .for_each(update_prio) \
@@ -125,7 +125,7 @@ def execution_plan(workers, config, **kwargs):
             workers, config["target_network_update_freq"]))
 
     return StandardMetricsReporting(
-        replay_op, workers, config, by_steps_trained=True)
+        train_op, workers, config, by_steps_trained=True)
 
 
 def get_policy_class(config: TrainerConfigDict) -> Optional[Type[Policy]]:

--- a/rllib/execution/metric_ops.py
+++ b/rllib/execution/metric_ops.py
@@ -48,7 +48,8 @@ def StandardMetricsReporting(
             workers,
             min_history=config["metrics_smoothing_episodes"],
             timeout_seconds=config["collect_metrics_timeout"],
-            selected_workers=selected_workers))
+            selected_workers=selected_workers,
+            by_steps_trained=by_steps_trained))
     return output_op
 
 
@@ -70,13 +71,15 @@ class CollectMetrics:
                  workers: WorkerSet,
                  min_history: int = 100,
                  timeout_seconds: int = 180,
-                 selected_workers: List[ActorHandle] = None):
+                 selected_workers: List[ActorHandle] = None,
+                 by_steps_trained: bool = False):
         self.workers = workers
         self.episode_history = []
         self.to_be_collected = []
         self.min_history = min_history
         self.timeout_seconds = timeout_seconds
         self.selected_workers = selected_workers
+        self.by_steps_trained = by_steps_trained
 
     def __call__(self, _: Any) -> Dict:
         # Collect worker metrics.
@@ -110,7 +113,9 @@ class CollectMetrics:
                     timer.mean_throughput, 3)
         res.update({
             "num_healthy_workers": len(self.workers.remote_workers()),
-            "timesteps_total": metrics.counters[STEPS_SAMPLED_COUNTER],
+            "timesteps_total": (metrics.counters[STEPS_TRAINED_COUNTER]
+                                if self.by_steps_trained
+                                else metrics.counters[STEPS_SAMPLED_COUNTER]),
             # tune.Trainable uses timesteps_this_iter for tracking
             # total timesteps.
             "timesteps_this_iter": metrics.counters[

--- a/rllib/execution/metric_ops.py
+++ b/rllib/execution/metric_ops.py
@@ -114,8 +114,8 @@ class CollectMetrics:
         res.update({
             "num_healthy_workers": len(self.workers.remote_workers()),
             "timesteps_total": (metrics.counters[STEPS_TRAINED_COUNTER]
-                                if self.by_steps_trained
-                                else metrics.counters[STEPS_SAMPLED_COUNTER]),
+                                if self.by_steps_trained else
+                                metrics.counters[STEPS_SAMPLED_COUNTER]),
             # tune.Trainable uses timesteps_this_iter for tracking
             # total timesteps.
             "timesteps_this_iter": metrics.counters[

--- a/rllib/execution/train_ops.py
+++ b/rllib/execution/train_ops.py
@@ -9,7 +9,8 @@ from ray.rllib.execution.common import \
     AGENT_STEPS_TRAINED_COUNTER, APPLY_GRADS_TIMER, COMPUTE_GRADS_TIMER, \
     LAST_TARGET_UPDATE_TS, LEARN_ON_BATCH_TIMER, \
     LOAD_BATCH_TIMER, NUM_TARGET_UPDATES, STEPS_SAMPLED_COUNTER, \
-    STEPS_TRAINED_COUNTER, WORKER_UPDATE_TIMER, _check_sample_batch_type, \
+    STEPS_TRAINED_COUNTER, STEPS_TRAINED_THIS_ITER_COUNTER, \
+    WORKER_UPDATE_TIMER, _check_sample_batch_type, \
     _get_global_vars, _get_shared_metrics
 from ray.rllib.policy.sample_batch import SampleBatch, DEFAULT_POLICY_ID, \
     MultiAgentBatch
@@ -75,6 +76,7 @@ class TrainOneStep:
             metrics.info[LEARNER_INFO] = learner_info
             learn_timer.push_units_processed(batch.count)
         metrics.counters[STEPS_TRAINED_COUNTER] += batch.count
+        metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = batch.count
         if isinstance(batch, MultiAgentBatch):
             metrics.counters[
                 AGENT_STEPS_TRAINED_COUNTER] += batch.agent_steps()
@@ -209,6 +211,7 @@ class MultiGPUTrainOneStep:
         learn_timer.push_units_processed(samples.count)
 
         metrics.counters[STEPS_TRAINED_COUNTER] += samples.count
+        metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = samples.count
         metrics.counters[AGENT_STEPS_TRAINED_COUNTER] += samples.agent_steps()
         metrics.info[LEARNER_INFO] = learner_info
 
@@ -296,6 +299,7 @@ class ApplyGradients:
         gradients, count = item
         metrics = _get_shared_metrics()
         metrics.counters[STEPS_TRAINED_COUNTER] += count
+        metrics.counters[STEPS_TRAINED_THIS_ITER_COUNTER] = count
 
         apply_timer = metrics.timers[APPLY_GRADS_TIMER]
         with apply_timer:

--- a/rllib/tuned_examples/cql/pendulum-cql.yaml
+++ b/rllib/tuned_examples/cql/pendulum-cql.yaml
@@ -7,7 +7,7 @@ pendulum-cql:
     run: CQL
     stop:
         evaluation/episode_reward_mean: -700
-        timesteps_total: 100000
+        timesteps_total: 200000
     config:
         # Works for both torch and tf.
         framework: tf

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -690,6 +690,7 @@ def run_learning_tests_from_yaml(
                     "timesteps_total": "ts",
                     "episodes_this_iter": "train_episodes",
                     "episode_reward_mean": "reward_mean",
+                    "evaluation/episode_reward_mean": "eval_reward_mean",
                 },
                 sort_by_metric=True,
                 max_report_frequency=30,


### PR DESCRIPTION
## Why are these changes needed?

These agents do not have sample steps, so without training steps, we can't calculate metrics at the end of a trial.

## Related issue number

Closes #20526

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
