### PR TITLE
[runtime env] Parse local conda/pip requirements files before sending runtime env to Ray Client Server

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -12,7 +12,8 @@ import socket
 import math
 import traceback
 from typing import Optional, Any, List, Dict
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stdout, redirect_stderr, contextmanager
+
 import yaml
 import logging
 import tempfile
@@ -1064,3 +1065,11 @@ def get_and_run_node_killer(node_kill_interval_s,
     if not no_start:
         node_killer.run.remote()
     return node_killer
+
+
+@contextmanager
+def chdir(d: str):
+    old_dir = os.getcwd()
+    os.chdir(d)
+    yield
+    os.chdir(old_dir)

--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -47,14 +47,18 @@ class JobConfig:
         """Serialize the struct into protobuf string"""
         return self.get_proto_job_config().SerializeToString()
 
-    def set_runtime_env(self, runtime_env: Optional[Dict[str, Any]]) -> None:
+    def set_runtime_env(self,
+                        runtime_env: Optional[Dict[str, Any]],
+                        validate: bool = False) -> None:
         """Modify the runtime_env of the JobConfig.
 
-        We don't validate the runtime_env here because it may go through some
-        translation before actually being passed to C++ (e.g., working_dir
-        translated from a local directory to a URI).
+        We don't validate the runtime_env by default here because it may go
+        through some translation before actually being passed to C++ (e.g.,
+        working_dir translated from a local directory to a URI.
         """
         self.runtime_env = runtime_env if runtime_env is not None else {}
+        if validate:
+            self.runtime_env = self._validate_runtime_env()[0]
         self._cached_pb = None
 
     def set_ray_namespace(self, ray_namespace: str) -> None:

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -1,5 +1,4 @@
 import os
-from contextlib import contextmanager
 from pathlib import Path
 import pytest
 import subprocess
@@ -21,7 +20,7 @@ from ray._private.runtime_env.conda import (
 from ray._private.runtime_env.conda_utils import get_conda_env_list
 from ray._private.test_utils import (run_string_as_driver,
                                      run_string_as_driver_nonblocking,
-                                     wait_for_condition, get_log_batch)
+                                     wait_for_condition, get_log_batch, chdir)
 from ray._private.utils import get_conda_env_dir, get_conda_bin_executable
 
 if not os.environ.get("CI"):
@@ -855,14 +854,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
             "pip": ["pip-install-test"]
         }).remote()
         assert ray.get(a.test.remote()) == "Hello"
-
-
-@contextmanager
-def chdir(dir):
-    old_dir = os.getcwd()
-    os.chdir(dir)
-    yield
-    os.chdir(old_dir)
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_runtime_env_conda.py
+++ b/python/ray/tests/test_runtime_env_conda.py
@@ -1,8 +1,10 @@
 import os
 import pytest
 import sys
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, chdir
 import yaml
+import tempfile
+from pathlib import Path
 
 import ray
 
@@ -59,6 +61,52 @@ def generate_runtime_env_dict(field, spec_format, tmp_path):
     os.environ.get("CI") and sys.platform != "linux",
     reason="Requires PR wheels built in CI, so only run on linux CI machines.")
 @pytest.mark.parametrize("field", ["conda", "pip"])
