### PR TITLE
Lease timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ python/.eggs
 *.so
 *.dylib
 *.dll
+python/ray/_raylet.pyd
 
 # Incremental linking files
 *.ilk

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -241,9 +241,12 @@ def test_call_matrix(shutdown_only):
                     check(source_actor, dest_actor, is_large, out_of_band)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_call_order(shutdown_only):
-    ray.init(num_cpus=4)
+    ray.init(
+        num_cpus=4,
+        _system_config={
+            "worker_lease_timeout_milliseconds": 6000,
+        })
 
     @ray.remote
     def small_value():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The tests run much slower on windows. Once the Actor's worker lease expires, the tasks remain unclaimed. So lengthen the lease timeout.

Also trivially add a binary file to `.gitignore`

## Related issue number

Related to issue #20173, 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
