### PR TITLE
[data] Make block splitting feature flagged off by default

### DIFF
--- a/doc/source/data/dataset-execution-model.rst
+++ b/doc/source/data/dataset-execution-model.rst
@@ -17,6 +17,10 @@ Datasets uses Ray tasks to read data from remote storage. When reading from a fi
 
 In the common case, each read task produces a single output block. Read tasks may split the output into multiple blocks if the data exceeds the target max block size (2GiB by default). This automatic block splitting avoids out-of-memory errors when reading very large single files (e.g., a 100-gigabyte CSV file). All of the built-in datasources except for JSON currently support automatic block splitting.
 
+.. note::
+
+  Block splitting is currently off by default. See the block size tuning section below on how to enable block splitting.
+
 Deferred Read Task Execution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -105,7 +109,9 @@ The number of read tasks can also be increased by increasing the ``parallelism``
 Tuning Max Block Size
 ~~~~~~~~~~~~~~~~~~~~~
 
-The max target block size can be adjusted via the Dataset context API. For example, to configure a max target block size of 8GiB, run ``ray.data.context.DatasetContext.get_current().target_max_block_size = 8192 * 1024 * 1024`` prior to creating the Dataset. Lower block sizes reduce the max amount of object store and Python heap memory required during execution. However, having too many blocks may introduce task scheduling overheads.
+Block splitting is off by default. To enable block splitting, run ``ray.data.context.DatasetContext.get_current().block_splitting_enabled = True``.
+
+Once enabled, the max target block size can be adjusted via the Dataset context API. For example, to configure a max target block size of 8GiB, run ``ray.data.context.DatasetContext.get_current().target_max_block_size = 8192 * 1024 * 1024`` prior to creating the Dataset. Lower block sizes reduce the max amount of object store and Python heap memory required during execution. However, having too many blocks may introduce task scheduling overheads.
 
 We do not recommend adjusting this value for most workloads. However, if shuffling a large amount of data, increasing the block size limit reduces the number of intermediate blocks (as a rule of thumb, shuffle creates ``O(num_blocks**2)`` intermediate blocks). Alternatively, you can ``.repartition()`` the dataset to reduce the number of blocks prior to shuffle/groupby operations. If you're seeing out of memory errors during map tasks, reducing the max block size may also be worth trying.
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -33,6 +33,10 @@ BlockPartition = List[Tuple[ObjectRef[Block], "BlockMetadata"]]
 # same type as the metadata that describes each block in the partition.
 BlockPartitionMetadata = "BlockMetadata"
 
+# TODO(ekl) replace this with just `BlockPartition` once block splitting is on
+# by default. When block splitting is off, the type is a plain block.
+MaybeBlockPartition = Union[Block, BlockPartition]
+
 
 @DeveloperAPI
 class BlockMetadata:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -21,9 +21,11 @@ class DatasetContext:
     """
 
     def __init__(self, block_owner: ray.actor.ActorHandle,
+                 block_splitting_enabled: bool,
                  target_max_block_size: int):
         """Private constructor (use get_current() instead)."""
         self.block_owner = block_owner
+        self.block_splitting_enabled = block_splitting_enabled
         self.target_max_block_size = target_max_block_size
 
     @staticmethod
@@ -39,7 +41,9 @@ class DatasetContext:
 
             if _default_context is None:
                 _default_context = DatasetContext(
-                    None, DEFAULT_TARGET_MAX_BLOCK_SIZE)
+                    block_owner=None,
+                    block_splitting_enabled=False,
+                    target_max_block_size=DEFAULT_TARGET_MAX_BLOCK_SIZE)
 
             if _default_context.block_owner is None:
                 owner = _DesignatedBlockOwner.options(

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -11,6 +11,9 @@ _context_lock = threading.Lock()
 # The max target block size in bytes for reads and transformations.
 DEFAULT_TARGET_MAX_BLOCK_SIZE = 2048 * 1024 * 1024
 
+# Whether block splitting is on by default
+DEFAULT_BLOCK_SPLITTING_ENABLED = False
+
 
 @DeveloperAPI
 class DatasetContext:
@@ -41,7 +44,7 @@ class DatasetContext:
             if _default_context is None:
                 _default_context = DatasetContext(
                     block_owner=None,
-                    block_splitting_enabled=False,
+                    block_splitting_enabled=DEFAULT_BLOCK_SPLITTING_ENABLED,
                     target_max_block_size=DEFAULT_TARGET_MAX_BLOCK_SIZE)
 
             if _default_context.block_owner is None:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -21,8 +21,7 @@ class DatasetContext:
     """
 
     def __init__(self, block_owner: ray.actor.ActorHandle,
-                 block_splitting_enabled: bool,
-                 target_max_block_size: int):
+                 block_splitting_enabled: bool, target_max_block_size: int):
         """Private constructor (use get_current() instead)."""
         self.block_owner = block_owner
         self.block_splitting_enabled = block_splitting_enabled

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -6,7 +6,7 @@ import numpy as np
 import ray
 from ray.types import ObjectRef
 from ray.data.block import Block, BlockAccessor, BlockMetadata, T, \
