### PR TITLE
[train] update Trainer._is_tune_enabled to work when Tune is not installed

### DIFF
--- a/.buildkite/pipeline.gpu.large.yml
+++ b/.buildkite/pipeline.gpu.large.yml
@@ -2,7 +2,7 @@
   conditions: ["RAY_CI_TRAIN_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
-    - SGD_TESTING=1 INSTALL_HOROVOD=1 ./ci/travis/install-dependencies.sh
+    - TRAIN_TESTING=1 TUNE_TESTING=1 INSTALL_HOROVOD=1 ./ci/travis/install-dependencies.sh
     - pip install -Ur ./python/requirements_ml_docker.txt
     - ./ci/travis/env_info.sh
     - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=gpu,gpu_only python/ray/train/...
@@ -11,7 +11,7 @@
   conditions: ["RAY_CI_TRAIN_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
-    - SGD_TESTING=1 DATA_PROCESSING_TESTING=1 PYTHON=3.7 ./ci/travis/install-dependencies.sh
+    - TRAIN_TESTING=1 DATA_PROCESSING_TESTING=1 PYTHON=3.7 ./ci/travis/install-dependencies.sh
     # Because Python version changed, we need to re-install Ray here
     - rm -rf ./python/ray/thirdparty_files; rm -rf ./python/ray/pickle5_files; ./ci/travis/ci.sh build
     - pip install -Ur ./python/requirements_ml_docker.txt

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -695,8 +695,15 @@
   conditions: ["RAY_CI_TRAIN_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
-    - SGD_TESTING=1 INSTALL_HOROVOD=1 ./ci/travis/install-dependencies.sh
-    - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=-gpu_only python/ray/train/...
+    - TRAIN_TESTING=1 INSTALL_HOROVOD=1 ./ci/travis/install-dependencies.sh
+    - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=-gpu_only,-tune python/ray/train/...
+
+- label: ":steam_locomotive: :octopus: Train + Tune tests and examples"
+  conditions: ["RAY_CI_TRAIN_AFFECTED"]
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
+    - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/travis/install-dependencies.sh
+    - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=tune,-gpu_only python/ray/train/...
 
 - label: ":octopus: SGD tests and examples"
   conditions: ["RAY_CI_SGD_AFFECTED"]

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -360,7 +360,7 @@ install_dependencies() {
   fi
 
   # Additional Train test dependencies.
-  if [ "${TRAIN_TESTING-}" != 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
+  if [ "${TRAIN_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
     pip install -r "${WORKSPACE_DIR}"/python/requirements/ml/requirements_train.txt
   fi
 

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -361,7 +361,7 @@ install_dependencies() {
 
   # Additional Train test dependencies.
   if [ "${TRAIN_TESTING-}" != 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
-    pip install -r "${WORKSPACE_DIR}"/python/requirements/ml/requirements_dl.txt
+    pip install -r "${WORKSPACE_DIR}"/python/requirements/ml/requirements_train.txt
   fi
 
 

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -307,7 +307,7 @@ install_dependencies() {
 
   if [ -n "${PYTHON-}" ] && [ "${MINIMAL_INSTALL-}" != 1 ]; then
     # Remove this entire section once Serve dependencies are fixed.
-    if [ "${DOC_TESTING-}" != 1 ] && [ "${SGD_TESTING-}" != 1 ] && [ "${TUNE_TESTING-}" != 1 ] && [ "${RLLIB_TESTING-}" != 1 ]; then
+    if [ "${DOC_TESTING-}" != 1 ] && [ "${SGD_TESTING-}" != 1 ] && [ "${TRAIN_TESTING-}" != 1 ] && [ "${TUNE_TESTING-}" != 1 ] && [ "${RLLIB_TESTING-}" != 1 ]; then
       # PyTorch is installed first since we are using a "-f" directive to find the wheels.
       # We want to install the CPU version only.
       local torch_url="https://download.pytorch.org/whl/torch_stable.html"
@@ -387,7 +387,7 @@ install_dependencies() {
   fi
 
   # Remove this entire section once Serve dependencies are fixed.
-  if [ "${MINIMAL_INSTALL-}" != 1 ] && [ "${DOC_TESTING-}" != 1 ] && [ "${SGD_TESTING-}" != 1 ] && [ "${TUNE_TESTING-}" != 1 ] && [ "${RLLIB_TESTING-}" != 1 ]; then
+  if [ "${MINIMAL_INSTALL-}" != 1 ] && [ "${DOC_TESTING-}" != 1 ] && [ "${SGD_TESTING-}" != 1 ] && [ "${TRAIN_TESTING-}" != 1 ] && [ "${TUNE_TESTING-}" != 1 ] && [ "${RLLIB_TESTING-}" != 1 ]; then
     # If CI has deemed that a different version of Torch
     # should be installed, then upgrade/downgrade to that specific version.
     if [ -n "${TORCH_VERSION-}" ]; then

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -359,6 +359,12 @@ install_dependencies() {
     pip install 'recsim>=0.2.4'
   fi
 
+  # Additional Train test dependencies.
+  if [ "${TRAIN_TESTING-}" != 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
+    pip install -r "${WORKSPACE_DIR}"/python/requirements/ml/requirements_dl.txt
+  fi
+
+
   # Additional Tune/SGD/Doc test dependencies.
   if [ "${TUNE_TESTING-}" = 1 ] || [ "${SGD_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
     pip install -r "${WORKSPACE_DIR}"/python/requirements/ml/requirements_tune.txt

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -47,7 +47,7 @@ py_test(
     size = "medium",
     main = "examples/tune_cifar_pytorch_pbt_example.py",
     srcs = ["examples/tune_cifar_pytorch_pbt_example.py"],
-    tags = ["team:ml", "exclusive", "pytorch"],
+    tags = ["team:ml", "exclusive", "pytorch", "tune"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -57,7 +57,7 @@ py_test(
     size = "medium",
     main = "examples/tune_linear_dataset_example.py",
     srcs = ["examples/tune_linear_dataset_example.py"],
-    tags = ["team:ml", "exclusive", "gpu_only"],
+    tags = ["team:ml", "exclusive", "gpu_only", "tune"],
     deps = [":train_lib"],
     args = ["--smoke-test", "--use-gpu"]
 )
@@ -67,7 +67,7 @@ py_test(
     size = "medium",
     main = "examples/tune_linear_example.py",
     srcs = ["examples/tune_linear_example.py"],
-    tags = ["team:ml", "exclusive"],
+    tags = ["team:ml", "exclusive", "tune"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -129,7 +129,7 @@ py_test(
     name = "test_tune",
     size = "medium",
     srcs = ["tests/test_tune.py"],
-    tags = ["team:ml", "exclusive"],
+    tags = ["team:ml", "exclusive", "tune"],
     deps = [":train_lib"]
 )
 

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -35,7 +35,7 @@ py_test(
     size = "large",
     main = "examples/transformers/transformers_example.py",
     srcs = ["examples/transformers/transformers_example.py"],
-    tags = ["team:ml", "exclusive"],
+    tags = ["team:ml", "exclusive", "tune"],
     deps = [":train_lib"],
     args = ["--model_name_or_path=bert-base-cased", "--task_name=mrpc",
     "--max_length=32", "--per_device_train_batch_size=64",

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -219,7 +219,7 @@ class Trainer:
 
     def _is_tune_enabled(self):
         """Whether or not this Trainer is part of a Tune session."""
-        return tune is not None and tune.is_session_enabled()
+        return TUNE_INSTALLED and tune.is_session_enabled()
 
     def start(self, initialization_hook: Optional[Callable[[], None]] = None):
         """Starts the training execution service.

--- a/python/requirements/ml/requirements_train.txt
+++ b/python/requirements/ml/requirements_train.txt
@@ -1,0 +1,10 @@
+-r requirements_dl.txt
+
+mlflow==1.21.0
+
+# Dependencies for Hugging Face examples:
+# `python/ray/train/examples/transformers/transformers_example.py`
+transformers==4.10.0
+accelerate==0.5.1
+datasets==1.14.0
+sentencepiece==0.1.96

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -40,9 +40,3 @@ transformers==4.10.0
 wandb==0.12.5
 xgboost==1.3.3
 zoopt==0.4.1
-
-# Dependencies for Hugging Face examples:
-# `python/ray/train/examples/transformers/transformers_example.py`
-accelerate==0.5.1
-datasets==1.14.0
-sentencepiece==0.1.96


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes minimal install path which raises the following error:
```python
from ray.train import Trainer
trainer = Trainer(backend="torch", num_workers=2)
```
```
    return tune is not None and tune.is_session_enabled()
AttributeError: type object 'object' has no attribute 'is_session_enabled'
```

### Root Cause 
When Tune is not installed, `tune` defaults to `object`, not `None`.

```
tune = PlacementGroupFactory = Trainable = object
```
With this logic, `tune` will never be `None`.

### Fix
Update the check to check if `TUNE_INSTALLED` instead of `tune is not None`.

### Testing
This was not caught in testing before because we previously always installed Tune dependencies when running Train tests. In this PR, a new `TRAIN_TESTING` flag is introduced which will install dependencies from a new `requirements_train.txt` file. Train tests will be run on an environment without Tune, with separate pipeline steps split out to test `Train + Tune` tests (which will install both Train and Tune dependencies).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
