### PR TITLE
SampleBatch.concat_samples fix incorrect max_seq_len calculation

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -194,8 +194,15 @@ class SampleBatch(dict):
             if s.count > 0:
                 assert s.zero_padded == zero_padded
                 assert s.time_major == time_major
+                if (s.max_seq_len is None or max_seq_len is None)\
+                   and s.max_seq_len != max_seq_len:
+                    raise ValueError(
+                        "Samples must consistently provide or omit max_seq_len"
+                    )
                 if zero_padded:
                     assert s.max_seq_len == max_seq_len
+                if max_seq_len is not None:
+                    max_seq_len = max(max_seq_len, s.max_seq_len)
                 concat_samples.append(s)
                 if s.get(SampleBatch.SEQ_LENS) is not None:
                     concatd_seq_lens.extend(s[SampleBatch.SEQ_LENS])

--- a/rllib/policy/tests/test_sample_batch.py
+++ b/rllib/policy/tests/test_sample_batch.py
@@ -95,6 +95,36 @@ class TestSampleBatch(unittest.TestCase):
         concatd_2 = s1.concat(s2)
         check(concatd, concatd_2)
 
+    def test_concat_max_seq_len(self):
+        """Tests, SampleBatches.concat_samples() max_seq_len."""
+        s1 = SampleBatch({
+            "a": np.array([1, 2, 3]),
+            "b": {
+                "c": np.array([4, 5, 6])
+            },
+            SampleBatch.SEQ_LENS: [1, 2]
+        })
+        s2 = SampleBatch({
+            "a": np.array([2, 3, 4]),
+            "b": {
+                "c": np.array([5, 6, 7])
+            },
+            SampleBatch.SEQ_LENS: [3]
+        })
+
+        s3 = SampleBatch({
+            "a": np.array([2, 3, 4]),
+            "b": {
+                "c": np.array([5, 6, 7])
+            },
+        })
+
+        concatd = SampleBatch.concat_samples([s1, s2])
+        check(concatd.max_seq_len, s2.max_seq_len)
+
+        with self.assertRaises(ValueError):
+            SampleBatch.concat_samples([s1, s2, s3])
+
     def test_rows(self):
         s1 = SampleBatch({
             "a": np.array([[1, 1], [2, 2], [3, 3]]),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Updates SampleBatch.concate_samples to check each samples max_seq_len and assign the appropriate one.

@sven1977  @gjoliver 
There is one addition that I would like to make but I was not sure what you thought. It is logically possible (but I am not sure if it is possible in the code base) that one of the sample_batches in the list has max_seq_len==None. Currently that is untested and would result in an exception. We could add a check for it and raise a ValueError if you think that is appropriate.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #20703 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [N/A] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
