### PR TITLE
[gcs] Fix can not resue actor name in same namespace

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -537,8 +537,10 @@ Status GcsActorManager::CreateActor(const ray::rpc::CreateActorRequest &request,
 
   // Remove the actor from the unresolved actor map.
   const auto job_id = JobID::FromBinary(request.task_spec().job_id());
-  auto actor =
-      std::make_shared<GcsActor>(request.task_spec(), get_ray_namespace_(job_id));
+  const auto &actor_namespace = iter->second->GetRayNamespace();
+  auto actor = std::make_shared<GcsActor>(
+      request.task_spec(),
+      actor_namespace.empty() ? get_ray_namespace_(job_id) : actor_namespace);
   actor->GetMutableActorTableData()->set_state(rpc::ActorTableData::PENDING_CREATION);
   const auto &actor_table_data = actor->GetActorTableData();
   // Pub this state for dashboard showing.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -282,6 +282,24 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// change.
   void SchedulePendingActors();
 
+  /// Destroy an actor that has gone out of scope. This cleans up all local
+  /// state associated with the actor and marks the actor as dead. For owned
+  /// actors, this should be called when all actor handles have gone out of
+  /// scope or the owner has died.
+  /// NOTE: This method can be called multiple times in out-of-order and should be
+  /// idempotent.
+  ///
+  /// \param[in] actor_id The actor id to destroy.
+  /// \param[in] death_cause The reason why actor is destroyed.
+  void DestroyActor(const ActorID &actor_id, const rpc::ActorDeathCause &death_cause);
+
+  /// Kill the specified actor.
+  ///
+  /// \param actor_id ID of the actor to kill.
+  /// \param force_kill Whether to force kill an actor by killing the worker.
+  /// \param no_restart If set to true, the killed actor will not be restarted anymore.
+  void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
+
   /// Handle a node death. This will restart all actors associated with the
   /// specified node id, including actors which are scheduled or have been
   /// created on this node. Actors whose owners have died (possibly due to this
@@ -375,17 +393,6 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// called for detached actors.
   void PollOwnerForActorOutOfScope(const std::shared_ptr<GcsActor> &actor);
 
-  /// Destroy an actor that has gone out of scope. This cleans up all local
-  /// state associated with the actor and marks the actor as dead. For owned
-  /// actors, this should be called when all actor handles have gone out of
-  /// scope or the owner has died.
-  /// NOTE: This method can be called multiple times in out-of-order and should be
-  /// idempotent.
-  ///
-  /// \param[in] actor_id The actor id to destroy.
-  /// \param[in] death_cause The reason why actor is destroyed.
-  void DestroyActor(const ActorID &actor_id, const rpc::ActorDeathCause &death_cause);
-
   /// Get unresolved actors that were submitted from the specified node.
   absl::flat_hash_map<WorkerID, absl::flat_hash_set<ActorID>>
   GetUnresolvedActorsByOwnerNode(const NodeID &node_id) const;
@@ -414,13 +421,6 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   ///
   /// \param actor The actor to be removed.
   void RemoveActorFromOwner(const std::shared_ptr<GcsActor> &actor);
-
-  /// Kill the specified actor.
-  ///
-  /// \param actor_id ID of the actor to kill.
-  /// \param force_kill Whether to force kill an actor by killing the worker.
-  /// \param no_restart If set to true, the killed actor will not be restarted anymore.
-  void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
 
   /// Notify CoreWorker to kill the specified actor.
   ///

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -282,24 +282,6 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// change.
   void SchedulePendingActors();
 
-  /// Destroy an actor that has gone out of scope. This cleans up all local
-  /// state associated with the actor and marks the actor as dead. For owned
-  /// actors, this should be called when all actor handles have gone out of
-  /// scope or the owner has died.
-  /// NOTE: This method can be called multiple times in out-of-order and should be
-  /// idempotent.
-  ///
-  /// \param[in] actor_id The actor id to destroy.
-  /// \param[in] death_cause The reason why actor is destroyed.
-  void DestroyActor(const ActorID &actor_id, const rpc::ActorDeathCause &death_cause);
-
-  /// Kill the specified actor.
-  ///
-  /// \param actor_id ID of the actor to kill.
-  /// \param force_kill Whether to force kill an actor by killing the worker.
-  /// \param no_restart If set to true, the killed actor will not be restarted anymore.
-  void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
-
   /// Handle a node death. This will restart all actors associated with the
   /// specified node id, including actors which are scheduled or have been
   /// created on this node. Actors whose owners have died (possibly due to this
@@ -393,6 +375,17 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// called for detached actors.
   void PollOwnerForActorOutOfScope(const std::shared_ptr<GcsActor> &actor);
 
+  /// Destroy an actor that has gone out of scope. This cleans up all local
+  /// state associated with the actor and marks the actor as dead. For owned
+  /// actors, this should be called when all actor handles have gone out of
+  /// scope or the owner has died.
+  /// NOTE: This method can be called multiple times in out-of-order and should be
+  /// idempotent.
+  ///
+  /// \param[in] actor_id The actor id to destroy.
+  /// \param[in] death_cause The reason why actor is destroyed.
+  void DestroyActor(const ActorID &actor_id, const rpc::ActorDeathCause &death_cause);
+
   /// Get unresolved actors that were submitted from the specified node.
   absl::flat_hash_map<WorkerID, absl::flat_hash_set<ActorID>>
   GetUnresolvedActorsByOwnerNode(const NodeID &node_id) const;
@@ -421,6 +414,13 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   ///
   /// \param actor The actor to be removed.
   void RemoveActorFromOwner(const std::shared_ptr<GcsActor> &actor);
+
+  /// Kill the specified actor.
+  ///
+  /// \param actor_id ID of the actor to kill.
+  /// \param force_kill Whether to force kill an actor by killing the worker.
+  /// \param no_restart If set to true, the killed actor will not be restarted anymore.
+  void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart);
 
   /// Notify CoreWorker to kill the specified actor.
   ///

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -164,11 +164,12 @@ class GcsActorManagerTest : public ::testing::Test {
     return address;
   }
 
