### PR TITLE
[RLlib] Use SampleBrach instead of input dict whenever possible

### DIFF
--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -89,13 +89,13 @@ def cql_loss(policy: Policy, model: ModelV2,
     next_obs = train_batch[SampleBatch.NEXT_OBS]
     terminals = train_batch[SampleBatch.DONES]
 
-    model_out_t, _ = model(SampleBatch(obs=obs, is_training=True), [], None)
+    model_out_t, _ = model(SampleBatch(obs=obs, _is_training=True), [], None)
 
     model_out_tp1, _ = model(
-        SampleBatch(obs=next_obs, is_training=True), [], None)
+        SampleBatch(obs=next_obs, _is_training=True), [], None)
 
     target_model_out_tp1, _ = policy.target_model(
-        SampleBatch(obs=next_obs, is_training=True), [], None)
+        SampleBatch(obs=next_obs, _is_training=True), [], None)
 
     action_dist_class = _get_dist_class(policy, policy.config,
                                         policy.action_space)

--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -91,11 +91,11 @@ def cql_loss(policy: Policy, model: ModelV2,
 
     model_out_t, _ = model(SampleBatch(obs=obs, is_training=True), [], None)
 
-    model_out_tp1, _ = model(SampleBatch(
-        obs=next_obs, is_training=True), [], None)
+    model_out_tp1, _ = model(
+        SampleBatch(obs=next_obs, is_training=True), [], None)
 
-    target_model_out_tp1, _ = policy.target_model(SampleBatch(
-        obs=next_obs, is_training=True), [], None)
+    target_model_out_tp1, _ = policy.target_model(
+        SampleBatch(obs=next_obs, is_training=True), [], None)
 
     action_dist_class = _get_dist_class(policy, policy.config,
                                         policy.action_space)

--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -89,20 +89,13 @@ def cql_loss(policy: Policy, model: ModelV2,
     next_obs = train_batch[SampleBatch.NEXT_OBS]
     terminals = train_batch[SampleBatch.DONES]
 
-    model_out_t, _ = model({
-        "obs": obs,
-        "is_training": True,
-    }, [], None)
+    model_out_t, _ = model(SampleBatch(obs=obs, is_training=True), [], None)
 
-    model_out_tp1, _ = model({
-        "obs": next_obs,
-        "is_training": True,
-    }, [], None)
+    model_out_tp1, _ = model(SampleBatch(
+        obs=next_obs, is_training=True), [], None)
 
-    target_model_out_tp1, _ = policy.target_model({
-        "obs": next_obs,
-        "is_training": True,
-    }, [], None)
+    target_model_out_tp1, _ = policy.target_model(SampleBatch(
+        obs=next_obs, is_training=True), [], None)
 
     action_dist_class = _get_dist_class(policy, policy.config,
                                         policy.action_space)

--- a/rllib/agents/cql/cql_torch_policy.py
+++ b/rllib/agents/cql/cql_torch_policy.py
@@ -92,11 +92,11 @@ def cql_loss(policy: Policy, model: ModelV2,
 
     model_out_t, _ = model(SampleBatch(obs=obs, _is_training=True), [], None)
 
-    model_out_tp1, _ = model(SampleBatch(
-        obs=next_obs, _is_training=True), [], None)
+    model_out_tp1, _ = model(
+        SampleBatch(obs=next_obs, _is_training=True), [], None)
 
-    target_model_out_tp1, _ = target_model(SampleBatch(
-        obs=next_obs, _is_training=True), [], None)
+    target_model_out_tp1, _ = target_model(
+        SampleBatch(obs=next_obs, _is_training=True), [], None)
 
     action_dist_class = _get_dist_class(policy, policy.config,
                                         policy.action_space)

--- a/rllib/agents/cql/cql_torch_policy.py
+++ b/rllib/agents/cql/cql_torch_policy.py
@@ -90,20 +90,13 @@ def cql_loss(policy: Policy, model: ModelV2,
     next_obs = train_batch[SampleBatch.NEXT_OBS]
     terminals = train_batch[SampleBatch.DONES]
 
-    model_out_t, _ = model({
-        "obs": obs,
-        "is_training": True,
-    }, [], None)
+    model_out_t, _ = model(SampleBatch(obs=obs, _is_training=True), [], None)
 
-    model_out_tp1, _ = model({
-        "obs": next_obs,
-        "is_training": True,
-    }, [], None)
+    model_out_tp1, _ = model(SampleBatch(
+        obs=next_obs, _is_training=True), [], None)
 
-    target_model_out_tp1, _ = target_model({
-        "obs": next_obs,
-        "is_training": True,
-    }, [], None)
+    target_model_out_tp1, _ = target_model(SampleBatch(
+        obs=next_obs, _is_training=True), [], None)
 
     action_dist_class = _get_dist_class(policy, policy.config,
                                         policy.action_space)

--- a/rllib/agents/ddpg/ddpg_tf_policy.py
+++ b/rllib/agents/ddpg/ddpg_tf_policy.py
@@ -97,10 +97,8 @@ def get_distribution_inputs_and_class(
         explore: bool = True,
         is_training: bool = False,
         **kwargs) -> Tuple[TensorType, ActionDistribution, List[TensorType]]:
-    model_out, _ = model({
-        "obs": obs_batch,
-        "is_training": is_training,
-    }, [], None)
+    model_out, _ = model(
+        SampleBatch(obs=obs_batch, _is_training=is_training), [], None)
     dist_inputs = model.get_policy_output(model_out)
 
     if isinstance(policy.action_space, Simplex):
@@ -121,14 +119,10 @@ def ddpg_actor_critic_loss(policy: Policy, model: ModelV2, _,
     huber_threshold = policy.config["huber_threshold"]
     l2_reg = policy.config["l2_reg"]
 
-    input_dict = {
-        "obs": train_batch[SampleBatch.CUR_OBS],
-        "is_training": True,
-    }
-    input_dict_next = {
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "is_training": True,
-    }
+    input_dict = SampleBatch(obs=train_batch[SampleBatch.CUR_OBS],
+                             _is_training=True)
+    input_dict_next = SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS],
+                                  _is_training=True)
 
     model_out_t, _ = model(input_dict, [], None)
     model_out_tp1, _ = model(input_dict_next, [], None)

--- a/rllib/agents/ddpg/ddpg_tf_policy.py
+++ b/rllib/agents/ddpg/ddpg_tf_policy.py
@@ -119,10 +119,10 @@ def ddpg_actor_critic_loss(policy: Policy, model: ModelV2, _,
     huber_threshold = policy.config["huber_threshold"]
     l2_reg = policy.config["l2_reg"]
 
-    input_dict = SampleBatch(obs=train_batch[SampleBatch.CUR_OBS],
-                             _is_training=True)
-    input_dict_next = SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS],
-                                  _is_training=True)
+    input_dict = SampleBatch(
+        obs=train_batch[SampleBatch.CUR_OBS], _is_training=True)
+    input_dict_next = SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS], _is_training=True)
 
     model_out_t, _ = model(input_dict, [], None)
     model_out_tp1, _ = model(input_dict_next, [], None)