-    BlockPartition, BlockPartitionMetadata
+    BlockPartition, BlockPartitionMetadata, MaybeBlockPartition
 from ray.data.context import DatasetContext
 from ray.data.impl.arrow_block import ArrowRow
 from ray.util.annotations import DeveloperAPI

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -135,12 +135,11 @@ class ReadTask(Callable[[], BlockPartition]):
             if len(partition) == 0:
                 raise ValueError("Read task must return non-empty list.")
             return partition
-
-        # Block splitting disabled case.
-        builder = DelegatingArrowBlockBuilder()
-        for block in result:
-            builder.add_block(block)
-        return builder.build()
+        else:
+            builder = DelegatingArrowBlockBuilder()
+            for block in result:
+                builder.add_block(block)
+            return builder.build()
 
 
 class RangeDatasource(Datasource[Union[ArrowRow, int]]):

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -8,9 +8,9 @@ from ray.types import ObjectRef
 from ray.data.block import Block, BlockAccessor, BlockMetadata, T, \
     BlockPartition, BlockPartitionMetadata, MaybeBlockPartition
 from ray.data.context import DatasetContext
-from ray.data.impl.arrow_block import ArrowRow
-from ray.util.annotations import DeveloperAPI
+from ray.data.impl.arrow_block import ArrowRow, DelegatingArrowBlockBuilder
 from ray.data.impl.util import _check_pyarrow_version
+from ray.util.annotations import DeveloperAPI
 
 WriteResult = Any
 
@@ -140,7 +140,7 @@ class ReadTask(Callable[[], BlockPartition]):
         builder = DelegatingArrowBlockBuilder()
         for block in result:
             builder.add_block(block)
-        return build.build()
+        return builder.build()
 
 
 class RangeDatasource(Datasource[Union[ArrowRow, int]]):

--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -67,7 +67,8 @@ class TaskPool(ComputeStrategy):
             all_refs = [
                 map_block.remote(b, fn, m.input_files) for b, m in blocks
             ]
-            data_refs, refs = zip(*all_refs)
+            data_refs = [r[0] for r in all_refs]
+            refs = [r[1] for r in all_refs]
 
         # Common wait for non-data refs.
         try:

--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -67,8 +67,7 @@ class TaskPool(ComputeStrategy):
             all_refs = [
                 map_block.remote(b, fn, m.input_files) for b, m in blocks
             ]
-            data_refs = [r[0] for r in all_refs]
-            refs = [r[1] for r in all_refs]
+            data_refs, refs = zip(*all_refs)
 
         # Common wait for non-data refs.
         try:

