### PR TITLE
[Internal Observability] Move debug_state.txt to the log dir + support gcs_server debug state

### DIFF
--- a/python/ray/autoscaler/_private/cluster_dump.py
+++ b/python/ray/autoscaler/_private/cluster_dump.py
@@ -206,7 +206,7 @@ def get_local_debug_state(archive: Archive,
         archive.open()
 
     session_dir = os.path.expanduser(session_dir)
-    debug_state_file = os.path.join(session_dir, "debug_state.txt")
+    debug_state_file = os.path.join(session_dir, "logs/debug_state.txt")
 
     if not os.path.exists(debug_state_file):
         raise LocalCommandFailed("No `debug_state.txt` file found.")

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1663,7 +1663,7 @@ def local_dump(stream: bool = False,
     "--debug-state/--no-debug-state",
     is_flag=True,
     default=True,
-    help="Collect debug_state.txt from ray session dir")
+    help="Collect debug_state.txt from ray log dir")
 @click.option(
     "--pip/--no-pip",
     is_flag=True,

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -281,7 +281,7 @@ def test_worker_startup_count(ray_start_cluster):
     # Check "debug_state.txt" to ensure no extra workers were started.
     session_dir = ray.worker.global_worker.node.address_info["session_dir"]
     session_path = Path(session_dir)
-    debug_state_path = session_path / "debug_state.txt"
+    debug_state_path = session_path / "logs" / "debug_state.txt"
 
     def get_num_workers():
         with open(debug_state_path) as f:

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -188,7 +188,7 @@ def test_no_spurious_worker_startup(shutdown_only):
     # Check "debug_state.txt" to ensure no extra workers were started.
     session_dir = ray.worker.global_worker.node.address_info["session_dir"]
     session_path = Path(session_dir)
-    debug_state_path = session_path / "debug_state.txt"
+    debug_state_path = session_path / "logs" / "debug_state.txt"
 
     def get_num_workers():
         with open(debug_state_path) as f:

--- a/release/long_running_distributed_tests/README.rst
+++ b/release/long_running_distributed_tests/README.rst
@@ -30,7 +30,7 @@ Debugging
 ---------
 The primary method to debug the test while it is running is to view the logs and the dashboard from the UI. After the test has failed, you can still view the stdout logs in the UI and also inspect
 the logs under ``/tmp/ray/session*/logs/`` and
-``/tmp/ray/session*/debug_state.txt``.
+``/tmp/ray/session*/logs/debug_state.txt``.
 
 Shut Down the Workloads
 -----------------------

--- a/release/long_running_tests/README.rst
+++ b/release/long_running_tests/README.rst
@@ -38,7 +38,7 @@ Debugging
 ---------
 The primary method to debug the test while it is running is to view the logs and the dashboard from the UI. After the test has failed, you can still view the stdout logs in the UI and also inspect
 the logs under ``/tmp/ray/session*/logs/`` and
-``/tmp/ray/session*/debug_state.txt``.
+``/tmp/ray/session*/logs/debug_state.txt``.
 
 .. To check up on the workloads, run either
 .. ``anyscale session --name="*" execute check-load``, which

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -31,10 +31,10 @@ RAY_CONFIG(bool, event_stats, false)
 RAY_CONFIG(bool, legacy_scheduler_warnings, true)
 
 /// The interval of periodic event loop stats print.
-/// -1 means the feature is disabled. In this case, stats are only available to
-/// debug_state.txt for raylets.
+/// -1 means the feature is disabled. In this case, stats are available to
+/// debug_state_*.txt
 /// NOTE: This requires event_stats=1.
-RAY_CONFIG(int64_t, event_stats_print_interval_ms, 10000)
+RAY_CONFIG(int64_t, event_stats_print_interval_ms, 60000)
 
 /// In theory, this is used to detect Ray cookie mismatches.
 /// This magic number (hex for "RAY") is used instead of zero, rationale is
@@ -271,8 +271,6 @@ RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5);
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)
 /// Maximum number of dead nodes in GCS server memory cache.
 RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)
-/// The interval at which the gcs server will print debug info.
-RAY_CONFIG(int64_t, gcs_dump_debug_log_interval_minutes, 1)
 // The interval at which the gcs server will pull a new resource.
 RAY_CONFIG(int, gcs_resource_report_poll_period_ms, 100)
 // The number of concurrent polls to polls to GCS.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1267,23 +1267,29 @@ std::string GcsActorManager::DebugString() const {
     num_named_actors += pair.second.size();
   }
   std::ostringstream stream;
