### PR TITLE
fix autoscaling config is not loaded when calling options()

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -876,7 +876,7 @@ class Deployment:
         if ray_actor_options is None:
             ray_actor_options = self._ray_actor_options
 
-        if _autoscaling_config is None:
+        if _autoscaling_config is not None:
             new_config.autoscaling_config = _autoscaling_config
 
         if _graceful_shutdown_wait_loop_s is not None:


### PR DESCRIPTION
## Why are these changes needed?

when using options() to change the autoscaling config, it has no effect. The reason is the bug in the line I changed.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [x] This PR is not tested :(