--- a/rllib/agents/ddpg/ddpg_torch_policy.py
+++ b/rllib/agents/ddpg/ddpg_torch_policy.py
@@ -51,10 +51,10 @@ def ddpg_actor_critic_loss(policy: Policy, model: ModelV2, _,
     huber_threshold = policy.config["huber_threshold"]
     l2_reg = policy.config["l2_reg"]
 
-    input_dict = SampleBatch(obs=train_batch[SampleBatch.CUR_OBS],
-                             _is_training=True)
-    input_dict_next = SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS],
-                                  _is_training=True)
+    input_dict = SampleBatch(
+        obs=train_batch[SampleBatch.CUR_OBS], _is_training=True)
+    input_dict_next = SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS], _is_training=True)
 
     model_out_t, _ = model(input_dict, [], None)
     model_out_tp1, _ = model(input_dict_next, [], None)

--- a/rllib/agents/ddpg/ddpg_torch_policy.py
+++ b/rllib/agents/ddpg/ddpg_torch_policy.py
@@ -51,14 +51,10 @@ def ddpg_actor_critic_loss(policy: Policy, model: ModelV2, _,
     huber_threshold = policy.config["huber_threshold"]
     l2_reg = policy.config["l2_reg"]
 
-    input_dict = {
-        "obs": train_batch[SampleBatch.CUR_OBS],
-        "is_training": True,
-    }
-    input_dict_next = {
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "is_training": True,
-    }
+    input_dict = SampleBatch(obs=train_batch[SampleBatch.CUR_OBS],
+                             _is_training=True)
+    input_dict_next = SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS],
+                                  _is_training=True)
 
     model_out_t, _ = model(input_dict, [], None)
     model_out_tp1, _ = model(input_dict_next, [], None)

