### PR TITLE
Add Pydantic validation to Serve AutoscalingConfig class

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import pydantic
 from google.protobuf.json_format import MessageToDict
 from pydantic import BaseModel, NonNegativeFloat, PositiveInt, validator
+from pydantic.types import NonNegativeInt, PositiveFloat
 from ray.serve.constants import DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT
 from ray.serve.generated.serve_pb2 import (
     DeploymentConfig as DeploymentConfigProto, AutoscalingConfig as
@@ -20,30 +21,37 @@ class AutoscalingConfig(BaseModel):
     # `src/ray/protobuf/serve.proto`.
 
     # Publicly exposed options
-    min_replicas: int = 1
-    max_replicas: int = 1
-    target_num_ongoing_requests_per_replica: int = 1
+    min_replicas: NonNegativeInt = 1
+    max_replicas: PositiveInt = 1
+    target_num_ongoing_requests_per_replica: NonNegativeInt = 1
 
     # Private options below.
 
     # Metrics scraping options
 
     # How often to scrape for metrics
-    metrics_interval_s: float = 10.0
+    metrics_interval_s: PositiveFloat = 10.0
     # Time window to average over for metrics.
-    look_back_period_s: float = 30.0
+    look_back_period_s: PositiveFloat = 30.0
 
     # Internal autoscaling configuration options
 
     # Multiplicative "gain" factor to limit scaling decisions
-    smoothing_factor: float = 1.0
+    smoothing_factor: PositiveFloat = 1.0
 
     # How frequently to make autoscaling decisions
     # loop_period_s: float = CONTROL_LOOP_PERIOD_S
     # How long to wait before scaling down replicas
-    downscale_delay_s: float = 600.0
+    downscale_delay_s: NonNegativeFloat = 600.0
     # How long to wait before scaling up replicas
-    upscale_delay_s: float = 30.0
+    upscale_delay_s: NonNegativeFloat = 30.0
+
+    @validator("max_replicas")
+    def max_replicas_greater_than_or_equal_to_min_replicas(cls, v, values):
+        if "min_replicas" in values and v < values["min_replicas"]:
+            raise ValueError("max_replicas must be greater than"
+                             "or equal to min_replicas!")
+        return v
 
     # TODO(architkulkarni): implement below
     # The number of replicas to start with when creating the deployment
@@ -53,7 +61,6 @@ class AutoscalingConfig(BaseModel):
     # panic_mode_threshold: float = 2.0
 
     # TODO(architkulkarni): Add reasonable defaults
-    # TODO(architkulkarni): Add pydantic validation.  E.g. max_replicas>=min
 
 
 class DeploymentConfig(BaseModel):

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pydantic
 from google.protobuf.json_format import MessageToDict
-from pydantic import BaseModel, NonNegativeFloat, PositiveInt, validator
-from pydantic.types import NonNegativeInt, PositiveFloat
+from pydantic import (BaseModel, NonNegativeFloat, PositiveFloat,
+                      NonNegativeInt, PositiveInt, validator)
 from ray.serve.constants import DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT
 from ray.serve.generated.serve_pb2 import (
     DeploymentConfig as DeploymentConfigProto, AutoscalingConfig as

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -49,8 +49,9 @@ class AutoscalingConfig(BaseModel):
     @validator("max_replicas")
     def max_replicas_greater_than_or_equal_to_min_replicas(cls, v, values):
         if "min_replicas" in values and v < values["min_replicas"]:
-            raise ValueError("max_replicas must be greater than"
-                             "or equal to min_replicas!")
+            raise ValueError(f"""max_replicas ({v}) must be greater than """
+                             f"""or equal to min_replicas """
+                             f"""({values["min_replicas"]})!""")
         return v
 
     # TODO(architkulkarni): implement below

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -11,29 +11,20 @@ def test_autoscaling_config_validation():
 
     with pytest.raises(ValidationError):
         # min_replicas must be nonnegative
-        AutoscalingConfig(
-            min_replicas=-1
-        )
-    
+        AutoscalingConfig(min_replicas=-1)
+
     with pytest.raises(ValidationError):
         # max_replicas must be positive
-        AutoscalingConfig(
-            max_replicas=0
-        )
-    
+        AutoscalingConfig(max_replicas=0)
+
     with pytest.raises(ValidationError):
         # max_replicas must be nonnegative
-        AutoscalingConfig(
-            target_num_ongoing_requests_per_replica=-1
-        )
-    
+        AutoscalingConfig(target_num_ongoing_requests_per_replica=-1)
+
     with pytest.raises(ValueError):
         # max_replicas must be greater than or equal to min_replicas
-        AutoscalingConfig(
-            min_replicas=100,
-            max_replicas=1
-        )
-    
+        AutoscalingConfig(min_replicas=100, max_replicas=1)
+
     # Default values should not raise an error
     AutoscalingConfig()
 

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -6,6 +6,38 @@ from ray.serve.config import (DeploymentConfig, DeploymentMode, HTTPOptions,
 from ray.serve.config import AutoscalingConfig
 
 
+def test_autoscaling_config_validation():
+    # Check validation over publicly exposed options
+
+    with pytest.raises(ValidationError):
+        # min_replicas must be nonnegative
+        AutoscalingConfig(
+            min_replicas=-1
+        )
+    
+    with pytest.raises(ValidationError):
+        # max_replicas must be positive
+        AutoscalingConfig(
+            max_replicas=0
+        )
+    
+    with pytest.raises(ValidationError):
+        # max_replicas must be nonnegative
+        AutoscalingConfig(
+            target_num_ongoing_requests_per_replica=-1
+        )
+    
+    with pytest.raises(ValueError):
+        # max_replicas must be greater than or equal to min_replicas
+        AutoscalingConfig(
+            min_replicas=100,
+            max_replicas=1
+        )
+    
+    # Default values should not raise an error
+    AutoscalingConfig()
+
+
 def test_deployment_config_validation():
     # Test unknown key.
     with pytest.raises(ValidationError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

These changes validate `AutoscalingConfig`'s options with `Pydantic` to ensure non-default options obey logical constraints (e.g. `max_replicas >= min_replicas`). Also, `AutoscalingConfig` option types are now more precise (e.g. `PositiveInt` instead of `int`).

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #19569.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
      -  The `test_autoscaling_config_validation` test has been added to `test_config.py` to check that invalid options raise appropriate exceptions.