### PR TITLE
[testing] Turn on chaos test for non-streaming shuffle

### DIFF
--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -143,6 +143,10 @@ def store_stats_summary(reply):
     if reply.store_stats.consumed_bytes > 0:
         store_summary += ("Objects consumed by Ray tasks: {} MiB.\n".format(
             int(reply.store_stats.consumed_bytes / (1024 * 1024))))
+    if reply.store_stats.num_object_recovery_attempts > 0:
+        store_summary += ("{} objects lost from plasma store, {} reconstructed.\n".format(
+            reply.store_stats.num_object_recovery_attempts,
+            reply.store_stats.num_objects_reconstructed))
     if reply.store_stats.object_pulls_queued:
         store_summary += (
             "Object fetches queued, waiting for available memory.")

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -144,9 +144,10 @@ def store_stats_summary(reply):
         store_summary += ("Objects consumed by Ray tasks: {} MiB.\n".format(
             int(reply.store_stats.consumed_bytes / (1024 * 1024))))
     if reply.store_stats.num_object_recovery_attempts > 0:
-        store_summary += ("{} objects lost from plasma store, {} reconstructed.\n".format(
-            reply.store_stats.num_object_recovery_attempts,
-            reply.store_stats.num_objects_reconstructed))
+        store_summary += (
+            "{} objects lost from plasma store, {} reconstructed.\n".format(
+                reply.store_stats.num_object_recovery_attempts,
+                reply.store_stats.num_objects_reconstructed))
     if reply.store_stats.object_pulls_queued:
         store_summary += (
             "Object fetches queued, waiting for available memory.")

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -185,7 +185,7 @@ class ShuffleStatusTracker:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
-    "set_kill_interval", [(False, None), (False, 60)], indirect=True)
+    "set_kill_interval", [(True, None), (True, 60), (False, None), (False, 60)], indirect=True)
 def test_nonstreaming_shuffle(set_kill_interval):
     lineage_reconstruction_enabled, kill_interval, _ = set_kill_interval
     try:

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -169,8 +169,6 @@ class ShuffleStatusTracker:
                 timeout=1,
                 num_returns=len(self.map_refs),
                 fetch_local=False)
-            if ready:
-                print("Still waiting on map refs", self.map_refs)
             self.num_map += len(ready)
         elif self.reduce_refs:
             ready, self.reduce_refs = ray.wait(
@@ -178,15 +176,15 @@ class ShuffleStatusTracker:
                 timeout=1,
                 num_returns=len(self.reduce_refs),
                 fetch_local=False)
-            if ready:
-                print("Still waiting on reduce refs", self.reduce_refs)
             self.num_reduce += len(ready)
         return self.num_map, self.num_reduce
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
-    "set_kill_interval", [(True, None), (True, 60), (False, None), (False, 60)], indirect=True)
+    "set_kill_interval", [(True, None), (True, 60), (False, None),
+                          (False, 60)],
+    indirect=True)
 def test_nonstreaming_shuffle(set_kill_interval):
     lineage_reconstruction_enabled, kill_interval, _ = set_kill_interval
     try:

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -3,6 +3,7 @@ import random
 import string
 
 import ray
+from ray.internal.internal_api import memory_summary
 
 import pytest
 import time
@@ -205,6 +206,11 @@ def test_nonstreaming_shuffle(set_kill_interval):
     except (RayTaskError, ObjectLostError):
         assert kill_interval is not None
         assert not lineage_reconstruction_enabled
+
+    if kill_interval is not None:
+        stats = memory_summary("auto", stats_only=True)
+        print(stats)
+        assert "objects lost from plasma store" in stats
 
 
 @pytest.mark.skip(reason="https://github.com/ray-project/ray/issues/20713")

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -208,7 +208,8 @@ def test_nonstreaming_shuffle(set_kill_interval):
     if kill_interval is not None:
         stats = memory_summary("auto", stats_only=True)
         print(stats)
-        assert "objects lost from plasma store" in stats
+    else:
+        assert "objects lost from plasma store" not in stats
 
 
 @pytest.mark.skip(reason="https://github.com/ray-project/ray/issues/20713")

--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -194,9 +194,7 @@ def test_stats(ray_start_cluster):
 
     cluster = ray_start_cluster
     # Head node with no resources.
