### PR TITLE
enable passing serve tests on windows

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -140,12 +140,7 @@ test_python() {
       python/ray/serve/...
       python/ray/tests/...
       -python/ray/serve:conda_env # runtime_env unsupported on Windows
-      -python/ray/serve:test_api # segfault on windows? https://github.com/ray-project/ray/issues/12541
-      -python/ray/serve:test_cli # cli
-      -python/ray/serve:test_router # timeout
-      -python/ray/serve:test_handle # "fatal error" (?) https://github.com/ray-project/ray/pull/13695
-      -python/ray/serve:test_controller_crashes # timeout
-      -python/ray/serve:test_standalone # timeout
+      -python/ray/serve:test_handle # timeout error (?) https://github.com/ray-project/ray/issues/21106
       -python/ray/tests:test_actor_advanced # timeout
       -python/ray/tests:test_actor_failures # flaky
       -python/ray/tests:test_advanced_2

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -140,7 +140,6 @@ test_python() {
       python/ray/serve/...
       python/ray/tests/...
       -python/ray/serve:conda_env # runtime_env unsupported on Windows
-      -python/ray/serve:test_handle # timeout error (?) https://github.com/ray-project/ray/issues/21106
       -python/ray/tests:test_actor_advanced # timeout
       -python/ray/tests:test_actor_failures # flaky
       -python/ray/tests:test_advanced_2

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -265,7 +265,7 @@ py_test(
 
 py_test(
     name = "test_cli",
-    size = "small",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -157,7 +157,7 @@ py_test(
 
 py_test(
     name = "test_handle",
-    size = "small",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Enable passing tests on windows to extend CI coverage

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

xref issue #21106, there is a timeout when running tests through bazel that does not show up when running via pytest

cc @pcmoritz 