### PR TITLE
Fix job sdk's lazy import of requests that led to minimal build failure

### DIFF
--- a/dashboard/modules/job/sdk.py
+++ b/dashboard/modules/job/sdk.py
@@ -97,7 +97,7 @@ class JobSubmissionClient:
             raise ConnectionError(
                 f"Failed to connect to Ray at address: {self._address}.")
 
-    def _raise_error(self, r: requests.Response):
+    def _raise_error(self, r: "requests.Response"):
         raise RuntimeError(
             f"Request failed with status code {r.status_code}: {r.text}.")
 


### PR DESCRIPTION
We don't expect user to have `requests` module installed for minimal build, thus used lazy import. However we're still using requests module as type hints and will break things at import time. 


Closes #20574

## Test plan

pip uninstall requests  -> Do basic stuff with Ray such as ray start / top, ensure we can repro errors;

Apply the fix in this PR, test again and ensure we can do normal operations without seeing error at import time, no `requests` module installed.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
