### PR TITLE
[Part 3] Improve ActorDiedError message: Passing error info

### DIFF
--- a/src/mock/ray/core_worker/task_manager.h
+++ b/src/mock/ray/core_worker/task_manager.h
@@ -25,8 +25,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
               (override));
   MOCK_METHOD(bool, FailOrRetryPendingTask,
               (const TaskID &task_id, rpc::ErrorType error_type, const Status *status,
-               const rpc::RayException *creation_task_exception,
-               bool mark_task_object_failed),
+               const rpc::RayErrorInfo *ray_error_info, bool mark_task_object_failed),
               (override));
   MOCK_METHOD(void, OnTaskDependenciesInlined,
               (const std::vector<ObjectID> &inlined_dependency_ids,
@@ -35,7 +34,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
   MOCK_METHOD(bool, MarkTaskCanceled, (const TaskID &task_id), (override));
   MOCK_METHOD(void, MarkTaskReturnObjectsFailed,
               (const TaskSpecification &spec, rpc::ErrorType error_type,
-               const rpc::RayException *creation_task_exception),
+               const rpc::RayErrorInfo *ray_error_info),
               (override));
   MOCK_METHOD(absl::optional<TaskSpecification>, GetTaskSpec, (const TaskID &task_id),
               (const, override));

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -438,7 +438,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id) {
 
 bool TaskManager::FailOrRetryPendingTask(const TaskID &task_id, rpc::ErrorType error_type,
                                          const Status *status,
-                                         const rpc::RayException *creation_task_exception,
+                                         const rpc::RayErrorInfo *ray_error_info,
                                          bool mark_task_object_failed) {
   // Note that this might be the __ray_terminate__ task, so we don't log
   // loudly with ERROR here.
@@ -487,7 +487,7 @@ bool TaskManager::FailOrRetryPendingTask(const TaskID &task_id, rpc::ErrorType e
     RemoveFinishedTaskReferences(spec, release_lineage, rpc::Address(),
                                  ReferenceCounter::ReferenceTableProto());
     if (mark_task_object_failed) {
-      MarkTaskReturnObjectsFailed(spec, error_type, creation_task_exception);
+      MarkTaskReturnObjectsFailed(spec, error_type, ray_error_info);
     }
   }
 
@@ -611,22 +611,26 @@ bool TaskManager::MarkTaskCanceled(const TaskID &task_id) {
   return it != submissible_tasks_.end();
 }
 
-void TaskManager::MarkTaskReturnObjectsFailed(
-    const TaskSpecification &spec, rpc::ErrorType error_type,
-    const rpc::RayException *creation_task_exception) {
+void TaskManager::MarkTaskReturnObjectsFailed(const TaskSpecification &spec,
+                                              rpc::ErrorType error_type,
+                                              const rpc::RayErrorInfo *ray_error_info) {
   const TaskID task_id = spec.TaskId();
   RAY_LOG(DEBUG) << "Treat task as failed. task_id: " << task_id
                  << ", error_type: " << ErrorType_Name(error_type);
   int64_t num_returns = spec.NumReturns();
   for (int i = 0; i < num_returns; i++) {
     const auto object_id = ObjectID::FromIndex(task_id, /*index=*/i + 1);
-    if (creation_task_exception != nullptr) {
+    if (ray_error_info == nullptr) {
+      RAY_UNUSED(in_memory_store_->Put(RayObject(error_type), object_id));
+      continue;
+    }
+
+    if (ray_error_info->has_actor_init_failure()) {
+      auto creation_task_exception = ray_error_info->actor_init_failure();
       const auto final_buffer =
-          SerializePBToMsgPack<rpc::RayException>(creation_task_exception);
+          SerializePBToMsgPack<rpc::RayException>(&creation_task_exception);
       RAY_UNUSED(in_memory_store_->Put(
           RayObject(error_type, final_buffer->Data(), final_buffer->Size()), object_id));
-    } else {
-      RAY_UNUSED(in_memory_store_->Put(RayObject(error_type), object_id));
     }
   }
 }

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -33,10 +33,10 @@ class TaskFinisherInterface {
 
   virtual bool RetryTaskIfPossible(const TaskID &task_id) = 0;
 
-  virtual bool FailOrRetryPendingTask(
-      const TaskID &task_id, rpc::ErrorType error_type, const Status *status,
-      const rpc::RayException *creation_task_exception = nullptr,
-      bool mark_task_object_failed = true) = 0;
+  virtual bool FailOrRetryPendingTask(const TaskID &task_id, rpc::ErrorType error_type,
+                                      const Status *status,
+                                      const rpc::RayErrorInfo *ray_error_info = nullptr,
+                                      bool mark_task_object_failed = true) = 0;
 
   virtual void OnTaskDependenciesInlined(
       const std::vector<ObjectID> &inlined_dependency_ids,
@@ -46,7 +46,7 @@ class TaskFinisherInterface {
 
   virtual void MarkTaskReturnObjectsFailed(
       const TaskSpecification &spec, rpc::ErrorType error_type,
-      const rpc::RayException *creation_task_exception = nullptr) = 0;
+      const rpc::RayErrorInfo *ray_error_info = nullptr) = 0;
 
   virtual absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
 
@@ -139,15 +139,13 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// \param[in] task_id ID of the pending task.
   /// \param[in] error_type The type of the specific error.
   /// \param[in] status Optional status message.
-  /// \param[in] creation_task_exception If this arg is set, it means this task failed
-  /// because the callee actor is dead caused by an exception thrown in creation task,
-  /// only applies when error_type=ACTOR_DIED.
+  /// \param[in] ray_error_info The error information of a given error type.
   /// \param[in] mark_task_object_failed whether or not it marks the task
   /// return object as failed.
   /// \return Whether the task will be retried or not.
   bool FailOrRetryPendingTask(const TaskID &task_id, rpc::ErrorType error_type,
                               const Status *status = nullptr,
-                              const rpc::RayException *creation_task_exception = nullptr,
+                              const rpc::RayErrorInfo *ray_error_info = nullptr,
                               bool mark_task_object_failed = true) override;
 
   /// Treat a pending task's returned Ray object as failed. The lock should not be held
@@ -155,11 +153,10 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   ///
   /// \param[in] spec The TaskSpec that contains return object.
   /// \param[in] error_type The error type the returned Ray object will store.
-  /// \param[in] creation_task_exception The serialized actor init exception.
+  /// \param[in] ray_error_info The error information of a given error type.
   void MarkTaskReturnObjectsFailed(
       const TaskSpecification &spec, rpc::ErrorType error_type,
-      const rpc::RayException *creation_task_exception = nullptr) override
-      LOCKS_EXCLUDED(mu_);
+      const rpc::RayErrorInfo *ray_error_info = nullptr) override LOCKS_EXCLUDED(mu_);
 
   /// A task's dependencies were inlined in the task spec. This will decrement
   /// the ref count for the dependency IDs. If the dependencies contained other

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -122,7 +122,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   bool FailOrRetryPendingTask(const TaskID &task_id, rpc::ErrorType error_type,
                               const Status *status,
-                              const rpc::RayException *creation_task_exception = nullptr,
+                              const rpc::RayErrorInfo *ray_error_info = nullptr,
                               bool mark_task_object_failed = true) override {
     num_tasks_failed++;
     return true;
@@ -136,7 +136,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   void MarkTaskReturnObjectsFailed(
       const TaskSpecification &spec, rpc::ErrorType error_type,
-      const rpc::RayException *creation_task_exception = nullptr) override {}
+      const rpc::RayErrorInfo *ray_error_info = nullptr) override {}
 
   bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
 

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.cc
@@ -110,19 +110,19 @@ Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(TaskSpecification task_spe
     // Do not hold the lock while calling into task_finisher_.
     task_finisher_.MarkTaskCanceled(task_id);
     rpc::ErrorType error_type;
-    const rpc::RayException *creation_task_exception = nullptr;
+    std::unique_ptr<rpc::RayErrorInfo> error_info = nullptr;
     {
       absl::MutexLock lock(&mu_);
       auto queue = client_queues_.find(task_spec.ActorId());
       auto &death_cause = queue->second.death_cause;
       error_type = GenErrorTypeFromDeathCause(death_cause.get());
-      creation_task_exception = GetCreationTaskExceptionFromDeathCause(death_cause.get());
+      error_info = GetErrorInfoFromActorDeathCause(death_cause.get());
     }
     auto status = Status::IOError("cancelling task of dead actor");
     // No need to increment the number of completed tasks since the actor is
     // dead.
     RAY_UNUSED(!task_finisher_.FailOrRetryPendingTask(task_id, error_type, &status,
-                                                      creation_task_exception));
+                                                      error_info.get()));
   }
 
   // If the task submission subsequently fails, then the client will receive
@@ -255,20 +255,14 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(
       auto status = Status::IOError("cancelling all pending tasks of dead actor");
       auto task_ids = queue->second.actor_submit_queue->ClearAllTasks();
       rpc::ErrorType error_type = GenErrorTypeFromDeathCause(death_cause);
-      const rpc::RayException *creation_task_exception =
-          GetCreationTaskExceptionFromDeathCause(death_cause);
-      if (creation_task_exception != nullptr) {
-        RAY_LOG(INFO) << "Creation task formatted exception: "
-                      << creation_task_exception->formatted_exception_string()
-                      << ", actor_id: " << actor_id;
-      }
+      const auto error_info = GetErrorInfoFromActorDeathCause(death_cause);
 
       for (auto &task_id : task_ids) {
         task_finisher_.MarkTaskCanceled(task_id);
         // No need to increment the number of completed tasks since the actor is
         // dead.
         RAY_UNUSED(!task_finisher_.FailOrRetryPendingTask(task_id, error_type, &status,
-                                                          creation_task_exception));
+                                                          error_info.get()));
       }
 
       auto &wait_for_death_info_tasks = queue->second.wait_for_death_info_tasks;
@@ -277,7 +271,7 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(
                     << wait_for_death_info_tasks.size() << ", actor_id=" << actor_id;
       for (auto &net_err_task : wait_for_death_info_tasks) {
         RAY_UNUSED(task_finisher_.MarkTaskReturnObjectsFailed(
-            net_err_task.second, error_type, creation_task_exception));
+            net_err_task.second, error_type, error_info.get()));
       }
 
       // No need to clean up tasks that have been sent and are waiting for
@@ -409,11 +403,13 @@ void CoreWorkerDirectActorTaskSubmitter::PushActorTask(ClientQueue &queue,
           auto &queue = queue_pair->second;
 
           bool is_actor_dead = (queue.state == rpc::ActorTableData::DEAD);
+          const auto error_info =
+              GetErrorInfoFromActorDeathCause(queue.death_cause.get());
           // If the actor is already dead, immediately mark the task object is failed.
           // Otherwise, it will have grace period until it makrs the object is dead.
           will_retry = task_finisher_.FailOrRetryPendingTask(
               task_id, GenErrorTypeFromDeathCause(queue.death_cause.get()), &status,
-              GetCreationTaskExceptionFromDeathCause(queue.death_cause.get()),
+              error_info.get(),
               /*mark_task_object_failed*/ is_actor_dead);
           if (!is_actor_dead && !will_retry) {
             // No retry == actor is dead.

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -554,7 +554,7 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
             while (!task_queue.empty()) {
               auto &task_spec = task_queue.front();
               RAY_UNUSED(task_finisher_->MarkTaskReturnObjectsFailed(
-                  task_spec, rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED, nullptr));
+                  task_spec, rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED));
               task_queue.pop_front();
             }
             if (scheduling_key_entry.CanDelete()) {

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -151,6 +151,24 @@ inline const std::string &GetDeathCauseString(const rpc::ActorDeathCause *death_
   return death_cause_string.at(death_cause_case);
 }
 
+/// Get the error information from the actor death cause.
+/// \param[in] death_cause The rpc message that contains the actos death information.
+/// \return RayErrorInfo that has propagated death cause. Nullptr if not sufficient
+/// information is provided.
+inline std::unique_ptr<rpc::RayErrorInfo> GetErrorInfoFromActorDeathCause(
+    const rpc::ActorDeathCause *death_cause) {
+  auto creation_task_exception = GetCreationTaskExceptionFromDeathCause(death_cause);
+  if (creation_task_exception == nullptr) {
+    return nullptr;
+  }
+  auto error_info = std::make_unique<rpc::RayErrorInfo>();
+  if (creation_task_exception != nullptr) {
+    // Shouldn't use Swap here because we don't own the pointer.
+    error_info->mutable_actor_init_failure()->CopyFrom(*creation_task_exception);
+  }
+  return error_info;
+}
+
 }  // namespace gcs
 
 }  // namespace ray

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -154,7 +154,6 @@ enum ErrorType {
 message RayErrorInfo {
   oneof error {
     RayException actor_init_failure = 1;
-    RayActorDiedError actor_died = 2;
   }
 }
 
@@ -167,19 +166,6 @@ message RayException {
   bytes serialized_exception = 2;
   // The formatted exception string.
   string formatted_exception_string = 3;
-}
-
-message RayActorDiedError {
-  // The address of the the actor.
-  Address address = 1;
-  // Name of the actor.
-  string name = 2;
-  // The process id of this actor.
-  uint32 pid = 3;
-  // The class name of the dead actor.
-  string class_name = 4;
-  // The error message of the dead actor error.
-  string error_message = 5;
 }
 
 /// The runtime environment describes all the runtime packages needed to

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -150,6 +150,14 @@ enum ErrorType {
   OBJECT_FETCH_TIMED_OUT = 14;
 }
 
+/// The information per ray error type.
+message RayErrorInfo {
+  oneof error {
+    RayException actor_init_failure = 1;
+    RayActorDiedError actor_died = 2;
+  }
+}
+
 /// The task exception encapsulates all information about task
 /// execution execeptions.
 message RayException {
@@ -159,6 +167,19 @@ message RayException {
   bytes serialized_exception = 2;
   // The formatted exception string.
   string formatted_exception_string = 3;
+}
+
+message RayActorDiedError {
+  // The address of the the actor.
+  Address address = 1;
+  // Name of the actor.
+  string name = 2;
+  // The process id of this actor.
+  uint32 pid = 3;
+  // The class name of the dead actor.
+  string class_name = 4;
+  // The error message of the dead actor error.
+  string error_message = 5;
 }
 
 /// The runtime environment describes all the runtime packages needed to

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -155,7 +155,7 @@ message ActorTableData {
   Address owner_address = 10;
   // Whether the actor is persistent.
   bool is_detached = 11;
-  // Name of the actor. Only populated if is_detached is true.
+  // Name of the actor.
   string name = 12;
   // Last timestamp that the actor state was updated.
   double timestamp = 13;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In this PR, instead of passing specific "creation_task_exception", we pass RayErrorInfo. This will allow us to pass any type of error metadata to MarkTaskReturnObjectFailed. 

This PR is basically refactoring. 

## Related issue number

https://github.com/ray-project/ray/issues/20534

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
