### PR TITLE
[Dask-on-Ray] Add Dask config helper, set task-based shuffle by default.

### DIFF
--- a/doc/source/data/dask-on-ray.rst
+++ b/doc/source/data/dask-on-ray.rst
@@ -62,7 +62,7 @@ Here's an example:
   For execution on a Ray cluster, you should *not* use the
   `Dask.distributed <https://distributed.dask.org/en/latest/quickstart.html>`__
   client; simply use plain Dask and its collections, and pass ``ray_dask_get``
-  to ``.compute()`` calls or set the scheduler in one of the other ways detailed `here <https://docs.dask.org/en/latest/scheduling.html#configuration>`__. Follow the instructions for
+  to ``.compute()`` calls, set the scheduler in one of the other ways detailed `here <https://docs.dask.org/en/latest/scheduling.html#configuration>`__, or use our ``enable_dask_on_ray`` configuration helper. Follow the instructions for
   :ref:`using Ray on a cluster <using-ray-on-a-cluster>` to modify the
   ``ray.init()`` call.
 

--- a/python/ray/util/dask/__init__.py
+++ b/python/ray/util/dask/__init__.py
@@ -1,5 +1,6 @@
 import dask
-from .scheduler import ray_dask_get, ray_dask_get_sync
+from .scheduler import ray_dask_get, ray_dask_get_sync, enable_dask_on_ray, \
+    disable_dask_on_ray
 from .callbacks import (
     RayDaskCallback,
     local_ray_callbacks,
@@ -39,13 +40,10 @@ def patch_dask(ray_dask_persist, ray_dask_persist_mixin):
 
 patch_dask(ray_dask_persist, ray_dask_persist_mixin)
 
-# Manually set the global Dask scheduler config at import time.
-# We also force the task-based shuffle to be used since the disk-based
-# shuffle doesn't work for a multi-node Ray cluster that doesn't share
-# the filesystem.
-dask.config.set(scheduler=ray_dask_get, shuffle="tasks")
-
 __all__ = [
+    # Config
+    "enable_dask_on_ray",
+    "disable_dask_on_ray",
     # Schedulers
     "ray_dask_get",
     "ray_dask_get_sync",

--- a/python/ray/util/dask/__init__.py
+++ b/python/ray/util/dask/__init__.py
@@ -39,6 +39,12 @@ def patch_dask(ray_dask_persist, ray_dask_persist_mixin):
 
 patch_dask(ray_dask_persist, ray_dask_persist_mixin)
 
+# Manually set the global Dask scheduler config at import time.
+# We also force the task-based shuffle to be used since the disk-based
+# shuffle doesn't work for a multi-node Ray cluster that doesn't share
+# the filesystem.
+dask.config.set(scheduler=ray_dask_get, shuffle="tasks")
+
 __all__ = [
     # Schedulers
     "ray_dask_get",

--- a/python/ray/util/dask/examples/dask_ray_scheduler_example.py
+++ b/python/ray/util/dask/examples/dask_ray_scheduler_example.py
@@ -1,6 +1,5 @@
 import ray
-from ray.util.dask import ray_dask_get
-import dask
+from ray.util.dask import ray_dask_get, enable_dask_on_ray, disable_dask_on_ray
 import dask.array as da
 import dask.dataframe as dd
 import numpy as np
@@ -15,14 +14,21 @@ d_arr = da.from_array(np.random.randint(0, 1000, size=(256, 256)))
 # The Dask scheduler submits the underlying task graph to Ray.
 d_arr.mean().compute(scheduler=ray_dask_get)
 
-# Set the scheduler to ray_dask_get in your config so you don't have to
-# specify it on each compute call.
-dask.config.set(scheduler=ray_dask_get)
+# Use our Dask config helper to set the scheduler to ray_dask_get globally,
+# without having to specify it on each compute call.
+enable_dask_on_ray()
 
 df = dd.from_pandas(
     pd.DataFrame(
         np.random.randint(0, 100, size=(1024, 2)), columns=["age", "grade"]),
     npartitions=2)
 df.groupby(["age"]).mean().compute()
+
+disable_dask_on_ray()
+
+# The Dask config helper can be used as a context manager, limiting the scope
+# of the Dask-on-Ray scheduler to the context.
+with enable_dask_on_ray():
+    d_arr.mean().compute()
 
 ray.shutdown()

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -3,21 +3,76 @@ import threading
 from collections import defaultdict
 from dataclasses import dataclass
 from multiprocessing.pool import ThreadPool
+from typing import Optional
 
 import ray
 
+import dask
 from dask.core import istask, ishashable, _execute_task
 from dask.system import CPU_COUNT
 from dask.threaded import pack_exception, _thread_get_id
 
-from .callbacks import local_ray_callbacks, unpack_ray_callbacks
-from .common import unpack_object_refs
-from .scheduler_utils import get_async, apply_sync
+from ray.util.dask.callbacks import local_ray_callbacks, unpack_ray_callbacks
+from ray.util.dask.common import unpack_object_refs
+from ray.util.dask.scheduler_utils import get_async, apply_sync
 
 main_thread = threading.current_thread()
 default_pool = None
 pools = defaultdict(dict)
 pools_lock = threading.Lock()
+
+
+def enable_dask_on_ray(
+        shuffle: Optional[str] = "tasks",
+        use_shuffle_optimization: Optional[bool] = True,
+) -> dask.config.set:
+    """
+    Enable Dask-on-Ray scheduler. This helper sets the Dask-on-Ray scheduler
+    as the default Dask scheduler in the Dask config. By default, it will also
+    cause the task-based shuffle to be used for any Dask shuffle operations
+    (required for multi-node Ray clusters, not sharing a filesystem), and will
+    enable a Ray-specific shuffle optimization.
+
+    >>> enable_dask_on_ray()
+    >>> ddf.compute()  # <-- will use the Dask-on-Ray scheduler.
+
+    If used as a context manager, the Dask-on-Ray scheduler will only be used
+    within the context's scope.
+
+    >>> with enable_dask_on_ray():
+    ...     ddf.compute()  # <-- will use the Dask-on-Ray scheduler.
+    >>> ddf.compute()  # <-- won't use the Dask-on-Ray scheduler.
+
+    Args:
+        shuffle: The shuffle method used by Dask, either "tasks" or
+            "disk". This should be "tasks" if using a multi-node Ray cluster.
+            Defaults to "tasks".
+        use_shuffle_optimization: Enable our custom Ray-specific shuffle
+            optimization. Defaults to True.
+    Returns:
+        The Dask config object, which can be used as a context manager to limit
+        the scope of the Dask-on-Ray scheduler to the corresponding context.
+    """
+    if use_shuffle_optimization:
+        from ray.util.dask.optimizations import dataframe_optimize
+    else:
+        dataframe_optimize = None
+    # Manually set the global Dask scheduler config.
+    # We also force the task-based shuffle to be used since the disk-based
+    # shuffle doesn't work for a multi-node Ray cluster that doesn't share
+    # the filesystem.
+    return dask.config.set(
+        scheduler=ray_dask_get,
+        shuffle=shuffle,
+        dataframe_optimize=dataframe_optimize)
+
+
+def disable_dask_on_ray():
+    """
+    Unsets the scheduler, shuffle method, and DataFrame optimizer.
+    """
+    return dask.config.set(
+        scheduler=None, shuffle=None, dataframe_optimize=None)
 
 
 def ray_dask_get(dsk, keys, **kwargs):

--- a/python/ray/util/dask/tests/test_dask_optimization.py
+++ b/python/ray/util/dask/tests/test_dask_optimization.py
@@ -6,12 +6,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from ray.tests.conftest import *  # noqa
 from ray.util.dask import dataframe_optimize
 from ray.util.dask.optimizations import (rewrite_simple_shuffle_layer,
                                          MultipleReturnSimpleShuffleLayer)
 
 
-def test_rewrite_simple_shuffle_layer():
+def test_rewrite_simple_shuffle_layer(ray_start_regular_shared):
     npartitions = 10
     df = dd.from_pandas(
         pd.DataFrame(
@@ -35,7 +36,7 @@ def test_rewrite_simple_shuffle_layer():
 
 
 @mock.patch("ray.util.dask.optimizations.rewrite_simple_shuffle_layer")
-def test_dataframe_optimize(mock_rewrite):
+def test_dataframe_optimize(mock_rewrite, ray_start_regular_shared):
     def side_effect(dsk, keys):
         return rewrite_simple_shuffle_layer(dsk, keys)
 


### PR DESCRIPTION
Dask default's to a disk-based shuffle even thought we're using a distributed scheduler, which appears to be resulting in dropped data since the filesystem isn't shared across nodes. Dask Distributed manually sets the shuffle algorithm in the global config to the task-based shuffle, which the Dask-on-Ray scheduler should probably do as well.

This PR adds a Dask config helper, `enable_dask_on_ray`, that sets Dask-on-Ray as the default scheduler along with changing the default shuffle to a task-based shuffle. The shuffle method can still be overridden by the user by manually specifying `df.set_index(shuffle="disk")`.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #20108, closes #20992, closed #14048

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
