### PR TITLE
Remove duplicate test (in test_component_failure_2)

### DIFF
--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -1,4 +1,3 @@
-import os
 import signal
 import sys
 import time
@@ -9,7 +8,6 @@ import ray
 import ray.ray_constants as ray_constants
 from ray.cluster_utils import Cluster, cluster_not_supported
 from ray._private.test_utils import (
-    RayTestTimeoutException,
     get_other_nodes,
     wait_for_condition,
 )
@@ -32,59 +30,6 @@ def ray_start_workers_separate_multinode(request):
     # The code after the yield will run as teardown code.
     ray.shutdown()
     cluster.shutdown()
-
-
-def test_worker_failed(ray_start_workers_separate_multinode):
-    num_nodes, num_initial_workers = (ray_start_workers_separate_multinode)
-
-    if num_nodes == 4 and sys.platform == "win32":
-        pytest.skip("Failing on Windows.")
-
-    @ray.remote
-    def get_pids():
-        time.sleep(0.25)
-        return os.getpid()
-
-    start_time = time.time()
-    pids = set()
-    while len(pids) < num_nodes * num_initial_workers:
-        new_pids = ray.get([
-            get_pids.remote()
-            for _ in range(2 * num_nodes * num_initial_workers)
-        ])
-        for pid in new_pids:
-            pids.add(pid)
-        if time.time() - start_time > 60:
-            raise RayTestTimeoutException(
-                "Timed out while waiting to get worker PIDs.")
-
-    @ray.remote
-    def f(x):
-        time.sleep(0.5)
-        return x
-
-    # Submit more tasks than there are workers so that all workers and
-    # cores are utilized.
-    object_refs = [f.remote(i) for i in range(num_initial_workers * num_nodes)]
-    object_refs += [f.remote(object_ref) for object_ref in object_refs]
-    # Allow the tasks some time to begin executing.
-    time.sleep(0.1)
-    # Kill the workers as the tasks execute.
-    for pid in pids:
-        try:
-            os.kill(pid, SIGKILL)
-        except OSError:
-            # The process may have already exited due to worker capping.
-            pass
-        time.sleep(0.1)
-    # Make sure that we either get the object or we get an appropriate
-    # exception.
-    for object_ref in object_refs:
-        try:
-            ray.get(object_ref)
-        except (ray.exceptions.RayTaskError,
-                ray.exceptions.WorkerCrashedError):
-            pass
 
 
 def _test_component_failed(cluster, component_type):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_component_failure_2::test_worker_failed` is a duplicate of `test_mulitnode_failure::test_worker_failed` 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
