### PR TITLE
[tune] Add random state to `BasicVariantGenerator`

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -216,7 +216,7 @@ py_test(
 
 py_test(
     name = "test_sample",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_sample.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive", "tests_dir_S"],

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -31,15 +31,12 @@ class _BackwardsCompatibleNumpyRng:
                  generator_or_seed: Optional[Union[
                      "random_generator", np.random.RandomState, int]] = None):
         if generator_or_seed is None:
-            self._rng = None
-            return
-        if isinstance(generator_or_seed, np.random.RandomState):
+            self._rng = np.random
+        elif isinstance(generator_or_seed, np.random.RandomState):
             self._rng = generator_or_seed
-            return
-        if isinstance(generator_or_seed, random_generator):
+        elif isinstance(generator_or_seed, random_generator):
             self._rng = generator_or_seed
-            return
-        if LEGACY_RNG:
+        elif LEGACY_RNG:
             self._rng = np.random.RandomState(generator_or_seed)
         else:
             self._rng = np.random.default_rng(generator_or_seed)

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -30,26 +30,27 @@ class _BackwardsCompatibleNumpyRng:
                  generator_or_seed: Optional[Union[
                      "random_generator", np.random.RandomState, int]] = None):
         if generator_or_seed is None:
-            self.legacy_rng = True
             self.rng = np.random
             return
         if isinstance(generator_or_seed, np.random.RandomState):
-            self.legacy_rng = True
             self.rng = generator_or_seed
             return
         if isinstance(generator_or_seed, random_generator):
-            self.legacy_rng = False
             self.rng = generator_or_seed
             return
         if LEGACY_RNG:
-            self.legacy_rng = True
             self.rng = np.random.RandomState(generator_or_seed)
         else:
-            self.legacy_rng = False
             self.rng = np.random.default_rng(generator_or_seed)
+
+    @property
+    def legacy_rng(self) -> bool:
+        return not isinstance(self.rng, random_generator)
 
     def __getattr__(self, name: str) -> Any:
         # https://numpy.org/doc/stable/reference/random/new-or-different.html
+        if name in ("legacy_rng", "rng"):
+            return self.__dict__[name]
         if self.legacy_rng:
             if name == "integers":
                 name = "randint"

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -47,7 +47,7 @@ class _BackwardsCompatibleNumpyRng:
     @property
     def rng(self):
         # don't set self._rng to np.random to avoid picking issues
-        return self._rng if self._rng else np.random
+        return self._rng if self._rng is not None else np.random
 
     def __getattr__(self, name: str) -> Any:
         # https://numpy.org/doc/stable/reference/random/new-or-different.html

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -62,6 +62,10 @@ class _BackwardsCompatibleNumpyRng:
         return getattr(self.rng, name)
 
 
+RANDOM_STATE = Union[None, _BackwardsCompatibleNumpyRng, random_generator,
+                     np.random.RandomState, int]
+
+
 class Domain:
     """Base class to specify a type and valid range to sample parameters from.
 
@@ -98,9 +102,7 @@ class Domain:
     def sample(self,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional[
-                   Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                         np.random.RandomState, int]] = None):
+               random_state: Optional["RANDOM_STATE"] = None):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
         sampler = self.get_sampler()
@@ -127,9 +129,7 @@ class Sampler:
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional[
-                   Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                         np.random.RandomState, int]] = None):
+               random_state: Optional["RANDOM_STATE"] = None):
         raise NotImplementedError
 
 
@@ -170,9 +170,7 @@ class Grid(Sampler):
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional[
-                   Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                         np.random.RandomState, int]] = None):
+               random_state: Optional["RANDOM_STATE"] = None):
         return RuntimeError("Do not call `sample()` on grid.")
 
 
@@ -182,9 +180,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional[
-                       Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                             np.random.RandomState, int]] = None):
+                   random_state: Optional["RANDOM_STATE"] = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > float("-inf"), \
@@ -199,9 +195,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional[
-                       Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                             np.random.RandomState, int]] = None):
+                   random_state: Optional["RANDOM_STATE"] = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > 0, \
@@ -220,9 +214,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional[
-                       Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                             np.random.RandomState, int]] = None):
+                   random_state: Optional["RANDOM_STATE"] = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert not domain.lower or domain.lower == float("-inf"), \
@@ -307,9 +299,7 @@ class Integer(Domain):
                    domain: "Integer",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional[
-                       Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                             np.random.RandomState, int]] = None):
+                   random_state: Optional["RANDOM_STATE"] = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             items = random_state.integers(
@@ -321,9 +311,7 @@ class Integer(Domain):
                    domain: "Integer",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional[
-                       Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                             np.random.RandomState, int]] = None):
+                   random_state: Optional["RANDOM_STATE"] = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > 0, \
@@ -388,9 +376,7 @@ class Categorical(Domain):
                    domain: "Categorical",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional[
-                       Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                             np.random.RandomState, int]] = None):
+                   random_state: Optional["RANDOM_STATE"] = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             items = random_state.choice(domain.categories, size=size).tolist()
@@ -431,9 +417,7 @@ class Function(Domain):
                    domain: "Function",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional[
-                       Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                             np.random.RandomState, int]] = None):
+                   random_state: Optional["RANDOM_STATE"] = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             if domain.pass_spec:
@@ -493,9 +477,7 @@ class Quantized(Sampler):
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional[
-                   Union[_BackwardsCompatibleNumpyRng, "random_generator",
-                         np.random.RandomState, int]] = None):
+               random_state: Optional["RANDOM_STATE"] = None):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
         values = self.sampler.sample(

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -9,11 +9,11 @@ import numpy as np
 # Backwards compatibility
 try:
     # Added in numpy>=1.17 but we require numpy>=1.16
-    random_generator = np.random.Generator
+    np_random_generator = np.random.Generator
     LEGACY_RNG = False
 except AttributeError:
 
-    class random_generator:
+    class np_random_generator:
         pass
 
     LEGACY_RNG = True
@@ -27,14 +27,15 @@ class _BackwardsCompatibleNumpyRng:
     """
     _rng = None
 
