### PR TITLE
Revert "[tune] Elongate test_trial_scheduler_pbt timeout."

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -313,8 +313,6 @@ py_test(
 py_test(
     name = "test_trial_scheduler_pbt",
     size = "large",
-    # This may be a bit exaggerated but just to see if tests pass
-    timeout = "eternal",
     srcs = ["tests/test_trial_scheduler_pbt.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive", "tests_dir_T"],


### PR DESCRIPTION
Not solving the problem and negatively affecting our test time. Will investigate more.

Reverts ray-project/ray#21120