### PR TITLE
[1/gcs-mem-kv]  Memory mode for internal kv

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -351,7 +351,7 @@
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,client_tests,-flaky
       --test_env=RAY_CLIENT_MODE=1 --test_env=RAY_PROFILING=1
-      --test_env=RAY_gcs_grpc_based_pubsub=true
+      --test_env=RAY_gcs_grpc_based_pubsub=true --test_env=RAY_gcs_storage=memory
       -- //python/ray/tests/...
 - label: ":redis: HA GCS (Medium A-J)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
@@ -359,7 +359,7 @@
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,medium_size_python_tests_a_to_j,-flaky
-      --test_env=RAY_gcs_grpc_based_pubsub=true
+      --test_env=RAY_gcs_grpc_based_pubsub=true --test_env=RAY_gcs_storage=memory
       -- //python/ray/tests/...
       -//python/ray/tests:test_client_multi -//python/ray/tests:test_component_failures_3
       -//python/ray/tests:test_healthcheck -//python/ray/tests:test_gcs_fault_tolerance
@@ -370,7 +370,7 @@
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,medium_size_python_tests_k_to_z,-flaky
-      --test_env=RAY_gcs_grpc_based_pubsub=true
+      --test_env=RAY_gcs_grpc_based_pubsub=true --test_env=RAY_gcs_storage=memory
       -- //python/ray/tests/...
       -//python/ray/tests:test_multinode_failures_2 -//python/ray/tests:test_ray_debugger
       -//python/ray/tests:test_placement_group_2 -//python/ray/tests:test_placement_group_3

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1499,6 +1499,29 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "gcs_kv_manager_test",
+    size = "small",
+    srcs = [
+        "src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc",
+    ],
+    args = [
+        "$(location redis-server)",
+        "$(location redis-cli)",
+    ],
+    copts = COPTS,
+    data = [
+        "//:redis-cli",
+        "//:redis-server",
+    ],
+    tags = ["team:core"],
+    deps = [
+        ":gcs_server_lib",
+        ":gcs_test_util_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "gcs_server_test_util",
     hdrs = [

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -280,6 +280,8 @@ RAY_CONFIG(uint64_t, gcs_max_concurrent_resource_pulls, 100)
 RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
 // Feature flag to enable grpc based pubsub in GCS.
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, false)
+// Storage backend for gcs
+RAY_CONFIG(std::string, gcs_storage, "redis")
 
 /// Duration to sleep after failing to put an object in plasma because it is full.
 RAY_CONFIG(uint32_t, object_store_full_delay_ms, 10)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -280,7 +280,7 @@ RAY_CONFIG(uint64_t, gcs_max_concurrent_resource_pulls, 100)
 RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
 // Feature flag to enable grpc based pubsub in GCS.
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, false)
-// Storage backend for gcs
+// Storage backend for gcs. It can be redis or memory
 RAY_CONFIG(std::string, gcs_storage, "redis")
 
 /// Duration to sleep after failing to put an object in plasma because it is full.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -280,7 +280,7 @@ RAY_CONFIG(uint64_t, gcs_max_concurrent_resource_pulls, 100)
 RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
 // Feature flag to enable grpc based pubsub in GCS.
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, false)
-// Storage backend for gcs. It can be redis or memory
+// The storage backend to use for the GCS. It can be either 'redis' or 'memory'.
 RAY_CONFIG(std::string, gcs_storage, "redis")
 
 /// Duration to sleep after failing to put an object in plasma because it is full.

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -20,71 +20,72 @@ namespace ray {
 namespace gcs {
 
 void RedisInternalKV::Get(const std::string &key,
-                          std::function<void(std::optional<std::string>)> cb) {
+                          std::function<void(std::optional<std::string>)> callback) {
   std::vector<std::string> cmd = {"HGET", key, "value"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [cb = std::move(cb)](auto redis_reply) {
+      cmd, [callback = std::move(callback)](auto redis_reply) {
         if (!redis_reply->IsNil()) {
-          cb(redis_reply->ReadAsString());
+          callback(redis_reply->ReadAsString());
         } else {
-          cb(std::nullopt);
+          callback(std::nullopt);
         }
       }));
 }
 
 void RedisInternalKV::Put(const std::string &key, const std::string &value,
-                          bool overwrite, std::function<void(bool)> cb) {
+                          bool overwrite, std::function<void(bool)> callback) {
   std::vector<std::string> cmd = {overwrite ? "HSET" : "HSETNX", key, "value", value};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [cb = std::move(cb)](auto redis_reply) {
+      cmd, [callback = std::move(callback)](auto redis_reply) {
         auto added_num = redis_reply->ReadAsInteger();
-        cb(added_num != 0);
+        callback(added_num != 0);
       }));
 }
 
-void RedisInternalKV::Del(const std::string &key, std::function<void(bool)> cb) {
+void RedisInternalKV::Del(const std::string &key, std::function<void(bool)> callback) {
   std::vector<std::string> cmd = {"HDEL", key, "value"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd,
-      [cb = std::move(cb)](auto redis_reply) { cb(redis_reply->ReadAsInteger() != 0); }));
+      cmd, [callback = std::move(callback)](auto redis_reply) {
+        callback(redis_reply->ReadAsInteger() != 0);
+      }));
 }
 