-  std::shared_ptr<gcs::GcsActor> RegisterActor(const JobID &job_id, int max_restarts = 0,
-                                               bool detached = false,
-                                               const std::string &name = "") {
+  std::shared_ptr<gcs::GcsActor> RegisterActor(
+      const JobID &job_id, int max_restarts = 0, bool detached = false,
+      const std::string &name = "", const std::string &ray_namespace = "") {
     std::promise<std::shared_ptr<gcs::GcsActor>> promise;
-    auto request = Mocker::GenRegisterActorRequest(job_id, max_restarts, detached, name);
+    auto request = Mocker::GenRegisterActorRequest(job_id, max_restarts, detached, name,
+                                                   ray_namespace);
     // `DestroyActor` triggers some asynchronous operations.
     // If we register an actor after destroying an actor, it may result in multithreading
     // reading and writing the same variable. In order to avoid the problem of
@@ -968,6 +969,46 @@ TEST_F(GcsActorManagerTest, TestRayNamespace) {
     ASSERT_TRUE(status.IsNotFound());
     ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "").Binary(),
               request1.task_spec().actor_creation_task_spec().actor_id());
+  }
+}
+
+TEST_F(GcsActorManagerTest, TestReuseActorNameInNamespace) {
+  auto job_id_1 = JobID::FromInt(1);
+  auto job_id_2 = JobID::FromInt(2);
+
+  std::string actor_name = "actor";
+  std::string ray_namespace = "actor_namespace";
+
+  auto request =
+      Mocker::GenRegisterActorRequest(job_id_1, 0, true, actor_name, ray_namespace);
+  ActorID actor_id =
+      ActorID::FromBinary(request.task_spec().actor_creation_task_spec().actor_id());
+  {
+    Status status = gcs_actor_manager_->RegisterActor(
+        request, [](const std::shared_ptr<gcs::GcsActor> &actor) {});
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
+              actor_id.Binary());
+  }
+
+  auto kill_request = Mocker::GenKillActorViaGcsRequest(actor_id);
+  {
+    ray::rpc::ActorDeathCause death_cause;
+    death_cause.mutable_killed_by_app_context()->set_error_message(
+        "The actor is dead because it was killed by `ray.kill`.");
+    gcs_actor_manager_->DestroyActor(actor_id, death_cause);
+    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
+              ActorID::Nil().Binary());
+  }
+
+  {
+    auto request_1 =
+        Mocker::GenRegisterActorRequest(job_id_2, 0, true, actor_name, ray_namespace);
+    Status status = gcs_actor_manager_->RegisterActor(
+        request_1, [](const std::shared_ptr<gcs::GcsActor> &actor) {});
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
+              actor_id.Binary());
   }
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -164,9 +164,10 @@ class GcsActorManagerTest : public ::testing::Test {
     return address;
   }
 
