### PR TITLE
[RLlib] Change return type of try_reset to MultiEnvDict

### DIFF
--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -161,7 +161,7 @@ class BaseEnv:
 
     @PublicAPI
     def try_reset(self,
-                  env_id: Optional[EnvID] = None) -> Optional[MultiAgentDict]:
+                  env_id: Optional[EnvID] = None) -> Optional[MultiEnvDict]:
         """Attempt to reset the sub-env with the given id or all sub-envs.
 
         If the environment does not support synchronous reset, None can be

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -173,10 +173,10 @@ class BaseEnv:
                 the entire Env (i.e. all sub-environments).
 
         Note: A MultiAgentDict is returned when using the deprecated wrapper
-            classes such as `ray.rllib.env.base_env._MultiAgentEnvToBaseEnv,
-            however for consistency with the poll() method, a MultiEnvDict is
-            returned from the new wrapper classes, such as
-            ray.rllib.env.multi_agent_env.MultiAgentEnvWrapper
+        classes such as `ray.rllib.env.base_env._MultiAgentEnvToBaseEnv,
+        however for consistency with the poll() method, a MultiEnvDict is
+        returned from the new wrapper classes, such as
+        ray.rllib.env.multi_agent_env.MultiAgentEnvWrapper
 
         Returns:
             The reset (multi-agent) observation dict. None if reset is not

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -1,4 +1,5 @@
-from typing import Callable, Tuple, Optional, List, Dict, Any, TYPE_CHECKING
+from typing import Callable, Tuple, Optional, List, Dict, Any, TYPE_CHECKING,\
+    Union
 
 import ray
 from ray.rllib.utils.annotations import Deprecated, override, PublicAPI
@@ -160,8 +161,8 @@ class BaseEnv:
         raise NotImplementedError
 
     @PublicAPI
-    def try_reset(self,
-                  env_id: Optional[EnvID] = None) -> Optional[MultiEnvDict]:
+    def try_reset(self, env_id: Optional[EnvID] = None
+                  ) -> Optional[Union[MultiAgentDict, MultiEnvDict]]:
         """Attempt to reset the sub-env with the given id or all sub-envs.
 
         If the environment does not support synchronous reset, None can be
@@ -170,6 +171,12 @@ class BaseEnv:
         Args:
             env_id: The sub-environment's ID if applicable. If None, reset
                 the entire Env (i.e. all sub-environments).
+
+        Note: A MultiAgentDict is returned when using the deprecated wrapper
+            classes such as `ray.rllib.env.base_env._MultiAgentEnvToBaseEnv,
+            however for consistency with the poll() method, a MultiEnvDict is
+            returned from the new wrapper classes, such as
+            ray.rllib.env.multi_agent_env.MultiAgentEnvWrapper
 
         Returns:
             The reset (multi-agent) observation dict. None if reset is not

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -173,10 +173,10 @@ class BaseEnv:
                 the entire Env (i.e. all sub-environments).
 
         Note: A MultiAgentDict is returned when using the deprecated wrapper
-        classes such as `ray.rllib.env.base_env._MultiAgentEnvToBaseEnv,
-        however for consistency with the poll() method, a MultiEnvDict is
+        classes such as `ray.rllib.env.base_env._MultiAgentEnvToBaseEnv`,
+        however for consistency with the poll() method, a `MultiEnvDict` is
         returned from the new wrapper classes, such as
-        ray.rllib.env.multi_agent_env.MultiAgentEnvWrapper
+        `ray.rllib.env.multi_agent_env.MultiAgentEnvWrapper`.
 
         Returns:
             The reset (multi-agent) observation dict. None if reset is not

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -327,11 +327,12 @@ class MultiAgentEnvWrapper(BaseEnv):
 
     @override(BaseEnv)
     def try_reset(self,
-                  env_id: Optional[EnvID] = None) -> Optional[MultiAgentDict]:
+                  env_id: Optional[EnvID] = None) -> Optional[MultiEnvDict]:
         obs = self.env_states[env_id].reset()
         assert isinstance(obs, dict), "Not a multi-agent obs"
         if obs is not None and env_id in self.dones:
             self.dones.remove(env_id)
+        obs = {env_id: obs}
         return obs
 
     @override(BaseEnv)

--- a/rllib/env/remote_base_env.py
+++ b/rllib/env/remote_base_env.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 import ray
 from ray.rllib.env.base_env import BaseEnv, _DUMMY_AGENT_ID, ASYNC_RESET_RETURN
 from ray.rllib.utils.annotations import override, PublicAPI
