### PR TITLE
Move the worker_startup_token_counter_ to the  Process for process ha…

### DIFF
--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -35,15 +35,17 @@ void ProcessHelper::StartRayNode(const int redis_port, const std::string redis_p
     cmdargs.insert(cmdargs.end(), head_args.begin(), head_args.end());
   }
   RAY_LOG(INFO) << CreateCommandLine(cmdargs);
-  RAY_CHECK(!Process::Spawn(cmdargs, true).second);
+  StartupToken token = GetNewStartupToken();
+  RAY_CHECK(!Process::Spawn(token, cmdargs, true).second);
   std::this_thread::sleep_for(std::chrono::seconds(5));
   return;
 }
 
 void ProcessHelper::StopRayNode() {
   std::vector<std::string> cmdargs({"ray", "stop"});
+  StartupToken token = GetNewStartupToken();
   RAY_LOG(INFO) << CreateCommandLine(cmdargs);
-  RAY_CHECK(!Process::Spawn(cmdargs, true).second);
+  RAY_CHECK(!Process::Spawn(token, cmdargs, true).second);
   std::this_thread::sleep_for(std::chrono::seconds(3));
   return;
 }

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -73,7 +73,7 @@ void AgentManager::StartAgent() {
   env.insert({"RESTART_COUNT", std::to_string(agent_restart_count_)});
   env.insert({"MAX_RESTART_COUNT",
               std::to_string(RayConfig::instance().agent_max_restart_count())});
-  Process child(argv.data(), nullptr, ec, false, env);
+  Process child(GetNewStartupToken(), argv.data(), nullptr, ec, false, env);
   if (!child.IsValid() || ec) {
     // The worker failed to start. This is a fatal error.
     RAY_LOG(FATAL) << "Failed to start agent with return value " << ec << ": "

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1136,7 +1136,7 @@ void NodeManager::ProcessRegisterClientRequestMessage(
     // Register the new driver.
     RAY_CHECK(pid >= 0);
     // Don't need to set shim pid for driver
-    worker->SetProcess(Process::FromPid(pid));
+    worker->SetProcess(Process::FromPidAndToken(pid, worker_startup_token));
     // Compute a dummy driver task id from a given driver.
     const TaskID driver_task_id = TaskID::ComputeDriverTaskId(worker_id);
     worker->AssignTaskId(driver_task_id);

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -385,8 +385,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   void TryKillingIdleWorkers();
 
  protected:
-  void update_worker_startup_token_counter();
-
   /// Asynchronously start a new worker process. Once the worker process has
   /// registered with an external server, the process should create and
   /// register N workers, then add them to the pool.
@@ -423,7 +421,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \param[in] env Additional environment variables to be set on this process besides
   /// the environment variables of the parent process.
   /// \return An object representing the started worker process.
-  virtual Process StartProcess(const std::vector<std::string> &worker_command_args,
+  virtual Process StartProcess(StartupToken token,
+                               const std::vector<std::string> &worker_command_args,
                                const ProcessEnvironment &env);
 
   /// Push an warning message to user if worker pool is getting to big.
@@ -433,11 +432,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   void PopWorkerCallbackInternal(const PopWorkerCallback &callback,
                                  std::shared_ptr<WorkerInterface> worker,
                                  PopWorkerStatus status);
-
-  /// Gloabl startup token variable. Incremented once assigned
-  /// to a worker process and is added to
-  /// state.starting_worker_processes.
-  StartupToken worker_startup_token_counter_;
 
   struct IOWorkerState {
     /// The pool of idle I/O workers.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

PR #19014 introduced the idea of a StartupToken to uniquely identify a task via a counter. This PR extends the idea and moves the StartupToken to the Process class. The changes are:
- Add a global `StartupToken ray::GetNewStartupToken();` function to return-and-increment the counter
- Add a `StartupToken ray::Process::_startup_token` member so that each process has a token
- Change `ray::Process::GetId()` to return the token rather than the process PID. This required some other changes to refactor the class to avoid confusion, since the class still must expose a `GetProcPID()` interface, as well as the global `ray::GetPID()` function that returns the current OS PID.
- Pass the StartupToken into the various routines to create a `ray::Process`

This does not solve the problem, but it does enable exposing it on linux. If I add a `time.sleep(2)` to the direct task `small_value`, then the `test_actor_call_order` test in `test_basic_2.py` hangs on linux like it does on windows.

More work is needed to figure out where the actor task -> direct task dependency hangs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#20792, #20173, maybe others
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