-    def __init__(self,
-                 generator_or_seed: Optional[Union[
-                     "random_generator", np.random.RandomState, int]] = None):
+    def __init__(
+            self,
+            generator_or_seed: Optional[Union[
+                "np_random_generator", np.random.RandomState, int]] = None):
         if generator_or_seed is None:
             self._rng = np.random
         elif isinstance(generator_or_seed, np.random.RandomState):
             self._rng = generator_or_seed
-        elif isinstance(generator_or_seed, random_generator):
+        elif isinstance(generator_or_seed, np_random_generator):
             self._rng = generator_or_seed
         elif LEGACY_RNG:
             self._rng = np.random.RandomState(generator_or_seed)
@@ -43,7 +44,7 @@ class _BackwardsCompatibleNumpyRng:
 
     @property
     def legacy_rng(self) -> bool:
-        return not isinstance(self._rng, random_generator)
+        return not isinstance(self._rng, np_random_generator)
 
     @property
     def rng(self):
@@ -59,7 +60,7 @@ class _BackwardsCompatibleNumpyRng:
         return getattr(self.rng, name)
 
 
-RANDOM_STATE = Union[None, _BackwardsCompatibleNumpyRng, random_generator,
+RANDOM_STATE = Union[None, _BackwardsCompatibleNumpyRng, np_random_generator,
                      np.random.RandomState, int]
 
 
@@ -99,7 +100,7 @@ class Domain:
     def sample(self,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional["RANDOM_STATE"] = None):
+               random_state: "RANDOM_STATE" = None):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
         sampler = self.get_sampler()
@@ -126,7 +127,7 @@ class Sampler:
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional["RANDOM_STATE"] = None):
+               random_state: "RANDOM_STATE" = None):
         raise NotImplementedError
 
 
@@ -167,7 +168,7 @@ class Grid(Sampler):
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional["RANDOM_STATE"] = None):
+               random_state: "RANDOM_STATE" = None):
         return RuntimeError("Do not call `sample()` on grid.")
 
 
@@ -177,7 +178,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional["RANDOM_STATE"] = None):
+                   random_state: "RANDOM_STATE" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > float("-inf"), \
@@ -192,7 +193,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional["RANDOM_STATE"] = None):
+                   random_state: "RANDOM_STATE" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > 0, \
@@ -211,7 +212,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional["RANDOM_STATE"] = None):
+                   random_state: "RANDOM_STATE" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert not domain.lower or domain.lower == float("-inf"), \
@@ -296,7 +297,7 @@ class Integer(Domain):
                    domain: "Integer",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional["RANDOM_STATE"] = None):
+                   random_state: "RANDOM_STATE" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             items = random_state.integers(
@@ -308,7 +309,7 @@ class Integer(Domain):
                    domain: "Integer",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional["RANDOM_STATE"] = None):
+                   random_state: "RANDOM_STATE" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > 0, \
@@ -373,7 +374,7 @@ class Categorical(Domain):
                    domain: "Categorical",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional["RANDOM_STATE"] = None):
+                   random_state: "RANDOM_STATE" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             items = random_state.choice(domain.categories, size=size).tolist()
@@ -414,7 +415,7 @@ class Function(Domain):
                    domain: "Function",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: Optional["RANDOM_STATE"] = None):
