### PR TITLE
Startup token ownership

### DIFF
--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -175,7 +175,6 @@ def test_redefining_remote_functions(shutdown_only):
         assert ray.get(ray.get(h.remote(i))) == i
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_call_matrix(shutdown_only):
     ray.init(object_store_memory=1000 * 1024 * 1024)
 
@@ -241,7 +240,6 @@ def test_call_matrix(shutdown_only):
                     check(source_actor, dest_actor, is_large, out_of_band)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_call_order(shutdown_only):
     ray.init(num_cpus=4)
 
@@ -265,7 +263,6 @@ def test_actor_call_order(shutdown_only):
                     for i in range(100)]) == list(range(100))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_pass_by_ref_order_optimization(shutdown_only):
     ray.init(num_cpus=4)
 
@@ -303,7 +300,6 @@ def test_actor_pass_by_ref_order_optimization(shutdown_only):
     assert delta < 10, "did not skip slow value"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_cpus": 1,
@@ -359,7 +355,6 @@ def test_get_multiple(ray_start_regular_shared):
     assert results == indices
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_get_with_timeout(ray_start_regular_shared):
     SignalActor = create_remote_signal_actor(ray)
     signal = SignalActor.remote()
@@ -383,7 +378,6 @@ def test_get_with_timeout(ray_start_regular_shared):
 
 
 # https://github.com/ray-project/ray/issues/6329
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_call_actors_indirect_through_tasks(ray_start_regular_shared):
     @ray.remote
     class Counter:
@@ -413,7 +407,6 @@ def test_call_actors_indirect_through_tasks(ray_start_regular_shared):
         ray.get(zoo.remote([c]))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_inline_arg_memory_corruption(ray_start_regular_shared):
     @ray.remote
     def f():
@@ -434,7 +427,6 @@ def test_inline_arg_memory_corruption(ray_start_regular_shared):
         ray.get(a.add.remote(f.remote()))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_skip_plasma(ray_start_regular_shared):
     @ray.remote
@@ -452,7 +444,6 @@ def test_skip_plasma(ray_start_regular_shared):
     assert ray.get(obj_ref) == 2
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_actor_large_objects(ray_start_regular_shared):
     @ray.remote
