### PR TITLE
When dont' start raylet, set the object_store_memory to 0 so as not to affect the memory check.

### DIFF
--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -117,6 +117,8 @@ class RayParams:
             worker available externally to the node it is running on. This will
             bind on 0.0.0.0 instead of localhost.
         env_vars (dict): Override environment variables for the raylet.
+        is_start_raylet (bool): default true, if false, set the
+            object_store_memory to 0 so as not to affect the memory check.
     """
 
     def __init__(
@@ -172,6 +174,7 @@ class RayParams:
         tracing_startup_hook=None,
         no_monitor=False,
         env_vars=None,
+        is_start_raylet=True,
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address
@@ -226,6 +229,7 @@ class RayParams:
         self.env_vars = env_vars
         self._system_config = _system_config or {}
         self._enable_object_reconstruction = enable_object_reconstruction
+        self.is_start_raylet = is_start_raylet
         self._check_usage()
 
         # Set the internal config options for object reconstruction.

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -84,9 +84,12 @@ class ResourceSpec(
         assert self.resolved()
 
         memory_units = ray_constants.to_memory_units(self.memory, round_up=False)
-        object_store_memory_units = ray_constants.to_memory_units(
-            self.object_store_memory, round_up=False
-        )
+        if self.object_store_memory == 0:
+            object_store_memory_units = 0
+        else:
+            object_store_memory_units = ray_constants.to_memory_units(
+                self.object_store_memory, round_up=False
+            )
 
         resources = dict(
             self.resources,

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -484,13 +484,17 @@ class Node:
                 object_store_memory,
                 resources,
             ) = merge_resources(env_resources, self._ray_params.resources)
+            if not self._ray_params.is_start_raylet:
+                fin_object_store_memory = 0
+            elif object_store_memory is None:
+                fin_object_store_memory = self._ray_params.object_store_memory
+            else:
+                fin_object_store_memory = object_store_memory
             self._resource_spec = ResourceSpec(
                 self._ray_params.num_cpus if num_cpus is None else num_cpus,
                 self._ray_params.num_gpus if num_gpus is None else num_gpus,
                 self._ray_params.memory if memory is None else memory,
-                self._ray_params.object_store_memory
-                if object_store_memory is None
-                else object_store_memory,
+                fin_object_store_memory,
                 resources,
                 self._ray_params.redis_max_memory,
             ).resolve(is_head=self.head, node_ip_address=self.node_ip_address)

--- a/python/ray/tests/test_object_store_memory_check.py
+++ b/python/ray/tests/test_object_store_memory_check.py
@@ -1,0 +1,13 @@
+import sys
+import pytest
+import ray
+
+
+def test_object_store_memory_check():
+    prefix_msg = "After taking into account object.*"
+    with pytest.raises(ValueError, match=prefix_msg):
+        ray.init(object_store_memory=int(999 * 1024 * 1024 * 1024))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
## Why are these changes needed?
When dont' start raylet, set the object_store_memory to 0 so as not to affect the memory check.
Merge ant team change to ray-project/ray.

The current community structure is that the Head node will also start raylet. But the ant cluster deployment mode is that the head node only has gcs and dashboard, and does not start raylet. This modification is to adapt to the scenario where the ant's internal head node does not start the raylet. In order to keep the community and internal code consistent, the community merged the code in the past.

## Related issue number
#21068

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
