### PR TITLE
[release][m1] Update sanity check python versions for M1 mac

### DIFF
--- a/release/util/pip_download_test.sh
+++ b/release/util/pip_download_test.sh
@@ -31,7 +31,14 @@ pip install --upgrade pip
 # This is required to use conda activate
 source "$(conda info --base)/etc/profile.d/conda.sh"
 
-for PYTHON_VERSION in "3.6" "3.7" "3.8" "3.9"
+if [[ `uname -m` == 'arm64' ]]; then
+  echo M1
+  PYTHON_VERSIONS=( "3.8" "3.9" )
+else
+  PYTHON_VERSION=( "3.6" "3.7" "3.8" "3.9" )
+fi
+
+for PYTHON_VERSION in $PYTHON_VERSIONS
 do
     env_name="${RAY_VERSION}-${PYTHON_VERSION}-env"
     conda create -y -n "${env_name}" python=${PYTHON_VERSION}

--- a/release/util/pip_download_test.sh
+++ b/release/util/pip_download_test.sh
@@ -31,7 +31,7 @@ pip install --upgrade pip
 # This is required to use conda activate
 source "$(conda info --base)/etc/profile.d/conda.sh"
 
-if [[ `uname -m` == 'arm64' ]] && [[ $OSTYPE == "darwin"* ]]; then
+if [[ $(uname -m) == 'arm64' ]] && [[ $OSTYPE == "darwin"* ]]; then
   PYTHON_VERSIONS=( "3.8" "3.9" )
 else
   PYTHON_VERSION=( "3.6" "3.7" "3.8" "3.9" )
@@ -40,7 +40,7 @@ fi
 for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"
 do
     env_name="${RAY_VERSION}-${PYTHON_VERSION}-env"
-    conda create -y -n "${env_name}" python=${PYTHON_VERSION}
+    conda create -y -n "${env_name}" python="${PYTHON_VERSION}"
     conda activate "${env_name}"
     printf "\n\n\n"
     echo "========================================================="
@@ -51,7 +51,7 @@ do
     printf "\n\n\n"
 
     # TODO (Alex): Get rid of this once grpc adds working PyPI wheels for M1 macs.
-    if [[ `uname -m` == 'arm64' ]] && [[ $OSTYPE == "darwin"* ]]; then
+    if [[ $(uname -m) == 'arm64' ]] && [[ $OSTYPE == "darwin"* ]]; then
         conda install -y grpcio
     fi
 

--- a/release/util/pip_download_test.sh
+++ b/release/util/pip_download_test.sh
@@ -31,14 +31,13 @@ pip install --upgrade pip
 # This is required to use conda activate
 source "$(conda info --base)/etc/profile.d/conda.sh"
 
-if [[ `uname -m` == 'arm64' ]]; then
-  echo M1
+if [[ `uname -m` == 'arm64' ]] && [[ $OSTYPE == "darwin"* ]]; then
   PYTHON_VERSIONS=( "3.8" "3.9" )
 else
   PYTHON_VERSION=( "3.6" "3.7" "3.8" "3.9" )
 fi
 
-for PYTHON_VERSION in $PYTHON_VERSIONS
+for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"
 do
     env_name="${RAY_VERSION}-${PYTHON_VERSION}-env"
     conda create -y -n "${env_name}" python=${PYTHON_VERSION}
@@ -50,6 +49,11 @@ do
     echo "This should be equal to ${PYTHON_VERSION}"
     echo "========================================================="
     printf "\n\n\n"
+
+    # TODO (Alex): Get rid of this once grpc adds working PyPI wheels for M1 macs.
+    if [[ `uname -m` == 'arm64' ]] && [[ $OSTYPE == "darwin"* ]]; then
+        conda install -y grpcio
+    fi
 
     # shellcheck disable=SC2102
     pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ray[cpp]=="${RAY_VERSION}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a minor update to our release sanity check script so that it runs out of the box on M1. Since M1s only support python 3.8 and 3.9, we shouldn't try to install python 3.6 or 3.7. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
