### PR TITLE
Add python unit test to make sure task in default group doesn't block others.

### DIFF
--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -4,6 +4,7 @@ import sys
 import threading
 import pytest
 import ray
+import time
 
 
 # This tests the methods are executed in the correct eventloop.
@@ -120,6 +121,7 @@ def test_default_concurrency_group_does_not_block_others():
             pass
 
         async def f1(self):
+            time.sleep(10000)
             return "never return"
 
         @ray.method(concurrency_group="my_group")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR only adds a unit tests for Python concurrency group.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#20475

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