--- a/rllib/agents/dqn/simple_q_tf_policy.py
+++ b/rllib/agents/dqn/simple_q_tf_policy.py
@@ -180,11 +180,10 @@ def compute_q_values(policy: Policy,
                      obs: TensorType,
                      explore,
                      is_training=None) -> TensorType:
-    model_out, _ = model({
-        SampleBatch.OBS: obs,
-        "is_training": is_training
-        if is_training is not None else policy._get_is_training_placeholder(),
-    }, [], None)
+    _is_training = (is_training if is_training is not None
+                    else policy._get_is_training_placeholder())
+    model_out, _ = model(
+        SampleBatch(obs=obs, _is_training=_is_training), [], None)
 
     return model_out
 

--- a/rllib/agents/dqn/simple_q_tf_policy.py
+++ b/rllib/agents/dqn/simple_q_tf_policy.py
@@ -180,8 +180,8 @@ def compute_q_values(policy: Policy,
                      obs: TensorType,
                      explore,
                      is_training=None) -> TensorType:
-    _is_training = (is_training if is_training is not None
-                    else policy._get_is_training_placeholder())
+    _is_training = (is_training if is_training is not None else
+                    policy._get_is_training_placeholder())
     model_out, _ = model(
         SampleBatch(obs=obs, _is_training=_is_training), [], None)
 

--- a/rllib/agents/sac/rnnsac_torch_policy.py
+++ b/rllib/agents/sac/rnnsac_torch_policy.py
@@ -215,28 +215,25 @@ def actor_critic_loss(
     assert state_batches
     seq_lens = train_batch.get(SampleBatch.SEQ_LENS)
 
-    model_out_t, state_in_t = model({
-        "obs": train_batch[SampleBatch.CUR_OBS],
-        "prev_actions": train_batch[SampleBatch.PREV_ACTIONS],
-        "prev_rewards": train_batch[SampleBatch.PREV_REWARDS],
-        "is_training": True,
-    }, state_batches, seq_lens)
+    model_out_t, state_in_t = model(SampleBatch(
+        obs=train_batch[SampleBatch.CUR_OBS],
+        prev_actions=train_batch[SampleBatch.PREV_ACTIONS],
+        prev_rewards=train_batch[SampleBatch.PREV_REWARDS],
+        _is_training=True), state_batches, seq_lens)
     states_in_t = model.select_state(state_in_t, ["policy", "q", "twin_q"])
 
-    model_out_tp1, state_in_tp1 = model({
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "prev_actions": train_batch[SampleBatch.ACTIONS],
-        "prev_rewards": train_batch[SampleBatch.REWARDS],
-        "is_training": True,
-    }, state_batches, seq_lens)
+    model_out_tp1, state_in_tp1 = model(SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS],
+        prev_actions=train_batch[SampleBatch.ACTIONS],
+        prev_rewards=train_batch[SampleBatch.REWARDS],
+        _is_training=True), state_batches, seq_lens)
     states_in_tp1 = model.select_state(state_in_tp1, ["policy", "q", "twin_q"])
 
-    target_model_out_tp1, target_state_in_tp1 = target_model({
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "prev_actions": train_batch[SampleBatch.ACTIONS],
-        "prev_rewards": train_batch[SampleBatch.REWARDS],
-        "is_training": True,
-    }, state_batches, seq_lens)
+    target_model_out_tp1, target_state_in_tp1 = target_model(SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS],
+        prev_actions=train_batch[SampleBatch.ACTIONS],
+        prev_rewards=train_batch[SampleBatch.REWARDS],
+        _is_training=True), state_batches, seq_lens)
     target_states_in_tp1 = target_model.select_state(state_in_tp1,
                                                      ["policy", "q", "twin_q"])
 

