### PR TITLE
[Core] fix wrong memory size reporting

### DIFF
--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -197,8 +197,7 @@ double ResourceSet::GetNumCpusAsDouble() const {
 std::string format_resource(std::string resource_name, double quantity) {
   if (resource_name == "object_store_memory" ||
       resource_name.find(kMemory_ResourceLabel) == 0) {
-    // The memory resources (in 50MiB unit) are converted to GiB
-    return std::to_string(quantity * 50 / 1024) + " GiB";
+    return std::to_string(quantity / (1024 * 1024 * 1024)) + " GiB";
   }
   return std::to_string(quantity);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current resource reporting is run in OSS.  Revert the change. For example it reported
```
InitialConfigResources: {node:172.31.45.118: 1.000000}, {object_store_memory: 468605759.960938 GiB},
```
For 10GB memory object_store.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
