### PR TITLE
[RLlib] Update max_seq_len in pad_batch_to_sequences_of_same_size

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1222,6 +1222,13 @@ py_test(
 )
 
 py_test(
+    name = "policy/tests/test_rnn_sequencing",
+    tags = ["team:ml", "policy"],
+    size = "small",
+    srcs = ["policy/tests/test_rnn_sequencing.py"]
+)
+
+py_test(
     name = "policy/tests/test_sample_batch",
     tags = ["team:ml", "policy"],
     size = "small",

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -134,6 +134,8 @@ def pad_batch_to_sequences_of_same_size(
     for i, k in enumerate(state_keys):
         batch[k] = initial_states[i]
     batch[SampleBatch.SEQ_LENS] = np.array(seq_lens)
+    if dynamic_max:
+        batch.max_seq_len = max(seq_lens)
 
     if log_once("rnn_ma_feed_dict"):
         logger.info("Padded input for RNN/Attn.Nets/MA:\n\n{}\n".format(

--- a/rllib/policy/tests/test_rnn_sequencing.py
+++ b/rllib/policy/tests/test_rnn_sequencing.py
@@ -1,0 +1,90 @@
+import numpy as np
+import unittest
+
+import ray
+from ray.rllib.policy.rnn_sequencing import pad_batch_to_sequences_of_same_size
+from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.view_requirement import ViewRequirement
+from ray.rllib.utils.test_utils import check
+
+
+class TestRNNSequencing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_pad_batch_dynamic_max(self):
+        """Test pad_batch_to_sequences_of_same_size when dynamic_max = True"""
+        view_requirements = {
+            "state_in_0": ViewRequirement(
+                "state_out_0",
+                shift=[-1],
+                used_for_training=False,
+                used_for_compute_actions=True,
+                batch_repeat_value=1)
+        }
+        max_seq_len = 20
+        num_seqs = np.random.randint(1, 20)
+        seq_lens = np.random.randint(1, max_seq_len, size=(num_seqs))
+        max_len = np.max(seq_lens)
+        sum_seq_lens = np.sum(seq_lens)
+
+        s1 = SampleBatch(
+            {
+                "a": np.arange(sum_seq_lens),
+                "b": np.arange(sum_seq_lens),
+                "seq_lens": seq_lens,
+                "state_in_0": [[0]] * num_seqs
+            },
+            _max_seq_len=max_seq_len)
+
+        pad_batch_to_sequences_of_same_size(
+            s1,
+            max_seq_len=max_seq_len,
+            feature_keys=["a", "b"],
+            view_requirements=view_requirements)
+        check(s1.max_seq_len, max_len)
+        check(s1["a"].shape[0], max_len * num_seqs)
+        check(s1["b"].shape[0], max_len * num_seqs)
+
+    def test_pad_batch_fixed_max(self):
+        """Test pad_batch_to_sequences_of_same_size when dynamic_max = False"""
+        view_requirements = {
+            "state_in_0": ViewRequirement(
+                "state_out_0",
+                shift="-3:-1",
+                used_for_training=False,
+                used_for_compute_actions=True,
+                batch_repeat_value=1)
+        }
+        max_seq_len = 20
+        num_seqs = np.random.randint(1, 20)
+        seq_lens = np.random.randint(1, max_seq_len, size=(num_seqs))
+        sum_seq_lens = np.sum(seq_lens)
+        s1 = SampleBatch(
+            {
+                "a": np.arange(sum_seq_lens),
+                "b": np.arange(sum_seq_lens),
+                "seq_lens": seq_lens,
+                "state_in_0": [[0]] * num_seqs
+            },
+            _max_seq_len=max_seq_len)
+
+        pad_batch_to_sequences_of_same_size(
+            s1,
+            max_seq_len=max_seq_len,
+            feature_keys=["a", "b"],
+            view_requirements=view_requirements)
+        check(s1.max_seq_len, max_seq_len)
+        check(s1["a"].shape[0], max_seq_len * num_seqs)
+        check(s1["b"].shape[0], max_seq_len * num_seqs)
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/utils/sgd.py
+++ b/rllib/utils/sgd.py
@@ -92,13 +92,23 @@ def do_minibatch_sgd(samples, policies, local_worker, num_sgd_iter,
     # no matter the setup (multi-GPU, multi-agent, minibatch SGD,
     # tf vs torch).
     learner_info_builder = LearnerInfoBuilder(num_devices=1)
-    for policy_id in policies.keys():
+    for policy_id, policy in policies.items():
         if policy_id not in samples.policy_batches:
             continue
 
         batch = samples.policy_batches[policy_id]
         for field in standardize_fields:
             batch[field] = standardized(batch[field])
+
+        # Check to make sure that the sgd_minibatch_size is not smaller
+        # than max_seq_len otherwise this will cause indexing errors while
+        # performing sgd when using a RNN or Attention model
+        if policy.is_recurrent() and \
+           policy.config["model"]["max_seq_len"] > sgd_minibatch_size:
+            raise ValueError("`sgd_minibatch_size` ({}) cannot be smaller than"
+                             "`max_seq_len` ({}).".format(
+                                 sgd_minibatch_size,
+                                 policy.config["model"]["max_seq_len"]))
 
         for i in range(num_sgd_iter):
             for minibatch in minibatches(batch, sgd_minibatch_size):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There where two issues causing the associated issue.

1. pad_batch_to_sequences_of_same_size was not updating max_seq_len when dynamic_max=True. This caused sequence slice alignment issues when doing sgd in ppo with an RNN or Attention model

2. When using an RNN or Attention model the sgd_minibatch_size must be >= to max_seq_len otherwise it will cause slice index issues n doing sgd in ppo

I also added a tests max_seq_len in pad_batch_to_sequences_of_same_size for when dynamic_max is True or False.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #19976 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [N/A] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