+def test_files_remote_cluster(start_cluster, field):
+    """Test that requirements files are parsed on the driver, not the cluster.
+
+    This is the desired behavior because the file paths only make sense on the
+    driver machine. The files do not exist on the remote cluster.
+    """
+    cluster, address = start_cluster
+
+    # cd into a temporary directory and pass in pip/conda requirements file
+    # using a relative path.  Since the cluster has already been started,
+    # the cwd of the processes on the cluster nodes will not be this
+    # temporary directory.  So if the nodes try to read the requirements file,
+    # this test should fail because the relative path won't make sense.
+    with tempfile.TemporaryDirectory() as tmpdir, chdir(tmpdir):
+        if field == "conda":
+            conda_dict = {
+                "dependencies": ["pip", {
+                    "pip": ["pip-install-test==0.5"]
+                }]
+            }
+            relative_filepath = "environment.yml"
+            conda_file = Path(relative_filepath)
+            conda_file.write_text(yaml.dump(conda_dict))
+            runtime_env = {"conda": relative_filepath}
+        elif field == "pip":
+            pip_list = ["pip-install-test==0.5"]
+            relative_filepath = "requirements.txt"
+            pip_file = Path(relative_filepath)
+            pip_file.write_text("\n".join(pip_list))
+            runtime_env = {"pip": relative_filepath}
+
+        ray.init(address, runtime_env=runtime_env)
+
+        @ray.remote
+        def f():
+            import pip_install_test  # noqa: F401
+            return True
+
+        # Ensure that the runtime env has been installed.
+        assert ray.get(f.remote())
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform != "linux",
+    reason="Requires PR wheels built in CI, so only run on linux CI machines.")
+@pytest.mark.parametrize("field", ["conda", "pip"])
 @pytest.mark.parametrize("spec_format", ["file", "python_object"])
 def test_job_level_gc(start_cluster, field, spec_format, tmp_path):
     """Tests that job-level conda env is GC'd when the job exits."""
@@ -84,6 +132,16 @@ def test_job_level_gc(start_cluster, field, spec_format, tmp_path):
     ray.shutdown()
 
     wait_for_condition(lambda: check_local_files_gced(cluster), timeout=30)
+
+    # Check that we can reconnect with the same env.  (In other words, ensure
+    # the conda env was fully deleted and not left in some kind of corrupted
+    # state that prevents reinstalling the same conda env.)
+
+    ray.init(
+        address,
+        runtime_env=generate_runtime_env_dict(field, spec_format, tmp_path))
+
+    assert ray.get(f.remote())
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-
 import os
 from pathlib import Path
 import sys
@@ -13,7 +11,7 @@ import ray
 import ray.experimental.internal_kv as kv
 from ray.tests.test_runtime_env_working_dir \
     import tmp_working_dir  # noqa: F401
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, chdir
 from ray._private.runtime_env import RAY_WORKER_DEV_EXCLUDES
 from ray._private.runtime_env.packaging import GCS_STORAGE_MAX_SIZE
 # This test requires you have AWS credentials set up (any AWS credentials will
@@ -23,14 +21,6 @@ from ray._private.runtime_env.packaging import GCS_STORAGE_MAX_SIZE
 # Calling `test_module.one()` should return `2`.
 # If you find that confusing, take it up with @jiaodong...
 S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
-
-
-@contextmanager
-def chdir(d: str):
-    old_dir = os.getcwd()
-    os.chdir(d)
-    yield
-    os.chdir(old_dir)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -684,7 +684,7 @@ class Worker:
                         runtime_env, tmp_dir, logger=logger)
                     # Remove excludes, it isn't relevant after the upload step.
                     runtime_env.pop("excludes", None)
-                    job_config.set_runtime_env(runtime_env)
+                    job_config.set_runtime_env(runtime_env, validate=True)
 
                 serialized_job_config = pickle.dumps(job_config)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Validate the runtime env before sending it to the Ray Client Server.  Validation rewrites the `pip` or `conda` field if it contains a local path to a requirements file, replacing it with a Python object containing the file contents (List in the case of a pip requirements.txt, dict in the case of a conda environment.yml). This prevents errors when the validation is run again on the remote nodes.  

In the future we should refactor jobconfig.py so a validated runtime env is passed in once at the beginning, instead of running validation every time we serialize the JobConfig.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #20876 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests (Will add release test once this is merged.  Can't do it beforehand because `conda` runtime_env requires the Ray wheel to exist on AWS, so I can't manually run the release test using Ray built from source.)
   - [ ] This PR is not tested :(
