### PR TITLE
Add chaos test for shuffle

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -947,7 +947,6 @@ def get_and_run_node_killer(node_kill_interval_s):
             # -- logger. --
             logging.basicConfig(level=logging.INFO)
 
-
         def ready(self):
             pass
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -965,10 +965,13 @@ def get_and_run_node_killer(node_kill_interval_s):
                         break
 
                 if node_to_kill_port is not None:
-                    self._kill_raylet(
-                        node_to_kill_ip, node_to_kill_port, graceful=False)
+                    try:
+                        self._kill_raylet(
+                            node_to_kill_ip, node_to_kill_port, graceful=False)
+                    except Exception:
+                        pass
                     logging.info(
-                        "Killing a node of address: "
+                        f"Killed node {node_id} at address: "
                         f"{node_to_kill_ip}, port: {node_to_kill_port}")
                     self.killed_nodes.add(node_id)
                 await asyncio.sleep(self.node_kill_interval_s)

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -53,7 +53,7 @@ class AutoscalingCluster:
         custom_config.update(config_kwargs)
         return custom_config
 
-    def start(self):
+    def start(self, _system_config=None):
         """Start the cluster.
 
         After this call returns, you can connect to the cluster with
@@ -74,6 +74,9 @@ class AutoscalingCluster:
         if self._head_resources:
             cmd.append("--resources='{}'".format(
                 json.dumps(self._head_resources)))
+        if _system_config is not None:
+            cmd.append("--system-config={}".format(
+                json.dumps(_system_config, separators=(',',':'))))
         env = os.environ.copy()
         env.update({
             "AUTOSCALER_UPDATE_INTERVAL_S": "1",

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -21,7 +21,8 @@ class AutoscalingCluster:
     See test_autoscaler_fake_multinode.py for an end-to-end example.
     """
 
-    def __init__(self, head_resources: dict, worker_node_types: dict):
+    def __init__(self, head_resources: dict, worker_node_types: dict,
+                 **config_kwargs):
         """Create the cluster.
 
         Args:
@@ -29,10 +30,12 @@ class AutoscalingCluster:
             worker_node_types: autoscaler node types config for worker nodes.
         """
         self._head_resources = head_resources
-        self._config = self._generate_config(head_resources, worker_node_types)
+        self._config = self._generate_config(head_resources, worker_node_types,
+                                             **config_kwargs)
         self._process = None
 