+                   random_state: "RANDOM_STATE" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             if domain.pass_spec:
@@ -474,7 +475,7 @@ class Quantized(Sampler):
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: Optional["RANDOM_STATE"] = None):
+               random_state: "RANDOM_STATE" = None):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
         values = self.sampler.sample(

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -60,8 +60,8 @@ class _BackwardsCompatibleNumpyRng:
         return getattr(self.rng, name)
 
 
-RANDOM_STATE = Union[None, _BackwardsCompatibleNumpyRng, np_random_generator,
-                     np.random.RandomState, int]
+RandomState = Union[None, _BackwardsCompatibleNumpyRng, np_random_generator,
+                    np.random.RandomState, int]
 
 
 class Domain:
@@ -100,7 +100,7 @@ class Domain:
     def sample(self,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: "RANDOM_STATE" = None):
+               random_state: "RandomState" = None):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
         sampler = self.get_sampler()
@@ -127,7 +127,7 @@ class Sampler:
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: "RANDOM_STATE" = None):
+               random_state: "RandomState" = None):
         raise NotImplementedError
 
 
@@ -168,7 +168,7 @@ class Grid(Sampler):
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: "RANDOM_STATE" = None):
+               random_state: "RandomState" = None):
         return RuntimeError("Do not call `sample()` on grid.")
 
 
@@ -178,7 +178,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: "RANDOM_STATE" = None):
+                   random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > float("-inf"), \
@@ -193,7 +193,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: "RANDOM_STATE" = None):
+                   random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > 0, \
@@ -212,7 +212,7 @@ class Float(Domain):
                    domain: "Float",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: "RANDOM_STATE" = None):
+                   random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert not domain.lower or domain.lower == float("-inf"), \
@@ -297,7 +297,7 @@ class Integer(Domain):
                    domain: "Integer",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: "RANDOM_STATE" = None):
+                   random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             items = random_state.integers(
@@ -309,7 +309,7 @@ class Integer(Domain):
                    domain: "Integer",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: "RANDOM_STATE" = None):
+                   random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             assert domain.lower > 0, \
@@ -374,7 +374,7 @@ class Categorical(Domain):
                    domain: "Categorical",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: "RANDOM_STATE" = None):
+                   random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             items = random_state.choice(domain.categories, size=size).tolist()
@@ -415,7 +415,7 @@ class Function(Domain):
                    domain: "Function",
                    spec: Optional[Union[List[Dict], Dict]] = None,
                    size: int = 1,
-                   random_state: "RANDOM_STATE" = None):
+                   random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             if domain.pass_spec:
@@ -475,7 +475,7 @@ class Quantized(Sampler):
                domain: Domain,
                spec: Optional[Union[List[Dict], Dict]] = None,
                size: int = 1,
-               random_state: "RANDOM_STATE" = None):
+               random_state: "RandomState" = None):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
         values = self.sampler.sample(

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -32,7 +32,7 @@ class _BackwardsCompatibleNumpyRng:
             generator_or_seed: Optional[Union[
                 "np_random_generator", np.random.RandomState, int]] = None):
         if generator_or_seed is None:
-            self._rng = np.random
+            self._rng = None
         elif isinstance(generator_or_seed, np.random.RandomState):
             self._rng = generator_or_seed
         elif isinstance(generator_or_seed, np_random_generator):

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -31,11 +31,9 @@ class _BackwardsCompatibleNumpyRng:
             self,
             generator_or_seed: Optional[Union[
                 "np_random_generator", np.random.RandomState, int]] = None):
-        if generator_or_seed is None:
-            self._rng = None
-        elif isinstance(generator_or_seed, np.random.RandomState):
-            self._rng = generator_or_seed
-        elif isinstance(generator_or_seed, np_random_generator):
+        if (generator_or_seed is None
+                or isinstance(generator_or_seed,
+                              (np.random.RandomState, np_random_generator))):
             self._rng = generator_or_seed
         elif LEGACY_RNG:
             self._rng = np.random.RandomState(generator_or_seed)
@@ -48,6 +46,7 @@ class _BackwardsCompatibleNumpyRng:
 
     @property
     def rng(self):
+        # don't set self._rng to np.random to avoid picking issues
         return self._rng if self._rng else np.random
 
     def __getattr__(self, name: str) -> Any:

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -10,7 +10,7 @@ import numpy as np
 from ray.tune.error import TuneError
 from ray.tune.experiment import Experiment, convert_to_experiment_list
 from ray.tune.config_parser import make_parser, create_trial_from_spec
