### PR TITLE
Env checker for base envs

### DIFF
--- a/rllib/utils/tests/test_check_env.py
+++ b/rllib/utils/tests/test_check_env.py
@@ -1,8 +1,11 @@
 from unittest.mock import Mock, MagicMock
 
+import gym
 import pytest
-from ray.rllib.examples.env.random_env import RandomEnv
-from ray.rllib.utils.pre_checks import check_gym_environments
+
+from ray.rllib import BaseEnv
+from ray.rllib.examples.env.random_env import RandomEnv, RandomMultiAgentEnv
+from ray.rllib.utils.pre_checks import check_gym_environments, check_base_env
 
 
 class TestGymCheckEnv():
@@ -108,6 +111,15 @@ class TestGymCheckEnv():
         error = "Your step function must return a info that is a dict."
         with pytest.raises(AssertionError, match=error):
             check_gym_environments(env)
+        del env
+
+
+class TestCheckBaseEnv():
+
+    def test_base_env_check(self):
+        env = BaseEnv.to_base_env(RandomMultiAgentEnv())
+        # env = BaseEnv.to_base_env(gym.make("CartPole-v1"))
+        check_base_env(env)
         del env
 
 


### PR DESCRIPTION


## Why are these changes needed?

This is an env checker for any environments that inherit from `BaseEnvs`

There are some problems I'm running into: 

@sven1977 
1) How to do figure out what all of the environment ids are for a given environment? For multi-agent envs, this is just an integer, but given the flexibility of this api, an env id could be any type of literal (int, string, anything hashable)

2) How do I construct multi_env_dictionaries for arbitrary environments. It seems that I could use something like `_with_dummy_agent_obs` but what if there is some mapping from agents to environments that I am not aware of?

I'll update this as I have more questions. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