-    def _generate_config(self, head_resources, worker_node_types):
+    def _generate_config(self, head_resources, worker_node_types,
+                         **config_kwargs):
         base_config = yaml.safe_load(
             open(
                 os.path.join(
@@ -45,6 +48,7 @@ class AutoscalingCluster:
             "node_config": {},
             "max_workers": 0,
         }
+        custom_config.update(config_kwargs)
         return custom_config
 
     def start(self):

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -76,7 +76,7 @@ class AutoscalingCluster:
                 json.dumps(self._head_resources)))
         if _system_config is not None:
             cmd.append("--system-config={}".format(
-                json.dumps(_system_config, separators=(',',':'))))
+                json.dumps(_system_config, separators=(",", ":"))))
         env = os.environ.copy()
         env.update({
             "AUTOSCALER_UPDATE_INTERVAL_S": "1",

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -100,14 +100,32 @@ class _StatusTracker:
     def __init__(self):
         self.num_map = 0
         self.num_reduce = 0
+        self.map_refs = []
+        self.reduce_refs = []
 
-    def inc(self):
-        self.num_map += 1
-
-    def inc2(self):
-        self.num_reduce += 1
+    def register_objectrefs(self, map_refs, reduce_refs):
+        self.map_refs = map_refs
+        self.reduce_refs = reduce_refs
 
     def get_progress(self):
+        if self.map_refs:
+            ready, self.map_refs = ray.wait(
+                self.map_refs,
+                timeout=1,
+                num_returns=len(self.map_refs),
+                fetch_local=False)
+            if not ready:
+                print("Still waiting on map refs", self.map_refs)
+            self.num_map += len(ready)
+        elif self.reduce_refs:
+            ready, self.reduce_refs = ray.wait(
+                self.reduce_refs,
+                timeout=1,
+                num_returns=len(self.reduce_refs),
+                fetch_local=False)
+            if not ready:
+                print("Still waiting on reduce refs", self.reduce_refs)
+            self.num_reduce += len(ready)
         return self.num_map, self.num_reduce
 
 
@@ -194,6 +212,8 @@ def simple_shuffle(*,
     ]
 
     if tracker:
+        tracker.register_objectrefs.remote(
+            [map_out[0] for map_out in shuffle_map_out], shuffle_reduce_out)
         render_progress_bar(tracker, input_num_partitions,
                             output_num_partitions)
 
@@ -216,14 +236,15 @@ def run(ray_address=None,
         num_nodes=None,
         num_cpus=8,
         no_streaming=False,
-        use_wait=False):
+        use_wait=False,
+        tracker=None):
     import numpy as np
     import time
 
     is_multi_node = num_nodes
     if ray_address:
         print("Connecting to a existing cluster...")
-        ray.init(address=ray_address)
+        ray.init(address=ray_address, ignore_reinit_error=True)
     elif is_multi_node:
         print("Emulating a cluster...")
         print(f"Num nodes: {num_nodes}")
@@ -238,14 +259,14 @@ def run(ray_address=None,
     partition_size = int(partition_size)
     num_partitions = num_partitions
     rows_per_partition = partition_size // (8 * 2)
-    tracker = _StatusTracker.remote()
+    if tracker is None:
+        tracker = _StatusTracker.remote()
     use_wait = use_wait
 
     def input_reader(i: PartitionID) -> Iterable[InType]:
         for _ in range(num_partitions):
             yield np.ones(
                 (rows_per_partition // num_partitions, 2), dtype=np.int64)
-        tracker.inc.remote()
 
     def output_writer(i: PartitionID,
                       shuffle_inputs: List[ObjectRef]) -> OutType:
@@ -261,7 +282,6 @@ def run(ray_address=None,
                 arr = ray.get(ready)
                 total += arr.size * arr.itemsize
 
-        tracker.inc2.remote()
         return total
 
     def output_writer_non_streaming(i: PartitionID,
@@ -269,7 +289,6 @@ def run(ray_address=None,
         total = 0
         for arr in shuffle_inputs:
             total += arr.size * arr.itemsize
-        tracker.inc2.remote()
         return total
 
     if no_streaming:

--- a/python/ray/experimental/shuffle.py
+++ b/python/ray/experimental/shuffle.py
@@ -114,8 +114,6 @@ class _StatusTracker:
                 timeout=1,
                 num_returns=len(self.map_refs),
                 fetch_local=False)
-            if not ready:
-                print("Still waiting on map refs", self.map_refs)
             self.num_map += len(ready)
         elif self.reduce_refs:
             ready, self.reduce_refs = ray.wait(
@@ -123,8 +121,6 @@ class _StatusTracker:
                 timeout=1,
                 num_returns=len(self.reduce_refs),
                 fetch_local=False)
-            if not ready:
-                print("Still waiting on reduce refs", self.reduce_refs)
             self.num_reduce += len(ready)
         return self.num_map, self.num_reduce
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -446,8 +446,7 @@ def _ray_start_chaos_cluster(request):
         ray.get(node_killer.stop_run.remote())
         killed = ray.get(node_killer.get_total_killed_nodes.remote())
         assert len(killed) > 0
-        died = set(
-            [node["NodeID"] for node in ray.nodes() if not node["Alive"]])
+        died = set(node["NodeID"] for node in ray.nodes() if not node["Alive"])
         assert killed == died, (f"Raylets {died - killed} that "
                                 "we did not kill crashed")
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -439,10 +439,11 @@ def _ray_start_chaos_cluster(request):
     yield cluster
 
     if kill_interval is not None:
-        num_killed = ray.get(node_killer.get_total_killed_nodes.remote())
-        assert num_killed > 0
-        num_died = len([node for node in ray.nodes() if not node["Alive"]])
-        assert num_killed == num_died, "Raylets that we did not kill crashed"
+        ray.get(node_killer.stop_run.remote())
+        killed = ray.get(node_killer.get_total_killed_nodes.remote())
+        assert len(killed) > 0
+        died = set([node["NodeID"] for node in ray.nodes() if not node["Alive"]])
+        assert killed == died, f"Raylets {died - killed} that we did not kill crashed"
 
     ray.shutdown()
     cluster.shutdown()

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -428,10 +428,10 @@ def _ray_start_chaos_cluster(request):
     kill_interval = param.pop("kill_interval", None)
     config = param.pop("_system_config", {})
     config.update({
-            "num_heartbeats_timeout": 10,
-            "raylet_heartbeat_period_milliseconds": 100,
-            "task_retry_delay_ms": 100,
-            })
+        "num_heartbeats_timeout": 10,
+        "raylet_heartbeat_period_milliseconds": 100,
+        "task_retry_delay_ms": 100,
+    })
     # Config of workers that are re-started.
     head_resources = param.pop("head_resources")
     worker_node_types = param.pop("worker_node_types")

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -455,8 +455,8 @@ def _ray_start_chaos_cluster(request):
         killed = ray.get(node_killer.get_total_killed_nodes.remote())
         assert len(killed) > 0
         died = {node["NodeID"] for node in ray.nodes() if not node["Alive"]}
-        assert killed == died, (f"Raylets {died - killed} that "
-                                "we did not kill crashed")
+        assert died.issubset(killed), (f"Raylets {died - killed} that "
+                                       "we did not kill crashed")
 
     ray.shutdown()
     cluster.shutdown()

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -451,7 +451,7 @@ def _ray_start_chaos_cluster(request):
         ray.get(node_killer.stop_run.remote())
         killed = ray.get(node_killer.get_total_killed_nodes.remote())
         assert len(killed) > 0
-        died = set(node["NodeID"] for node in ray.nodes() if not node["Alive"])
+        died = {node["NodeID"] for node in ray.nodes() if not node["Alive"]}
         assert killed == died, (f"Raylets {died - killed} that "
                                 "we did not kill crashed")
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -442,8 +442,10 @@ def _ray_start_chaos_cluster(request):
         ray.get(node_killer.stop_run.remote())
         killed = ray.get(node_killer.get_total_killed_nodes.remote())
         assert len(killed) > 0
-        died = set([node["NodeID"] for node in ray.nodes() if not node["Alive"]])
-        assert killed == died, f"Raylets {died - killed} that we did not kill crashed"
+        died = set(
+            [node["NodeID"] for node in ray.nodes() if not node["Alive"]])
+        assert killed == died, (f"Raylets {died - killed} that "
+                                "we did not kill crashed")
 
     ray.shutdown()
     cluster.shutdown()

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -419,7 +419,7 @@ def slow_spilling_config(request, tmp_path):
 
 
 def _ray_start_chaos_cluster(request):
-    os.environ["RAY_num_heartbeats_timeout"] = "5"
+    os.environ["RAY_num_heartbeats_timeout"] = "10"
     os.environ["RAY_raylet_heartbeat_period_milliseconds"] = "100"
     os.environ["RAY_task_retry_delay_ms"] = "100"
     param = getattr(request, "param", {})

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -454,4 +454,4 @@ def _ray_start_chaos_cluster(request):
 def ray_start_chaos_cluster(request):
     """Returns the cluster and chaos thread.
     """
-    return _ray_start_cluster(request)
+    return _ray_start_chaos_cluster(request)

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -34,7 +34,7 @@ def set_kill_interval(request):
         },
         "kill_interval": kill_interval,
         "head_resources": {
-            "CPU": 1,
+            "CPU": 0,
         },
         "worker_node_types": {
             "cpu_node": {
@@ -125,7 +125,7 @@ def test_chaos_actor_retry(set_kill_interval):
     # assert_no_system_failure(p, 10)
 
 
-@ray.remote
+@ray.remote(num_cpus=0)
 class ShuffleStatusTracker:
     def __init__(self):
         self.num_map = 0

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -156,8 +156,8 @@ def test_nonstreaming_shuffle(set_kill_interval):
 
 
 @pytest.mark.parametrize(
-    "set_kill_interval", [(True, None), (True, 20), (False, None),
-                          (False, 20)],
+    "set_kill_interval", [(True, None), (True, 30), (False, None),
+                          (False, 30)],
     indirect=True)
 def test_streaming_shuffle(set_kill_interval):
     lineage_reconstruction_enabled, kill_interval, _ = set_kill_interval

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -159,6 +159,7 @@ class ShuffleStatusTracker:
         return self.num_map, self.num_reduce
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
     "set_kill_interval", [(False, None), (False, 60)], indirect=True)
 def test_nonstreaming_shuffle(set_kill_interval):
@@ -183,6 +184,7 @@ def test_nonstreaming_shuffle(set_kill_interval):
 
 
 @pytest.mark.skip(reason="https://github.com/ray-project/ray/issues/20713")
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
     "set_kill_interval", [(True, None), (True, 60), (False, None),
                           (False, 60)],

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -1,11 +1,9 @@
 import sys
 import random
 import string
-import os
 
 import ray
 
-import numpy as np
 import pytest
 import time
 
@@ -33,7 +31,7 @@ def set_kill_interval(request):
         "_system_config": {
             "lineage_pinning_enabled": lineage_reconstruction_enabled,
             "max_direct_call_object_size": 1000,
-            },
+        },
         "kill_interval": kill_interval,
         "head_resources": {
             "CPU": 1,
@@ -45,7 +43,7 @@ def set_kill_interval(request):
                 },
                 "node_config": {
                     "object_store_memory": int(200e6),
-                    },
+                },
                 "min_workers": 0,
                 "max_workers": 3,
             },
@@ -161,10 +159,8 @@ class ShuffleStatusTracker:
         return self.num_map, self.num_reduce
 
 
-
 @pytest.mark.parametrize(
-    "set_kill_interval", [(False, None), (False, 60)],
-    indirect=True)
+    "set_kill_interval", [(False, None), (False, 60)], indirect=True)
 def test_nonstreaming_shuffle(set_kill_interval):
     lineage_reconstruction_enabled, kill_interval, _ = set_kill_interval
     try:
