### PR TITLE
[rllib] Updating Repeated space. Allowing numpy arrays and adding representation

### DIFF
--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -316,7 +316,7 @@ class RepeatedValuesPreprocessor(Preprocessor):
     @override(Preprocessor)
     def write(self, observation: TensorType, array: np.ndarray,
               offset: int) -> None:
-        if not isinstance(observation, list):
+        if not isinstance(observation, (list,np.ndarray)):
             raise ValueError("Input for {} must be list type, got {}".format(
                 self, observation))
         elif len(observation) > self._obs_space.max_len:

--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -316,7 +316,7 @@ class RepeatedValuesPreprocessor(Preprocessor):
     @override(Preprocessor)
     def write(self, observation: TensorType, array: np.ndarray,
               offset: int) -> None:
-        if not isinstance(observation, (list,np.ndarray)):
+        if not isinstance(observation, (list, np.ndarray)):
             raise ValueError("Input for {} must be list type, got {}".format(
                 self, observation))
         elif len(observation) > self._obs_space.max_len:

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -1067,9 +1067,10 @@ class TorchPolicy(Policy):
                 with lock:
                     results[shard_idx] = (all_grads, grad_info)
             except Exception as e:
+                import traceback
                 with lock:
                     results[shard_idx] = (ValueError(
-                        e.args[0] + "\n" +
+                        e.args[0] + "\n traceback" + traceback.format_exc() + "\n" +
                         "In tower {} on device {}".format(shard_idx, device)),
                                           e)
 

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -1070,7 +1070,8 @@ class TorchPolicy(Policy):
                 import traceback
                 with lock:
                     results[shard_idx] = (ValueError(
-                        e.args[0] + "\n traceback" + traceback.format_exc() + "\n" +
+                        e.args[0] + "\n traceback" + traceback.format_exc() +
+                        "\n" +
                         "In tower {} on device {}".format(shard_idx, device)),
                                           e)
 

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -28,7 +28,7 @@ class Repeated(gym.Space):
         ]
 
     def contains(self, x):
-        return ((isinstance(x, list) or isinstance(x, np.ndarray))
+        return (isinstance(x, (list,np.ndarray))
                 and len(x) <= self.max_len
                 and all(self.child_space.contains(c) for c in x))
 

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -1,4 +1,5 @@
 import gym
+import numpy as np
 
 from ray.rllib.utils.annotations import PublicAPI
 
@@ -27,7 +28,8 @@ class Repeated(gym.Space):
         ]
 
     def contains(self, x):
-        return ((isinstance(x, list) or isinstance(x, np.ndarray)) and len(x) <= self.max_len
+        return ((isinstance(x, list) or isinstance(x, np.ndarray))
+                and len(x) <= self.max_len
                 and all(self.child_space.contains(c) for c in x))
 
     def __repr__(self):

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -27,5 +27,8 @@ class Repeated(gym.Space):
         ]
 
     def contains(self, x):
-        return (isinstance(x, list) and len(x) <= self.max_len
+        return ((isinstance(x, list) or isinstance(x, np.ndarray)) and len(x) <= self.max_len
                 and all(self.child_space.contains(c) for c in x))
+
+    def __repr__(self):
+        return "Repeated({}, {})".format(self.child_space, self.max_len)

--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -28,8 +28,7 @@ class Repeated(gym.Space):
         ]
 
     def contains(self, x):
-        return (isinstance(x, (list,np.ndarray))
-                and len(x) <= self.max_len
+        return (isinstance(x, (list, np.ndarray)) and len(x) <= self.max_len
                 and all(self.child_space.contains(c) for c in x))
 
     def __repr__(self):


### PR DESCRIPTION

## Why are these changes needed?

The Repeated space does not allow numpy arrays. This is inefficient for many environments, because a numpy array would have to be converted to a list (in env) and again by rllibs sample collection. 

The representation is added in case someone wants to use this space in a print statement.

## Related issue number

None, optimizations only

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
