### PR TITLE
[WIP][workflow] Systematic implementation for workflow reference

### DIFF
--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -155,13 +155,12 @@ def deep_nested(x):
     return deep_nested.remote(x + 1)
 
 
-def _resolve_workflow_output(workflow_id: str, output: ray.ObjectRef):
-    while isinstance(output, ray.ObjectRef):
-        output = ray.get(output)
-    return output
-
-
 def test_workflow_output_resolving(workflow_start_regular_shared):
+    from ray.workflow.workflow_ref import _resolve_object_ref as _resol
+
+    def _resolve_workflow_output(workflow_id, ref):
+        return _resol(ref)
+
     # deep nested workflow
     nested_ref = deep_nested.remote(30)
     original_func = workflow_access._resolve_workflow_output

--- a/python/ray/workflow/tests/test_dynamic_workflow_ref.py
+++ b/python/ray/workflow/tests/test_dynamic_workflow_ref.py
@@ -2,7 +2,7 @@ from ray.tests.conftest import *  # noqa
 
 import pytest
 from ray import workflow
-from ray.workflow.common import WorkflowRef
+from ray.workflow.common import WorkflowRef, Workflow
 
 
 @workflow.step
@@ -14,7 +14,8 @@ def test_dynamic_workflow_ref(workflow_start_regular_shared):
     # This test also shows different "style" of running workflows.
     first_step = incr.step(0)
     assert first_step.run("test_dynamic_workflow_ref") == 1
-    second_step = incr.step(WorkflowRef(first_step.step_id))
+    ref = Workflow.from_ref(WorkflowRef(first_step.step_id))
+    second_step = incr.step(ref)
     # Without rerun, it'll just return the previous result
     assert second_step.run("test_dynamic_workflow_ref") == 1
     # TODO (yic) We need re-run to make this test work

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -139,7 +139,6 @@ def test_workflow_storage(workflow_start_regular):
     input_metadata = {
         "name": "test_basic_workflows.append1",
         "workflows": ["def"],
-        "workflow_refs": ["some_ref"],
         "step_options": step_options.to_dict(),
     }
     output_metadata = {
@@ -180,7 +179,7 @@ def test_workflow_storage(workflow_start_regular):
     asyncio_run(wf_storage._put(wf_storage._key_step_output(step_id), output))
 
     assert wf_storage.load_step_output(step_id) == output
-    assert wf_storage.load_step_args(step_id, [], []) == args
+    assert wf_storage.load_step_args(step_id, []) == args
     assert wf_storage.load_step_func_body(step_id)(33) == 34
     assert ray.get(wf_storage.load_object_ref(
         obj_ref.hex())) == object_resolved
@@ -232,7 +231,6 @@ def test_workflow_storage(workflow_start_regular):
         args_valid=True,
         func_body_valid=True,
         workflows=input_metadata["workflows"],
-        workflow_refs=input_metadata["workflow_refs"],
         step_options=step_options)
     assert inspect_result.is_recoverable()
 
@@ -248,7 +246,6 @@ def test_workflow_storage(workflow_start_regular):
     assert inspect_result == workflow_storage.StepInspectResult(
         func_body_valid=True,
         workflows=input_metadata["workflows"],
-        workflow_refs=input_metadata["workflow_refs"],
         step_options=step_options)
     assert not inspect_result.is_recoverable()
 
@@ -259,9 +256,7 @@ def test_workflow_storage(workflow_start_regular):
             True))
     inspect_result = wf_storage.inspect_step(step_id)
     assert inspect_result == workflow_storage.StepInspectResult(
-        workflows=input_metadata["workflows"],
-        workflow_refs=input_metadata["workflow_refs"],
-        step_options=step_options)
+        workflows=input_metadata["workflows"], step_options=step_options)
     assert not inspect_result.is_recoverable()
 
     step_id = "some_step6"

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -220,7 +220,8 @@ class _VirtualActorMethodHelper:
                 state_ref = None
             else:
                 ws = WorkflowStorage(actor_id, get_global_storage())
-                state_ref = WorkflowRef(ws.get_entrypoint_step_id())
+                state_ref = Workflow.from_ref(
+                    WorkflowRef(ws.get_entrypoint_step_id()))
             # This is a hack to insert a positional argument.
             flattened_args = [signature.DUMMY_TYPE, state_ref] + flattened_args
         workflow_inputs = serialization_context.make_workflow_inputs(
@@ -529,7 +530,7 @@ class VirtualActor:
                                                     self._storage.storage_url):
             wf = method_helper.step(*args, **kwargs)
             if method_helper.readonly:
-                return execute_workflow(wf).volatile_output
+                return execute_workflow(wf).volatile_output.output_ref
             else:
                 return wf.run_async(self._actor_id)
 

