### PR TITLE
[WIP] Opt-in some Ray nightly tests to use production job

### DIFF
--- a/release/serve_tests/compute_tpl_single_node.yaml
+++ b/release/serve_tests/compute_tpl_single_node.yaml
@@ -1,4 +1,6 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+# cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+# aioa_aws_242090849690_us_west_2_0000
+cloud_id: cld_HSrCZdMCYDe1NmMCJhYRgQ4p
 region: us-west-2
 
 max_workers: 0

--- a/release/serve_tests/serve_tests.yaml
+++ b/release/serve_tests/serve_tests.yaml
@@ -33,7 +33,8 @@
   run:
     timeout: 7200
     long_running: False
-    script: python workloads/serve_micro_benchmark.py
+    use_anyscale_job: True
+    script: python release/serve_tests/workloads/serve_micro_benchmark.py
 
   smoke_test:
     timeout: 600

--- a/release/serve_tests/workloads/serve_micro_benchmark.py
+++ b/release/serve_tests/workloads/serve_micro_benchmark.py
@@ -15,7 +15,7 @@ async def main():
     # Give default cluster parameter values based on smoke_test config
     # if user provided values explicitly, use them instead.
     # IS_SMOKE_TEST is set by args of releaser's e2e.py
-    smoke_test = os.environ.get("IS_SMOKE_TEST", "1")
+    smoke_test = os.environ.get("IS_SMOKE_TEST", "0")
     if smoke_test == "1":
         setup_local_single_node_cluster(1)
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR begins the migration of one serve, single node tests to use [production job](https://docs.anyscale.com/user-guide/run-and-monitor/production-jobs) as a way to launch nightly tests. 

Currently I was able to:
- [x] launch a job and have it successfully finishes
There are still works to be done:
- [ ] Customize cloud id
- [ ] Result downloading (state.json)
- [ ] Error handling

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
