### PR TITLE
[codeowners] Add code owners on west coast to java

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,11 +27,11 @@
 #!/python/ray/rllib/ @ray-project/ray-core-python
 
 # Java worker.
-/java/dependencies.bzl @jovany-wang @kfstorm @raulchen
-/java/pom.xml @jovany-wang @kfstorm @raulchen
-/java/pom_template.xml @jovany-wang @kfstorm @raulchen
-/java/*/pom_template.xml @jovany-wang @kfstorm @raulchen
-/java/api/ @jovany-wang @kfstorm @raulchen
+/java/dependencies.bzl @jovany-wang @kfstorm @raulchen @ericl @iycheng
+/java/pom.xml @jovany-wang @kfstorm @raulchen @ericl @iycheng
+/java/pom_template.xml @jovany-wang @kfstorm @raulchen @ericl @iycheng
+/java/*/pom_template.xml @jovany-wang @kfstorm @raulchen @ericl @iycheng
+/java/api/ @jovany-wang @kfstorm @raulchen @ericl @iycheng
 
 # Ray Client
 /src/ray/protobuf/ray_client.proto @ijrsvt @ameerhajali @ckw017 @mwtian


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We need code owners on the java files so that we can revert changes to java files that break CI. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