-  stream << "GcsActorManager: {RegisterActor request count: "
+  stream << "GcsActorManager: "
+         << "\n- RegisterActor request count: "
          << counts_[CountType::REGISTER_ACTOR_REQUEST]
-         << ", CreateActor request count: " << counts_[CountType::CREATE_ACTOR_REQUEST]
-         << ", GetActorInfo request count: " << counts_[CountType::GET_ACTOR_INFO_REQUEST]
-         << ", GetNamedActorInfo request count: "
+         << "\n- CreateActor request count: " << counts_[CountType::CREATE_ACTOR_REQUEST]
+         << "\n- GetActorInfo request count: "
+         << counts_[CountType::GET_ACTOR_INFO_REQUEST]
+         << "\n- GetNamedActorInfo request count: "
          << counts_[CountType::GET_NAMED_ACTOR_INFO_REQUEST]
-         << ", GetAllActorInfo request count: "
+         << "\n- GetAllActorInfo request count: "
          << counts_[CountType::GET_ALL_ACTOR_INFO_REQUEST]
-         << ", KillActor request count: " << counts_[CountType::KILL_ACTOR_REQUEST]
-         << ", ListNamedActors request count: "
+         << "\n- KillActor request count: " << counts_[CountType::KILL_ACTOR_REQUEST]
+         << "\n- ListNamedActors request count: "
          << counts_[CountType::LIST_NAMED_ACTORS_REQUEST]
-         << ", Registered actors count: " << registered_actors_.size()
-         << ", Destroyed actors count: " << destroyed_actors_.size()
-         << ", Named actors count: " << num_named_actors
-         << ", Unresolved actors count: " << unresolved_actors_.size()
-         << ", Pending actors count: " << pending_actors_.size()
-         << ", Created actors count: " << created_actors_.size() << "}";
+         << "\n- Registered actors count: " << registered_actors_.size()
+         << "\n- Destroyed actors count: " << destroyed_actors_.size()
+         << "\n- Named actors count: " << num_named_actors
+         << "\n- Unresolved actors count: " << unresolved_actors_.size()
+         << "\n- Pending actors count: " << pending_actors_.size()
+         << "\n- Created actors count: " << created_actors_.size()
+         << "\n- owners_: " << owners_.size()
+         << "\n- actor_to_register_callbacks_: " << actor_to_register_callbacks_.size()
+         << "\n- actor_to_create_callbacks_: " << actor_to_create_callbacks_.size()
+         << "\n- sorted_destroyed_actor_list_: " << sorted_destroyed_actor_list_.size();
   return stream.str();
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -434,6 +434,17 @@ bool GcsActorScheduler::KillActorOnWorker(const rpc::Address &worker_address,
   return true;
 }
 
