### PR TITLE
[C++ Worker] fix uninit ray runtime instance

### DIFF
--- a/cpp/src/ray/api.cc
+++ b/cpp/src/ray/api.cc
@@ -25,7 +25,6 @@ void Init(ray::RayConfig &config, int argc, char **argv) {
   if (!IsInitialized()) {
     internal::ConfigInternal::Instance().Init(config, argc, argv);
     auto runtime = internal::AbstractRayRuntime::DoInit();
-    internal::RayRuntimeHolder::Instance().Init(runtime);
     is_init_ = true;
   }
 }

--- a/cpp/src/ray/api.cc
+++ b/cpp/src/ray/api.cc
@@ -19,7 +19,7 @@
 
 namespace ray {
 
-static bool is_init_;
+static bool is_init_ = false;
 
 void Init(ray::RayConfig &config, int argc, char **argv) {
   if (!IsInitialized()) {

--- a/cpp/src/ray/runtime/abstract_ray_runtime.cc
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.cc
@@ -52,15 +52,15 @@ std::shared_ptr<AbstractRayRuntime> AbstractRayRuntime::DoInit() {
   } else {
     ProcessHelper::GetInstance().RayStart(TaskExecutor::ExecuteTask);
     runtime = std::shared_ptr<AbstractRayRuntime>(new NativeRayRuntime());
-    internal::RayRuntimeHolder::Instance().Init(runtime);
     RAY_LOG(INFO) << "Native ray runtime started.";
-    if (ConfigInternal::Instance().worker_type == WorkerType::WORKER) {
-      // Load functions from code search path.
-      FunctionHelper::GetInstance().LoadFunctionsFromPaths(
-          ConfigInternal::Instance().code_search_path);
-    }
   }
   RAY_CHECK(runtime);
+  internal::RayRuntimeHolder::Instance().Init(runtime);
+  if (ConfigInternal::Instance().worker_type == WorkerType::WORKER) {
+    // Load functions from code search path.
+    FunctionHelper::GetInstance().LoadFunctionsFromPaths(
+        ConfigInternal::Instance().code_search_path);
+  }
   abstract_ray_runtime_ = runtime;
   return runtime;
 }

--- a/cpp/src/ray/runtime/abstract_ray_runtime.cc
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.cc
@@ -52,6 +52,7 @@ std::shared_ptr<AbstractRayRuntime> AbstractRayRuntime::DoInit() {
   } else {
     ProcessHelper::GetInstance().RayStart(TaskExecutor::ExecuteTask);
     runtime = std::shared_ptr<AbstractRayRuntime>(new NativeRayRuntime());
+    internal::RayRuntimeHolder::Instance().Init(runtime);
     RAY_LOG(INFO) << "Native ray runtime started.";
     if (ConfigInternal::Instance().worker_type == WorkerType::WORKER) {
       // Load functions from code search path.

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -64,6 +64,10 @@ std::pair<const RemoteFunctionMap_t &, const RemoteMemberFunctionMap_t &>
 GetRemoteFunctions() {
   return init_func_manager.GetRemoteFunctions();
 }
+
+void InitRayRuntime(std::shared_ptr<RayRuntime> runtime) {
+  RayRuntimeHolder::Instance().Init(runtime);
+}
 }  // namespace internal
 
 namespace internal {

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -45,7 +45,7 @@ GetRemoteFunctions();
 BOOST_DLL_ALIAS(internal::GetRemoteFunctions, GetRemoteFunctions);
 
 void InitRayRuntime(std::shared_ptr<RayRuntime> runtime);
-BOOST_DLL_ALIAS(internal::MyInit, InitRayRuntime);
+BOOST_DLL_ALIAS(internal::InitRayRuntime, InitRayRuntime);
 }  // namespace internal
 
 namespace internal {

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -43,6 +43,9 @@ BOOST_DLL_ALIAS(internal::GetFunctionManager, GetFunctionManager);
 std::pair<const RemoteFunctionMap_t &, const RemoteMemberFunctionMap_t &>
 GetRemoteFunctions();
 BOOST_DLL_ALIAS(internal::GetRemoteFunctions, GetRemoteFunctions);
+
+void InitRayRuntime(std::shared_ptr<RayRuntime> runtime);
+BOOST_DLL_ALIAS(internal::MyInit, InitRayRuntime);
 }  // namespace internal
 
 namespace internal {

--- a/cpp/src/ray/util/function_helper.cc
+++ b/cpp/src/ray/util/function_helper.cc
@@ -86,8 +86,10 @@ std::string FunctionHelper::LoadAllRemoteFunctions(const std::string lib_path,
                      << "' not found in " << lib_path;
     return "";
   }
-  // In some compiler, the static ray runtime maybe a new instance in dynamic library, so
-  // we need init it in dynamic library to make sure the new instance valid.
+  // Both default worker and user dynamic library static link libray_api.so which has a
+  // singleton class RayRuntimeHolder, the user dynamic library will get a new un-init
+  // instance of RayRuntimeHolder, so we need to init the RayRuntimeHolder singleton when
+  // loading the user dynamic library to make sure the new instance valid.
   auto init_func =
       boost::dll::import_alias<void(std::shared_ptr<RayRuntime>)>(lib, "InitRayRuntime");
   init_func(RayRuntimeHolder::Instance().Runtime());

--- a/cpp/src/ray/util/function_helper.cc
+++ b/cpp/src/ray/util/function_helper.cc
@@ -86,6 +86,12 @@ std::string FunctionHelper::LoadAllRemoteFunctions(const std::string lib_path,
                      << "' not found in " << lib_path;
     return "";
   }
+  // In some compiler, the static ray runtime maybe a new instance in dynamic library, so
+  // we need init it in dynamic library to make sure the new instance valid.
+  auto init_func =
+      boost::dll::import_alias<void(std::shared_ptr<RayRuntime>)>(lib, "InitRayRuntime");
+  init_func(RayRuntimeHolder::Instance().Runtime());
+
   auto get_remote_func = boost::dll::import_alias<
       std::pair<const RemoteFunctionMap_t &, const RemoteMemberFunctionMap_t &>()>(
       lib, internal_function_name);

--- a/cpp/src/ray/util/function_helper.h
+++ b/cpp/src/ray/util/function_helper.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <ray/api/common_types.h>
-#include <ray/api/function_manager.h>
+#include <ray/api/ray_runtime_holder.h>
 
 #include <boost/dll.hpp>
 #include <memory>


### PR DESCRIPTION
## Why are these changes needed?

In some compiler, the static ray runtime in ray runtime holder maybe a new un-init instance in dynamic library, 
so we need to init ray time holder in dynamic library to make sure the new instance valid.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
