### PR TITLE
[datasets] Add an env var for default progress bar behavior

### DIFF
--- a/python/ray/data/impl/progress_bar.py
+++ b/python/ray/data/impl/progress_bar.py
@@ -1,6 +1,7 @@
 from typing import List, Any
 
 import ray
+from ray.ray_constants import env_integer
 from ray.types import ObjectRef
 from ray.util.annotations import PublicAPI
 
@@ -12,12 +13,17 @@ except ImportError:
     needs_warning = True
 
 # Whether progress bars are enabled in this process.
-_enabled: bool = True
+_enabled: bool = not bool(env_integer("RAY_DATA_DISABLE_PROGRESS_BARS", 0))
 
 
 @PublicAPI
 def set_progress_bars(enabled: bool) -> bool:
     """Set whether progress bars are enabled.
+
+    The default behavior is controlled by the
+    ``RAY_DATA_DISABLE_PROGRESS_BARS`` environment variable. By default,
+    it is set to "0". Setting it to "1" will disable progress bars, unless
+    they are reenabled by this method.
 
     Returns:
         Whether progress bars were previously enabled.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a `RAY_DATA_DISABLE_PROGRESS_BARS` env var to control the default progress bar behavior. The default value is "0". Setting it to "1" disables progress bars, unless they are reenabled again by the `set_progress_bars` method.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