-void RedisInternalKV::Exists(const std::string &key, std::function<void(bool)> cb) {
+void RedisInternalKV::Exists(const std::string &key, std::function<void(bool)> callback) {
   std::vector<std::string> cmd = {"HEXISTS", key, "value"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [cb = std::move(cb)](auto redis_reply) {
+      cmd, [callback = std::move(callback)](auto redis_reply) {
         bool exists = redis_reply->ReadAsInteger() > 0;
-        cb(exists);
+        callback(exists);
       }));
 }
 
 void RedisInternalKV::Keys(const std::string &prefix,
-                           std::function<void(std::vector<std::string>)> cb) {
+                           std::function<void(std::vector<std::string>)> callback) {
   std::vector<std::string> cmd = {"KEYS", prefix + "*"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [cb = std::move(cb)](auto redis_reply) {
+      cmd, [callback = std::move(callback)](auto redis_reply) {
         const auto &reply = redis_reply->ReadAsStringArray();
         std::vector<std::string> results;
         for (const auto &r : reply) {
           RAY_CHECK(r.has_value());
           results.emplace_back(*r);
         }
-        cb(std::move(results));
+        callback(std::move(results));
       }));
 }
 
 void MemoryInternalKV::Get(const std::string &key,
-                           std::function<void(std::optional<std::string>)> cb) {
-  absl::ReaderMutexLock _(&mu_);
+                           std::function<void(std::optional<std::string>)> callback) {
+  absl::ReaderMutexLock lock(&mu_);
   auto it = map_.find(key);
   auto val = it == map_.end() ? std::nullopt : std::make_optional(it->second);
-  if (cb != nullptr) {
-    RunCB(std::bind(std::move(cb), std::move(val)));
+  if (callback != nullptr) {
+    io_context_->post(std::bind(std::move(callback), std::move(val)));
   }
 }
 
 void MemoryInternalKV::Put(const std::string &key, const std::string &value,
-                           bool overwrite, std::function<void(bool)> cb) {
+                           bool overwrite, std::function<void(bool)> callback) {
   absl::WriterMutexLock _(&mu_);
   auto it = map_.find(key);
   bool inserted = false;
@@ -96,12 +97,12 @@ void MemoryInternalKV::Put(const std::string &key, const std::string &value,
     map_[key] = value;
     inserted = true;
   }
-  if (cb != nullptr) {
-    RunCB(std::bind(std::move(cb), inserted));
+  if (callback != nullptr) {
+    io_context_->post(std::bind(std::move(callback), inserted));
   }
 }
 
-void MemoryInternalKV::Del(const std::string &key, std::function<void(bool)> cb) {
+void MemoryInternalKV::Del(const std::string &key, std::function<void(bool)> callback) {
   absl::WriterMutexLock _(&mu_);
   auto it = map_.find(key);
   bool deleted = true;
@@ -110,37 +111,38 @@ void MemoryInternalKV::Del(const std::string &key, std::function<void(bool)> cb)
   } else {
     map_.erase(it);
   }
-  if (cb != nullptr) {
-    RunCB(std::bind(std::move(cb), deleted));
+  if (callback != nullptr) {
+    io_context_->post(std::bind(std::move(callback), deleted));
   }
 }
 
-void MemoryInternalKV::Exists(const std::string &key, std::function<void(bool)> cb) {
-  absl::ReaderMutexLock _(&mu_);
+void MemoryInternalKV::Exists(const std::string &key,
+                              std::function<void(bool)> callback) {
+  absl::ReaderMutexLock lock(&mu_);
   bool existed = map_.find(key) != map_.end();
-  if (cb != nullptr) {
-    RunCB(std::bind(std::move(cb), existed));
+  if (callback != nullptr) {
+    io_context_->post(std::bind(std::move(callback), existed));
   }
 }
 
 void MemoryInternalKV::Keys(const std::string &prefix,
-                            std::function<void(std::vector<std::string>)> cb) {
-  absl::ReaderMutexLock _(&mu_);
+                            std::function<void(std::vector<std::string>)> callback) {
+  absl::ReaderMutexLock lock(&mu_);
   std::vector<std::string> keys;
   auto iter = map_.lower_bound(prefix);
   while (iter != map_.end() && absl::StartsWith(iter->first, prefix)) {
     keys.push_back(iter->first);
     iter++;
   }
-  if (cb != nullptr) {
-    RunCB(std::bind(std::move(cb), std::move(keys)));
+  if (callback != nullptr) {
+    io_context_->post(std::bind(std::move(callback), std::move(keys)));
   }
 }
 
 void GcsInternalKVManager::HandleInternalKVGet(
     const rpc::InternalKVGetRequest &request, rpc::InternalKVGetReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  auto cb = [reply, send_reply_callback](std::optional<std::string> val) {
+  auto callback = [reply, send_reply_callback](std::optional<std::string> val) {
     if (val) {
       reply->set_value(*val);
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -149,49 +151,50 @@ void GcsInternalKVManager::HandleInternalKVGet(
                          Status::NotFound("Failed to find the key"));
     }
   };
-  kv_instance_->Get(request.key(), std::move(cb));
+  kv_instance_->Get(request.key(), std::move(callback));
 }
 
 void GcsInternalKVManager::HandleInternalKVPut(
     const rpc::InternalKVPutRequest &request, rpc::InternalKVPutReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  auto cb = [reply, send_reply_callback](bool newly_added) {
+  auto callback = [reply, send_reply_callback](bool newly_added) {
     reply->set_added_num(newly_added ? 1 : 0);
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };
-  kv_instance_->Put(request.key(), request.value(), request.overwrite(), std::move(cb));
+  kv_instance_->Put(request.key(), request.value(), request.overwrite(),
+                    std::move(callback));
 }
 
 void GcsInternalKVManager::HandleInternalKVDel(
     const rpc::InternalKVDelRequest &request, rpc::InternalKVDelReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  auto cb = [reply, send_reply_callback](bool deleted) {
+  auto callback = [reply, send_reply_callback](bool deleted) {
     reply->set_deleted_num(deleted ? 1 : 0);
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };
-  kv_instance_->Del(request.key(), std::move(cb));
+  kv_instance_->Del(request.key(), std::move(callback));
 }
 
 void GcsInternalKVManager::HandleInternalKVExists(
     const rpc::InternalKVExistsRequest &request, rpc::InternalKVExistsReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  auto cb = [reply, send_reply_callback](bool exists) {
+  auto callback = [reply, send_reply_callback](bool exists) {
     reply->set_exists(exists);
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };
-  kv_instance_->Exists(request.key(), std::move(cb));
+  kv_instance_->Exists(request.key(), std::move(callback));
 }
 
 void GcsInternalKVManager::HandleInternalKVKeys(
     const rpc::InternalKVKeysRequest &request, rpc::InternalKVKeysReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  auto cb = [reply, send_reply_callback](std::vector<std::string> keys) {
+  auto callback = [reply, send_reply_callback](std::vector<std::string> keys) {
     for (auto &result : keys) {
       reply->add_results(std::move(result));
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };
-  kv_instance_->Keys(request.prefix(), std::move(cb));
+  kv_instance_->Keys(request.prefix(), std::move(callback));
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -20,72 +20,58 @@ namespace gcs {
 void GcsInternalKVManager::HandleInternalKVGet(
     const rpc::InternalKVGetRequest &request, rpc::InternalKVGetReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  std::vector<std::string> cmd = {"HGET", request.key(), "value"};
-  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [reply, send_reply_callback](auto redis_reply) {
-        if (!redis_reply->IsNil()) {
-          reply->set_value(redis_reply->ReadAsString());
-          GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-        } else {
-          GCS_RPC_SEND_REPLY(send_reply_callback, reply,
-                             Status::NotFound("Failed to find the key"));
-        }
-      }));
+  kv_instance_->Get(request.key(),
+                    [reply, send_reply_callback](std::optional<std::string> val) {
+                      if(val) {
+                        reply->set_value(*val);
+                        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+                      } else {
+                        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::NotFound("Failed to find the key"));
+                      }
+                    });
 }
 
 void GcsInternalKVManager::HandleInternalKVPut(
     const rpc::InternalKVPutRequest &request, rpc::InternalKVPutReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  std::vector<std::string> cmd = {request.overwrite() ? "HSET" : "HSETNX", request.key(),
-                                  "value", request.value()};
-  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [reply, send_reply_callback](auto redis_reply) {
-        reply->set_added_num(redis_reply->ReadAsInteger());
+  kv_instance_->Put(
+      request.key(),
+      request.value(),
+      request.overwrite(),
+      [reply, send_reply_callback](bool newly_added) {
+        reply->set_added_num(newly_added ? 1 : 0);
         GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-      }));
+      });
 }
 
 void GcsInternalKVManager::HandleInternalKVDel(
     const rpc::InternalKVDelRequest &request, rpc::InternalKVDelReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  InternalKVDelAsync(request.key(), [reply, send_reply_callback](int deleted_num) {
-    reply->set_deleted_num(deleted_num);
-    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-  });
-}
-
-void GcsInternalKVManager::InternalKVDelAsync(const std::string &key,
-                                              std::function<void(int)> cb) {
-  std::vector<std::string> cmd = {"HDEL", key, "value"};
-  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [cb](auto redis_reply) { cb(redis_reply->ReadAsInteger()); }));
+  kv_instance_->Del(request.key(), [reply, send_reply_callback](bool deleted) {
+                                     reply->set_deleted_num(deleted ? 1 : 0);
+                                     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+                                   });
 }
 
 void GcsInternalKVManager::HandleInternalKVExists(
     const rpc::InternalKVExistsRequest &request, rpc::InternalKVExistsReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  std::vector<std::string> cmd = {"HEXISTS", request.key(), "value"};
-  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [reply, send_reply_callback](auto redis_reply) {
-        bool exists = redis_reply->ReadAsInteger() > 0;
-        reply->set_exists(exists);
-        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-      }));
+  kv_instance_->Exists(key, [reply, send_reply_callback](bool exists) {
+                              reply->set_exists(exists);
+                              GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+                            });
 }
 
 void GcsInternalKVManager::HandleInternalKVKeys(
     const rpc::InternalKVKeysRequest &request, rpc::InternalKVKeysReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  std::vector<std::string> cmd = {"KEYS", request.prefix() + "*"};
-  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [reply, send_reply_callback](auto redis_reply) {
-        const auto &results = redis_reply->ReadAsStringArray();
-        for (const auto &result : results) {
-          RAY_CHECK(result.has_value());
-          reply->add_results(*result);
-        }
-        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-      }));
+  kv_instance_->Keys(request.prefix(), [reply, send_reply_callback] (std::vector<std::string> keys) {
+                                         for (auto &result : keys) {
+                                           reply->add_results(std::move(result));
+                                         }
+                                         GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+
+                                       });
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -13,120 +13,126 @@
 // limitations under the License.
 
 #include "ray/gcs/gcs_server/gcs_kv_manager.h"
+
 #include "absl/strings/match.h"
 
 namespace ray {
 namespace gcs {
 
-void RedisInternalKV::Get(const std::string& key, std::function<void(std::optional<std::string>)> cb)  {
+void RedisInternalKV::Get(const std::string &key,
+                          std::function<void(std::optional<std::string>)> cb) {
   std::vector<std::string> cmd = {"HGET", key, "value"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
       cmd, [cb = std::move(cb)](auto redis_reply) {
-             if (!redis_reply->IsNil()) {
-               cb(redis_reply->ReadAsString());
-             } else {
-               cb(std::nullopt);
-             }
+        if (!redis_reply->IsNil()) {
+          cb(redis_reply->ReadAsString());
+        } else {
+          cb(std::nullopt);
+        }
       }));
 }
 
-void RedisInternalKV::Put(const std::string& key, const std::string& value, bool overwrite, std::function<void(bool)> cb)  {
+void RedisInternalKV::Put(const std::string &key, const std::string &value,
+                          bool overwrite, std::function<void(bool)> cb) {
   std::vector<std::string> cmd = {overwrite ? "HSET" : "HSETNX", key, "value", value};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
       cmd, [cb = std::move(cb)](auto redis_reply) {
-             auto added_num = redis_reply->ReadAsInteger();
-             cb(added_num != 0);
+        auto added_num = redis_reply->ReadAsInteger();
+        cb(added_num != 0);
       }));
 }
 
-void RedisInternalKV::Del(const std::string& key, std::function<void(bool)> cb) {
+void RedisInternalKV::Del(const std::string &key, std::function<void(bool)> cb) {
   std::vector<std::string> cmd = {"HDEL", key, "value"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
-      cmd, [cb = std::move(cb)](auto redis_reply) {
-             cb(redis_reply->ReadAsInteger() != 0);
-           }));
+      cmd,
+      [cb = std::move(cb)](auto redis_reply) { cb(redis_reply->ReadAsInteger() != 0); }));
 }
 
-void RedisInternalKV::Exists(const std::string& key, std::function<void(bool)> cb) {
+void RedisInternalKV::Exists(const std::string &key, std::function<void(bool)> cb) {
   std::vector<std::string> cmd = {"HEXISTS", key, "value"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
       cmd, [cb = std::move(cb)](auto redis_reply) {
-             bool exists = redis_reply->ReadAsInteger() > 0;
-             cb(exists);
+        bool exists = redis_reply->ReadAsInteger() > 0;
+        cb(exists);
       }));
 }
 
-void RedisInternalKV::Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) {
+void RedisInternalKV::Keys(const std::string &prefix,
+                           std::function<void(std::vector<std::string>)> cb) {
   std::vector<std::string> cmd = {"KEYS", prefix + "*"};
   RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
       cmd, [cb = std::move(cb)](auto redis_reply) {
-             const auto &reply = redis_reply->ReadAsStringArray();
-             std::vector<std::string> results;
-             for (const auto &r : reply) {
-               RAY_CHECK(r.has_value());
-               results.emplace_back(*r);
-             }
-             cb(std::move(results));
+        const auto &reply = redis_reply->ReadAsStringArray();
+        std::vector<std::string> results;
+        for (const auto &r : reply) {
+          RAY_CHECK(r.has_value());
+          results.emplace_back(*r);
+        }
+        cb(std::move(results));
       }));
 }
 
-void MemoryInternalKV::Get(const std::string& key, std::function<void(std::optional<std::string>)> cb) {
+void MemoryInternalKV::Get(const std::string &key,
+                           std::function<void(std::optional<std::string>)> cb) {
   absl::ReaderMutexLock _(&mu_);
   auto it = map_.find(key);
   auto val = it == map_.end() ? std::nullopt : std::make_optional(it->second);
-  if(cb != nullptr) {
+  if (cb != nullptr) {
     RunCB(std::bind(std::move(cb), std::move(val)));
   }
 }
 
-void MemoryInternalKV::Put(const std::string& key, const std::string& value, bool overwrite, std::function<void(bool)> cb) {
+void MemoryInternalKV::Put(const std::string &key, const std::string &value,
+                           bool overwrite, std::function<void(bool)> cb) {
   absl::WriterMutexLock _(&mu_);
   auto it = map_.find(key);
   bool inserted = false;
-  if(it != map_.end()) {
-    if(overwrite) {
+  if (it != map_.end()) {
+    if (overwrite) {
       it->second = value;
     }
   } else {
     map_[key] = value;
     inserted = true;
   }
-  if(cb != nullptr) {
+  if (cb != nullptr) {
     RunCB(std::bind(std::move(cb), inserted));
   }
 }
 
-void MemoryInternalKV::Del(const std::string& key, std::function<void(bool)> cb) {
+void MemoryInternalKV::Del(const std::string &key, std::function<void(bool)> cb) {
   absl::WriterMutexLock _(&mu_);
   auto it = map_.find(key);
   bool deleted = true;
-  if(it == map_.end()) {
+  if (it == map_.end()) {
     deleted = false;
   } else {
     map_.erase(it);
   }
-  if(cb != nullptr) {
+  if (cb != nullptr) {
     RunCB(std::bind(std::move(cb), deleted));
   }
 }
 
-void MemoryInternalKV::Exists(const std::string& key, std::function<void(bool)> cb) {
+void MemoryInternalKV::Exists(const std::string &key, std::function<void(bool)> cb) {
   absl::ReaderMutexLock _(&mu_);
   bool existed = map_.find(key) != map_.end();
-  if(cb != nullptr) {
+  if (cb != nullptr) {
     RunCB(std::bind(std::move(cb), existed));
   }
 }
 
-void MemoryInternalKV::Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) {
+void MemoryInternalKV::Keys(const std::string &prefix,
+                            std::function<void(std::vector<std::string>)> cb) {
   absl::ReaderMutexLock _(&mu_);
   std::vector<std::string> keys;
   auto iter = map_.lower_bound(prefix);
-  while(iter != map_.end() && absl::StartsWith(iter->first, prefix)) {
+  while (iter != map_.end() && absl::StartsWith(iter->first, prefix)) {
     keys.push_back(iter->first);
     iter++;
   }
-  if(cb != nullptr) {
+  if (cb != nullptr) {
     RunCB(std::bind(std::move(cb), std::move(keys)));
   }
 }
@@ -135,13 +141,14 @@ void GcsInternalKVManager::HandleInternalKVGet(
     const rpc::InternalKVGetRequest &request, rpc::InternalKVGetReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   auto cb = [reply, send_reply_callback](std::optional<std::string> val) {
-              if(val) {
-                reply->set_value(*val);
-                GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-              } else {
-                GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::NotFound("Failed to find the key"));
-              }
-            };
+    if (val) {
+      reply->set_value(*val);
+      GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+    } else {
+      GCS_RPC_SEND_REPLY(send_reply_callback, reply,
+                         Status::NotFound("Failed to find the key"));
+    }
+  };
   kv_instance_->Get(request.key(), std::move(cb));
 }
 
@@ -149,23 +156,19 @@ void GcsInternalKVManager::HandleInternalKVPut(
     const rpc::InternalKVPutRequest &request, rpc::InternalKVPutReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   auto cb = [reply, send_reply_callback](bool newly_added) {
-              reply->set_added_num(newly_added ? 1 : 0);
-              GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-            };
-  kv_instance_->Put(
-      request.key(),
-      request.value(),
-      request.overwrite(),
-      std::move(cb));
+    reply->set_added_num(newly_added ? 1 : 0);
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
+  kv_instance_->Put(request.key(), request.value(), request.overwrite(), std::move(cb));
 }
 
 void GcsInternalKVManager::HandleInternalKVDel(
     const rpc::InternalKVDelRequest &request, rpc::InternalKVDelReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   auto cb = [reply, send_reply_callback](bool deleted) {
-                                     reply->set_deleted_num(deleted ? 1 : 0);
-                                     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-            };
+    reply->set_deleted_num(deleted ? 1 : 0);
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
   kv_instance_->Del(request.key(), std::move(cb));
 }
 
@@ -173,22 +176,21 @@ void GcsInternalKVManager::HandleInternalKVExists(
     const rpc::InternalKVExistsRequest &request, rpc::InternalKVExistsReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   auto cb = [reply, send_reply_callback](bool exists) {
-                              reply->set_exists(exists);
-                              GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-            };
+    reply->set_exists(exists);
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
   kv_instance_->Exists(request.key(), std::move(cb));
 }
 
 void GcsInternalKVManager::HandleInternalKVKeys(
     const rpc::InternalKVKeysRequest &request, rpc::InternalKVKeysReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  auto cb = [reply, send_reply_callback] (std::vector<std::string> keys) {
-                                         for (auto &result : keys) {
-                                           reply->add_results(std::move(result));
-                                         }
-                                         GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-
-            };
+  auto cb = [reply, send_reply_callback](std::vector<std::string> keys) {
+    for (auto &result : keys) {
+      reply->add_results(std::move(result));
+    }
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
   kv_instance_->Keys(request.prefix(), std::move(cb));
 }
 

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -20,58 +20,62 @@ namespace gcs {
 void GcsInternalKVManager::HandleInternalKVGet(
     const rpc::InternalKVGetRequest &request, rpc::InternalKVGetReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  kv_instance_->Get(request.key(),
-                    [reply, send_reply_callback](std::optional<std::string> val) {
-                      if(val) {
-                        reply->set_value(*val);
-                        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-                      } else {
-                        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::NotFound("Failed to find the key"));
-                      }
-                    });
+  auto cb = [reply, send_reply_callback](std::optional<std::string> val) {
+              if(val) {
+                reply->set_value(*val);
+                GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+              } else {
+                GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::NotFound("Failed to find the key"));
+              }
+            };
+  kv_instance_->Get(request.key(), std::move(cb));
 }
 
 void GcsInternalKVManager::HandleInternalKVPut(
     const rpc::InternalKVPutRequest &request, rpc::InternalKVPutReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
+  auto cb = [reply, send_reply_callback](bool newly_added) {
+              reply->set_added_num(newly_added ? 1 : 0);
+              GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+            };
   kv_instance_->Put(
       request.key(),
       request.value(),
       request.overwrite(),
-      [reply, send_reply_callback](bool newly_added) {
-        reply->set_added_num(newly_added ? 1 : 0);
-        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-      });
+      std::move(cb));
 }
 
 void GcsInternalKVManager::HandleInternalKVDel(
     const rpc::InternalKVDelRequest &request, rpc::InternalKVDelReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  kv_instance_->Del(request.key(), [reply, send_reply_callback](bool deleted) {
+  auto cb = [reply, send_reply_callback](bool deleted) {
                                      reply->set_deleted_num(deleted ? 1 : 0);
                                      GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-                                   });
+            };
+  kv_instance_->Del(request.key(), std::move(cb));
 }
 
 void GcsInternalKVManager::HandleInternalKVExists(
     const rpc::InternalKVExistsRequest &request, rpc::InternalKVExistsReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  kv_instance_->Exists(key, [reply, send_reply_callback](bool exists) {
+  auto cb = [reply, send_reply_callback](bool exists) {
                               reply->set_exists(exists);
                               GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-                            });
+            };
+  kv_instance_->Exists(key, std::move(cb));
 }
 
 void GcsInternalKVManager::HandleInternalKVKeys(
     const rpc::InternalKVKeysRequest &request, rpc::InternalKVKeysReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  kv_instance_->Keys(request.prefix(), [reply, send_reply_callback] (std::vector<std::string> keys) {
+  auto cb = [reply, send_reply_callback] (std::vector<std::string> keys) {
                                          for (auto &result : keys) {
                                            reply->add_results(std::move(result));
                                          }
                                          GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 
-                                       });
+            };
+  kv_instance_->Keys(request.prefix(), std::move(cb));
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -80,7 +80,7 @@ void MemoryInternalKV::Get(const std::string &key,
   auto it = map_.find(key);
   auto val = it == map_.end() ? std::nullopt : std::make_optional(it->second);
   if (callback != nullptr) {
-    io_context_->post(std::bind(std::move(callback), std::move(val)));
+    io_context_.post(std::bind(std::move(callback), std::move(val)));
   }
 }
 
@@ -98,7 +98,7 @@ void MemoryInternalKV::Put(const std::string &key, const std::string &value,
     inserted = true;
   }
   if (callback != nullptr) {
-    io_context_->post(std::bind(std::move(callback), inserted));
+    io_context_.post(std::bind(std::move(callback), inserted));
   }
 }
 
@@ -112,7 +112,7 @@ void MemoryInternalKV::Del(const std::string &key, std::function<void(bool)> cal
     map_.erase(it);
   }
   if (callback != nullptr) {
-    io_context_->post(std::bind(std::move(callback), deleted));
+    io_context_.post(std::bind(std::move(callback), deleted));
   }
 }
 
@@ -121,7 +121,7 @@ void MemoryInternalKV::Exists(const std::string &key,
   absl::ReaderMutexLock lock(&mu_);
   bool existed = map_.find(key) != map_.end();
   if (callback != nullptr) {
-    io_context_->post(std::bind(std::move(callback), existed));
+    io_context_.post(std::bind(std::move(callback), existed));
   }
 }
 
@@ -135,7 +135,7 @@ void MemoryInternalKV::Keys(const std::string &prefix,
     iter++;
   }
   if (callback != nullptr) {
-    io_context_->post(std::bind(std::move(callback), std::move(keys)));
+    io_context_.post(std::bind(std::move(callback), std::move(keys)));
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.cc
@@ -13,9 +13,123 @@
 // limitations under the License.
 
 #include "ray/gcs/gcs_server/gcs_kv_manager.h"
+#include "absl/strings/match.h"
 
 namespace ray {
 namespace gcs {
+
+void RedisInternalKV::Get(const std::string& key, std::function<void(std::optional<std::string>)> cb)  {
+  std::vector<std::string> cmd = {"HGET", key, "value"};
+  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
+      cmd, [cb = std::move(cb)](auto redis_reply) {
+             if (!redis_reply->IsNil()) {
+               cb(redis_reply->ReadAsString());
+             } else {
+               cb(std::nullopt);
+             }
+      }));
+}
+
+void RedisInternalKV::Put(const std::string& key, const std::string& value, bool overwrite, std::function<void(bool)> cb)  {
+  std::vector<std::string> cmd = {overwrite ? "HSET" : "HSETNX", key, "value", value};
+  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
+      cmd, [cb = std::move(cb)](auto redis_reply) {
+             auto added_num = redis_reply->ReadAsInteger();
+             cb(added_num != 0);
+      }));
+}
+
+void RedisInternalKV::Del(const std::string& key, std::function<void(bool)> cb) {
+  std::vector<std::string> cmd = {"HDEL", key, "value"};
+  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
+      cmd, [cb = std::move(cb)](auto redis_reply) {
+             cb(redis_reply->ReadAsInteger() != 0);
+           }));
+}
+
+void RedisInternalKV::Exists(const std::string& key, std::function<void(bool)> cb) {
+  std::vector<std::string> cmd = {"HEXISTS", key, "value"};
+  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
+      cmd, [cb = std::move(cb)](auto redis_reply) {
+             bool exists = redis_reply->ReadAsInteger() > 0;
+             cb(exists);
+      }));
+}
+
+void RedisInternalKV::Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) {
+  std::vector<std::string> cmd = {"KEYS", prefix + "*"};
+  RAY_CHECK_OK(redis_client_->GetPrimaryContext()->RunArgvAsync(
+      cmd, [cb = std::move(cb)](auto redis_reply) {
+             const auto &reply = redis_reply->ReadAsStringArray();
+             std::vector<std::string> results;
+             for (const auto &r : reply) {
+               RAY_CHECK(r.has_value());
+               results.emplace_back(*r);
+             }
+             cb(std::move(results));
+      }));
+}
+
+void MemoryInternalKV::Get(const std::string& key, std::function<void(std::optional<std::string>)> cb) {
+  absl::ReaderMutexLock _(&mu_);
+  auto it = map_.find(key);
+  auto val = it == map_.end() ? std::nullopt : std::make_optional(it->second);
+  if(cb != nullptr) {
+    RunCB(std::bind(std::move(cb), std::move(val)));
+  }
+}
+
+void MemoryInternalKV::Put(const std::string& key, const std::string& value, bool overwrite, std::function<void(bool)> cb) {
+  absl::WriterMutexLock _(&mu_);
+  auto it = map_.find(key);
+  bool inserted = false;
+  if(it != map_.end()) {
+    if(overwrite) {
+      it->second = value;
+    }
+  } else {
+    map_[key] = value;
+    inserted = true;
+  }
+  if(cb != nullptr) {
+    RunCB(std::bind(std::move(cb), inserted));
+  }
+}
+
+void MemoryInternalKV::Del(const std::string& key, std::function<void(bool)> cb) {
+  absl::WriterMutexLock _(&mu_);
+  auto it = map_.find(key);
+  bool deleted = true;
+  if(it == map_.end()) {
+    deleted = false;
+  } else {
+    map_.erase(it);
+  }
+  if(cb != nullptr) {
+    RunCB(std::bind(std::move(cb), deleted));
+  }
+}
+
+void MemoryInternalKV::Exists(const std::string& key, std::function<void(bool)> cb) {
+  absl::ReaderMutexLock _(&mu_);
+  bool existed = map_.find(key) != map_.end();
+  if(cb != nullptr) {
+    RunCB(std::bind(std::move(cb), existed));
+  }
+}
+
+void MemoryInternalKV::Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) {
+  absl::ReaderMutexLock _(&mu_);
+  std::vector<std::string> keys;
+  auto iter = map_.lower_bound(prefix);
+  while(iter != map_.end() && absl::StartsWith(iter->first, prefix)) {
+    keys.push_back(iter->first);
+    iter++;
+  }
+  if(cb != nullptr) {
+    RunCB(std::bind(std::move(cb), std::move(keys)));
+  }
+}
 
 void GcsInternalKVManager::HandleInternalKVGet(
     const rpc::InternalKVGetRequest &request, rpc::InternalKVGetReply *reply,
@@ -62,7 +176,7 @@ void GcsInternalKVManager::HandleInternalKVExists(
                               reply->set_exists(exists);
                               GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
             };
-  kv_instance_->Exists(key, std::move(cb));
+  kv_instance_->Exists(request.key(), std::move(cb));
 }
 
 void GcsInternalKVManager::HandleInternalKVKeys(

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -24,22 +24,50 @@ namespace ray {
 namespace gcs {
 
 
+/// \class InternalKVInterface
+/// The interface for internal kv implementation. Ideally we should merge this
+/// with store client, but due to compatibility issue, we keep them separated
+/// right now.
 class InternalKVInterface {
  public:
+  /// Get the value associated with `key`
+  ///
+  /// \param key The key to fetch
+  /// \param cb Callback function.
   virtual void Get(const std::string& key,
                    std::function<void(std::optional<std::string>)> cb) = 0;
 
+  /// Associate key with value.
+  ///
+  /// \param key The key for the pair
+  /// \param value The value for the pair
+  /// \param overwrite If the key has existed before this op, nothing will happen
+  ///    unless `overwrite` is set to be true.
+  /// \param cb Callback function.
   virtual void Put(const std::string& key,
                    const std::string& value,
                    bool overwrite,
                    std::function<void(bool)> cb) = 0;
 
+  /// Delete the key from the store
+  ///
+  /// \param key The key to be deleted
+  /// \param cb Callback function.
   virtual void Del(const std::string& key, std::function<void(bool)> cb) = 0;
 
+  /// Check whether the key exists in the store
+  ///
+  /// \param key The key to be checked.
+  /// \param cb Callback function.
   virtual void Exists(const std::string& key, std::function<void(bool)> cb) = 0;
 
+  /// Get the keys for a given prefix.
+  ///
+  /// \param prefix The prefix to be scaned.
+  /// \param cb Callback function.
   virtual void Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) = 0;
 
+  virtual ~InternalKVInterface() {};
 };
 
 

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -14,15 +14,15 @@
 
 #pragma once
 #include <memory>
-#include "absl/synchronization/mutex.h"
+
 #include "absl/container/btree_map.h"
+#include "absl/synchronization/mutex.h"
 #include "ray/gcs/redis_client.h"
 #include "ray/gcs/store_client/redis_store_client.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 
 namespace ray {
 namespace gcs {
-
 
 /// \class InternalKVInterface
 /// The interface for internal kv implementation. Ideally we should merge this
@@ -34,7 +34,7 @@ class InternalKVInterface {
   ///
   /// \param key The key to fetch
   /// \param cb Callback function.
-  virtual void Get(const std::string& key,
+  virtual void Get(const std::string &key,
                    std::function<void(std::optional<std::string>)> cb) = 0;
 
   /// Associate key with value.
@@ -44,74 +44,73 @@ class InternalKVInterface {
   /// \param overwrite If the key has existed before this op, nothing will happen
   ///    unless `overwrite` is set to be true.
   /// \param cb Callback function.
-  virtual void Put(const std::string& key,
-                   const std::string& value,
-                   bool overwrite,
+  virtual void Put(const std::string &key, const std::string &value, bool overwrite,
                    std::function<void(bool)> cb) = 0;
 
   /// Delete the key from the store
   ///
   /// \param key The key to be deleted
   /// \param cb Callback function.
-  virtual void Del(const std::string& key, std::function<void(bool)> cb) = 0;
+  virtual void Del(const std::string &key, std::function<void(bool)> cb) = 0;
 
   /// Check whether the key exists in the store
   ///
   /// \param key The key to be checked.
   /// \param cb Callback function.
-  virtual void Exists(const std::string& key, std::function<void(bool)> cb) = 0;
+  virtual void Exists(const std::string &key, std::function<void(bool)> cb) = 0;
 
   /// Get the keys for a given prefix.
   ///
   /// \param prefix The prefix to be scaned.
   /// \param cb Callback function.
-  virtual void Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) = 0;
+  virtual void Keys(const std::string &prefix,
+                    std::function<void(std::vector<std::string>)> cb) = 0;
 
-  virtual ~InternalKVInterface() {};
+  virtual ~InternalKVInterface(){};
 };
-
 
 class RedisInternalKV : public InternalKVInterface {
  public:
-  RedisInternalKV(RedisClient* redis_client)
-      : redis_client_(redis_client) {}
+  RedisInternalKV(RedisClient *redis_client) : redis_client_(redis_client) {}
 
-  void Get(const std::string& key, std::function<void(std::optional<std::string>)> cb) override;
+  void Get(const std::string &key,
+           std::function<void(std::optional<std::string>)> cb) override;
 
-  void Put(const std::string& key, const std::string& value, bool overwrite, std::function<void(bool)> cb) override;
+  void Put(const std::string &key, const std::string &value, bool overwrite,
+           std::function<void(bool)> cb) override;
 
-  void Del(const std::string& key, std::function<void(bool)> cb) override;
+  void Del(const std::string &key, std::function<void(bool)> cb) override;
 
-  void Exists(const std::string& key, std::function<void(bool)> cb) override;
+  void Exists(const std::string &key, std::function<void(bool)> cb) override;
 
-  void Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) override;
-
+  void Keys(const std::string &prefix,
+            std::function<void(std::vector<std::string>)> cb) override;
 
  private:
-  RedisClient* redis_client_;
+  RedisClient *redis_client_;
 };
 
 class MemoryInternalKV : public InternalKVInterface {
  public:
-  MemoryInternalKV(instrumented_io_context* io_context)
-      : io_context_(io_context) {
+  MemoryInternalKV(instrumented_io_context *io_context) : io_context_(io_context) {
     RAY_CHECK(io_context != nullptr);
   }
-  void Get(const std::string& key, std::function<void(std::optional<std::string>)> cb) override;
+  void Get(const std::string &key,
+           std::function<void(std::optional<std::string>)> cb) override;
 
-  void Put(const std::string& key, const std::string& value, bool overwrite, std::function<void(bool)> cb) override;
+  void Put(const std::string &key, const std::string &value, bool overwrite,
+           std::function<void(bool)> cb) override;
 
-  void Del(const std::string& key, std::function<void(bool)> cb) override;
+  void Del(const std::string &key, std::function<void(bool)> cb) override;
 
-  void Exists(const std::string& key, std::function<void(bool)> cb) override;
+  void Exists(const std::string &key, std::function<void(bool)> cb) override;
 
-  void Keys(const std::string& prefix, std::function<void(std::vector<std::string>)> cb) override;
+  void Keys(const std::string &prefix,
+            std::function<void(std::vector<std::string>)> cb) override;
 
  private:
-  void RunCB(std::function<void()> cb) {
-    io_context_->post(std::move(cb));
-  }
-  instrumented_io_context* io_context_;
+  void RunCB(std::function<void()> cb) { io_context_->post(std::move(cb)); }
+  instrumented_io_context *io_context_;
   absl::btree_map<std::string, std::string> map_;
   absl::Mutex mu_;
 };
@@ -141,14 +140,11 @@ class GcsInternalKVManager : public rpc::InternalKVHandler {
                             rpc::InternalKVKeysReply *reply,
                             rpc::SendReplyCallback send_reply_callback) override;
 
-  InternalKVInterface& GetInstance() {
-    return *kv_instance_;
-  }
+  InternalKVInterface &GetInstance() { return *kv_instance_; }
+
  private:
   std::unique_ptr<InternalKVInterface> kv_instance_;
 };
-
-
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -92,9 +92,7 @@ class RedisInternalKV : public InternalKVInterface {
 
 class MemoryInternalKV : public InternalKVInterface {
  public:
-  MemoryInternalKV(instrumented_io_context *io_context) : io_context_(io_context) {
-    RAY_CHECK(io_context != nullptr);
-  }
+  MemoryInternalKV(instrumented_io_context &io_context) : io_context_(io_context) {}
   void Get(const std::string &key,
            std::function<void(std::optional<std::string>)> callback) override;
 
@@ -109,7 +107,7 @@ class MemoryInternalKV : public InternalKVInterface {
             std::function<void(std::vector<std::string>)> callback) override;
 
  private:
-  instrumented_io_context *io_context_;
+  instrumented_io_context &io_context_;
   absl::Mutex mu_;
   absl::btree_map<std::string, std::string> map_ GUARDED_BY(mu_);
 };

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -30,41 +30,41 @@ namespace gcs {
 /// right now.
 class InternalKVInterface {
  public:
-  /// Get the value associated with `key`
+  /// Get the value associated with `key`.
   ///
-  /// \param key The key to fetch
-  /// \param cb Callback function.
+  /// \param key The key to fetch.
+  /// \param callback Callback function.
   virtual void Get(const std::string &key,
-                   std::function<void(std::optional<std::string>)> cb) = 0;
+                   std::function<void(std::optional<std::string>)> callback) = 0;
 
-  /// Associate key with value.
+  /// Associate a key with the specified value.
   ///
-  /// \param key The key for the pair
-  /// \param value The value for the pair
-  /// \param overwrite If the key has existed before this op, nothing will happen
-  ///    unless `overwrite` is set to be true.
-  /// \param cb Callback function.
+  /// \param key The key for the pair.
+  /// \param value The value for the pair.
+  /// \param overwrite Whether to overwrite existing values. Otherwise, the update
+  ///   will be ignored.
+  /// \param callback Callback function.
   virtual void Put(const std::string &key, const std::string &value, bool overwrite,
-                   std::function<void(bool)> cb) = 0;
+                   std::function<void(bool)> callback) = 0;
 
-  /// Delete the key from the store
+  /// Delete the key from the store.
   ///
-  /// \param key The key to be deleted
-  /// \param cb Callback function.
-  virtual void Del(const std::string &key, std::function<void(bool)> cb) = 0;
+  /// \param key The key to be deleted.
+  /// \param callback Callback function.
+  virtual void Del(const std::string &key, std::function<void(bool)> callback) = 0;
 
-  /// Check whether the key exists in the store
+  /// Check whether the key exists in the store.
   ///
   /// \param key The key to be checked.
-  /// \param cb Callback function.
-  virtual void Exists(const std::string &key, std::function<void(bool)> cb) = 0;
+  /// \param callback Callback function.
+  virtual void Exists(const std::string &key, std::function<void(bool)> callback) = 0;
 
   /// Get the keys for a given prefix.
   ///
   /// \param prefix The prefix to be scaned.
-  /// \param cb Callback function.
+  /// \param callback Callback function.
   virtual void Keys(const std::string &prefix,
-                    std::function<void(std::vector<std::string>)> cb) = 0;
+                    std::function<void(std::vector<std::string>)> callback) = 0;
 
   virtual ~InternalKVInterface(){};
 };
@@ -74,17 +74,17 @@ class RedisInternalKV : public InternalKVInterface {
   RedisInternalKV(RedisClient *redis_client) : redis_client_(redis_client) {}
 
   void Get(const std::string &key,
-           std::function<void(std::optional<std::string>)> cb) override;
+           std::function<void(std::optional<std::string>)> callback) override;
 
   void Put(const std::string &key, const std::string &value, bool overwrite,
-           std::function<void(bool)> cb) override;
+           std::function<void(bool)> callback) override;
 
-  void Del(const std::string &key, std::function<void(bool)> cb) override;
+  void Del(const std::string &key, std::function<void(bool)> callback) override;
 
-  void Exists(const std::string &key, std::function<void(bool)> cb) override;
+  void Exists(const std::string &key, std::function<void(bool)> callback) override;
 
   void Keys(const std::string &prefix,
-            std::function<void(std::vector<std::string>)> cb) override;
+            std::function<void(std::vector<std::string>)> callback) override;
 
  private:
   RedisClient *redis_client_;
@@ -96,23 +96,22 @@ class MemoryInternalKV : public InternalKVInterface {
     RAY_CHECK(io_context != nullptr);
   }
   void Get(const std::string &key,
-           std::function<void(std::optional<std::string>)> cb) override;
+           std::function<void(std::optional<std::string>)> callback) override;
 
   void Put(const std::string &key, const std::string &value, bool overwrite,
-           std::function<void(bool)> cb) override;
+           std::function<void(bool)> callback) override;
 
-  void Del(const std::string &key, std::function<void(bool)> cb) override;
+  void Del(const std::string &key, std::function<void(bool)> callback) override;
 
-  void Exists(const std::string &key, std::function<void(bool)> cb) override;
+  void Exists(const std::string &key, std::function<void(bool)> callback) override;
 
   void Keys(const std::string &prefix,
-            std::function<void(std::vector<std::string>)> cb) override;
+            std::function<void(std::vector<std::string>)> callback) override;
 
  private:
-  void RunCB(std::function<void()> cb) { io_context_->post(std::move(cb)); }
   instrumented_io_context *io_context_;
-  absl::btree_map<std::string, std::string> map_;
   absl::Mutex mu_;
+  absl::btree_map<std::string, std::string> map_ GUARDED_BY(mu_);
 };
 
 /// This implementation class of `InternalKVHandler`.

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -405,7 +405,7 @@ void GcsServer::InitKVManager() {
   if (RayConfig::instance().gcs_storage() == "redis") {
     instance = std::make_unique<RedisInternalKV>(redis_client_.get());
   } else if (RayConfig::instance().gcs_storage() == "memory") {
-    instance = std::make_unique<MemoryInternalKV>(&main_service_);
+    instance = std::make_unique<MemoryInternalKV>(main_service_);
   } else {
     RAY_LOG(FATAL) << "Unsupported gcs storage: " << RayConfig::instance().gcs_storage();
   }

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -401,7 +401,7 @@ void GcsServer::InitStatsHandler() {
 }
 
 void GcsServer::InitKVManager() {
-  kv_manager_ = std::make_unique<GcsInternalKVManager>(redis_client_);
+  kv_manager_ = std::make_unique<GcsRedisInternalKVManager>(redis_client_);
   kv_service_ = std::make_unique<rpc::InternalKVGrpcService>(main_service_, *kv_manager_);
   // Register service.
   rpc_server_.RegisterService(*kv_service_);

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -402,9 +402,9 @@ void GcsServer::InitStatsHandler() {
 
 void GcsServer::InitKVManager() {
   std::unique_ptr<InternalKVInterface> instance;
-  if(RayConfig::instance().gcs_storage() == "redis") {
+  if (RayConfig::instance().gcs_storage() == "redis") {
     instance = std::make_unique<RedisInternalKV>(redis_client_.get());
-  } else if(RayConfig::instance().gcs_storage() == "memory") {
+  } else if (RayConfig::instance().gcs_storage() == "memory") {
     instance = std::make_unique<MemoryInternalKV>(&main_service_);
   } else {
     RAY_LOG(FATAL) << "Unsupported gcs storage: " << RayConfig::instance().gcs_storage();
@@ -448,9 +448,7 @@ void GcsServer::InitRuntimeEnvManager() {
           } else {
             auto uri = plugin_uri.substr(protocol_pos);
             this->kv_manager_->GetInstance().Del(
-                uri, [cb = std::move(cb)](bool deleted) {
-                       cb(false);
-                     });
+                uri, [cb = std::move(cb)](bool deleted) { cb(false); });
           }
         }
       });

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -427,7 +427,7 @@ void GcsServer::InitPubSubHandler() {
 
 void GcsServer::InitRuntimeEnvManager() {
   runtime_env_manager_ = std::make_unique<RuntimeEnvManager>(
-      /*deleter=*/[this](const std::string &plugin_uri, auto cb) {
+      /*deleter=*/[this](const std::string &plugin_uri, auto callback) {
         // A valid runtime env URI is of the form "plugin|protocol://hash".
         std::string plugin_sep = "|";
         std::string protocol_sep = "://";
@@ -437,18 +437,18 @@ void GcsServer::InitRuntimeEnvManager() {
             plugin_end_pos == std::string::npos) {
           RAY_LOG(ERROR) << "Plugin URI must be of form "
                          << "<plugin>|<protocol>://<hash>, got " << plugin_uri;
-          cb(false);
+          callback(false);
         } else {
           auto protocol_pos = plugin_end_pos + plugin_sep.size();
           int protocol_len = protocol_end_pos - protocol_pos;
           auto protocol = plugin_uri.substr(protocol_pos, protocol_len);
           if (protocol != "gcs") {
             // Some URIs do not correspond to files in the GCS.  Skip deletion for these.
-            cb(true);
+            callback(true);
           } else {
             auto uri = plugin_uri.substr(protocol_pos);
             this->kv_manager_->GetInstance().Del(
-                uri, [cb = std::move(cb)](bool deleted) { cb(false); });
+                uri, [callback = std::move(callback)](bool deleted) { callback(false); });
           }
         }
       });

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -209,7 +209,7 @@ class GcsServer {
   /// Placement Group info handler and service.
   std::unique_ptr<rpc::PlacementGroupInfoGrpcService> placement_group_info_service_;
   /// Global KV storage handler and service.
-  std::unique_ptr<rpc::InternalKVHandler> kv_manager_;
+  std::unique_ptr<GcsInternalKVManager> kv_manager_;
   std::unique_ptr<rpc::InternalKVGrpcService> kv_service_;
   /// GCS PubSub handler and service.
   std::unique_ptr<InternalPubSubHandler> pubsub_handler_;

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -209,7 +209,7 @@ class GcsServer {
   /// Placement Group info handler and service.
   std::unique_ptr<rpc::PlacementGroupInfoGrpcService> placement_group_info_service_;
   /// Global KV storage handler and service.
-  std::unique_ptr<GcsInternalKVManager> kv_manager_;
+  std::unique_ptr<rpc::InternalKVHandler> kv_manager_;
   std::unique_ptr<rpc::InternalKVGrpcService> kv_service_;
   /// GCS PubSub handler and service.
   std::unique_ptr<InternalPubSubHandler> pubsub_handler_;

--- a/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
@@ -44,6 +44,8 @@ class GcsKVManagerTest : public ::testing::TestWithParam<std::string> {
   void TearDown() override {
     io_service.stop();
     thread_io_service->join();
+    redis_client.reset();
+    kv_instance.reset();
   }
 
   std::unique_ptr<ray::gcs::RedisClient> redis_client;
@@ -61,8 +63,8 @@ TEST_P(GcsKVManagerTest, TestInternalKV) {
   kv_instance->Get("A", [](auto b) { ASSERT_EQ("C", *b); });
 
   kv_instance->Put("A_1", "B", false, [](auto b) { ASSERT_TRUE(b); });
-  kv_instance->Put("A_2", "C", false, [](auto b) { ASSERT_FALSE(b); });
-  kv_instance->Put("A_3", "C", false, [](auto b) { ASSERT_FALSE(b); });
+  kv_instance->Put("A_2", "C", false, [](auto b) { ASSERT_TRUE(b); });
+  kv_instance->Put("A_3", "C", false, [](auto b) { ASSERT_TRUE(b); });
 
   kv_instance->Keys("A_", [](std::vector<std::string> keys) {
     auto expected = std::vector<std::string>{"A_1", "A_2", "A_3"};

--- a/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "ray/common/test_util.h"
+#include "ray/gcs/gcs_server/gcs_kv_manager.h"
+
+class GcsKVManagerTest : public ::testing::TestWithParam<std::string> {
+ public:
+  GcsKVManagerTest() {
+    ray::TestSetupUtil::StartUpRedisServers(std::vector<int>());
+  }
+
+  void SetUp() override {
+    thread_io_service = std::make_unique<std::thread>(
+        [this] {
+          boost::asio::io_service::work work(io_service);
+          io_service.run();
+        });
+    ASSERT_TRUE(GetParam() == "redis" || GetParam() == "memory");
+    ray::gcs::RedisClientOptions redis_client_options(
+        "127.0.0.1", ray::TEST_REDIS_SERVER_PORTS.front(), "", false);
+    redis_client = std::make_unique<ray::gcs::RedisClient>(redis_client_options);
+    auto status = redis_client->Connect(io_service);
+    RAY_CHECK(status.ok()) << "Failed to init redis gcs client as " << status;
+    if(GetParam() == "redis") {
+      kv_instance = std::make_unique<ray::gcs::RedisInternalKV>(redis_client.get());
+    } else if(GetParam() == "memory") {
+      kv_instance = std::make_unique<ray::gcs::MemoryInternalKV>(&io_service);
+    }
+  }
+
+  void TearDown() override {
+    io_service.stop();
+    thread_io_service->join();
+  }
+
+  std::unique_ptr<ray::gcs::RedisClient> redis_client;
+  std::unique_ptr<std::thread> thread_io_service;
+  instrumented_io_context io_service;
+  std::unique_ptr<ray::gcs::InternalKVInterface> kv_instance;
+};
+
+
+TEST_P(GcsKVManagerTest, TestInternalKV) {
+  kv_instance->Get("A", [](auto b) { ASSERT_FALSE(b.has_value()); });
+  kv_instance->Put("A", "B", false, [](auto b) { ASSERT_TRUE(b); });
+  kv_instance->Put("A", "C",  false, [](auto b) { ASSERT_FALSE(b); });
+  kv_instance->Get("A", [](auto b) { ASSERT_EQ("B", *b); });
+  kv_instance->Put("A", "C", true, [](auto b) { ASSERT_FALSE(b); });
+  kv_instance->Get("A", [](auto b) { ASSERT_EQ("C", *b); });
+
+  kv_instance->Put("A_1", "B", false, [](auto b) { ASSERT_TRUE(b); });
+  kv_instance->Put("A_2", "C",  false, [](auto b) { ASSERT_FALSE(b); });
+  kv_instance->Put("A_3", "C",  false, [](auto b) { ASSERT_FALSE(b); });
+
+  kv_instance->Keys("A_", [](std::vector<std::string> keys) {
+                            auto expected = std::vector<std::string>{"A_1", "A_2", "A_3"};
+                            ASSERT_EQ(expected, keys);
+                          });
+}
+
+
+INSTANTIATE_TEST_SUITE_P(
+    GcsKVManagerTestFixture,
+    GcsKVManagerTest,
+    ::testing::Values("redis", "memory"));
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  RAY_CHECK(argc == 3);
+  ray::TEST_REDIS_SERVER_EXEC_PATH = argv[1];
+  ray::TEST_REDIS_CLIENT_EXEC_PATH = argv[2];
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
@@ -37,7 +37,7 @@ class GcsKVManagerTest : public ::testing::TestWithParam<std::string> {
     if (GetParam() == "redis") {
       kv_instance = std::make_unique<ray::gcs::RedisInternalKV>(redis_client.get());
     } else if (GetParam() == "memory") {
-      kv_instance = std::make_unique<ray::gcs::MemoryInternalKV>(&io_service);
+      kv_instance = std::make_unique<ray::gcs::MemoryInternalKV>(io_service);
     }
   }
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -21,7 +21,7 @@
 
 namespace ray {
 
-class GcsServerTest  :public :: testing::Test {
+class GcsServerTest : public ::testing::Test {
  public:
   GcsServerTest() { TestSetupUtil::StartUpRedisServers(std::vector<int>()); }
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -21,13 +21,14 @@
 
 namespace ray {
 
-class GcsServerTest : public ::testing::Test {
+class GcsServerTest : public ::testing::TestWithParam<char*> {
  public:
   GcsServerTest() { TestSetupUtil::StartUpRedisServers(std::vector<int>()); }
 
   virtual ~GcsServerTest() { TestSetupUtil::ShutDownRedisServers(); }
 
   void SetUp() override {
+    ray::RayConfig::instance().gcs_storage() = GetParam();
     gcs::GcsServerConfig config;
     config.grpc_server_port = 0;
     config.grpc_server_name = "MockedGcsServer";
@@ -527,6 +528,11 @@ TEST_F(GcsServerTest, TestWorkerInfo) {
 
 // TODO(sang): Add tests after adding asyncAdd
 
+
+INSTANTIATE_TEST_CASE_P(
+    GcsServerTest,
+    GcsServerTestFixture,
+    ::testing::Values("redis", "memory"));
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is part work of redis removal. In this PR we introduced a new mode for internal kv, memory mode.
There are two ways to address this:
- Update store client and use store client in internal kv
- Add memory table into internal kv directly.

The former one actually is a better choice since it put everything related to storage into a lowerlevel. But it's pretty hard to do this now, since internal kv use hset/hget and redis store client use set/get, so the data will not be compatible and it'll be a brake change.

So the easier way to do this is 2) and it's what this PR doing.

Next: use the flag for store client

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
