### PR TITLE
[ci][windows] Skip test_worker_capping.py::test_zero_cpu_scheduling

### DIFF
--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -138,7 +138,7 @@ def test_zero_cpu_scheduling(shutdown_only):
     block_driver_ref = block_driver.acquire.remote()
 
     # Both tasks should be running, so the driver should be unblocked.
-    ready, not_ready = ray.wait([block_driver_ref], timeout=1)
+    ready, not_ready = ray.wait([block_driver_ref], timeout=5)
     assert len(not_ready) == 0
 
 

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -120,10 +120,7 @@ def test_limit_concurrency(shutdown_only):
     assert len(not_ready) == 1
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Times out on windows"
-)
+@pytest.mark.skipif(sys.platform == "win32", reason="Times out on windows.")
 def test_zero_cpu_scheduling(shutdown_only):
     ray.init(num_cpus=1)
 

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import platform
 import sys
 import tempfile
 import time
@@ -119,6 +120,10 @@ def test_limit_concurrency(shutdown_only):
     assert len(not_ready) == 1
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Times out on windows"
+)
 def test_zero_cpu_scheduling(shutdown_only):
     ray.init(num_cpus=1)
 

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import platform
 import pytest
 import sys
 import tempfile

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -143,7 +143,7 @@ def test_zero_cpu_scheduling(shutdown_only):
     block_driver_ref = block_driver.acquire.remote()
 
     # Both tasks should be running, so the driver should be unblocked.
-    ready, not_ready = ray.wait([block_driver_ref], timeout=5)
+    ready, not_ready = ray.wait([block_driver_ref], timeout=1)
     assert len(not_ready) == 0
 
 

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import platform
+import pytest
 import sys
 import tempfile
 import time


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1 second doesn't seem to be a long enough timeout for test_worker_capping.py::test_zero_cpu_scheduling on windows. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
