### PR TITLE
[Jobs] Update CLI examples to use the same setup

### DIFF
--- a/doc/source/ray-job-submission/overview.rst
+++ b/doc/source/ray-job-submission/overview.rst
@@ -64,11 +64,14 @@ We can put this file in a local directory of your choice, with filename "script.
 
 .. code-block:: bash
 
-    export RAY_RUNTIME_ENV_LOCAL_DEV_MODE="1"  # If you're using locally build version of ray
-
    ❯ ray start --head
     Local node IP: 127.0.0.1
     INFO services.py:1360 -- View the Ray dashboard at http://127.0.0.1:8265
+
+.. note::
+
+    If you're building from ray source instead of any pre-built or nightly wheels, please set extra environment variable if you want to use runtime environment features.
+    :code:`export RAY_RUNTIME_ENV_LOCAL_DEV_MODE="1"`
 
 Ray Job APIs
 ------------

--- a/doc/source/ray-job-submission/overview.rst
+++ b/doc/source/ray-job-submission/overview.rst
@@ -64,6 +64,8 @@ We can put this file in a local directory of your choice, with filename "script.
 
 .. code-block:: bash
 
+    export RAY_RUNTIME_ENV_LOCAL_DEV_MODE="1"  # If you're using locally build version of ray
+
    ❯ ray start --head
     Local node IP: 127.0.0.1
     INFO services.py:1360 -- View the Ray dashboard at http://127.0.0.1:8265
@@ -99,18 +101,36 @@ If we have :code:`RAY_ADDRESS` environment variable set with a local Ray cluster
 
 .. code-block::
 
-    ❯ ray job submit -- "python -c 'print(123); import time; time.sleep(5)'"
-    2021-11-18 16:14:47,602	INFO cli.py:103 -- Job submitted successfully: raysubmit_GsQYzyvZpgNicU8F.
-    2021-11-18 16:14:47,602	INFO cli.py:104 -- Query the status of the job using: `ray job status raysubmit_GsQYzyvZpgNicU8F`.
+    ❯ ray job submit --runtime-env-json='{"working_dir": "./", "pip": ["requests==2.26.0"]}' -- "python script.py"
+    2021-12-01 23:04:52,672	INFO cli.py:25 -- Creating JobSubmissionClient at address: http://127.0.0.1:8265
+    2021-12-01 23:04:52,809	INFO sdk.py:144 -- Uploading package gcs://_ray_pkg_bbcc8ca7e83b4dc0.zip.
+    2021-12-01 23:04:52,810	INFO packaging.py:352 -- Creating a file package for local directory './'.
+    2021-12-01 23:04:52,878	INFO cli.py:105 -- Job submitted successfully: raysubmit_RXhvSyEPbxhcXtm6.
+    2021-12-01 23:04:52,878	INFO cli.py:106 -- Query the status of the job using: `ray job status raysubmit_RXhvSyEPbxhcXtm6`.
 
+    ❯ ray job status raysubmit_RXhvSyEPbxhcXtm6
+    2021-12-01 23:05:00,356	INFO cli.py:25 -- Creating JobSubmissionClient at address: http://127.0.0.1:8265
+    2021-12-01 23:05:00,371	INFO cli.py:127 -- Job status for 'raysubmit_RXhvSyEPbxhcXtm6': PENDING.
+    2021-12-01 23:05:00,371	INFO cli.py:129 -- Job has not started yet, likely waiting for the runtime_env to be set up.
 
-    ❯ ray job status raysubmit_GsQYzyvZpgNicU8F
-    2021-11-18 16:15:07,727	INFO cli.py:125 -- Job status for 'raysubmit_GsQYzyvZpgNicU8F': SUCCEEDED.
-    2021-11-18 16:15:07,727	INFO cli.py:127 -- Job finished successfully.
+    ❯ ray job status raysubmit_RXhvSyEPbxhcXtm6
+    2021-12-01 23:05:37,751	INFO cli.py:25 -- Creating JobSubmissionClient at address: http://127.0.0.1:8265
+    2021-12-01 23:05:37,764	INFO cli.py:127 -- Job status for 'raysubmit_RXhvSyEPbxhcXtm6': SUCCEEDED.
+    2021-12-01 23:05:37,764	INFO cli.py:129 -- Job finished successfully.
 
+    ❯ ray job logs raysubmit_RXhvSyEPbxhcXtm6
+    2021-12-01 23:05:59,026	INFO cli.py:25 -- Creating JobSubmissionClient at address: http://127.0.0.1:8265
+    2021-12-01 23:05:23,037	INFO worker.py:851 -- Connecting to existing Ray cluster at address: 127.0.0.1:6379
+    (pid=runtime_env) 2021-12-01 23:05:23,212	WARNING conda.py:54 -- Injecting /Users/jiaodong/Workspace/ray/python to environment /tmp/ray/session_2021-12-01_23-04-44_771129_7693/runtime_resources/conda/99305e1352b2dcc9d5f38c2721c7c1f1cc0551d5 because _inject_current_ray flag is on.
+    (pid=runtime_env) 2021-12-01 23:05:23,212	INFO conda.py:328 -- Finished setting up runtime environment at /tmp/ray/session_2021-12-01_23-04-44_771129_7693/runtime_resources/conda/99305e1352b2dcc9d5f38c2721c7c1f1cc0551d5
+    (pid=runtime_env) 2021-12-01 23:05:23,213	INFO working_dir.py:85 -- Setup working dir for gcs://_ray_pkg_bbcc8ca7e83b4dc0.zip
+    1
+    2
+    3
+    4
+    5
+    2.26.0
 
-    ❯ ray job logs raysubmit_GsQYzyvZpgNicU8F
-    123
 
 
 Ray Job SDK


### PR DESCRIPTION
## Why are these changes needed?

Current docs https://docs.ray.io/en/master/ray-job-submission/overview.html started with CLI but is a very minimal example. This changes it to the better script.py one, same for SDK.

## Related issue number

Closes #20835

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
