### PR TITLE
Use timeout for all blocking call implementation with std::promise

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1750,6 +1750,7 @@ Status CoreWorker::KillActor(const ActorID &actor_id, bool force_kill, bool no_r
       cb(Status::Invalid(stream.str()));
     }
   });
+  // SANG-TODO Add timer.
   const auto &status = f.get();
   actor_manager_->OnActorKilled(actor_id);
   return status;

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -216,7 +216,7 @@ void CoreWorkerProcess::InitializeSystemConfig() {
     io_service.run();
   });
   thread.join();
-
+  // SANG-TODO Add timeout
   RayConfig::instance().initialize(promise.get_future().get());
 }
 

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1334,6 +1334,7 @@ Status InternalKVAccessor::Put(const std::string &key, const std::string &value,
         added = static_cast<bool>(added_num.value_or(0));
         ret_promise.set_value(status);
       }));
+  // SANG-TODO Add timeout
   return ret_promise.get_future().get();
 }
 
@@ -1345,6 +1346,7 @@ Status InternalKVAccessor::Keys(const std::string &prefix,
         value = values.value_or(std::vector<std::string>());
         ret_promise.set_value(status);
       }));
+  // SANG-TODO Add timeout
   return ret_promise.get_future().get();
 }
 
@@ -1356,6 +1358,7 @@ Status InternalKVAccessor::Get(const std::string &key, std::string &value) {
     }
     ret_promise.set_value(status);
   }));
+  // SANG-TODO Add timeout
   return ret_promise.get_future().get();
 }
 
@@ -1363,6 +1366,7 @@ Status InternalKVAccessor::Del(const std::string &key) {
   std::promise<Status> ret_promise;
   RAY_CHECK_OK(AsyncInternalKVDel(
       key, [&ret_promise](Status status) { ret_promise.set_value(status); }));
+  // SANG-TODO Add timeout
   return ret_promise.get_future().get();
 }
 
@@ -1375,6 +1379,7 @@ Status InternalKVAccessor::Exists(const std::string &key, bool &exist) {
         }
         ret_promise.set_value(status);
       }));
+  // SANG-TODO Add timeout
   return ret_promise.get_future().get();
 }
 

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -49,6 +49,7 @@ GlobalStateAccessor::GlobalStateAccessor(const std::string &redis_address,
     promise.set_value(true);
     io_service_->run();
   });
+  // SANG-TODO Add timeout
   promise.get_future().get();
 }
 
@@ -83,6 +84,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllJobInfo() {
         TransformForMultiItemCallback<rpc::JobTableData>(job_table_data, promise)));
   }
   promise.get_future().get();
+  // SANG-TODO Add timeout
   return job_table_data;
 }
 
@@ -93,6 +95,7 @@ JobID GlobalStateAccessor::GetNextJobID() {
     RAY_CHECK_OK(gcs_client_->Jobs().AsyncGetNextJobID(
         [&promise](const JobID &job_id) { promise.set_value(job_id); }));
   }
+  // SANG-TODO Add timeout
   return promise.get_future().get();
 }
 
@@ -104,6 +107,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllNodeInfo() {
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncGetAll(
         TransformForMultiItemCallback<rpc::GcsNodeInfo>(node_table_data, promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return node_table_data;
 }
@@ -117,6 +121,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllProfileInfo() {
         TransformForMultiItemCallback<rpc::ProfileTableData>(profile_table_data,
                                                              promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return profile_table_data;
 }
@@ -142,6 +147,7 @@ std::string GlobalStateAccessor::GetNodeResourceInfo(const NodeID &node_id) {
     absl::ReaderMutexLock lock(&mutex_);
     RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetResources(node_id, on_done));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return node_resource_map.SerializeAsString();
 }
@@ -155,6 +161,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllAvailableResources() {
         TransformForMultiItemCallback<rpc::AvailableResources>(available_resources,
                                                                promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return available_resources;
 }
@@ -168,6 +175,7 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetAllResourceUsage() {
         TransformForItemCallback<rpc::ResourceUsageBatchData>(resource_batch_data,
                                                               promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return resource_batch_data;
 }
@@ -180,6 +188,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllActorInfo() {
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAll(
         TransformForMultiItemCallback<rpc::ActorTableData>(actor_table_data, promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return actor_table_data;
 }
@@ -193,6 +202,7 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetActorInfo(const ActorID &ac
         actor_id, TransformForOptionalItemCallback<rpc::ActorTableData>(actor_table_data,
                                                                         promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return actor_table_data;
 }
@@ -207,6 +217,7 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetWorkerInfo(
         worker_id, TransformForOptionalItemCallback<rpc::WorkerTableData>(
                        worker_table_data, promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return worker_table_data;
 }
@@ -219,6 +230,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllWorkerInfo() {
     RAY_CHECK_OK(gcs_client_->Workers().AsyncGetAll(
         TransformForMultiItemCallback<rpc::WorkerTableData>(worker_table_data, promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return worker_table_data;
 }
@@ -235,6 +247,7 @@ bool GlobalStateAccessor::AddWorkerInfo(const std::string &serialized_string) {
           promise.set_value(true);
         }));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return true;
 }
@@ -248,6 +261,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllPlacementGroupInfo() {
         TransformForMultiItemCallback<rpc::PlacementGroupTableData>(
             placement_group_table_data, promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return placement_group_table_data;
 }
@@ -263,6 +277,7 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetPlacementGroupInfo(
         TransformForOptionalItemCallback<rpc::PlacementGroupTableData>(
             placement_group_table_data, promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return placement_group_table_data;
 }
@@ -278,6 +293,7 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetPlacementGroupByName(
         TransformForOptionalItemCallback<rpc::PlacementGroupTableData>(
             placement_group_table_data, promise)));
   }
+  // SANG-TODO Add timeout
   promise.get_future().get();
   return placement_group_table_data;
 }
@@ -323,6 +339,7 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
                 std::pair<Status, std::vector<rpc::GcsNodeInfo>>(status, nodes));
           }));
     }
+    // SANG-TODO Add timeout
     auto result = promise.get_future().get();
     auto status = result.first;
     if (!status.ok()) {

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -81,6 +81,7 @@ int main(int argc, char *argv[]) {
     boost::asio::io_service::work work(service);
     service.run();
   }).detach();
+  // SANG-TODO Add timeout
   promise->get_future().get();
 
   const ray::stats::TagsType global_tags = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we have lots of std::promise->get_future()->get() without timeout. This is a fragile implementation as it can easily cause hangs. Ideally, we should set timeout + upstreaming the failing status to the language frontend to handle it better.

The PR is not in progress yet. I only added where this pattern is used. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
