### PR TITLE
[Job][Docs] Update oss docs arch image

### DIFF
--- a/doc/source/ray-job-submission/overview.rst
+++ b/doc/source/ray-job-submission/overview.rst
@@ -282,4 +282,4 @@ Job Submission Architecture
 
 The following diagram shows the underlying structure and steps for each Job submission.
 
-.. image:: https://raw.githubusercontent.com/ray-project/images/master/docs/job/job_subimssion_arch.png
+.. image:: https://raw.githubusercontent.com/ray-project/images/master/docs/job/job_submission_arch_v2.png


### PR DESCRIPTION
## Why are these changes needed?

We had a new round of knowledge sharing with some re-work on arch. This image reflects the most up-to-date arch where previous one was from original design.

new content: https://raw.githubusercontent.com/ray-project/images/master/docs/job/job_submission_arch_v2.png

<img width="1733" alt="job_submission_arch_v2" src="https://user-images.githubusercontent.com/6372689/146058101-3d8f4f93-4c09-4b23-b3af-9466a8cc18fd.png">


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