--- a/rllib/agents/sac/rnnsac_torch_policy.py
+++ b/rllib/agents/sac/rnnsac_torch_policy.py
@@ -215,25 +215,28 @@ def actor_critic_loss(
     assert state_batches
     seq_lens = train_batch.get(SampleBatch.SEQ_LENS)
 
-    model_out_t, state_in_t = model(SampleBatch(
-        obs=train_batch[SampleBatch.CUR_OBS],
-        prev_actions=train_batch[SampleBatch.PREV_ACTIONS],
-        prev_rewards=train_batch[SampleBatch.PREV_REWARDS],
-        _is_training=True), state_batches, seq_lens)
+    model_out_t, state_in_t = model(
+        SampleBatch(
+            obs=train_batch[SampleBatch.CUR_OBS],
+            prev_actions=train_batch[SampleBatch.PREV_ACTIONS],
+            prev_rewards=train_batch[SampleBatch.PREV_REWARDS],
+            _is_training=True), state_batches, seq_lens)
     states_in_t = model.select_state(state_in_t, ["policy", "q", "twin_q"])
 
-    model_out_tp1, state_in_tp1 = model(SampleBatch(
-        obs=train_batch[SampleBatch.NEXT_OBS],
-        prev_actions=train_batch[SampleBatch.ACTIONS],
-        prev_rewards=train_batch[SampleBatch.REWARDS],
-        _is_training=True), state_batches, seq_lens)
+    model_out_tp1, state_in_tp1 = model(
+        SampleBatch(
+            obs=train_batch[SampleBatch.NEXT_OBS],
+            prev_actions=train_batch[SampleBatch.ACTIONS],
+            prev_rewards=train_batch[SampleBatch.REWARDS],
+            _is_training=True), state_batches, seq_lens)
     states_in_tp1 = model.select_state(state_in_tp1, ["policy", "q", "twin_q"])
 
-    target_model_out_tp1, target_state_in_tp1 = target_model(SampleBatch(
-        obs=train_batch[SampleBatch.NEXT_OBS],
-        prev_actions=train_batch[SampleBatch.ACTIONS],
-        prev_rewards=train_batch[SampleBatch.REWARDS],
-        _is_training=True), state_batches, seq_lens)
+    target_model_out_tp1, target_state_in_tp1 = target_model(
+        SampleBatch(
+            obs=train_batch[SampleBatch.NEXT_OBS],
+            prev_actions=train_batch[SampleBatch.ACTIONS],
+            prev_rewards=train_batch[SampleBatch.REWARDS],
+            _is_training=True), state_batches, seq_lens)
     target_states_in_tp1 = target_model.select_state(state_in_tp1,
                                                      ["policy", "q", "twin_q"])
 

--- a/rllib/agents/sac/sac_tf_model.py
+++ b/rllib/agents/sac/sac_tf_model.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.tf.tf_modelv2 import TFModelV2
+from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils import force_list
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
@@ -240,15 +241,17 @@ class SACTFModel(TFModelV2):
         # Continuous case -> concat actions to model_out.
         if actions is not None:
             if self.concat_obs_and_actions:
-                input_dict = {"obs": tf.concat([model_out, actions], axis=-1)}
+                input_dict = SampleBatch(
+                    obs=tf.concat([model_out, actions], axis=-1))
             else:
-                input_dict = {"obs": force_list(model_out) + [actions]}
+                input_dict = SampleBatch(
+                    obs=force_list(model_out) + [actions])
         # Discrete case -> return q-vals for all actions.
         else:
-            input_dict = {"obs": model_out}
+            input_dict = SampleBatch(obs=model_out)
         # Switch on training mode (when getting Q-values, we are usually in
         # training).
-        input_dict["is_training"] = True
+        input_dict.set_training(True)
 
         out, _ = net(input_dict, [], None)
         return out

--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -199,10 +199,9 @@ def get_distribution_inputs_and_class(
             (in the RNN case).
     """
     # Get base-model (forward) output (this should be a noop call).
-    forward_out, state_out = model({
-        "obs": obs_batch,
-        "is_training": policy._get_is_training_placeholder(),
-    }, [], None)
+    forward_out, state_out = model(SampleBatch(
+        obs=obs_batch,
+        _is_training=policy._get_is_training_placeholder()), [], None)
     # Use the base output to get the policy outputs from the SAC model's
     # policy components.
     distribution_inputs = model.get_policy_output(forward_out)
@@ -231,24 +230,22 @@ def sac_actor_critic_loss(
     # Should be True only for debugging purposes (e.g. test cases)!
     deterministic = policy.config["_deterministic_loss"]
 
+    _is_training = policy._get_is_training_placeholder()
     # Get the base model output from the train batch.
-    model_out_t, _ = model({
-        "obs": train_batch[SampleBatch.CUR_OBS],
-        "is_training": policy._get_is_training_placeholder(),
-    }, [], None)
+    model_out_t, _ = model(SampleBatch(
+        obs=train_batch[SampleBatch.CUR_OBS],
+        _is_training=_is_training), [], None)
 
     # Get the base model output from the next observations in the train batch.
-    model_out_tp1, _ = model({
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "is_training": policy._get_is_training_placeholder(),
-    }, [], None)
+    model_out_tp1, _ = model(SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS],
+        _is_training=_is_training), [], None)
 
     # Get the target model's base outputs from the next observations in the
     # train batch.
-    target_model_out_tp1, _ = policy.target_model({
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "is_training": policy._get_is_training_placeholder(),
-    }, [], None)
+    target_model_out_tp1, _ = policy.target_model(SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS],
+        _is_training=_is_training), [], None)
 
     # Discrete actions case.
     if model.discrete:

--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -199,9 +199,10 @@ def get_distribution_inputs_and_class(
             (in the RNN case).
     """
     # Get base-model (forward) output (this should be a noop call).
-    forward_out, state_out = model(SampleBatch(
-        obs=obs_batch,
-        _is_training=policy._get_is_training_placeholder()), [], None)
+    forward_out, state_out = model(
+        SampleBatch(
+            obs=obs_batch, _is_training=policy._get_is_training_placeholder()),
+        [], None)
     # Use the base output to get the policy outputs from the SAC model's
     # policy components.
     distribution_inputs = model.get_policy_output(forward_out)
@@ -232,20 +233,23 @@ def sac_actor_critic_loss(
 
     _is_training = policy._get_is_training_placeholder()
     # Get the base model output from the train batch.
-    model_out_t, _ = model(SampleBatch(
-        obs=train_batch[SampleBatch.CUR_OBS],
-        _is_training=_is_training), [], None)
+    model_out_t, _ = model(
+        SampleBatch(
+            obs=train_batch[SampleBatch.CUR_OBS], _is_training=_is_training),
+        [], None)
 
     # Get the base model output from the next observations in the train batch.
-    model_out_tp1, _ = model(SampleBatch(
-        obs=train_batch[SampleBatch.NEXT_OBS],
-        _is_training=_is_training), [], None)
+    model_out_tp1, _ = model(
+        SampleBatch(
+            obs=train_batch[SampleBatch.NEXT_OBS], _is_training=_is_training),
+        [], None)
 
     # Get the target model's base outputs from the next observations in the
     # train batch.
-    target_model_out_tp1, _ = policy.target_model(SampleBatch(
-        obs=train_batch[SampleBatch.NEXT_OBS],
-        _is_training=_is_training), [], None)
+    target_model_out_tp1, _ = policy.target_model(
+        SampleBatch(
+            obs=train_batch[SampleBatch.NEXT_OBS], _is_training=_is_training),
+        [], None)
 
     # Discrete actions case.
     if model.discrete:

--- a/rllib/agents/sac/sac_torch_model.py
+++ b/rllib/agents/sac/sac_torch_model.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
-from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils import force_list
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_torch
@@ -249,17 +248,17 @@ class SACTorchModel(TorchModelV2, nn.Module):
         # Continuous case -> concat actions to model_out.
         if actions is not None:
             if self.concat_obs_and_actions:
-                input_dict = SampleBatch(
-                    obs=torch.cat([model_out, actions], dim=-1))
+                input_dict = {"obs": torch.cat([model_out, actions], dim=-1)}
             else:
-                input_dict = SampleBatch(
-                    obs=force_list(model_out) + [actions])
+                # TODO(junogng) : SampleBatch doesn't support list columns yet.
+                #     Use ModelInputDict.
+                input_dict = {"obs": force_list(model_out) + [actions]}
         # Discrete case -> return q-vals for all actions.
         else:
-            input_dict = SampleBatch(obs=model_out)
+            input_dict = {"obs": model_out}
         # Switch on training mode (when getting Q-values, we are usually in
         # training).
-        input_dict.set_training(True)
+        input_dict["is_training"] = True
 
         out, _ = net(input_dict, [], None)
         return out

--- a/rllib/agents/sac/sac_torch_policy.py
+++ b/rllib/agents/sac/sac_torch_policy.py
@@ -175,20 +175,17 @@ def actor_critic_loss(
     # Should be True only for debugging purposes (e.g. test cases)!
     deterministic = policy.config["_deterministic_loss"]
 
-    model_out_t, _ = model({
-        "obs": train_batch[SampleBatch.CUR_OBS],
-        "is_training": True,
-    }, [], None)
+    model_out_t, _ = model(SampleBatch(
+        obs=train_batch[SampleBatch.CUR_OBS],
+        is_training=True), [], None)
 
-    model_out_tp1, _ = model({
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "is_training": True,
-    }, [], None)
+    model_out_tp1, _ = model(SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS],
+        is_training=True), [], None)
 
-    target_model_out_tp1, _ = target_model({
-        "obs": train_batch[SampleBatch.NEXT_OBS],
-        "is_training": True,
-    }, [], None)
+    target_model_out_tp1, _ = target_model(SampleBatch(
+        obs=train_batch[SampleBatch.NEXT_OBS],
+        is_training=True), [], None)
 
     alpha = torch.exp(model.log_alpha)
 

--- a/rllib/agents/sac/sac_torch_policy.py
+++ b/rllib/agents/sac/sac_torch_policy.py
@@ -175,17 +175,17 @@ def actor_critic_loss(
     # Should be True only for debugging purposes (e.g. test cases)!
     deterministic = policy.config["_deterministic_loss"]
 
-    model_out_t, _ = model(SampleBatch(
-        obs=train_batch[SampleBatch.CUR_OBS],
-        is_training=True), [], None)
+    model_out_t, _ = model(
+        SampleBatch(obs=train_batch[SampleBatch.CUR_OBS], is_training=True),
+        [], None)
 
-    model_out_tp1, _ = model(SampleBatch(
-        obs=train_batch[SampleBatch.NEXT_OBS],
-        is_training=True), [], None)
+    model_out_tp1, _ = model(
+        SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS], is_training=True),
+        [], None)
 
-    target_model_out_tp1, _ = target_model(SampleBatch(
-        obs=train_batch[SampleBatch.NEXT_OBS],
-        is_training=True), [], None)
+    target_model_out_tp1, _ = target_model(
+        SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS], is_training=True),
+        [], None)
 
     alpha = torch.exp(model.log_alpha)
 

