### PR TITLE
[Core] Update job id to hex in JOB_LOG_PATTERN (#20612)

### DIFF
--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -25,7 +25,7 @@ from ray._private.ray_logging import setup_component_logger
 logger = logging.getLogger(__name__)
 
 # The groups are worker id, job id, and pid.
-JOB_LOG_PATTERN = re.compile(".*worker-([0-9a-f]+)-(\d+)-(\d+)")
+JOB_LOG_PATTERN = re.compile(".*worker-([0-9a-f]+)-([0-9a-f]+)-(\d+)")
 # The groups are job id.
 RUNTIME_ENV_SETUP_PATTERN = re.compile(".*runtime_env_setup-(\d+).log")
 # Log name update interval under pressure.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

While sharing one ray cluster with multi jobs, we found some remote tasks logs got mixed together.

Also: https://discuss.ray.io/t/worker-logs-are-sent-to-multiple-clients/3715


<!-- Please give a short summary of the change and the problem this solves. -->

After some dig, I found it was happend at [`print_logs`](https://github.com/ray-project/ray/blob/master/python/ray/worker.py#L479-L482)
and when `job_id` is `None`, and the invalid `job_id` comes from a [wrong pattern](https://github.com/ray-project/ray/blob/master/python/ray/_private/log_monitor.py#L166-L172)

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #20612

cc @rkooo567 seems you already have some work related. #19974 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
