### PR TITLE
[RLlib] [WIP] [MultiAgentEnv Refactor #1] Add new methods to base env

### DIFF
--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Callable, Tuple, Optional, List, Dict, Any, TYPE_CHECKING,\
     Union
 
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from ray.rllib.env.vector_env import VectorEnv
 
 ASYNC_RESET_RETURN = "async_reset_return"
+
+logger = logging.getLogger(__name__)
 
 
 @PublicAPI
@@ -195,6 +198,16 @@ class BaseEnv:
         return []
 
     @PublicAPI
+    def get_agent_ids(self) -> Dict[EnvID, List[AgentID]]:
+        """Return the agent ids for each sub-environment.
+
+        Returns:
+            A dict mapping from env_id to a list of agent_ids.
+        """
+        logger.warning("get_agent_ids() has not been implemented")
+        return {}
+
+    @PublicAPI
     def try_render(self, env_id: Optional[EnvID] = None) -> None:
         """Tries to render the sub-environment with the given id or all.
 
@@ -245,10 +258,72 @@ class BaseEnv:
         """
         raise NotImplementedError
 
+    @PublicAPI
+    def action_space_sample(self, agent_id: list = None) -> MultiEnvDict:
+        """Returns a random action for each environment, and potentially each
+            agent in that environment.
+
+        Args:
+            agent_id: List of agent ids to sample actions for. If None or empty
+                list, sample actions for all agents in the environment.
+
+        Returns:
+            A random action for each environment.
+        """
+        del agent_id
+        return {}
+
+    @PublicAPI
+    def observation_space_sample(self, agent_id: list = None) -> MultiEnvDict:
+        """Returns a random observation for each environment, and potentially
+            each agent in that environment.
+
+        Args:
+            agent_id: List of agent ids to sample actions for. If None or empty
+                list, sample actions for all agents in the environment.
+
+        Returns:
+            A random action for each environment.
+        """
+        logger.warning("observation_space_sample() has not been implemented")
+        return {}
+
+    @PublicAPI
+    def last(self) -> Tuple[MultiEnvDict, MultiEnvDict, MultiEnvDict,
+                            MultiEnvDict, MultiEnvDict]:
+        """Returns the last observations, rewards, and done flags that were
+            returned by the environment.
+
+        Returns:
+            The last observations, rewards, and done flags for each environment
+        """
+        logger.warning("last has not been implemented for this environment.")
+        return {}, {}, {}, {}, {}
+
+    @PublicAPI
     def observation_space_contains(self, x: MultiEnvDict) -> bool:
+        """Checks if the given observation is valid for each environment.
+
+        Args:
+            x: Observations to check.
+
+        Returns:
+            True if the observations are contained within their respective
+                spaces. False otherwise.
+        """
         self._space_contains(self.observation_space, x)
 
+    @PublicAPI
     def action_space_contains(self, x: MultiEnvDict) -> bool:
+        """Checks if the given actions is valid for each environment.
+
+        Args:
+            x: Actions to check.
+
+        Returns:
+            True if the actions are contained within their respective
+                spaces. False otherwise.
+        """
         return self._space_contains(self.action_space, x)
 
     @staticmethod


### PR DESCRIPTION
RLlib Environments are difficult to test. Particularly Base Environments and MultiAgentEnvironments. This is because they are missing necessary required fields in order to test them.

The biggest issue that I face right now is that the MultiAgentEnv API is too loosely defined to write basic environment tests where I would follow this rough workflow:

```
reset_obs = env.try_reset()
assert env.obs_space_contains(reset_obs)
sampled_actions = env.action_space_sample()
env.send_actions(sampled_actions)
next_obs, dones, rewards, infos = env.poll()

assert env.obs_space_contains(next_obs)
assert isinstance(dones, dict)
assert isinstance(rewards, dict)
assert isinstance(infos, dict)
```

Because the MultiAgentEnv API is too loosely defined to be able to follow this workflow, I can’t write a BaseEnv checking module.

This PR Adds the necessary BaseEnv methods for making BaseEnvs unit-testable and checkable with an environment checking module.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
