### PR TITLE
[RLlib] Always attach latest eval metrics.

### DIFF
--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -1,4 +1,3 @@
-
 a2c-breakoutnoframeskip-v4:
     env: BreakoutNoFrameskip-v4
     run: A2C
@@ -163,7 +162,7 @@ appo-pongnoframeskip-v4:
 #        evaluation_config:
 #            input: sampler
 
- cql-halfcheetahbulletenv-v0:
+cql-halfcheetahbulletenv-v0:
     env: HalfCheetahBulletEnv-v0
     run: CQL
     pass_criteria:

--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -212,6 +212,7 @@ cql-halfcheetahbulletenv-v0:
         evaluation_interval: 3
         evaluation_config:
             input: sampler
+        always_attach_evaluation_results: True
 
 ddpg-hopperbulletenv-v0:
     env: HopperBulletEnv-v0

--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -163,56 +163,56 @@ appo-pongnoframeskip-v4:
 #        evaluation_config:
 #            input: sampler
 
-# cql-halfcheetahbulletenv-v0:
-#    env: HalfCheetahBulletEnv-v0
-#    run: CQL
-#    pass_criteria:
-#        episode_reward_mean: 400.0
-#        timesteps_total: 10000000
-#    stop:
-#        time_total_s: 3600
-#    config:
-#        # Use input produced by expert SAC algo.
-#        input: ["~/halfcheetah_expert_sac.zip"]
-#        actions_in_input_normalized: true
-#
-#        soft_horizon: False
-#        horizon: 1000
-#        Q_model:
-#            fcnet_activation: relu
-#            fcnet_hiddens: [256, 256, 256]
-#        policy_model:
-#            fcnet_activation: relu
-#            fcnet_hiddens: [256, 256, 256]
-#        tau: 0.005
-#        target_entropy: auto
-#        no_done_at_end: false
-#        n_step: 3
-#        rollout_fragment_length: 1
-#        prioritized_replay: false
-#        train_batch_size: 256
-#        target_network_update_freq: 0
-#        timesteps_per_iteration: 1000
-#        learning_starts: 256
-#        optimization:
-#            actor_learning_rate: 0.0001
-#            critic_learning_rate: 0.0003
-#            entropy_learning_rate: 0.0001
-#        num_workers: 0
-#        num_gpus: 1
-#        metrics_smoothing_episodes: 5
-#
-#        # CQL Configs
-#        min_q_weight: 5.0
-#        bc_iters: 20000
-#        temperature: 1.0
-#        num_actions: 10
-#        lagrangian: False
-#
-#        # Switch on online evaluation.
-#        evaluation_interval: 3
-#        evaluation_config:
-#            input: sampler
+ cql-halfcheetahbulletenv-v0:
+    env: HalfCheetahBulletEnv-v0
+    run: CQL
+    pass_criteria:
+        episode_reward_mean: 400.0
+        timesteps_total: 10000000
+    stop:
+        time_total_s: 3600
+    config:
+        # Use input produced by expert SAC algo.
+        input: ["~/halfcheetah_expert_sac.zip"]
+        actions_in_input_normalized: true
+
+        soft_horizon: False
+        horizon: 1000
+        Q_model:
+            fcnet_activation: relu
+            fcnet_hiddens: [256, 256, 256]
+        policy_model:
+            fcnet_activation: relu
+            fcnet_hiddens: [256, 256, 256]
+        tau: 0.005
+        target_entropy: auto
+        no_done_at_end: false
+        n_step: 3
+        rollout_fragment_length: 1
+        prioritized_replay: false
+        train_batch_size: 256
+        target_network_update_freq: 0
+        timesteps_per_iteration: 1000
+        learning_starts: 256
+        optimization:
+            actor_learning_rate: 0.0001
+            critic_learning_rate: 0.0003
+            entropy_learning_rate: 0.0001
+        num_workers: 0
+        num_gpus: 1
+        metrics_smoothing_episodes: 5
+
+        # CQL Configs
+        min_q_weight: 5.0
+        bc_iters: 20000
+        temperature: 1.0
+        num_actions: 10
+        lagrangian: False
+
+        # Switch on online evaluation.
+        evaluation_interval: 3
+        evaluation_config:
+            input: sampler
 
 ddpg-hopperbulletenv-v0:
     env: HopperBulletEnv-v0

