### PR TITLE
[dataset][monitoring 0][wip] add helper function to monitor a block or a function's latency and success/failure

### DIFF
--- a/python/ray/_private/metrics.py
+++ b/python/ray/_private/metrics.py
@@ -1,0 +1,67 @@
+import functools
+import time
+from ray.util.metrics import Counter, Histogram
+from typing import Dict, Callable
+
+
+class FunctionMetricsCollector:
+    """A helper class that implements the context manager and decorator
+    for recording function/block execution.
+    """
+    HISTOGRAMS: Dict[str, Histogram] = dict()
+    SUCCESS_COUNTERS: Dict[str, Counter] = dict()
+    FAILURE_COUNTERS: Dict[str, Counter] = dict()
+
+    def __init__(self, name: str):
+        self._latency_historgram = self.get_latency_histogram(name)
+        self._success_counter = self.get_success_counter(name)
+        self._failure_counter = self.get_failure_counter(name)
+
+    def __enter__(self):
+        self._start_time = time.time()
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._latency_historgram.observe(
+            int((time.time() - self._start_time) * 1000))
+        if exc_val:
+            self._failure_counter.inc()
+        else:
+            self._success_counter.inc()
+
+    def __call__(self, f: Callable) -> Callable:
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            with self:
+                return f(*args, **kwargs)
+
+        return wrapped
+
+    def get_latency_histogram(self, name: str) -> Histogram:
+        if name not in self.HISTOGRAMS:
+            self.HISTOGRAMS[name] = Histogram(
+                f"{name}.latency_ms", boundaries=[1.0, 2.0])
+        return self.HISTOGRAMS[name]
+
+    def get_success_counter(self, name: str) -> Counter:
+        if name not in self.SUCCESS_COUNTERS:
+            self.SUCCESS_COUNTERS[name] = Counter(f"{name}.success")
+        return self.SUCCESS_COUNTERS[name]
+
+    def get_failure_counter(self, name: str) -> Counter:
+        if name not in self.FAILURE_COUNTERS:
+            self.FAILURE_COUNTERS[name] = Counter(f"{name}.failure")
+        return self.FAILURE_COUNTERS[name]
+
+
+def record_function(name: str) -> FunctionMetricsCollector:
+    """Record the latency and success/failure counter in a
+    block of code or function.
+
+    Can be used as a function decorator or context manager.
+    Upon function/block execution finishes, it records the
+    latency into {name}.latency_ms histogram. It also bumps the
+    {name}.success/{name}.failure counter depending on
+    wether the function/block raises exception.
+    """
+    return FunctionMetricsCollector(name)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This add private helper function to make it easier to track a function or a block of execution.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
