### PR TITLE
Add missing deployment calls in doc

### DIFF
--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -36,7 +36,7 @@ FastAPI HTTP Deployments
 If you want to define more complex HTTP handling logic, Serve integrates with `FastAPI <https://fastapi.tiangolo.com/>`_. This allows you to define a Serve deployment using the :mod:`@serve.ingress <ray.serve.api.ingress>` decorator that wraps a FastAPI app with its full range of features. The most basic example of this is shown below, but for more details on all that FastAPI has to offer such as variable routes, automatic type validation, dependency injection (e.g., for database connections), and more, please check out `their documentation <https://fastapi.tiangolo.com/>`_.
 
 .. code-block:: python
-    
+
     import ray
 
     from fastapi import FastAPI
@@ -58,9 +58,9 @@ If you want to define more complex HTTP handling logic, Serve integrates with `F
 Now if you send a request to ``/hello``, this will be routed to the ``root`` method of our deployment. We can also easily leverage FastAPI to define multiple routes with different HTTP methods:
 
 .. code-block:: python
-    
+
     import ray
-    
+
     from fastapi import FastAPI
     from ray import serve
 
@@ -84,9 +84,9 @@ Now if you send a request to ``/hello``, this will be routed to the ``root`` met
 You can also pass in an existing FastAPI app to a deployment to serve it as-is:
 
 .. code-block:: python
-    
+
     import ray
-    
+
     from fastapi import FastAPI
     from ray import serve
 
@@ -105,12 +105,14 @@ You can also pass in an existing FastAPI app to a deployment to serve it as-is:
     class FastAPIWrapper:
         pass
 
+    FastAPIWrapper.deploy()
+
 This is useful for scaling out an existing FastAPI app with no modifications necessary.
 Existing middlewares, automatic OpenAPI documentation generation, and other advanced FastAPI features should work as-is.
 You can also combine routes defined this way with routes defined on the deployment:
 
 .. code-block:: python
-    
+
     import ray
 
     from fastapi import FastAPI
@@ -137,6 +139,9 @@ You can also combine routes defined this way with routes defined on the deployme
         @app.get("/subpath")
         def method(self):
             return "Hello 2!"
+
+    FastAPIWrapper1.deploy()
+    FastAPIWrapper2.deploy()
 
 In this example, requests to both ``/api1`` and ``/api2`` would return ``Hello from the root!`` while a request to ``/api1/subpath`` would return ``Hello 1!`` and a request to ``/api2/subpath`` would return ``Hello 2!``.
 
@@ -197,8 +202,8 @@ reach a deployment through HTTP via a specific route. When you issue a request
 to a deployment through ``ServeHandle``, the request is load balanced across
 available replicas in the same way an HTTP request is.
 
-To call a Ray Serve deployment from python, use :mod:`Deployment.get_handle <ray.serve.api.Deployment>` 
-to get a handle to the deployment, then use 
+To call a Ray Serve deployment from python, use :mod:`Deployment.get_handle <ray.serve.api.Deployment>`
+to get a handle to the deployment, then use
 :mod:`handle.remote <ray.serve.handle.RayServeHandle.remote>` to send requests
 to that deployment. These requests can pass ordinary args and kwargs that are
 passed directly to the method. This returns a Ray ``ObjectRef`` whose result


### PR DESCRIPTION
## Why are these changes needed?

Some code snippets in [our documentation](https://docs.ray.io/en/latest/serve/http-servehandle.html#fastapi-http-deployments)  is missing `deploy()` call to be fully reproducible on user laptop as standalone scripts. User has reported this from #serve channel.  

## Related issue number

Closes #20768

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
