### PR TITLE
Starting workers map

### DIFF
--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -175,7 +175,6 @@ def test_redefining_remote_functions(shutdown_only):
         assert ray.get(ray.get(h.remote(i))) == i
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_call_matrix(shutdown_only):
     ray.init(object_store_memory=1000 * 1024 * 1024)
 
@@ -241,7 +240,6 @@ def test_call_matrix(shutdown_only):
                     check(source_actor, dest_actor, is_large, out_of_band)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_call_order(shutdown_only):
     ray.init(num_cpus=4)
 
@@ -265,7 +263,6 @@ def test_actor_call_order(shutdown_only):
                     for i in range(100)]) == list(range(100))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_pass_by_ref_order_optimization(shutdown_only):
     ray.init(num_cpus=4)
 
@@ -303,7 +300,6 @@ def test_actor_pass_by_ref_order_optimization(shutdown_only):
     assert delta < 10, "did not skip slow value"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_cpus": 1,
@@ -359,7 +355,6 @@ def test_get_multiple(ray_start_regular_shared):
     assert results == indices
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_get_with_timeout(ray_start_regular_shared):
     SignalActor = create_remote_signal_actor(ray)
     signal = SignalActor.remote()
@@ -383,7 +378,6 @@ def test_get_with_timeout(ray_start_regular_shared):
 
 
 # https://github.com/ray-project/ray/issues/6329
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_call_actors_indirect_through_tasks(ray_start_regular_shared):
     @ray.remote
     class Counter:
@@ -413,7 +407,6 @@ def test_call_actors_indirect_through_tasks(ray_start_regular_shared):
         ray.get(zoo.remote([c]))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_inline_arg_memory_corruption(ray_start_regular_shared):
     @ray.remote
     def f():
@@ -434,7 +427,6 @@ def test_inline_arg_memory_corruption(ray_start_regular_shared):
         ray.get(a.add.remote(f.remote()))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_skip_plasma(ray_start_regular_shared):
     @ray.remote
@@ -452,7 +444,6 @@ def test_skip_plasma(ray_start_regular_shared):
     assert ray.get(obj_ref) == 2
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_actor_large_objects(ray_start_regular_shared):
     @ray.remote
