### PR TITLE
[Release] Use large instance type for long running `impala` test

### DIFF
--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -1,16 +1,26 @@
 base_image: "anyscale/ray:nightly-py37"
 env_vars: {}
+
 debian_packages:
   - curl
+  - unzip
 
 python:
   pip_packages:
+    - gym[atari]
+    - pytest
+    - tensorflow
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y numpy ray || true
-  - sudo rm -rf /home/ray/anaconda3/lib/python3.7/site-packages/numpy
-  - pip3 install numpy==1.19 || true
-  - pip3 install -U ray[all] gym[atari] autorom[accept-rom-license]
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
-  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
+    - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
+    - pip uninstall -y numpy ray || true
+    - sudo rm -rf /home/ray/anaconda3/lib/python3.7/site-packages/numpy
+    - pip3 install numpy==1.19 || true
+    - pip3 install pytest || true
+    - pip3 install -U ray[all] gym[atari] autorom[accept-rom-license]
+    - pip3 install ray[all]
+    # TODO (Alex): Ideally we would install all the dependencies from the new
+    # version too, but pip won't be able to find the new version of ray-cpp.
+    - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+    - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -1,4 +1,4 @@
-base_image: "anyscale/ray-ml:nightly-py37-gpu"
+base_image: "anyscale/ray:nightly-py37"
 env_vars: {}
 debian_packages:
   - curl

--- a/release/long_running_tests/long_running_tests.yaml
+++ b/release/long_running_tests/long_running_tests.yaml
@@ -32,7 +32,7 @@
 - name: impala
   cluster:
     app_config: app_config_np.yaml
-    compute_template: tpl_cpu_1.yaml
+    compute_template: tpl_cpu_1_large.yaml
 
   run:
     timeout: 86400
@@ -156,7 +156,7 @@
 - name: serve
   cluster:
     app_config: app_config.yaml
-    compute_template: tpl_cpu_1_hd.yaml
+    compute_template: tpl_cpu_1.yaml
 
   run:
     timeout: 86400
@@ -171,7 +171,7 @@
 - name: serve_failure
   cluster:
     app_config: app_config.yaml
-    compute_template: tpl_cpu_1_hd.yaml
+    compute_template: tpl_cpu_1.yaml
 
   run:
     timeout: 86400

--- a/release/long_running_tests/tpl_cpu_1_large.yaml
+++ b/release/long_running_tests/tpl_cpu_1_large.yaml
@@ -5,11 +5,11 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: m5.2xlarge
+    instance_type: m5.4xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.2xlarge
+      instance_type: m5.4xlarge
       min_workers: 0
       max_workers: 0
       use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Running out of memory with m5.2xlarge, so use m5.4xlarge instead.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #20690 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
