### PR TITLE
[core] Remove spammy code in object directory client

### DIFF
--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -556,14 +556,10 @@ void ReferenceCounter::DeleteReferenceInternal(ReferenceTable::iterator it,
 }
 
 void ReferenceCounter::EraseReference(ReferenceTable::iterator it) {
-  // NOTE(swang): We have to send this message to subscribers in case they
+  // NOTE(swang): We have to publish failure to subscribers in case they
   // subscribe after the ref is already deleted.
-  rpc::PubMessage pub_message;
-  pub_message.set_key_id(it->first.Binary());
-  pub_message.set_channel_type(rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL);
-  auto object_locations_msg = pub_message.mutable_worker_object_locations_message();
-  object_locations_msg->set_ref_removed(true);
-  object_info_publisher_->Publish(pub_message);
+  object_info_publisher_->PublishFailure(
+      rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL, it->first.Binary());
 
   RAY_CHECK(it->second.ShouldDelete(lineage_pinning_enabled_));
   auto index_it = reconstructable_owned_objects_index_.find(it->first);

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -229,9 +229,7 @@ class MockDistributedPublisher : public pubsub::PublisherInterface {
   }
 
   void PublishFailure(const rpc::ChannelType channel_type,
-                      const std::string &key_id_binary) {
-    RAY_LOG(FATAL) << "No need to implement it for testing.";
-  }
+                      const std::string &key_id_binary) {}
 
   void Publish(const rpc::PubMessage &pub_message) {
     if (pub_message.channel_type() == rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL) {

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -284,7 +284,7 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
           location_info, object_id,
           /*location_lookup_failed*/ !location_info.ref_removed());
       if (location_info.ref_removed()) {
-        RAY_LOG(ERROR)
+        RAY_LOG(DEBUG)
             << "Failed to get locations for " << object_id
             << ", object already released by distributed reference counting protocol";
         mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -290,10 +290,15 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
       const auto object_id = ObjectID::FromBinary(object_id_binary);
       rpc::WorkerObjectLocationsPubMessage location_info;
       if (!status.ok()) {
+        RAY_LOG(INFO) << "Worker " << worker_id << " failed to get the location for "
+                      << object_id << status.ToString();
         mark_as_failed_(object_id, rpc::ErrorType::OWNER_DIED);
       } else {
         // Owner is still alive but published a failure because the ref was
         // deleted.
+        RAY_LOG(INFO)
+            << "Worker " << worker_id << " failed to get the location for " << object_id
+            << ", object already released by distributed reference counting protocol";
         mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
       }
       // Location lookup can fail if the owner is reachable but no longer has a
@@ -427,11 +432,11 @@ ray::Status OwnershipBasedObjectDirectory::LookupLocations(
           bool pending_creation = false;
 
           if (!status.ok()) {
-            RAY_LOG(ERROR) << "Worker " << worker_id << " failed to get the location for "
-                           << object_id << status.ToString();
+            RAY_LOG(INFO) << "Worker " << worker_id << " failed to get the location for "
+                          << object_id << status.ToString();
             mark_as_failed_(object_id, rpc::ErrorType::OWNER_DIED);
           } else if (reply.object_location_info().ref_removed()) {
-            RAY_LOG(ERROR)
+            RAY_LOG(INFO)
                 << "Worker " << worker_id << " failed to get the location for "
                 << object_id
                 << ", object already released by distributed reference counting protocol";

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -286,10 +286,16 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     };
 
     auto failure_callback = [this, owner_address](const std::string &object_id_binary,
-                                                  const Status &) {
+                                                  const Status &status) {
       const auto object_id = ObjectID::FromBinary(object_id_binary);
-      mark_as_failed_(object_id, rpc::ErrorType::OWNER_DIED);
       rpc::WorkerObjectLocationsPubMessage location_info;
+      if (!status.ok()) {
+        mark_as_failed_(object_id, rpc::ErrorType::OWNER_DIED);
+      } else {
+        // Owner is still alive but published a failure because the ref was
+        // deleted.
+        mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
+      }
       // Location lookup can fail if the owner is reachable but no longer has a
       // record of this ObjectRef, most likely due to an issue with the
       // distributed reference counting protocol.

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -290,14 +290,14 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
       const auto object_id = ObjectID::FromBinary(object_id_binary);
       rpc::WorkerObjectLocationsPubMessage location_info;
       if (!status.ok()) {
-        RAY_LOG(INFO) << "Worker " << worker_id << " failed to get the location for "
-                      << object_id << status.ToString();
+        RAY_LOG(INFO) << "Failed to get the location for " << object_id
+                      << status.ToString();
         mark_as_failed_(object_id, rpc::ErrorType::OWNER_DIED);
       } else {
         // Owner is still alive but published a failure because the ref was
         // deleted.
         RAY_LOG(INFO)
-            << "Worker " << worker_id << " failed to get the location for " << object_id
+            << "Failed to get the location for " << object_id
             << ", object already released by distributed reference counting protocol";
         mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
       }

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -283,12 +283,6 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
       ObjectLocationSubscriptionCallback(
           location_info, object_id,
           /*location_lookup_failed*/ !location_info.ref_removed());
-      if (location_info.ref_removed()) {
-        RAY_LOG(DEBUG)
-            << "Failed to get locations for " << object_id
-            << ", object already released by distributed reference counting protocol";
-        mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
-      }
     };
 
     auto failure_callback = [this, owner_address](const std::string &object_id_binary,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removes some error checking code in the object directory client. It should be redundant, since object fetches will timeout after too long without location notifications anyway.