### PR TITLE
[Serve] Run long poll callbacks in event loop

### DIFF
--- a/python/ray/serve/long_poll.py
+++ b/python/ray/serve/long_poll.py
@@ -1,6 +1,7 @@
 import asyncio
 from asyncio.events import AbstractEventLoop
 import random
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -17,7 +18,13 @@ from ray.serve.utils import logger
 # a few seconds and let each client retry on their end.
 # We randomly select a timeout within this range to avoid a "thundering herd"
 # when there are many clients subscribing at the same time.
-LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S = (30, 60)
+LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S = (
+    int(
+        os.environ.get("LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_LOWER_BOUND",
+                       "30")),
+    int(
+        os.environ.get("LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_UPPER_BOUND",
+                       "60")))
 
 
 class LongPollNamespace(Enum):
@@ -50,18 +57,21 @@ class LongPollClient:
         host_actor(ray.ActorHandle): handle to actor embedding LongPollHost.
         key_listeners(Dict[str, AsyncCallable]): a dictionary mapping keys to
           callbacks to be called on state update for the corresponding keys.
-        call_in_event_loop(Optional[AbstractEventLoop]): an optional event loop
-          to post the callback into. The callbacks were called within a cpp
-          core worker thread if the event loop is not passed in.
+        call_in_event_loop(AbstractEventLoop): an asyncio event loop
+          to post the callback into.
     """
 
     def __init__(
             self,
             host_actor,
             key_listeners: Dict[KeyType, UpdateStateCallable],
-            call_in_event_loop: Optional[AbstractEventLoop] = None,
+            call_in_event_loop: AbstractEventLoop,
     ) -> None:
         assert len(key_listeners) > 0
+        # We used to allow this to be optional, but due to Ray Client issue
+        # we now enforce all long poll client to post callback to event loop
+        # See https://github.com/ray-project/ray/issues/20971
+        assert call_in_event_loop is not None
 
         self.host_actor = host_actor
         self.key_listeners = key_listeners
@@ -104,6 +114,17 @@ class LongPollClient:
         self._current_ref._on_completed(
             lambda update: self._process_update(update))
 
+    def _schedule_to_event_loop(self, callback):
+        # Schedule the next iteration only if the loop is running.
+        # The event loop might not be running if users used a cached
+        # version across loops.
+        if self.event_loop.is_running():
+            self.event_loop.call_soon_threadsafe(callback)
+        else:
+            logger.error("The event loop is closed, shutting down long poll "
+                         "client.")
+            self.is_running = False
+
     def _process_update(self, updates: Dict[str, UpdatedObject]):
         if isinstance(updates, (ray.exceptions.RayActorError)):
             # This can happen during shutdown where the controller is
@@ -127,7 +148,9 @@ class LongPollClient:
                 # Some error happened in the controller. It could be a bug or
                 # some undesired state.
                 logger.error("LongPollHost errored\n" + updates.traceback_str)
-            self._poll_next()
+            # We must call this in event loop so it works in Ray Client.
+            # See https://github.com/ray-project/ray/issues/20971
+            self._schedule_to_event_loop(self._poll_next)
             return
 
         logger.debug(f"LongPollClient {self} received updates for keys: "
@@ -143,19 +166,7 @@ class LongPollClient:
                 callback(arg)
                 self._on_callback_completed(trigger_at=len(updates))
 
-            if self.event_loop is None:
-                chained()
-            else:
-                # Schedule the next iteration only if the loop is running.
-                # The event loop might not be running if users used a cached
-                # version across loops.
-                if self.event_loop.is_running():
-                    self.event_loop.call_soon_threadsafe(chained)
-                else:
-                    logger.error(
-                        "The event loop is closed, shutting down long poll "
-                        "client.")
-                    self.is_running = False
+            self._schedule_to_event_loop(chained)
 
 
 class LongPollHost:

--- a/python/ray/serve/long_poll.py
+++ b/python/ray/serve/long_poll.py
@@ -5,8 +5,7 @@ import os
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import (Any, Optional, Tuple, Callable, DefaultDict, Dict, Set,
-                    Union)
+from typing import (Any, Tuple, Callable, DefaultDict, Dict, Set, Union)
 
 import ray
 from ray.serve.utils import logger

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -91,7 +91,8 @@ def test_long_poll_restarts(serve_instance):
     assert new_timer.object_snapshot != timer.object_snapshot
 
 
-def test_client(serve_instance):
+@pytest.mark.asyncio
+async def test_client(serve_instance):
     host = ray.remote(LongPollHost).remote()
 
     # Write two values
@@ -106,10 +107,12 @@ def test_client(serve_instance):
     def key_2_callback(result):
         callback_results["key_2"] = result
 
-    client = LongPollClient(host, {
-        "key_1": key_1_callback,
-        "key_2": key_2_callback,
-    })
+    client = LongPollClient(
+        host, {
+            "key_1": key_1_callback,
+            "key_2": key_2_callback,
+        },
+        call_in_event_loop=asyncio.get_event_loop())
 
     while len(client.object_snapshots) == 0:
         time.sleep(0.1)
@@ -124,7 +127,7 @@ def test_client(serve_instance):
         values.add(client.object_snapshots["key_2"])
         if 1999 in values:
             break
-        time.sleep(1)
+        await asyncio.sleep(1)
     assert 1999 in values
 
     assert callback_results == {"key_1": 100, "key_2": 1999}

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -1,6 +1,7 @@
 import random
 import subprocess
 import sys
+import time
 
 import pytest
 import requests
@@ -28,8 +29,13 @@ def ray_client_instance(scope="module"):
 
 
 @pytest.fixture
-def serve_with_client(ray_client_instance):
-    ray.util.connect(ray_client_instance, namespace="default_test_namespace")
+def serve_with_client(ray_client_instance, ray_init_kwargs=None):
+    if ray_init_kwargs is None:
+        ray_init_kwargs = dict()
+    ray.init(
+        f"ray://{ray_client_instance}",
+        namespace="default_test_namespace",
+        **ray_init_kwargs)
     assert ray.util.client.ray.is_connected()
 
     yield
@@ -147,6 +153,37 @@ def test_quickstart_counter(serve_with_client):
     print("query 1 finished")
     assert ray.get(Counter.get_handle().remote()) == {"count": 2}
     print("query 2 finished")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
+@pytest.mark.parametrize(
+    "serve_with_client", [{
+        "runtime_env": {
+            "env_vars": {
+                "LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_LOWER_BOUND": "1",
+                "LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_UPPER_BOUND": "2",
+            }
+        }
+    }],
+    indirect=True)
+def test_handle_hanging(serve_with_client):
+    # With https://github.com/ray-project/ray/issues/20971
+    # the following will hang forever.
+
+    serve.start()
+
+    @serve.deployment
+    def f():
+        return 1
+
+    f.deploy()
+
+    handle = f.get_handle()
+    for _ in range(5):
+        assert ray.get(handle.remote()) == 1
+        time.sleep(0.5)
+
+    ray.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR make sure long poll client's poll_next method is always called inside an event loop as scheduled callback. This prevent the bug that occurs in Ray Client where the ObjectRef's callback cannot be used to execute other Ray command because ray client is single threaded. 

The tradeoff we are making here is that all long poll client must specify an event loop from now on. This is fine because all existing usage actually already pass event loop in. We just need to fix a test to make the enforcement.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #20971
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