+std::string GcsActorScheduler::DebugString() const {
+  std::ostringstream stream;
+  stream << "GcsActorScheduler: "
+         << "\n- node_to_actors_when_leasing_: " << node_to_actors_when_leasing_.size()
+         << "\n- node_to_workers_when_creating_: "
+         << node_to_workers_when_creating_.size()
+         << "\n- nodes_of_releasing_unused_workers_: "
+         << nodes_of_releasing_unused_workers_.size();
+  return stream.str();
+}
+
 NodeID RayletBasedActorScheduler::SelectNode(std::shared_ptr<GcsActor> actor) {
   // Select a node to lease worker for the actor.
   std::shared_ptr<rpc::GcsNodeInfo> node;

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -79,6 +79,8 @@ class GcsActorSchedulerInterface {
   /// \param actor The actor to be destoryed.
   virtual void OnActorDestruction(std::shared_ptr<GcsActor> actor) = 0;
 
+  virtual std::string DebugString() const = 0;
+
   virtual ~GcsActorSchedulerInterface() {}
 };
 
@@ -154,6 +156,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   ///
   /// \param actor The actor to be destoryed.
   void OnActorDestruction(std::shared_ptr<GcsActor> actor) override {}
+
+  std::string DebugString() const override;
 
  protected:
   /// The GcsLeasedWorker is kind of abstraction of remote leased worker inside raylet. It

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -270,13 +270,14 @@ void GcsNodeManager::AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node) 
 
 std::string GcsNodeManager::DebugString() const {
   std::ostringstream stream;
-  stream << "GcsNodeManager: {RegisterNode request count: "
+  stream << "GcsNodeManager: "
+         << "\n- RegisterNode request count: "
          << counts_[CountType::REGISTER_NODE_REQUEST]
-         << ", DrainNode request count: " << counts_[CountType::DRAIN_NODE_REQUEST]
-         << ", GetAllNodeInfo request count: "
+         << "\n- DrainNode request count: " << counts_[CountType::DRAIN_NODE_REQUEST]
+         << "\n- GetAllNodeInfo request count: "
          << counts_[CountType::GET_ALL_NODE_INFO_REQUEST]
-         << ", GetInternalConfig request count: "
-         << counts_[CountType::GET_INTERNAL_CONFIG_REQUEST] << "}";
+         << "\n- GetInternalConfig request count: "
+         << counts_[CountType::GET_INTERNAL_CONFIG_REQUEST];
   return stream.str();
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -864,24 +864,25 @@ std::string GcsPlacementGroupManager::DebugString() const {
     num_pgs += it.second.size();
   }
   std::ostringstream stream;
-  stream << "GcsPlacementGroupManager: {CreatePlacementGroup request count: "
+  stream << "GcsPlacementGroupManager: "
+         << "\n- CreatePlacementGroup request count: "
          << counts_[CountType::CREATE_PLACEMENT_GROUP_REQUEST]
-         << ", RemovePlacementGroup request count: "
+         << "\n- RemovePlacementGroup request count: "
          << counts_[CountType::REMOVE_PLACEMENT_GROUP_REQUEST]
-         << ", GetPlacementGroup request count: "
+         << "\n- GetPlacementGroup request count: "
          << counts_[CountType::GET_PLACEMENT_GROUP_REQUEST]
-         << ", GetAllPlacementGroup request count: "
+         << "\n- GetAllPlacementGroup request count: "
          << counts_[CountType::GET_ALL_PLACEMENT_GROUP_REQUEST]
-         << ", WaitPlacementGroupUntilReady request count: "
+         << "\n- WaitPlacementGroupUntilReady request count: "
          << counts_[CountType::WAIT_PLACEMENT_GROUP_UNTIL_READY_REQUEST]
-         << ", GetNamedPlacementGroup request count: "
+         << "\n- GetNamedPlacementGroup request count: "
          << counts_[CountType::GET_NAMED_PLACEMENT_GROUP_REQUEST]
-         << ", Scheduling pending placement group count: "
+         << "\n- Scheduling pending placement group count: "
          << counts_[CountType::SCHEDULING_PENDING_PLACEMENT_GROUP]
-         << ", Registered placement groups count: " << registered_placement_groups_.size()
-         << ", Named placement group count: " << num_pgs
-         << ", Pending placement groups count: " << pending_placement_groups_.size()
-         << "}";
+         << "\n- Registered placement groups count: "
+         << registered_placement_groups_.size()
+         << "\n- Named placement group count: " << num_pgs
+         << "\n- Pending placement groups count: " << pending_placement_groups_.size();
   return stream.str();
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -439,18 +439,19 @@ void GcsResourceManager::UpdatePlacementGroupLoad(
 
 std::string GcsResourceManager::DebugString() const {
   std::ostringstream stream;
-  stream << "GcsResourceManager: {GetResources request count: "
+  stream << "GcsResourceManager: "
+         << "\n- GetResources request count: "
          << counts_[CountType::GET_RESOURCES_REQUEST]
-         << ", GetAllAvailableResources request count"
+         << "\n- GetAllAvailableResources request count"
          << counts_[CountType::GET_ALL_AVAILABLE_RESOURCES_REQUEST]
-         << ", UpdateResources request count: "
+         << "\n- UpdateResources request count: "
          << counts_[CountType::UPDATE_RESOURCES_REQUEST]
-         << ", DeleteResources request count: "
+         << "\n- DeleteResources request count: "
          << counts_[CountType::DELETE_RESOURCES_REQUEST]
-         << ", ReportResourceUsage request count: "
+         << "\n- ReportResourceUsage request count: "
          << counts_[CountType::REPORT_RESOURCE_USAGE_REQUEST]
-         << ", GetAllResourceUsage request count: "
-         << counts_[CountType::GET_ALL_RESOURCE_USAGE_REQUEST] << "}";
+         << "\n- GetAllResourceUsage request count: "
+         << counts_[CountType::GET_ALL_RESOURCE_USAGE_REQUEST];
   return stream.str();
 }
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/gcs_server/gcs_server.h"
 
+#include <fstream>
+
 #include "ray/common/asio/asio_util.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/network_util.h"
@@ -42,6 +44,7 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
       raylet_client_pool_(
           std::make_shared<rpc::NodeManagerClientPool>(client_call_manager_)),
       pubsub_periodical_runner_(main_service_),
+      periodical_runner_(main_service),
       is_started_(false),
       is_stopped_(false) {}
 
@@ -151,13 +154,20 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
   // detector is already run.
   gcs_heartbeat_manager_->Start();
 
-  // Print debug info periodically.
-  PrintDebugInfo();
-
-  // Print the asio event loop stats periodically if configured.
-  PrintAsioStats();
-
   CollectStats();
+
+  periodical_runner_.RunFnPeriodically(
+      [this] {
+        RAY_LOG(INFO) << GetDebugState();
+        PrintAsioStats();
+      },
+      /*ms*/ RayConfig::instance().event_stats_print_interval_ms(),
+      "GCSServer.deadline_timer.debug_state_event_stats_print");
+
+  periodical_runner_.RunFnPeriodically(
+      [this] { DumpDebugStateToFile(); },
+      /*ms*/ RayConfig::instance().debug_dump_period_milliseconds(),
+      "GCSServer.deadline_timer.debug_state_dump");
 
   is_started_ = true;
 }
@@ -515,24 +525,27 @@ void GcsServer::CollectStats() {
       (RayConfig::instance().metrics_report_interval_ms() / 2) /* milliseconds */);
 }
 
