### PR TITLE
[serve] support not exposing deployments over http

### DIFF
--- a/dashboard/modules/snapshot/snapshot_schema.json
+++ b/dashboard/modules/snapshot/snapshot_schema.json
@@ -181,7 +181,7 @@
                       "type": "integer"
                     },
                     "httpRoute": {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     "name": {
                       "type": "string"

--- a/dashboard/modules/snapshot/tests/test_snapshot.py
+++ b/dashboard/modules/snapshot/tests/test_snapshot.py
@@ -162,7 +162,7 @@ my_func_deleted.delete()
     assert entry_deleted["name"] == "my_func_deleted"
     assert entry_deleted["version"] == "v1"
     assert entry_deleted["namespace"] == "serve"
-    assert entry_deleted["httpRoute"] == "/my_func_deleted"
+    assert entry_deleted["httpRoute"] is None
     assert entry_deleted["className"] == "my_func_deleted"
     assert entry_deleted["status"] == "DELETED"
     assert entry["rayJobId"] is not None

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -993,6 +993,7 @@ def deployment(
             passed when you call `.deploy()` on the returned Deployment.
         route_prefix (Optional[str]): Requests to paths under this HTTP path
             prefix will be routed to this deployment. Defaults to '/{name}'.
+            When set to 'None', no HTTP endpoint will be created.
             Routing is done based on longest-prefix match, so if you have
             deployment A with a prefix of '/a' and deployment B with a prefix
             of '/a/b', requests to '/a', '/a/', and '/a/c' go to A and requests

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -915,7 +915,8 @@ class Deployment:
             self._config == other._config,
             self._init_args == other._init_args,
             self._init_kwargs == other._init_kwargs,
-            self._route_prefix == other._route_prefix,
+            # compare route prefix with default value resolved
+            self.route_prefix == other.route_prefix,
             self._ray_actor_options == self._ray_actor_options,
         ])
 

--- a/python/ray/serve/common.py
+++ b/python/ray/serve/common.py
@@ -17,7 +17,7 @@ Duration = float
 
 @dataclass
 class EndpointInfo:
-    route: Optional[str] = None
+    route: str
 
 
 class DeploymentInfo:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -220,10 +220,7 @@ class ServeController:
             entry["class_name"] = (
                 deployment_info.replica_config.func_or_class_name)
             entry["version"] = deployment_info.version or "None"
-            # TODO(architkulkarni): When we add the feature to allow
-            # deployments with no HTTP route, update the below line.
-            # Or refactor the route_prefix logic in the Deployment class.
-            entry["http_route"] = route_prefix or f"/{deployment_name}"
+            entry["http_route"] = route_prefix
             entry["start_time"] = deployment_info.start_time_ms
             entry["end_time"] = deployment_info.end_time_ms or 0
             entry["status"] = ("DELETED"
@@ -333,8 +330,9 @@ class ServeController:
 
         goal_id, updating = self.deployment_state_manager.deploy(
             name, deployment_info)
-        endpoint_info = EndpointInfo(route=route_prefix)
-        self.endpoint_state.update_endpoint(name, endpoint_info)
+        if route_prefix is not None:
+            endpoint_info = EndpointInfo(route=route_prefix)
+            self.endpoint_state.update_endpoint(name, endpoint_info)
         return goal_id, updating
 
     def delete_deployment(self, name: str) -> Optional[GoalId]:

--- a/python/ray/serve/endpoint_state.py
+++ b/python/ray/serve/endpoint_state.py
@@ -54,8 +54,7 @@ class EndpointState:
         """
         existing_route_endpoint = self._get_endpoint_for_route(
             endpoint_info.route)
-        if (endpoint_info.route is not None
-                and existing_route_endpoint is not None
+        if (existing_route_endpoint is not None
                 and existing_route_endpoint != endpoint):
             raise ValueError(
                 f"route_prefix '{endpoint_info.route}' is already registered.")

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -3,11 +3,10 @@ import concurrent.futures
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Union, Coroutine
 import threading
-from enum import Enum
 
 from ray.serve.common import EndpointTag
 from ray.actor import ActorHandle
-from ray.serve.utils import get_random_letters
+from ray.serve.utils import get_random_letters, DEFAULT
 from ray.serve.router import Router, RequestMetadata
 from ray.util import metrics
 
@@ -33,12 +32,6 @@ class HandleOptions:
     shard_key: Optional[str] = None
     http_method: str = "GET"
     http_headers: Dict[str, str] = field(default_factory=dict)
-
-
-# Use a global singleton enum to emulate default options. We cannot use None
-# for those option because None is a valid new value.
-class DEFAULT(Enum):
-    VALUE = 1
 
 
 class RayServeHandle:

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -111,14 +111,8 @@ class LongestPrefixRouter:
         routes = []
         route_info = {}
         for endpoint, info in endpoints.items():
-            # Default case where the user did not specify a route prefix.
-            if info.route is None:
-                route = f"/{endpoint}"
-            else:
-                route = info.route
-
-            routes.append(route)
-            route_info[route] = endpoint
+            routes.append(info.route)
+            route_info[info.route] = endpoint
             if endpoint in self.handles:
                 existing_handles.remove(endpoint)
             else:
@@ -208,7 +202,7 @@ class HTTPProxy:
                        endpoints: Dict[EndpointTag, EndpointInfo]) -> None:
         self.route_info: Dict[str, Tuple[EndpointTag, List[str]]] = dict()
         for endpoint, info in endpoints.items():
-            route = info.route if info.route is not None else f"/{endpoint}"
+            route = info.route
             self.route_info[route] = endpoint
 
         self.prefix_router.update_routes(endpoints)

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -19,6 +19,7 @@ import ray
 from ray import serve
 from ray.exceptions import GetTimeoutError
 from ray.serve.http_util import make_fastapi_class_based_view
+from ray.serve.utils import DEFAULT
 from ray._private.test_utils import SignalActor
 
 
@@ -410,7 +411,7 @@ def test_asgi_compatible(serve_instance):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
-@pytest.mark.parametrize("route_prefix", [None, "/", "/subpath"])
+@pytest.mark.parametrize("route_prefix", [DEFAULT.VALUE, "/", "/subpath"])
 def test_doc_generation(serve_instance, route_prefix):
     app = FastAPI()
 
@@ -423,10 +424,7 @@ def test_doc_generation(serve_instance, route_prefix):
 
     App.deploy()
 
-    if route_prefix is None:
-        prefix = "/App"
-    else:
-        prefix = route_prefix
+    prefix = App.route_prefix
 
     if not prefix.endswith("/"):
         prefix += "/"

--- a/python/ray/serve/tests/test_http_prefix_matching.py
+++ b/python/ray/serve/tests/test_http_prefix_matching.py
@@ -21,7 +21,7 @@ def test_no_match(mock_longest_prefix_router):
 
 def test_default_route(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo()})
+    router.update_routes({"endpoint": EndpointInfo(route="/endpoint")})
 
     route, handle = router.match_route("/nonexistent")
     assert route is None and handle is None
@@ -77,12 +77,12 @@ def test_prefix_match(mock_longest_prefix_router):
 
 def test_update_routes(mock_longest_prefix_router):
     router = mock_longest_prefix_router
-    router.update_routes({"endpoint": EndpointInfo()})
+    router.update_routes({"endpoint": EndpointInfo(route="/endpoint")})
 
     route, handle = router.match_route("/endpoint")
     assert route == "/endpoint" and handle == "endpoint"
 
-    router.update_routes({"endpoint2": EndpointInfo()})
+    router.update_routes({"endpoint2": EndpointInfo(route="/endpoint2")})
 
     route, handle = router.match_route("/endpoint")
     assert route is None and handle is None

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -88,6 +88,21 @@ def test_routes_endpoint(serve_instance):
     assert routes["/hello"] == "D3", routes
 
 
+def test_deployment_without_route(serve_instance):
+    @serve.deployment(route_prefix=None)
+    class D:
+        def __call__(self, *args):
+            return "1"
+
+    D.deploy()
+    routes = requests.get("http://localhost:8000/-/routes").json()
+    assert len(routes) == 0
+
+    # make sure the deployment is not exposed under the default route
+    r = requests.get(f"http://localhost:8000/{D.name}")
+    assert r.status_code == 404
+
+
 def test_deployment_options_default_route(serve_instance):
     @serve.deployment(name="1")
     class D1:

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -19,8 +19,15 @@ from ray.exceptions import RayTaskError
 from ray.util.serialization import StandaloneSerializationContext
 from ray.serve.constants import HTTP_PROXY_TIMEOUT
 from ray.serve.http_util import build_starlette_request, HTTPRequestWrapper
+from enum import Enum
 
 ACTOR_FAILURE_RETRY_TIMEOUT_S = 60
+
+
+# Use a global singleton enum to emulate default options. We cannot use None
+# for those option because None is a valid new value.
+class DEFAULT(Enum):
+    VALUE = 1
 
 
 def parse_request_item(request_item):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://discuss.ray.io/t/disable-route-for-serve-backend/2895
Currently it is not possible to have a deployment that is only accessible through serve handles.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #17083

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
