### PR TITLE
[Nightly tests] Promote some tests stable.

### DIFF
--- a/release/nightly_tests/chaos_test.yaml
+++ b/release/nightly_tests/chaos_test.yaml
@@ -12,7 +12,6 @@
     timeout: 3600
     prepare: python wait_cluster.py 10 600; python setup_chaos.py --no-start
     script: python chaos_test/test_chaos_basic.py --workload=tasks
-  stable: false
 
 - name: chaos_many_actors
   cluster:
@@ -23,7 +22,6 @@
     timeout: 3600
     prepare: python wait_cluster.py 10 600; python setup_chaos.py --no-start
     script: python chaos_test/test_chaos_basic.py --workload=actors
-  stable: false
 
 - name: chaos_dask_on_ray_large_scale_test_no_spilling
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Mark staging tests that pass 10+ time in a row as stable tests



## Related issue number

<!-- For example: "Closes #1234" -->
<img width="1483" alt="Screen Shot 2021-11-27 at 7 00 21 AM" src="https://user-images.githubusercontent.com/18510752/143686567-84670fca-8001-4606-90e3-df252d03d2b0.png">


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
