### PR TITLE
Increase in `num_tasks` for stable wait times in `test_worker_capping:test_exponential_wait`

### DIFF
--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -147,7 +147,7 @@ def test_zero_cpu_scheduling(shutdown_only):
 def test_exponential_wait(shutdown_only):
     ray.init(num_cpus=2)
 
-    num_tasks = 4
+    num_tasks = 6
 
     @ray.remote(num_cpus=0)
     class Barrier:
@@ -177,8 +177,8 @@ def test_exponential_wait(shutdown_only):
 
     # Assert that last_wwait / second_last ~= 2, with a healthy buffer since ci
     # is noisy.
-    assert 1 < last_wait / second_last < 4
-    assert 2 < last_wait < 4
+    assert 2 * second_last < last_wait < 4 * second_last
+    assert 7 < last_wait < 10
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -177,7 +177,7 @@ def test_exponential_wait(shutdown_only):
 
     # Assert that last_wwait / second_last ~= 2, with a healthy buffer since ci
     # is noisy.
-    assert 2 * second_last < last_wait < 4 * second_last
+    assert second_last < last_wait < 4 * second_last
     assert 7 < last_wait
 
 

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -178,7 +178,7 @@ def test_exponential_wait(shutdown_only):
     # Assert that last_wwait / second_last ~= 2, with a healthy buffer since ci
     # is noisy.
     assert 2 * second_last < last_wait < 4 * second_last
-    assert 7 < last_wait < 10
+    assert 7 < last_wait
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `results` with lesser tasks contains un-stable wait times, so increased the number of tasks in a hope for less noisy wait times. Minor in changes in assert comparisons have also been made for lesser error. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

cc: @wuisawesome 