### PR TITLE
[Internal Observability] [Part 2] Share the same code for RecordMetrics & DebugString for cluster task manager.

### DIFF
--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -56,10 +56,7 @@ ClusterTaskManager::ClusterTaskManager(
       get_time_ms_(get_time_ms),
       sched_cls_cap_enabled_(RayConfig::instance().worker_cap_enabled()),
       sched_cls_cap_interval_ms_(sched_cls_cap_interval_ms),
-      sched_cls_cap_max_ms_(RayConfig::instance().worker_cap_max_backoff_delay_ms()),
-      metric_tasks_queued_(0),
-      metric_tasks_dispatched_(0),
-      metric_tasks_spilled_(0) {}
+      sched_cls_cap_max_ms_(RayConfig::instance().worker_cap_max_backoff_delay_ms()) {}
 
 bool ClusterTaskManager::SchedulePendingTasks() {
   // Always try to schedule infeasible tasks in case they are now feasible.
@@ -942,7 +939,7 @@ bool ClusterTaskManager::AnyPendingTasksForResourceAcquisition(
   return *any_pending;
 }
 
-std::string ClusterTaskManager::DebugStr() const {
+void ClusterTaskManager::UpdateDebugStates() const {
   auto accumulator =
       [](size_t state,
          const std::pair<int, std::deque<std::shared_ptr<internal::Work>>> &pair) {
@@ -954,7 +951,7 @@ std::string ClusterTaskManager::DebugStr() const {
   size_t num_worker_not_started_by_job_config_not_exist = 0;
   size_t num_worker_not_started_by_registration_timeout = 0;
   size_t num_worker_not_started_by_process_rate_limit = 0;
-  size_t num_worker_waiting_for_workers = 0;
+  size_t num_tasks_waiting_for_workers = 0;
   size_t num_cancelled_tasks = 0;
 
   size_t num_infeasible_tasks = std::accumulate(
@@ -968,7 +965,7 @@ std::string ClusterTaskManager::DebugStr() const {
                                &num_worker_not_started_by_job_config_not_exist,
                                &num_worker_not_started_by_registration_timeout,
                                &num_worker_not_started_by_process_rate_limit,
-                               &num_worker_waiting_for_workers, &num_cancelled_tasks](
+                               &num_tasks_waiting_for_workers, &num_cancelled_tasks](
                                   size_t state,
                                   const std::pair<
                                       int, std::deque<std::shared_ptr<internal::Work>>>
@@ -977,7 +974,7 @@ std::string ClusterTaskManager::DebugStr() const {
     for (auto work_it = work_queue.begin(); work_it != work_queue.end();) {
       const auto &work = *work_it++;
       if (work->GetState() == internal::WorkStatus::WAITING_FOR_WORKER) {
-        num_worker_waiting_for_workers += 1;
+        num_tasks_waiting_for_workers += 1;
       } else if (work->GetState() == internal::WorkStatus::CANCELLED) {
         num_cancelled_tasks += 1;
       } else if (work->GetUnscheduledCause() ==
@@ -1009,28 +1006,64 @@ std::string ClusterTaskManager::DebugStr() const {
       std::accumulate(tasks_to_dispatch_.begin(), tasks_to_dispatch_.end(), (size_t)0,
                       per_work_accumulator);
 
-  if (num_tasks_to_schedule + num_tasks_to_dispatch + num_infeasible_tasks > 1000) {
+  /// Update the internal states.
+  internal_stats_.num_waiting_for_resource = num_waiting_for_resource;
+  internal_stats_.num_waiting_for_plasma_memory = num_waiting_for_plasma_memory;
+  internal_stats_.num_waiting_for_remote_node_resources =
+      num_waiting_for_remote_node_resources;
+  internal_stats_.num_worker_not_started_by_job_config_not_exist =
+      num_worker_not_started_by_job_config_not_exist;
+  internal_stats_.num_worker_not_started_by_registration_timeout =
+      num_worker_not_started_by_registration_timeout;
+  internal_stats_.num_worker_not_started_by_process_rate_limit =
+      num_worker_not_started_by_process_rate_limit;
+  internal_stats_.num_tasks_waiting_for_workers = num_tasks_waiting_for_workers;
+  internal_stats_.num_cancelled_tasks = num_cancelled_tasks;
+  internal_stats_.num_infeasible_tasks = num_infeasible_tasks;
+  internal_stats_.num_tasks_to_schedule = num_tasks_to_schedule;
+  internal_stats_.num_tasks_to_dispatch = num_tasks_to_dispatch;
+}
+
+void ClusterTaskManager::RecordMetrics() const {
+  /// This method intentionally doesn't call UpdateDebugState() because
+  /// that function is expensive. UpdateDebugState is called by DebugStr method
+  /// and they are always periodically called by node manager.
+  stats::NumReceivedTasks.Record(internal_stats_.num_tasks_to_schedule);
+  stats::NumDispatchedTasks.Record(internal_stats_.num_tasks_to_dispatch);
+  stats::NumSpilledTasks.Record(internal_stats_.metric_tasks_spilled);
+  stats::NumInfeasibleSchedulingClasses.Record(infeasible_tasks_.size());
+  stats::NumInfeasibleTasks.Record(internal_stats_.num_infeasible_tasks);
+}
+
+std::string ClusterTaskManager::DebugStr() const {
+  UpdateDebugStates();
+  if (internal_stats_.num_tasks_to_schedule + internal_stats_.num_tasks_to_dispatch +
+          internal_stats_.num_infeasible_tasks >
+      1000) {
     RAY_LOG(WARNING)
         << "More than 1000 tasks are queued in this node. This can cause slow down.";
   }
 
   std::stringstream buffer;
   buffer << "========== Node: " << self_node_id_ << " =================\n";
-  buffer << "Infeasible queue length: " << num_infeasible_tasks << "\n";
-  buffer << "Schedule queue length: " << num_tasks_to_schedule << "\n";
-  buffer << "Dispatch queue length: " << num_tasks_to_dispatch << "\n";
-  buffer << "num_waiting_for_resource: " << num_waiting_for_resource << "\n";
-  buffer << "num_waiting_for_plasma_memory: " << num_waiting_for_plasma_memory << "\n";
+  buffer << "Infeasible queue length: " << internal_stats_.num_infeasible_tasks << "\n";
+  buffer << "Schedule queue length: " << internal_stats_.num_tasks_to_schedule << "\n";
+  buffer << "Dispatch queue length: " << internal_stats_.num_tasks_to_dispatch << "\n";
+  buffer << "num_waiting_for_resource: " << internal_stats_.num_waiting_for_resource
+         << "\n";
+  buffer << "num_waiting_for_plasma_memory: "
+         << internal_stats_.num_waiting_for_plasma_memory << "\n";
   buffer << "num_waiting_for_remote_node_resources: "
-         << num_waiting_for_remote_node_resources << "\n";
+         << internal_stats_.num_waiting_for_remote_node_resources << "\n";
   buffer << "num_worker_not_started_by_job_config_not_exist: "
-         << num_worker_not_started_by_job_config_not_exist << "\n";
+         << internal_stats_.num_worker_not_started_by_job_config_not_exist << "\n";
   buffer << "num_worker_not_started_by_registration_timeout: "
-         << num_worker_not_started_by_registration_timeout << "\n";
+         << internal_stats_.num_worker_not_started_by_registration_timeout << "\n";
   buffer << "num_worker_not_started_by_process_rate_limit: "
-         << num_worker_not_started_by_process_rate_limit << "\n";
-  buffer << "num_worker_waiting_for_workers: " << num_worker_waiting_for_workers << "\n";
-  buffer << "num_cancelled_tasks: " << num_cancelled_tasks << "\n";
+         << internal_stats_.num_worker_not_started_by_process_rate_limit << "\n";
+  buffer << "num_tasks_waiting_for_workers: "
+         << internal_stats_.num_tasks_waiting_for_workers << "\n";
+  buffer << "num_cancelled_tasks: " << internal_stats_.num_cancelled_tasks << "\n";
   buffer << "Waiting tasks size: " << waiting_tasks_index_.size() << "\n";
   buffer << "Number of executing tasks: " << executing_task_args_.size() << "\n";
   buffer << "Number of pinned task arguments: " << pinned_task_arguments_.size() << "\n";
@@ -1085,23 +1118,6 @@ std::string ClusterTaskManager::DebugStr() const {
   return buffer.str();
 }
 
-void ClusterTaskManager::RecordMetrics() {
-  stats::NumReceivedTasks.Record(metric_tasks_queued_);
-  stats::NumDispatchedTasks.Record(metric_tasks_dispatched_);
-  stats::NumSpilledTasks.Record(metric_tasks_spilled_);
-  stats::NumInfeasibleSchedulingClasses.Record(infeasible_tasks_.size());
-
-  metric_tasks_queued_ = 0;
-  metric_tasks_dispatched_ = 0;
-  metric_tasks_spilled_ = 0;
-
-  uint64_t num_infeasible_tasks = 0;
-  for (const auto &pair : infeasible_tasks_) {
-    num_infeasible_tasks += pair.second.size();
-  }
-  stats::NumInfeasibleTasks.Record(num_infeasible_tasks);
-}
-
 void ClusterTaskManager::TryLocalInfeasibleTaskScheduling() {
   for (auto shapes_it = infeasible_tasks_.begin();
        shapes_it != infeasible_tasks_.end();) {
@@ -1142,7 +1158,6 @@ void ClusterTaskManager::Dispatch(
     const std::shared_ptr<TaskResourceInstances> &allocated_instances,
     const RayTask &task, rpc::RequestWorkerLeaseReply *reply,
     std::function<void(void)> send_reply_callback) {
-  metric_tasks_dispatched_++;
   const auto &task_spec = task.GetTaskSpecification();
 
   worker->SetBundleId(task_spec.PlacementGroupBundleId());
@@ -1225,7 +1240,7 @@ void ClusterTaskManager::Spillback(const NodeID &spillback_to,
     return;
   }
 
-  metric_tasks_spilled_++;
+  internal_stats_.metric_tasks_spilled++;
   const auto &task = work->task;
   const auto &task_spec = task.GetTaskSpecification();
   RAY_LOG(DEBUG) << "Spilling task " << task_spec.TaskId() << " to node " << spillback_to;

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -329,11 +329,11 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
                                      bool requires_object_store_memory,
                                      bool force_spillback, bool *is_infeasible);
 
-  /// Update the internal states.
+  /// Recompute the debug stats.
   /// It is needed because updating the debug state is expensive for cluster_task_manager.
   /// TODO(sang): Update the internal states value dynamically instead of iterating the
   /// data structure.
-  void UpdateDebugStates() const;
+  void RecomputeDebugStats() const;
 
   const NodeID &self_node_id_;
   /// Responsible for resource tracking/view of the cluster.
@@ -462,33 +462,33 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
   struct InternalStats {
     /// Number of tasks that are spilled to other
     /// nodes because it cannot be scheduled locally.
-    size_t metric_tasks_spilled = 0;
+    int64_t metric_tasks_spilled = 0;
     /// Number of tasks that are waiting for
     /// resources to be available locally.
-    size_t num_waiting_for_resource = 0;
+    int64_t num_waiting_for_resource = 0;
     /// Number of tasks that are waiting for available memory
     /// from the plasma store.
-    size_t num_waiting_for_plasma_memory = 0;
+    int64_t num_waiting_for_plasma_memory = 0;
     /// Number of tasks that are waiting for nodes with available resources.
-    size_t num_waiting_for_remote_node_resources = 0;
+    int64_t num_waiting_for_remote_node_resources = 0;
     /// Number of workers that couldn't be started because the job config wasn't local.
-    size_t num_worker_not_started_by_job_config_not_exist = 0;
+    int64_t num_worker_not_started_by_job_config_not_exist = 0;
     /// Number of workers that couldn't be started because the worker registration timed
     /// out.
-    size_t num_worker_not_started_by_registration_timeout = 0;
+    int64_t num_worker_not_started_by_registration_timeout = 0;
     /// Number of workers that couldn't be started becasue it hits the worker startup rate
     /// limit.
-    size_t num_worker_not_started_by_process_rate_limit = 0;
+    int64_t num_worker_not_started_by_process_rate_limit = 0;
     /// Number of tasks that are waiting for worker processes to start.
-    size_t num_tasks_waiting_for_workers = 0;
+    int64_t num_tasks_waiting_for_workers = 0;
     /// Number of cancelled tasks.
-    size_t num_cancelled_tasks = 0;
+    int64_t num_cancelled_tasks = 0;
     /// Number of infeasible tasks.
-    size_t num_infeasible_tasks = 0;
+    int64_t num_infeasible_tasks = 0;
     /// Number of tasks to schedule.
-    size_t num_tasks_to_schedule = 0;
+    int64_t num_tasks_to_schedule = 0;
     /// Number of tasks to dispatch.
-    size_t num_tasks_to_dispatch = 0;
+    int64_t num_tasks_to_dispatch = 0;
   };
 
   mutable InternalStats internal_stats_;

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -260,7 +260,8 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
   // Schedule and dispatch tasks.
   void ScheduleAndDispatchTasks() override;
 
-  void RecordMetrics() override;
+  /// Record the internal metrics.
+  void RecordMetrics() const override;
 
   /// The helper to dump the debug state of the cluster task manater.
   std::string DebugStr() const override;
@@ -327,6 +328,12 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
   std::string GetBestSchedulableNode(const internal::Work &work,
                                      bool requires_object_store_memory,
                                      bool force_spillback, bool *is_infeasible);
+
+  /// Update the internal states.
+  /// It is needed because updating the debug state is expensive for cluster_task_manager.
+  /// TODO(sang): Update the internal states value dynamically instead of iterating the
+  /// data structure.
+  void UpdateDebugStates() const;
 
   const NodeID &self_node_id_;
   /// Responsible for resource tracking/view of the cluster.
@@ -452,10 +459,39 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
 
   const int64_t sched_cls_cap_max_ms_;
 
-  /// Metrics collected since the last report.
-  uint64_t metric_tasks_queued_;
-  uint64_t metric_tasks_dispatched_;
-  uint64_t metric_tasks_spilled_;
+  struct InternalStats {
+    /// Number of tasks that are spilled to other
+    /// nodes because it cannot be scheduled locally.
+    size_t metric_tasks_spilled = 0;
+    /// Number of tasks that are waiting for
+    /// resources to be available locally.
+    size_t num_waiting_for_resource = 0;
+    /// Number of tasks that are waiting for available memory
+    /// from the plasma store.
+    size_t num_waiting_for_plasma_memory = 0;
+    /// Number of tasks that are waiting for nodes with available resources.
+    size_t num_waiting_for_remote_node_resources = 0;
+    /// Number of workers that couldn't be started because the job config wasn't local.
+    size_t num_worker_not_started_by_job_config_not_exist = 0;
+    /// Number of workers that couldn't be started because the worker registration timed
+    /// out.
+    size_t num_worker_not_started_by_registration_timeout = 0;
+    /// Number of workers that couldn't be started becasue it hits the worker startup rate
+    /// limit.
+    size_t num_worker_not_started_by_process_rate_limit = 0;
+    /// Number of tasks that are waiting for worker processes to start.
+    size_t num_tasks_waiting_for_workers = 0;
+    /// Number of cancelled tasks.
+    size_t num_cancelled_tasks = 0;
+    /// Number of infeasible tasks.
+    size_t num_infeasible_tasks = 0;
+    /// Number of tasks to schedule.
+    size_t num_tasks_to_schedule = 0;
+    /// Number of tasks to dispatch.
+    size_t num_tasks_to_dispatch = 0;
+  };
+
+  mutable InternalStats internal_stats_;
 
   /// Determine whether a task should be immediately dispatched,
   /// or placed on a wait queue.

--- a/src/ray/raylet/scheduling/cluster_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager_interface.h
@@ -128,8 +128,8 @@ class ClusterTaskManagerInterface {
   /// The helper to dump the debug state of the cluster task manater.
   virtual std::string DebugStr() const = 0;
 
-  /// Report high frequency scheduling metrics.
-  virtual void RecordMetrics() = 0;
+  /// Record the internal metrics.
+  virtual void RecordMetrics() const = 0;
 
   /// Check if there are enough available resources for the given input.
   virtual bool IsLocallySchedulable(const RayTask &task) const = 0;


### PR DESCRIPTION
This reverts commit 06005a527d7d0ad8bf308a7e98a99e2da2625f3b.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Share the same code for RecordMetrics & DebugString for cluster task manager.

Both requires almost identical (and also expensive) operation. This PR makes them share the same `UpdateState` code which stores stats in the struct. 

Note that we don't update state when metrics are recorded because the debug string is anyway consistently called and states are updated.

Ideally, we should dynamically update the stats.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
