### PR TITLE
[RLlib] [MultiAgentEnv Refactor #2] Change space types for `BaseEnvs` and `MultiAgentEnvs`

### DIFF
--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -271,6 +271,7 @@ class BaseEnv:
         Returns:
             A random action for each environment.
         """
+        logger.warning("action_space_sample() has not been implemented")
         del agent_id
         return {}
 
@@ -287,6 +288,7 @@ class BaseEnv:
             A random action for each environment.
         """
         logger.warning("observation_space_sample() has not been implemented")
+        del agent_id
         return {}
 
     @PublicAPI
@@ -337,8 +339,6 @@ class BaseEnv:
         Returns:
             True if the observations of x are contained in space.
         """
-        # this removes the agent_id key and inner dicts
-        # in MultiEnvDicts
         agents = set(self.get_agent_ids())
         for multi_agent_dict in x.values():
             for agent_id, obs in multi_agent_dict:

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -234,12 +234,10 @@ class BaseEnv:
     @PublicAPI
     @property
     def observation_space(self) -> gym.Space:
-        """Returns the observation space for each environment.
+        """Returns the observation space for each agent.
 
         Note: samples from the observation space need to be preprocessed into a
             `MultiEnvDict` before being used by a policy.
-
-        The space will either be a gym.space directly corresponding to the
 
         Returns:
             The observation space for each environment.
@@ -249,7 +247,7 @@ class BaseEnv:
     @PublicAPI
     @property
     def action_space(self) -> gym.Space:
-        """Returns the action space for each environment.
+        """Returns the action space for each agent.
 
         Note: samples from the action space need to be preprocessed into a
             `MultiEnvDict` before being passed to `send_actions`.

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -340,16 +340,13 @@ class BaseEnv:
         # this removes the agent_id key and inner dicts
         # in MultiEnvDicts
         agents = set(self.get_agent_ids())
-        ret = True
-        for _, multi_agent_dict in x.items():
+        for multi_agent_dict in x.values():
             for agent_id, obs in multi_agent_dict:
-                if agent_id != _DUMMY_AGENT_ID:
-                    if agent_id not in agents:
-                        return False
-                    if not space[agent_id].contains(obs):
-                        return False
+                if (agent_id not in agents) or (
+                        not space[agent_id].contains(obs)):
+                    return False
 
-        return ret
+        return True
 
 
 # Fixed agent identifier when there is only the single agent in the env

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -1,4 +1,3 @@
-import abc
 import gym
 import logging
 from typing import Callable, Dict, List, Tuple, Type, Optional, Union, Set
@@ -17,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @PublicAPI
-class MultiAgentEnv(gym.Env, abc.ABC):
+class MultiAgentEnv(gym.Env):
     """An environment that hosts multiple independent agents.
 
     Agents are identified by (string) agent ids. Note that these "agents" here

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -23,6 +23,7 @@ class MultiAgentEnv(abc.ABC):
     are not to be confused with RLlib Trainers, which are also sometimes
     referred to as "agents" or "RL agents".
     """
+
     def __init__(self):
         self.observation_space = None
         self.action_space = None
@@ -96,8 +97,8 @@ class MultiAgentEnv(abc.ABC):
             x: Observations to check.
 
         Returns:
-            True if the observation space contains the given all observations in
-                x.
+            True if the observation space contains the given all observations
+                in x.
         """
         logger.warning("observation_space_contains() has not been implemented")
         raise True
@@ -121,8 +122,9 @@ class MultiAgentEnv(abc.ABC):
             agent in that environment.
 
         Args:
-            agent_ids: List of agent ids to sample actions for. If None or empty
-                list, sample actions for all agents in the environment.
+            agent_ids: List of agent ids to sample actions for. If None or
+                empty list, sample actions for all agents in the
+                environment.
 
         Returns:
             A random action for each environment.
@@ -138,8 +140,9 @@ class MultiAgentEnv(abc.ABC):
         the agents in agent_ids.
 
         Args:
-            agent_ids: List of agent ids to sample actions for. If None or empty
-                list, sample actions for all agents in the environment.
+            agent_ids: List of agent ids to sample actions for. If None or
+                empty list, sample actions for all agents in the
+                environment.
 
         Returns:
             A random action for each environment.
@@ -320,23 +323,30 @@ def make_multi_agent(
             self.action_space = self.agents[0].action_space
 
         @override(MultiAgentEnv)
-        def observation_space_sample(self, agent_ids: list = None) -> MultiEnvDict:
+        def observation_space_sample(self,
+                                     agent_ids: list = None) -> MultiEnvDict:
             if agent_ids is None:
                 agent_ids = list(range(len(self.agents)))
-            obs = {env_id: {
-                agent_id: self.observation_space.sample()
-                for agent_id in agent_ids
-            } for env_id in range(len(self.agents))}
+            obs = {
+                env_id: {
+                    agent_id: self.observation_space.sample()
+                    for agent_id in agent_ids
+                }
+                for env_id in range(len(self.agents))
+            }
             return obs
 
         @override(MultiAgentEnv)
         def action_space_sample(self, agent_ids: list = None) -> MultiEnvDict:
             if agent_ids is None:
                 agent_ids = list(range(len(self.agents)))
-            obs = {env_id: {
-                agent_id: self.action_space.sample()
-                for agent_id in agent_ids
-            } for env_id in range(len(self.agents))}
+            obs = {
+                env_id: {
+                    agent_id: self.action_space.sample()
+                    for agent_id in agent_ids
+                }
+                for env_id in range(len(self.agents))
+            }
             return obs
 
         @override(MultiAgentEnv)

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -535,19 +535,21 @@ class MultiAgentEnvWrapper(BaseEnv):
 
     @override(BaseEnv)
     def observation_space_contains(self, x: MultiEnvDict) -> bool:
-        return self.envs[0].observation_space_contains(x)
+        return all(
+            self.envs[0].observation_space_contains(val) for val in x.values())
 
     @override(BaseEnv)
     def action_space_contains(self, x: MultiEnvDict) -> bool:
-        return self.envs[0].action_space_contains(x)
+        return all(
+            self.envs[0].action_space_contains(val) for val in x.values())
 
     @override(BaseEnv)
-    def observation_space_sample(self, agent_id: list = None) -> MultiEnvDict:
-        return self.envs[0].observation_space_sample(agent_id)
+    def observation_space_sample(self, agent_ids: list = None) -> MultiEnvDict:
+        return self.envs[0].observation_space_sample(agent_ids)
 
     @override(BaseEnv)
-    def action_space_sample(self, agent_id: list = None) -> MultiEnvDict:
-        return self.envs[0].action_space_sample(agent_id)
+    def action_space_sample(self, agent_ids: list = None) -> MultiEnvDict:
+        return self.envs[0].action_space_sample(agent_ids)
 
 
 class _MultiAgentEnvState:

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -192,10 +192,10 @@ class MultiAgentEnv(gym.Env):
 
     @PublicAPI
     def get_agent_ids(self) -> Set[AgentID]:
-        """Returns a list of agent ids in the environment.
+        """Returns a set of agent ids in the environment.
 
         Returns:
-            List of agent ids.
+            set of agent ids.
         """
         if not isinstance(self._agent_ids, set):
             self._agent_ids = set(self._agent_ids)

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -1,5 +1,5 @@
 import gym
-from typing import Callable, Dict, List, Tuple, Type, Optional, Union
+from typing import Callable, Dict, List, Tuple, Type, Optional, Union, Set
 
 from ray.rllib.env.base_env import BaseEnv
 from ray.rllib.env.env_context import EnvContext
@@ -19,6 +19,15 @@ class MultiAgentEnv(gym.Env):
     are not to be confused with RLlib Trainers, which are also sometimes
     referred to as "agents" or "RL agents".
     """
+
+    @PublicAPI
+    def get_agent_ids(self) -> Set[AgentID]:
+        """Returns a list of agent ids in the environment.
+
+        Returns:
+            List of agent ids.
+        """
+        return {}
 
     @PublicAPI
     def reset(self) -> MultiAgentDict:
@@ -355,18 +364,13 @@ class MultiAgentEnvWrapper(BaseEnv):
     @override(BaseEnv)
     @PublicAPI
     def observation_space(self) -> gym.spaces.Dict:
-        space = {
-            _id: env.observation_space
-            for _id, env in enumerate(self.envs)
-        }
-        return gym.spaces.Dict(space)
+        self.envs[0].observation_space
 
     @property
     @override(BaseEnv)
     @PublicAPI
     def action_space(self) -> gym.Space:
-        space = {_id: env.action_space for _id, env in enumerate(self.envs)}
-        return gym.spaces.Dict(space)
+        return self.envs[0].action_space
 
 
 class _MultiAgentEnvState:

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @PublicAPI
-class MultiAgentEnv(abc.ABC):
+class MultiAgentEnv(gym.Env, abc.ABC):
     """An environment that hosts multiple independent agents.
 
     Agents are identified by (string) agent ids. Note that these "agents" here

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -1,0 +1,50 @@
+import pytest
+from ray.rllib.env.multi_agent_env import make_multi_agent
+from ray.rllib.tests.test_nested_observation_spaces import NestedMultiAgentEnv
+
+
+class TestMultiAgentEnv:
+    def test_space_in_preferred_format(self):
+        env = NestedMultiAgentEnv()
+        spaces_in_preferred_format = \
+            env._check_if_space_maps_agent_id_to_sub_space()
+        assert spaces_in_preferred_format, "Space is not in preferred " \
+                                           "format"
+        env2 = make_multi_agent("CartPole-v1")()
+        spaces_in_preferred_format = \
+            env2._check_if_space_maps_agent_id_to_sub_space()
+        assert not spaces_in_preferred_format, "Space should not be in " \
+                                               "preferred format but is."
+
+    def test_spaces_sample_contain_in_preferred_format(self):
+        env = NestedMultiAgentEnv()
+        # this environment has spaces that are in the preferred format
+        # for multi-agent environments where the spaces are dict spaces
+        # mapping agent-ids to sub-spaces
+        obs = env.observation_space_sample()
+        assert env.observation_space_contains(obs), "Observation space does " \
+                                                    "not contain obs"
+
+        action = env.action_space_sample()
+        assert env.action_space_contains(action), "Action space does " \
+                                                  "not contain action"
+
+    def test_spaces_sample_contain_not_in_preferred_format(self):
+        env = make_multi_agent("CartPole-v1")({"num_agents": 2})
+        # this environment has spaces that are not in the preferred format
+        # for multi-agent environments where the spaces not in the preferred
+        # format, users must override the observation_space_contains,
+        # action_space_contains observation_space_sample,
+        # and action_space_sample methods in order to do proper checks
+        obs = env.observation_space_sample()
+        assert env.observation_space_contains(obs), "Observation space does " \
+                                                    "not contain obs"
+        action = env.action_space_sample()
+        assert env.action_space_contains(action), "Action space does " \
+                                                  "not contain action"
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/env/vector_env.py
+++ b/rllib/env/vector_env.py
@@ -339,24 +339,3 @@ class VectorEnvWrapper(BaseEnv):
     @PublicAPI
     def action_space(self) -> gym.Space:
         return self._action_space
-
-    @staticmethod
-    def _space_contains(space: gym.Space, x: MultiEnvDict) -> bool:
-        """Check if the given space contains the observations of x.
-
-        Args:
-            space: The space to if x's observations are contained in.
-            x: The observations to check.
-
-        Note: With vector envs, we can process the raw observations
-            and ignore the agent ids and env ids, since vector envs'
-            sub environements are guaranteed to be the same
-
-        Returns:
-            True if the observations of x are contained in space.
-        """
-        for _, multi_agent_dict in x.items():
-            for _, element in multi_agent_dict.items():
-                if not space.contains(element):
-                    return False
-        return True

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -120,6 +120,15 @@ class RepeatedSpaceEnv(gym.Env):
 
 class NestedMultiAgentEnv(MultiAgentEnv):
     def __init__(self):
+        self.observation_space = spaces.Dict({
+            "dict_agent": DICT_SPACE,
+            "tuple_agent": TUPLE_SPACE
+        })
+        self.action_space = spaces.Dict({
+            "dict_agent": spaces.Discrete(1),
+            "tuple_agent": spaces.Discrete(1)
+        })
+        self._agent_ids = {"dict_agent", "tuple_agent"}
         self.steps = 0
 
     def reset(self):


### PR DESCRIPTION
Environment's spaces should always be of the format:

`{agent_id_1: space_1, agent_id_2 : space_2}` in the multi-agent case, and `gym.Space` for non-multi-agent vectorized environments. 

**This differs from a change I made recently where my spaces mapped `{env_id : env.space}`. I misunderstood that when a base environment has multiple sub environments, this can only mean that the environment has been vectorized, and not that multiple different types of environments have been initialized in the `BaseEnv`.** 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
