### PR TITLE
[Tune] Allow tuples in variant generator

### DIFF
--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -382,7 +382,7 @@ def _split_resolved_unresolved_values(
                 resolved_vars[(k, ) + path] = value
             for (path, value) in _unresolved_children.items():
                 unresolved_vars[(k, ) + path] = value
-        elif isinstance(v, list):
+        elif isinstance(v, (list, tuple)):
             # Recurse into a list
             for i, elem in enumerate(v):
                 _resolved_children, _unresolved_children = \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I don't see a reason why lists are supported, but tuples are not. Even though tuples are suggested in the documentation as the format for defining policies in the multi-agent setup (RLlib).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #20729

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