@@ -473,7 +464,6 @@ def test_actor_large_objects(ray_start_regular_shared):
     assert isinstance(ray.get(obj_ref), np.ndarray)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_pass_by_ref(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -502,7 +492,6 @@ def test_actor_pass_by_ref(ray_start_regular_shared):
         ray.get(a.f.remote(error.remote()))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_actor_recursive(ray_start_regular_shared):
     @ray.remote
     class Actor:
@@ -526,7 +515,6 @@ def test_actor_recursive(ray_start_regular_shared):
     assert result == [x * 2 for x in range(100)]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows")
 def test_actor_concurrent(ray_start_regular_shared):
     @ray.remote
     class Batcher:
@@ -553,7 +541,6 @@ def test_actor_concurrent(ray_start_regular_shared):
     assert r1 == r2 == r3
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows")
 def test_actor_max_concurrency(ray_start_regular_shared):
     """
     Test that an actor of max_concurrency=N should only run
@@ -587,7 +574,6 @@ def test_actor_max_concurrency(ray_start_regular_shared):
     assert ray.get(actor.get_num_threads.remote()) <= CONCURRENCY
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_wait(ray_start_regular_shared):
     @ray.remote
     def f(delay):
@@ -635,7 +621,6 @@ def test_wait(ray_start_regular_shared):
         ray.wait([1])
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows")
 def test_duplicate_args(ray_start_regular_shared):
     @ray.remote
     def f(arg1,
@@ -675,7 +660,6 @@ def test_get_correct_node_ip():
         assert found_ip == "10.0.0.111"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
 def test_load_code_from_local(ray_start_regular_shared):
     # This case writes a driver python file to a temporary directory.
     #
@@ -716,7 +700,6 @@ if __name__ == "__main__":
         assert b"OK" in output
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Segfaults on windows")
 @pytest.mark.skipif(
     client_test_enabled(), reason="JobConfig doesn't work in client mode")
 def test_use_dynamic_function_and_class():

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -455,12 +455,12 @@ void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
       bool used;
       TaskID task_id;
       InvokePopWorkerCallbackForProcess(state.starting_dedicated_workers_to_tasks,
-                                        proc_startup_token, nullptr, status,
-                                        &found, &used, &task_id);
+                                        proc_startup_token, nullptr, status, &found,
+                                        &used, &task_id);
       if (!found) {
         InvokePopWorkerCallbackForProcess(state.starting_workers_to_tasks,
-                                          proc_startup_token, nullptr,
-                                          status, &found, &used, &task_id);
+                                          proc_startup_token, nullptr, status, &found,
+                                          &used, &task_id);
       }
       state.starting_worker_processes.erase(it);
       if (IsIOWorkerType(worker_type)) {
@@ -816,7 +816,8 @@ void WorkerPool::PopDeleteWorker(
 }
 
 void WorkerPool::InvokePopWorkerCallbackForProcess(
-    absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo> &starting_workers_to_tasks,
+    absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo>
+        &starting_workers_to_tasks,
     StartupToken startup_token, const std::shared_ptr<WorkerInterface> &worker,
     const PopWorkerStatus &status, bool *found, bool *worker_used, TaskID *task_id) {
   *found = false;
@@ -841,8 +842,8 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
   bool used;
   TaskID task_id;
   InvokePopWorkerCallbackForProcess(state.starting_dedicated_workers_to_tasks,
-                                    worker->GetStartupToken(), worker, PopWorkerStatus::OK,
-                                    &found, &used, &task_id);
+                                    worker->GetStartupToken(), worker,
+                                    PopWorkerStatus::OK, &found, &used, &task_id);
   if (found) {
     // The worker is used for the actor creation task with dynamic options.
     if (!used) {
@@ -854,8 +855,8 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
   }
 
   InvokePopWorkerCallbackForProcess(state.starting_workers_to_tasks,
-                                    worker->GetStartupToken(), worker, PopWorkerStatus::OK,
-                                    &found, &used, &task_id);
+                                    worker->GetStartupToken(), worker,
+                                    PopWorkerStatus::OK, &found, &used, &task_id);
   // The worker is not used for the actor creation task with dynamic options.
   if (!used) {
     // Put the worker to the idle pool.

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -182,7 +182,7 @@ void WorkerPool::update_worker_startup_token_counter() {
   worker_startup_token_counter_ += 1;
 }
 
-Process WorkerPool::StartWorkerProcess(
+std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
     const Language &language, const rpc::WorkerType worker_type, const JobID &job_id,
     PopWorkerStatus *status, const std::vector<std::string> &dynamic_options,
     const int runtime_env_hash, const std::string &serialized_runtime_env_context,
@@ -196,7 +196,7 @@ Process WorkerPool::StartWorkerProcess(
       // Will reschedule ready tasks in `NodeManager::HandleJobStarted`.
       *status = PopWorkerStatus::JobConfigMissing;
       process_failed_job_config_missing_++;
-      return Process();
+      return {Process(), (StartupToken)-1};
     }
     job_config = &it->second;
   }
@@ -219,7 +219,7 @@ Process WorkerPool::StartWorkerProcess(
                    << " pending registration";
     *status = PopWorkerStatus::TooManyStartingWorkerProcesses;
     process_failed_rate_limited_++;
-    return Process();
+    return {Process(), (StartupToken)-1};
   }
   // Either there are no workers pending registration or the worker start is being forced.
   RAY_LOG(DEBUG) << "Starting new worker process, current pool has " << state.idle.size()
@@ -422,12 +422,13 @@ Process WorkerPool::StartWorkerProcess(
       worker_startup_token_counter_,
       StartingWorkerProcessInfo{workers_to_start, workers_to_start, worker_type, proc,
                                 start});
+  StartupToken worker_startup_token = worker_startup_token_counter_;
   update_worker_startup_token_counter();
   if (IsIOWorkerType(worker_type)) {
     auto &io_worker_state = GetIOWorkerStateFromWorkerType(worker_type, state);
     io_worker_state.num_starting_io_workers++;
   }
-  return proc;
+  return {proc, worker_startup_token};
 }
 
 void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
@@ -453,10 +454,12 @@ void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
       bool found;
       bool used;
       TaskID task_id;
-      InvokePopWorkerCallbackForProcess(state.starting_dedicated_workers_to_tasks, proc,
-                                        nullptr, status, &found, &used, &task_id);
+      InvokePopWorkerCallbackForProcess(state.starting_dedicated_workers_to_tasks,
+                                        proc_startup_token, nullptr, status,
+                                        &found, &used, &task_id);
       if (!found) {
-        InvokePopWorkerCallbackForProcess(state.starting_workers_to_tasks, proc, nullptr,
+        InvokePopWorkerCallbackForProcess(state.starting_workers_to_tasks,
+                                          proc_startup_token, nullptr,
                                           status, &found, &used, &task_id);
       }
       state.starting_worker_processes.erase(it);
@@ -813,12 +816,12 @@ void WorkerPool::PopDeleteWorker(
 }
 
 void WorkerPool::InvokePopWorkerCallbackForProcess(
-    absl::flat_hash_map<Process, TaskWaitingForWorkerInfo> &starting_workers_to_tasks,
-    const Process &proc, const std::shared_ptr<WorkerInterface> &worker,
+    absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo> &starting_workers_to_tasks,
+    StartupToken startup_token, const std::shared_ptr<WorkerInterface> &worker,
     const PopWorkerStatus &status, bool *found, bool *worker_used, TaskID *task_id) {
   *found = false;
   *worker_used = false;
-  auto it = starting_workers_to_tasks.find(proc);
+  auto it = starting_workers_to_tasks.find(startup_token);
   if (it != starting_workers_to_tasks.end()) {
     *found = true;
     *task_id = it->second.task_id;
@@ -838,7 +841,7 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
   bool used;
   TaskID task_id;
   InvokePopWorkerCallbackForProcess(state.starting_dedicated_workers_to_tasks,
-                                    worker->GetShimProcess(), worker, PopWorkerStatus::OK,
+                                    worker->GetStartupToken(), worker, PopWorkerStatus::OK,
                                     &found, &used, &task_id);
   if (found) {
     // The worker is used for the actor creation task with dynamic options.
@@ -851,7 +854,7 @@ void WorkerPool::PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
   }
 
   InvokePopWorkerCallbackForProcess(state.starting_workers_to_tasks,
-                                    worker->GetShimProcess(), worker, PopWorkerStatus::OK,
+                                    worker->GetStartupToken(), worker, PopWorkerStatus::OK,
                                     &found, &used, &task_id);
   // The worker is not used for the actor creation task with dynamic options.
   if (!used) {
@@ -1031,7 +1034,7 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
                                      const std::string &serialized_runtime_env_context,
                                      const PopWorkerCallback &callback) -> Process {
     PopWorkerStatus status = PopWorkerStatus::OK;
-    Process proc = StartWorkerProcess(
+    auto [proc, startup_token] = StartWorkerProcess(
         task_spec.GetLanguage(), rpc::WorkerType::WORKER, task_spec.JobId(), &status,
         dynamic_options, task_spec.GetRuntimeEnvHash(), serialized_runtime_env_context,
         allocated_instances_serialized_json);
@@ -1040,9 +1043,9 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
       WarnAboutSize();
       auto task_info = TaskWaitingForWorkerInfo{task_spec.TaskId(), callback};
       if (dedicated) {
-        state.starting_dedicated_workers_to_tasks[proc] = std::move(task_info);
+        state.starting_dedicated_workers_to_tasks[startup_token] = std::move(task_info);
       } else {
-        state.starting_workers_to_tasks[proc] = std::move(task_info);
+        state.starting_workers_to_tasks[startup_token] = std::move(task_info);
       }
     } else {
       // TODO(SongGuyang): Wait until a worker is pushed or a worker can be started If
@@ -1366,7 +1369,7 @@ void WorkerPool::TryStartIOWorkers(const Language &language,
     }
     for (; expected_workers_num > 0; expected_workers_num--) {
       PopWorkerStatus status;
-      Process proc =
+      auto [proc, startup_token] =
           StartWorkerProcess(ray::Language::PYTHON, worker_type, JobID::Nil(), &status);
       if (!proc.IsValid()) {
         // We may hit the maximum worker start up concurrency limit. Stop.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -405,9 +405,9 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \param serialized_runtime_env_context The context of runtime env.
   /// \param allocated_instances_serialized_json The allocated resource instances
   //  json string.
-  /// \return The id of the process that we started if it's positive, otherwise it means
+  /// \return The process that we started and a token. If the token is less than 0,
   /// we didn't start a process.
-  Process StartWorkerProcess(
+  std::tuple<Process, StartupToken> StartWorkerProcess(
       const Language &language, const rpc::WorkerType worker_type, const JobID &job_id,
       PopWorkerStatus *status /*output*/,
       const std::vector<std::string> &dynamic_options = {},
@@ -500,12 +500,12 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     /// same with worker process PID, except starting worker process in container.
     absl::flat_hash_map<StartupToken, StartingWorkerProcessInfo>
         starting_worker_processes;
-    /// A map for looking up the task by the pid of starting worker process.
-    absl::flat_hash_map<Process, TaskWaitingForWorkerInfo> starting_workers_to_tasks;
-    /// A map for looking up the task with dynamic options by the pid of
+    /// A map for looking up the task by the startup token of starting worker process.
+    absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo> starting_workers_to_tasks;
+    /// A map for looking up the task with dynamic options by the startup token of
     /// starting worker process. Note that this is used for the dedicated worker
     /// processes.
-    absl::flat_hash_map<Process, TaskWaitingForWorkerInfo>
+    absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo>
         starting_dedicated_workers_to_tasks;
     /// We'll push a warning to the user every time a multiple of this many
     /// worker processes has been started.
@@ -599,7 +599,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// Try to find a task that is associated with the given worker process from the given
   /// queue. If found, invoke its PopWorkerCallback.
   /// \param workers_to_tasks The queue of tasks which waiting for workers.
-  /// \param proc The process which the worker belongs to.
+  /// \param startup_token The counter representing the worker.
   /// \param worker A new idle worker. If the worker is empty, we could also callback
   /// to the task.
   /// \param status The pop worker status which will be forwarded to
@@ -609,8 +609,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// true.
   /// \param task_id  The related task id.
   void InvokePopWorkerCallbackForProcess(
-      absl::flat_hash_map<Process, TaskWaitingForWorkerInfo> &workers_to_tasks,
-      const Process &proc, const std::shared_ptr<WorkerInterface> &worker,
+      absl::flat_hash_map<StartupToken, TaskWaitingForWorkerInfo> &workers_to_tasks,
+      StartupToken startup_token, const std::shared_ptr<WorkerInterface> &worker,
       const PopWorkerStatus &status, bool *found /* output */,
       bool *worker_used /* output */, TaskID *task_id /* output */);
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -599,7 +599,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// Try to find a task that is associated with the given worker process from the given
   /// queue. If found, invoke its PopWorkerCallback.
   /// \param workers_to_tasks The queue of tasks which waiting for workers.
-  /// \param startup_token The counter representing the worker.
+  /// \param startup_token The startup token representing the worker.
   /// \param worker A new idle worker. If the worker is empty, we could also callback
   /// to the task.
   /// \param status The pop worker status which will be forwarded to

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -492,8 +492,8 @@ TEST_F(WorkerPoolTest, CompareWorkerProcessObjects) {
 
 TEST_F(WorkerPoolTest, HandleWorkerRegistration) {
   PopWorkerStatus status;
-  auto [proc, token] = worker_pool_->StartWorkerProcess(Language::JAVA, rpc::WorkerType::WORKER,
-                                                  JOB_ID, &status);
+  auto [proc, token] = worker_pool_->StartWorkerProcess(
+      Language::JAVA, rpc::WorkerType::WORKER, JOB_ID, &status);
   std::vector<std::shared_ptr<WorkerInterface>> workers;
   for (int i = 0; i < NUM_WORKERS_PER_PROCESS_JAVA; i++) {
     workers.push_back(worker_pool_->CreateWorker(Process(), Language::JAVA));
@@ -984,8 +984,8 @@ TEST_F(WorkerPoolTest, DeleteWorkerPushPop) {
 TEST_F(WorkerPoolTest, NoPopOnCrashedWorkerProcess) {
   // Start a Java worker process.
   PopWorkerStatus status;
-  auto [proc, token] = worker_pool_->StartWorkerProcess(Language::JAVA, rpc::WorkerType::WORKER,
-                                                  JOB_ID, &status);
+  auto [proc, token] = worker_pool_->StartWorkerProcess(
+      Language::JAVA, rpc::WorkerType::WORKER, JOB_ID, &status);
   auto worker1 = worker_pool_->CreateWorker(Process(), Language::JAVA);
   auto worker2 = worker_pool_->CreateWorker(Process(), Language::JAVA);
 
@@ -1248,8 +1248,8 @@ TEST_F(WorkerPoolTest, TestWorkerCappingWithExitDelay) {
   for (int i = 0; i < POOL_SIZE_SOFT_LIMIT * 2; i++) {
     for (const auto &language : languages) {
       PopWorkerStatus status;
-      auto[proc, token] = worker_pool_->StartWorkerProcess(language, rpc::WorkerType::WORKER,
-                                                      JOB_ID, &status);
+      auto [proc, token] = worker_pool_->StartWorkerProcess(
+          language, rpc::WorkerType::WORKER, JOB_ID, &status);
       int workers_to_start =
           language == Language::JAVA ? NUM_WORKERS_PER_PROCESS_JAVA : 1;
       for (int j = 0; j < workers_to_start; j++) {

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -492,7 +492,7 @@ TEST_F(WorkerPoolTest, CompareWorkerProcessObjects) {
 
 TEST_F(WorkerPoolTest, HandleWorkerRegistration) {
   PopWorkerStatus status;
-  Process proc = worker_pool_->StartWorkerProcess(Language::JAVA, rpc::WorkerType::WORKER,
+  auto [proc, token] = worker_pool_->StartWorkerProcess(Language::JAVA, rpc::WorkerType::WORKER,
                                                   JOB_ID, &status);
   std::vector<std::shared_ptr<WorkerInterface>> workers;
   for (int i = 0; i < NUM_WORKERS_PER_PROCESS_JAVA; i++) {
@@ -984,7 +984,7 @@ TEST_F(WorkerPoolTest, DeleteWorkerPushPop) {
 TEST_F(WorkerPoolTest, NoPopOnCrashedWorkerProcess) {
   // Start a Java worker process.
   PopWorkerStatus status;
-  Process proc = worker_pool_->StartWorkerProcess(Language::JAVA, rpc::WorkerType::WORKER,
+  auto [proc, token] = worker_pool_->StartWorkerProcess(Language::JAVA, rpc::WorkerType::WORKER,
                                                   JOB_ID, &status);
   auto worker1 = worker_pool_->CreateWorker(Process(), Language::JAVA);
   auto worker2 = worker_pool_->CreateWorker(Process(), Language::JAVA);
@@ -1036,7 +1036,7 @@ TEST_F(WorkerPoolTest, TestWorkerCapping) {
   int num_workers = POOL_SIZE_SOFT_LIMIT + 2;
   for (int i = 0; i < num_workers; i++) {
     PopWorkerStatus status;
-    Process proc = worker_pool_->StartWorkerProcess(
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
         Language::PYTHON, rpc::WorkerType::WORKER, job_id, &status);
     auto worker = worker_pool_->CreateWorker(Process(), Language::PYTHON, job_id);
     worker->SetStartupToken(worker_pool_->GetStartupToken(proc));
@@ -1130,7 +1130,7 @@ TEST_F(WorkerPoolTest, TestWorkerCapping) {
   // Start two IO workers. These don't count towards the limit.
   {
     PopWorkerStatus status;
-    Process proc = worker_pool_->StartWorkerProcess(
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
         Language::PYTHON, rpc::WorkerType::SPILL_WORKER, job_id, &status);
     auto worker = CreateSpillWorker(Process());
     RAY_CHECK_OK(worker_pool_->RegisterWorker(worker, proc.GetId(), proc.GetId(),
@@ -1142,7 +1142,7 @@ TEST_F(WorkerPoolTest, TestWorkerCapping) {
   }
   {
     PopWorkerStatus status;
-    Process proc = worker_pool_->StartWorkerProcess(
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
         Language::PYTHON, rpc::WorkerType::RESTORE_WORKER, job_id, &status);
     auto worker = CreateRestoreWorker(Process());
     RAY_CHECK_OK(worker_pool_->RegisterWorker(worker, proc.GetId(), proc.GetId(),
@@ -1185,7 +1185,7 @@ TEST_F(WorkerPoolTest, TestWorkerCappingLaterNWorkersNotOwningObjects) {
   int num_workers = POOL_SIZE_SOFT_LIMIT * 2;
   for (int i = 0; i < num_workers; i++) {
     PopWorkerStatus status;
-    Process proc = worker_pool_->StartWorkerProcess(
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
         Language::PYTHON, rpc::WorkerType::WORKER, job_id, &status);
     auto worker = worker_pool_->CreateWorker(Process(), Language::PYTHON, job_id);
     worker->SetStartupToken(worker_pool_->GetStartupToken(proc));
@@ -1248,7 +1248,7 @@ TEST_F(WorkerPoolTest, TestWorkerCappingWithExitDelay) {
   for (int i = 0; i < POOL_SIZE_SOFT_LIMIT * 2; i++) {
     for (const auto &language : languages) {
       PopWorkerStatus status;
-      Process proc = worker_pool_->StartWorkerProcess(language, rpc::WorkerType::WORKER,
+      auto[proc, token] = worker_pool_->StartWorkerProcess(language, rpc::WorkerType::WORKER,
                                                       JOB_ID, &status);
       int workers_to_start =
           language == Language::JAVA ? NUM_WORKERS_PER_PROCESS_JAVA : 1;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
PR #19014 introduced the idea of a StartupToken to uniquely identify a worker via a counter. This PR
- returns the `Process` and the `StartupToken` from `StartWorkerProcess` (previously only `Process` was returned)
- Change the `starting_workers_to_tasks` map to index via the `StartupToken`, which seems to fix the windows failures.
- Unskip the windows tests in test_basic_2.py

It seems once a fix to PR #18167 goes in, the starting_workers_to_tasks map will be removed, which should remove the need for the changes to `StartWorkerProcess` made in this PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#20792, #20173, maybe others. Replaces #20898 and #20937

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
