### PR TITLE
[Autoscaler] Add autoscaler update time prometheus metric.

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -330,6 +330,11 @@ class StandardAutoscaler:
         if not self.provider.is_readonly():
             self.launch_required_nodes(to_launch)
 
+        # Record the amount of time the autoscaler took for
+        # this _update() iteration. Use a log scale.
+        update_time = time.time() - self.last_update_time
+        self.prom_metrics.update_time.observe(math.log10(update_time))
+
     def terminate_nodes_to_enforce_config_constraints(self, now: float):
         """Terminates nodes to enforce constraints defined by the autoscaling
         config.

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -331,9 +331,9 @@ class StandardAutoscaler:
             self.launch_required_nodes(to_launch)
 
         # Record the amount of time the autoscaler took for
-        # this _update() iteration. Use a log scale.
+        # this _update() iteration.
         update_time = time.time() - self.last_update_time
-        self.prom_metrics.update_time.observe(math.log10(update_time))
+        self.prom_metrics.update_time.observe(update_time)
 
     def terminate_nodes_to_enforce_config_constraints(self, now: float):
         """Terminates nodes to enforce constraints defined by the autoscaling

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -51,7 +51,7 @@ try:
             self.update_time: Histogram = Histogram(
                 "update_time",
                 "Autoscaler update time. This is the time for an autoscaler "
-                "update iteration to complete, measured on a log scale.",
+                "update iteration to complete.",
                 unit="seconds",
                 namespace="autoscaler",
                 registry=self.registry,

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -50,7 +50,7 @@ try:
                 buckets=histogram_buckets)
             self.update_time: Histogram = Histogram(
                 "update_time",
-                "Autoscaler update time. This is the time for an autoscaler"
+                "Autoscaler update time. This is the time for an autoscaler "
                 "update iteration to complete, measured on a log scale.",
                 unit="seconds",
                 namespace="autoscaler",

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -26,7 +26,7 @@ try:
             ]
             # Buckets: .01 seconds to 1000 seconds.
             # Used for autoscaler update time.
-            log_update_time_buckets = [-2, -1, 0, 1, 2, 3]
+            update_time_buckets = [.01, .1, 1, 10, 100, 1000]
             self.worker_create_node_time: Histogram = Histogram(
                 "worker_create_node_time_seconds",
                 "Worker launch time. This is the time it takes for a call to "
@@ -52,10 +52,10 @@ try:
                 "update_time",
                 "Autoscaler update time. This is the time for an autoscaler"
                 "update iteration to complete, measured on a log scale.",
-                unit="log_10(time / 1sec)",
+                unit="seconds",
                 namespace="autoscaler",
                 registry=self.registry,
-                buckets=log_update_time_buckets)
+                buckets=update_time_buckets)
             self.pending_nodes: Gauge = Gauge(
                 "pending_nodes",
                 "Number of nodes pending to be started.",

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -24,6 +24,9 @@ try:
                 5, 10, 20, 30, 45, 60, 90, 120, 180, 240, 300, 360, 480, 600,
                 720, 900, 1200, 1500, 1800
             ]
+            # Buckets: .01 seconds to 1000 seconds.
+            # Used for autoscaler update time.
+            log_update_time_buckets = [-2, -1, 0, 1, 2, 3]
             self.worker_create_node_time: Histogram = Histogram(
                 "worker_create_node_time_seconds",
                 "Worker launch time. This is the time it takes for a call to "
@@ -45,6 +48,14 @@ try:
                 namespace="autoscaler",
                 registry=self.registry,
                 buckets=histogram_buckets)
