### PR TITLE
[autoscaler] use same tag specs on volumes during ec2 node creation

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -371,6 +371,10 @@ class AWSNodeProvider(NodeProvider):
         tag_specs = [{
             "ResourceType": "instance",
             "Tags": tag_pairs,
+        },
+        {
+            "ResourceType": "volume",
+            "Tags": [p for p in tag_pairs if p["Key"] != "Name"],
         }]
         user_tag_specs = conf.get("TagSpecifications", [])
         AWSNodeProvider._merge_tag_specs(tag_specs, user_tag_specs)

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -371,8 +371,7 @@ class AWSNodeProvider(NodeProvider):
         tag_specs = [{
             "ResourceType": "instance",
             "Tags": tag_pairs,
-        },
-        {
+        }, {
             "ResourceType": "volume",
             "Tags": [p for p in tag_pairs if p["Key"] != "Name"],
         }]

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -322,9 +322,7 @@ class AWSNodeProvider(NodeProvider):
         node provider tag specs is modified in-place.
 
         This allows users to add tags and override values of existing
-        tags with their own, and only applies to the resource type
-        "instance". All other resource types are appended to the list of
-        tag specs.
+        tags with their own.
 
         Args:
             tag_specs (List[Dict[str, Any]]): base node provider tag specs
@@ -332,18 +330,16 @@ class AWSNodeProvider(NodeProvider):
         """
 
         for user_tag_spec in user_tag_specs:
-            if user_tag_spec["ResourceType"] == "instance":
-                for user_tag in user_tag_spec["Tags"]:
-                    exists = False
-                    for tag in tag_specs[0]["Tags"]:
-                        if user_tag["Key"] == tag["Key"]:
-                            exists = True
-                            tag["Value"] = user_tag["Value"]
-                            break
-                    if not exists:
-                        tag_specs[0]["Tags"] += [user_tag]
-            else:
-                tag_specs += [user_tag_spec]
+            for user_tag in user_tag_spec["Tags"]:
+                exists = False
+                for tag in tag_specs[0]["Tags"]:
+                    if user_tag["Key"] == tag["Key"]:
+                        exists = True
+                        tag["Value"] = user_tag["Value"]
+                        break
+                if not exists:
+                    tag_specs[0]["Tags"] += [user_tag]
+
 
     def _create_node(self, node_config, tags, count):
         created_nodes_dict = {}


### PR DESCRIPTION
## Related issue number

Fixes #20817 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
