### PR TITLE
[tune] Scheduler interface V2 - Draft

### DIFF
--- a/python/ray/tune/decision_store.py
+++ b/python/ray/tune/decision_store.py
@@ -1,0 +1,108 @@
+import logging
+from typing import Optional, Tuple
+
+from ray.tune import TuneError
+from ray.tune.schedulers import SchedulingDecision
+from ray.tune.trial import Trial
+
+logger = logging.getLogger(__name__)
+
+
+class DecisionStore:
+    """Scheduling decision store.
+
+    There may be multiple decisions generated per Tune event. Sometimes,
+    the execution of these decisions cannot be done within the life span of
+    the Tune step that generates them. For example, a trial may need to finish
+    saving first before the following decision can be executed. Or a trial
+    may need to finish replace(back into RUNNING state) before SAVE can be
+    executed. To avoid blocking Tune loop, such "finish I before II" pattern is
+    done across multiple Tune steps. This class manages decision caching in
+    the process.
+
+    Secondly, the class assigns explicit executing order to various decisions.
+    i.e. REPLACE > SAVE > the rest.
+
+    Thirdly, the class serves as a validator to check if certain decision is
+    meaningful given the state a trial is at.
+    """
+
+    def __init__(self):
+        # A map between trial and (STOP, PAUSE, CONTINUE) decisions.
+        self._decisions = {}
+        # A set of trials to save.
+        self._trials_to_save = set()
+        # Trials to replace with metadata.
+        self._trials_to_replace = {}
+
+    def add_decision(self, trial, scheduling_decision):
+        if scheduling_decision.type == SchedulingDecision.SAVE:
+            assert trial.status == Trial.RUNNING
+            self._trials_to_save.add(trial)
+        elif scheduling_decision.type == SchedulingDecision.REPLACE:
+            # REPLACE and (PAUSE, CONTINUE, STOP) should be exclusive.
+            assert trial not in self._decisions
+            assert scheduling_decision.metadata
+            self._trials_to_replace[trial] = scheduling_decision
+        elif scheduling_decision.type in (SchedulingDecision.PAUSE,
+                                          SchedulingDecision.CONTINUE,
+                                          SchedulingDecision.STOP):
+            # REPLACE and (PAUSE, CONTINUE, STOP) should be exclusive.
+            assert trial not in self._trials_to_replace
+            decision_types = set()
+            if trial in self._decisions:
+                decision_types.add(self._decisions[trial].type)
+            decision_types.add(scheduling_decision.type)
+            if SchedulingDecision.STOP in decision_types:
+                self._decisions[trial] = SchedulingDecision(
+                    SchedulingDecision.STOP)
+            elif SchedulingDecision.PAUSE in decision_types:
+                self._decisions[trial] = SchedulingDecision(
+                    SchedulingDecision.PAUSE)
+            else:
+                self._decisions[trial] = SchedulingDecision(
+                    SchedulingDecision.CONTINUE)
+        else:
+            raise TuneError("Unexpected TrialSchedulerV2 decision type!!")
+
+    def add_decisions(self, decisions):
+        for trial, decision in decisions.items():
+            self.add_decision(trial, decision)
+
+    def get_decision(
+            self) -> Tuple[Optional[Trial], Optional[SchedulingDecision]]:
+        """Get next decision to execute."""
+        if len(self._trials_to_replace) > 0:
+            trial, decision = self._trials_to_replace.popitem()
+            assert trial.status in (Trial.RUNNING, Trial.PAUSED)
+            return trial, decision
+        trials_to_save = [
+            t for t in self._trials_to_save if t.status == Trial.RUNNING
+        ]
+        if len(trials_to_save) > 0:
+            trial = trials_to_save.pop()
+            self._trials_to_save.remove(trial)
+            return trial, SchedulingDecision(SchedulingDecision.SAVE)
+        for t in self._trials_to_save:
+            assert t.status == Trial.PAUSED
+            logger.info(f"Delayed saving for {t} as it's just being replaced "
+                        f"and is currently in PAUSED state.")
+        # Now do the rest.
+        if len(self._decisions) > 0:
+            trial, decision = self._decisions.popitem()
+            if decision.type == SchedulingDecision.STOP:
+                assert (trial.status == Trial.RUNNING
+                        and trial.internal_status == Trial.WAITING) or (
+                            Trial.status == Trial.PAUSED)
+            else:
+                assert (trial.status == Trial.RUNNING
+                        and trial.internal_status == Trial.WAITING)
+            return trial, decision
+        return None, None
+
+    def should_save(self, trial):
+        if trial in self._trials_to_save:
+            self._trials_to_save.remove(trial)
+            return True
+        else:
+            return False

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -854,12 +854,12 @@ class RayTrialExecutor(TrialExecutor):
         with self._change_working_directory(trial):
             if storage == Checkpoint.MEMORY:
                 value = trial.runner.save_to_object.remote()
