### PR TITLE
[Release] Use NCCL backend for release tests

### DIFF
--- a/python/ray/train/examples/train_linear_example.py
+++ b/python/ray/train/examples/train_linear_example.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn as nn
 import ray.train as train
 from ray.train import Trainer
-from ray.train.torch import TorchConfig
 from ray.train.callbacks import JsonLoggerCallback, TBXLoggerCallback
 
 
@@ -89,9 +88,7 @@ def train_func(config):
 
 def train_linear(num_workers=2, use_gpu=False, epochs=3):
     trainer = Trainer(
-        backend=TorchConfig(backend="gloo"),
-        num_workers=num_workers,
-        use_gpu=use_gpu)
+        backend="torch", num_workers=num_workers, use_gpu=use_gpu)
     config = {"lr": 1e-2, "hidden_size": 1, "batch_size": 4, "epochs": epochs}
     trainer.start()
     results = trainer.run(

--- a/release/ml_user_tests/ray-lightning/app_config.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config.yaml
@@ -1,6 +1,4 @@
 base_image: "anyscale/ray-ml:nightly-py37-gpu"
-env_vars:
-  PL_TORCH_DISTRIBUTED_BACKEND: gloo
 
 debian_packages:
   - curl

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -1,6 +1,4 @@
 base_image: "anyscale/ray-ml:nightly-py37-gpu"
-env_vars:
-  PL_TORCH_DISTRIBUTED_BACKEND: gloo
 
 debian_packages:
   - curl

--- a/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
+++ b/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
@@ -13,6 +13,7 @@ if __name__ == "__main__":
 
     # Manually set NCCL_SOCKET_IFNAME to "ens3" so NCCL training works on
     # anyscale_default_cloud.
+    # See https://github.com/pytorch/pytorch/issues/68893 for more details.
     # Passing in runtime_env to ray.init() will also set it for all the
     # workers.
     runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}

--- a/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
+++ b/release/ml_user_tests/ray-lightning/ray_lightning_user_test.py
@@ -9,11 +9,18 @@ if __name__ == "__main__":
     start = time.time()
 
     addr = os.environ.get("RAY_ADDRESS")
-    job_name = os.environ.get("RAY_JOB_NAME", "horovod_user_test")
+    job_name = os.environ.get("RAY_JOB_NAME", "ray_lightning_user_test")
+
+    # Manually set NCCL_SOCKET_IFNAME to "ens3" so NCCL training works on
+    # anyscale_default_cloud.
+    # Passing in runtime_env to ray.init() will also set it for all the
+    # workers.
+    runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}
+
     if addr is not None and addr.startswith("anyscale://"):
-        ray.init(address=addr, job_name=job_name)
+        ray.init(address=addr, job_name=job_name, runtime_env=runtime_env)
     else:
-        ray.init(address="auto")
+        ray.init(address="auto", runtime_env=runtime_env)
 
     main(num_workers=6, use_gpu=True, max_steps=50)
 

--- a/release/ml_user_tests/train/train_torch_linear_test.py
+++ b/release/ml_user_tests/train/train_torch_linear_test.py
@@ -12,10 +12,16 @@ if __name__ == "__main__":
     addr = os.environ.get("RAY_ADDRESS")
     job_name = os.environ.get("RAY_JOB_NAME", "train_torch_linear_test")
 
+    # Manually set NCCL_SOCKET_IFNAME to "ens3" so NCCL training works on
+    # anyscale_default_cloud.
+    # Passing in runtime_env to ray.init() will also set it for all the
+    # workers.
+    runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}
+
     if addr is not None and addr.startswith("anyscale://"):
-        ray.init(address=addr, job_name=job_name)
+        ray.init(address=addr, job_name=job_name, runtime_env=runtime_env)
     else:
-        ray.init(address="auto")
+        ray.init(address="auto", runtime_env=runtime_env)
 
     results = train_linear(num_workers=6, use_gpu=True, epochs=20)
 

--- a/release/ml_user_tests/train/train_torch_linear_test.py
+++ b/release/ml_user_tests/train/train_torch_linear_test.py
@@ -14,6 +14,7 @@ if __name__ == "__main__":
 
     # Manually set NCCL_SOCKET_IFNAME to "ens3" so NCCL training works on
     # anyscale_default_cloud.
+    # See https://github.com/pytorch/pytorch/issues/68893 for more details.
     # Passing in runtime_env to ray.init() will also set it for all the
     # workers.
     runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Now that we've found a workaround for running with nccl backend on anyscale_default_cloud, we can run the GPU training release tests using nccl instead of gloo to identify any future regressions.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #20658 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