--- a/python/ray/data/impl/lazy_block_list.py
+++ b/python/ray/data/impl/lazy_block_list.py
@@ -19,9 +19,9 @@ class LazyBlockList(BlockList):
     """
 
     def __init__(self,
-                 calls: Callable[[], ObjectRef[BlockPartition]],
+                 calls: Callable[[], ObjectRef[MaybeBlockPartition]],
                  metadata: List[BlockPartitionMetadata],
-                 block_partitions: List[ObjectRef[BlockPartition]] = None):
+                 block_partitions: List[ObjectRef[MaybeBlockPartition]] = None):
         self._calls = calls
         self._num_blocks = len(self._calls)
         self._metadata = metadata
@@ -74,6 +74,7 @@ class LazyBlockList(BlockList):
 
     def iter_blocks_with_metadata(
             self) -> Iterator[Tuple[ObjectRef[Block], BlockMetadata]]:
+        context = DatasetContext.get_current()
         self._check_if_cleared()
         outer = self
 
@@ -87,14 +88,19 @@ class LazyBlockList(BlockList):
 
             def __next__(self):
                 while not self._buffer:
-                    partition = ray.get(next(self._base_iter))
+                    if context.block_splitting_enabled:
+                        part_ref, _ = next(self._base_iter)
+                        partition = ray.get(part_ref)
+                    else:
+                        block, metadata = next(self._base_iter)
+                        partition = [(block, metadata)]
                     for ref, metadata in partition:
                         self._buffer.append((ref, metadata))
                 return self._buffer.pop(0)
 
         return Iter()
 
-    def _iter_block_partitions(self) -> Iterator[ObjectRef[BlockPartition]]:
+    def _iter_block_partitions(self) -> Iterator[Tuple[ObjectRef[MaybeBlockPartition], BlockPartitionMetadata]]:
         self._check_if_cleared()
         outer = self
 
@@ -108,12 +114,14 @@ class LazyBlockList(BlockList):
             def __next__(self):
                 self._pos += 1
                 if self._pos < len(outer._calls):
-                    return outer._get_or_compute(self._pos)
+                    return (
+                        outer._get_or_compute(self._pos),
+                        self._metadata[self._pos])
                 raise StopIteration
 
         return Iter()
 
-    def _get_or_compute(self, i: int) -> ObjectRef[BlockPartition]:
+    def _get_or_compute(self, i: int) -> ObjectRef[MaybeBlockPartition]:
         self._check_if_cleared()
         assert i < len(self._calls), i
         # Check if we need to compute more block_partitions.

--- a/python/ray/data/impl/lazy_block_list.py
+++ b/python/ray/data/impl/lazy_block_list.py
@@ -5,8 +5,9 @@ import numpy as np
 
 import ray
 from ray.types import ObjectRef
-from ray.data.block import Block, BlockMetadata, BlockPartition, \
-    BlockPartitionMetadata, MaybeBlockPartition
+from ray.data.block import Block, BlockMetadata, BlockPartitionMetadata, \
+    MaybeBlockPartition
+from ray.data.context import DatasetContext
 from ray.data.impl.block_list import BlockList
 
 
@@ -18,10 +19,11 @@ class LazyBlockList(BlockList):
     .take() the first few rows or view the schema).
     """
 
-    def __init__(self,
-                 calls: Callable[[], ObjectRef[MaybeBlockPartition]],
-                 metadata: List[BlockPartitionMetadata],
-                 block_partitions: List[ObjectRef[MaybeBlockPartition]] = None):
+    def __init__(
+            self,
+            calls: Callable[[], ObjectRef[MaybeBlockPartition]],
+            metadata: List[BlockPartitionMetadata],
+            block_partitions: List[ObjectRef[MaybeBlockPartition]] = None):
         self._calls = calls
         self._num_blocks = len(self._calls)
         self._metadata = metadata
@@ -100,7 +102,8 @@ class LazyBlockList(BlockList):
 
         return Iter()
 
-    def _iter_block_partitions(self) -> Iterator[Tuple[ObjectRef[MaybeBlockPartition], BlockPartitionMetadata]]:
+    def _iter_block_partitions(self) -> Iterator[Tuple[ObjectRef[
+            MaybeBlockPartition], BlockPartitionMetadata]]:
         self._check_if_cleared()
         outer = self
 
@@ -114,9 +117,8 @@ class LazyBlockList(BlockList):
             def __next__(self):
                 self._pos += 1
                 if self._pos < len(outer._calls):
-                    return (
-                        outer._get_or_compute(self._pos),
-                        self._metadata[self._pos])
+                    return (outer._get_or_compute(self._pos),
+                            outer._metadata[self._pos])
                 raise StopIteration
 
         return Iter()

--- a/python/ray/data/impl/lazy_block_list.py
+++ b/python/ray/data/impl/lazy_block_list.py
@@ -6,7 +6,7 @@ import numpy as np
 import ray
 from ray.types import ObjectRef
 from ray.data.block import Block, BlockMetadata, BlockPartition, \
-    BlockPartitionMetadata
+    BlockPartitionMetadata, MaybeBlockPartition
 from ray.data.impl.block_list import BlockList
 
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
 import ray
 from ray.types import ObjectRef
 from ray.util.annotations import PublicAPI, DeveloperAPI
-from ray.data.block import Block, BlockAccessor, BlockMetadata
+from ray.data.block import Block, BlockAccessor, BlockMetadata, \
+    MaybeBlockPartition
 from ray.data.context import DatasetContext
 from ray.data.dataset import Dataset
 from ray.data.datasource import Datasource, RangeDatasource, \
@@ -24,8 +25,7 @@ from ray.data.datasource import Datasource, RangeDatasource, \
 from ray.data.impl.arrow_block import ArrowRow, \
     DelegatingArrowBlockBuilder
 from ray.data.impl.block_list import BlockList
