### PR TITLE
[BUILD] Use bazel-skylib rule to check bazel version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,4 +17,6 @@ grpc_extra_deps()
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
-versions.check(minimum_bazel_version = "3.4.0")
+# When the bazel version is updated, make sure to update it
+# in setup.py as well.
+versions.check(minimum_bazel_version = "4.2.1")

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,6 +23,8 @@ import urllib.request
 logger = logging.getLogger(__name__)
 
 SUPPORTED_PYTHONS = [(3, 6), (3, 7), (3, 8), (3, 9)]
+# When the bazel version is updated, make sure to update it
+# in WORKSPACE file as well.
 SUPPORTED_BAZEL = (4, 2, 1)
 
 ROOT_DIR = os.path.dirname(__file__)
@@ -484,17 +486,6 @@ def build(build_python, build_java, build_cpp):
                 "--target=" + os.path.join(ROOT_DIR, THIRDPARTY_SUBDIR)
             ] + pip_packages,
             env=dict(os.environ, CC="gcc"))
-
-    version_info = bazel_invoke(subprocess.check_output, ["--version"])
-    bazel_version_str = version_info.rstrip().decode("utf-8").split(" ", 1)[1]
-    bazel_version_split = bazel_version_str.split(".")
-    bazel_version_digits = [
-        "".join(takewhile(str.isdigit, s)) for s in bazel_version_split
-    ]
-    bazel_version = tuple(map(int, bazel_version_digits))
-    if bazel_version < SUPPORTED_BAZEL:
-        logger.warning("Expected Bazel version {} but found {}".format(
-            ".".join(map(str, SUPPORTED_BAZEL)), bazel_version_str))
 
     bazel_flags = ["--verbose_failures"]
     if BAZEL_LIMIT_CPUS:

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,7 +13,6 @@ import tempfile
 import zipfile
 
 from itertools import chain
-from itertools import takewhile
 from enum import Enum
 
 import urllib.error


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Bazel has a rule for enforcing the version so we can just reuse that.

This redundant bazel version check logic in setup.py is also causing issue when building conda package, because conda has its own version of bazel and it doesn't support `--version`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
