### PR TITLE
[Nightly tests] Add memory monitor to scalability tests

### DIFF
--- a/benchmarks/distributed/test_many_actors.py
+++ b/benchmarks/distributed/test_many_actors.py
@@ -39,13 +39,17 @@ def no_resource_leaks():
 ray.init(address="auto")
 
 test_utils.wait_for_condition(no_resource_leaks)
+monitor_actor = test_utils.monitor_memory_usage()
 start_time = time.time()
 test_max_actors()
 end_time = time.time()
+ray.get(monitor_actor.stop_run.remote())
+used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
+print(f"Peak memory usage: {round(used_gb, 2)}GB")
+print(f"Peak memory usage per processes:\n {usage}")
 test_utils.wait_for_condition(no_resource_leaks)
 
 rate = MAX_ACTORS_IN_CLUSTER / (end_time - start_time)
-
 print(f"Success! Started {MAX_ACTORS_IN_CLUSTER} actors in "
       f"{end_time - start_time}s. ({rate} actors/s)")
 
@@ -55,6 +59,8 @@ if "TEST_OUTPUT_JSON" in os.environ:
         "actors_per_second": rate,
         "num_actors": MAX_ACTORS_IN_CLUSTER,
         "time": end_time - start_time,
-        "success": "1"
+        "success": "1",
+        "_peak_memory": round(used_gb, 2),
+        "_peak_process_memory": usage
     }
     json.dump(results, out_file)

--- a/benchmarks/distributed/test_many_pgs.py
+++ b/benchmarks/distributed/test_many_pgs.py
@@ -65,13 +65,17 @@ def no_resource_leaks():
 ray.init(address="auto")
 
 test_utils.wait_for_condition(no_resource_leaks)
+monitor_actor = test_utils.monitor_memory_usage()
 start_time = time.time()
 test_many_placement_groups()
 end_time = time.time()
+ray.get(monitor_actor.stop_run.remote())
+used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
+print(f"Peak memory usage: {round(used_gb, 2)}GB")
+print(f"Peak memory usage per processes:\n {usage}")
 test_utils.wait_for_condition(no_resource_leaks)
 
 rate = MAX_PLACEMENT_GROUPS / (end_time - start_time)
-
 print(f"Success! Started {MAX_PLACEMENT_GROUPS} pgs in "
       f"{end_time - start_time}s. ({rate} pgs/s)")
 
@@ -81,6 +85,8 @@ if "TEST_OUTPUT_JSON" in os.environ:
         "pgs_per_second": rate,
         "num_pgs": MAX_PLACEMENT_GROUPS,
         "time": end_time - start_time,
-        "success": "1"
+        "success": "1",
+        "_peak_memory": round(used_gb, 2),
+        "_peak_process_memory": usage
     }
     json.dump(results, out_file)

--- a/benchmarks/distributed/test_many_tasks.py
+++ b/benchmarks/distributed/test_many_tasks.py
@@ -54,13 +54,17 @@ def test(num_tasks):
     ray.init(address="auto")
 
     test_utils.wait_for_condition(no_resource_leaks)
+    monitor_actor = test_utils.monitor_memory_usage()
     start_time = time.time()
     test_max_running_tasks(num_tasks)
     end_time = time.time()
+    ray.get(monitor_actor.stop_run.remote())
+    used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
+    print(f"Peak memory usage: {round(used_gb, 2)}GB")
+    print(f"Peak memory usage per processes:\n {usage}")
     test_utils.wait_for_condition(no_resource_leaks)
 
     rate = num_tasks / (end_time - start_time - sleep_time)
-
     print(f"Success! Started {num_tasks} tasks in {end_time - start_time}s. "
           f"({rate} tasks/s)")
 
@@ -70,7 +74,9 @@ def test(num_tasks):
             "tasks_per_second": rate,
             "num_tasks": num_tasks,
             "time": end_time - start_time,
-            "success": "1"
+            "success": "1",
+            "_peak_memory": round(used_gb, 2),
+            "_peak_process_memory": usage
         }
         json.dump(results, out_file)
 

--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -366,7 +366,6 @@
     timeout: 3600
     prepare: python wait_cluster.py 2 600
     script: python placement_group_tests/long_running_performance_test.py --num-stages 2000
-  stable: false
 
 - name: placement_group_performance_test
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds memory monitoring to scalability envelope tests so that we can compare the peak memory usage for both nonHA & HA.

NOTE: the current way of adding memory monitor is not great, and we should implement fixture to support this better, but that's not in progress yet. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
