### PR TITLE
[autoscaler][commands] Fix load metrics summary

### DIFF
--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -4,7 +4,7 @@ from functools import reduce
 import logging
 from numbers import Number
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import ray.ray_constants
@@ -34,7 +34,7 @@ class LoadMetricsSummary:
     # Counts of demand bundles requested by autoscaler.sdk.request_resources
     request_demand: List[DictCount]
     node_types: List[DictCount]
-    # IP of the head node.
+    # Optionally included for backwards compatibility: IP of the head node.
     head_ip: Optional[NodeIP] = None
 
 

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -34,6 +34,8 @@ class LoadMetricsSummary:
     # Counts of demand bundles requested by autoscaler.sdk.request_resources
     request_demand: List[DictCount]
     node_types: List[DictCount]
+    # IP of the head node.
+    head_ip: Optional[NodeIP] = None
 
 
 def add_resources(dict1: Dict[str, float],

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -1409,6 +1409,12 @@ class LoadMetricsTest(unittest.TestCase):
         # Ensure summary_dict is json-serializable
         json.dumps(summary_dict)
 
+        # Backwards compatibility check: head_ip is correctly processed
+        # when included as an argument to LoadMetricsSummary.
+        summary_dict["head_ip"] = "1.1.1.1"
+        # No compatibility issue.
+        LoadMetricsSummary(**summary_dict)
+
 
 class AutoscalingTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Running `ray status` with the changes from https://github.com/ray-project/ray/pull/20359
while running an autoscaler older than those changes 
results in an error on input "head_ip" to LoadMetricsSummary.
See https://github.com/ray-project/ray/pull/20359#issuecomment-975045355
This PR fixes the bug by restoring head_ip as an optional parameter of LoadMetricsSummary.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