@@ -473,7 +464,6 @@ def test_actor_large_objects(ray_start_regular_shared):
     assert isinstance(ray.get(obj_ref), np.ndarray)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_pass_by_ref(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -502,7 +492,6 @@ def test_actor_pass_by_ref(ray_start_regular_shared):
         ray.get(a.f.remote(error.remote()))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_recursive(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -526,7 +515,6 @@ def test_actor_recursive(ray_start_regular_shared):
     assert result == [x * 2 for x in range(100)]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows")
 def test_actor_concurrent(ray_start_regular_shared):
     @ray.remote
     class Batcher:
@@ -553,7 +541,6 @@ def test_actor_concurrent(ray_start_regular_shared):
     assert r1 == r2 == r3
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows")
 def test_actor_max_concurrency(ray_start_regular_shared):
     """
     Test that an actor of max_concurrency=N should only run
@@ -587,7 +574,6 @@ def test_actor_max_concurrency(ray_start_regular_shared):
     assert ray.get(actor.get_num_threads.remote()) <= CONCURRENCY
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_wait(ray_start_regular_shared):
     @ray.remote
     def f(delay):
@@ -635,7 +621,6 @@ def test_wait(ray_start_regular_shared):
         ray.wait([1])
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows")
 def test_duplicate_args(ray_start_regular_shared):
     @ray.remote
     def f(arg1,
@@ -675,7 +660,6 @@ def test_get_correct_node_ip():
         assert found_ip == "10.0.0.111"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_load_code_from_local(ray_start_regular_shared):
     # This case writes a driver python file to a temporary directory.
     #
@@ -716,7 +700,6 @@ if __name__ == "__main__":
         assert b"OK" in output
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on windows")
 @pytest.mark.skipif(
     client_test_enabled(), reason="JobConfig doesn't work in client mode")
 def test_use_dynamic_function_and_class():

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -182,7 +182,9 @@ void KillProcessBySocketName(std::string socket_name) {
     pid_t pid = -1;
     pidfile >> pid;
     RAY_CHECK(pid != -1);
-    Process::FromPid(pid).Kill();
+    // The startup_token is not going to be checked, so no effort needs to be
+    // made to match it
+    Process::FromPidAndStartupToken(pid, /*startup_token */-1).Kill();
   }
   ASSERT_EQ(unlink(pidfile_path.c_str()), 0);
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1098,7 +1098,7 @@ void NodeManager::ProcessRegisterClientRequestMessage(
   }
   auto worker = std::dynamic_pointer_cast<WorkerInterface>(std::make_shared<Worker>(
       job_id, runtime_env_hash, worker_id, language, worker_type, worker_ip_address,
-      client, client_call_manager_, worker_startup_token));
+      client, client_call_manager_));
 
   auto send_reply_callback = [this, client, job_id](Status status, int assigned_port) {
     flatbuffers::FlatBufferBuilder fbb;
@@ -1136,7 +1136,7 @@ void NodeManager::ProcessRegisterClientRequestMessage(
     // Register the new driver.
     RAY_CHECK(pid >= 0);
     // Don't need to set shim pid for driver
-    worker->SetProcess(Process::FromPid(pid));
+    worker->SetProcess(Process::FromPidAndStartupToken(pid, worker_startup_token));
     // Compute a dummy driver task id from a given driver.
     const TaskID driver_task_id = TaskID::ComputeDriverTaskId(worker_id);
     worker->AssignTaskId(driver_task_id);

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -30,9 +30,8 @@ Worker::Worker(const JobID &job_id, const int runtime_env_hash, const WorkerID &
                const Language &language, rpc::WorkerType worker_type,
                const std::string &ip_address,
                std::shared_ptr<ClientConnection> connection,
-               rpc::ClientCallManager &client_call_manager, StartupToken startup_token)
+               rpc::ClientCallManager &client_call_manager)
     : worker_id_(worker_id),
-      startup_token_(startup_token),
       language_(language),
       worker_type_(worker_type),
       ip_address_(ip_address),
@@ -63,15 +62,9 @@ WorkerID Worker::WorkerId() const { return worker_id_; }
 
 Process Worker::GetProcess() const { return proc_; }
 
-StartupToken Worker::GetStartupToken() const { return startup_token_; }
-
 void Worker::SetProcess(Process proc) {
   RAY_CHECK(proc_.IsNull());  // this procedure should not be called multiple times
   proc_ = std::move(proc);
-}
-
-void Worker::SetStartupToken(StartupToken startup_token) {
-  startup_token_ = startup_token;
 }
 
 Process Worker::GetShimProcess() const {

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -49,8 +49,6 @@ class WorkerInterface {
   virtual WorkerID WorkerId() const = 0;
   /// Return the worker process.
   virtual Process GetProcess() const = 0;
-  /// Return the worker process's startup token
-  virtual StartupToken GetStartupToken() const = 0;
   virtual void SetProcess(Process proc) = 0;
   /// Return the worker shim process.
   virtual Process GetShimProcess() const = 0;
@@ -110,8 +108,6 @@ class WorkerInterface {
   virtual bool IsAvailableForScheduling() const = 0;
 
  protected:
-  virtual void SetStartupToken(StartupToken startup_token) = 0;
-
   FRIEND_TEST(WorkerPoolTest, PopWorkerMultiTenancy);
   FRIEND_TEST(WorkerPoolTest, TestWorkerCapping);
   FRIEND_TEST(WorkerPoolTest, TestWorkerCappingLaterNWorkersNotOwningObjects);
@@ -129,7 +125,8 @@ class Worker : public WorkerInterface {
   Worker(const JobID &job_id, const int runtime_env_hash, const WorkerID &worker_id,
          const Language &language, rpc::WorkerType worker_type,
          const std::string &ip_address, std::shared_ptr<ClientConnection> connection,
-         rpc::ClientCallManager &client_call_manager, StartupToken startup_token);
+         // rpc::ClientCallManager &client_call_manager, StartupToken startup_token);
+         rpc::ClientCallManager &client_call_manager);
   /// A destructor responsible for freeing all worker state.
   ~Worker() {}
   rpc::WorkerType GetWorkerType() const;
@@ -142,8 +139,6 @@ class Worker : public WorkerInterface {
   WorkerID WorkerId() const;
   /// Return the worker process.
   Process GetProcess() const;
-  /// Return the worker process's startup token
-  StartupToken GetStartupToken() const;
   void SetProcess(Process proc);
   /// Return this worker shim process.
   Process GetShimProcess() const;
@@ -218,18 +213,13 @@ class Worker : public WorkerInterface {
     return rpc_client_.get();
   }
 
- protected:
-  void SetStartupToken(StartupToken startup_token);
-
  private:
   /// The worker's ID.
   WorkerID worker_id_;
   /// The worker's process.
   Process proc_;
-  /// The worker's process's startup_token
-  StartupToken startup_token_;
   /// The worker's shim process. The shim process PID is the same with worker process PID,
-  /// except starting worker process in container.
+  /// except starting worker process in container and on windows.
   Process shim_proc_;
   /// The language type of this worker.
   Language language_;

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -125,7 +125,6 @@ class Worker : public WorkerInterface {
   Worker(const JobID &job_id, const int runtime_env_hash, const WorkerID &worker_id,
          const Language &language, rpc::WorkerType worker_type,
          const std::string &ip_address, std::shared_ptr<ClientConnection> connection,
-         // rpc::ClientCallManager &client_call_manager, StartupToken startup_token);
          rpc::ClientCallManager &client_call_manager);
   /// A destructor responsible for freeing all worker state.
   ~Worker() {}

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -67,8 +67,7 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service, const NodeID node_id
                        const std::string &native_library_path,
                        std::function<void()> starting_worker_timeout_callback,
                        int ray_debugger_external, const std::function<double()> get_time)
-    : worker_startup_token_counter_(0),
-      io_service_(&io_service),
+    : io_service_(&io_service),
       node_id_(node_id),
       node_address_(node_address),
       num_workers_soft_limit_(num_workers_soft_limit),
@@ -175,10 +174,6 @@ void WorkerPool::PopWorkerCallbackInternal(const PopWorkerCallback &callback,
   }
 }
 
-void WorkerPool::update_worker_startup_token_counter() {
-  worker_startup_token_counter_ += 1;
-}
-
 Process WorkerPool::StartWorkerProcess(
     const Language &language, const rpc::WorkerType worker_type, const JobID &job_id,
     PopWorkerStatus *status, const std::vector<std::string> &dynamic_options,
@@ -221,6 +216,9 @@ Process WorkerPool::StartWorkerProcess(
   // Either there are no workers pending registration or the worker start is being forced.
   RAY_LOG(DEBUG) << "Starting new worker process, current pool has " << state.idle.size()
                  << " workers";
+
+  // TODO: do we really need to pass this in from outside the process?
+  StartupToken worker_startup_token_counter_ = GetNewStartupToken();
 
   int workers_to_start = 1;
   if (dynamic_options.empty()) {
@@ -406,19 +404,18 @@ Process WorkerPool::StartWorkerProcess(
 
   // Start a process and measure the startup time.
   auto start = std::chrono::high_resolution_clock::now();
-  Process proc = StartProcess(worker_command_args, env);
+  Process proc = StartProcess(worker_command_args, env, worker_startup_token_counter_);
   auto end = std::chrono::high_resolution_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
   stats::ProcessStartupTimeMs.Record(duration.count());
   stats::NumWorkersStarted.Record(1);
   RAY_LOG(INFO) << "Started worker process of " << workers_to_start
-                << " worker(s) with pid " << proc.GetId();
+                << " worker(s) with pid " << proc.GetId() << ", token " << proc.GetStartupToken() << ", wanted " << worker_startup_token_counter_;
   MonitorStartingWorkerProcess(proc, worker_startup_token_counter_, language,
                                worker_type);
   state.starting_worker_processes.emplace(
       worker_startup_token_counter_,
       StartingWorkerProcessInfo{workers_to_start, workers_to_start, worker_type, proc});
-  update_worker_startup_token_counter();
   if (IsIOWorkerType(worker_type)) {
     auto &io_worker_state = GetIOWorkerStateFromWorkerType(worker_type, state);
     io_worker_state.num_starting_io_workers++;
@@ -449,9 +446,11 @@ void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
       bool found;
       bool used;
       TaskID task_id;
+      RAY_LOG(INFO) << "looking for dedicated workers for token " << proc.GetStartupToken();
       InvokePopWorkerCallbackForProcess(state.starting_dedicated_workers_to_tasks, proc,
                                         nullptr, status, &found, &used, &task_id);
       if (!found) {
+        RAY_LOG(INFO) << "looking for any workers for token " << proc.GetStartupToken();
         InvokePopWorkerCallbackForProcess(state.starting_workers_to_tasks, proc, nullptr,
                                           status, &found, &used, &task_id);
       }
@@ -469,10 +468,10 @@ void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
 }
 
 Process WorkerPool::StartProcess(const std::vector<std::string> &worker_command_args,
-                                 const ProcessEnvironment &env) {
-  if (RAY_LOG_ENABLED(DEBUG)) {
+                                 const ProcessEnvironment &env,
+                                 StartupToken startup_token) {
+  if (RAY_LOG_ENABLED(INFO)) {
     std::string debug_info;
-    debug_info.append("Starting worker process with command:");
     for (const auto &arg : worker_command_args) {
       debug_info.append(" ").append(arg);
     }
@@ -489,7 +488,8 @@ Process WorkerPool::StartProcess(const std::vector<std::string> &worker_command_
       debug_info.pop_back();
     }
     debug_info.append(".");
-    RAY_LOG(DEBUG) << debug_info;
+    RAY_LOG(INFO) << "Starting worker process token " 
+                   << startup_token << " with command:" << debug_info;
   }
 
   // Launch the process to create the worker.
@@ -500,7 +500,7 @@ Process WorkerPool::StartProcess(const std::vector<std::string> &worker_command_
   }
   argv.push_back(NULL);
 
-  Process child(argv.data(), io_service_, ec, /*decouple=*/false, env);
+  Process child(argv.data(), io_service_, ec, /*decouple=*/false, env, startup_token);
   if (!child.IsValid() || ec) {
     // errorcode 24: Too many files. This is caused by ulimit.
     if (ec.value() == 24) {
@@ -596,10 +596,12 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
     send_reply_callback(status, /*port=*/0);
     return status;
   }
-  auto shim_process = Process::FromPid(worker_shim_pid);
+  auto shim_process = Process::FromPidAndStartupToken(worker_shim_pid, worker_startup_token);
   worker->SetShimProcess(shim_process);
-  auto process = Process::FromPid(pid);
+  auto process = Process::FromPidAndStartupToken(pid, worker_startup_token);
   worker->SetProcess(process);
+  RAY_LOG(INFO) << "RegisterWorker() got " << worker_startup_token << ", expected " << shim_process.GetStartupToken() << " or " << process.GetStartupToken();
+  RAY_CHECK(shim_process.GetStartupToken() == worker_startup_token);
 
   // The port that this worker's gRPC server should listen on. 0 if the worker
   // should bind on a random port.
@@ -624,8 +626,9 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
 void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker) {
   auto &state = GetStateForLanguage(worker->GetLanguage());
   const auto &shim_process = worker->GetShimProcess();
-  const StartupToken worker_startup_token = worker->GetStartupToken();
   RAY_CHECK(shim_process.IsValid());
+  const StartupToken worker_startup_token = shim_process.GetStartupToken();
+  RAY_LOG(INFO) << "OnWorkerStarted with token " << worker_startup_token;
 
   auto it = state.starting_worker_processes.find(worker_startup_token);
   if (it != state.starting_worker_processes.end()) {
@@ -635,6 +638,8 @@ void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker)
       // We may have slots to start more workers now.
       TryStartIOWorkers(worker->GetLanguage());
     }
+  } else {
+    RAY_LOG(INFO) << "OnWorkerStarted no starting_worker_process for token " << worker_startup_token;
   }
   const auto &worker_type = worker->GetWorkerType();
   if (IsIOWorkerType(worker_type)) {
@@ -808,14 +813,22 @@ void WorkerPool::InvokePopWorkerCallbackForProcess(
     const PopWorkerStatus &status, bool *found, bool *worker_used, TaskID *task_id) {
   *found = false;
   *worker_used = false;
+  RAY_LOG(INFO) << "InvokePopWorkerCallbackForProcess looking for " << proc.GetStartupToken() << " for pid " << proc.GetId();
   auto it = starting_workers_to_tasks.find(proc);
   if (it != starting_workers_to_tasks.end()) {
     *found = true;
     *task_id = it->second.task_id;
+    RAY_LOG(INFO) << "InvokePopWorkerCallbackForProcess found " << it->first.GetStartupToken() << ", pid " << it->first.GetId();
     const auto &callback = it->second.callback;
     RAY_CHECK(callback);
     *worker_used = callback(worker, status);
     starting_workers_to_tasks.erase(it);
+  } else {
+    RAY_LOG(INFO) << "InvokePopWorkerCallbackForProcess could not find process, valid tokens are:";
+    for (it = starting_workers_to_tasks.begin(); it != starting_workers_to_tasks.end(); it++) {
+      RAY_LOG(INFO) << "InvokePopWorkerCallbackForProcess " << it->first.GetStartupToken() << ", pid " << it->first.GetId();
+    }
+    RAY_LOG(INFO) << "InvokePopWorkerCallbackForProcess --------------------------";
   }
 }
 
@@ -827,6 +840,8 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
   bool found;
   bool used;
   TaskID task_id;
+  RAY_LOG(INFO) << "PushWorker, looking for shim process " << worker->GetShimProcess().GetStartupToken();
+  RAY_LOG(INFO) << "PushWorker,                  process " << worker->GetProcess().GetStartupToken();
   InvokePopWorkerCallbackForProcess(state.starting_dedicated_workers_to_tasks,
                                     worker->GetShimProcess(), worker, PopWorkerStatus::OK,
                                     &found, &used, &task_id);
@@ -840,6 +855,8 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
     return;
   }
 
+  RAY_LOG(INFO) << "PushWorker, looking for shim process " << worker->GetShimProcess().GetStartupToken();
+  RAY_LOG(INFO) << "PushWorker,                  process " << worker->GetProcess().GetStartupToken();
   InvokePopWorkerCallbackForProcess(state.starting_workers_to_tasks,
                                     worker->GetShimProcess(), worker, PopWorkerStatus::OK,
                                     &found, &used, &task_id);
@@ -890,7 +907,8 @@ void WorkerPool::TryKillingIdleWorkers() {
       continue;
     }
     auto shim_process = idle_worker->GetShimProcess();
-    auto worker_startup_token = idle_worker->GetStartupToken();
+    // XXX Should this be the shim process startup token or the real process?
+    auto worker_startup_token = shim_process.GetStartupToken();
     auto &worker_state = GetStateForLanguage(idle_worker->GetLanguage());
 
     if (worker_state.starting_worker_processes.count(worker_startup_token) > 0) {
@@ -1029,6 +1047,7 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
       RAY_CHECK(proc.IsValid());
       WarnAboutSize();
       auto task_info = TaskWaitingForWorkerInfo{task_spec.TaskId(), callback};
+      RAY_LOG(INFO) << "PopWorker started proc w/token " << proc.GetStartupToken() << ", pid " << proc.GetId() << " dedicated " << dedicated;
       if (dedicated) {
         state.starting_dedicated_workers_to_tasks[proc] = std::move(task_info);
       } else {

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -385,8 +385,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   void TryKillingIdleWorkers();
 
  protected:
-  void update_worker_startup_token_counter();
-
   /// Asynchronously start a new worker process. Once the worker process has
   /// registered with an external server, the process should create and
   /// register N workers, then add them to the pool.
@@ -422,9 +420,10 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \param worker_command_args The command arguments of new worker process.
   /// \param[in] env Additional environment variables to be set on this process besides
   /// the environment variables of the parent process.
+  /// \param[in] startup_token The StartupToken to assign to the process
   /// \return An object representing the started worker process.
   virtual Process StartProcess(const std::vector<std::string> &worker_command_args,
-                               const ProcessEnvironment &env);
+                               const ProcessEnvironment &env, StartupToken startup_token);
 
   /// Push an warning message to user if worker pool is getting to big.
   virtual void WarnAboutSize();
@@ -433,11 +432,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   void PopWorkerCallbackInternal(const PopWorkerCallback &callback,
                                  std::shared_ptr<WorkerInterface> worker,
                                  PopWorkerStatus status);
-
-  /// Gloabl startup token variable. Incremented once assigned
-  /// to a worker process and is added to
-  /// state.starting_worker_processes.
-  StartupToken worker_startup_token_counter_;
 
   struct IOWorkerState {
     /// The pool of idle I/O workers.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -493,11 +493,11 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     absl::flat_hash_map<StartupToken, StartingWorkerProcessInfo>
         starting_worker_processes;
     /// A map for looking up the task by the pid of starting worker process.
-    absl::flat_hash_map<Process, TaskWaitingForWorkerInfo> starting_workers_to_tasks;
+    absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo> starting_workers_to_tasks;
     /// A map for looking up the task with dynamic options by the pid of
     /// starting worker process. Note that this is used for the dedicated worker
     /// processes.
-    absl::flat_hash_map<Process, TaskWaitingForWorkerInfo>
+    absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo>
         starting_dedicated_workers_to_tasks;
     /// We'll push a warning to the user every time a multiple of this many
     /// worker processes has been started.
@@ -601,7 +601,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// true.
   /// \param task_id  The related task id.
   void InvokePopWorkerCallbackForProcess(
-      absl::flat_hash_map<Process, TaskWaitingForWorkerInfo> &workers_to_tasks,
+      absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo> &workers_to_tasks,
       const Process &proc, const std::shared_ptr<WorkerInterface> &worker,
       const PopWorkerStatus &status, bool *found /* output */,
       bool *worker_used /* output */, TaskID *task_id /* output */);

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -351,7 +351,6 @@ Process::Process(const char *argv[], void *io_service, std::error_code &ec, bool
     p_ = std::make_shared<ProcessFD>(std::move(procfd));
   }
   startup_token_ = (startup_token >= 0) ? startup_token: GetNewStartupToken();
-  RAY_LOG(INFO) << "Process::Process(..., " << startup_token <<") -> " << startup_token_;
 }
 
 std::error_code Process::Call(const std::vector<std::string> &args,

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -56,8 +56,9 @@ class ProcessFD;
 class Process {
  protected:
   std::shared_ptr<ProcessFD> p_;
+  StartupToken startup_token_;
 
-  explicit Process(pid_t pid);
+  explicit Process(pid_t pid, StartupToken startup_token);
 
  public:
   ~Process();
@@ -74,16 +75,18 @@ class Process {
   /// \param[in] env Additional environment variables to be set on this process besides
   /// the environment variables of the parent process.
   explicit Process(const char *argv[], void *io_service, std::error_code &ec,
-                   bool decouple = false, const ProcessEnvironment &env = {});
+                   bool decouple = false, const ProcessEnvironment &env = {},
+                   StartupToken startup_token = -1);
   /// Convenience function to run the given command line and wait for it to finish.
   static std::error_code Call(const std::vector<std::string> &args,
                               const ProcessEnvironment &env = {});
   static Process CreateNewDummy();
-  static Process FromPid(pid_t pid);
+  static Process FromPidAndStartupToken(pid_t pid, StartupToken startup_token);
   pid_t GetId() const;
   /// Returns an opaque pointer or handle to the underlying process object.
   /// Implementation detail, used only for identity testing. Do not dereference.
   const void *Get() const;
+  StartupToken GetStartupToken() const;
   bool IsNull() const;
   bool IsValid() const;
   /// Forcefully kills the process. Unsafe for unowned processes.
@@ -107,6 +110,11 @@ pid_t GetPID();
 bool IsParentProcessAlive();
 
 bool IsProcessAlive(pid_t pid);
+
+/// Gloabl startup token variable. Every call increments it by one.
+/// Used as a process identifier, espcecially in worker_pool.cc
+/// state.starting_worker_processes
+StartupToken GetNewStartupToken();
 
 }  // namespace ray
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
PR #19014 introduced the idea of a StartupToken to uniquely identify a worker via a counter. This PR extends the idea and moves the StartupToken to the Process class. The changes are:

- Add a global `StartupToken ray::GetNewStartupToken()` function to return-and-increment the counter to `process.h`, remove the `WorkerPool::update_worker_startup_token_counter` function and the `Worker` methods to manipulate the `StartupToken`.
- Add a `StartupToken ray::Process::startup_token_ member` so that each process has a token
- Pass the StartupToken into the various routines to create a `ray::Process(...)`
- Remove the `StartupToken` from the `Worker` wrapper class, `Worker::GetStartupToken` delegates to the shim process's `proc.GetStartupToken()`

And then I could
- Change the `starting_workers_to_tasks` map to index via the process StartupToken, which seems to fix the windows failures.

## Related issue number
#20792, #20173, maybe others. Replaces #20898

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
