### PR TITLE
[Draft][RFC] Use create_node_with_resources only for FakeMultiNodeProvider.

### DIFF
--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -83,6 +83,11 @@ class FakeMultiNodeProvider(NodeProvider):
         raise AssertionError("Readonly node provider cannot be updated")
 
     def create_node_with_resources(self, node_config, tags, count, resources):
+        """Create nodes with a given resource config.
+
+        Replacement for NodeProvider.create_nodes used by the autoscaler
+        only for this class (FakeMultiNodeProvider).
+        """
         with self.lock:
             node_type = tags[TAG_RAY_USER_NODE_TYPE]
             next_id = self._next_hex_node_id()

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -124,18 +124,6 @@ class NodeProvider:
         """
         raise NotImplementedError
 
-    def create_node_with_resources(
-            self, node_config: Dict[str, Any], tags: Dict[str, str],
-            count: int,
-            resources: Dict[str, float]) -> Optional[Dict[str, Any]]:
-        """Create nodes with a given resource config.
-
-        This is the method actually called by the autoscaler. Prefer to
-        implement this when possible directly, otherwise it delegates to the
-        create_node() implementation.
-        """
-        return self.create_node(node_config, tags, count)
-
     def set_node_tags(self, node_id: str, tags: Dict[str, str]) -> None:
         """Sets the tag values (string dict) for the specified node."""
         raise NotImplementedError


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adding `create_node_with_resources` to the NodeProvider interface in https://github.com/ray-project/ray/pull/18987 might have caused issues for some external node providers. 

This draft PR proposes removing the method from the NodeProvider interface. Instead, it's proposed to only implement it for the FakeMultiNodeProvider and do an instance check in the node launcher. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