--- a/python/ray/workflow/workflow_ref.py
+++ b/python/ray/workflow/workflow_ref.py
@@ -1,0 +1,115 @@
+from typing import Union, List, Any
+import logging
+
+import ray
+from ray.workflow import recovery
+from ray.workflow import workflow_context
+from ray.workflow import workflow_storage
+from ray.workflow.common import WorkflowRef
+from ray.workflow.workflow_access import get_or_create_management_actor
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_object_ref(ref: ray.ObjectRef) -> Any:
+    """
+    Resolves the ObjectRef into the object instance.
+
+    This applies to a nested object ref recursively.
+
+    Returns:
+        The object instance.
+    """
+    while isinstance(ref, (WorkflowRef, ray.ObjectRef)):
+        if isinstance(ref, ray.ObjectRef):
+            ref = ray.get(ref)
+            continue
+        if ref.is_dynamic:
+            raise ValueError(
+                "Cannot process dynamic workflow output reference")
+        if ref.is_resolved:
+            ref = ref.output
+        else:
+            ref = ray.get(ref.output_ref)
+    return ref
+
+
+def _resolve_dynamic_workflow_refs(workflow_refs: "List[WorkflowRef]"):
+    """Get the output of a workflow step with the step ID at runtime.
+
+    We lookup the output by the following order:
+    1. Query cached step output in the workflow manager. Fetch the physical
+       output object.
+    2. If failed to fetch the physical output object, look into the storage
+       to see whether the output is checkpointed. Load the checkpoint.
+    3. If failed to load the checkpoint, resume the step and get the output.
+    """
+    workflow_manager = get_or_create_management_actor()
+    context = workflow_context.get_workflow_step_context()
+    workflow_id = context.workflow_id
+    storage_url = context.storage_url
+    workflow_ref_mapping = []
+    for workflow_ref in workflow_refs:
+        step_ref = ray.get(
+            workflow_manager.get_cached_step_output.remote(
+                workflow_id, workflow_ref.step_id))
+        get_cached_step = False
+        if step_ref is not None:
+            try:
+                output = _resolve_object_ref(step_ref)
+                get_cached_step = True
+            except Exception:
+                get_cached_step = False
+        if not get_cached_step:
+            wf_store = workflow_storage.get_workflow_storage()
+            try:
+                output = wf_store.load_step_output(workflow_ref.step_id)
+            except Exception:
+                current_step_id = workflow_context.get_current_step_id()
+                logger.warning("Failed to get the output of step "
+                               f"{workflow_ref.step_id}. Trying to resume it. "
+                               f"Current step: '{current_step_id}'")
+                step_ref = recovery.resume_workflow_step(
+                    workflow_id, workflow_ref.step_id, storage_url,
+                    None).persisted_output
+                output = _resolve_object_ref(step_ref.output_ref)
+        workflow_ref_mapping.append(output)
+    return workflow_ref_mapping
+
+
+def resolve_workflow_refs(
+        refs: Union[WorkflowRef, List[WorkflowRef]]) -> Union[Any, List[Any]]:
+    """Resolve workflow ref(s) into result(s).
+
+    This function returns the result(s) in the input order, but it may not
+    resolve it in the input order if it contains dynamic workflow refs.
+
+    Args:
+        refs: A workflow ref or a list of workflow refs.
+
+    Returns:
+        The result(s) of the input workflow ref(s).
+    """
+    is_individual_ref = isinstance(refs, WorkflowRef)
+    if is_individual_ref:
+        refs = [refs]
+    results = []
+    dynamic_refs = []
+    dynamic_refs_map = []
+    for i, r in enumerate(refs):
+        if r.has_output:
+            results.append(r.output)
+        elif r.output_ref is not None:
+            results.append(_resolve_object_ref(r.output_ref))
+        else:
+            dynamic_refs.append(r)
+            dynamic_refs_map.append(i)
+            results.append(None)
+
+    if dynamic_refs:
+        dynamic_results = _resolve_dynamic_workflow_refs(dynamic_refs)
+        assert len(dynamic_results) == len(dynamic_refs_map)
+        for i, r in zip(dynamic_refs_map, dynamic_results):
+            results[i] = r
+
+    return results[0] if is_individual_ref else results


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is some work required for inplace workflow step execution w/o serialization + systematic implementation of `workflow.wait`.

We extended workflow reference to represent more diverse workflow output: workflow of unknown state, objectref and physical object instances.

With this PR is beneficial for:

1. Simpler and more consistent recovery logic.
2. Remove one "TODO" for better workflow output caching.
3. Simpler implementation for `workflow.wait`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
