### PR TITLE
[Serve] Reduce test_cluster flakiness by increasing timeout

### DIFF
--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -160,7 +160,7 @@ def test_replica_startup_status_transitions(ray_cluster):
         print(status)
         return status == PENDING_INITIALIZATION
 
-    wait_for_condition(is_replica_pending_initialization)
+    wait_for_condition(is_replica_pending_initialization, timeout=25)
 
     # send signal to complete replica intialization
     signal.send.remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, the `test_replica_startup_status_transitions` test is flaky, causing `test_cluster.py` to be flaky. The test times out on the `wait_for_condition(is_replica_pending_initialization)` call, so this change increases the timeout from 10 seconds to 25 seconds.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
