### PR TITLE
[WIP] Pull out event stats out of the asio instrumented event loop

### DIFF
--- a/src/ray/common/asio/event_stats.h
+++ b/src/ray/common/asio/event_stats.h
@@ -1,0 +1,170 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <boost/asio.hpp>
+#include <limits>
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "ray/common/ray_config.h"
+#include "ray/util/logging.h"
+
+/// Count, queueing, and execution statistics for a given event.
+struct EventStats {
+  // Counts.
+  int64_t cum_count = 0;
+  int64_t curr_count = 0;
+
+  // Execution stats.
+  int64_t cum_execution_time = 0;
+  int64_t running_count = 0;
+};
+
+/// Count and queueing statistics over all events.
+struct GlobalStats {
+  // Queue stats.
+  int64_t cum_queue_time = 0;
+  int64_t min_queue_time = std::numeric_limits<int64_t>::max();
+  int64_t max_queue_time = -1;
+};
+
+/// A mutex wrapper around a handler stats struct.
+struct GuardedEventStats {
+  // Stats for some handler.
+  EventStats stats;
+
+  // The mutex protecting the reading and writing of these stats.
+  // This mutex should be acquired with a reader lock before reading, and should be
+  // acquired with a writer lock before writing.
+  mutable absl::Mutex mutex;
+};
+
+/// A mutex wrapper around a handler stats struct.
+struct GuardedGlobalStats {
+  // Stats over all handlers.
+  GlobalStats stats;
+
+  // The mutex protecting the reading and writing of these stats.
+  // This mutex should be acquired with a reader lock before reading, and should be
+  // acquired with a writer lock before writing.
+  mutable absl::Mutex mutex;
+};
+
+/// An opaque stats handle, used to manually instrument event handlers.
+struct EventHandle {
+  std::string event_name;
+  int64_t start_time;
+  std::shared_ptr<GuardedEventStats> handler_stats;
+  std::shared_ptr<GuardedGlobalStats> global_stats;
+  std::atomic<bool> execution_recorded;
+
+  EventHandle(std::string event_name_, int64_t start_time_,
+              std::shared_ptr<GuardedEventStats> handler_stats_,
+              std::shared_ptr<GuardedGlobalStats> global_stats_)
+      : event_name(std::move(event_name_)),
+        start_time(start_time_),
+        handler_stats(std::move(handler_stats_)),
+        global_stats(std::move(global_stats_)),
+        execution_recorded(false) {}
+
+  void ZeroAccumulatedQueuingDelay() { start_time = absl::GetCurrentTimeNanos(); }
+
+  ~EventHandle() {
+    if (!execution_recorded) {
+      // If handler execution was never recorded, we need to clean up some queueing
+      // stats in order to prevent those stats from leaking.
+      absl::MutexLock lock(&(handler_stats->mutex));
+      handler_stats->stats.curr_count--;
+    }
+  }
+};
+
+class EventTracker {
+ public:
+  /// Initializes the global stats struct after calling the base contructor.
+  EventTracker() : global_stats_(std::make_shared<GuardedGlobalStats>()) {}
+
+  /// Sets the queueing start time, increments the current and cumulative counts and
+  /// returns an opaque handle for these stats. This is used in conjunction with
+  /// RecordExecution() to manually instrument an event.
+  ///
+  /// The returned opaque stats handle should be given to a subsequent RecordExecution()
+  /// call.
+  ///
+  /// \param name A human-readable name to which collected stats will be associated.
+  /// \param expected_queueing_delay_ns How much to pad the observed queueing start time,
+  ///  in nanoseconds.
+  /// \return An opaque stats handle, to be given to RecordExecution().
+  std::shared_ptr<EventHandle> RecordStart(const std::string &name,
+                                           int64_t expected_queueing_delay_ns = 0);
+
+  /// Records stats about the provided function's execution. This is used in conjunction
+  /// with RecordStart() to manually instrument an event loop handler that doesn't call
+  /// .post().
+  ///
+  /// \param fn The function to execute and instrument.
+  /// \param handle An opaque stats handle returned by RecordStart().
+  static void RecordExecution(const std::function<void()> &fn,
+                              std::shared_ptr<EventHandle> handle);
+
+  /// Returns a snapshot view of the global count, queueing, and execution statistics
+  /// across all handlers.
+  ///
+  /// \return A snapshot view of the global handler stats.
+  GlobalStats get_global_stats() const;
+
+  /// Returns a snapshot view of the count, queueing, and execution statistics for the
+  /// provided event type.
+  ///
+  /// \param event_name The name of the event whose stats should be returned.
+  /// \return A snapshot view of the event's stats.
+  absl::optional<EventStats> get_event_stats(const std::string &event_name) const
+      LOCKS_EXCLUDED(mutex_);
+
+  /// Returns snapshot views of the count, queueing, and execution statistics for all
+  /// events.
+  ///
+  /// \return A vector containing snapshot views of stats for all events.
+  std::vector<std::pair<std::string, EventStats>> get_event_stats() const
+      LOCKS_EXCLUDED(mutex_);
+
+  /// Builds and returns a statistics summary string. Used by the DebugString() of
+  /// objects that used this io_context wrapper, such as the raylet and the core worker.
+  ///
+  /// \return A stats summary string, suitable for inclusion in an object's
+  /// DebugString().
+  std::string StatsString() const LOCKS_EXCLUDED(mutex_);
+
+ private:
+  using EventStatsTable =
+      absl::flat_hash_map<std::string, std::shared_ptr<GuardedEventStats>>;
+  /// Get the mutex-guarded stats for this event if it exists, otherwise create the
+  /// stats for this handler and return an iterator pointing to it.
+  ///
+  /// \param name A human-readable name for the handler, to be used for viewing stats
+  /// for the provided handler.
+  std::shared_ptr<GuardedEventStats> GetOrCreate(const std::string &name);
+
+  /// Global stats, across all handlers.
+  std::shared_ptr<GuardedGlobalStats> global_stats_;
+
+  /// Table of per-handler post stats.
+  /// We use a std::shared_ptr value in order to ensure pointer stability.
+  EventStatsTable post_handler_stats_ GUARDED_BY(mutex_);
+
+  /// Protects access to the per-handler post stats table.
+  mutable absl::Mutex mutex_;
+};
+

