### PR TITLE
[Core][GCS] add feature flag for GCS bootstrapping, and flag to pass GCS address to raylet

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -281,6 +281,8 @@ RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, false)
 // The storage backend to use for the GCS. It can be either 'redis' or 'memory'.
 RAY_CONFIG(std::string, gcs_storage, "redis")
+// Feature flag to enable GCS based bootstrapping.
+RAY_CONFIG(bool, bootstrap_with_gcs, false)
 
 /// Duration to sleep after failing to put an object in plasma because it is full.
 RAY_CONFIG(uint32_t, object_store_full_delay_ms, 10)

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -32,8 +32,7 @@ DEFINE_int32(node_manager_port, -1, "The port of node manager.");
 DEFINE_int32(metrics_agent_port, -1, "The port of metrics agent.");
 DEFINE_int32(metrics_export_port, 1, "Maximum startup concurrency");
 DEFINE_string(node_ip_address, "", "The ip address of this node.");
-DEFINE_string(gcs_address, "", "The IP address of GCS server.");
-DEFINE_int32(gcs_port, -1, "The port of GCS server.");
+DEFINE_string(gcs_address, "", "The address of the GCS server, including IP and port.");
 DEFINE_string(redis_address, "", "The ip address of redis server.");
 DEFINE_int32(redis_port, -1, "The port of redis server.");
 DEFINE_int32(min_worker_port, 0,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -32,6 +32,8 @@ DEFINE_int32(node_manager_port, -1, "The port of node manager.");
 DEFINE_int32(metrics_agent_port, -1, "The port of metrics agent.");
 DEFINE_int32(metrics_export_port, 1, "Maximum startup concurrency");
 DEFINE_string(node_ip_address, "", "The ip address of this node.");
+DEFINE_string(gcs_address, "", "The IP address of GCS server.");
+DEFINE_int32(gcs_port, -1, "The port of GCS server.");
 DEFINE_string(redis_address, "", "The ip address of redis server.");
 DEFINE_int32(redis_port, -1, "The port of redis server.");
 DEFINE_int32(min_worker_port, 0,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
It seems raylet takes redis IP and port separately, so I'm using separate flag here for GCS too. Feel free to suggest alternatives.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