--- a/rllib/agents/sac/sac_torch_policy.py
+++ b/rllib/agents/sac/sac_torch_policy.py
@@ -176,15 +176,15 @@ def actor_critic_loss(
     deterministic = policy.config["_deterministic_loss"]
 
     model_out_t, _ = model(
-        SampleBatch(obs=train_batch[SampleBatch.CUR_OBS], is_training=True),
+        SampleBatch(obs=train_batch[SampleBatch.CUR_OBS], _is_training=True),
         [], None)
 
     model_out_tp1, _ = model(
-        SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS], is_training=True),
+        SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS], _is_training=True),
         [], None)
 
     target_model_out_tp1, _ = target_model(
-        SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS], is_training=True),
+        SampleBatch(obs=train_batch[SampleBatch.NEXT_OBS], _is_training=True),
         [], None)
 
     alpha = torch.exp(model.log_alpha)

--- a/rllib/contrib/maddpg/maddpg_policy.py
+++ b/rllib/contrib/maddpg/maddpg_policy.py
@@ -323,10 +323,10 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
         with tf1.variable_scope(scope, reuse=tf1.AUTO_REUSE) as scope:
             if use_state_preprocessor:
                 model_n = [
-                    ModelCatalog.get_model({
-                        SampleBatch.OBS: obs,
-                        "is_training": self._get_is_training_placeholder(),
-                    }, obs_space, act_space, 1, self.config["model"])
+                    ModelCatalog.get_model(SampleBatch(
+                        obs=obs,
+                        _is_training=self._get_is_training_placeholder()),
+                        obs_space, act_space, 1, self.config["model"])
                     for obs, obs_space, act_space in zip(
                         obs_n, obs_space_n, act_space_n)
                 ]
