### PR TITLE
[tune] Introduce TrialCheckpoint class, making checkpoint down/upload easie

### DIFF
--- a/doc/source/tune/api_docs/analysis.rst
+++ b/doc/source/tune/api_docs/analysis.rst
@@ -43,3 +43,9 @@ ExperimentAnalysis (tune.ExperimentAnalysis)
 
 .. autoclass:: ray.tune.ExperimentAnalysis
     :members:
+
+TrialCheckpoint (tune.cloud.TrialCheckpoint)
+--------------------------------------------
+
+.. autoclass:: ray.tune.cloud.TrialCheckpoint
+    :members:

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -55,6 +55,14 @@ py_test(
 )
 
 py_test(
+    name = "test_cloud",
+    size = "medium",
+    srcs = ["tests/test_cloud.py"],
+    deps = [":tune_lib"],
+    tags = ["team:ml", "exclusive", "tests_dir_C"],
+)
+
+py_test(
     name = "test_cluster",
     size = "large",
     srcs = ["tests/test_cluster.py"],

--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -200,6 +200,9 @@ class ExperimentAnalysis:
 
         If you didn't pass these parameters, use
         `get_best_checkpoint(trial, metric, mode)` instead.
+
+        Returns:
+            :class:`TrialCheckpoint <ray.tune.cloud.TrialCheckpoint>` object.
         """
         if not self.default_metric or not self.default_mode:
             raise ValueError(

--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -6,6 +6,7 @@ from numbers import Number
 from typing import Any, Dict, List, Optional, Tuple
 
 from ray.util.debug import log_once
+from ray.tune.syncer import SyncConfig
 from ray.tune.utils import flatten_dict
 from ray.tune.utils.serialization import TuneFunctionDecoder
 from ray.tune.utils.util import is_nan_or_inf
@@ -64,7 +65,8 @@ class ExperimentAnalysis:
                  experiment_checkpoint_path: str,
                  trials: Optional[List[Trial]] = None,
                  default_metric: Optional[str] = None,
-                 default_mode: Optional[str] = None):
+                 default_mode: Optional[str] = None,
+                 sync_config: Optional[SyncConfig] = None):
         experiment_checkpoint_path = os.path.expanduser(
             experiment_checkpoint_path)
 

--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -427,9 +427,7 @@ class ExperimentAnalysis:
 
         best_path, best_metric = best_path_metrics[0]
         return TrialCheckpoint(
-            local_path=best_path,
-            cloud_path=self._parse_cloud_path(best_path),
-            metrics={metric: best_metric})
+            local_path=best_path, cloud_path=self._parse_cloud_path(best_path))
 
     def get_all_configs(self, prefix: bool = False) -> Dict[str, Dict]:
         """Returns a list of all configurations.

--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -72,11 +72,30 @@ class TrialCheckpoint(os.PathLike):
         self.local_path = local_path
         self.cloud_path = cloud_path
 
+    # The following magic methods are implemented to keep backwards
+    # compatibility with the old path-based return values.
     def __str__(self):
         return self.local_path or self.cloud_path
 
     def __fspath__(self):
         return self.local_path
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.local_path == other
+        elif isinstance(other, TrialCheckpoint):
+            return (self.local_path == other.local_path
+                    and self.cloud_path == other.cloud_path)
+
+    def __add__(self, other):
+        if isinstance(other, str):
+            return self.local_path + other
+        raise NotImplementedError
+
+    def __radd__(self, other):
+        if isinstance(other, str):
+            return other + self.local_path
+        raise NotImplementedError
 
     def __repr__(self):
         return (f"<TrialCheckpoint "

--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -1,0 +1,247 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Optional
+
+from ray import logger
+from ray.tune.sync_client import (S3_PREFIX, GS_PREFIX, HDFS_PREFIX,
+                                  ALLOWED_REMOTE_PREFIXES)
+from ray.util import PublicAPI
+
+
+def is_cloud_target(target: str):
+    return any(target.startswith(prefix) for prefix in ALLOWED_REMOTE_PREFIXES)
+
+
+def _clear_bucket(bucket: str):
+    if not is_cloud_target(bucket):
+        raise ValueError(
+            f"Could not clear bucket contents: "
+            f"Bucket `{bucket}` is not a valid or supported cloud target.")
+
+    try:
+        if bucket.startswith(S3_PREFIX):
+            subprocess.check_call(
+                ["aws", "s3", "rm", "--recursive", "--quiet", bucket])
+        elif bucket.startswith(GS_PREFIX):
+            subprocess.check_call(["gsutil", "-m", "rm", "-f", "-r", bucket])
+        elif bucket.startswith(HDFS_PREFIX):
+            subprocess.check_call(["hdfs", "dfs", "-rm", "-r", bucket])
+
+    except Exception as e:
+        logger.warning(
+            f"Caught exception when clearing bucket `{bucket}`: {e}")
+
+
+def _download_from_bucket(bucket: str, local_path: str):
+    if not is_cloud_target(bucket):
+        raise ValueError(
+            f"Could not download from bucket: "
+            f"Bucket `{bucket}` is not a valid or supported cloud target.")
+
+    if bucket.startswith(S3_PREFIX):
+        subprocess.check_call(
+            ["aws", "s3", "cp", "--recursive", "--quiet", bucket, local_path])
+    elif bucket.startswith(GS_PREFIX):
+        subprocess.check_call(["gsutil", "-m", "cp", "-r", bucket, local_path])
+    elif bucket.startswith(HDFS_PREFIX):
+        subprocess.check_call(["hdfs", "dfs", "-get", bucket, local_path])
+
+
+def _upload_to_bucket(bucket: str, local_path: str):
+    if not is_cloud_target(bucket):
+        raise ValueError(
+            f"Could not download from bucket: "
+            f"Bucket `{bucket}` is not a valid or supported cloud target.")
+
+    if bucket.startswith(S3_PREFIX):
+        subprocess.check_call(
+            ["aws", "s3", "cp", "--recursive", "--quiet", local_path, bucket])
+    elif bucket.startswith(GS_PREFIX):
+        subprocess.check_call(["gsutil", "-m", "cp", "-r", local_path, bucket])
+    elif bucket.startswith(HDFS_PREFIX):
+        subprocess.check_call(["hdfs", "dfs", "-put", local_path, bucket])
+
+
+@PublicAPI(stability="beta")
+class TrialCheckpoint:
+    def __init__(self,
+                 local_path: Optional[str] = None,
+                 cloud_path: Optional[str] = None):
+        self.local_path = local_path
+        self.cloud_path = cloud_path
+
+    def download(self,
+                 cloud_path: Optional[str] = None,
+                 local_path: Optional[str] = None,
+                 overwrite: bool = False,
+                 update_local_path: bool = True) -> str:
+        """Download checkpoint from cloud.
+
+        If a ``local_path`` argument is provided and ``update_local_path=True``
+        the ``self.local_path`` will be overwritten.
+
+        This will then fetch the checkpoint directory from cloud storage
+        and save it to ``self.local_path``.
+
+        Args:
+            local_path (Optional[str]): Local path to save checkpoint at.
+            overwrite (bool): If True, overwrites potential existing
+                checkpoint. If False, exits if ``self.local_dir`` already
+                exists and has files in it.
+            update_local_path (bool): If True, the ``self.local_path``
+                attribute will be updated by tehe ``local_path`` argument,
+                if provided.
+
+        """
+        cloud_path = cloud_path or self.cloud_path
+        if not cloud_path:
+            raise RuntimeError(
+                "Could not download trial checkpoint: No cloud "
+                "path is set. Fix this by either passing a "
+                "`cloud_path` to your call to `download()` or by "
+                "passing a `cloud_path` into the constructor. The latter "
+                "should automatically be done if you pass the correct "
+                "`tune.SyncConfig`.")
+
+        local_path = local_path or self.local_path
+
+        if not local_path:
+            raise RuntimeError(
+                "Could not download trial checkpoint: No local "
+                "path is set. Fix this by either passing a "
+                "`local_path` to your call to `download()` or by "
+                "passing a `local_path` into the constructor.")
+
+        if update_local_path:
+            self.local_path = local_path
+
+        if not overwrite and (os.path.exists(local_path)
+                              and len(os.listdir(local_path)) > 0):
+            # Local path already exists and we should not overwrite,
+            # so return.
+            return local_path
+
+        # Else: Actually download
+
+        # Delete existing dir
+        shutil.rmtree(local_path, ignore_errors=True)
+        # Re-create
+        os.makedirs(local_path, 0o755, exist_ok=True)
+
+        # Here we trigger the actual download
+        _download_from_bucket(cloud_path, local_path)
+
+        # Local dir exists and is not empty
+        return local_path
+
+    def upload(self,
+               cloud_path: Optional[str] = None,
+               local_path: Optional[str] = None,
+               clean_before: bool = False,
+               update_cloud_path: bool = True):
+        local_path = local_path or self.local_path
+        if not local_path:
+            raise RuntimeError("Could not upload trial checkpoint: No local "
+                               "path is set. Fix this by either passing a "
+                               "`local_path` to your call to `upload()` or by "
+                               "passing a `local_path` into the constructor.")
+
+        cloud_path = cloud_path or self.cloud_path
+        if not cloud_path:
+            raise RuntimeError(
+                "Could not download trial checkpoint: No cloud "
+                "path is set. Fix this by either passing a "
+                "`cloud_path` to your call to `download()` or by "
+                "passing a `cloud_path` into the constructor. The latter "
+                "should automatically be done if you pass the correct "
+                "`tune.SyncConfig`.")
+
+        if update_cloud_path:
+            self.cloud_path = cloud_path
+
+        if clean_before:
+            logger.info(
+                f"Clearing bucket contents before upload: {cloud_path}")
+            _clear_bucket(cloud_path)
+
+        # Actually upload
+        _upload_to_bucket(cloud_path, local_path)
+
+    def save(self,
+             path: Optional[str] = None,
+             overwrite: bool = True,
+             force_download: bool = False):
+        """Save trial checkpoint to directory or cloud storage.
+
+        If this trial has a local path, store to the
+        """
+        temp_dirs = set()
+        # Per default, save cloud checkpoint
+        if not path:
+            if self.cloud_path and self.local_path:
+                path = self.local_path
+            else:
+                raise RuntimeError(
+                    "Cannot save trial checkpoint: No target path "
+                    "specified and no default local directory available. "
+                    "Please pass a `path` argument to `save()`.")
+
+        if is_cloud_target(path):
+            # Storing on cloud
+            if not self.local_path and not self.cloud_path:
+                raise RuntimeError(
+                    f"Cannot save trial checkpoint to cloud target "
+                    f"`{path}`: No existing local or cloud path was "
+                    f"found. This indicates an error when loading "
+                    f"the checkpoints. Please report this issue.")
+            elif not self.local_path:
+                # No local copy, yet. Download to temp dir
+                local_path = tempfile.mkdtemp(prefix="tune_checkpoint_")
+                temp_dirs.add(local_path)
+            else:
+                local_path = self.local_path
+
+            if self.cloud_path:
+                # Do not update local path as it might be a temp file
+                local_path = self.download(
+                    local_path=local_path,
+                    overwrite=force_download,
+                    update_local_path=False)
+
+            # We should now have a checkpoint available locally
+            if not os.path.exists(local_path) or len(
+                    os.listdir(local_path)) == 0:
+                raise RuntimeError(
+                    f"No checkpoint found in directory `{local_path}` after "
+                    f"download - maybe the bucket is empty or downloading "
+                    f"failed?")
+
+            # Only update cloud path if it wasn't set before
+            cloud_path = self.upload(
+                cloud_path=path,
+                local_path=local_path,
+                clean_before=True,
+                update_cloud_path=not self.cloud_path)
+
+            # Clean up temporary directories
+            for temp_dir in temp_dirs:
+                shutil.rmtree(temp_dir)
+
+            return cloud_path
+
+        # Else: path is a local target
+        if self.local_path and not force_download:
+            # If we have a local copy, use it
+
+            if path == self.local_path:
+                # Nothing to do
+                return self.local_path
+
+            # Both local, just copy tree
+            shutil.copytree(self.local_path, path)
+            return path
+
+        # Else: Download
+        return self.download(local_path=path, overwrite=force_download)

--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -65,7 +65,7 @@ def _upload_to_bucket(bucket: str, local_path: str):
 
 
 @PublicAPI(stability="beta")
-class TrialCheckpoint:
+class TrialCheckpoint(os.PathLike):
     def __init__(self,
                  local_path: Optional[str] = None,
                  cloud_path: Optional[str] = None):
@@ -74,6 +74,9 @@ class TrialCheckpoint:
 
     def __str__(self):
         return self.local_path or self.cloud_path
+
+    def __fspath__(self):
+        return self.local_path
 
     def __repr__(self):
         return (f"<TrialCheckpoint "

--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -169,6 +169,8 @@ class TrialCheckpoint:
         # Actually upload
         _upload_to_bucket(cloud_path, local_path)
 
+        return cloud_path
+
     def save(self,
              path: Optional[str] = None,
              overwrite: bool = True,

--- a/python/ray/tune/tests/test_cloud.py
+++ b/python/ray/tune/tests/test_cloud.py
@@ -10,11 +10,11 @@ from ray.tune.cloud import TrialCheckpoint
 
 class TrialCheckpointTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.test_dir = tempfile.mkdtemp()
+        self.local_dir = tempfile.mkdtemp()
         self.cloud_dir = "s3://invalid"
 
     def tearDown(self) -> None:
-        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.local_dir)
 
     def testDownloadNoDefaults(self):
         state = {}
@@ -30,7 +30,7 @@ class TrialCheckpointTest(unittest.TestCase):
         # Case: Local dir is passed
         checkpoint = TrialCheckpoint()
         with self.assertRaisesRegex(RuntimeError, "No cloud path"):
-            checkpoint.download(local_path=self.test_dir)
+            checkpoint.download(local_path=self.local_dir)
 
         # Case: Cloud dir is passed
         checkpoint = TrialCheckpoint()
@@ -41,11 +41,11 @@ class TrialCheckpointTest(unittest.TestCase):
         checkpoint = TrialCheckpoint()
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(
-                local_path=self.test_dir, cloud_path=self.cloud_dir)
+                local_path=self.local_dir, cloud_path=self.cloud_dir)
 
-        self.assertEquals(self.test_dir, path)
+        self.assertEquals(self.local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
-        self.assertIn(self.test_dir, state["cmd"])
+        self.assertIn(self.local_dir, state["cmd"])
 
     def testDownloadDefaultLocal(self):
         state = {}
@@ -56,26 +56,26 @@ class TrialCheckpointTest(unittest.TestCase):
         other_local_dir = "/tmp/invalid"
 
         # Case: Nothing is passed
-        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
         with self.assertRaisesRegex(RuntimeError, "No cloud path"):
             checkpoint.download()
 
         # Case: Local dir is passed
-        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
         with self.assertRaisesRegex(RuntimeError, "No cloud path"):
             checkpoint.download(local_path=other_local_dir)
 
         # Case: Cloud dir is passed
-        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(cloud_path=self.cloud_dir)
 
-        self.assertEquals(self.test_dir, path)
+        self.assertEquals(self.local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
-        self.assertIn(self.test_dir, state["cmd"])
+        self.assertIn(self.local_dir, state["cmd"])
 
         # Case: Both are passed
-        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(
                 local_path=other_local_dir, cloud_path=self.cloud_dir)
@@ -83,7 +83,7 @@ class TrialCheckpointTest(unittest.TestCase):
         self.assertEquals(other_local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
-        self.assertNotIn(self.test_dir, state["cmd"])
+        self.assertNotIn(self.local_dir, state["cmd"])
 
     def testDownloadDefaultCloud(self):
         state = {}
@@ -101,11 +101,11 @@ class TrialCheckpointTest(unittest.TestCase):
         # Case: Local dir is passed
         checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
         with patch("subprocess.check_call", check_call):
-            path = checkpoint.download(local_path=self.test_dir)
+            path = checkpoint.download(local_path=self.local_dir)
 
-        self.assertEquals(self.test_dir, path)
+        self.assertEquals(self.local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
-        self.assertIn(self.test_dir, state["cmd"])
+        self.assertIn(self.local_dir, state["cmd"])
 
         # Case: Cloud dir is passed
         checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
@@ -116,9 +116,9 @@ class TrialCheckpointTest(unittest.TestCase):
         checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(
-                local_path=self.test_dir, cloud_path=other_cloud_dir)
+                local_path=self.local_dir, cloud_path=other_cloud_dir)
 
-        self.assertEquals(self.test_dir, path)
+        self.assertEquals(self.local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
         self.assertIn(other_cloud_dir, state["cmd"])
         self.assertNotIn(self.cloud_dir, state["cmd"])
@@ -134,18 +134,18 @@ class TrialCheckpointTest(unittest.TestCase):
 
         # Case: Nothing is passed
         checkpoint = TrialCheckpoint(
-            local_path=self.test_dir, cloud_path=self.cloud_dir)
+            local_path=self.local_dir, cloud_path=self.cloud_dir)
 
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download()
 
-        self.assertEquals(self.test_dir, path)
+        self.assertEquals(self.local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
-        self.assertIn(self.test_dir, state["cmd"])
+        self.assertIn(self.local_dir, state["cmd"])
 
         # Case: Local dir is passed
         checkpoint = TrialCheckpoint(
-            local_path=self.test_dir, cloud_path=self.cloud_dir)
+            local_path=self.local_dir, cloud_path=self.cloud_dir)
 
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(local_path=other_local_dir)
@@ -153,11 +153,11 @@ class TrialCheckpointTest(unittest.TestCase):
         self.assertEquals(other_local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
-        self.assertNotIn(self.test_dir, state["cmd"])
+        self.assertNotIn(self.local_dir, state["cmd"])
 
         # Case: Both are passed
         checkpoint = TrialCheckpoint(
-            local_path=self.test_dir, cloud_path=self.cloud_dir)
+            local_path=self.local_dir, cloud_path=self.cloud_dir)
 
         with patch("subprocess.check_call", check_call):
 
@@ -167,10 +167,164 @@ class TrialCheckpointTest(unittest.TestCase):
         self.assertEquals(other_local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
-        self.assertNotIn(self.test_dir, state["cmd"])
+        self.assertNotIn(self.local_dir, state["cmd"])
         self.assertIn(other_cloud_dir, state["cmd"])
         self.assertNotIn(self.cloud_dir, state["cmd"])
 
+    def testUploadNoDefaults(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint()
+        with self.assertRaises(RuntimeError):
+            checkpoint.upload()
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint()
+        with self.assertRaisesRegex(RuntimeError, "No cloud path"):
+            checkpoint.upload(local_path=self.local_dir)
+
+        # Case: Cloud dir is passed
+        checkpoint = TrialCheckpoint()
+        with self.assertRaisesRegex(RuntimeError, "No local path"):
+            checkpoint.upload(cloud_path=self.cloud_dir)
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint()
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.upload(
+                local_path=self.local_dir, cloud_path=self.cloud_dir)
+
+        self.assertEquals(self.cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.cloud_dir, state["cmd"])
+
+    def testUploadDefaultLocal(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        other_local_dir = "/tmp/invalid"
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
+        with self.assertRaisesRegex(RuntimeError, "No cloud path"):
+            checkpoint.upload()
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
+        with self.assertRaisesRegex(RuntimeError, "No cloud path"):
+            checkpoint.upload(local_path=other_local_dir)
+
+        # Case: Cloud dir is passed
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.upload(cloud_path=self.cloud_dir)
+
+        self.assertEquals(self.cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.cloud_dir, state["cmd"])
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint(local_path=self.local_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.upload(
+                local_path=other_local_dir, cloud_path=self.cloud_dir)
+
+        self.assertEquals(self.cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_local_dir, state["cmd"])
+        self.assertNotIn(self.local_dir, state["cmd"])
+
+    def testUploadDefaultCloud(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        other_cloud_dir = "s3://other"
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with self.assertRaisesRegex(RuntimeError, "No local path"):
+            checkpoint.upload()
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.upload(local_path=self.local_dir)
+
+        self.assertEquals(self.cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.cloud_dir, state["cmd"])
+
+        # Case: Cloud dir is passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with self.assertRaisesRegex(RuntimeError, "No local path"):
+            checkpoint.upload(cloud_path=other_cloud_dir)
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.upload(
+                local_path=self.local_dir, cloud_path=other_cloud_dir)
+
+        self.assertEquals(other_cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_cloud_dir, state["cmd"])
+        self.assertNotIn(self.cloud_dir, state["cmd"])
+
+    def testUploadDefaultBoth(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        other_local_dir = "/tmp/other"
+        other_cloud_dir = "s3://other"
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint(
+            local_path=self.local_dir, cloud_path=self.cloud_dir)
+
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.upload()
+
+        self.assertEquals(self.cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.cloud_dir, state["cmd"])
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint(
+            local_path=self.local_dir, cloud_path=self.cloud_dir)
+
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.upload(local_path=other_local_dir)
+
+        self.assertEquals(self.cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_local_dir, state["cmd"])
+        self.assertNotIn(self.local_dir, state["cmd"])
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint(
+            local_path=self.local_dir, cloud_path=self.cloud_dir)
+
+        with patch("subprocess.check_call", check_call):
+
+            path = checkpoint.upload(
+                local_path=other_local_dir, cloud_path=other_cloud_dir)
+
+        self.assertEquals(other_cloud_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_local_dir, state["cmd"])
+        self.assertNotIn(self.local_dir, state["cmd"])
+        self.assertIn(other_cloud_dir, state["cmd"])
+        self.assertNotIn(self.cloud_dir, state["cmd"])
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/tune/tests/test_cloud.py
+++ b/python/ray/tune/tests/test_cloud.py
@@ -19,6 +19,10 @@ class TrialCheckpointApiTest(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.local_dir)
 
+    def ensureCheckpointFile(self):
+        with open(os.path.join(self.local_dir, "checkpoint.txt"), "wt") as f:
+            f.write("checkpoint\n")
+
     def testDownloadNoDefaults(self):
         state = {}
 
@@ -362,7 +366,7 @@ class TrialCheckpointApiTest(unittest.TestCase):
         checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
 
         with patch("subprocess.check_call", check_call):
-            path = checkpoint.save(self.local_dir)
+            path = checkpoint.save(self.local_dir, force_download=True)
 
         self.assertEquals(self.local_dir, path)
         self.assertEquals(state["cmd"][0], "aws")
@@ -371,6 +375,7 @@ class TrialCheckpointApiTest(unittest.TestCase):
 
         # Case: Default local dir, pass local dir
         checkpoint = TrialCheckpoint(local_path=self.local_dir)
+        self.ensureCheckpointFile()
 
         with patch("shutil.copytree", copytree):
             path = checkpoint.save(other_local_dir)

--- a/python/ray/tune/tests/test_cloud.py
+++ b/python/ray/tune/tests/test_cloud.py
@@ -590,13 +590,11 @@ class TrialCheckpointEndToEndTest(unittest.TestCase):
             # Save!
             cp2.save(other_local_dir)
 
-            # Directory now exists
-            self.assertTrue(os.path.exists(cp2.local_path))
+            # Directory still does not exist (as we save to other dir)
+            self.assertFalse(os.path.exists(cp2.local_path))
             cp_content = _load_cp(other_local_dir)
             self.assertEquals(cp_content["train_id"], 2)
             self.assertEquals(cp_content["score"], 9)
-            cp_content_2 = _load_cp(cp2.local_path)
-            self.assertEquals(cp_content, cp_content_2)
 
             # Clean up
             shutil.rmtree(other_local_dir)

--- a/python/ray/tune/tests/test_cloud.py
+++ b/python/ray/tune/tests/test_cloud.py
@@ -1,0 +1,177 @@
+import tempfile
+import unittest
+
+import shutil
+import sys
+from unittest.mock import patch
+
+from ray.tune.cloud import TrialCheckpoint
+
+
+class TrialCheckpointTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+        self.cloud_dir = "s3://invalid"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def testDownloadNoDefaults(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint()
+        with self.assertRaises(RuntimeError):
+            checkpoint.download()
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint()
+        with self.assertRaisesRegex(RuntimeError, "No cloud path"):
+            checkpoint.download(local_path=self.test_dir)
+
+        # Case: Cloud dir is passed
+        checkpoint = TrialCheckpoint()
+        with self.assertRaisesRegex(RuntimeError, "No local path"):
+            checkpoint.download(cloud_path=self.cloud_dir)
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint()
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.download(
+                local_path=self.test_dir, cloud_path=self.cloud_dir)
+
+        self.assertEquals(self.test_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.test_dir, state["cmd"])
+
+    def testDownloadDefaultLocal(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        other_local_dir = "/tmp/invalid"
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        with self.assertRaisesRegex(RuntimeError, "No cloud path"):
+            checkpoint.download()
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        with self.assertRaisesRegex(RuntimeError, "No cloud path"):
+            checkpoint.download(local_path=other_local_dir)
+
+        # Case: Cloud dir is passed
+        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.download(cloud_path=self.cloud_dir)
+
+        self.assertEquals(self.test_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.test_dir, state["cmd"])
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint(local_path=self.test_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.download(
+                local_path=other_local_dir, cloud_path=self.cloud_dir)
+
+        self.assertEquals(other_local_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_local_dir, state["cmd"])
+        self.assertNotIn(self.test_dir, state["cmd"])
+
+    def testDownloadDefaultCloud(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        other_cloud_dir = "s3://other"
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with self.assertRaisesRegex(RuntimeError, "No local path"):
+            checkpoint.download()
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.download(local_path=self.test_dir)
+
+        self.assertEquals(self.test_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.test_dir, state["cmd"])
+
+        # Case: Cloud dir is passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with self.assertRaisesRegex(RuntimeError, "No local path"):
+            checkpoint.download(cloud_path=other_cloud_dir)
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint(cloud_path=self.cloud_dir)
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.download(
+                local_path=self.test_dir, cloud_path=other_cloud_dir)
+
+        self.assertEquals(self.test_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_cloud_dir, state["cmd"])
+        self.assertNotIn(self.cloud_dir, state["cmd"])
+
+    def testDownloadDefaultBoth(self):
+        state = {}
+
+        def check_call(cmd, *args, **kwargs):
+            state["cmd"] = cmd
+
+        other_local_dir = "/tmp/other"
+        other_cloud_dir = "s3://other"
+
+        # Case: Nothing is passed
+        checkpoint = TrialCheckpoint(
+            local_path=self.test_dir, cloud_path=self.cloud_dir)
+
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.download()
+
+        self.assertEquals(self.test_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(self.test_dir, state["cmd"])
+
+        # Case: Local dir is passed
+        checkpoint = TrialCheckpoint(
+            local_path=self.test_dir, cloud_path=self.cloud_dir)
+
+        with patch("subprocess.check_call", check_call):
+            path = checkpoint.download(local_path=other_local_dir)
+
+        self.assertEquals(other_local_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_local_dir, state["cmd"])
+        self.assertNotIn(self.test_dir, state["cmd"])
+
+        # Case: Both are passed
+        checkpoint = TrialCheckpoint(
+            local_path=self.test_dir, cloud_path=self.cloud_dir)
+
+        with patch("subprocess.check_call", check_call):
+
+            path = checkpoint.download(
+                local_path=other_local_dir, cloud_path=other_cloud_dir)
+
+        self.assertEquals(other_local_dir, path)
+        self.assertEquals(state["cmd"][0], "aws")
+        self.assertIn(other_local_dir, state["cmd"])
+        self.assertNotIn(self.test_dir, state["cmd"])
+        self.assertIn(other_cloud_dir, state["cmd"])
+        self.assertNotIn(self.cloud_dir, state["cmd"])
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -175,7 +175,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
             })
 
         # check if it's loaded correctly
-        last_checkpoint = new_ea.get_last_checkpoint()
+        last_checkpoint = new_ea.get_last_checkpoint().local_path
         assert self.test_path in last_checkpoint
         assert "checkpoint_000002" in last_checkpoint
 

--- a/python/ray/tune/tests/test_trainable_util.py
+++ b/python/ray/tune/tests/test_trainable_util.py
@@ -41,7 +41,7 @@ class TrainableUtilTest(unittest.TestCase):
             default_metric="score",
             default_mode="max")
         df = a.dataframe()
-        checkpoint_dir = a.get_best_checkpoint(df["logdir"].iloc[0])
+        checkpoint_dir = a.get_best_checkpoint(df["logdir"].iloc[0]).local_path
         assert checkpoint_dir.endswith("/checkpoint_000001/")
 
     def testFindCheckpointDir(self):

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -13,6 +13,7 @@ import uuid
 
 import ray
 import ray.cloudpickle as pickle
+from ray.tune.cloud import TrialCheckpoint
 from ray.tune.logger import Logger
 from ray.tune.resources import Resources
 from ray.tune.result import (
@@ -445,6 +446,10 @@ class Trainable:
                                           self.logdir)
             self.storage_client.wait()
 
+        # Ensure TrialCheckpoints are converted
+        if isinstance(checkpoint_path, TrialCheckpoint):
+            checkpoint_path = checkpoint_path.local_path
+
         with open(checkpoint_path + ".tune_metadata", "rb") as f:
             metadata = pickle.load(f)
         self._experiment_id = metadata["experiment_id"]
@@ -490,6 +495,10 @@ class Trainable:
         Args:
             checkpoint_path (str): Path to checkpoint.
         """
+        # Ensure TrialCheckpoints are converted
+        if isinstance(checkpoint_path, TrialCheckpoint):
+            checkpoint_path = checkpoint_path.local_path
+
         try:
             checkpoint_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
         except FileNotFoundError:

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -637,7 +637,8 @@ def run(
         runner.checkpoint_file,
         trials=trials,
         default_metric=metric,
-        default_mode=mode)
+        default_mode=mode,
+        sync_config=sync_config)
 
 
 @PublicAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently there is no smooth way to access checkpoints on cloud storage after a run. This is especially true when e.g. the best checkpoint was trained on a worker node (and not the head node) - the checkpoint lives on cloud storage but may have to be downloaded to the driver node for postprocessing.

This PR adds a `TrialCheckpoint` abstraction that is returned by `ExperimentAnalysis.get_best_checkpoint()` and `ExperimentAnalysis.best_checkpoint` (instead of the local trial path previously, which did not ensure consistency or even local existence of the checkpoint).

The `TrialCheckpoint` keeps a record of a local and cloud location and offers utilities to sync between these:

- the `TrialCheckpoint.download()` method allows downloading from cloud storage to local storage
- the `TrialCheckpoint.upload()` method allows uploading from local storage to cloud storage
- the `TrialCheckpoint.save()` method allows saving to both local and cloud storage and fetches the checkpoint from cloud before if needed

This PR adds a new module, `ray.tune.cloud`, which includes the checkpoint syncing logic. This is somewhat of a duplicate to the `ray.tune.sync_client` abstractions. This is currently sensible in order to avoid refactoring sync clients in this PR. In a future PR, this should be consolidated.

The PR also adds API and local/CI end to end tests. In a follow-up PR, the features should be tested in the tune cloud checkpointing release tests.

Example usage:

```
    best_checkpoint = analysis.best_checkpoint
    print("Remote checkpoint path", best_checkpoint.cloud_path)
    best_checkpoint.save("./out_checkpoint_dir")
```

Backwards compatibility is achieved by making this a `os.PathLike` class.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
