### PR TITLE
[serve] don't swallow exceptions in deployment initialization

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -239,7 +239,7 @@ py_test(
 )
 
 py_test(
-    name = "test_warnings",
+    name = "test_logs",
     size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -274,6 +274,8 @@ class ActorReplicaWrapper:
                 self._graceful_shutdown_timeout_s = (
                     deployment_config.graceful_shutdown_timeout_s)
             except Exception:
+                logger.exception(
+                    f"Exception in deployment '{self._deployment_name}'")
                 return ReplicaStartupStatus.FAILED, None
 
         return ReplicaStartupStatus.SUCCEEDED, version

--- a/python/ray/serve/tests/test_logs.py
+++ b/python/ray/serve/tests/test_logs.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from ray import serve
 from ray.serve.deployment_state import (SLOW_STARTUP_WARNING_S,
@@ -62,3 +63,18 @@ def test_slow_initialization_warning(serve_instance, capsys):
     # make sure that exactly one warning was printed
     # for this deployment
     assert captured.err.count(expected_warning) == 1
+
+
+def test_deployment_init_error_logging(serve_instance, capsys):
+    @serve.deployment
+    class D:
+        def __init__(self):
+            0 / 0
+
+    with pytest.raises(RuntimeError):
+        D.deploy()
+
+    captured = capsys.readouterr()
+
+    assert "Exception in deployment 'D'" in captured.err
+    assert "ZeroDivisionError" in captured.err


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Log errors that happen in user deployment and initialization code (see linked issue).

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #20610

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
