### PR TITLE
[Java]Init gcs client in runtime only if necessary

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
@@ -54,7 +54,7 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
   protected TaskExecutor taskExecutor;
   protected FunctionManager functionManager;
   protected RuntimeContext runtimeContext;
-  protected GcsClient gcsClient;
+  GcsClient gcsClient;
 
   protected ObjectStore objectStore;
   protected TaskSubmitter taskSubmitter;
@@ -217,19 +217,19 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
 
   @Override
   public PlacementGroup getPlacementGroup(PlacementGroupId id) {
-    return gcsClient.getPlacementGroupInfo(id);
+    return getGcsClient().getPlacementGroupInfo(id);
   }
 
   @Override
   public PlacementGroup getPlacementGroup(String name, String namespace) {
     return namespace == null
-        ? gcsClient.getPlacementGroupInfo(name, runtimeContext.getNamespace())
-        : gcsClient.getPlacementGroupInfo(name, namespace);
+        ? getGcsClient().getPlacementGroupInfo(name, runtimeContext.getNamespace())
+        : getGcsClient().getPlacementGroupInfo(name, namespace);
   }
 
   @Override
   public List<PlacementGroup> getAllPlacementGroups() {
-    return gcsClient.getAllPlacementGroupInfo();
+    return getGcsClient().getAllPlacementGroupInfo();
   }
 
   @Override
@@ -398,8 +398,11 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
 
   @Override
   public GcsClient getGcsClient() {
+    createGcsClient();
     return gcsClient;
   }
+
+  abstract void createGcsClient();
 
   @Override
   public void setIsContextSet(boolean isContextSet) {

--- a/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/AbstractRayRuntime.java
@@ -28,7 +28,6 @@ import io.ray.runtime.functionmanager.FunctionDescriptor;
 import io.ray.runtime.functionmanager.FunctionManager;
 import io.ray.runtime.functionmanager.PyFunctionDescriptor;
 import io.ray.runtime.functionmanager.RayFunction;
-import io.ray.runtime.gcs.GcsClient;
 import io.ray.runtime.generated.Common;
 import io.ray.runtime.generated.Common.Language;
 import io.ray.runtime.object.ObjectRefImpl;
@@ -54,7 +53,6 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
   protected TaskExecutor taskExecutor;
   protected FunctionManager functionManager;
   protected RuntimeContext runtimeContext;
-  GcsClient gcsClient;
 
   protected ObjectStore objectStore;
   protected TaskSubmitter taskSubmitter;
@@ -395,14 +393,6 @@ public abstract class AbstractRayRuntime implements RayRuntimeInternal {
   public RuntimeContext getRuntimeContext() {
     return runtimeContext;
   }
-
-  @Override
-  public GcsClient getGcsClient() {
-    createGcsClient();
-    return gcsClient;
-  }
-
-  abstract void createGcsClient();
 
   @Override
   public void setIsContextSet(boolean isContextSet) {

--- a/java/runtime/src/main/java/io/ray/runtime/RayDevRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayDevRuntime.java
@@ -83,6 +83,11 @@ public class RayDevRuntime extends AbstractRayRuntime {
   }
 
   @Override
+  void createGcsClient() {
+    throw new UnsupportedOperationException("Ray doesn't have gcs client in local mode.");
+  }
+
+  @Override
   public Object getAsyncContext() {
     return new AsyncContext(((LocalModeWorkerContext) workerContext).getCurrentTask());
   }

--- a/java/runtime/src/main/java/io/ray/runtime/RayDevRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayDevRuntime.java
@@ -8,6 +8,7 @@ import io.ray.api.placementgroup.PlacementGroup;
 import io.ray.api.runtimecontext.ResourceValue;
 import io.ray.runtime.config.RayConfig;
 import io.ray.runtime.context.LocalModeWorkerContext;
+import io.ray.runtime.gcs.GcsClient;
 import io.ray.runtime.generated.Common.TaskSpec;
 import io.ray.runtime.object.LocalModeObjectStore;
 import io.ray.runtime.task.LocalModeTaskExecutor;
@@ -83,7 +84,7 @@ public class RayDevRuntime extends AbstractRayRuntime {
   }
 
   @Override
-  void createGcsClient() {
+  public GcsClient getGcsClient() {
     throw new UnsupportedOperationException("Ray doesn't have gcs client in local mode.");
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There's a redis connection in gcs client, but most time the gcs client is never used in worker. We can make the initialization lazy to reduce redis connections.
After that, the number of redis connections reduces from 2 to 1 in one core worker.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