-    cluster.add_node(
-        num_cpus=0,
-        _system_config=config)
+    cluster.add_node(num_cpus=0, _system_config=config)
     ray.init(address=cluster.address)
     # Node to place the initial object.
     node_to_kill = cluster.add_node(

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2905,6 +2905,10 @@ void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &
                                           stats);
   }
 
+  ObjectRecoveryStats recovery_stats = object_recovery_manager_->GetStats();
+  stats->set_num_object_recovery_attempts(recovery_stats.num_object_recovery_attempts);
+  stats->set_num_objects_reconstructed(recovery_stats.num_objects_reconstructed);
+
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 

--- a/src/ray/core_worker/object_recovery_manager.h
+++ b/src/ray/core_worker/object_recovery_manager.h
@@ -25,6 +25,14 @@
 namespace ray {
 namespace core {
 
+struct ObjectRecoveryStats {
+  /// Number of objects that we attempted to recover (by
+  /// pinning another copy, storing an error, etc).
+  int64_t num_object_recovery_attempts = 0;
+  /// Number of objects that were successfully reconstructed.
+  int64_t num_objects_reconstructed = 0;
+};
+
 typedef std::function<std::shared_ptr<PinObjectsInterface>(const std::string &ip_address,
                                                            int port)>
     ObjectPinningClientFactoryFn;
@@ -89,6 +97,8 @@ class ObjectRecoveryManager {
   /// reconstruction failure callback will be called for this object).
   bool RecoverObject(const ObjectID &object_id);
 
+  ObjectRecoveryStats GetStats() const;
+
  private:
   /// Pin a new copy for a lost object from the given locations or, if that
   /// fails, attempt to reconstruct it by resubmitting the task that created
@@ -141,6 +151,8 @@ class ObjectRecoveryManager {
   /// Objects that are currently pending recovery. Calls to RecoverObject for
   /// objects currently in this set are idempotent.
   absl::flat_hash_set<ObjectID> objects_pending_recovery_ GUARDED_BY(mu_);
+
+  ObjectRecoveryStats stats_ GUARDED_BY(mu_);
 };
 
 }  // namespace core

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -520,6 +520,11 @@ message CoreWorkerStats {
   uint32 pid = 22;
   // The worker type.
   WorkerType worker_type = 23;
+  // Number of objects that we attempted to recover (by
+  // pinning another copy, storing an error, etc).
+  int64 num_object_recovery_attempts = 24;
+  /// Number of objects that were successfully reconstructed.
+  int64 num_objects_reconstructed = 25;
 }
 
 message MetricPoint {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -186,6 +186,11 @@ message ObjectStoreStats {
   // the node has more pull requests than available object store
   // memory.
   bool object_pulls_queued = 13;
+  // Number of objects that we attempted to recover (by
+  // pinning another copy, storing an error, etc).
+  int64 num_object_recovery_attempts = 14;
+  /// Number of objects that were successfully reconstructed.
+  int64 num_objects_reconstructed = 15;
 }
 
 message GetNodeStatsReply {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2309,6 +2309,12 @@ rpc::ObjectStoreStats AccumulateStoreStats(
     if (cur_store.object_pulls_queued()) {
       store_stats.set_object_pulls_queued(true);
     }
+    for (const auto &core_worker_stats : reply.core_workers_stats()) {
+      store_stats.set_num_object_recovery_attempts(
+          store_stats.num_object_recovery_attempts() + core_worker_stats.num_object_recovery_attempts());
+      store_stats.set_num_objects_reconstructed(
+          store_stats.num_objects_reconstructed() + core_worker_stats.num_objects_reconstructed());
+    }
   }
   return store_stats;
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2311,9 +2311,11 @@ rpc::ObjectStoreStats AccumulateStoreStats(
     }
     for (const auto &core_worker_stats : reply.core_workers_stats()) {
       store_stats.set_num_object_recovery_attempts(
-          store_stats.num_object_recovery_attempts() + core_worker_stats.num_object_recovery_attempts());
+          store_stats.num_object_recovery_attempts() +
+          core_worker_stats.num_object_recovery_attempts());
       store_stats.set_num_objects_reconstructed(
-          store_stats.num_objects_reconstructed() + core_worker_stats.num_objects_reconstructed());
+          store_stats.num_objects_reconstructed() +
+          core_worker_stats.num_objects_reconstructed());
     }
   }
   return store_stats;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Tests that non-streaming shuffle can recover with lineage reconstruction enabled.

## Related issue number

Closes #20408.