### PR TITLE
[Train] Clarify `Session.get_next` docstring

### DIFF
--- a/python/ray/train/session.py
+++ b/python/ray/train/session.py
@@ -105,7 +105,7 @@ class Session:
 
     def get_next(self) -> Optional[TrainingResult]:
         """Get the next ``TrainingResult`` from the result queue.
-        
+
         If the result queue is empty, then this function returns None.
         """
         if not self.training_started:

--- a/python/ray/train/session.py
+++ b/python/ray/train/session.py
@@ -104,7 +104,7 @@ class Session:
         return func_output
 
     def get_next(self) -> Optional[TrainingResult]:
-        """Get the next ``TrainingResult`` from the result queue.
+        """Gets the next ``TrainingResult`` from the result queue.
 
         If the result queue is empty, then this function returns None.
         """

--- a/python/ray/train/session.py
+++ b/python/ray/train/session.py
@@ -106,7 +106,7 @@ class Session:
     def get_next(self) -> Optional[TrainingResult]:
         """Gets the next ``TrainingResult`` from the result queue.
 
-        If the result queue is empty, then this function returns None.
+        If the result queue is empty, then this function returns ``None``.
         """
         if not self.training_started:
             raise RuntimeError("Please call start before calling get_next.")

--- a/python/ray/train/session.py
+++ b/python/ray/train/session.py
@@ -104,7 +104,10 @@ class Session:
         return func_output
 
     def get_next(self) -> Optional[TrainingResult]:
-        """Gets next result from the queue."""
+        """Get the next ``TrainingResult`` from the result queue.
+        
+        If the result queue is empty, then this function returns None.
+        """
         if not self.training_started:
             raise RuntimeError("Please call start before calling get_next.")
         result = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR addresses ~~two issues~~ an issue with the `Session.get_next` docstring:
- ~~The docstring summary is in the wrong tense.~~ It's unclear whether the tense should be imperative or non-imperative. The Ray documentation states that we use Google style (which is non-imperative), but we are formatting using PEP8 (which is imperative). Moreover, we use both imperative and non-imperative summaries across the Ray Train code. I've stuck with a non-imperative summary for consistency with the rest of the `Session` class.
- The docstring doesn't describe the  conditions under which the function returns `None`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
