### PR TITLE
[Datasets] Bump NumPy version to >= 1.19.0 for Python 3.6.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -223,6 +223,8 @@ if setup_spec.type == SetupType.RAY:
     if sys.version_info >= (3, 7):
         # Numpy dropped python 3.6 support in 1.20.
         setup_spec.extras["data"].append("numpy >= 1.20")
+    else:
+        setup_spec.extras["data"].append("numpy >= 1.19")
 
     # Ray Serve depends on the Ray dashboard components.
     setup_spec.extras["serve"] = list(


### PR DESCRIPTION
Datasets groupby boundary sampling requires `numpy>=1.19.0` otherwise it fails to concatenate the Arrow table columns. The below traceback is for Python 3.7 (not sure why the current `numpy>=1.20.0` constraint didn't work there), but this applies for Python 3.6 as well.
```
Traceback (most recent call last):
  File "/home/ubuntu/train.py", line 496, in <module>
    read_dataset(data_path))
  File "/home/ubuntu/train.py", line 70, in preprocess_train_data
    return self._preprocess(ds, False)
  File "/home/ubuntu/train.py", line 102, in _preprocess
    agg_ds = ds.groupby("fruit").mean("feature_1")
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/data/grouped_dataset.py", line 360, in mean
    return self._aggregate_on(Mean, on)
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/data/grouped_dataset.py", line 128, in _aggregate_on
    return self.aggregate(*aggs)
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/data/grouped_dataset.py", line 88, in aggregate
    if isinstance(self._key, str) else self._key, num_reducers)
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/data/impl/sort.py", line 59, in sample_boundaries
    sample_items = np.concatenate(samples)
  File "<__array_function__ internals>", line 6, in concatenate
ValueError: cannot copy sequence with size 10 to array axis with dimension 1
```

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
