### PR TITLE
[Ray Client] Pickle task options for ray client

### DIFF
--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -17,9 +17,7 @@ from ray._private.test_utils import (
     run_string_as_driver, wait_for_condition, is_placement_group_removed,
     convert_actor_state)
 from ray.exceptions import RaySystemError
-from ray._raylet import PlacementGroupID
-from ray.util.placement_group import (PlacementGroup, placement_group,
-                                      remove_placement_group)
+from ray.util.placement_group import (placement_group, remove_placement_group)
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 import ray.experimental.internal_kv as internal_kv
 from ray.autoscaler._private.util import DEBUG_AUTOSCALING_ERROR, \
@@ -408,45 +406,6 @@ def test_placement_group_gpu_assigned(ray_start_cluster, connect_to_client):
         gpu_ids_res.add(ray.get(f.options(placement_group=pg2).remote()))
 
         assert len(gpu_ids_res) == 2
-
-
-def test_placement_group_client_option_serialization():
-    """Tests conversion of placement group to json-serializable dict and back.
-
-    Tests conversion
-    placement_group -> dict -> placement_group and
-    dict -> placement_group -> dict
-    with and without non-null bundle cache.
-    """
-
-    # Tests conversion from dict to placement group and back.
-    def dict_to_pg_to_dict(pg_dict_in):
-        pg = PlacementGroup.from_dict(pg_dict_in)
-        pg_dict_out = pg.to_dict()
-        assert pg_dict_in == pg_dict_out
-
-    # Tests conversion from placement group to dict and back.
-    def pg_to_dict_to_pg(pg_in):
-        pg_dict = pg_in.to_dict()
-        pg_out = PlacementGroup.from_dict(pg_dict)
-        assert pg_out.id == pg_in.id
-        assert pg_out.bundle_cache == pg_in.bundle_cache
-
-    pg_id = PlacementGroupID(id=bytes(16))
-    id_string = bytes(16).hex()
-    bundle_cache = [{"CPU": 2}, {"custom_resource": 5}]
-
-    pg_with_bundles = PlacementGroup(id=pg_id, bundle_cache=bundle_cache)
-    pg_to_dict_to_pg(pg_with_bundles)
-
-    pg_no_bundles = PlacementGroup(id=pg_id)
-    pg_to_dict_to_pg(pg_no_bundles)
-
-    pg_dict_with_bundles = {"id": id_string, "bundle_cache": bundle_cache}
-    dict_to_pg_to_dict(pg_dict_with_bundles)
-
-    pg_dict_no_bundles = {"id": id_string, "bundle_cache": None}
-    dict_to_pg_to_dict(pg_dict_no_bundles)
 
 
 def test_actor_scheduling_not_block_with_placement_group(ray_start_cluster):

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 # This version string is incremented to indicate breaking changes in the
 # protocol that require upgrading the client version.
-CURRENT_PROTOCOL_VERSION = "2021-09-22"
+CURRENT_PROTOCOL_VERSION = "2021-12-07"
 
 
 class _ClientContext:

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -12,9 +12,9 @@ import grpc
 import os
 import uuid
 import inspect
+import pickle
 from ray.util.inspect import is_cython, is_class_method,\
     is_function_or_method, is_static_method
-import json
 import logging
 import threading
 from collections import OrderedDict
