### PR TITLE
Deflake test_multi_node_3.py::test_calling_start_head

### DIFF
--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -99,7 +99,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     blocked.poll()
     assert blocked.returncode is None
 
-    kill_process_by_name("raylet")
+    kill_process_by_name("raylet", SIGKILL=False)
     wait_for_children_of_pid_to_exit(blocked.pid, timeout=30)
     blocked.wait()
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -99,7 +99,7 @@ def test_calling_start_ray_head(call_ray_stop_only):
     blocked.poll()
     assert blocked.returncode is None
 
-    kill_process_by_name("raylet", SIGKILL=False)
+    kill_process_by_name("raylet", SIGKILL=True)
     wait_for_children_of_pid_to_exit(blocked.pid, timeout=30)
     blocked.wait()
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test seems to be flaking since ray stop sometimes fails when sending SIGTERM only. While that's desirable to fix, the test is still testing the intended behavior even if we send SIGKILL.