### PR TITLE
Remove deprecated username-password GitHub use case from documentation

### DIFF
--- a/doc/source/dependency-management.rst
+++ b/doc/source/dependency-management.rst
@@ -291,13 +291,6 @@ Here is a list of different use cases and corresponding URLs:
     runtime_env = {"working_dir": ("https://github.com"
                                    "/[username]/[repository]/archive/[commit hash].zip")}
 
-- Example: Retrieve package from a private GitHub repository using username and password
-
-.. code-block:: python
-
-    runtime_env = {"working_dir": ("https://[username]:[password]@github.com"
-                                   "/[username]/[private repository]/archive/[commit hash].zip")}
-
 - Example: Retrieve package from a private GitHub repository using a Personal Access Token
 
 .. code-block:: python


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The documentation update in #20352 provided HTTPS URL templates for users to include packages hosted on their remote Git providers as their `runtime_env`'s `working_dir` or `py_module`. The template for using a private GitHub repository by specifying a username and a password in the URL relies on a [deprecated authentication method](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/). This documentation change removes that template. If users want to use a private GitHub repository in their `runtime_env`, they must [create a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), and include that instead. The Personal Access Token URL template is still included in the documentation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Modifies documentation from #20352.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - Documentation PR– no testing needed.
