### PR TITLE
Revert "[runtime env] Allow working_dir and py_module to be Path type"

### DIFF
--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -2,7 +2,6 @@ import logging
 import os
 from types import ModuleType
 from typing import Any, Dict, Optional
-from pathlib import Path
 
 from ray.experimental.internal_kv import _internal_kv_initialized
 from ray._private.runtime_env.context import RuntimeEnvContext
@@ -48,8 +47,6 @@ def upload_py_modules_if_needed(
         if isinstance(module, str):
             # module_path is a local path or a URI.
             module_path = module
-        elif isinstance(module, Path):
-            module_path = str(module)
         elif isinstance(module, ModuleType):
             # NOTE(edoakes): Python allows some installed Python packages to
             # be split into multiple directories. We could probably handle

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from typing import Any, Dict, Optional
-from pathlib import Path
 
 from ray._private.runtime_env.utils import RuntimeEnv
 from ray.experimental.internal_kv import _internal_kv_initialized
@@ -25,13 +24,10 @@ def upload_working_dir_if_needed(
     if working_dir is None:
         return runtime_env
 
-    if not isinstance(working_dir, str) and not isinstance(working_dir, Path):
+    if not isinstance(working_dir, str):
         raise TypeError(
-            "working_dir must be a string or Path (either a local path "
-            f"or remote URI), got {type(working_dir)}.")
-
-    if isinstance(working_dir, Path):
-        working_dir = str(working_dir)
+            "working_dir must be a string (either a local path or remote "
+            f"URI), got {type(working_dir)}.")
 
     # working_dir is already a URI -- just pass it through.
     try:

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -46,10 +46,7 @@ def tmp_working_dir():
         yield tmp_dir
 
 
-@pytest.mark.parametrize("option", [
-    "failure", "working_dir", "py_modules", "py_modules_path",
-    "working_dir_path"
-])
+@pytest.mark.parametrize("option", ["failure", "working_dir", "py_modules"])
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_lazy_reads(start_cluster, tmp_working_dir, option: str):
     """Tests the case where we lazily read files or import inside a task/actor.
@@ -65,20 +62,11 @@ def test_lazy_reads(start_cluster, tmp_working_dir, option: str):
             ray.init(address)
         elif option == "working_dir":
             ray.init(address, runtime_env={"working_dir": tmp_working_dir})
-        elif option == "working_dir_path":
-            ray.init(
-                address, runtime_env={"working_dir": Path(tmp_working_dir)})
         elif option == "py_modules":
             ray.init(
                 address,
                 runtime_env={
                     "py_modules": [str(Path(tmp_working_dir) / "test_module")]
-                })
-        elif option == "py_modules_path":
-            ray.init(
-                address,
-                runtime_env={
-                    "py_modules": [Path(tmp_working_dir) / "test_module"]
                 })
 
     call_ray_init()


### PR DESCRIPTION
Reverts ray-project/ray#20810

This PR increased the flakiness of test_working_dir to unacceptably high. 

<img width="436" alt="Screen Shot 2021-12-02 at 10 07 58 AM" src="https://user-images.githubusercontent.com/5459654/144478757-714761ef-e45d-4276-8e48-006b6e639ac5.png">


The PR is not faulty, it just increases the number of tests and we seem to be hitting the timeout.

Rather than fix-forward, the policy is to revert this PR to fix the build because reverts can be merged without waiting for tests to pass.

After reverting we will split up the working_dir tests into two files to prevent the timeout and un-revert the PR.

 