### PR TITLE
[Core][Dashboard Pubsub 1/n] Allow a channel to have subscribers to a key and to the whole channel concurrently

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1382,6 +1382,22 @@ cc_test(
 )
 
 cc_test(
+    name = "pubsub_integration_test",
+    timeout = "short",
+    srcs = ["src/ray/pubsub/test/integration_test.cc"],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        ":pubsub_cc_grpc",
+        ":pubsub_lib",
+        "//src/ray/protobuf:pubsub_cc_proto",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "publisher_test",
     size = "small",
     srcs = ["src/ray/pubsub/test/publisher_test.cc"],

--- a/src/ray/core_worker/reference_count_test.cc
+++ b/src/ray/core_worker/reference_count_test.cc
@@ -238,17 +238,15 @@ class MockDistributedPublisher : public pubsub::PublisherInterface {
       // TODO(swang): Test object locations pubsub too.
       return;
     }
-    auto maybe_subscribers = directory_->GetSubscriberIdsByKeyId(pub_message.key_id());
+    const auto subscribers = directory_->GetSubscriberIdsByKeyId(pub_message.key_id());
     const auto oid = ObjectID::FromBinary(pub_message.key_id());
-    if (maybe_subscribers.has_value()) {
-      for (const auto &subscriber_id : maybe_subscribers.value().get()) {
-        const auto id = GenerateID(publisher_id_, subscriber_id);
-        const auto it = subscription_callback_map_->find(id);
-        if (it != subscription_callback_map_->end()) {
-          const auto callback_it = it->second.find(oid);
-          RAY_CHECK(callback_it != it->second.end());
-          callback_it->second(pub_message);
-        }
+    for (const auto &subscriber_id : subscribers) {
+      const auto id = GenerateID(publisher_id_, subscriber_id);
+      const auto it = subscription_callback_map_->find(id);
+      if (it != subscription_callback_map_->end()) {
+        const auto callback_it = it->second.find(oid);
+        RAY_CHECK(callback_it != it->second.end());
+        callback_it->second(pub_message);
       }
     }
   }

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -145,7 +145,7 @@ Status GcsClient::Connect(instrumented_io_context &io_service) {
   rpc::Address gcs_address;
   gcs_address.set_ip_address(current_gcs_server_address_.first);
   gcs_address.set_port(current_gcs_server_address_.second);
-  /// TODO(mwtian): refactor pubsub::Subscriber to avoid this.
+  /// TODO(mwtian): refactor pubsub::Subscriber to avoid faking worker ID.
   gcs_address.set_worker_id(UniqueID::FromRandom().Binary());
 
   std::unique_ptr<pubsub::Subscriber> subscriber;

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -145,7 +145,7 @@ Status GcsClient::Connect(instrumented_io_context &io_service) {
   rpc::Address gcs_address;
   gcs_address.set_ip_address(current_gcs_server_address_.first);
   gcs_address.set_port(current_gcs_server_address_.second);
-  /// TODO: refactor pubsub::Subscriber to avoid this.
+  /// TODO(mwtian): refactor pubsub::Subscriber to avoid this.
   gcs_address.set_worker_id(UniqueID::FromRandom().Binary());
 
   std::unique_ptr<pubsub::Subscriber> subscriber;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -80,6 +80,7 @@ void GcsServer::Start() {
             rpc::ChannelType::RAY_ERROR_INFO_CHANNEL,
             rpc::ChannelType::RAY_LOG_CHANNEL,
             rpc::ChannelType::RAY_PYTHON_FUNCTION_CHANNEL,
+            rpc::ChannelType::RAY_NODE_RESOURCE_USAGE_CHANNEL,
         },
         /*periodical_runner=*/&pubsub_periodical_runner_,
         /*get_time_ms=*/[]() { return absl::GetCurrentTimeNanos() / 1e6; },

--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -334,7 +334,7 @@ Status GcsSubscriber::SubscribeAllJobs(
       const JobID id = JobID::FromBinary(msg.key_id());
       subscribe(id, msg.job_message());
     };
-    // TODO: Improve error handling, e.g. try to resubscribe automatically.
+    // TODO(mwtian): Improve error handling, e.g. try to resubscribe automatically.
     auto subscription_failure_callback = [](const std::string &, const Status &status) {
       RAY_LOG(WARNING) << "Subscription to Job channel failed: " << status.ToString();
     };

--- a/src/ray/protobuf/BUILD
+++ b/src/ray/protobuf/BUILD
@@ -75,7 +75,7 @@ proto_library(
 )
 
 cc_proto_library(
-    name = "loggings_cc_proto",
+    name = "logging_cc_proto",
     deps = [":logging_proto"],
 )
 
@@ -267,6 +267,7 @@ proto_library(
         ":dependency_proto",
         ":gcs_proto",
         ":logging_proto",
+        ":reporter_proto",
     ],
 )
 

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -21,6 +21,7 @@ import "src/ray/protobuf/common.proto";
 import "src/ray/protobuf/dependency.proto";
 import "src/ray/protobuf/gcs.proto";
 import "src/ray/protobuf/logging.proto";
+import "src/ray/protobuf/reporter.proto";
 
 /// Each channel is prefixed by the name of its components.
 /// For example, for pubsub channels that are used by core workers,
@@ -48,6 +49,8 @@ enum ChannelType {
   RAY_LOG_CHANNEL = 9;
   /// A channel for keys to pickled python functions and actor classes.
   RAY_PYTHON_FUNCTION_CHANNEL = 10;
+  /// A channel for reporting node resource usage stats.
+  RAY_NODE_RESOURCE_USAGE_CHANNEL = 11;
 }
 
 ///
@@ -72,6 +75,7 @@ message PubMessage {
     ErrorTableData error_info_message = 12;
     LogBatch log_batch_message = 13;
     PythonFunction python_function_message = 14;
+    NodeResourceUsage node_resource_usage_message = 15;
 
     // The message that indicates the given key id is not available anymore.
     FailureMessage failure_message = 6;

--- a/src/ray/protobuf/reporter.proto
+++ b/src/ray/protobuf/reporter.proto
@@ -52,6 +52,14 @@ message ReportOCMetricsRequest {
 message ReportOCMetricsReply {
 }
 
+// Resource usage reported by the node reporter.
+message NodeResourceUsage {
+  // Node resource usage in serialized json.
+  // TODO: add schema for the subfields, e.g.
+  // https://github.com/ray-project/ray/blob/e54d3117a40c20ca5441d38ffc72b908bc1b0609/dashboard/modules/reporter/reporter_agent.py#L330-L347
+  string json = 1;
+}
+
 // Service for communicating with the reporter.py process on a remote node.
 service ReporterService {
   // Get the profiling stats.

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -31,13 +31,8 @@ bool SubscriptionIndex::AddEntry(const std::string &key_id,
     return subscribers_to_all_.insert(subscriber_id).second;
   }
 
-  // Skip if the channel is already in all-entity subscription mode.
-  if (!subscribers_to_all_.empty()) {
-    return false;
-  }
-
   auto &subscribing_key_ids = subscribers_to_key_id_[subscriber_id];
-  auto key_added = subscribing_key_ids.emplace(key_id).second;
+  bool key_added = subscribing_key_ids.emplace(key_id).second;
   auto &subscriber_map = key_id_to_subscribers_[key_id];
   auto subscriber_added = subscriber_map.emplace(subscriber_id).second;
 
@@ -45,29 +40,31 @@ bool SubscriptionIndex::AddEntry(const std::string &key_id,
   return key_added;
 }
 
-absl::optional<std::reference_wrapper<const absl::flat_hash_set<SubscriberID>>>
-SubscriptionIndex::GetSubscriberIdsByKeyId(const std::string &key_id) const {
+std::vector<SubscriberID> SubscriptionIndex::GetSubscriberIdsByKeyId(
+    const std::string &key_id) const {
+  std::vector<SubscriberID> subscribers;
   if (!subscribers_to_all_.empty()) {
-    return subscribers_to_all_;
+    subscribers.insert(subscribers.end(), subscribers_to_all_.begin(),
+                       subscribers_to_all_.end());
   }
   auto it = key_id_to_subscribers_.find(key_id);
-  if (it == key_id_to_subscribers_.end()) {
-    return absl::nullopt;
+  if (it != key_id_to_subscribers_.end()) {
+    auto &ids = it->second;
+    subscribers.insert(subscribers.end(), ids.begin(), ids.end());
   }
-  return absl::optional<std::reference_wrapper<const absl::flat_hash_set<SubscriberID>>>{
-      std::ref(it->second)};
+  return subscribers;
 }
 
 bool SubscriptionIndex::EraseSubscriber(const SubscriberID &subscriber_id) {
-  if (!subscribers_to_all_.empty()) {
-    return subscribers_to_all_.erase(subscriber_id) > 0;
-  }
+  // Erase subscriber of all keys.
+  bool erased = subscribers_to_all_.erase(subscriber_id) > 0;
 
   auto subscribing_message_it = subscribers_to_key_id_.find(subscriber_id);
   if (subscribing_message_it == subscribers_to_key_id_.end()) {
-    return false;
+    return erased;
   }
 
+  // Erase subscriber of individual keys.
   auto &subscribing_messages = subscribing_message_it->second;
   for (const auto &key_id : subscribing_messages) {
     // Erase the subscriber from the object map.
@@ -87,14 +84,12 @@ bool SubscriptionIndex::EraseSubscriber(const SubscriberID &subscriber_id) {
 
 bool SubscriptionIndex::EraseEntry(const std::string &key_id,
                                    const SubscriberID &subscriber_id) {
-  if (!subscribers_to_all_.empty()) {
-    if (!key_id.empty()) {
-      return false;
-    }
+  // Erase the subscriber of all keys.
+  if (key_id.empty()) {
     return subscribers_to_all_.erase(subscriber_id) > 0;
   }
 
-  // Erase keys from subscribers.
+  // Erase keys from the subscriber of individual keys.
   auto subscribers_to_message_it = subscribers_to_key_id_.find(subscriber_id);
   if (subscribers_to_message_it == subscribers_to_key_id_.end()) {
     return false;
@@ -257,15 +252,15 @@ void Publisher::Publish(const rpc::PubMessage &pub_message) {
   RAY_CHECK(subscription_index_it != subscription_index_map_.end());
   // TODO(sang): Currently messages are lost if publish happens
   // before there's any subscriber for the object.
-  auto maybe_subscribers =
+  const auto subscribers =
       subscription_index_it->second.GetSubscriberIdsByKeyId(pub_message.key_id());
-  if (!maybe_subscribers.has_value()) {
+  if (subscribers.empty()) {
     return;
   }
 
   cum_pub_message_cnt_[channel_type]++;
 
-  for (const auto &subscriber_id : maybe_subscribers.value().get()) {
+  for (const auto &subscriber_id : subscribers) {
     auto it = subscribers_.find(subscriber_id);
     RAY_CHECK(it != subscribers_.end());
     auto &subscriber = it->second;

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -62,7 +62,7 @@ bool SubscriptionIndex::EraseSubscriber(const SubscriberID &subscriber_id) {
   }
 
   // Erase subscriber of individual keys.
-  auto &subscribing_keys = subscribing_key_it->second;
+  const auto &subscribing_keys = subscribing_key_it->second;
   for (const auto &key_id : subscribing_keys) {
     // Erase the subscriber from the object map.
     auto subscribers_it = key_id_to_subscribers_.find(key_id);
@@ -290,6 +290,8 @@ bool Publisher::UnregisterSubscriber(const SubscriberID &subscriber_id) {
 
 void Publisher::UnregisterAll() {
   absl::MutexLock lock(&mutex_);
+  // Save the subscriber IDs to be removed, because UnregisterSubscriberInternal()
+  // erases from subscribers_.
   std::vector<SubscriberID> ids;
   for (const auto &[id, subscriber] : subscribers_) {
     ids.push_back(id);

--- a/src/ray/pubsub/publisher.h
+++ b/src/ray/pubsub/publisher.h
@@ -48,9 +48,8 @@ class SubscriptionIndex {
   /// NOTE: The method is idempotent. If it adds a duplicated entry, it will be no-op.
   bool AddEntry(const std::string &key_id, const SubscriberID &subscriber_id);
 
-  /// Returns the set of subscriber ids that are subscribing to the given object ids.
-  absl::optional<std::reference_wrapper<const absl::flat_hash_set<SubscriberID>>>
-  GetSubscriberIdsByKeyId(const std::string &key_id) const;
+  /// Returns a vector of subscriber ids that are subscribing to the given object ids.
+  std::vector<SubscriberID> GetSubscriberIdsByKeyId(const std::string &key_id) const;
 
   /// Erases the subscriber from the index.
   /// Returns whether the subscriber exists before the call.

--- a/src/ray/pubsub/publisher.h
+++ b/src/ray/pubsub/publisher.h
@@ -38,24 +38,27 @@ using SubscriberID = UniqueID;
 
 namespace pub_internal {
 
-/// Per-channel index for subscribers and the entities they subscribe to.
+/// Per-channel two-way index for subscribers and the keys they subscribe to.
+/// Also supports subscribers to all keys in the channel.
 class SubscriptionIndex {
  public:
   SubscriptionIndex() = default;
   ~SubscriptionIndex() = default;
 
-  /// Adds a new entry to the index.
+  /// Adds a new subscriber and the key it subscribes to.
+  /// When `key_id` is empty, the subscriber subscribes to all keys.
   /// NOTE: The method is idempotent. If it adds a duplicated entry, it will be no-op.
   bool AddEntry(const std::string &key_id, const SubscriberID &subscriber_id);
 
   /// Returns a vector of subscriber ids that are subscribing to the given object ids.
   std::vector<SubscriberID> GetSubscriberIdsByKeyId(const std::string &key_id) const;
 
-  /// Erases the subscriber from the index.
+  /// Erases the subscriber from this index.
   /// Returns whether the subscriber exists before the call.
   bool EraseSubscriber(const SubscriberID &subscriber_id);
 
-  /// Erases the entity id and subscriber id from the index.
+  /// Erases the subscriber from the particular key.
+  /// When `key_id` is empty, the subscriber subscribes to all keys.
   bool EraseEntry(const std::string &key_id, const SubscriberID &subscriber_id);
 
   /// Test only.

--- a/src/ray/pubsub/publisher.h
+++ b/src/ray/pubsub/publisher.h
@@ -298,6 +298,9 @@ class Publisher : public PublisherInterface {
   /// \return True if erased. False otherwise.
   bool UnregisterSubscriber(const SubscriberID &subscriber_id);
 
+  /// Flushes all inflight pollings and unregisters all subscribers.
+  void UnregisterAll();
+
   /// Check all subscribers, detect which subscribers are dead or its connection is timed
   /// out, and clean up their metadata. This uses the goal-oriented logic to clean up all
   /// metadata that can happen by subscriber failures. It is how it works;

--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -220,12 +220,7 @@ std::string SubscriberChannel::DebugString() const {
 ///////////////////////////////////////////////////////////////////////////////
 
 Subscriber::~Subscriber() {
-  if (!mutex_.LockWhenWithTimeout(absl::Condition(this, &Subscriber::CheckNoLeaks_Locked),
-                                  absl::Seconds(5))) {
-    // TODO(mwtian): ensure there is no leak during destruction.
-    RAY_LOG(DEBUG) << "Subscriber has inflight data during destruction";
-  }
-  mutex_.Unlock();
+  // TODO(mwtian): flush Subscriber and ensure there is no leak during destruction.
 }
 
 bool Subscriber::Subscribe(std::unique_ptr<rpc::SubMessage> sub_message,
@@ -460,10 +455,6 @@ void Subscriber::SendCommandBatchIfPossible(const rpc::Address &publisher_addres
 
 bool Subscriber::CheckNoLeaks() const {
   absl::MutexLock lock(&mutex_);
-  return CheckNoLeaks_Locked();
-}
-
-bool Subscriber::CheckNoLeaks_Locked() const {
   bool leaks = false;
   for (const auto &channel_it : channels_) {
     if (!channel_it.second->CheckNoLeaks()) {

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -327,7 +327,7 @@ class Subscriber : public SubscriberInterface {
     }
   }
 
-  ~Subscriber() = default;
+  ~Subscriber();
 
   bool Subscribe(std::unique_ptr<rpc::SubMessage> sub_message,
                  const rpc::ChannelType channel_type,
@@ -381,7 +381,10 @@ class Subscriber : public SubscriberInterface {
   FRIEND_TEST(SubscriberTest, TestUnsubscribeInSubscriptionCallback);
   FRIEND_TEST(SubscriberTest, TestCommandsCleanedUponPublishFailure);
   // Testing only. Check if there are leaks.
-  bool CheckNoLeaks() const;
+  bool CheckNoLeaks() const LOCKS_EXCLUDED(mutex_);
+
+  // Makes sure destructor runs after there is no remaining data.
+  bool CheckNoLeaks_Locked() const EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   ///
   /// Private fields

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -371,6 +371,7 @@ class Subscriber : public SubscriberInterface {
   /// Testing fields
   ///
 
+  FRIEND_TEST(IntegrationTest, SubscribersToOneIDAndAllIDs);
   FRIEND_TEST(SubscriberTest, TestBasicSubscription);
   FRIEND_TEST(SubscriberTest, TestSingleLongPollingWithMultipleSubscriptions);
   FRIEND_TEST(SubscriberTest, TestMultiLongPollingWithTheSameSubscription);
@@ -382,9 +383,6 @@ class Subscriber : public SubscriberInterface {
   FRIEND_TEST(SubscriberTest, TestCommandsCleanedUponPublishFailure);
   // Testing only. Check if there are leaks.
   bool CheckNoLeaks() const LOCKS_EXCLUDED(mutex_);
-
-  // Makes sure destructor runs after there is no remaining data.
-  bool CheckNoLeaks_Locked() const EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   ///
   /// Private fields

--- a/src/ray/pubsub/test/integration_test.cc
+++ b/src/ray/pubsub/test/integration_test.cc
@@ -164,7 +164,7 @@ class IntegrationTest : public ::testing::Test {
         },
         /*periodic_runner=*/periodic_runner_.get(),
         /*get_time_ms=*/[]() -> double { return absl::ToUnixMicros(absl::Now()); },
-        /*subscriber_timeout_ms=*/30e6,
+        /*subscriber_timeout_ms=*/absl::ToInt64Microseconds(absl::Seconds(30)),
         /*batch_size=*/100);
     publisher_service_ = std::make_unique<PublisherServiceImpl>(std::move(publisher));
 

--- a/src/ray/pubsub/test/integration_test.cc
+++ b/src/ray/pubsub/test/integration_test.cc
@@ -1,0 +1,34 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "ray/common/asio/instrumented_io_context.h"
+#include "ray/pubsub/publisher.h"
+#include "ray/pubsub/subscriber.h"
+
+
+namespace ray {
+namespace pubsub {
+
+class IntegrationTest : public ::testing::Test {
+ public:
+  IntegrationTest() {}
+  ~IntegrationTest() {}
+
+};
+
+}  // namespace pubsub
+}  // namespace ray

--- a/src/ray/pubsub/test/integration_test.cc
+++ b/src/ray/pubsub/test/integration_test.cc
@@ -12,23 +12,279 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <string>
 
+#include "absl/synchronization/blocking_counter.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/asio/io_service_pool.h"
+#include "ray/common/asio/periodical_runner.h"
+#include "ray/common/grpc_util.h"
 #include "ray/pubsub/publisher.h"
 #include "ray/pubsub/subscriber.h"
-
+#include "src/ray/protobuf/pubsub.grpc.pb.h"
+#include "src/ray/protobuf/pubsub.pb.h"
 
 namespace ray {
 namespace pubsub {
 
-class IntegrationTest : public ::testing::Test {
+// Implements PublisherService for handling subscriber polling.
+class PublisherServiceImpl final : public rpc::PublisherService::CallbackService {
  public:
-  IntegrationTest() {}
-  ~IntegrationTest() {}
+  explicit PublisherServiceImpl(std::unique_ptr<Publisher> publisher)
+      : publisher_(std::move(publisher)) {}
 
+  grpc::ServerUnaryReactor *PubsubLongPolling(
+      grpc::CallbackServerContext *context, const rpc::PubsubLongPollingRequest *request,
+      rpc::PubsubLongPollingReply *reply) override {
+    const auto subscriber_id = UniqueID::FromBinary(request->subscriber_id());
+    auto *reactor = context->DefaultReactor();
+    publisher_->ConnectToSubscriber(
+        subscriber_id, reply,
+        [reactor](ray::Status status, std::function<void()> success_cb,
+                  std::function<void()> failure_cb) {
+          // Long polling should always succeed.
+          RAY_CHECK_OK(status);
+          RAY_CHECK(success_cb == nullptr);
+          RAY_CHECK(failure_cb == nullptr);
+          reactor->Finish(grpc::Status::OK);
+        });
+    return reactor;
+  }
+
+  // For simplicity, all work is done on the GRPC thread.
+  grpc::ServerUnaryReactor *PubsubCommandBatch(
+      grpc::CallbackServerContext *context, const rpc::PubsubCommandBatchRequest *request,
+      rpc::PubsubCommandBatchReply *reply) override {
+    const auto subscriber_id = UniqueID::FromBinary(request->subscriber_id());
+    auto *reactor = context->DefaultReactor();
+    for (const auto &command : request->commands()) {
+      if (command.has_unsubscribe_message()) {
+        publisher_->UnregisterSubscription(command.channel_type(), subscriber_id,
+                                           command.key_id().empty()
+                                               ? std::nullopt
+                                               : std::make_optional(command.key_id()));
+      } else if (command.has_subscribe_message()) {
+        publisher_->RegisterSubscription(command.channel_type(), subscriber_id,
+                                         command.key_id().empty()
+                                             ? std::nullopt
+                                             : std::make_optional(command.key_id()));
+      } else {
+        RAY_LOG(FATAL)
+            << "Invalid command has received, "
+            << static_cast<int>(command.command_message_one_of_case())
+            << ". If you see this message, please file an issue to Ray Github.";
+      }
+    }
+    reactor->Finish(grpc::Status::OK);
+    return reactor;
+  }
+
+  Publisher &GetPublisher() { return *publisher_; }
+
+ private:
+  std::unique_ptr<Publisher> publisher_;
 };
+
+// Adapts GcsRpcClient to SubscriberClientInterface for making RPC calls. Thread safe.
+class CallbackSubscriberClient final : public pubsub::SubscriberClientInterface {
+ public:
+  explicit CallbackSubscriberClient(const std::string &address) {
+    auto channel = grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+    stub_ = rpc::PublisherService::NewStub(std::move(channel));
+  }
+
+  ~CallbackSubscriberClient() final = default;
+
+  void PubsubLongPolling(
+      const rpc::PubsubLongPollingRequest &request,
+      const rpc::ClientCallback<rpc::PubsubLongPollingReply> &callback) final {
+    auto *context = new grpc::ClientContext;
+    auto *reply = new rpc::PubsubLongPollingReply;
+    stub_->async()->PubsubLongPolling(context, &request, reply,
+                                      [callback, context, reply](grpc::Status s) {
+                                        callback(GrpcStatusToRayStatus(s), *reply);
+                                        delete reply;
+                                        delete context;
+                                      });
+  }
+
+  void PubsubCommandBatch(
+      const rpc::PubsubCommandBatchRequest &request,
+      const rpc::ClientCallback<rpc::PubsubCommandBatchReply> &callback) final {
+    auto *context = new grpc::ClientContext;
+    auto *reply = new rpc::PubsubCommandBatchReply;
+    stub_->async()->PubsubCommandBatch(context, &request, reply,
+                                       [callback, context, reply](grpc::Status s) {
+                                         callback(GrpcStatusToRayStatus(s), *reply);
+                                         delete reply;
+                                         delete context;
+                                       });
+  }
+
+ private:
+  std::unique_ptr<rpc::PublisherService::Stub> stub_;
+};
+
+class IntegrationTest : public ::testing::Test {
+ protected:
+  IntegrationTest() {
+    // Initialize publisher address.
+    address_ = "127.0.0.1:7928";
+    address_proto_.set_ip_address("127.0.0.1");
+    address_proto_.set_port(7928);
+    address_proto_.set_worker_id(UniqueID::FromRandom().Binary());
+    io_service_.Run();
+    periodic_runner_ = std::make_unique<PeriodicalRunner>(*io_service_.Get());
+
+    SetupServer();
+  }
+
+  ~IntegrationTest() {
+    // Stop callback runners.
+    io_service_.Stop();
+    // Assume no new subscriber is connected after the unregisteration above. Otherwise
+    // shutdown would hang below.
+    server_->Shutdown();
+  }
+
+  void SetupServer() {
+    if (server_ != nullptr) {
+      server_->Shutdown();
+    }
+
+    auto publisher = std::make_unique<Publisher>(
+        /*channels=*/
+        std::vector<rpc::ChannelType>{
+            rpc::ChannelType::GCS_ACTOR_CHANNEL,
+        },
+        /*periodic_runner=*/periodic_runner_.get(),
+        /*get_time_ms=*/[]() { return absl::ToUnixMicros(absl::Now()); },
+        /*subscriber_timeout_ms=*/30e6,
+        /*batch_size=*/100);
+    publisher_service_ = std::make_unique<PublisherServiceImpl>(std::move(publisher));
+
+    grpc::EnableDefaultHealthCheckService(true);
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(address_, grpc::InsecureServerCredentials());
+    builder.RegisterService(publisher_service_.get());
+    server_ = builder.BuildAndStart();
+  }
+
+  std::unique_ptr<Subscriber> CreateSubscriber() {
+    return std::make_unique<Subscriber>(
+        UniqueID::FromRandom(),
+        /*channels=*/
+        std::vector<rpc::ChannelType>{
+            rpc::ChannelType::GCS_ACTOR_CHANNEL,
+        },
+        /*max_command_batch_size=*/3,
+        /*get_client=*/
+        [](const rpc::Address &address) {
+          return std::make_shared<CallbackSubscriberClient>(
+              absl::StrCat(address.ip_address(), ":", address.port()));
+        },
+        io_service_.Get());
+  }
+
+  std::string address_;
+  rpc::Address address_proto_;
+  IOServicePool io_service_ = IOServicePool(3);
+  std::unique_ptr<PeriodicalRunner> periodic_runner_;
+  std::unique_ptr<PublisherServiceImpl> publisher_service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+TEST_F(IntegrationTest, SubscribersToOneIDAndAllIDs) {
+  const std::string subscribed_actor =
+      ActorID::FromHex("f4ce02420592ca68c1738a0d01000000").Binary();
+  absl::BlockingCounter counter(2);
+  absl::Mutex mu;
+
+  std::vector<rpc::ActorTableData> actors_1;
+  auto subscriber_1 = CreateSubscriber();
+  subscriber_1->Subscribe(
+      std::make_unique<rpc::SubMessage>(), rpc::ChannelType::GCS_ACTOR_CHANNEL,
+      address_proto_, subscribed_actor,
+      /*subscribe_done_callback=*/
+      [&counter](Status status) {
+        RAY_CHECK_OK(status);
+        counter.DecrementCount();
+      },
+      /*subscribe_item_callback=*/
+      [&mu, &actors_1](const rpc::PubMessage &msg) {
+        absl::MutexLock lock(&mu);
+        actors_1.push_back(msg.actor_message());
+      },
+      /*subscription_failure_callback=*/
+      [](const std::string &, const Status &status) { RAY_CHECK_OK(status); });
+
+  std::vector<rpc::ActorTableData> actors_2;
+  auto subscriber_2 = CreateSubscriber();
+  subscriber_2->SubscribeChannel(
+      std::make_unique<rpc::SubMessage>(), rpc::ChannelType::GCS_ACTOR_CHANNEL,
+      address_proto_,
+      /*subscribe_done_callback=*/
+      [&counter](Status status) {
+        RAY_CHECK_OK(status);
+        counter.DecrementCount();
+      },
+      /*subscribe_item_callback=*/
+      [&mu, &actors_2](const rpc::PubMessage &msg) {
+        absl::MutexLock lock(&mu);
+        actors_2.push_back(msg.actor_message());
+      },
+      /*subscription_failure_callback=*/
+      [](const std::string &, const Status &status) { RAY_CHECK_OK(status); });
+
+  // Wait for subscriptions done before trying to publish.
+  counter.Wait();
+
+  rpc::ActorTableData actor_data;
+  actor_data.set_actor_id(subscribed_actor);
+  actor_data.set_state(rpc::ActorTableData::ALIVE);
+  actor_data.set_name("test actor");
+  rpc::PubMessage msg;
+  msg.set_channel_type(rpc::ChannelType::GCS_ACTOR_CHANNEL);
+  msg.set_key_id(subscribed_actor);
+  *msg.mutable_actor_message() = actor_data;
+
+  publisher_service_->GetPublisher().Publish(msg);
+
+  absl::MutexLock lock(&mu);
+
+  auto received_id = [&mu, &actors_1]() {
+    mu.AssertReaderHeld();  // For annotalysis.
+    return actors_1.size() == 1;
+  };
+  if (!mu.AwaitWithTimeout(absl::Condition(&received_id), absl::Seconds(10))) {
+    FAIL() << "Subscriber for actor ID did not receive the published message.";
+  }
+
+  auto received_all = [&mu, &actors_2]() {
+    mu.AssertReaderHeld();  // For annotalysis.
+    return actors_2.size() == 1;
+  };
+  if (!mu.AwaitWithTimeout(absl::Condition(&received_all), absl::Seconds(10))) {
+    FAIL() << "Subscriber for actor channel did not receive the published message.";
+  }
+
+  EXPECT_EQ(actors_1[0].actor_id(), actor_data.actor_id());
+  EXPECT_EQ(actors_2[0].actor_id(), actor_data.actor_id());
+
+  // This is necessary to avoid invalid memory access during shutdown.
+  // TODO(mwtian): cancel inflight polls during subscriber shutdown, and remove the
+  // shutdown logic below.
+  subscriber_1->Unsubscribe(rpc::ChannelType::GCS_ACTOR_CHANNEL, address_proto_,
+                            subscribed_actor);
+  subscriber_2->UnsubscribeChannel(rpc::ChannelType::GCS_ACTOR_CHANNEL, address_proto_);
+  // Flush all the inflight long polling.
+  publisher_service_->GetPublisher().UnregisterAll();
+}
 
 }  // namespace pubsub
 }  // namespace ray

--- a/src/ray/pubsub/test/publisher_test.cc
+++ b/src/ray/pubsub/test/publisher_test.cc
@@ -55,6 +55,12 @@ class PublisherTest : public ::testing::Test {
     return pub_message;
   }
 
+  bool HasSubscriber(const std::vector<SubscriberID> &subscribers,
+                     const SubscriberID &subscriber) {
+    return std::find(subscribers.begin(), subscribers.end(), subscriber) !=
+           subscribers.end();
+  }
+
   instrumented_io_context io_service_;
   std::shared_ptr<PeriodicalRunner> periodic_runner_;
   std::shared_ptr<Publisher> object_status_publisher_;
@@ -76,9 +82,9 @@ TEST_F(PublisherTest, TestSubscriptionIndexSingeNodeSingleObject) {
   SubscriptionIndex subscription_index;
   subscription_index.AddEntry(oid.Binary(), node_id);
   const auto &subscribers_from_index =
-      subscription_index.GetSubscriberIdsByKeyId(oid.Binary()).value().get();
+      subscription_index.GetSubscriberIdsByKeyId(oid.Binary());
   for (const auto &node_id : subscribers) {
-    ASSERT_TRUE(subscribers_from_index.count(node_id) > 0);
+    ASSERT_TRUE(HasSubscriber(subscribers_from_index, node_id));
   }
 }
 
@@ -98,9 +104,9 @@ TEST_F(PublisherTest, TestSubscriptionIndexMultiNodeSingleObject) {
     subscription_index.AddEntry(oid.Binary(), node_id);
   }
   const auto &subscribers_from_index =
-      subscription_index.GetSubscriberIdsByKeyId(oid.Binary()).value().get();
+      subscription_index.GetSubscriberIdsByKeyId(oid.Binary());
   for (const auto &node_id : subscribers_map_.at(oid)) {
-    ASSERT_TRUE(subscribers_from_index.count(node_id) > 0);
+    ASSERT_TRUE(HasSubscriber(subscribers_from_index, node_id));
   }
 
   ///
@@ -116,16 +122,16 @@ TEST_F(PublisherTest, TestSubscriptionIndexMultiNodeSingleObject) {
     subscription_index.AddEntry(oid2.Binary(), node_id);
   }
   const auto &subscribers_from_index2 =
-      subscription_index.GetSubscriberIdsByKeyId(oid2.Binary()).value().get();
+      subscription_index.GetSubscriberIdsByKeyId(oid2.Binary());
   for (const auto &node_id : subscribers_map_.at(oid2)) {
-    ASSERT_TRUE(subscribers_from_index2.count(node_id) > 0);
+    ASSERT_TRUE(HasSubscriber(subscribers_from_index2, node_id));
   }
 
   // Make sure oid1 entries are not corrupted.
   const auto &subscribers_from_index3 =
-      subscription_index.GetSubscriberIdsByKeyId(oid.Binary()).value().get();
+      subscription_index.GetSubscriberIdsByKeyId(oid.Binary());
   for (const auto &node_id : subscribers_map_.at(oid)) {
-    ASSERT_TRUE(subscribers_from_index3.count(node_id) > 0);
+    ASSERT_TRUE(HasSubscriber(subscribers_from_index3, node_id));
   }
 }
 
@@ -163,9 +169,9 @@ TEST_F(PublisherTest, TestSubscriptionIndexErase) {
     i++;
   }
   const auto &subscribers_from_index =
-      subscription_index.GetSubscriberIdsByKeyId(oid.Binary()).value().get();
+      subscription_index.GetSubscriberIdsByKeyId(oid.Binary());
   for (const auto &node_id : subscribers_map_.at(oid)) {
-    ASSERT_TRUE(subscribers_from_index.count(node_id) > 0);
+    ASSERT_TRUE(HasSubscriber(subscribers_from_index, node_id));
   }
 
   // Delete all entries and make sure the oid is removed from the index.
@@ -221,8 +227,8 @@ TEST_F(PublisherTest, TestSubscriptionIndexEraseSubscriber) {
   subscription_index.EraseSubscriber(node_ids[0]);
   ASSERT_FALSE(subscription_index.HasSubscriber(node_ids[0]));
   const auto &subscribers_from_index =
-      subscription_index.GetSubscriberIdsByKeyId(oid.Binary()).value().get();
-  ASSERT_TRUE(subscribers_from_index.count(node_ids[0]) == 0);
+      subscription_index.GetSubscriberIdsByKeyId(oid.Binary());
+  ASSERT_FALSE(HasSubscriber(subscribers_from_index, node_ids[0]));
 
   for (int i = 1; i < 6; i++) {
     subscription_index.EraseSubscriber(node_ids[i]);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For actor channel, GCS clients subscribe to a single actor but dashboard subscribes to all actors. This change makes supporting this possible.

Most of the added code is in `integration_test.cc`, which tests the publisher and subscriber together.

Also, add the basic support for dashboard reporter pubsub.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