--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <utility>
 #include "ray/stats/metric.h"
+#include "ray/stats/event_stats.h"
 
 DEFINE_stats(operation_count, "operation count", ("Method"), (), ray::stats::GAUGE);
 DEFINE_stats(operation_run_time_ms, "operation execution time", ("Method"), (),
@@ -68,7 +69,7 @@ void instrumented_io_context::post(std::function<void()> handler,
   if (!RayConfig::instance().event_stats()) {
     return boost::asio::io_context::post(std::move(handler));
   }
-  const auto stats_handle = RecordStart(name);
+  const auto stats_handle = event_stats_->RecordStart(name);
   // References are only invalidated upon deletion of the corresponding item from the
   // table, which we won't do until this io_context is deleted. Provided that
   // GuardedHandlerStats synchronizes internal access, we can concurrently write to the
@@ -76,7 +77,7 @@ void instrumented_io_context::post(std::function<void()> handler,
   // readers lock in the callback.
   boost::asio::io_context::post(
       [handler = std::move(handler), stats_handle = std::move(stats_handle)]() {
-        RecordExecution(handler, std::move(stats_handle));
+        EventStats::RecordExecution(handler, std::move(stats_handle));
       });
 }
 
@@ -91,7 +92,7 @@ void instrumented_io_context::post(std::function<void()> handler,
   stats_handle->ZeroAccumulatedQueuingDelay();
   boost::asio::io_context::post(
       [handler = std::move(handler), stats_handle = std::move(stats_handle)]() {
-        RecordExecution(handler, std::move(stats_handle));
+        EventStats::RecordExecution(handler, std::move(stats_handle));
       });
 }
 
@@ -100,7 +101,7 @@ void instrumented_io_context::dispatch(std::function<void()> handler,
   if (!RayConfig::instance().event_stats()) {
     return boost::asio::io_context::post(std::move(handler));
   }
-  const auto stats_handle = RecordStart(name);
+  const auto stats_handle = event_stats_->RecordStart(name);
   // References are only invalidated upon deletion of the corresponding item from the
   // table, which we won't do until this io_context is deleted. Provided that
   // GuardedHandlerStats synchronizes internal access, we can concurrently write to the
@@ -108,176 +109,6 @@ void instrumented_io_context::dispatch(std::function<void()> handler,
   // readers lock in the callback.
   boost::asio::io_context::dispatch(
       [handler = std::move(handler), stats_handle = std::move(stats_handle)]() {
-        RecordExecution(handler, std::move(stats_handle));
+        EventStats::RecordExecution(handler, std::move(stats_handle));
       });
-}
-
-std::shared_ptr<StatsHandle> instrumented_io_context::RecordStart(
-    const std::string &name, int64_t expected_queueing_delay_ns) {
-  auto stats = GetOrCreate(name);
-  int64_t curr_count = 0;
-  {
-    absl::MutexLock lock(&(stats->mutex));
-    stats->stats.cum_count++;
-    curr_count = ++stats->stats.curr_count;
-  }
-  STATS_operation_count.Record(curr_count, name);
-  STATS_operation_active_count.Record(curr_count, name);
-  return std::make_shared<StatsHandle>(
-      name, absl::GetCurrentTimeNanos() + expected_queueing_delay_ns, stats,
-      global_stats_);
-}
-
-void instrumented_io_context::RecordExecution(const std::function<void()> &fn,
-                                              std::shared_ptr<StatsHandle> handle) {
-  int64_t start_execution = absl::GetCurrentTimeNanos();
-  // Update running count
-  {
-    auto &stats = handle->handler_stats;
-    absl::MutexLock lock(&(stats->mutex));
-    stats->stats.running_count++;
-  }
-  // Execute actual handler.
-  fn();
-  int64_t end_execution = absl::GetCurrentTimeNanos();
-  // Update execution time stats.
-  const auto execution_time_ns = end_execution - start_execution;
-  // Update handler-specific stats.
-  STATS_operation_run_time_ms.Record(execution_time_ns / 1000000, handle->handler_name);
-  {
-    auto &stats = handle->handler_stats;
-    absl::MutexLock lock(&(stats->mutex));
-    // Handler-specific execution stats.
-    stats->stats.cum_execution_time += execution_time_ns;
-    // Handler-specific current count.
-    stats->stats.curr_count--;
-    STATS_operation_active_count.Record(stats->stats.curr_count, handle->handler_name);
-    // Handler-specific running count.
-    stats->stats.running_count--;
-  }
-  // Update global stats.
-  const auto queue_time_ns = start_execution - handle->start_time;
-  STATS_operation_queue_time_ms.Record(queue_time_ns / 1000000, handle->handler_name);
-  {
-    auto global_stats = handle->global_stats;
-    absl::MutexLock lock(&(global_stats->mutex));
-    // Global queue stats.
-    global_stats->stats.cum_queue_time += queue_time_ns;
-    if (global_stats->stats.min_queue_time > queue_time_ns) {
-      global_stats->stats.min_queue_time = queue_time_ns;
-    }
-    if (global_stats->stats.max_queue_time < queue_time_ns) {
-      global_stats->stats.max_queue_time = queue_time_ns;
-    }
-  }
-  handle->execution_recorded = true;
-}
-
-std::shared_ptr<GuardedHandlerStats> instrumented_io_context::GetOrCreate(
-    const std::string &name) {
-  // Get this handler's stats.
-  std::shared_ptr<GuardedHandlerStats> result;
-  mutex_.ReaderLock();
-  auto it = post_handler_stats_.find(name);
-  if (it == post_handler_stats_.end()) {
-    mutex_.ReaderUnlock();
-    // Lock the table until we have added the entry. We use try_emplace and handle a
-    // failed insertion in case the item was added before we acquire the writers lock;
-    // this allows the common path, in which the handler already exists in the hash table,
-    // to only require the readers lock.
-    absl::WriterMutexLock lock(&mutex_);
-    const auto pair =
-        post_handler_stats_.try_emplace(name, std::make_shared<GuardedHandlerStats>());
-    if (pair.second) {
-      it = pair.first;
-    } else {
-      it = post_handler_stats_.find(name);
-      // If try_emplace failed to insert the item, the item is guaranteed to exist in
-      // the table.
-      RAY_CHECK(it != post_handler_stats_.end());
-    }
-    result = it->second;
-  } else {
-    result = it->second;
-    mutex_.ReaderUnlock();
-  }
-  return result;
-}
-
-GlobalStats instrumented_io_context::get_global_stats() const {
-  return to_global_stats_view(global_stats_);
-}
-
-absl::optional<HandlerStats> instrumented_io_context::get_handler_stats(
-    const std::string &handler_name) const {
-  absl::ReaderMutexLock lock(&mutex_);
-  auto it = post_handler_stats_.find(handler_name);
-  if (it == post_handler_stats_.end()) {
-    return {};
-  }
-  return to_handler_stats_view(it->second);
-}
-
-std::vector<std::pair<std::string, HandlerStats>>
-instrumented_io_context::get_handler_stats() const {
-  // We lock the stats table while copying the table into a vector.
-  absl::ReaderMutexLock lock(&mutex_);
-  std::vector<std::pair<std::string, HandlerStats>> stats;
-  stats.reserve(post_handler_stats_.size());
-  std::transform(
-      post_handler_stats_.begin(), post_handler_stats_.end(), std::back_inserter(stats),
-      [](const std::pair<std::string, std::shared_ptr<GuardedHandlerStats>> &p) {
-        return std::make_pair(p.first, to_handler_stats_view(p.second));
-      });
-  return stats;
-}
-
-std::string instrumented_io_context::StatsString() const {
-  if (!RayConfig::instance().event_stats()) {
-    return "Stats collection disabled, turn on "
-           "event_stats "
-           "flag to enable event loop stats collection";
-  }
-  auto stats = get_handler_stats();
-  // Sort stats by cumulative count, outside of the table lock.
-  sort(stats.begin(), stats.end(),
-       [](const std::pair<std::string, HandlerStats> &a,
-          const std::pair<std::string, HandlerStats> &b) {
-         return a.second.cum_count > b.second.cum_count;
-       });
-  int64_t cum_count = 0;
-  int64_t curr_count = 0;
-  int64_t cum_execution_time = 0;
-  std::stringstream handler_stats_stream;
-  for (const auto &entry : stats) {
-    cum_count += entry.second.cum_count;
-    curr_count += entry.second.curr_count;
-    cum_execution_time += entry.second.cum_execution_time;
-    handler_stats_stream << "\n\t" << entry.first << " - " << entry.second.cum_count
-                         << " total (" << entry.second.curr_count << " active";
-    if (entry.second.running_count > 0) {
-      handler_stats_stream << ", " << entry.second.running_count << " running";
-    }
-    handler_stats_stream << "), CPU time: mean = "
-                         << to_human_readable(entry.second.cum_execution_time /
-                                              static_cast<double>(entry.second.cum_count))
-                         << ", total = "
-                         << to_human_readable(entry.second.cum_execution_time);
-  }
-  const auto global_stats = get_global_stats();
-  std::stringstream stats_stream;
-  stats_stream << "\nGlobal stats: " << cum_count << " total (" << curr_count
-               << " active)";
-  stats_stream << "\nQueueing time: mean = "
-               << to_human_readable(global_stats.cum_queue_time /
-                                    static_cast<double>(cum_count))
-               << ", max = " << to_human_readable(global_stats.max_queue_time)
-               << ", min = " << to_human_readable(global_stats.min_queue_time)
-               << ", total = " << to_human_readable(global_stats.cum_queue_time);
-  stats_stream << "\nExecution time:  mean = "
-               << to_human_readable(cum_execution_time / static_cast<double>(cum_count))
-               << ", total = " << to_human_readable(cum_execution_time);
-  stats_stream << "\nHandler stats:";
-  stats_stream << handler_stats_stream.rdbuf();
-  return stats_stream.str();
 }

--- a/src/ray/common/asio/instrumented_io_context.cc
+++ b/src/ray/common/asio/instrumented_io_context.cc
@@ -18,51 +18,6 @@
 #include <iomanip>
 #include <iostream>
 #include <utility>
-#include "ray/stats/metric.h"
-#include "ray/stats/event_stats.h"
-
-DEFINE_stats(operation_count, "operation count", ("Method"), (), ray::stats::GAUGE);
-DEFINE_stats(operation_run_time_ms, "operation execution time", ("Method"), (),
-             ray::stats::GAUGE);
-DEFINE_stats(operation_queue_time_ms, "operation queuing time", ("Method"), (),
-             ray::stats::GAUGE);
-DEFINE_stats(operation_active_count, "activate operation number", ("Method"), (),
-             ray::stats::GAUGE);
-namespace {
-
-/// A helper for creating a snapshot view of the global stats.
-/// This acquires a reader lock on the provided global stats, and creates a
-/// lockless copy of the stats.
-GlobalStats to_global_stats_view(std::shared_ptr<GuardedGlobalStats> stats) {
-  absl::MutexLock lock(&(stats->mutex));
-  return GlobalStats(stats->stats);
-}
-
-/// A helper for creating a snapshot view of the stats for a handler.
-/// This acquires a lock on the provided guarded handler stats, and creates a
-/// lockless copy of the stats.
-HandlerStats to_handler_stats_view(std::shared_ptr<GuardedHandlerStats> stats) {
-  absl::MutexLock lock(&(stats->mutex));
-  return HandlerStats(stats->stats);
-}
-
-/// A helper for converting a duration into a human readable string, such as "5.346 ms".
-std::string to_human_readable(double duration) {
-  static const std::array<std::string, 4> to_unit{{"ns", "us", "ms", "s"}};
-  size_t idx = std::min(to_unit.size() - 1,
-                        static_cast<size_t>(std::log(duration) / std::log(1000)));
-  double new_duration = duration / std::pow(1000, idx);
-  std::stringstream result;
-  result << std::fixed << std::setprecision(3) << new_duration << " " << to_unit[idx];
-  return result.str();
-}
-
-/// A helper for converting a duration into a human readable string, such as "5.346 ms".
-std::string to_human_readable(int64_t duration) {
-  return to_human_readable(static_cast<double>(duration));
-}
-
-}  // namespace
 
 void instrumented_io_context::post(std::function<void()> handler,
                                    const std::string name) {

--- a/src/ray/common/asio/instrumented_io_context.h
+++ b/src/ray/common/asio/instrumented_io_context.h
@@ -20,84 +20,13 @@
 #include "absl/synchronization/mutex.h"
 #include "ray/common/ray_config.h"
 #include "ray/util/logging.h"
-
-/// Count, queueing, and execution statistics for an asio handler.
-struct HandlerStats {
-  // Counts.
-  int64_t cum_count = 0;
-  int64_t curr_count = 0;
-
-  // Execution stats.
-  int64_t cum_execution_time = 0;
-  int64_t running_count = 0;
-};
-
-/// Count and queueing statistics over all asio handlers.
-struct GlobalStats {
-  // Queue stats.
-  int64_t cum_queue_time = 0;
-  int64_t min_queue_time = std::numeric_limits<int64_t>::max();
-  int64_t max_queue_time = -1;
-};
-
-/// A mutex wrapper around a handler stats struct.
-struct GuardedHandlerStats {
-  // Stats for some handler.
-  HandlerStats stats;
-
-  // The mutex protecting the reading and writing of these stats.
-  // This mutex should be acquired with a reader lock before reading, and should be
-  // acquired with a writer lock before writing.
-  mutable absl::Mutex mutex;
-};
-
-/// A mutex wrapper around a handler stats struct.
-struct GuardedGlobalStats {
-  // Stats over all handlers.
-  GlobalStats stats;
-
-  // The mutex protecting the reading and writing of these stats.
-  // This mutex should be acquired with a reader lock before reading, and should be
-  // acquired with a writer lock before writing.
-  mutable absl::Mutex mutex;
-};
-
-/// An opaque stats handle, used to manually instrument event loop handlers that don't
-/// hook into a .post() call.
-// TODO Pull out the tracker from ASIO
-struct StatsHandle {
-  std::string handler_name;
-  int64_t start_time;
-  std::shared_ptr<GuardedHandlerStats> handler_stats;
-  std::shared_ptr<GuardedGlobalStats> global_stats;
-  std::atomic<bool> execution_recorded;
-
-  StatsHandle(std::string handler_name_, int64_t start_time_,
-              std::shared_ptr<GuardedHandlerStats> handler_stats_,
-              std::shared_ptr<GuardedGlobalStats> global_stats_)
-      : handler_name(std::move(handler_name_)),
-        start_time(start_time_),
-        handler_stats(std::move(handler_stats_)),
-        global_stats(std::move(global_stats_)),
-        execution_recorded(false) {}
-
-  void ZeroAccumulatedQueuingDelay() { start_time = absl::GetCurrentTimeNanos(); }
-
-  ~StatsHandle() {
-    if (!execution_recorded) {
-      // If handler execution was never recorded, we need to clean up some queueing
-      // stats in order to prevent those stats from leaking.
-      absl::MutexLock lock(&(handler_stats->mutex));
-      handler_stats->stats.curr_count--;
-    }
-  }
-};
+#include "ray/stats/event_stats.h"
 
 /// A proxy for boost::asio::io_context that collects statistics about posted handlers.
 class instrumented_io_context : public boost::asio::io_context {
  public:
   /// Initializes the global stats struct after calling the base contructor.
-  instrumented_io_context() : global_stats_(std::make_shared<GuardedGlobalStats>()) {}
+  instrumented_io_context(std::shared_ptr<EventStats> event_stats) : event_stats_(event_stats) {}
 
   /// A proxy post function that collects count, queueing, and execution statistics for
   /// the given handler.
@@ -125,75 +54,7 @@ class instrumented_io_context : public boost::asio::io_context {
   void dispatch(std::function<void()> handler, const std::string name = "UNKNOWN")
       LOCKS_EXCLUDED(mutex_);
 
-  /// Sets the queueing start time, increments the current and cumulative counts and
-  /// returns an opaque handle for these stats. This is used in conjunction with
-  /// RecordExecution() to manually instrument an event loop handler that doesn't call
-  /// .post().
-  ///
-  /// The returned opaque stats handle should be given to a subsequent RecordExecution()
-  /// call.
-  ///
-  /// \param name A human-readable name to which collected stats will be associated.
-  /// \param expected_queueing_delay_ns How much to pad the observed queueing start time,
-  ///  in nanoseconds.
-  /// \return An opaque stats handle, to be given to RecordExecution().
-  std::shared_ptr<StatsHandle> RecordStart(const std::string &name,
-                                           int64_t expected_queueing_delay_ns = 0);
-
-  /// Records stats about the provided function's execution. This is used in conjunction
-  /// with RecordStart() to manually instrument an event loop handler that doesn't call
-  /// .post().
-  ///
-  /// \param fn The function to execute and instrument.
-  /// \param handle An opaque stats handle returned by RecordStart().
-  static void RecordExecution(const std::function<void()> &fn,
-                              std::shared_ptr<StatsHandle> handle);
-
-  /// Returns a snapshot view of the global count, queueing, and execution statistics
-  /// across all handlers.
-  ///
-  /// \return A snapshot view of the global handler stats.
-  GlobalStats get_global_stats() const;
-
-  /// Returns a snapshot view of the count, queueing, and execution statistics for the
-  /// provided handler.
-  ///
-  /// \param handler_name The name of the handler whose stats should be returned.
-  /// \return A snapshot view of the handler's stats.
-  absl::optional<HandlerStats> get_handler_stats(const std::string &handler_name) const
-      LOCKS_EXCLUDED(mutex_);
-
-  /// Returns snapshot views of the count, queueing, and execution statistics for all
-  /// handlers.
-  ///
-  /// \return A vector containing snapshot views of stats for all handlers.
-  std::vector<std::pair<std::string, HandlerStats>> get_handler_stats() const
-      LOCKS_EXCLUDED(mutex_);
-
-  /// Builds and returns a statistics summary string. Used by the DebugString() of
-  /// objects that used this io_context wrapper, such as the raylet and the core worker.
-  ///
-  /// \return A stats summary string, suitable for inclusion in an object's
-  /// DebugString().
-  std::string StatsString() const LOCKS_EXCLUDED(mutex_);
-
  private:
-  using HandlerStatsTable =
-      absl::flat_hash_map<std::string, std::shared_ptr<GuardedHandlerStats>>;
-  /// Get the mutex-guarded stats for this handler if it exists, otherwise create the
-  /// stats for this handler and return an iterator pointing to it.
-  ///
-  /// \param name A human-readable name for the handler, to be used for viewing stats
-  /// for the provided handler.
-  std::shared_ptr<GuardedHandlerStats> GetOrCreate(const std::string &name);
-
-  /// Global stats, across all handlers.
-  std::shared_ptr<GuardedGlobalStats> global_stats_;
-
-  /// Table of per-handler post stats.
-  /// We use a std::shared_ptr value in order to ensure pointer stability.
-  HandlerStatsTable post_handler_stats_ GUARDED_BY(mutex_);
-
-  /// Protects access to the per-handler post stats table.
-  mutable absl::Mutex mutex_;
+  /// The event stats tracker to use to record asio handler stats to.
+  std::shared_ptr<EventStats> event_stats_;
 };

--- a/src/ray/stats/event_stats.cc
+++ b/src/ray/stats/event_stats.cc
@@ -1,0 +1,234 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/common/asio/event_stats.h"
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <utility>
+#include "ray/stats/metric.h"
+
+DEFINE_stats(operation_count, "operation count", ("Method"), (), ray::stats::GAUGE);
+DEFINE_stats(operation_run_time_ms, "operation execution time", ("Method"), (),
+             ray::stats::GAUGE);
+DEFINE_stats(operation_queue_time_ms, "operation queuing time", ("Method"), (),
+             ray::stats::GAUGE);
+DEFINE_stats(operation_active_count, "activate operation number", ("Method"), (),
+             ray::stats::GAUGE);
+namespace {
+
+/// A helper for creating a snapshot view of the global stats.
+/// This acquires a reader lock on the provided global stats, and creates a
+/// lockless copy of the stats.
+GlobalStats to_global_stats_view(std::shared_ptr<GuardedGlobalStats> stats) {
+  absl::MutexLock lock(&(stats->mutex));
+  return GlobalStats(stats->stats);
+}
+
+/// A helper for creating a snapshot view of the stats for a event.
+/// This acquires a lock on the provided guarded event stats, and creates a
+/// lockless copy of the stats.
+EventStats to_event_stats_view(std::shared_ptr<GuardedEventStats> stats) {
+  absl::MutexLock lock(&(stats->mutex));
+  return EventStats(stats->stats);
+}
+
+/// A helper for converting a duration into a human readable string, such as "5.346 ms".
+std::string to_human_readable(double duration) {
+  static const std::array<std::string, 4> to_unit{{"ns", "us", "ms", "s"}};
+  size_t idx = std::min(to_unit.size() - 1,
+                        static_cast<size_t>(std::log(duration) / std::log(1000)));
+  double new_duration = duration / std::pow(1000, idx);
+  std::stringstream result;
+  result << std::fixed << std::setprecision(3) << new_duration << " " << to_unit[idx];
+  return result.str();
+}
+
+/// A helper for converting a duration into a human readable string, such as "5.346 ms".
+std::string to_human_readable(int64_t duration) {
+  return to_human_readable(static_cast<double>(duration));
+}
+
+}  // namespace
+
+std::shared_ptr<StatsHandle> EventStats::RecordStart(
+    const std::string &name, int64_t expected_queueing_delay_ns) {
+  auto stats = GetOrCreate(name);
+  int64_t curr_count = 0;
+  {
+    absl::MutexLock lock(&(stats->mutex));
+    stats->stats.cum_count++;
+    curr_count = ++stats->stats.curr_count;
+  }
+  STATS_operation_count.Record(curr_count, name);
+  STATS_operation_active_count.Record(curr_count, name);
+  return std::make_shared<StatsHandle>(
+      name, absl::GetCurrentTimeNanos() + expected_queueing_delay_ns, stats,
+      global_stats_);
+}
+
+void EventStats::RecordExecution(const std::function<void()> &fn,
+                                 std::shared_ptr<StatsHandle> handle) {
+  int64_t start_execution = absl::GetCurrentTimeNanos();
+  // Update running count
+  {
+    auto &stats = handle->event_stats;
+    absl::MutexLock lock(&(stats->mutex));
+    stats->stats.running_count++;
+  }
+  // Execute actual function.
+  fn();
+  int64_t end_execution = absl::GetCurrentTimeNanos();
+  // Update execution time stats.
+  const auto execution_time_ns = end_execution - start_execution;
+  // Update event-specific stats.
+  STATS_operation_run_time_ms.Record(execution_time_ns / 1000000, handle->event_name);
+  {
+    auto &stats = handle->event_stats;
+    absl::MutexLock lock(&(stats->mutex));
+    // Event-specific execution stats.
+    stats->stats.cum_execution_time += execution_time_ns;
+    // Event-specific current count.
+    stats->stats.curr_count--;
+    STATS_operation_active_count.Record(stats->stats.curr_count, handle->event_name);
+    // Event-specific running count.
+    stats->stats.running_count--;
+  }
+  // Update global stats.
+  const auto queue_time_ns = start_execution - handle->start_time;
+  STATS_operation_queue_time_ms.Record(queue_time_ns / 1000000, handle->event_name);
+  {
+    auto global_stats = handle->global_stats;
+    absl::MutexLock lock(&(global_stats->mutex));
+    // Global queue stats.
+    global_stats->stats.cum_queue_time += queue_time_ns;
+    if (global_stats->stats.min_queue_time > queue_time_ns) {
+      global_stats->stats.min_queue_time = queue_time_ns;
+    }
+    if (global_stats->stats.max_queue_time < queue_time_ns) {
+      global_stats->stats.max_queue_time = queue_time_ns;
+    }
+  }
+  handle->execution_recorded = true;
+}
+
+std::shared_ptr<GuardedEventStats> EventStats::GetOrCreate(
+    const std::string &name) {
+  // Get this event's stats.
+  std::shared_ptr<GuardedEventStats> result;
+  mutex_.ReaderLock();
+  auto it = post_event_stats_.find(name);
+  if (it == post_event_stats_.end()) {
+    mutex_.ReaderUnlock();
+    // Lock the table until we have added the entry. We use try_emplace and handle a
+    // failed insertion in case the item was added before we acquire the writers lock;
+    // this allows the common path, in which the handler already exists in the hash table,
+    // to only require the readers lock.
+    absl::WriterMutexLock lock(&mutex_);
+    const auto pair =
+        post_event_stats_.try_emplace(name, std::make_shared<GuardedEventStats>());
+    if (pair.second) {
+      it = pair.first;
+    } else {
+      it = post_event_stats_.find(name);
+      // If try_emplace failed to insert the item, the item is guaranteed to exist in
+      // the table.
+      RAY_CHECK(it != post_event_stats_.end());
+    }
+    result = it->second;
+  } else {
+    result = it->second;
+    mutex_.ReaderUnlock();
+  }
+  return result;
+}
+
+GlobalStats EventStats::get_global_stats() const {
+  return to_global_stats_view(global_stats_);
+}
+
+absl::optional<EventStats> EventStats::get_event_stats(
+    const std::string &event_name) const {
+  absl::ReaderMutexLock lock(&mutex_);
+  auto it = post_event_stats_.find(event_name);
+  if (it == post_event_stats_.end()) {
+    return {};
+  }
+  return to_event_stats_view(it->second);
+}
+
+std::vector<std::pair<std::string, EventStats>>
+EventStats::get_event_stats() const {
+  // We lock the stats table while copying the table into a vector.
+  absl::ReaderMutexLock lock(&mutex_);
+  std::vector<std::pair<std::string, EventStats>> stats;
+  stats.reserve(post_event_stats_.size());
+  std::transform(
+      post_event_stats_.begin(), post_event_stats_.end(), std::back_inserter(stats),
+      [](const std::pair<std::string, std::shared_ptr<GuardedEventStats>> &p) {
+        return std::make_pair(p.first, to_event_stats_view(p.second));
+      });
+  return stats;
+}
+
+std::string EventStats::StatsString() const {
+  if (!RayConfig::instance().event_stats()) {
+    return "Stats collection disabled, turn on "
+           "event_stats "
+           "flag to enable event loop stats collection";
+  }
+  auto stats = get_event_stats();
+  // Sort stats by cumulative count, outside of the table lock.
+  sort(stats.begin(), stats.end(),
+       [](const std::pair<std::string, EventStats> &a,
+          const std::pair<std::string, EventStats> &b) {
+         return a.second.cum_count > b.second.cum_count;
+       });
+  int64_t cum_count = 0;
+  int64_t curr_count = 0;
+  int64_t cum_execution_time = 0;
+  std::stringstream event_stats_stream;
+  for (const auto &entry : stats) {
+    cum_count += entry.second.cum_count;
+    curr_count += entry.second.curr_count;
+    cum_execution_time += entry.second.cum_execution_time;
+    event_stats_stream << "\n\t" << entry.first << " - " << entry.second.cum_count
+                         << " total (" << entry.second.curr_count << " active";
+    if (entry.second.running_count > 0) {
+      event_stats_stream << ", " << entry.second.running_count << " running";
+    }
+    event_stats_stream << "), CPU time: mean = "
+                         << to_human_readable(entry.second.cum_execution_time /
+                                              static_cast<double>(entry.second.cum_count))
+                         << ", total = "
+                         << to_human_readable(entry.second.cum_execution_time);
+  }
+  const auto global_stats = get_global_stats();
+  std::stringstream stats_stream;
+  stats_stream << "\nGlobal stats: " << cum_count << " total (" << curr_count
+               << " active)";
+  stats_stream << "\nQueueing time: mean = "
+               << to_human_readable(global_stats.cum_queue_time /
+                                    static_cast<double>(cum_count))
+               << ", max = " << to_human_readable(global_stats.max_queue_time)
+               << ", min = " << to_human_readable(global_stats.min_queue_time)
+               << ", total = " << to_human_readable(global_stats.cum_queue_time);
+  stats_stream << "\nExecution time:  mean = "
+               << to_human_readable(cum_execution_time / static_cast<double>(cum_count))
+               << ", total = " << to_human_readable(cum_execution_time);
+  stats_stream << "\nEvent stats:";
+  stats_stream << event_stats_stream.rdbuf();
+  return stats_stream.str();
+}

--- a/src/ray/stats/event_stats.h
+++ b/src/ray/stats/event_stats.h
@@ -43,7 +43,7 @@ struct GlobalStats {
 /// A mutex wrapper around a handler stats struct.
 struct GuardedEventStats {
   // Stats for some handler.
-  EventStats stats;
+  EventStats stats GUARDED_BY(mutex);
 
   // The mutex protecting the reading and writing of these stats.
   // This mutex should be acquired with a reader lock before reading, and should be
@@ -54,7 +54,7 @@ struct GuardedEventStats {
 /// A mutex wrapper around a handler stats struct.
 struct GuardedGlobalStats {
   // Stats over all handlers.
-  GlobalStats stats;
+  GlobalStats stats GUARDED_BY(mutex);
 
   // The mutex protecting the reading and writing of these stats.
   // This mutex should be acquired with a reader lock before reading, and should be
@@ -167,4 +167,3 @@ class EventTracker {
   /// Protects access to the per-handler post stats table.
   mutable absl::Mutex mutex_;
 };
-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently our general event stats tracker is embedded within the instrumented asio event handler. Pull it out as refactoring.