--- a/release/rllib_tests/performance_tests/performance_tests.yaml
+++ b/release/rllib_tests/performance_tests/performance_tests.yaml
@@ -100,6 +100,7 @@ cql-halfcheetahbulletenv-v0:
         evaluation_interval: 3
         evaluation_config:
             input: sampler
+        always_attach_evaluation_results: True
 
 sac-halfcheetahbulletenv-v0:
     env: HalfCheetahBulletEnv-v0

--- a/release/rllib_tests/performance_tests/performance_tests.yaml
+++ b/release/rllib_tests/performance_tests/performance_tests.yaml
@@ -52,55 +52,54 @@ appo-pongnoframeskip-v4:
         model:
             dim: 42
 
-# Bring cql test back after we make sure it learns.
-#cql-halfcheetahbulletenv-v0:
-#    env: HalfCheetahBulletEnv-v0
-#    run: CQL
-#    frameworks: [ "tf", "tf2", "torch" ]
-#    stop:
-#        time_total_s: 1800
-#    config:
-#        # Use input produced by expert SAC algo.
-#        input: ["~/halfcheetah_expert_sac.zip"]
-#        actions_in_input_normalized: true
-#
-#        soft_horizon: False
-#        horizon: 1000
-#        Q_model:
-#            fcnet_activation: relu
-#            fcnet_hiddens: [256, 256, 256]
-#        policy_model:
-#            fcnet_activation: relu
-#            fcnet_hiddens: [256, 256, 256]
-#        tau: 0.005
-#        target_entropy: auto
-#        no_done_at_end: false
-#        n_step: 3
-#        rollout_fragment_length: 1
-#        prioritized_replay: false
-#        train_batch_size: 256
-#        target_network_update_freq: 0
-#        timesteps_per_iteration: 1000
-#        learning_starts: 256
-#        optimization:
-#            actor_learning_rate: 0.0001
-#            critic_learning_rate: 0.0003
-#            entropy_learning_rate: 0.0001
-#        num_workers: 0
-#        num_gpus: 1
-#        metrics_smoothing_episodes: 5
-#
-#        # CQL Configs
-#        min_q_weight: 5.0
-#        bc_iters: 20000
-#        temperature: 1.0
-#        num_actions: 10
-#        lagrangian: False
-#
-#        # Switch on online evaluation.
-#        evaluation_interval: 3
-#        evaluation_config:
-#            input: sampler
+cql-halfcheetahbulletenv-v0:
+    env: HalfCheetahBulletEnv-v0
+    run: CQL
+    frameworks: [ "tf", "tf2", "torch" ]
+    stop:
+        time_total_s: 1800
+    config:
+        # Use input produced by expert SAC algo.
+        input: ["~/halfcheetah_expert_sac.zip"]
+        actions_in_input_normalized: true
+
+        soft_horizon: False
+        horizon: 1000
+        Q_model:
+            fcnet_activation: relu
+            fcnet_hiddens: [256, 256, 256]
+        policy_model:
+            fcnet_activation: relu
+            fcnet_hiddens: [256, 256, 256]
+        tau: 0.005
+        target_entropy: auto
+        no_done_at_end: false
+        n_step: 3
+        rollout_fragment_length: 1
+        prioritized_replay: false
+        train_batch_size: 256
+        target_network_update_freq: 0
+        timesteps_per_iteration: 1000
+        learning_starts: 256
+        optimization:
+            actor_learning_rate: 0.0001
+            critic_learning_rate: 0.0003
+            entropy_learning_rate: 0.0001
+        num_workers: 0
+        num_gpus: 1
+        metrics_smoothing_episodes: 5
+
+        # CQL Configs
+        min_q_weight: 5.0
+        bc_iters: 20000
+        temperature: 1.0
+        num_actions: 10
+        lagrangian: False
+
+        # Switch on online evaluation.
+        evaluation_interval: 3
+        evaluation_config:
+            input: sampler
 
 sac-halfcheetahbulletenv-v0:
     env: HalfCheetahBulletEnv-v0

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -161,6 +161,38 @@ class TestTrainer(unittest.TestCase):
             self.assertTrue("episode_reward_mean" in r1["evaluation"])
             self.assertNotEqual(r1["evaluation"], r3["evaluation"])
 
