### PR TITLE
[Java] Reopen Named Actor Test

### DIFF
--- a/java/test/src/main/java/io/ray/test/NamedActorTest.java
+++ b/java/test/src/main/java/io/ray/test/NamedActorTest.java
@@ -50,6 +50,7 @@ public class NamedActorTest extends BaseTest {
     Ray.actor(Counter::new).setName(name).remote();
   }
 
+  @Test
   public void testGetNonExistingNamedActor() {
     Assert.assertTrue(!Ray.getActor("non_existing_actor").isPresent());
   }


### PR DESCRIPTION
## Why are these changes needed?

We skipped testGetNonExistingNamedActor for some reason. Now this test is ready to open. This PR reopens this test.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
