### PR TITLE
[core] add runtime env info to task spec debug string

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -389,6 +389,23 @@ std::string TaskSpecification::DebugString() const {
            << "}";
   }
 
+  // Print runtime env.
+  if (HasRuntimeEnv()) {
+    const auto &runtime_env_info = RuntimeEnvInfo();
+    stream << ", serialized_runtime_env=" << SerializedRuntimeEnv();
+    const auto &uris = runtime_env_info.uris();
+    if (uris.size() > 0) {
+      stream << ", runtime_env_uris=";
+      for (const auto &uri : uris) {
+        stream << uri << ":";
+      }
+      // Erase the last ":"
+      stream.seekp(-1, std::ios_base::end);
+    }
+    stream << ", runtime_env_eager_install="
+           << runtime_env_info.runtime_env_eager_install();
+  }
+
   return stream.str();
 }
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -17,7 +17,6 @@
 #include "ray/common/buffer.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task_spec.h"
-#include "ray/util/logging.h"
 #include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
@@ -88,11 +87,7 @@ class TaskSpecBuilder {
   TaskSpecBuilder() : message_(std::make_shared<rpc::TaskSpec>()) {}
 
   /// Build the `TaskSpecification` object.
-  TaskSpecification Build() {
-    auto task_spec = TaskSpecification(message_);
-    RAY_LOG(DEBUG) << "Build task " << task_spec.DebugString();
-    return task_spec;
-  }
+  TaskSpecification Build() { return TaskSpecification(message_); }
 
   /// Get a reference to the internal protobuf message object.
   const rpc::TaskSpec &GetMessage() const { return *message_; }

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -17,6 +17,7 @@
 #include "ray/common/buffer.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task_spec.h"
+#include "ray/util/logging.h"
 #include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
@@ -87,7 +88,11 @@ class TaskSpecBuilder {
   TaskSpecBuilder() : message_(std::make_shared<rpc::TaskSpec>()) {}
 
   /// Build the `TaskSpecification` object.
-  TaskSpecification Build() { return TaskSpecification(message_); }
+  TaskSpecification Build() {
+    auto task_spec = TaskSpecification(message_);
+    RAY_LOG(DEBUG) << "Build task " << task_spec.DebugString();
+    return task_spec;
+  }
 
   /// Get a reference to the internal protobuf message object.
   const rpc::TaskSpec &GetMessage() const { return *message_; }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1864,7 +1864,6 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
                       task_options.serialized_runtime_env);
   builder.SetNormalTaskSpec(max_retries, retry_exceptions);
   TaskSpecification task_spec = builder.Build();
-  RAY_LOG(DEBUG) << "Submit task " << task_spec.DebugString();
   std::vector<rpc::ObjectReference> returned_refs;
   if (options_.is_local_mode) {
     returned_refs = ExecuteTaskLocalMode(task_spec);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1864,7 +1864,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
                       task_options.serialized_runtime_env);
   builder.SetNormalTaskSpec(max_retries, retry_exceptions);
   TaskSpecification task_spec = builder.Build();
-  RAY_LOG(DEBUG) << "Submit normal task " << task_spec.DebugString();
+  RAY_LOG(DEBUG) << "Submitting normal task " << task_spec.DebugString();
   std::vector<rpc::ObjectReference> returned_refs;
   if (options_.is_local_mode) {
     returned_refs = ExecuteTaskLocalMode(task_spec);
@@ -1949,7 +1949,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       << "Actor " << actor_id << " already exists";
   *return_actor_id = actor_id;
   TaskSpecification task_spec = builder.Build();
-  RAY_LOG(DEBUG) << "Submit actor creation task " << task_spec.DebugString();
+  RAY_LOG(DEBUG) << "Submitting actor creation task " << task_spec.DebugString();
   if (options_.is_local_mode) {
     // TODO(suquark): Should we consider namespace in local mode? Currently
     // it looks like two actors with two different namespaces become the
@@ -2127,7 +2127,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitActorTask(
 
   // Submit task.
   TaskSpecification task_spec = builder.Build();
-  RAY_LOG(DEBUG) << "Submit actor task " << task_spec.DebugString();
+  RAY_LOG(DEBUG) << "Submitting actor task " << task_spec.DebugString();
   std::vector<rpc::ObjectReference> returned_refs;
   if (options_.is_local_mode) {
     returned_refs = ExecuteTaskLocalMode(task_spec, actor_id);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1864,6 +1864,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
                       task_options.serialized_runtime_env);
   builder.SetNormalTaskSpec(max_retries, retry_exceptions);
   TaskSpecification task_spec = builder.Build();
+  RAY_LOG(DEBUG) << "Submit normal task " << task_spec.DebugString();
   std::vector<rpc::ObjectReference> returned_refs;
   if (options_.is_local_mode) {
     returned_refs = ExecuteTaskLocalMode(task_spec);
@@ -1948,6 +1949,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       << "Actor " << actor_id << " already exists";
   *return_actor_id = actor_id;
   TaskSpecification task_spec = builder.Build();
+  RAY_LOG(DEBUG) << "Submit actor creation task " << task_spec.DebugString();
   if (options_.is_local_mode) {
     // TODO(suquark): Should we consider namespace in local mode? Currently
     // it looks like two actors with two different namespaces become the
@@ -2125,6 +2127,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitActorTask(
 
   // Submit task.
   TaskSpecification task_spec = builder.Build();
+  RAY_LOG(DEBUG) << "Submit actor task " << task_spec.DebugString();
   std::vector<rpc::ObjectReference> returned_refs;
   if (options_.is_local_mode) {
     returned_refs = ExecuteTaskLocalMode(task_spec, actor_id);


### PR DESCRIPTION
## Why are these changes needed?
- During debugging, we want to print task specs in caller side. But we only have a printing for common tasks in `CoreWorker::SubmitTask` now. We should also print task spec for actor creation task and actor task.
- Add runtime env info to the printing content.
