### PR TITLE
[Serve] Bump test_cluster from small to medium

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -224,7 +224,7 @@ py_test(
 
 py_test(
     name = "test_cluster",
-    size = "small",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -126,16 +126,16 @@ def test_replica_startup_status_transitions(ray_cluster):
     signal = SignalActor.remote()
 
     @serve.deployment(version="1", ray_actor_options={"num_cpus": 2})
-    class D:
+    class E:
         def __init__(self):
             ray.get(signal.wait.remote())
 
-    D.deploy(_blocking=False)
+    E.deploy(_blocking=False)
 
     def get_replicas(replica_state):
         controller = serve_instance._controller
         replicas = ray.get(
-            controller._dump_replica_states_for_testing.remote(D.name))
+            controller._dump_replica_states_for_testing.remote(E.name))
         return replicas.get([replica_state])
 
     # wait for serve to start the replica, and catch a reference to it.
@@ -152,8 +152,15 @@ def test_replica_startup_status_transitions(ray_cluster):
 
     # add the necessary resources to allocate the replica
     cluster.add_node(num_cpus=4)
-    wait_for_condition(
-        lambda: (replica.check_started() == PENDING_INITIALIZATION))
+    wait_for_condition(lambda: (ray.cluster_resources().get("CPU", 0) >= 4))
+    wait_for_condition(lambda: (ray.available_resources().get("CPU", 0) >= 2))
+
+    def is_replica_pending_initialization():
+        status = replica.check_started()
+        print(status)
+        return status == PENDING_INITIALIZATION
+
+    wait_for_condition(is_replica_pending_initialization)
 
     # send signal to complete replica intialization
     signal.send.remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test was timing out on occasion, let's see if bumping the timeout fixes the flakiness.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
