### PR TITLE
[WINDOWS] remove complicated dos batch script that sometimes fails

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -101,7 +101,6 @@ def copy_to_workspace(name, srcs, dstdir = ""):
         name = name,
         srcs = srcs,
         outs = [name + ".out"],
-        # Keep this Bash script equivalent to the batch script below (or take out the batch script)
         cmd = r"""
             mkdir -p -- {dstdir}
             for f in {locations}; do
@@ -112,20 +111,6 @@ def copy_to_workspace(name, srcs, dstdir = ""):
         """.format(
             locations = src_locations,
             dstdir = "." + ("/" + dstdir.replace("\\", "/")).rstrip("/") + "/",
-        ),
-        # Keep this batch script equivalent to the Bash script above (or take out the batch script)
-        cmd_bat = """
-            (
-                if not exist {dstdir} mkdir {dstdir}
-            ) && (
-                for %f in ({locations}) do @(
-                    (if exist {dstdir}%~nxf del /f /q {dstdir}%~nxf) &&
-                    copy /B /Y %f {dstdir} >NUL
-                )
-            ) && >$@ echo %TIME%
-        """.replace("\r", "").replace("\n", " ").format(
-            locations = src_locations,
-            dstdir = "." + ("\\" + dstdir.replace("/", "\\")).rstrip("\\") + "\\",
         ),
         local = 1,
         tags = ["no-cache"],


### PR DESCRIPTION
The dos batch script was failing for some configuration of windows. Since bazel requires a functioning bash shell for windows, there is no reason to keep this version of the script around