+    def test_evaluation_option_always_attach_eval_metrics(self):
+        config = dqn.DEFAULT_CONFIG.copy()
+        config.update({
+            "env": "CartPole-v0",
+            "evaluation_interval": 2,
+            "evaluation_duration": 2,
+            "evaluation_config": {
+                "gamma": 0.98,
+            },
+            "always_attach_evaluation_results": True,
+            # Use a custom callback that asserts that we are running the
+            # configured exact number of episodes per evaluation.
+            "callbacks": AssertEvalCallback,
+        })
+
+        for _ in framework_iterator(config, frameworks=("tf", "torch")):
+            trainer = dqn.DQNTrainer(config=config)
+            # Should always see latest available eval results.
+            r0 = trainer.train()
+            r1 = trainer.train()
+            r2 = trainer.train()
+            r3 = trainer.train()
+            trainer.stop()
+
+            # Eval results are not available at step 0.
+            # But step 3 should still have it, even though no eval was
+            # run during that step.
+            self.assertFalse("evaluation" in r0)
+            self.assertTrue("evaluation" in r1)
+            self.assertTrue("evaluation" in r2)
+            self.assertTrue("evaluation" in r3)
+
     def test_evaluation_wo_evaluation_worker_set(self):
         config = a3c.DEFAULT_CONFIG.copy()
         config.update({
@@ -186,7 +218,8 @@ class TestTrainer(unittest.TestCase):
             # set.
             config["create_env_on_driver"] = True
             trainer_w_env_on_driver = a3c.A3CTrainer(config=config)
-            results = trainer_w_env_on_driver.evaluate()
+            trainer_w_env_on_driver.evaluate()
+            results = trainer_w_env_on_driver.evaluation_metrics
             assert "evaluation" in results
             assert "episode_reward_mean" in results["evaluation"]
             trainer_w_env_on_driver.stop()

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -167,6 +167,7 @@ class TestTrainer(unittest.TestCase):
             "env": "CartPole-v0",
             "evaluation_interval": 2,
             "evaluation_duration": 2,
+            "evaluation_duration_unit": "episodes",
             "evaluation_config": {
                 "gamma": 0.98,
             },

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -219,8 +219,7 @@ class TestTrainer(unittest.TestCase):
             # set.
             config["create_env_on_driver"] = True
             trainer_w_env_on_driver = a3c.A3CTrainer(config=config)
-            trainer_w_env_on_driver.evaluate()
-            results = trainer_w_env_on_driver.evaluation_metrics
+            results = trainer_w_env_on_driver.evaluate()
             assert "evaluation" in results
             assert "episode_reward_mean" in results["evaluation"]
             trainer_w_env_on_driver.stop()

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1181,10 +1181,13 @@ class Trainer(Trainable):
                     self.evaluation_workers.remote_workers())
             metrics["timesteps_this_iter"] = num_ts_run
 
-        # Usually evaluation does not run for every step.
+        # Evaluation does not run for every step.
         # Save evaluation metrics on trainer, so it can be attached to
         # subsequent step results as latest evaluation result.
         self.evaluation_metrics = {"evaluation": metrics}
+
+        # Also return the results here for convenience.
+        return self.evaluation_metrics
 
     @DeveloperAPI
     @staticmethod

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1002,7 +1002,7 @@ class Trainer(Trainable):
                     if self.config["evaluation_duration"] == "auto":
                         unit = self.config["evaluation_duration_unit"]
                         self.evaluate(
-                            duration_fn = functools.partial(
+                            duration_fn=functools.partial(
                                 auto_duration_fn, unit, self.config[
                                     "evaluation_num_workers"], self.config[
                                         "evaluation_config"]))
@@ -1014,8 +1014,8 @@ class Trainer(Trainable):
             else:
                 self.evaluate()
 
-        if (evaluate_this_iter or
-            self.config["always_attach_evaluation_results"]):
+        if (evaluate_this_iter
+                or self.config["always_attach_evaluation_results"]):
             # Attach latest available evaluation results to train results.
             assert isinstance(self.evaluation_metrics, dict), \
                 "Trainer.evaluate() needs to return a dict."


### PR DESCRIPTION
## Why are these changes needed?

Attach latest available eval metrics with every step result dict. So Tune doesn't get confused when most of the step results don't have eval metrics.
This allows us to bring back CQL tests.

## Related issue number


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