@@ -354,10 +354,10 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
                              scope=None):
         with tf1.variable_scope(scope, reuse=tf1.AUTO_REUSE) as scope:
             if use_state_preprocessor:
-                model = ModelCatalog.get_model({
-                    SampleBatch.OBS: obs,
-                    "is_training": self._get_is_training_placeholder(),
-                }, obs_space, act_space, 1, self.config["model"])
+                model = ModelCatalog.get_model(SampleBatch(
+                    obs=obs,
+                    _is_training=self._get_is_training_placeholder()),
+                    obs_space, act_space, 1, self.config["model"])
                 out = model.last_layer
             else:
                 model = None

--- a/rllib/contrib/maddpg/maddpg_policy.py
+++ b/rllib/contrib/maddpg/maddpg_policy.py
@@ -323,9 +323,10 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
         with tf1.variable_scope(scope, reuse=tf1.AUTO_REUSE) as scope:
             if use_state_preprocessor:
                 model_n = [
-                    ModelCatalog.get_model(SampleBatch(
-                        obs=obs,
-                        _is_training=self._get_is_training_placeholder()),
+                    ModelCatalog.get_model(
+                        SampleBatch(
+                            obs=obs,
+                            _is_training=self._get_is_training_placeholder()),
                         obs_space, act_space, 1, self.config["model"])
                     for obs, obs_space, act_space in zip(
                         obs_n, obs_space_n, act_space_n)
@@ -354,9 +355,10 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
                              scope=None):
         with tf1.variable_scope(scope, reuse=tf1.AUTO_REUSE) as scope:
             if use_state_preprocessor:
-                model = ModelCatalog.get_model(SampleBatch(
-                    obs=obs,
-                    _is_training=self._get_is_training_placeholder()),
+                model = ModelCatalog.get_model(
+                    SampleBatch(
+                        obs=obs,
+                        _is_training=self._get_is_training_placeholder()),
                     obs_space, act_space, 1, self.config["model"])
                 out = model.last_layer
             else:

--- a/rllib/examples/custom_model_api.py
+++ b/rllib/examples/custom_model_api.py
@@ -5,6 +5,7 @@ import numpy as np
 from ray.rllib.examples.models.custom_model_api import DuelingQModel, \
     TorchDuelingQModel, ContActionQModel, TorchContActionQModel
 from ray.rllib.models.catalog import ModelCatalog, MODEL_DEFAULTS
+from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 
 tf1, tf, tfv = try_import_tf()
@@ -51,10 +52,7 @@ if __name__ == "__main__":
     if args.framework == "torch":
         input_ = torch.from_numpy(input_)
 
-    input_dict = {
-        "obs": input_,
-        "is_training": False,
-    }
+    input_dict = SampleBatch(obs=input_, _is_training=False)
     out, state_outs = my_dueling_model(input_dict=input_dict)
     assert out.shape == (10, 256)
     # Pass `out` into `get_q_values`
@@ -90,10 +88,7 @@ if __name__ == "__main__":
     if args.framework == "torch":
         input_ = torch.from_numpy(input_)
 
-    input_dict = {
-        "obs": input_,
-        "is_training": False,
-    }
+    input_dict = SampleBatch(obs=input_, _is_training=False)
     # Note that for PyTorch, you will have to provide torch tensors here.
     out, state_outs = my_cont_action_q_model(input_dict=input_dict)
     assert out.shape == (10, 256)

--- a/rllib/examples/models/batch_norm_model.py
+++ b/rllib/examples/models/batch_norm_model.py
@@ -69,7 +69,8 @@ class KerasBatchNormModel(TFModelV2):
             is_training = input_dict["is_training"]
         # Have to batch the is_training flag (B=1).
         out, self._value_out = self.base_model(
-            [input_dict["obs"], tf.expand_dims(is_training, 0)])
+            [input_dict["obs"],
+             tf.expand_dims(is_training, 0)])
         return out, []
 
     @override(ModelV2)
@@ -117,9 +118,7 @@ class BatchNormModel(TFModelV2):
                     name="fc{}".format(i))
                 # Add a batch norm layer
                 last_layer = tf1.layers.batch_normalization(
-                    last_layer,
-                    training=is_training,
-                    name="bn_{}".format(i))
+                    last_layer, training=is_training, name="bn_{}".format(i))
 
             output = tf1.layers.dense(
                 last_layer,

--- a/rllib/examples/models/batch_norm_model.py
+++ b/rllib/examples/models/batch_norm_model.py
@@ -6,6 +6,7 @@ from ray.rllib.models.tf.tf_modelv2 import TFModelV2
 from ray.rllib.models.torch.misc import SlimFC, normc_initializer as \
     torch_normc_initializer
 from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
+from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 
@@ -62,10 +63,13 @@ class KerasBatchNormModel(TFModelV2):
 
     @override(ModelV2)
     def forward(self, input_dict, state, seq_lens):
+        if isinstance(input_dict, SampleBatch):
+            is_training = input_dict.is_training
+        else:
+            is_training = input_dict["is_training"]
         # Have to batch the is_training flag (B=1).
         out, self._value_out = self.base_model(
-            [input_dict["obs"],
-             tf.expand_dims(input_dict["is_training"], 0)])
+            [input_dict["obs"], tf.expand_dims(is_training, 0)])
         return out, []
 
     @override(ModelV2)
