### PR TITLE
[Datasets] Fix boolean tensor column slicing.

### DIFF
--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -524,15 +524,21 @@ def test_arrow_tensor_array_getitem(ray_start_regular_shared):
         np.testing.assert_array_equal(t_arr2[idx - 1], arr[idx])
 
 
-@pytest.mark.parametrize("test_arr", [
-    [[1, 2], [3, 4], [5, 6], [7, 8]],
-    [[1.5, 2.5], [3.3, 4.2], [5.2, 6.9], [7.6, 8.1]],
-    [[False, True], [True, False], [True, True], [False, False]],
+@pytest.mark.parametrize("test_arr,dtype", [
+    ([[1, 2], [3, 4], [5, 6], [7, 8]], None),
+    ([[1, 2], [3, 4], [5, 6], [7, 8]], np.int32),
+    ([[1, 2], [3, 4], [5, 6], [7, 8]], np.int16),
+    ([[1, 2], [3, 4], [5, 6], [7, 8]], np.longlong),
+    ([[1.5, 2.5], [3.3, 4.2], [5.2, 6.9], [7.6, 8.1]], None),
+    ([[1.5, 2.5], [3.3, 4.2], [5.2, 6.9], [7.6, 8.1]], np.float32),
+    ([[1.5, 2.5], [3.3, 4.2], [5.2, 6.9], [7.6, 8.1]], np.float16),
+    ([[False, True], [True, False], [True, True], [False, False]], None),
 ])
-def test_arrow_tensor_array_slice(test_arr):
+def test_arrow_tensor_array_slice(test_arr, dtype):
     # Test that ArrowTensorArray slicing works as expected.
-    arr = np.array(test_arr)
+    arr = np.array(test_arr, dtype=dtype)
     ata = ArrowTensorArray.from_numpy(arr)
+    np.testing.assert_array_equal(ata.to_numpy(), arr)
     slice1 = ata.slice(0, 2)
     np.testing.assert_array_equal(slice1.to_numpy(), arr[0:2])
     np.testing.assert_array_equal(slice1[1], arr[1])


### PR DESCRIPTION
Arrow byte-packs boolean arrays, with 8 entries per byte, and both Arrow and NumPy utilize bit-based offsets for indexing into data buffers. This PR adds support for properly indexing into boolean tensor columns by using bit-based offsets for such columns.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #20825 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