-from ray.data.impl.lazy_block_list import LazyBlockList, BlockPartition, \
-    BlockPartitionMetadata
+from ray.data.impl.lazy_block_list import LazyBlockList, BlockPartitionMetadata
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.util import _get_spread_resources_iter
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -161,7 +161,7 @@ def read_datasource(datasource: Datasource[T],
     read_tasks = datasource.prepare_read(parallelism, **read_args)
     context = DatasetContext.get_current()
 
-    def remote_read(task: ReadTask) -> Block:
+    def remote_read(task: ReadTask) -> MaybeBlockPartition:
         DatasetContext._set_current(context)
         return task()
 
@@ -185,7 +185,7 @@ def read_datasource(datasource: Datasource[T],
         # If no spread resource prefix given, yield an empty dictionary.
         resource_iter = itertools.repeat({})
 
-    calls: List[Callable[[], ObjectRef[BlockPartition]]] = []
+    calls: List[Callable[[], ObjectRef[MaybeBlockPartition]]] = []
     metadata: List[BlockPartitionMetadata] = []
 
     for task in read_tasks:

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -147,6 +147,12 @@ def test_split_read_csv(ray_start_regular_shared, tmp_path):
     for x in nrow[:-1]:
         assert 80 < x < 120, (x, nrow)
 
+    # Disabled.
+    ctx.target_max_block_size = 1_000_000
+    ctx.block_splitting_enabled = False
+    ds4 = gen("out4")
+    assert ds4._block_num_rows() == [1000]
+
 
 def test_split_read_parquet(ray_start_regular_shared, tmp_path):
     ctx = ray.data.context.DatasetContext.get_current()
@@ -200,6 +206,13 @@ def test_split_map(ray_start_regular_shared):
     ctx.target_max_block_size = 2_000_000
     nblocks = len(ds2.map(lambda x: x).get_internal_block_refs())
     assert 4 < nblocks < 7, nblocks
+
+    # Disabled.
+    ctx.target_max_block_size = 1_000_000
+    ctx.block_splitting_enabled = False
+    ds3 = ray.data.range(1000, parallelism=1).map(lambda _: ARROW_LARGE_VALUE)
+    nblocks = len(ds3.map(lambda x: x).get_internal_block_refs())
+    assert nblocks == 1, nblocks
 
 
 def test_split_flat_map(ray_start_regular_shared):

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -118,6 +118,7 @@ def test_arrow_size_add_block(ray_start_regular_shared):
 
 def test_split_read_csv(ray_start_regular_shared, tmp_path):
     ctx = ray.data.context.DatasetContext.get_current()
+    ctx.block_splitting_enabled = True
 
     def gen(name):
         path = os.path.join(tmp_path, name)
@@ -149,6 +150,7 @@ def test_split_read_csv(ray_start_regular_shared, tmp_path):
 
 def test_split_read_parquet(ray_start_regular_shared, tmp_path):
     ctx = ray.data.context.DatasetContext.get_current()
+    ctx.block_splitting_enabled = True
 
     def gen(name):
         path = os.path.join(tmp_path, name)
@@ -182,6 +184,7 @@ def test_split_map(ray_start_regular_shared):
     # Simple block
     ctx = ray.data.context.DatasetContext.get_current()
     ctx.target_max_block_size = 20_000_000
+    ctx.block_splitting_enabled = True
     ds1 = ray.data.range(1000, parallelism=1).map(lambda _: LARGE_VALUE)
     nblocks = len(ds1.map(lambda x: x).get_internal_block_refs())
     assert nblocks == 1, nblocks
@@ -203,6 +206,7 @@ def test_split_flat_map(ray_start_regular_shared):
     # Simple block
     ctx = ray.data.context.DatasetContext.get_current()
     ctx.target_max_block_size = 20_000_000
+    ctx.block_splitting_enabled = True
     ds1 = ray.data.range(1000, parallelism=1).map(lambda _: LARGE_VALUE)
     nblocks = len(ds1.flat_map(lambda x: [x]).get_internal_block_refs())
     assert nblocks == 1, nblocks
@@ -224,6 +228,7 @@ def test_split_map_batches(ray_start_regular_shared):
     # Simple block
     ctx = ray.data.context.DatasetContext.get_current()
     ctx.target_max_block_size = 20_000_000
+    ctx.block_splitting_enabled = True
     ds1 = ray.data.range(1000, parallelism=1).map(lambda _: LARGE_VALUE)
     nblocks = len(
         ds1.map_batches(lambda x: x, batch_size=16).get_internal_block_refs())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a feature flag for block splitting and makes it off by default. This makes it easier to debug problems potentially related to this feature. Criteria for enabling by default:
- We're confident all nightly tests pass (currently, there may be an issue with large-scale groupby with block splitting).
- We're confident lineage-based reconstruction can work with block splitting.