+            self.update_time: Histogram = Histogram(
+                "update_time",
+                "Autoscaler update time. This is the time for an autoscaler"
+                "update iteration to complete, measured on a log scale.",
+                unit="log_10(time / 1sec)",
+                namespace="autoscaler",
+                registry=self.registry,
+                buckets=log_update_time_buckets)
             self.pending_nodes: Gauge = Gauge(
                 "pending_nodes",
                 "Number of nodes pending to be started.",

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -1,5 +1,5 @@
 # An unique identifier for the head node and workers of this cluster.
-cluster_name: default
+cluster_name: defaultssssssssssssssssssssssssssssssssssssssss
 
 # The maximum number of workers nodes to launch in addition to the head
 # node.
@@ -15,7 +15,7 @@ upscaling_speed: 1.0
 # and opens all the necessary ports to support the Ray cluster.
 # Empty string means disabled.
 docker:
-    image: "rayproject/ray-ml:latest-gpu" # You can change this to latest-cpu if you don't need GPU support and want a faster startup
+    image: "rayproject/ray-ml:nightly-gpu" # You can change this to latest-cpu if you don't need GPU support and want a faster startup
     # image: rayproject/ray:latest-gpu   # use this one if you don't need ML dependencies, it's faster to pull
     container_name: "ray_container"
     # If true, pulls latest version of image. Otherwise, `docker run` will only pull the image
@@ -49,6 +49,7 @@ provider:
 # How Ray will authenticate with newly launched nodes.
 auth:
     ssh_user: ubuntu
+    ssh_private_key: ~/.ssh/DmitriAutoscaler.pem
 # By default Ray creates a new private keypair, but you can also use your own.
 # If you do so, make sure to also set "KeyName" in the head and worker node
 # configurations below.
@@ -70,6 +71,7 @@ available_node_types:
         # For more documentation on available fields, see:
         # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
         node_config:
+            KeyName: DmitriAutoscaler
             InstanceType: m5.large
             ImageId: ami-0a2363a9cff180a64 # Deep Learning AMI (Ubuntu) Version 30
             # You can provision additional disk space with a conf as follows
@@ -81,7 +83,7 @@ available_node_types:
     ray.worker.default:
         # The minimum number of worker nodes of this type to launch.
         # This number should be >= 0.
-        min_workers: 0
+        min_workers: 2
         # The maximum number of worker nodes of this type to launch.
         # This takes precedence over min_workers.
         max_workers: 2
@@ -96,6 +98,7 @@ available_node_types:
         # For more documentation on available fields, see:
         # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
         node_config:
+            KeyName: DmitriAutoscaler
             InstanceType: m5.large
             ImageId: ami-0a2363a9cff180a64 # Deep Learning AMI (Ubuntu) Version 30
             # Run workers on spot by default. Comment this out to use on-demand.

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -1,5 +1,5 @@
 # An unique identifier for the head node and workers of this cluster.
-cluster_name: defaultssssssssssssssssssssssssssssssssssssssss
+cluster_name: default
 
 # The maximum number of workers nodes to launch in addition to the head
 # node.
@@ -15,7 +15,7 @@ upscaling_speed: 1.0
 # and opens all the necessary ports to support the Ray cluster.
 # Empty string means disabled.
 docker:
-    image: "rayproject/ray-ml:nightly-gpu" # You can change this to latest-cpu if you don't need GPU support and want a faster startup
+    image: "rayproject/ray-ml:latest-gpu" # You can change this to latest-cpu if you don't need GPU support and want a faster startup
     # image: rayproject/ray:latest-gpu   # use this one if you don't need ML dependencies, it's faster to pull
     container_name: "ray_container"
     # If true, pulls latest version of image. Otherwise, `docker run` will only pull the image
@@ -49,7 +49,6 @@ provider:
 # How Ray will authenticate with newly launched nodes.
 auth:
     ssh_user: ubuntu
-    ssh_private_key: ~/.ssh/DmitriAutoscaler.pem
 # By default Ray creates a new private keypair, but you can also use your own.
 # If you do so, make sure to also set "KeyName" in the head and worker node
 # configurations below.
@@ -71,7 +70,6 @@ available_node_types:
         # For more documentation on available fields, see:
         # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
         node_config:
-            KeyName: DmitriAutoscaler
             InstanceType: m5.large
             ImageId: ami-0a2363a9cff180a64 # Deep Learning AMI (Ubuntu) Version 30
             # You can provision additional disk space with a conf as follows
@@ -83,7 +81,7 @@ available_node_types:
     ray.worker.default:
         # The minimum number of worker nodes of this type to launch.
         # This number should be >= 0.
-        min_workers: 2
+        min_workers: 0
         # The maximum number of worker nodes of this type to launch.
         # This takes precedence over min_workers.
         max_workers: 2
@@ -98,7 +96,6 @@ available_node_types:
         # For more documentation on available fields, see:
         # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
         node_config:
-            KeyName: DmitriAutoscaler
             InstanceType: m5.large
             ImageId: ami-0a2363a9cff180a64 # Deep Learning AMI (Ubuntu) Version 30
             # Run workers on spot by default. Comment this out to use on-demand.

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -1322,6 +1322,9 @@ class AutoscalingTest(unittest.TestCase):
         mock_metrics.started_nodes.inc.assert_called_with(2)
         assert mock_metrics.worker_create_node_time.observe.call_count == 2
         autoscaler.update()
+        # The two autoscaler update iterations in this test led to two
+        # observations of the update time.
+        assert mock_metrics.update_time.observe.call_count == 2
         self.waitForNodes(2)
 
         # running_workers metric should be set to 2

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -78,7 +78,7 @@ _AUTOSCALER_METRICS = [
     "autoscaler_successful_updates", "autoscaler_failed_updates",
     "autoscaler_failed_create_nodes", "autoscaler_recovering_nodes",
     "autoscaler_successful_recoveries", "autoscaler_failed_recoveries",
-    "autoscaler_drain_node_exceptions"
+    "autoscaler_drain_node_exceptions", "autoscaler_update_time"
 ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

It's useful when measuring autoscaler performance to know how long the autoscaler takes for update iterations.
This PR adds a prometheus metric for that. A log scale is used; depending on the situation, we've seen the update time range from .1 second to a few minutes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