@@ -100,6 +104,10 @@ class BatchNormModel(TFModelV2):
         last_layer = input_dict["obs"]
         hiddens = [256, 256]
         with tf1.variable_scope("model", reuse=tf1.AUTO_REUSE):
+            if isinstance(input_dict, SampleBatch):
+                is_training = input_dict.is_training
+            else:
+                is_training = input_dict["is_training"]
             for i, size in enumerate(hiddens):
                 last_layer = tf1.layers.dense(
                     last_layer,
@@ -110,7 +118,7 @@ class BatchNormModel(TFModelV2):
                 # Add a batch norm layer
                 last_layer = tf1.layers.batch_normalization(
                     last_layer,
-                    training=input_dict["is_training"],
+                    training=is_training,
                     name="bn_{}".format(i))
 
             output = tf1.layers.dense(
@@ -194,10 +202,13 @@ class TorchBatchNormModel(TorchModelV2, nn.Module):
 
     @override(ModelV2)
     def forward(self, input_dict, state, seq_lens):
+        if isinstance(input_dict, SampleBatch):
+            is_training = bool(input_dict.is_training)
+        else:
+            is_training = bool(input_dict.get("is_training", False))
         # Set the correct train-mode for our hidden module (only important
         # b/c we have some batch-norm layers).
-        self._hidden_layers.train(
-            mode=bool(input_dict.get("is_training", False)))
+        self._hidden_layers.train(mode=is_training)
         self._hidden_out = self._hidden_layers(input_dict["obs"])
         logits = self._logits(self._hidden_out)
         return logits, []

--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -272,7 +272,7 @@ class ModelV2:
         """
 
         input_dict = train_batch.copy()
-        input_dict["is_training"] = is_training
+        input_dict.set_training(is_training)
         states = []
         i = 0
         while "state_in_{}".format(i) in input_dict:

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -285,7 +285,11 @@ class TFPolicy(Policy):
         timestep = timestep if timestep is not None else self.global_timestep
 
         # Switch off is_training flag in our batch.
-        input_dict["is_training"] = False
+        if isinstance(input_dict, SampleBatch):
+            input_dict.set_training(False)
+        else:
+            # Deprecated dict input.
+            input_dict["is_training"] = False
 
         builder = TFRunBuilder(self.get_session(),
                                "compute_actions_from_input_dict")


### PR DESCRIPTION
## Why are these changes needed?

To get rid of all the SampleBatch["is_training"] deprecated warnings.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
