### PR TITLE
[script][format] check copyright for .proto files

### DIFF
--- a/ci/travis/copyright-format.sh
+++ b/ci/travis/copyright-format.sh
@@ -87,7 +87,7 @@ for directory in "${INCLUDES_CPP_DIRS[@]}"; do
         fi
         cmd_args="${cmd_args}*'"
     done
-    cmd_args="${cmd_args} \( -name '*.cc' -or -name '*.h' \)"
+    cmd_args="${cmd_args} \( -name '*.cc' -or -name '*.h' -or -name '*.proto' \)"
     eval "${cmd_args}" > "$FILE_LIST_TMP_FILE"
     while IFS=$'\n' read -r f
     do

--- a/src/ray/protobuf/event.proto
+++ b/src/ray/protobuf/event.proto
@@ -1,3 +1,17 @@
+// Copyright 2020-2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 syntax = "proto3";
 option cc_enable_arenas = true;
 


### PR DESCRIPTION
## Why are these changes needed?
- I found that we also have a copyright header in .proto files. Add it to the copyright formatter.