### PR TITLE
[rllib] Env to base env refactor

### DIFF
--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -1,8 +1,7 @@
 from typing import Callable, Tuple, Optional, List, Dict, Any, TYPE_CHECKING
 
 import ray
-from ray.rllib.utils.annotations import DeveloperAPI, Deprecated, override, \
-    PublicAPI
+from ray.rllib.utils.annotations import Deprecated, override, PublicAPI
 from ray.rllib.utils.typing import AgentID, EnvID, EnvType, MultiAgentDict, \
     MultiEnvDict, PartialTrainerConfigDict
 

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -305,7 +305,6 @@ def _with_dummy_agent_id(env_id_to_values: Dict[EnvID, Any],
     return {k: {dummy_id: v} for (k, v) in env_id_to_values.items()}
 
 
-@DeveloperAPI
 def with_dummy_agent_id(env_id_to_values: Dict[EnvID, Any],
                         dummy_id: "AgentID" = _DUMMY_AGENT_ID) -> MultiEnvDict:
     return {k: {dummy_id: v} for (k, v) in env_id_to_values.items()}

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -381,6 +381,9 @@ class _ExternalEnvToBaseEnv(BaseEnv):
                 _with_dummy_agent_id(off_policy_actions)
 
 
+@Deprecated(old="ray.rllib.env.base_env._VectorEnvToBaseEnv",
+            new="ray.rllib.env.multi_agent_env.VectorEnvWrapper",
+            error=False)
 class _VectorEnvToBaseEnv(BaseEnv):
     """Internal adapter of VectorEnv to BaseEnv.
 
@@ -440,6 +443,9 @@ class _VectorEnvToBaseEnv(BaseEnv):
         return self.vector_env.try_render_at(env_id)
 
 
+@Deprecated(old="ray.rllib.env.base_env._MultiAgentEnvToBaseEnv",
+            new="ray.rllib.env.multi_agent_env.MultiAgentEnvWrapper",
+            error=False)
 class _MultiAgentEnvToBaseEnv(BaseEnv):
     """Internal adapter of MultiAgentEnv to BaseEnv.
 
@@ -521,6 +527,9 @@ class _MultiAgentEnvToBaseEnv(BaseEnv):
         return self.envs[env_id].render()
 
 
+@Deprecated(old="ray.rllib.env.base_env._MultiAgentEnvState",
+            new="ray.rllib.env.multi_agent_env._MultiAgentEnvState",
+            error=False)
 class _MultiAgentEnvState:
     def __init__(self, env: MultiAgentEnv):
         assert isinstance(env, MultiAgentEnv)

--- a/rllib/env/external_env.py
+++ b/rllib/env/external_env.py
@@ -2,10 +2,15 @@ from six.moves import queue
 import gym
 import threading
 import uuid
-from typing import Optional
+from typing import Optional, Tuple, TYPE_CHECKING
 
-from ray.rllib.utils.annotations import PublicAPI
-from ray.rllib.utils.typing import EnvActionType, EnvObsType, EnvInfoDict
+from ray.rllib.env.base_env import BaseEnv
+from ray.rllib.utils.annotations import override, PublicAPI
+from ray.rllib.utils.typing import EnvActionType, EnvInfoDict, EnvObsType, \
+    MultiEnvDict
+
+if TYPE_CHECKING:
+    from ray.rllib.models.preprocessors import Preprocessor
 
 
 @PublicAPI
@@ -277,3 +282,92 @@ class _ExternalEnvEpisode:
         with self.results_avail_condition:
             self.data_queue.put_nowait(item)
             self.results_avail_condition.notify()
+
+
+class ExternalEnvWrapper(BaseEnv):
+    """Internal adapter of ExternalEnv to BaseEnv."""
+
+    def __init__(self,
+                 external_env: "ExternalEnv",
+                 preprocessor: "Preprocessor" = None):
+        from ray.rllib.env.external_multi_agent_env import \
+            ExternalMultiAgentEnv
+        self.external_env = external_env
+        self.prep = preprocessor
+        self.multiagent = issubclass(type(external_env), ExternalMultiAgentEnv)
+        self.action_space = external_env.action_space
+        if preprocessor:
+            self.observation_space = preprocessor.observation_space
+        else:
+            self.observation_space = external_env.observation_space
+        external_env.start()
+
+    @override(BaseEnv)
+    def poll(self) -> Tuple[MultiEnvDict, MultiEnvDict, MultiEnvDict,
+                            MultiEnvDict, MultiEnvDict]:
+        with self.external_env._results_avail_condition:
+            results = self._poll()
+            while len(results[0]) == 0:
+                self.external_env._results_avail_condition.wait()
+                results = self._poll()
+                if not self.external_env.is_alive():
+                    raise Exception("Serving thread has stopped.")
+        limit = self.external_env._max_concurrent_episodes
+        assert len(results[0]) < limit, \
+            ("Too many concurrent episodes, were some leaked? This "
+             "ExternalEnv was created with max_concurrent={}".format(limit))
+        return results
+
+    @override(BaseEnv)
+    def send_actions(self, action_dict: MultiEnvDict) -> None:
+        from ray.rllib.env.base_env import _DUMMY_AGENT_ID
+        if self.multiagent:
+            for env_id, actions in action_dict.items():
+                self.external_env._episodes[env_id].action_queue.put(actions)
+        else:
+            for env_id, action in action_dict.items():
+                self.external_env._episodes[env_id].action_queue.put(
+                    action[_DUMMY_AGENT_ID])
+
+    def _poll(self) -> Tuple[MultiEnvDict, MultiEnvDict, MultiEnvDict,
+                             MultiEnvDict, MultiEnvDict]:
+        from ray.rllib.env.base_env import with_dummy_agent_id
+        all_obs, all_rewards, all_dones, all_infos = {}, {}, {}, {}
+        off_policy_actions = {}
+        for eid, episode in self.external_env._episodes.copy().items():
+            data = episode.get_data()
+            cur_done = episode.cur_done_dict[
+                "__all__"] if self.multiagent else episode.cur_done
+            if cur_done:
+                del self.external_env._episodes[eid]
+            if data:
+                if self.prep:
+                    all_obs[eid] = self.prep.transform(data["obs"])
+                else:
+                    all_obs[eid] = data["obs"]
+                all_rewards[eid] = data["reward"]
+                all_dones[eid] = data["done"]
+                all_infos[eid] = data["info"]
+                if "off_policy_action" in data:
+                    off_policy_actions[eid] = data["off_policy_action"]
+        if self.multiagent:
+            # Ensure a consistent set of keys
+            # rely on all_obs having all possible keys for now.
+            for eid, eid_dict in all_obs.items():
+                for agent_id in eid_dict.keys():
+
+                    def fix(d, zero_val):
+                        if agent_id not in d[eid]:
+                            d[eid][agent_id] = zero_val
+
+                    fix(all_rewards, 0.0)
+                    fix(all_dones, False)
+                    fix(all_infos, {})
+            return (all_obs, all_rewards, all_dones, all_infos,
+                    off_policy_actions)
+        else:
+            return with_dummy_agent_id(all_obs), \
+                with_dummy_agent_id(all_rewards), \
+                with_dummy_agent_id(all_dones, "__all__"), \
+                with_dummy_agent_id(all_infos), \
+                with_dummy_agent_id(off_policy_actions)

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -1,9 +1,11 @@
 import gym
 from typing import Callable, Dict, List, Tuple, Type, Union
 
+from ray.rllib.env.base_env import BaseEnv
 from ray.rllib.env.env_context import EnvContext
 from ray.rllib.utils.annotations import ExperimentalAPI, override, PublicAPI
-from ray.rllib.utils.typing import AgentID, EnvType, MultiAgentDict
+from ray.rllib.utils.typing import AgentID, EnvType, MultiAgentDict, \
+    MultiEnvDict
 
 # If the obs space is Dict type, look for the global state under this key.
 ENV_STATE = "state"
@@ -214,3 +216,135 @@ def make_multi_agent(
             return self.agents[0].render(mode)
 
     return MultiEnv
+
+
+class MultiAgentEnvWrapper(BaseEnv):
+    """Internal adapter of MultiAgentEnv to BaseEnv.
+
+    This also supports vectorization if num_envs > 1.
+    """
+
+    def __init__(self, make_env: Callable[[int], EnvType],
+                 existing_envs: List["MultiAgentEnv"], num_envs: int):
+        """Wraps MultiAgentEnv(s) into the BaseEnv API.
+
+        Args:
+            make_env (Callable[[int], EnvType]): Factory that produces a new
+                MultiAgentEnv intance. Must be defined, if the number of
+                existing envs is less than num_envs.
+            existing_envs (List[MultiAgentEnv]): List of already existing
+                multi-agent envs.
+            num_envs (int): Desired num multiagent envs to have at the end in
+                total. This will include the given (already created)
+                `existing_envs`.
+        """
+        self.make_env = make_env
+        self.envs = existing_envs
+        self.num_envs = num_envs
+        self.dones = set()
+        while len(self.envs) < self.num_envs:
+            self.envs.append(self.make_env(len(self.envs)))
+        for env in self.envs:
+            assert isinstance(env, MultiAgentEnv)
+        self.env_states = [_MultiAgentEnvState(env) for env in self.envs]
+
+    @override(BaseEnv)
+    def poll(self) -> Tuple[MultiEnvDict, MultiEnvDict, MultiEnvDict,
+                            MultiEnvDict, MultiEnvDict]:
+        obs, rewards, dones, infos = {}, {}, {}, {}
+        for i, env_state in enumerate(self.env_states):
+            obs[i], rewards[i], dones[i], infos[i] = env_state.poll()
+        return obs, rewards, dones, infos, {}
+
+    @override(BaseEnv)
+    def send_actions(self, action_dict: MultiEnvDict) -> None:
+        for env_id, agent_dict in action_dict.items():
+            if env_id in self.dones:
+                raise ValueError("Env {} is already done".format(env_id))
+            env = self.envs[env_id]
+            obs, rewards, dones, infos = env.step(agent_dict)
+            assert isinstance(obs, dict), "Not a multi-agent obs"
+            assert isinstance(rewards, dict), "Not a multi-agent reward"
+            assert isinstance(dones, dict), "Not a multi-agent return"
+            assert isinstance(infos, dict), "Not a multi-agent info"
+            if set(infos).difference(set(obs)):
+                raise ValueError("Key set for infos must be a subset of obs: "
+                                 "{} vs {}".format(infos.keys(), obs.keys()))
+            if "__all__" not in dones:
+                raise ValueError(
+                    "In multi-agent environments, '__all__': True|False must "
+                    "be included in the 'done' dict: got {}.".format(dones))
+            if dones["__all__"]:
+                self.dones.add(env_id)
+            self.env_states[env_id].observe(obs, rewards, dones, infos)
+
+
+class _MultiAgentEnvState:
+    def __init__(self, env: MultiAgentEnv):
+        assert isinstance(env, MultiAgentEnv)
+        self.env = env
+        self.initialized = False
+        self.last_obs = {}
+        self.last_rewards = {}
+        self.last_dones = {"__all__": False}
+        self.last_infos = {}
+
+    def poll(
+            self
+    ) -> Tuple[MultiAgentDict, MultiAgentDict, MultiAgentDict, MultiAgentDict]:
+        if not self.initialized:
+            self.reset()
+            self.initialized = True
+
+        observations = self.last_obs
+        rewards = {}
+        dones = {"__all__": self.last_dones["__all__"]}
+        infos = {}
+
+        # If episode is done, release everything we have.
+        if dones["__all__"]:
+            rewards = self.last_rewards
+            self.last_rewards = {}
+            dones = self.last_dones
+            self.last_dones = {}
+            self.last_obs = {}
+            infos = self.last_infos
+            self.last_infos = {}
+        # Only release those agents' rewards/dones/infos, whose
+        # observations we have.
+        else:
+            for ag in observations.keys():
+                if ag in self.last_rewards:
+                    rewards[ag] = self.last_rewards[ag]
+                    del self.last_rewards[ag]
+                if ag in self.last_dones:
+                    dones[ag] = self.last_dones[ag]
+                    del self.last_dones[ag]
+                if ag in self.last_infos:
+                    infos[ag] = self.last_infos[ag]
+                    del self.last_infos[ag]
+
+        self.last_dones["__all__"] = False
+        return observations, rewards, dones, infos
+
+    def observe(self, obs: MultiAgentDict, rewards: MultiAgentDict,
+                dones: MultiAgentDict, infos: MultiAgentDict):
+        self.last_obs = obs
+        for ag, r in rewards.items():
+            if ag in self.last_rewards:
+                self.last_rewards[ag] += r
+            else:
+                self.last_rewards[ag] = r
+        for ag, d in dones.items():
+            if ag in self.last_dones:
+                self.last_dones[ag] = self.last_dones[ag] or d
+            else:
+                self.last_dones[ag] = d
+        self.last_infos = infos
+
+    def reset(self) -> MultiAgentDict:
+        self.last_obs = self.env.reset()
+        self.last_rewards = {}
+        self.last_dones = {"__all__": False}
+        self.last_infos = {}
+        return self.last_obs

--- a/rllib/env/vector_env.py
+++ b/rllib/env/vector_env.py
@@ -8,7 +8,6 @@ from ray.rllib.utils.annotations import Deprecated, override, PublicAPI
 from ray.rllib.utils.typing import EnvActionType, EnvID, EnvInfoDict, \
     EnvObsType, EnvType, MultiAgentDict, MultiEnvDict
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/rllib/env/vector_env.py
+++ b/rllib/env/vector_env.py
@@ -219,7 +219,7 @@ class _VectorizedGymEnv(VectorEnv):
         return self.envs[index].render()
 
 
-class VectorEnvToBaseEnv(BaseEnv):
+class VectorEnvWrapper(BaseEnv):
     """Internal adapter of VectorEnv to BaseEnv.
 
     We assume the caller will always send the full vector of actions in each
@@ -240,7 +240,7 @@ class VectorEnvToBaseEnv(BaseEnv):
     @override(BaseEnv)
     def poll(self) -> Tuple[MultiEnvDict, MultiEnvDict, MultiEnvDict,
                             MultiEnvDict, MultiEnvDict]:
-        from ray.rllib.env.base_env import _with_dummy_agent_id
+        from ray.rllib.env.base_env import with_dummy_agent_id
         if self.new_obs is None:
             self.new_obs = self.vector_env.vector_reset()
         new_obs = dict(enumerate(self.new_obs))
@@ -251,10 +251,10 @@ class VectorEnvToBaseEnv(BaseEnv):
         self.cur_rewards = []
         self.cur_dones = []
         self.cur_infos = []
-        return _with_dummy_agent_id(new_obs), \
-            _with_dummy_agent_id(rewards), \
-            _with_dummy_agent_id(dones, "__all__"), \
-            _with_dummy_agent_id(infos), {}
+        return with_dummy_agent_id(new_obs), \
+            with_dummy_agent_id(rewards), \
+            with_dummy_agent_id(dones, "__all__"), \
+            with_dummy_agent_id(infos), {}
 
     @override(BaseEnv)
     def send_actions(self, action_dict: MultiEnvDict) -> None:

--- a/rllib/env/vector_env.py
+++ b/rllib/env/vector_env.py
@@ -3,9 +3,11 @@ import gym
 import numpy as np
 from typing import Callable, List, Optional, Tuple
 
+from ray.rllib.env.base_env import BaseEnv
 from ray.rllib.utils.annotations import Deprecated, override, PublicAPI
-from ray.rllib.utils.typing import EnvActionType, EnvInfoDict, \
-    EnvObsType, EnvType
+from ray.rllib.utils.typing import EnvActionType, EnvID, EnvInfoDict, \
+    EnvObsType, EnvType, MultiAgentDict, MultiEnvDict
+
 
 logger = logging.getLogger(__name__)
 
@@ -215,3 +217,65 @@ class _VectorizedGymEnv(VectorEnv):
         if index is None:
             index = 0
         return self.envs[index].render()
+
+
+class VectorEnvToBaseEnv(BaseEnv):
+    """Internal adapter of VectorEnv to BaseEnv.
+
+    We assume the caller will always send the full vector of actions in each
+    call to send_actions(), and that they call reset_at() on all completed
+    environments before calling send_actions().
+    """
+
+    def __init__(self, vector_env: VectorEnv):
+        self.vector_env = vector_env
+        self.action_space = vector_env.action_space
+        self.observation_space = vector_env.observation_space
+        self.num_envs = vector_env.num_envs
+        self.new_obs = None  # lazily initialized
+        self.cur_rewards = [None for _ in range(self.num_envs)]
+        self.cur_dones = [False for _ in range(self.num_envs)]
+        self.cur_infos = [None for _ in range(self.num_envs)]
+
+    @override(BaseEnv)
+    def poll(self) -> Tuple[MultiEnvDict, MultiEnvDict, MultiEnvDict,
+                            MultiEnvDict, MultiEnvDict]:
+        from ray.rllib.env.base_env import _with_dummy_agent_id
+        if self.new_obs is None:
+            self.new_obs = self.vector_env.vector_reset()
+        new_obs = dict(enumerate(self.new_obs))
+        rewards = dict(enumerate(self.cur_rewards))
+        dones = dict(enumerate(self.cur_dones))
+        infos = dict(enumerate(self.cur_infos))
+        self.new_obs = []
+        self.cur_rewards = []
+        self.cur_dones = []
+        self.cur_infos = []
+        return _with_dummy_agent_id(new_obs), \
+            _with_dummy_agent_id(rewards), \
+            _with_dummy_agent_id(dones, "__all__"), \
+            _with_dummy_agent_id(infos), {}
+
+    @override(BaseEnv)
+    def send_actions(self, action_dict: MultiEnvDict) -> None:
+        from ray.rllib.env.base_env import _DUMMY_AGENT_ID
+        action_vector = [None] * self.num_envs
+        for i in range(self.num_envs):
+            action_vector[i] = action_dict[i][_DUMMY_AGENT_ID]
+        self.new_obs, self.cur_rewards, self.cur_dones, self.cur_infos = \
+            self.vector_env.vector_step(action_vector)
+
+    @override(BaseEnv)
+    def try_reset(self, env_id: Optional[EnvID] = None) -> MultiAgentDict:
+        from ray.rllib.env.base_env import _DUMMY_AGENT_ID
+        assert env_id is None or isinstance(env_id, int)
+        return {_DUMMY_AGENT_ID: self.vector_env.reset_at(env_id)}
+
+    @override(BaseEnv)
+    def get_sub_environments(self) -> List[EnvType]:
+        return self.vector_env.get_sub_environments()
+
+    @override(BaseEnv)
+    def try_render(self, env_id: Optional[EnvID] = None) -> None:
+        assert env_id is None or isinstance(env_id, int)
+        return self.vector_env.try_render_at(env_id)

--- a/rllib/env/wrappers/model_vector_env.py
+++ b/rllib/env/wrappers/model_vector_env.py
@@ -4,7 +4,7 @@ from gym.spaces import Discrete
 from ray.rllib.utils.annotations import override
 from ray.rllib.env.vector_env import VectorEnv
 from ray.rllib.evaluation.rollout_worker import get_global_worker
-from ray.rllib.env.base_env import BaseEnv
+from ray.rllib.env.base_env import BaseEnv, convert_to_base_env
 from ray.rllib.utils.typing import EnvType
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ def model_vector_env(env: EnvType) -> BaseEnv:
             observation_space=env.observation_space,
             action_space=env.action_space,
         )
-    return BaseEnv.to_base_env(
+    return convert_to_base_env(
         env,
         make_env=worker.make_sub_env_fn,
         num_envs=worker.num_envs,

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, \
 
 import ray
 from ray import cloudpickle as pickle
-from ray.rllib.env.base_env import BaseEnv
+from ray.rllib.env.base_env import BaseEnv, convert_to_base_env
 from ray.rllib.env.env_context import EnvContext
 from ray.rllib.env.external_env import ExternalEnv
 from ray.rllib.env.multi_agent_env import MultiAgentEnv
@@ -630,7 +630,7 @@ class RolloutWorker(ParallelIteratorWorker):
         # vectorized under the hood).
         else:
             # Always use vector env for consistency even if num_envs = 1.
-            self.async_env: BaseEnv = BaseEnv.to_base_env(
+            self.async_env: BaseEnv = convert_to_base_env(
                 self.env,
                 make_env=self.make_sub_env_fn,
                 num_envs=num_envs,

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -18,7 +18,8 @@ from ray.rllib.evaluation.episode import Episode
 from ray.rllib.evaluation.metrics import RolloutMetrics
 from ray.rllib.evaluation.sample_batch_builder import \
     MultiAgentSampleBatchBuilder
-from ray.rllib.env.base_env import BaseEnv, ASYNC_RESET_RETURN
+from ray.rllib.env.base_env import BaseEnv, convert_to_base_env, \
+    ASYNC_RESET_RETURN
 from ray.rllib.env.wrappers.atari_wrappers import get_wrapper_by_cls, \
     MonitorEnv
 from ray.rllib.models.preprocessors import Preprocessor
@@ -235,7 +236,7 @@ class SyncSampler(SamplerInput):
             if tf_sess is not None:
                 deprecation_warning(old="tf_sess")
 
-        self.base_env = BaseEnv.to_base_env(env)
+        self.base_env = convert_to_base_env(env)
         self.rollout_fragment_length = rollout_fragment_length
         self.horizon = horizon
         self.extra_batches = queue.Queue()
@@ -384,7 +385,7 @@ class AsyncSampler(threading.Thread, SamplerInput):
             assert getattr(f, "is_concurrent", False), \
                 "Observation Filter must support concurrent updates."
 
-        self.base_env = BaseEnv.to_base_env(env)
+        self.base_env = convert_to_base_env(env)
         threading.Thread.__init__(self)
         self.queue = queue.Queue(5)
         self.extra_batches = queue.Queue()

--- a/rllib/tests/test_multi_agent_env.py
+++ b/rllib/tests/test_multi_agent_env.py
@@ -15,7 +15,7 @@ from ray.rllib.examples.env.multi_agent import MultiAgentCartPole, \
     RoundRobinMultiAgent
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
 from ray.rllib.evaluation.tests.test_rollout_worker import MockPolicy
-from ray.rllib.env.base_env import _MultiAgentEnvToBaseEnv
+from ray.rllib.env.multi_agent_env import MultiAgentEnvWrapper
 from ray.rllib.policy.policy import PolicySpec
 from ray.rllib.utils.numpy import one_hot
 from ray.rllib.utils.test_utils import check
@@ -69,13 +69,13 @@ class TestMultiAgentEnv(unittest.TestCase):
         self.assertEqual(done["__all__"], True)
 
     def test_no_reset_until_poll(self):
-        env = _MultiAgentEnvToBaseEnv(lambda v: BasicMultiAgent(2), [], 1)
+        env = MultiAgentEnvWrapper(lambda v: BasicMultiAgent(2), [], 1)
         self.assertFalse(env.get_sub_environments()[0].resetted)
         env.poll()
         self.assertTrue(env.get_sub_environments()[0].resetted)
 
     def test_vectorize_basic(self):
-        env = _MultiAgentEnvToBaseEnv(lambda v: BasicMultiAgent(2), [], 2)
+        env = MultiAgentEnvWrapper(lambda v: BasicMultiAgent(2), [], 2)
         obs, rew, dones, _, _ = env.poll()
         self.assertEqual(obs, {0: {0: 0, 1: 0}, 1: {0: 0, 1: 0}})
         self.assertEqual(rew, {0: {}, 1: {}})
@@ -154,7 +154,7 @@ class TestMultiAgentEnv(unittest.TestCase):
             })
 
     def test_vectorize_round_robin(self):
-        env = _MultiAgentEnvToBaseEnv(lambda v: RoundRobinMultiAgent(2), [], 2)
+        env = MultiAgentEnvWrapper(lambda v: RoundRobinMultiAgent(2), [], 2)
         obs, rew, dones, _, _ = env.poll()
         self.assertEqual(obs, {0: {0: 0}, 1: {0: 0}})
         self.assertEqual(rew, {0: {}, 1: {}})

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -9,7 +9,7 @@ import ray
 from ray.rllib.agents.a3c import A2CTrainer
 from ray.rllib.agents.pg import PGTrainer
 from ray.rllib.env import MultiAgentEnv
-from ray.rllib.env.base_env import BaseEnv
+from ray.rllib.env.base_env import convert_to_base_env
 from ray.rllib.env.vector_env import VectorEnv
 from ray.rllib.models import ModelCatalog
 from ray.rllib.models.tf.tf_modelv2 import TFModelV2
@@ -420,7 +420,7 @@ class NestedSpacesTest(unittest.TestCase):
 
     def test_nested_dict_async(self):
         self.do_test_nested_dict(
-            lambda _: BaseEnv.to_base_env(NestedDictEnv()))
+            lambda _: convert_to_base_env(NestedDictEnv()))
 
     def test_nested_tuple_gym(self):
         self.do_test_nested_tuple(lambda _: NestedTupleEnv())
@@ -434,7 +434,7 @@ class NestedSpacesTest(unittest.TestCase):
 
     def test_nested_tuple_async(self):
         self.do_test_nested_tuple(
-            lambda _: BaseEnv.to_base_env(NestedTupleEnv()))
+            lambda _: convert_to_base_env(NestedTupleEnv()))
 
     def test_multi_agent_complex_spaces(self):
         ModelCatalog.register_custom_model("dict_spy", DictSpyModel)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`BaseEnv` is awkwardly the owner of a significant amount of code that does not belong to BaseEnv. This PR addresses that by moving `BaseEnv` wrappers to their corresponding class files, and (in progress) removing the `to_base_env` method from the `BaseEnv` class, as this class awkwardly returns an instance of itself doesn't rely on having access to itself, is a static function, and should probably be a standalone function.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

Should we add tests for these wrappers? There weren't tests for them already, so we probably should go back and add them eventually?