### PR TITLE
[tune] Show the name of training func, instead of just ImplicitFunction.

### DIFF
--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -568,6 +568,9 @@ def wrap_function(train_func: Callable[[Any], Any],
         _name = name or (train_func.__name__
                          if hasattr(train_func, "__name__") else "func")
 
+        def __repr__(self):
+            return self._name
+
         def _trainable_func(self, config, reporter, checkpoint_dir):
             if not use_checkpoint and not use_reporter:
                 fn = partial(train_func, config)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See sample output:
```
(train_mnist pid=39303) WARNING:tensorflow:From /Users/xwjiang/ray/python/ray/tune/examples/tf_distributed_keras_example.py:49: _CollectiveAllReduceStrategyExperimental.__init__ (from tensorflow.python.distribute.collective_all_reduce_strategy) is deprecated and will be removed in a future version.
(train_mnist pid=39303) Instructions for updating:
(train_mnist pid=39303) use distribute.MultiWorkerMirroredStrategy instead
(train_mnist pid=39303) 2021-12-10 17:45:26.471905: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
(train_mnist pid=39303) To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
(train_mnist pid=39303) 2021-12-10 17:45:26.476495: I tensorflow/core/distributed_runtime/rpc/grpc_channel.cc:272] Initialize GrpcChannelCache for job worker -> {0 -> 127.0.0.1:62516, 1 -> 127.0.0.1:62518}
(train_mnist pid=39303) 2021-12-10 17:45:26.477083: I tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc:427] Started server with target: grpc://127.0.0.1:62518
(train_mnist pid=39304) WARNING:tensorflow:From /Users/xwjiang/ray/python/ray/tune/examples/tf_distributed_keras_example.py:49: _CollectiveAllReduceStrategyExperimental.__init__ (from tensorflow.python.distribute.collective_all_reduce_strategy) is deprecated and will be removed in a future version.
(train_mnist pid=39304) Instructions for updating:
(train_mnist pid=39304) use distribute.MultiWorkerMirroredStrategy instead
(train_mnist pid=39304) 2021-12-10 17:45:26.471349: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
(train_mnist pid=39304) To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
(train_mnist pid=39304) 2021-12-10 17:45:26.476290: I tensorflow/core/distributed_runtime/rpc/grpc_channel.cc:272] Initialize GrpcChannelCache for job worker -> {0 -> 127.0.0.1:62516, 1 -> 127.0.0.1:62518}
(train_mnist pid=39304) 2021-12-10 17:45:26.476866: I tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc:427] Started server with target: grpc://127.0.0.1:62516
(train_mnist pid=39303) 2021-12-10 17:45:26.988813: W tensorflow/core/grappler/optimizers/data/auto_shard.cc:695] AUTO sharding policy will apply DATA sharding policy as it failed to apply FILE sharding policy because of the following reason: Found an unshardable source dataset: name: "TensorSliceDataset/_2"
(train_mnist pid=39303) op: "TensorSliceDataset"
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
