### PR TITLE
[Core] Rename PublisherService to SubscriberService

### DIFF
--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -215,7 +215,7 @@ message PubsubCommandBatchRequest {
 message PubsubCommandBatchReply {
 }
 
-service PublisherService {
+service SubscriberService {
   /// The long polling request sent to the publisher for pubsub operations.
   /// It is replied once there are batch of objects that need to be published to
   /// the caller (subscriber).

--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -330,11 +330,11 @@ void Subscriber::MakeLongPollingConnectionIfNotConnected(
 void Subscriber::MakeLongPollingPubsubConnection(const rpc::Address &publisher_address) {
   const auto publisher_id = PublisherID::FromBinary(publisher_address.worker_id());
   RAY_LOG(DEBUG) << "Make a long polling request to " << publisher_id;
-  auto publisher_client = get_client_(publisher_address);
+  auto subscriber_client = get_client_(publisher_address);
   rpc::PubsubLongPollingRequest long_polling_request;
   long_polling_request.set_subscriber_id(subscriber_id_.Binary());
 
-  publisher_client->PubsubLongPolling(
+  subscriber_client->PubsubLongPolling(
       long_polling_request,
       [this, publisher_address](Status status, const rpc::PubsubLongPollingReply &reply) {
         absl::MutexLock lock(&mutex_);
@@ -422,8 +422,8 @@ void Subscriber::SendCommandBatchIfPossible(const rpc::Address &publisher_addres
     }
 
     command_batch_sent_.emplace(publisher_id);
-    auto publisher_client = get_client_(publisher_address);
-    publisher_client->PubsubCommandBatch(
+    auto subscriber_client = get_client_(publisher_address);
+    subscriber_client->PubsubCommandBatch(
         command_batch_request,
         [this, publisher_address, publisher_id, done_cb = std::move(done_cb)](
             Status status, const rpc::PubsubCommandBatchReply &reply) {

--- a/src/ray/pubsub/test/integration_test.cc
+++ b/src/ray/pubsub/test/integration_test.cc
@@ -32,10 +32,10 @@
 namespace ray {
 namespace pubsub {
 
-// Implements PublisherService for handling subscriber polling.
-class PublisherServiceImpl final : public rpc::PublisherService::CallbackService {
+// Implements SubscriberService for handling subscriber polling.
+class SubscriberServiceImpl final : public rpc::SubscriberService::CallbackService {
  public:
-  explicit PublisherServiceImpl(std::unique_ptr<Publisher> publisher)
+  explicit SubscriberServiceImpl(std::unique_ptr<Publisher> publisher)
       : publisher_(std::move(publisher)) {}
 
   grpc::ServerUnaryReactor *PubsubLongPolling(
@@ -95,7 +95,7 @@ class CallbackSubscriberClient final : public pubsub::SubscriberClientInterface 
  public:
   explicit CallbackSubscriberClient(const std::string &address) {
     auto channel = grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
-    stub_ = rpc::PublisherService::NewStub(std::move(channel));
+    stub_ = rpc::SubscriberService::NewStub(std::move(channel));
   }
 
   ~CallbackSubscriberClient() final = default;
@@ -127,7 +127,7 @@ class CallbackSubscriberClient final : public pubsub::SubscriberClientInterface 
   }
 
  private:
-  std::unique_ptr<rpc::PublisherService::Stub> stub_;
+  std::unique_ptr<rpc::SubscriberService::Stub> stub_;
 };
 
 class IntegrationTest : public ::testing::Test {
@@ -166,7 +166,7 @@ class IntegrationTest : public ::testing::Test {
         /*get_time_ms=*/[]() -> double { return absl::ToUnixMicros(absl::Now()); },
         /*subscriber_timeout_ms=*/absl::ToInt64Microseconds(absl::Seconds(30)),
         /*batch_size=*/100);
-    publisher_service_ = std::make_unique<PublisherServiceImpl>(std::move(publisher));
+    publisher_service_ = std::make_unique<SubscriberServiceImpl>(std::move(publisher));
 
     grpc::EnableDefaultHealthCheckService(true);
     grpc::ServerBuilder builder;
@@ -195,7 +195,7 @@ class IntegrationTest : public ::testing::Test {
   rpc::Address address_proto_;
   IOServicePool io_service_ = IOServicePool(3);
   std::unique_ptr<PeriodicalRunner> periodic_runner_;
-  std::unique_ptr<PublisherServiceImpl> publisher_service_;
+  std::unique_ptr<SubscriberServiceImpl> publisher_service_;
   std::unique_ptr<grpc::Server> server_;
 };
 

--- a/src/ray/pubsub/test/integration_test.cc
+++ b/src/ray/pubsub/test/integration_test.cc
@@ -166,12 +166,12 @@ class IntegrationTest : public ::testing::Test {
         /*get_time_ms=*/[]() -> double { return absl::ToUnixMicros(absl::Now()); },
         /*subscriber_timeout_ms=*/absl::ToInt64Microseconds(absl::Seconds(30)),
         /*batch_size=*/100);
-    publisher_service_ = std::make_unique<SubscriberServiceImpl>(std::move(publisher));
+    subscriber_service_ = std::make_unique<SubscriberServiceImpl>(std::move(publisher));
 
     grpc::EnableDefaultHealthCheckService(true);
     grpc::ServerBuilder builder;
     builder.AddListeningPort(address_, grpc::InsecureServerCredentials());
-    builder.RegisterService(publisher_service_.get());
+    builder.RegisterService(subscriber_service_.get());
     server_ = builder.BuildAndStart();
   }
 
@@ -195,7 +195,7 @@ class IntegrationTest : public ::testing::Test {
   rpc::Address address_proto_;
   IOServicePool io_service_ = IOServicePool(3);
   std::unique_ptr<PeriodicalRunner> periodic_runner_;
-  std::unique_ptr<SubscriberServiceImpl> publisher_service_;
+  std::unique_ptr<SubscriberServiceImpl> subscriber_service_;
   std::unique_ptr<grpc::Server> server_;
 };
 
@@ -253,7 +253,7 @@ TEST_F(IntegrationTest, SubscribersToOneIDAndAllIDs) {
   msg.set_key_id(subscribed_actor);
   *msg.mutable_actor_message() = actor_data;
 
-  publisher_service_->GetPublisher().Publish(msg);
+  subscriber_service_->GetPublisher().Publish(msg);
 
   absl::MutexLock lock(&mu);
 
@@ -281,7 +281,7 @@ TEST_F(IntegrationTest, SubscribersToOneIDAndAllIDs) {
   subscriber_2->UnsubscribeChannel(rpc::ChannelType::GCS_ACTOR_CHANNEL, address_proto_);
 
   // Flush all the inflight long polling.
-  publisher_service_->GetPublisher().UnregisterAll();
+  subscriber_service_->GetPublisher().UnregisterAll();
 
   // Waiting here is necessary to avoid invalid memory access during shutdown.
   // TODO(mwtian): cancel inflight polls during subscriber shutdown, and remove the


### PR DESCRIPTION
## Why are these changes needed?

I think `PublisherClient` is a more reasonable name than `SubscriberClient` since XClient means ‘client used to access X’, like GcsClient.

Besides, in the current codebase we already called this client `publisher_client`(line 329/333), while the actual class name is `SubscriberClient`, this is inconsistent.
https://github.com/ray-project/ray/blob/a8d7897a56d8dc2d2af550adee8cd5399c39dfb9/src/ray/pubsub/subscriber.cc#L326-L339


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