-                checkpoint = Checkpoint(storage, value, result)
-                trial.on_checkpoint(checkpoint)
+                checkpoint = Checkpoint(Checkpoint.MEMORY, value, result)
+                trial.assign_checkpoint(checkpoint)
             else:
                 value = trial.runner.save.remote()
                 checkpoint = Checkpoint(storage, value, result)
-                trial.saving_to = checkpoint
+                trial.mark_saving(checkpoint)
                 self._running[value] = trial
         return checkpoint
 
@@ -914,7 +914,7 @@ class RayTrialExecutor(TrialExecutor):
                 ray.get(remote)
             else:
                 self._running[remote] = trial
-                trial.restoring_from = checkpoint
+                trial.mark_restoring(checkpoint)
 
     def export_trial_if_needed(self, trial: Trial) -> Dict:
         """Exports model of this trial based on trial.export_formats.

--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -1,5 +1,6 @@
 from ray._private.utils import get_function_args
-from ray.tune.schedulers.trial_scheduler import TrialScheduler, FIFOScheduler
+from ray.tune.schedulers.trial_scheduler import FIFOScheduler, TrialScheduler
+from ray.tune.schedulers.trial_scheduler_v2 import SchedulingDecision, TrialSchedulerV2
 from ray.tune.schedulers.hyperband import HyperBandScheduler
 from ray.tune.schedulers.hb_bohb import HyperBandForBOHB
 from ray.tune.schedulers.async_hyperband import (AsyncHyperBandScheduler,
@@ -67,8 +68,9 @@ def create_scheduler(
 
 
 __all__ = [
-    "TrialScheduler", "HyperBandScheduler", "AsyncHyperBandScheduler",
-    "ASHAScheduler", "MedianStoppingRule", "FIFOScheduler",
-    "PopulationBasedTraining", "PopulationBasedTrainingReplay",
-    "HyperBandForBOHB", "ResourceChangingScheduler"
+    "TrialScheduler", "SchedulingDecision", "TrialSchedulerV2",
+    "HyperBandScheduler", "AsyncHyperBandScheduler", "ASHAScheduler",
+    "MedianStoppingRule", "FIFOScheduler", "PopulationBasedTraining",
+    "PopulationBasedTrainingReplay", "HyperBandForBOHB",
+    "ResourceChangingScheduler"
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Hi Kai,
To help with review, there are some notes that may worth discussing.
* Part of this effort I think is about assigning very clear semantics to each Trial status and how to go from A to B. In light of that, I introduce `internal_status` to further distinguish within `RUNNING` status. Also enforce certain setters to modify trial status to enforce consistency.
* Consolidate stop_trial. There are stop_trial logic in process_trial_result as well as stop_trial. We should unify all the logic to stop_trial function, and this function should be the handler of any STOP scheduling decision. stop_trial will only stop trials that are in PAUSED, PENDING, RUNNING + WAITING status to avoid blocking.
* At one point we talked about REPLACE to also checkpoint the trial_to_clone. This may not work now that I take another look at pbt.py. Namely, if I were in async pbt, trial A is supposed to be checkpointed first and then continue training. When B comes in and is determined to need to be replaced by A, A's checkpoint needs to be there. We cannot wait till then to checkpoint A as A already proceeds. This is only an issue in async pbt. So I am afraid that we have to distinguish SAVE persistently and SAVE to memory in our scheduling decision.
* Introduces DecisionStore. Unfortunately the logic is a bit convoluted. It will be even so if we want to tell apart two different SAVEs. i.e. SAVE (to memory) > REPLCE > SAVE (to disk) > the rest...
* The Tune loop is modified in a way to facilitate gradual cut over to V2.
* Last but not least, I think pbt currently is not entirely working if checkpointing freq is coincidently the same as mutating frequency. We will run into situations that A is replaced but then immediately SAVE to disk. This will fail now, since REPLACE would put the trial back to PAUSED state and we cannot SAVE a paused trial.



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
