### PR TITLE
Revert "Treat doc warnings as errors in Makefile to mirror CI linter"

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -54,7 +54,7 @@ clean:
 	rm -rf site/_site site/Gemfile.lock site/.sass-cache
 
 html:
-	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
Reverts ray-project/ray#14917

This is actually causing lots of issues, because for some reason warnings often occur locally but not in CI.  Until we figure out why, let's revert this.