-from ray.tune.sample import (random_generator, _BackwardsCompatibleNumpyRng)
+from ray.tune.sample import random_generator, _BackwardsCompatibleNumpyRng
 from ray.tune.suggest.variant_generator import (
     count_variants, count_spec_samples, generate_variants, format_vars,
     flatten_resolved_vars, get_preset_variants)

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -5,10 +5,12 @@ import os
 import uuid
 from typing import Dict, List, Optional, Union
 import warnings
+import numpy as np
 
 from ray.tune.error import TuneError
 from ray.tune.experiment import Experiment, convert_to_experiment_list
 from ray.tune.config_parser import make_parser, create_trial_from_spec
+from ray.tune.sample import (random_generator, _BackwardsCompatibleNumpyRng)
 from ray.tune.suggest.variant_generator import (
     count_variants, count_spec_samples, generate_variants, format_vars,
     flatten_resolved_vars, get_preset_variants)
@@ -72,6 +74,10 @@ class _TrialIterator:
             lazily or eagerly. This is toggled depending
             on the size of the grid search.
         start (int): index at which to start counting trials.
+        random_state (int | np.random.Generator | np.random.RandomState):
+            Seed or numpy random generator to use for reproductible results.
+            If None (default), will use the global numpy random generator
+            (``np.random``).
     """
 
     def __init__(self,
@@ -82,7 +88,9 @@ class _TrialIterator:
                  output_path: str = "",
                  points_to_evaluate: Optional[List] = None,
                  lazy_eval: bool = False,
-                 start: int = 0):
+                 start: int = 0,
+                 random_state: Optional[Union[int, "random_generator",
+                                              np.random.RandomState]] = None):
         self.parser = make_parser()
         self.num_samples = num_samples
         self.uuid_prefix = uuid_prefix
@@ -95,6 +103,7 @@ class _TrialIterator:
         self.counter = start
         self.lazy_eval = lazy_eval
         self.variants = None
+        self.random_state = random_state
 
     def create_trial(self, resolved_vars, spec):
         trial_id = self.uuid_prefix + ("%05d" % self.counter)
@@ -140,7 +149,8 @@ class _TrialIterator:
                 get_preset_variants(
                     self.unresolved_spec,
                     config,
-                    constant_grid_search=self.constant_grid_search),
+                    constant_grid_search=self.constant_grid_search,
+                    random_state=self.random_state),
                 lazy_eval=self.lazy_eval)
             resolved_vars, spec = next(self.variants)
             return self.create_trial(resolved_vars, spec)
@@ -148,7 +158,8 @@ class _TrialIterator:
             self.variants = _VariantIterator(
                 generate_variants(
                     self.unresolved_spec,
-                    constant_grid_search=self.constant_grid_search),
+                    constant_grid_search=self.constant_grid_search,
+                    random_state=self.random_state),
                 lazy_eval=self.lazy_eval)
             self.num_samples_left -= 1
             resolved_vars, spec = next(self.variants)
@@ -180,6 +191,10 @@ class BasicVariantGenerator(SearchAlgorithm):
             grid search parameters. If this is set to ``False`` (default),
             Ray Tune will sample new random parameters in each grid search
             condition.
+        random_state (int | np.random.Generator | np.random.RandomState):
+            Seed or numpy random generator to use for reproductible results.
+            If None (default), will use the global numpy random generator
+            (``np.random``).
 
 
     Example:
@@ -247,11 +262,14 @@ class BasicVariantGenerator(SearchAlgorithm):
     def __init__(self,
                  points_to_evaluate: Optional[List[Dict]] = None,
                  max_concurrent: int = 0,
-                 constant_grid_search: bool = False):
+                 constant_grid_search: bool = False,
+                 random_state: Optional[Union[int, "random_generator",
+                                              np.random.RandomState]] = None):
         self._trial_generator = []
         self._iterators = []
         self._trial_iter = None
         self._finished = False
+        self._random_state = _BackwardsCompatibleNumpyRng(random_state)
 
         self._points_to_evaluate = points_to_evaluate or []
 
@@ -304,7 +322,8 @@ class BasicVariantGenerator(SearchAlgorithm):
                 output_path=experiment.dir_name,
                 points_to_evaluate=points_to_evaluate,
                 lazy_eval=lazy_eval,
-                start=previous_samples)
+                start=previous_samples,
+                random_state=self._random_state)
             self._iterators.append(iterator)
             self._trial_generator = itertools.chain(self._trial_generator,
                                                     iterator)

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -75,9 +75,10 @@ class _TrialIterator:
             on the size of the grid search.
         start (int): index at which to start counting trials.
         random_state (int | np.random.Generator | np.random.RandomState):
-            Seed or numpy random generator to use for reproductible results.
+            Seed or numpy random generator to use for reproducible results.
             If None (default), will use the global numpy random generator
-            (``np.random``).
+            (``np.random``). Please note that full reproducibility cannot
+            be guaranteed in a distributed enviroment.
     """
 
     def __init__(self,
@@ -192,9 +193,10 @@ class BasicVariantGenerator(SearchAlgorithm):
             Ray Tune will sample new random parameters in each grid search
             condition.
         random_state (int | np.random.Generator | np.random.RandomState):
-            Seed or numpy random generator to use for reproductible results.
+            Seed or numpy random generator to use for reproducible results.
             If None (default), will use the global numpy random generator
-            (``np.random``).
+            (``np.random``). Please note that full reproducibility cannot
+            be guaranteed in a distributed enviroment.
 
 
     Example:

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -10,7 +10,7 @@ import numpy as np
 from ray.tune.error import TuneError
 from ray.tune.experiment import Experiment, convert_to_experiment_list
 from ray.tune.config_parser import make_parser, create_trial_from_spec
-from ray.tune.sample import random_generator, _BackwardsCompatibleNumpyRng
+from ray.tune.sample import np_random_generator, _BackwardsCompatibleNumpyRng
 from ray.tune.suggest.variant_generator import (
     count_variants, count_spec_samples, generate_variants, format_vars,
     flatten_resolved_vars, get_preset_variants)
@@ -90,7 +90,7 @@ class _TrialIterator:
                  points_to_evaluate: Optional[List] = None,
                  lazy_eval: bool = False,
                  start: int = 0,
-                 random_state: Optional[Union[int, "random_generator",
+                 random_state: Optional[Union[int, "np_random_generator",
                                               np.random.RandomState]] = None):
         self.parser = make_parser()
         self.num_samples = num_samples
@@ -265,7 +265,7 @@ class BasicVariantGenerator(SearchAlgorithm):
                  points_to_evaluate: Optional[List[Dict]] = None,
                  max_concurrent: int = 0,
                  constant_grid_search: bool = False,
-                 random_state: Optional[Union[int, "random_generator",
+                 random_state: Optional[Union[int, "np_random_generator",
                                               np.random.RandomState]] = None):
         self._trial_generator = []
         self._iterators = []

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -1,23 +1,20 @@
 import copy
 import logging
 from collections.abc import Mapping
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 import numpy
 import random
 
 from ray.tune import TuneError
-from ray.tune.sample import (Categorical, Domain, Function,
-                             _BackwardsCompatibleNumpyRng, np_random_generator)
+from ray.tune.sample import (Categorical, Domain, Function, RandomState)
 
 logger = logging.getLogger(__name__)
 
 
 def generate_variants(unresolved_spec: Dict,
                       constant_grid_search: bool = False,
-                      random_state: Optional[Union[
-                          _BackwardsCompatibleNumpyRng, "np_random_generator",
-                          numpy.random.RandomState, int]] = None
+                      random_state: "RandomState" = None
                       ) -> Generator[Tuple[Dict, Dict], None, None]:
     """Generates variants from a spec (dict) with unresolved values.
 
@@ -185,9 +182,7 @@ def count_variants(spec: Dict, presets: Optional[List[Dict]] = None) -> int:
 def _generate_variants(
         spec: Dict,
         constant_grid_search: bool = False,
-        random_state: Optional[
-            Union[_BackwardsCompatibleNumpyRng, "np_random_generator",
-                  numpy.random.RandomState, int]] = None) -> Tuple[Dict, Dict]:
+        random_state: "RandomState" = None) -> Tuple[Dict, Dict]:
     spec = copy.deepcopy(spec)
     _, domain_vars, grid_vars = parse_spec_vars(spec)
 
@@ -234,13 +229,10 @@ def _generate_variants(
             yield resolved_vars, spec
 
 
-def get_preset_variants(
-        spec: Dict,
-        config: Dict,
-        constant_grid_search: bool = False,
-        random_state: Optional[
-            Union[_BackwardsCompatibleNumpyRng, "np_random_generator",
-                  numpy.random.RandomState, int]] = None):
+def get_preset_variants(spec: Dict,
+                        config: Dict,
+                        constant_grid_search: bool = False,
+                        random_state: "RandomState" = None):
     """Get variants according to a spec, initialized with a config.
 
     Variables from the spec are overwritten by the variables in the config.
@@ -306,9 +298,7 @@ def _resolve_domain_vars(
         spec: Dict,
         domain_vars: List[Tuple[Tuple, Domain]],
         allow_fail: bool = False,
-        random_state: Optional[
-            Union[_BackwardsCompatibleNumpyRng, "np_random_generator",
-                  numpy.random.RandomState, int]] = None) -> Tuple[bool, Dict]:
+        random_state: "RandomState" = None) -> Tuple[bool, Dict]:
     resolved = {}
     error = True
     num_passes = 0

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -7,8 +7,8 @@ import numpy
 import random
 
 from ray.tune import TuneError
-from ray.tune.sample import Categorical, Domain, Function
-from ray.tune.sample import _BackwardsCompatibleNumpyRng, random_generator
+from ray.tune.sample import (Categorical, Domain, Function,
+                             _BackwardsCompatibleNumpyRng, np_random_generator)
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def generate_variants(unresolved_spec: Dict,
                       constant_grid_search: bool = False,
                       random_state: Optional[Union[
-                          _BackwardsCompatibleNumpyRng, "random_generator",
+                          _BackwardsCompatibleNumpyRng, "np_random_generator",
                           numpy.random.RandomState, int]] = None
                       ) -> Generator[Tuple[Dict, Dict], None, None]:
     """Generates variants from a spec (dict) with unresolved values.
@@ -186,7 +186,7 @@ def _generate_variants(
         spec: Dict,
         constant_grid_search: bool = False,
         random_state: Optional[
-            Union[_BackwardsCompatibleNumpyRng, "random_generator",
+            Union[_BackwardsCompatibleNumpyRng, "np_random_generator",
                   numpy.random.RandomState, int]] = None) -> Tuple[Dict, Dict]:
     spec = copy.deepcopy(spec)
     _, domain_vars, grid_vars = parse_spec_vars(spec)
@@ -234,12 +234,13 @@ def _generate_variants(
             yield resolved_vars, spec
 
 
-def get_preset_variants(spec: Dict,
-                        config: Dict,
-                        constant_grid_search: bool = False,
-                        random_state: Optional[Union[
-                            _BackwardsCompatibleNumpyRng, "random_generator",
-                            numpy.random.RandomState, int]] = None):
+def get_preset_variants(
+        spec: Dict,
+        config: Dict,
+        constant_grid_search: bool = False,
+        random_state: Optional[
+            Union[_BackwardsCompatibleNumpyRng, "np_random_generator",
+                  numpy.random.RandomState, int]] = None):
     """Get variants according to a spec, initialized with a config.
 
     Variables from the spec are overwritten by the variables in the config.
@@ -306,7 +307,7 @@ def _resolve_domain_vars(
         domain_vars: List[Tuple[Tuple, Domain]],
         allow_fail: bool = False,
         random_state: Optional[
-            Union[_BackwardsCompatibleNumpyRng, "random_generator",
+            Union[_BackwardsCompatibleNumpyRng, "np_random_generator",
                   numpy.random.RandomState, int]] = None) -> Tuple[bool, Dict]:
     resolved = {}
     error = True

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -1,19 +1,23 @@
 import copy
 import logging
 from collections.abc import Mapping
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy
 import random
 
 from ray.tune import TuneError
 from ray.tune.sample import Categorical, Domain, Function
+from ray.tune.sample import _BackwardsCompatibleNumpyRng, random_generator
 
 logger = logging.getLogger(__name__)
 
 
 def generate_variants(unresolved_spec: Dict,
-                      constant_grid_search: bool = False
+                      constant_grid_search: bool = False,
+                      random_state: Optional[Union[
+                          _BackwardsCompatibleNumpyRng, "random_generator",
+                          numpy.random.RandomState, int]] = None
                       ) -> Generator[Tuple[Dict, Dict], None, None]:
     """Generates variants from a spec (dict) with unresolved values.
 
@@ -46,7 +50,9 @@ def generate_variants(unresolved_spec: Dict,
         (Dict of resolved variables, Spec object)
     """
     for resolved_vars, spec in _generate_variants(
-            unresolved_spec, constant_grid_search=constant_grid_search):
+            unresolved_spec,
+            constant_grid_search=constant_grid_search,
+            random_state=random_state):
         assert not _unresolved_values(spec)
         yield resolved_vars, spec
 
@@ -177,7 +183,11 @@ def count_variants(spec: Dict, presets: Optional[List[Dict]] = None) -> int:
 
 
 def _generate_variants(
-        spec: Dict, constant_grid_search: bool = False) -> Tuple[Dict, Dict]:
+        spec: Dict,
+        constant_grid_search: bool = False,
+        random_state: Optional[
+            Union[_BackwardsCompatibleNumpyRng, "random_generator",
+                  numpy.random.RandomState, int]] = None) -> Tuple[Dict, Dict]:
     spec = copy.deepcopy(spec)
     _, domain_vars, grid_vars = parse_spec_vars(spec)
 
@@ -194,7 +204,7 @@ def _generate_variants(
         # for grid search.
         # `_resolve_domain_vars` will alter `spec` directly
         all_resolved, resolved_vars = _resolve_domain_vars(
-            spec, domain_vars, allow_fail=True)
+            spec, domain_vars, allow_fail=True, random_state=random_state)
         if not all_resolved:
             # Not all variables have been resolved, but remove those that have
             # from the `to_resolve` list.
@@ -204,10 +214,13 @@ def _generate_variants(
     for resolved_spec in grid_search:
         if not constant_grid_search or not all_resolved:
             # In this path, we sample the remaining random variables
-            _, resolved_vars = _resolve_domain_vars(resolved_spec, to_resolve)
+            _, resolved_vars = _resolve_domain_vars(
+                resolved_spec, to_resolve, random_state=random_state)
 
         for resolved, spec in _generate_variants(
-                resolved_spec, constant_grid_search=constant_grid_search):
+                resolved_spec,
+                constant_grid_search=constant_grid_search,
+                random_state=random_state):
             for path, value in grid_vars:
                 resolved_vars[path] = _get_value(spec, path)
             for k, v in resolved.items():
@@ -223,7 +236,10 @@ def _generate_variants(
 
 def get_preset_variants(spec: Dict,
                         config: Dict,
-                        constant_grid_search: bool = False):
+                        constant_grid_search: bool = False,
+                        random_state: Optional[Union[
+                            _BackwardsCompatibleNumpyRng, "random_generator",
+                            numpy.random.RandomState, int]] = None):
     """Get variants according to a spec, initialized with a config.
 
     Variables from the spec are overwritten by the variables in the config.
@@ -267,7 +283,10 @@ def get_preset_variants(spec: Dict,
                         f"parameter `{'/'.join(path)}`: {domain}")
         assign_value(spec["config"], path, val)
 
-    return _generate_variants(spec, constant_grid_search=constant_grid_search)
+    return _generate_variants(
+        spec,
+        constant_grid_search=constant_grid_search,
+        random_state=random_state)
 
 
 def assign_value(spec: Dict, path: Tuple, value: Any):
@@ -282,9 +301,13 @@ def _get_value(spec: Dict, path: Tuple) -> Any:
     return spec
 
 
-def _resolve_domain_vars(spec: Dict,
-                         domain_vars: List[Tuple[Tuple, Domain]],
-                         allow_fail: bool = False) -> Tuple[bool, Dict]:
+def _resolve_domain_vars(
+        spec: Dict,
+        domain_vars: List[Tuple[Tuple, Domain]],
+        allow_fail: bool = False,
+        random_state: Optional[
+            Union[_BackwardsCompatibleNumpyRng, "random_generator",
+                  numpy.random.RandomState, int]] = None) -> Tuple[bool, Dict]:
     resolved = {}
     error = True
     num_passes = 0
@@ -295,7 +318,8 @@ def _resolve_domain_vars(spec: Dict,
             if path in resolved:
                 continue
             try:
-                value = domain.sample(_UnresolvedAccessGuard(spec))
+                value = domain.sample(
+                    _UnresolvedAccessGuard(spec), random_state=random_state)
             except RecursiveDependencyError as e:
                 error = e
             except Exception:

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -165,7 +165,7 @@ class SearchSpaceTest(unittest.TestCase):
 
         self._testTuneSampleAPI(config_generator())
 
-    def testReproductibility(self):
+    def testReproducibility(self):
         config = self.config.copy()
         config.pop("func")
 
@@ -212,7 +212,7 @@ class SearchSpaceTest(unittest.TestCase):
                 assertDictAlmostEqual(seed_new[0], seed_new[i])
                 assertDictAlmostEqual(seed_new[0], generator_new[i])
 
-    def testReproductibilityBasicVariantGenerator(self):
+    def testReproducibilityBasicVariantGenerator(self):
         config = self.config.copy()
         config.pop("func")
         from ray.tune.suggest.basic_variant import BasicVariantGenerator

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -10,6 +10,9 @@ from unittest.mock import patch
 import numpy as np
 import unittest
 
+import ray.tune.sample
+
+import ray
 from ray import tune
 from ray.tune import Experiment
 from ray.tune.suggest.util import logger
@@ -58,7 +61,7 @@ class SearchSpaceTest(unittest.TestCase):
         }
 
     def tearDown(self):
-        pass
+        ray.shutdown()
 
     def _testTuneSampleAPI(self, configs, ignore=None, check_stats=True):
         ignore = ignore or []
@@ -161,6 +164,136 @@ class SearchSpaceTest(unittest.TestCase):
                     yield generated["config"]
 
         self._testTuneSampleAPI(config_generator())
+
+    def testReproductibility(self):
+        config = self.config.copy()
+        config.pop("func")
+
+        def config_generator(random_state):
+            if random_state is None:
+                np.random.seed(1000)
+            for _, generated in generate_variants(
+                {
+                    "config": config
+                },
+                    random_state=ray.tune.sample._BackwardsCompatibleNumpyRng(
+                        random_state)):
+                yield generated["config"]
+
+        with patch("ray.tune.sample.LEGACY_RNG", True):
+            global_seed_legacy = [
+                next(config_generator(random_state=None)) for _ in range(100)
+            ]
+            seed_legacy = [
+                next(config_generator(random_state=1000)) for _ in range(100)
+            ]
+            generator_legacy = [
+                next(
+                    config_generator(random_state=np.random.RandomState(1000)))
+                for _ in range(100)
+            ]
+            for i in range(100):
+                assertDictAlmostEqual(global_seed_legacy[0],
+                                      global_seed_legacy[i])
+                assertDictAlmostEqual(global_seed_legacy[0], seed_legacy[i])
+                assertDictAlmostEqual(global_seed_legacy[0],
+                                      generator_legacy[i])
+
+        if not ray.tune.sample.LEGACY_RNG:
+            seed_new = [
+                next(config_generator(random_state=1000)) for _ in range(100)
+            ]
+            generator_new = [
+                next(
+                    config_generator(random_state=np.random.default_rng(1000)))
+                for _ in range(100)
+            ]
+            for i in range(100):
+                assertDictAlmostEqual(seed_new[0], seed_new[i])
+                assertDictAlmostEqual(seed_new[0], generator_new[i])
+
+    def testReproductibilityBasicVariantGenerator(self):
+        config = self.config.copy()
+        config.pop("func")
+        from ray.tune.suggest.basic_variant import BasicVariantGenerator
+
+        ray.init(num_cpus=1, local_mode=True)
+
+        num_samples = 5
+        params = dict(
+            run_or_experiment=_mock_objective,
+            config=config,
+            metric="uniform",
+            mode="max",
+            num_samples=num_samples,
+        )
+        with patch("ray.tune.sample.LEGACY_RNG", True):
+            np.random.seed(1000)
+            analysis_global_seed = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1),  # global seed
+                **params)
+            np.random.seed(1000)
+            analysis_global_seed_2 = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1),  # global seed
+                **params)
+            analysis_seed = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1, random_state=1000),
+                **params)
+            analysis_seed_2 = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1, random_state=1000),
+                **params)
+            analysis_generator = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1,
+                    random_state=np.random.RandomState(1000)),
+                **params)
+            analysis_generator_2 = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1,
+                    random_state=np.random.RandomState(1000)),
+                **params)
+            for i in range(num_samples):
+                assertDictAlmostEqual(analysis_global_seed.trials[i].config,
+                                      analysis_seed.trials[i].config)
+                assertDictAlmostEqual(analysis_global_seed.trials[i].config,
+                                      analysis_generator.trials[i].config)
+                assertDictAlmostEqual(analysis_global_seed.trials[i].config,
+                                      analysis_global_seed_2.trials[i].config)
+                assertDictAlmostEqual(analysis_global_seed.trials[i].config,
+                                      analysis_seed_2.trials[i].config)
+                assertDictAlmostEqual(analysis_global_seed.trials[i].config,
+                                      analysis_generator_2.trials[i].config)
+
+        if not ray.tune.sample.LEGACY_RNG:
+            analysis_seed = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1, random_state=1000),
+                **params)
+            analysis_seed_2 = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1, random_state=1000),
+                **params)
+            analysis_generator = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1,
+                    random_state=np.random.default_rng(1000)),
+                **params)
+            analysis_generator_2 = tune.run(
+                search_alg=BasicVariantGenerator(
+                    max_concurrent=1,
+                    random_state=np.random.default_rng(1000)),
+                **params)
+            for i in range(num_samples):
+                assertDictAlmostEqual(analysis_seed.trials[i].config,
+                                      analysis_generator.trials[i].config)
+                assertDictAlmostEqual(analysis_seed.trials[i].config,
+                                      analysis_seed_2.trials[i].config)
+                assertDictAlmostEqual(analysis_seed.trials[i].config,
+                                      analysis_generator_2.trials[i].config)
 
     def testBoundedFloat(self):
         bounded = tune.sample.Float(-4.2, 8.3)

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -11,7 +11,6 @@ import numpy as np
 import unittest
 
 import ray.tune.sample
-
 import ray
 from ray import tune
 from ray.tune import Experiment

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -10,8 +10,8 @@ from unittest.mock import patch
 import numpy as np
 import unittest
 
-import ray.tune.sample
 import ray
+import ray.tune.sample
 from ray import tune
 from ray.tune import Experiment
 from ray.tune.suggest.util import logger


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds an ability to set a random seed/numpy random generator in `BasicVariantGenerator`, allowing for reproducibility across separate runs. All the changes are fully backwards compatible. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
