### PR TITLE
Use thread local random number generator

### DIFF
--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -202,12 +202,7 @@ template <typename T>
 void FillRandom(T *data) {
   RAY_CHECK(data != nullptr);
 
-  // NOTE(pcm): The right way to do this is to have one absl::BitGen per
-  // thread (using the thread_local keyword), but that's not supported on
-  // older versions of macOS (see https://stackoverflow.com/a/29929949)
-  static std::mutex random_engine_mutex;
-  std::lock_guard<std::mutex> lock(random_engine_mutex);
-  static absl::BitGen generator;
+  thread_local absl::BitGen generator;
   for (size_t i = 0; i < data->size(); i++) {
     (*data)[i] = static_cast<uint8_t>(
         absl::Uniform(generator, 0, std::numeric_limits<uint8_t>::max()));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up from https://github.com/ray-project/ray/pull/20696. Removes the lock for random number generation and uses a thread local random number generator instead. This is now possible since we upgraded the compiler toolchain on macOS.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
