### PR TITLE
[tune] Elongate test_trial_scheduler_pbt timeout.

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -313,6 +313,8 @@ py_test(
 py_test(
     name = "test_trial_scheduler_pbt",
     size = "large",
+    # This may be a bit exaggerated but just to see if tests pass
+    timeout = "eternal",
     srcs = ["tests/test_trial_scheduler_pbt.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive", "tests_dir_T"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Pretty sure that the test suite is timing out at 900s now. Although locally it's only taking 600s.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