-from ray.rllib.utils.typing import MultiEnvDict, EnvType, EnvID, MultiAgentDict
+from ray.rllib.utils.typing import MultiEnvDict, EnvType, EnvID
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +184,7 @@ class RemoteBaseEnv(BaseEnv):
     @override(BaseEnv)
     @PublicAPI
     def try_reset(self,
-                  env_id: Optional[EnvID] = None) -> Optional[MultiAgentDict]:
+                  env_id: Optional[EnvID] = None) -> Optional[MultiEnvDict]:
         actor = self.actors[env_id]
         obj_ref = actor.reset.remote()
         self.pending[obj_ref] = actor

--- a/rllib/env/vector_env.py
+++ b/rllib/env/vector_env.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Optional, Tuple
 from ray.rllib.env.base_env import BaseEnv
 from ray.rllib.utils.annotations import Deprecated, override, PublicAPI
 from ray.rllib.utils.typing import EnvActionType, EnvID, EnvInfoDict, \
-    EnvObsType, EnvType, MultiAgentDict, MultiEnvDict
+    EnvObsType, EnvType, MultiEnvDict
 
 logger = logging.getLogger(__name__)
 
@@ -302,10 +302,14 @@ class VectorEnvWrapper(BaseEnv):
             self.vector_env.vector_step(action_vector)
 
     @override(BaseEnv)
-    def try_reset(self, env_id: Optional[EnvID] = None) -> MultiAgentDict:
+    def try_reset(self, env_id: Optional[EnvID] = None) -> MultiEnvDict:
         from ray.rllib.env.base_env import _DUMMY_AGENT_ID
         assert env_id is None or isinstance(env_id, int)
-        return {_DUMMY_AGENT_ID: self.vector_env.reset_at(env_id)}
+        return {
+            env_id if env_id is not None else 0: {
+                _DUMMY_AGENT_ID: self.vector_env.reset_at(env_id)
+            }
+        }
 
     @override(BaseEnv)
     def get_sub_environments(self) -> List[EnvType]:

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -970,7 +970,8 @@ def _process_observations(
                 resetted_obs: Dict[AgentID, EnvObsType] = all_agents_obs
             else:
                 del active_episodes[env_id]
-                resetted_obs: Dict[AgentID, EnvObsType] = base_env.try_reset(
+                resetted_obs: Dict[EnvID, Dict[AgentID, EnvObsType]] = \
+                    base_env.try_reset(
                     env_id)
             # Reset not supported, drop this env from the ready list.
             if resetted_obs is None:
@@ -982,6 +983,7 @@ def _process_observations(
             # If reset is async, we will get its result in some future poll.
             elif resetted_obs != ASYNC_RESET_RETURN:
                 new_episode: Episode = active_episodes[env_id]
+                resetted_obs = resetted_obs[env_id]
                 if observation_fn:
                     resetted_obs: Dict[AgentID, EnvObsType] = observation_fn(
                         agent_obs=resetted_obs,

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -967,7 +967,8 @@ def _process_observations(
             # Horizon hit and we have a soft horizon (no hard env reset).
             if hit_horizon and soft_horizon:
                 episode.soft_reset()
-                resetted_obs: Dict[AgentID, EnvObsType] = all_agents_obs
+                resetted_obs: Dict[EnvID, Dict[AgentID, EnvObsType]] = \
+                    {env_id: all_agents_obs}
             else:
                 del active_episodes[env_id]
                 resetted_obs: Dict[EnvID, Dict[AgentID, EnvObsType]] = \

--- a/rllib/tests/test_multi_agent_env.py
+++ b/rllib/tests/test_multi_agent_env.py
@@ -133,8 +133,8 @@ class TestMultiAgentEnv(unittest.TestCase):
                     1: 0
                 }
             }))
-        self.assertEqual(env.try_reset(0), {0: 0, 1: 0})
-        self.assertEqual(env.try_reset(1), {0: 0, 1: 0})
+        self.assertEqual(env.try_reset(0), {0: {0: 0, 1: 0}})
+        self.assertEqual(env.try_reset(1), {1: {0: 0, 1: 0}})
         env.send_actions({0: {0: 0, 1: 0}, 1: {0: 0, 1: 0}})
         obs, rew, dones, _, _ = env.poll()
         self.assertEqual(obs, {0: {0: 0, 1: 0}, 1: {0: 0, 1: 0}})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The return type of try reset should match that of poll() for BaseEnv. This would make it feasible to add methods for checking whether observations and actions belong to the env and observation spaces that I added to BaseEnv in #20832 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