-  std::shared_ptr<gcs::GcsActor> RegisterActor(
-      const JobID &job_id, int max_restarts = 0, bool detached = false,
-      const std::string &name = "", const std::string &ray_namespace = "") {
+  std::shared_ptr<gcs::GcsActor> RegisterActor(const JobID &job_id, int max_restarts = 0,
+                                               bool detached = false,
+                                               const std::string &name = "",
+                                               const std::string &ray_namespace = "") {
     std::promise<std::shared_ptr<gcs::GcsActor>> promise;
     auto request = Mocker::GenRegisterActorRequest(job_id, max_restarts, detached, name,
                                                    ray_namespace);
@@ -973,42 +974,43 @@ TEST_F(GcsActorManagerTest, TestRayNamespace) {
 }
 
 TEST_F(GcsActorManagerTest, TestReuseActorNameInNamespace) {
-  auto job_id_1 = JobID::FromInt(1);
-  auto job_id_2 = JobID::FromInt(2);
-
   std::string actor_name = "actor";
   std::string ray_namespace = "actor_namespace";
 
-  auto request =
+  auto job_id_1 = JobID::FromInt(1);
+  auto request_1 =
       Mocker::GenRegisterActorRequest(job_id_1, 0, true, actor_name, ray_namespace);
-  ActorID actor_id =
-      ActorID::FromBinary(request.task_spec().actor_creation_task_spec().actor_id());
+  ActorID actor_id_1 =
+      ActorID::FromBinary(request_1.task_spec().actor_creation_task_spec().actor_id());
   {
     Status status = gcs_actor_manager_->RegisterActor(
-        request, [](const std::shared_ptr<gcs::GcsActor> &actor) {});
+        request_1, [](const std::shared_ptr<gcs::GcsActor> &actor) {});
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
-              actor_id.Binary());
+              actor_id_1.Binary());
   }
 
