### PR TITLE
[tune] Remove unnecessary scan of self._running in RayTrialExecutor.

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -404,13 +404,9 @@ class RayTrialExecutor(TrialExecutor):
     def _train(self, trial):
         """Start one iteration of training and save remote id."""
 
-        if self._find_item(self._running, trial):
-            logging.debug(
-                "Trial {} already has a queued future. Skipping this "
-                "`train` call. This may occur if a trial has "
-                "been unpaused within a scheduler callback.".format(
-                    str(trial)))
-            return
+        assert not self._find_item(self._running, trial), (
+            f"Trial {trial} should not have an outstanding future when "
+            f"`train` is called.")
 
         assert trial.status == Trial.RUNNING, trial.status
         buffer_time_s = max(
@@ -440,8 +436,6 @@ class RayTrialExecutor(TrialExecutor):
             remote = _LocalWrapper(remote)
 
         self._running[remote] = trial
-        trial_item = self._find_item(self._running, trial)
-        assert len(trial_item) < 2, trial_item
 
     def _start_trial(self, trial) -> bool:
         """Starts trial and restores last result if trial was paused.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
