### PR TITLE
[Core] Remove BaseID Inheritance from ObjectRef

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -87,6 +87,10 @@ cdef class ObjectRef:
 
     cdef CObjectID native(self)
 
+    # To avoid the error of "Python int too large to convert to C ssize_t",
+    # here `cdef size_t` is required.
+    cdef size_t hash(self)
+
 cdef class ClientObjectRef(ObjectRef):
     cdef object _mutex
     cdef object _id_future

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -75,7 +75,7 @@ cdef class BaseID:
     # here `cdef size_t` is required.
     cdef size_t hash(self)
 
-cdef class ObjectRef(BaseID):
+cdef class ObjectRef:
     cdef:
         CObjectID data
         c_string owner_addr

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -34,7 +34,7 @@ def _set_future_helper(
         py_future.set_result(result)
 
 
-cdef class ObjectRef(BaseID):
+cdef class ObjectRef:
 
     def __init__(
             self, id, owner_addr="", call_site_data="",


### PR DESCRIPTION
## Why are these changes needed?
I think ObjectRef shouldn't inherit BaseID in Cython. Since in CPP code it doesn't either.

```cpp
template <typename T>
class ObjectRef {
 public:
  ObjectRef();
  ~ObjectRef();
...
}
```
This PR removes then BaseID inheritance.
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
