### PR TITLE
[Jobs] change get_job_submission_client_cluster_info back to the same positional args as 1.9

### DIFF
--- a/dashboard/modules/job/sdk.py
+++ b/dashboard/modules/job/sdk.py
@@ -32,11 +32,11 @@ class ClusterInfo:
 
 def get_job_submission_client_cluster_info(
         address: str,
-        # For backwards compatibility
-        *,
-        # only used in importlib case in parse_cluster_info, but needed
-        # in function signature.
-        create_cluster_if_needed: Optional[bool] = False,
+        # Only used in importlib case in parse_cluster_info, but needed
+        # in function signature. Included in ray 1.9 release.
+        create_cluster_if_needed: bool,
+        # NOTE: For compatibility, do not touch positional args above, only
+        # add new kwargs below.
         cookies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None) -> ClusterInfo:
@@ -63,7 +63,7 @@ def get_job_submission_client_cluster_info(
 
 def parse_cluster_info(
         address: str,
-        create_cluster_if_needed: bool = False,
+        create_cluster_if_needed: bool,
         cookies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None) -> ClusterInfo:
@@ -80,7 +80,7 @@ def parse_cluster_info(
     elif module_string == "ray":
         return get_job_submission_client_cluster_info(
             inner_address,
-            create_cluster_if_needed=create_cluster_if_needed,
+            create_cluster_if_needed,
             cookies=cookies,
             metadata=metadata,
             headers=headers)
@@ -98,7 +98,7 @@ def parse_cluster_info(
 
         return module.get_job_submission_client_cluster_info(
             inner_address,
-            create_cluster_if_needed=create_cluster_if_needed,
+            create_cluster_if_needed,
             cookies=cookies,
             metadata=metadata,
             headers=headers)
@@ -116,8 +116,12 @@ class JobSubmissionClient:
                 "The Ray jobs CLI & SDK require the ray[default] "
                 "installation: `pip install 'ray[default']``")
 
-        cluster_info = parse_cluster_info(address, create_cluster_if_needed,
-                                          cookies, metadata, headers)
+        cluster_info = parse_cluster_info(
+            address,
+            create_cluster_if_needed,
+            cookies=cookies,
+            metadata=metadata,
+            headers=headers)
         self._address = cluster_info.address
         self._cookies = cluster_info.cookies
         self._default_metadata = cluster_info.metadata or {}


### PR DESCRIPTION
## Why are these changes needed?

We had a flag `create_cluster_if_needed` in ray 1.9 release as positional args, and we want to extend this function with other features such as cookies / headers in request. There was a breaking change i merged earlier that  makes `create_cluster_if_needed` a kwargs which lead to inconsistency. 

This PR brings positional args back to the state in 1.9 and only added new args as kwargs, with inline comments that we should try to avoid touching positional args for this function in the future.

## Test Plan

`pytest * ` in jobs folder passed all existing tests.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
