### PR TITLE
DOC, BUILD: limit bazel resource usage with BAZEL_LIMIT_CPUS and document it

### DIFF
--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -120,6 +120,32 @@ directory will take effect without reinstalling the package.
 
 .. warning:: if you run ``python setup.py install``, files will be copied from the Ray directory to a directory of Python packages (``/lib/python3.6/site-packages/ray``). This means that changes you make to files in the Ray directory will not have any effect.
 
+Environment varaibles that influence this step
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can tweak the build with the following environment variables (in `setup.py`):
+
+- ``BUILD_JAVA``: If set and equal to ``1``, extra build steps will be executed
+  to build java portions of the codebase
+- ``RAY_INSTALL_CPP``: If set and equal to ``1``, ``ray-cpp`` will be installed
+- ``RAY_DISABLE_EXTRA_CPP``: If set and equal to ``1``, a regular (non -
+  ``cpp``) build will not provide some ``cpp`` interfaces
+- ``SKIP_BAZEL_BUILD``: If set and equal to ``1``, no bazel build steps will be
+  executed
+- ``SKIP_THIRDPARTY_INSTALL``: If set will skip installation of third-party
+  python packages
+- ``RAY_DEBUG_BUILD``: Can be set to ``debug``, ``asan``, or ``tsan``. Any
+  other value will be ignored
+- ``BAZEL_LIMIT_CPUS``: If set, it must be an integers. This will be fed to the
+  ``--local_cpu_resources`` argument for the call to bazel, which will limit the
+  number of CPUs used during bazel steps.
+- ``IS_AUTOMATED_BUILD``: Used in CI to tweak the build for the CI machines
+- ``SRC_DIR``: Can be set to the root of the source checkout, defaults to
+  ``None`` which is ``cwd()``
+- ``BAZEL_SH``: used on Windows to find a ``bash.exe``, see below
+- ``BAZEL_PATH``: used on Windows to find ``bazel.exe``, see below
+- ``MINGW_DIR``: used on Windows to find ``bazel.exe`` if not found in ``BAZEL_PATH``
+
 Building Ray on Windows (full)
 ------------------------------
 

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -120,7 +120,7 @@ directory will take effect without reinstalling the package.
 
 .. warning:: if you run ``python setup.py install``, files will be copied from the Ray directory to a directory of Python packages (``/lib/python3.6/site-packages/ray``). This means that changes you make to files in the Ray directory will not have any effect.
 
-Environment varaibles that influence this step
+Environment variables that influence this step
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can tweak the build with the following environment variables (in `setup.py`):

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,6 +28,7 @@ SUPPORTED_BAZEL = (4, 2, 1)
 ROOT_DIR = os.path.dirname(__file__)
 BUILD_JAVA = os.getenv("RAY_INSTALL_JAVA") == "1"
 SKIP_BAZEL_BUILD = os.getenv("SKIP_BAZEL_BUILD") == "1"
+BAZEL_LIMIT_CPUS = os.getenv("BAZEL_LIMIT_CPUS")
 
 PICKLE5_SUBDIR = os.path.join("ray", "pickle5_files")
 THIRDPARTY_SUBDIR = os.path.join("ray", "thirdparty_files")
@@ -495,7 +496,11 @@ def build(build_python, build_java, build_cpp):
         logger.warning("Expected Bazel version {} but found {}".format(
             ".".join(map(str, SUPPORTED_BAZEL)), bazel_version_str))
 
+    
     bazel_flags = ["--verbose_failures"]
+    if BAZEL_LIMIT_CPUS:
+        n = int(BAZEL_LIMIT_CPUS)  # the value must be an int
+        bazel_flags.append(f"--local_cpu_resources={n}")
 
     if not is_automated_build:
         bazel_precmd_flags = []

--- a/python/setup.py
+++ b/python/setup.py
@@ -495,7 +495,6 @@ def build(build_python, build_java, build_cpp):
     if bazel_version < SUPPORTED_BAZEL:
         logger.warning("Expected Bazel version {} but found {}".format(
             ".".join(map(str, SUPPORTED_BAZEL)), bazel_version_str))
-
     
     bazel_flags = ["--verbose_failures"]
     if BAZEL_LIMIT_CPUS:

--- a/python/setup.py
+++ b/python/setup.py
@@ -495,7 +495,7 @@ def build(build_python, build_java, build_cpp):
     if bazel_version < SUPPORTED_BAZEL:
         logger.warning("Expected Bazel version {} but found {}".format(
             ".".join(map(str, SUPPORTED_BAZEL)), bazel_version_str))
-    
+
     bazel_flags = ["--verbose_failures"]
     if BAZEL_LIMIT_CPUS:
         n = int(BAZEL_LIMIT_CPUS)  # the value must be an int


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

So I have a AMD machine with many cores and 32GB of memory. When I do `pip install -e .`, my machine crashes since bazel tries to use all the cores, but quickly runs out of memory. It seems there is no native way to set environment variables to tell bazel to limit its resource consumption, but there is a `--local_cpu_resources` command-line option.

This PR exposes that to the `pip install` via an environment variable. I also went through the setup.py and documented all the environment variables I could find.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
