### PR TITLE
[RLLib] Fix deprecation message and migrate import

### DIFF
--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -124,7 +124,7 @@ class BaseEnv:
             The resulting BaseEnv object.
         """
 
-        from ray.rllib.env.remote_vector_env import RemoteBaseEnv
+        from ray.rllib.env.remote_base_env import RemoteBaseEnv
         if remote_envs and num_envs == 1:
             raise ValueError(
                 "Remote envs only make sense to use if num_envs > 1 "

--- a/rllib/env/remote_vector_env.py
+++ b/rllib/env/remote_vector_env.py
@@ -2,7 +2,7 @@ from ray.rllib.env.remote_base_env import RemoteBaseEnv
 from ray.rllib.utils.deprecation import deprecation_warning
 
 deprecation_warning(
-    old="rllib.env.remote_base_env.RemoteVectorEnv",
+    old="rllib.env.remote_vector_env.RemoteVectorEnv",
     new="ray.rllib.env.remote_base_env.RemoteBaseEnv",
     error=False)
 


### PR DESCRIPTION
When trying to import a RemoteBaseEnv here: https://github.com/ray-project/ray/blob/15a51b7c65d5ef7653162631cf9537ac6b689e16/rllib/env/base_env.py#L127
we are triggering a deprecation warning here: https://github.com/ray-project/ray/blob/15a51b7c65d5ef7653162631cf9537ac6b689e16/rllib/env/remote_vector_env.py#L1-L9
that looks something like this:
WARNING deprecation.py:46 -- DeprecationWarning: `rllib.env.remote_base_env.RemoteVectorEnv` has been deprecated. Use `ray.rllib.env.remote_base_env.RemoteBaseEnv` instead. This will raise an error in the future!

I both updated the import to correctly import the new module, and changed the deprecation message to correctly show the deprecated module.