-void GcsServer::PrintDebugInfo() {
+void GcsServer::DumpDebugStateToFile() const {
+  std::fstream fs;
+  fs.open(config_.log_dir + "/debug_state_gcs.txt",
+          std::fstream::out | std::fstream::trunc);
+  fs << GetDebugState() << "\n\n";
+  fs << main_service_.StatsString();
+  fs.close();
+}
+
+std::string GcsServer::GetDebugState() const {
   std::ostringstream stream;
-  stream << gcs_node_manager_->DebugString() << "\n"
-         << gcs_actor_manager_->DebugString() << "\n"
-         << gcs_placement_group_manager_->DebugString() << "\n"
-         << gcs_publisher_->DebugString() << "\n"
-         << ((rpc::DefaultTaskInfoHandler *)task_info_handler_.get())->DebugString();
+  stream << gcs_node_manager_->DebugString() << "\n\n"
+         << gcs_actor_manager_->DebugString() << "\n\n"
+         << gcs_resource_manager_->DebugString() << "\n\n"
+         << gcs_placement_group_manager_->DebugString() << "\n\n"
+         << gcs_publisher_->DebugString() << "\n\n";
 
   if (config_.grpc_based_resource_broadcast) {
-    stream << "\n" << grpc_based_resource_broadcaster_->DebugString();
+    stream << grpc_based_resource_broadcaster_->DebugString();
   }
-  // TODO(ffbin): We will get the session_dir in the next PR, and write the log to
-  // gcs_debug_state.txt.
-  RAY_LOG(INFO) << stream.str();
-  execute_after(
-      main_service_, [this] { PrintDebugInfo(); },
-      (RayConfig::instance().gcs_dump_debug_log_interval_minutes() *
-       60000) /* milliseconds */);
+  return stream.str();
 }
 
 void GcsServer::PrintAsioStats() {
@@ -541,9 +554,6 @@ void GcsServer::PrintAsioStats() {
       RayConfig::instance().event_stats_print_interval_ms();
   if (event_stats_print_interval_ms != -1 && RayConfig::instance().event_stats()) {
     RAY_LOG(INFO) << "Event stats:\n\n" << main_service_.StatsString() << "\n\n";
-    execute_after(
-        main_service_, [this] { PrintAsioStats(); },
-        event_stats_print_interval_ms /* milliseconds */);
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -47,6 +47,7 @@ struct GcsServerConfig {
   std::string node_ip_address;
   bool grpc_based_resource_broadcast = false;
   bool grpc_pubsub_enabled = false;
+  std::string log_dir;
 };
 
 class GcsNodeManager;
@@ -145,7 +146,10 @@ class GcsServer {
   void CollectStats();
 
   /// Print debug info periodically.
-  void PrintDebugInfo();
+  std::string GetDebugState() const;
+
+  /// Dump the debug info to debug_state_gcs.txt.
+  void DumpDebugStateToFile() const;
 
   /// Print the asio event loop stats for debugging.
   void PrintAsioStats();
@@ -216,6 +220,8 @@ class GcsServer {
   std::shared_ptr<GcsPublisher> gcs_publisher_;
   /// Grpc based pubsub's periodical runner.
   PeriodicalRunner pubsub_periodical_runner_;
+  /// The runner to run function periodically.
+  PeriodicalRunner periodical_runner_;
   /// The gcs table storage.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::unique_ptr<ray::RuntimeEnvManager> runtime_env_manager_;

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -115,6 +115,7 @@ int main(int argc, char *argv[]) {
   gcs_server_config.grpc_based_resource_broadcast =
       RayConfig::instance().grpc_based_resource_broadcast();
   gcs_server_config.grpc_pubsub_enabled = RayConfig::instance().gcs_grpc_based_pubsub();
+  gcs_server_config.log_dir = log_dir;
   ray::gcs::GcsServer gcs_server(gcs_server_config, main_service);
 
   // Destroy the GCS server on a SIGTERM. The pointer to main_service is

--- a/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.cc
+++ b/src/ray/gcs/gcs_server/grpc_based_resource_broadcaster.cc
@@ -99,7 +99,7 @@ std::string GrpcBasedResourceBroadcaster::DebugString() {
     absl::MutexLock guard(&mutex_);
     node_num = nodes_.size();
   }
-  return absl::StrCat("GrpcBasedResourceBroadcaster: {Tracked nodes: ", node_num, "}");
+  return absl::StrCat("GrpcBasedResourceBroadcaster:\n- Tracked nodes: ", node_num);
 }
 
 void GrpcBasedResourceBroadcaster::SendBroadcast() {

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -35,6 +35,7 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
       const std::unordered_map<NodeID, std::vector<WorkerID>> &node_to_workers) {}
   void OnActorDestruction(std::shared_ptr<gcs::GcsActor> actor) {}
 
+  MOCK_CONST_METHOD0(DebugString, std::string());
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const NodeID &node_id));
   MOCK_METHOD2(CancelOnWorker, ActorID(const NodeID &node_id, const WorkerID &worker_id));
   MOCK_METHOD3(CancelOnLeasing, void(const NodeID &node_id, const ActorID &actor_id,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -208,6 +208,7 @@ int main(int argc, char *argv[]) {
             RayConfig::instance().metrics_report_interval_ms() / 2;
         node_manager_config.store_socket_name = store_socket_name;
         node_manager_config.temp_dir = temp_dir;
+        node_manager_config.log_dir = log_dir;
         node_manager_config.session_dir = session_dir;
         node_manager_config.resource_dir = resource_dir;
         node_manager_config.ray_debugger_external = ray_debugger_external;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2066,7 +2066,7 @@ void NodeManager::ProcessSubscribePlasmaReady(
 
 void NodeManager::DumpDebugState() const {
   std::fstream fs;
-  fs.open(initial_config_.session_dir + "/debug_state.txt",
+  fs.open(initial_config_.log_dir + "/debug_state.txt",
           std::fstream::out | std::fstream::trunc);
   fs << DebugString();
   fs.close();

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -90,6 +90,8 @@ struct NodeManagerConfig {
   std::string store_socket_name;
   /// The path to the ray temp dir.
   std::string temp_dir;
+  /// The path of this ray log dir.
+  std::string log_dir;
   /// The path of this ray session dir.
   std::string session_dir;
   /// The path of this ray resource dir.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is

- Moving debug_state.txt to the log directory. This will help us finding debug_state.txt from the dashboard. See below.
- Add debug_state_gcs.txt. This will display GCS' debug state. GCS will also dump debug state to the file every 10 seconds
- For periodic printing of debug state, I made it happen every 1 minute. This is because every 10 seconds usually is very spammy. 

<img width="1626" alt="Screen Shot 2021-11-25 at 2 13 16 AM" src="https://user-images.githubusercontent.com/18510752/143422650-ceb53465-2227-45d5-9c6f-65cd135bd45a.png">

TODO 
- [ ] unit test

## Related issue number

The first part of https://github.com/ray-project/ray/issues/20723

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
