### PR TITLE
Fix tf.random.uniform dtype

### DIFF
--- a/rllib/utils/exploration/random.py
+++ b/rllib/utils/exploration/random.py
@@ -78,16 +78,20 @@ class Random(Exploration):
                 shape = component.shape or (1, )
 
                 if isinstance(component, Discrete):
-                    return tf.random.uniform(
-                        shape=(batch_size, ) + component.shape,
-                        maxval=component.n,
+                    return tf.cast(
+                        tf.random.uniform(
+                            shape=(batch_size, ) + component.shape,
+                            maxval=component.n,
+                            dtype=tf.int64),
                         dtype=component.dtype)
                 elif isinstance(component, MultiDiscrete):
                     return tf.concat(
                         [
-                            tf.random.uniform(
-                                shape=(batch_size, 1),
-                                maxval=n,
+                            tf.cast(
+                                tf.random.uniform(
+                                    shape=(batch_size, 1),
+                                    maxval=n,
+                                    dtype=tf.int64),
                                 dtype=component.dtype) for n in component.nvec
                         ],
                         axis=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

tf.random.uniform only supports `float16`, `float32`, `float64`, `int32`, or `int64` as of tensorflow 2.7. This raises a ValueError when using, for example, Discrete actions with dtype=uint8 to save memory, like in the [SSD](https://github.com/eugenevinitsky/sequential_social_dilemma_games) environments.

Using tf.cast() is a little 'hacky', but works until tf supports other dtypes. This fix should probably also be applied with modifications in other places e.g. if component is a Box() and so on.

## Related issue number

## Checks

- [ Y] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [Y ] This PR is not tested :(
