### PR TITLE
Revert "[core] Ensure failed to register worker is killed and print better log"

### DIFF
--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -6,7 +6,6 @@ import pytest
 import grpc
 from grpc._channel import _InactiveRpcError
 import psutil
-import subprocess
 
 import ray.ray_constants as ray_constants
 
@@ -432,40 +431,6 @@ def test_gcs_drain(ray_start_cluster_head, error_pubsub):
     """
     a = A.options(num_cpus=0).remote()
     ray.get(a.ready.remote())
-
-
-def test_worker_start_timeout(monkeypatch, ray_start_cluster):
-    # This test is to make sure
-    #   1. when worker failed to register, raylet will print useful log
-    #   2. raylet will kill hanging worker
-    with monkeypatch.context() as m:
-        # this delay will make worker start slow
-        m.setenv(
-            "RAY_testing_asio_delay_us",
-            "InternalKVGcsService.grpc_server.InternalKVGet"
-            "=2000000:2000000")
-        m.setenv("RAY_worker_register_timeout_seconds", "1")
-        cluster = ray_start_cluster
-        cluster.add_node(num_cpus=4, object_store_memory=1e9)
-        script = """
-import ray
-ray.init(address='auto')
-
-@ray.remote
-def task():
-    return None
-
-ray.get(task.remote(), timeout=3)
-"""
-        with pytest.raises(subprocess.CalledProcessError) as e:
-            run_string_as_driver(script)
-
-        # make sure log is correct
-        assert ("The process is still alive, probably "
-                "it's hanging during start") in e.value.output.decode()
-        # worker will be killed so it won't try to register to raylet
-        assert ("Received a register request from an "
-                "unknown worker shim process") not in e.value.output.decode()
 
 
 if __name__ == "__main__":

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -462,13 +462,6 @@ int Process::Wait() const {
   return status;
 }
 
-bool Process::IsAlive() const {
-  if (p_) {
-    return IsProcessAlive(p_->GetId());
-  }
-  return false;
-}
-
 void Process::Kill() {
   if (p_) {
     pid_t pid = p_->GetId();

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -88,8 +88,6 @@ class Process {
   bool IsValid() const;
   /// Forcefully kills the process. Unsafe for unowned processes.
   void Kill();
-  /// Check whether the process is alive.
-  bool IsAlive() const;
   /// Convenience function to start a process in the background.
   /// \param pid_file A file to write the PID of the spawned process in.
   static std::pair<Process, std::error_code> Spawn(


### PR DESCRIPTION
`linux://python/ray/tests:test_runtime_env_complicated` looks flaky after this pr.
Reverts ray-project/ray#20964