### PR TITLE
[hotfix] Fix inference nightly test by upgrading numpy

### DIFF
--- a/release/nightly_tests/dataset/app_config.yaml
+++ b/release/nightly_tests/dataset/app_config.yaml
@@ -10,4 +10,9 @@ python:
 post_build_cmds:
   - pip uninstall -y ray || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  # TODO (Alex): We need to do this because the ray-ml image pins
+  # tensorflow=2.6, which requires numpy~=1.19.2. This is ok because the test
+  # doesn't actually use tensorflow, but in the long term, but we should
+  # consider upgrading to tensorflow 2.7 as a long term solution.
+  - pip install -U numpy>=1.20
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The ray-ml image depends on numpy ~=1.19.2 via the tensorflow==2.6 requirement. Unfortunately that's incompatible with Dataset (see here https://github.com/ray-project/ray/issues/20258#issuecomment-968610619). 

This PR upgrades the numpy dependency only for the nightly test. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #20258
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
