### PR TITLE
[CI] Make `num_files` optional for XGBoost test utils

### DIFF
--- a/python/ray/util/xgboost/release_test_util.py
+++ b/python/ray/util/xgboost/release_test_util.py
@@ -60,7 +60,7 @@ class TrackingCallback(TrainingCallback):
         put_queue(get_world_size())
 
 
-def get_parquet_files(path, num_files):
+def get_parquet_files(path, num_files=0):
     path = os.path.expanduser(path)
     if not os.path.exists(path):
         raise ValueError(f"Path does not exist: {path}")

--- a/python/ray/util/xgboost/release_test_util.py
+++ b/python/ray/util/xgboost/release_test_util.py
@@ -81,7 +81,7 @@ def train_ray(path,
               xgboost_params=None,
               **kwargs):
     if not isinstance(path, list):
-        path = get_parquet_files(path)
+        path = get_parquet_files(path, num_files=num_files)
 
     use_device_matrix = False
     if use_gpu:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Quick fix for release tests failing with:
```
  File "workloads/tune_small.py", line 34, in train_wrapper
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/util/xgboost/release_test_util.py", line 84, in train_ray
    path = get_parquet_files(path)
TypeError: get_parquet_files() missing 1 required positional argument: 'num_files'
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
