### PR TITLE
[ci/release] Remove quotation marks from pip installs

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -544,15 +544,6 @@ def _load_config(local_dir: str, config_file: Optional[str]) -> Optional[Dict]:
     return yaml.safe_load(content)
 
 
-def _wrap_app_config_pip_installs(app_config: Dict[Any, Any]):
-    """Wrap pip package install in quotation marks"""
-    if app_config.get("python", {}).get("pip_packages"):
-        new_pip_packages = []
-        for pip_package in app_config["python"]["pip_packages"]:
-            new_pip_packages.append(f"\"{pip_package}\"")
-        app_config["python"]["pip_packages"] = new_pip_packages
-
-
 def has_errored(result: Dict[Any, Any]) -> bool:
     return result.get("status", "invalid") != "finished"
 
@@ -1378,9 +1369,6 @@ def run_test_config(
     elif "autosuspend_mins" in test_config["run"]:
         raise ValueError(
             "'autosuspend_mins' is only supported if 'use_connect' is True.")
-
-    # Only wrap pip packages after we installed the app config packages
-    _wrap_app_config_pip_installs(app_config)
 
     # Add information to results dict
     def _update_results(results: Dict):

--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -6,7 +6,7 @@ debian_packages:
 python:
   pip_packages:
     - pandas>=1.3.0  # otherwise, a version mismatch between local and remote will cause an exception
-    - "git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray"
+    - git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
     - dask
     - fastapi
     - uvicorn

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -6,7 +6,7 @@ debian_packages:
 python:
   pip_packages:
     - pandas>=1.3.0  # otherwise, a version mismatch between local and remote will cause an exception
-    - "git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray"
+    - git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
     - modin>=0.11.0 # ray.services has been removed
     - s3fs
     - fastapi


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Quotation marks were needed in Anyscale app configs to avoid install errors when `#` were used e.g. in URLs.

Since this has been fixed on the Anyscale side, we can get rid of these.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