-  auto kill_request = Mocker::GenKillActorViaGcsRequest(actor_id);
+  auto kill_request = Mocker::GenKillActorViaGcsRequest(actor_id_1);
   {
     ray::rpc::ActorDeathCause death_cause;
     death_cause.mutable_killed_by_app_context()->set_error_message(
         "The actor is dead because it was killed by `ray.kill`.");
-    gcs_actor_manager_->DestroyActor(actor_id, death_cause);
+    gcs_actor_manager_->DestroyActor(actor_id_1, death_cause);
     ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
               ActorID::Nil().Binary());
   }
 
   {
-    auto request_1 =
+    auto job_id_2 = JobID::FromInt(2);
+    auto request_2 =
         Mocker::GenRegisterActorRequest(job_id_2, 0, true, actor_name, ray_namespace);
+    auto actor_id_2 =
+        ActorID::FromBinary(request_2.task_spec().actor_creation_task_spec().actor_id());
     Status status = gcs_actor_manager_->RegisterActor(
-        request_1, [](const std::shared_ptr<gcs::GcsActor> &actor) {});
+        request_2, [](const std::shared_ptr<gcs::GcsActor> &actor) {});
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
-              actor_id.Binary());
+              actor_id_2.Binary());
   }
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_based_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_based_actor_scheduler_test.cc
@@ -73,7 +73,7 @@ class GcsBasedActorSchedulerTest : public ::testing::Test {
 
     std::unordered_map<std::string, double> required_resources;
     auto actor_creating_task_spec = Mocker::GenActorCreationTask(
-        job_id, /*max_restarts=*/1, /*detached=*/true, /*name=*/"", owner_address,
+        job_id, /*max_restarts=*/1, /*detached=*/true, /*name=*/"", "", owner_address,
         required_resources, required_placement_resources);
     return std::make_shared<gcs::GcsActor>(actor_creating_task_spec.GetMessage(),
                                            /*ray_namespace=*/"");

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -83,13 +83,6 @@ struct Mocker {
     return request;
   }
 
-  static rpc::KillActorViaGcsRequest GenKillActorViaGcsRequest(const ActorID &actor_id) {
-    rpc::KillActorViaGcsRequest request;
-    request.set_actor_id(actor_id.Binary());
-    request.set_no_restart(true);
-    return request;
-  }
-
   static BundleSpecification GenBundleCreation(
       const PlacementGroupID &placement_group_id, const int bundle_index,
       absl::flat_hash_map<std::string, double> &unit_resource) {

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -31,7 +31,7 @@ namespace ray {
 struct Mocker {
   static TaskSpecification GenActorCreationTask(
       const JobID &job_id, int max_restarts, bool detached, const std::string &name,
-      const rpc::Address &owner_address,
+      const std::string &ray_namespace, const rpc::Address &owner_address,
       std::unordered_map<std::string, double> required_resources =
           std::unordered_map<std::string, double>(),
       std::unordered_map<std::string, double> required_placement_resources =
@@ -48,39 +48,45 @@ struct Mocker {
     rpc::SchedulingStrategy scheduling_strategy;
     scheduling_strategy.mutable_default_scheduling_strategy();
     builder.SetActorCreationTaskSpec(actor_id, {}, scheduling_strategy, max_restarts,
-                                     /*max_task_retries=*/0, {}, 1, detached, name);
+                                     /*max_task_retries=*/0, {}, 1, detached, name,
+                                     ray_namespace);
     return builder.Build();
   }
 
-  static rpc::CreateActorRequest GenCreateActorRequest(const JobID &job_id,
-                                                       int max_restarts = 0,
-                                                       bool detached = false,
-                                                       const std::string name = "") {
+  static rpc::CreateActorRequest  GenCreateActorRequest(
+      const JobID &job_id, int max_restarts = 0, bool detached = false,
+      const std::string &name = "", const std::string &ray_namespace = "") {
     rpc::Address owner_address;
     owner_address.set_raylet_id(NodeID::FromRandom().Binary());
     owner_address.set_ip_address("1234");
     owner_address.set_port(5678);
     owner_address.set_worker_id(WorkerID::FromRandom().Binary());
-    auto actor_creation_task_spec =
-        GenActorCreationTask(job_id, max_restarts, detached, name, owner_address);
+    auto actor_creation_task_spec = GenActorCreationTask(
+        job_id, max_restarts, detached, name, ray_namespace, owner_address);
     rpc::CreateActorRequest request;
     request.mutable_task_spec()->CopyFrom(actor_creation_task_spec.GetMessage());
     return request;
   }
 
-  static rpc::RegisterActorRequest GenRegisterActorRequest(const JobID &job_id,
-                                                           int max_restarts = 0,
-                                                           bool detached = false,
-                                                           const std::string name = "") {
+  static rpc::RegisterActorRequest GenRegisterActorRequest(
+      const JobID &job_id, int max_restarts = 0, bool detached = false,
+      const std::string &name = "", const std::string &ray_namespace = "") {
     rpc::Address owner_address;
     owner_address.set_raylet_id(NodeID::FromRandom().Binary());
     owner_address.set_ip_address("1234");
     owner_address.set_port(5678);
     owner_address.set_worker_id(WorkerID::FromRandom().Binary());
-    auto actor_creation_task_spec =
-        GenActorCreationTask(job_id, max_restarts, detached, name, owner_address);
+    auto actor_creation_task_spec = GenActorCreationTask(
+        job_id, max_restarts, detached, name, ray_namespace, owner_address);
     rpc::RegisterActorRequest request;
     request.mutable_task_spec()->CopyFrom(actor_creation_task_spec.GetMessage());
+    return request;
+  }
+
+  static rpc::KillActorViaGcsRequest GenKillActorViaGcsRequest(const ActorID &actor_id) {
+    rpc::KillActorViaGcsRequest request;
+    request.set_actor_id(actor_id.Binary());
+    request.set_no_restart(true);
     return request;
   }
 

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -53,7 +53,7 @@ struct Mocker {
     return builder.Build();
   }
 
-  static rpc::CreateActorRequest  GenCreateActorRequest(
+  static rpc::CreateActorRequest GenCreateActorRequest(
       const JobID &job_id, int max_restarts = 0, bool detached = false,
       const std::string &name = "", const std::string &ray_namespace = "") {
     rpc::Address owner_address;


### PR DESCRIPTION
Before this PR, GcsActorManager::CreateActor() would replace actor's namespace by
actors's owner job's namespace, even if actor is created by user with a user specified
namespace. But in named_actors_, actor is set to use user specified namespace by
GcsActorManager::RegisterActor before CreateActor() is called, So that
GcsActorManager::DestroyActor failed to find actor from named_actors_ by owner job's
namespace to remove, hence reuse actor name in same namespace failed for same name actor
not removed by GcsActorManager::DestroyActor in named_actors_.

issue #20611

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
