### PR TITLE
Pin redis back to `redis >= 3.5.0`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,6 @@ import glob
 import io
 import logging
 import os
-import platform
 import re
 import shutil
 import subprocess
@@ -268,19 +267,8 @@ if setup_spec.type == SetupType.RAY:
         "numpy >= 1.19.3; python_version >= '3.9'",
         "protobuf >= 3.15.3",
         "pyyaml",
+        "redis >= 3.5.0",
     ]
-
-if platform.system() == "Darwin" and platform.machine() == "arm64":
-    # TODO (Alex): `hiredis` doesn't have prebuilt M1 mac wheels yet. We can
-    # remove this, either when they add support, we remove redis, or we vendor
-    # redis/hiredis ourselves.
-    setup_spec.install_requires.append("redis >= 3.5.0")
-elif platform.system() == "Windows":
-    # TODO (Alex): Ray is not compatible with redis >= 4.0.0. We ened to either
-    # investigate why, or remove the redis dependency.
-    setup_spec.install_requires.append("redis >= 3.5.0, < 4.0")
-else:
-    setup_spec.install_requires.append("redis[hiredis] >= 3.5.0")
 
 
 def is_native_windows_or_msys():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With the release of redis 4.0.2, there are no more warning message issues. Therefore, we no longer need to pin a maximum version of redis. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