@@ -186,11 +182,10 @@ def test_nonstreaming_shuffle(set_kill_interval):
         assert not lineage_reconstruction_enabled
 
 
-
-@pytest.mark.skip(
-        reason="https://github.com/ray-project/ray/issues/20713")
+@pytest.mark.skip(reason="https://github.com/ray-project/ray/issues/20713")
 @pytest.mark.parametrize(
-    "set_kill_interval", [(True, None), (True, 60), (False, None), (False, 60)],
+    "set_kill_interval", [(True, None), (True, 60), (False, None),
+                          (False, 60)],
     indirect=True)
 def test_streaming_shuffle(set_kill_interval):
     lineage_reconstruction_enabled, kill_interval, _ = set_kill_interval

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -153,14 +153,18 @@ def set_kill_interval(request):
     cluster = _ray_start_chaos_cluster(request)
     while True:
         try:
-            yield (lineage_reconstruction_enabled, kill_interval, next(cluster))
+            yield (lineage_reconstruction_enabled, kill_interval,
+                   next(cluster))
         except StopIteration:
             break
     if lineage_reconstruction_enabled:
         del os.environ["RAY_lineage_pinning_enabled"]
 
 
-@pytest.mark.parametrize("set_kill_interval", [(True, None), (True, 30), (False, None), (False, 30)], indirect=True)
+@pytest.mark.parametrize(
+    "set_kill_interval", [(True, None), (True, 30), (False, None),
+                          (False, 30)],
+    indirect=True)
 def test_nonstreaming_shuffle(set_kill_interval):
     lineage_reconstruction_enabled, kill_interval, _ = set_kill_interval
     try:
