### PR TITLE
[Test] [runtime_env] Deflake test by bumping tasks_finish_quickly timeout from 1s to 2s

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -661,7 +661,7 @@ def test_env_installation_nonblocking(shutdown_only):
             # Env installation takes around 10 to 60 seconds.  If we fail the
             # below assert, we can be pretty sure an env installation blocked
             # the task.
-            assert time.time() - start < 1.0
+            assert time.time() - start < 2.0
             time.sleep(gap_s)
 
     assert_tasks_finish_quickly()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This assertion was failing with times in the range 1.00s-1.05s, so bump the timeout to 2.0s.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
