### PR TITLE
[client][test] skip test_valid_actor_state_2

### DIFF
--- a/python/ray/tests/test_client_reconnect.py
+++ b/python/ray/tests/test_client_reconnect.py
@@ -333,7 +333,9 @@ def test_valid_actor_state():
         assert ray.get(ref) == 100
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on windows")
+# TODO(ckw017): investigate why test is flaking on HA GCS
+# details: https://github.com/ray-project/ray/issues/20907
+@pytest.mark.skipif(True, reason="Flaky on Windows and HA GCS")
 def test_valid_actor_state_2():
     """
     Do a full disconnect (cancel channel) every 11 requests. Failure


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Test_valid_actor_state_2 is currently very flaky on the HA GCS tests with "Worker has no attribute 'core_worker'". It looks like the actor isn't really left in invalid state, but rather the current way the test fixtures are written is having a weird interaction with the driver on the server. More details at #20907

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