@@ -179,6 +183,7 @@ def test_nonstreaming_shuffle(set_kill_interval):
             tracker=tracker)
     except (RayTaskError, ObjectLostError):
         assert kill_interval is not None
+        assert not lineage_reconstruction_enabled
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -170,7 +170,7 @@ def test_shuffle(set_kill_interval):
             ray_address="auto",
             no_streaming=True,
             num_partitions=200,
-            partition_size=15e6,
+            partition_size=10e6,
             tracker=tracker)
     except (RayTaskError, ObjectLostError):
         assert kill_interval is not None

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -130,8 +130,9 @@ def test_chaos_actor_retry(ray_start_chaos_cluster):
 @pytest.fixture
 def set_kill_interval(request):
     lineage_reconstruction_enabled, kill_interval = request.param
-    if lineage_reconstruction_enabled:
-        os.environ["RAY_lineage_pinning_enabled"] = "1"
+    os.environ["RAY_lineage_pinning_enabled"] = ("1" if
+                                                 lineage_reconstruction_enabled
+                                                 else "0")
     request.param = {
         "kill_interval": kill_interval,
         "head_resources": {
@@ -157,8 +158,7 @@ def set_kill_interval(request):
                    next(cluster))
         except StopIteration:
             break
-    if lineage_reconstruction_enabled:
-        del os.environ["RAY_lineage_pinning_enabled"]
+    del os.environ["RAY_lineage_pinning_enabled"]
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -4,6 +4,7 @@ import ray
 
 import pytest
 import grpc
+from grpc._channel import _InactiveRpcError
 import psutil
 
 import ray.ray_constants as ray_constants
@@ -286,8 +287,11 @@ def test_raylet_graceful_shutdown_through_rpc(ray_start_cluster_head,
         channel = grpc.insecure_channel(raylet_address)
         stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
         print(f"Sending a shutdown request to {ip}:{port}")
-        stub.ShutdownRaylet(
-            node_manager_pb2.ShutdownRayletRequest(graceful=graceful))
+        try:
+            stub.ShutdownRaylet(
+                node_manager_pb2.ShutdownRayletRequest(graceful=graceful))
+        except _InactiveRpcError:
+            assert not graceful
 
     """
     Kill the first worker non-gracefully.

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -234,6 +234,10 @@ class MockDistributedPublisher : public pubsub::PublisherInterface {
   }
 
   void Publish(const rpc::PubMessage &pub_message) {
+    if (pub_message.channel_type() == rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL) {
+      // TODO(swang): Test object locations pubsub too.
+      return;
+    }
     auto maybe_subscribers = directory_->GetSubscriberIdsByKeyId(pub_message.key_id());
     const auto oid = ObjectID::FromBinary(pub_message.key_id());
     if (maybe_subscribers.has_value()) {

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -284,6 +284,9 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
           location_info, object_id,
           /*location_lookup_failed*/ !location_info.ref_removed());
       if (location_info.ref_removed()) {
+        RAY_LOG(ERROR)
+            << "Failed to get locations for " << object_id
+            << ", object already released by distributed reference counting protocol";
         mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
       }
     };

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1724,17 +1724,16 @@ void NodeManager::HandleShutdownRaylet(const rpc::ShutdownRayletRequest &request
                                        rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(INFO)
       << "Shutdown RPC has received. Shutdown will happen after the RPC is replied.";
+  // Exit right away if it is not graceful.
+  if (!request.graceful()) {
+    std::_Exit(EXIT_SUCCESS);
+  }
   if (is_node_drained_) {
     RAY_LOG(INFO) << "Node already has received the shutdown request. The shutdown "
                      "request RPC is ignored.";
     return;
   }
-  auto graceful = request.graceful();
-  auto shutdown_after_reply = [graceful]() {
-    // Exit right away if it is not graceful.
-    if (!graceful) {
-      std::_Exit(EXIT_SUCCESS);
-    }
+  auto shutdown_after_reply = []() {
     // Note that the callback is posted to the io service after the shutdown GRPC request
     // is replied. Otherwise, the RPC might not be replied to GCS before it shutsdown
     // itself. Implementation note: When raylet is shutdown by ray stop, the CLI sends a
@@ -1742,7 +1741,7 @@ void NodeManager::HandleShutdownRaylet(const rpc::ShutdownRayletRequest &request
     // we raise a sigterm to itself so that it can re-use the same graceful shutdown code
     // path. The sigterm is handled in the entry point (raylet/main.cc)'s signal handler.
     auto signo = SIGTERM;
-    RAY_LOG(INFO) << "Sending a signal to itself. shutting down. graceful " << graceful
+    RAY_LOG(INFO) << "Sending a signal to itself. shutting down. "
                   << ". Signo: " << signo;
     // raise return 0 if succeeds. If it fails to gracefully shutdown, it kills itself
     // forcefully.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a working failure test for streaming and non-streaming shuffle, without lineage reconstruction. This does a few things.

Test improvements:
- modifies AutoscalingCluster to allow passing an idle node timeout (the default is very low)
- some small improvements to the NodeKiller actor to hopefully improve flakiness.

Shuffle fixes:
- modifies `shuffle` tracker to wait on futures instead of having tasks signal. During failures, tasks may never signal the tracker, so we can't rely on these to track progress.

Core fixes:
- raylet will exit immediately if it receives the Shutdown RPC with graceful=False - there was a bug here where it's supposed to exit after replying to the client, but the gRPC server goes down for an unknown reason and the client reply is never sent
- On reference deletion, the owner now publishes an additional message to subscribers that the object has been deleted. Previously, this was causing a hang in streaming shuffle because the raylets pulling an object subscribed after the object was already deleted, so they never received the error signal.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
