### PR TITLE
[Nightly Test] Fix a wrong prepare script for object store nightly test

### DIFF
--- a/benchmarks/benchmark_tests.yaml
+++ b/benchmarks/benchmark_tests.yaml
@@ -19,12 +19,11 @@
 
   cluster:
     app_config: app_config.yaml
-    prepare: python distributed/wait_cluster.py --num-nodes=50
     compute_template: object_store.yaml
 
   run:
     timeout: 3600
-    prepare: sleep 0
+    prepare: python distributed/wait_cluster.py --num-nodes=50
     script: python object_store/test_object_store.py
 
 - name: many_actors


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

By mistake, we are running sleep 0 instead of wait_cluster.py This PR fixes it. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
