### PR TITLE
[WIP][Workflow] Optimize out tail recursion in python

### DIFF
--- a/python/ray/workflow/tests/test_inplace_workflows.py
+++ b/python/ray/workflow/tests/test_inplace_workflows.py
@@ -60,6 +60,20 @@ def test_inplace_workflows(workflow_start_regular_shared):
     assert exp_remote.step(k, n).run() == k * 2**n
 
 
+@workflow.step
+def tail_recursion(n):
+    import inspect
+    # check if the stack is growing
+    assert len(inspect.stack(0)) < 20
+    if n <= 0:
+        return "ok"
+    return tail_recursion.options(allow_inplace=True).step(n - 1)
+
+
+def test_tail_recursion_optimization(workflow_start_regular_shared):
+    tail_recursion.step(30).run()
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when performing inplace workflow steps, we call them in the place where they returned. This causes recursion in python and would result in stack overflow; it also prevents us from releasing the stack frame variables of a previous step. This PR performs tail recursion optimization in python.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