@@ -414,14 +414,7 @@ def set_task_options(task: ray_client_pb2.ClientTask,
         task.ClearField(field)
         return
 
-    # If there's a non-null "placement_group" in `options`, convert the
-    # placement group to a dict so that `options` can be passed to json.dumps.
-    pg = options.get("placement_group", None)
-    if pg and pg != "default":
-        options["placement_group"] = options["placement_group"].to_dict()
-
-    options_str = json.dumps(options)
-    getattr(task, field).json_options = options_str
+    getattr(task, field).pickled_options = pickle.dumps(options)
 
 
 def return_refs(futures: List[concurrent.futures.Future]

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -34,7 +34,6 @@ from ray.util.client.server.dataservicer import DataServicer
 from ray.util.client.server.logservicer import LogstreamServicer
 from ray.util.client.server.server_stubs import current_server
 from ray.ray_constants import env_integer
-from ray.util.placement_group import PlacementGroup
 from ray._private.client_mode_hook import disable_client_hook
 from ray._private.tls_utils import add_port_to_grpc_server
 
@@ -652,16 +651,10 @@ def encode_exception(exception) -> str:
 
 def decode_options(
         options: ray_client_pb2.TaskOptions) -> Optional[Dict[str, Any]]:
-    if options.json_options == "":
+    if not options.pickled_options:
         return None
-    opts = json.loads(options.json_options)
+    opts = pickle.loads(options.pickled_options)
     assert isinstance(opts, dict)
-
-    if isinstance(opts.get("placement_group", None), dict):
-        # Placement groups in Ray client options are serialized as dicts.
-        # Convert the dict to a PlacementGroup.
-        opts["placement_group"] = PlacementGroup.from_dict(
-            opts["placement_group"])
 
     return opts
 

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -96,48 +96,6 @@ class PlacementGroup:
         self._fill_bundle_cache_if_needed()
         return len(self.bundle_cache)
 
-    def to_dict(self) -> dict:
-        """Convert this placement group into a dict for purposes of json
-        serialization.
-
-        Used when passing a placement group as an option to a Ray client remote
-        function. See set_task_options in util/client/common.py.
-
-        Return:
-            Dictionary with json-serializable keys representing the placemnent
-            group.
-        """
-        # Placement group id is converted to a hex /string/ to make it
-        # serializable.
-        return {"id": self.id.hex(), "bundle_cache": self.bundle_cache}
-
-    @staticmethod
-    def from_dict(pg_dict: dict) -> "PlacementGroup":
-        """Instantiate and return a PlacementGroup from its json-serializable
-        dict representation.
-
-        Used by Ray Client on server-side to deserialize placement group
-        option. See decode_options in util/client/server/server.py.
-
-        Args:
-            serializable_form(dict): Dictionary representing a placement group.
-        Return:
-            A placement group made from the data in the input dict.
-        """
-        # Validate serialized dict
-        assert isinstance(pg_dict, dict)
-        assert pg_dict.keys() == {"id", "bundle_cache"}
-        # The value associated to key "id" is a hex string.
-        assert isinstance(pg_dict["id"], str)
-        if pg_dict["bundle_cache"] is not None:
-            assert isinstance(pg_dict["bundle_cache"], list)
-
-        # Deserialize and return a Placement Group.
-        id_bytes = bytes.fromhex(pg_dict["id"])
-        pg_id = PlacementGroupID(id_bytes)
-        bundle_cache = pg_dict["bundle_cache"]
-        return PlacementGroup(pg_id, bundle_cache)
-
     def _fill_bundle_cache_if_needed(self) -> None:
         if not self.bundle_cache:
             self.bundle_cache = _get_bundle_cache(self.id)

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -41,11 +41,11 @@ message Arg {
 // TODO(barakmich): In the longer term, if everything were a client,
 // this message could be the actual standard for which options are
 // allowed in the API. Today, however, it's a bit flexible and defined in the
-// Python code. So for now, it's a stand-in message with a json field, but
+// Python code. So for now, it's a stand-in message with a pickle field, but
 // this is forwards-compatible with deprecating that field and instituting
 // strongly defined and typed fields, without migrating the original ClientTask.
 message TaskOptions {
-  string json_options = 1;
+  bytes pickled_options = 1;
 }
 
 // Represents one unit of work to be executed by the server.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We can just pickle task options instead of json so that we don't need to write custom `to_dict` and `from_dict` methods for complex python option objects (e.g. PlacementGroup).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
