### PR TITLE
Revert "[Core][GCS] Use `port` and `address` flags to configure GCS s…

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -206,9 +206,10 @@ class JobSupervisor:
                 "runtime_env": self._runtime_env,
                 "metadata": self._metadata,
             })
-            ray_address = ray._private.services.get_ray_address_to_use_or_die()
-            os.environ[
-                ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE] = ray_address
+            ray_redis_address = ray._private.services.find_redis_address_or_die(  # noqa: E501
+            )
+            os.environ[ray_constants.
+                       RAY_ADDRESS_ENVIRONMENT_VARIABLE] = ray_redis_address
 
             log_path = self._log_client.get_log_file_path(self._job_id)
             child_process = self._exec_entrypoint(log_path)

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -12,9 +12,10 @@ class RayParams:
     """A class used to store the parameters used by Ray.
 
     Attributes:
-        bootstrap_address (str): The address of Redis / GCS server to connect
-            to for bootstrapping. If this address is not provided, then this
-            command will start the Ray cluster.
+        external_addresses (str): The address of external Redis server to
+            connect to, in format of "ip1:port1,ip2:port2,...".  If this
+            address is provided, then ray won't start Redis instances in the
+            head node but use external Redis server(s) instead.
         redis_address (str): The address of the Redis server to connect to. If
             this address is not provided, then this command will start Redis, a
             raylet, a plasma store, a plasma manager, and some workers.
@@ -61,10 +62,6 @@ class RayParams:
             processes should be redirected to files.
         redirect_output (bool): True if stdout and stderr for non-worker
             processes should be redirected to files and false otherwise.
-        external_addresses (str): The address of external Redis server to
-            connect to, in format of "ip1:port1,ip2:port2,...".  If this
-            address is provided, then ray won't start Redis instances in the
-            head node but use external Redis server(s) instead.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
         redis_max_clients: If provided, attempt to configure Redis with this
@@ -125,7 +122,7 @@ class RayParams:
     """
 
     def __init__(self,
-                 bootstrap_address=None,
+                 external_addresses=None,
                  redis_address=None,
                  num_cpus=None,
                  num_gpus=None,
@@ -148,7 +145,6 @@ class RayParams:
                  driver_mode=None,
                  redirect_worker_output=None,
                  redirect_output=None,
-                 external_addresses=None,
                  num_redis_shards=None,
                  redis_max_clients=None,
                  redis_password=ray_constants.REDIS_DEFAULT_PASSWORD,
@@ -177,7 +173,8 @@ class RayParams:
                  tracing_startup_hook=None,
                  no_monitor=False,
                  env_vars=None):
-        self.bootstrap_address = bootstrap_address
+        self.object_ref_seed = object_ref_seed
+        self.external_addresses = external_addresses
         self.redis_address = redis_address
         self.num_cpus = num_cpus
         self.num_gpus = num_gpus
@@ -199,7 +196,6 @@ class RayParams:
         self.driver_mode = driver_mode
         self.redirect_worker_output = redirect_worker_output
         self.redirect_output = redirect_output
-        self.external_addresses = external_addresses
         self.num_redis_shards = num_redis_shards
         self.redis_max_clients = redis_max_clients
         self.redis_password = redis_password
@@ -222,7 +218,6 @@ class RayParams:
         self.metrics_export_port = metrics_export_port
         self.tracing_startup_hook = tracing_startup_hook
         self.no_monitor = no_monitor
-        self.object_ref_seed = object_ref_seed
         self.start_initial_python_workers_for_first_job = (
             start_initial_python_workers_for_first_job)
         self.ray_debugger_external = ray_debugger_external

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -178,7 +178,7 @@ def new_port(lower_bound=10000, upper_bound=65535, denylist=None):
     return port
 
 
-def find_redis_address():
+def find_redis_address(address=None):
     """
     Attempts to find all valid Ray redis addresses on this node.
 
@@ -255,6 +255,8 @@ def find_redis_address():
                         # TODO(ekl): Find a robust solution for locating Redis.
                         if arg.startswith("--redis-address="):
                             proc_addr = arg.split("=")[1]
+                            if address is not None and address != proc_addr:
+                                continue
                             redis_addresses.add(proc_addr)
         except psutil.AccessDenied:
             pass
@@ -263,11 +265,19 @@ def find_redis_address():
     return redis_addresses
 
 
-def _find_redis_address_or_die():
-    """Find one Redis address unambiguously, or raise an error.
-
-    Callers outside of this module should use get_ray_address_to_use_or_die()
+def get_ray_address_to_use_or_die():
     """
+    Attempts to find an address for an existing Ray cluster if it is not
+    already specified as an environment variable.
+    Returns:
+        A string to pass into `ray.init(address=...)`
+    """
+    return os.environ.get(ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE,
+                          find_redis_address_or_die())
+
+
+def find_redis_address_or_die():
+
     redis_addresses = find_redis_address()
     if len(redis_addresses) > 1:
         raise ConnectionError(
@@ -279,123 +289,6 @@ def _find_redis_address_or_die():
             "Could not find any running Ray instance. "
             "Please specify the one to connect to by setting `address`.")
     return redis_addresses.pop()
-
-
-def find_gcs_address():
-    """
-    Attempts to find all valid Ray GCS address on this node.
-
-    Returns:
-        Set of detected Redis instances.
-    """
-    # Currently, this extracts the --gcs_address flag from the command
-    # that launched the raylet running on this node, if any. Anyone looking to
-    # edit this function should be warned that these commands look like, for
-    # example:
-    # /usr/local/lib/python3.8/dist-packages/ray/core/src/ray/raylet/raylet
-    # --gcs_address=123.456.78.910:6379 --node_ip_address=123.456.78.910
-    # --raylet_socket_name=... --store_socket_name=... --object_manager_port=0
-    # --min_worker_port=10000 --max_worker_port=19999
-    # --node_manager_port=58578 --maximum_startup_concurrency=8
-    # --static_resource_list=node:123.456.78.910,1.0,object_store_memory,66
-    # --config_list=plasma_store_as_thread,True
-    # --python_worker_command=/usr/bin/python
-    #     /usr/local/lib/python3.8/dist-packages/ray/workers/default_worker.py
-    #     --gcs-address=123.456.78.910:6379
-    #     --node-ip-address=123.456.78.910 --node-manager-port=58578
-    #     --object-store-name=... --raylet-name=...
-    #     --temp-dir=/tmp/ray
-    #     --metrics-agent-port=41856
-    #     --java_worker_command= --cpp_worker_command=
-    #     --temp_dir=/tmp/ray --session_dir=...
-    #     --metrics-agent-port=41856 --metrics_export_port=64229
-    #     --agent_command=/usr/bin/python
-    #     -u /usr/local/lib/python3.8/dist-packages/ray/dashboard/agent.py
-    #         --gcs-address=123.456.78.910:6379 --metrics-export-port=64229
-    #         --dashboard-agent-port=41856 --node-manager-port=58578
-    #         --object-store-name=... --raylet-name=... --temp-dir=/tmp/ray
-    #         --log-dir=/tmp/ray/session_2020-11-08_14-29-07_199128_278000/logs
-    #         --object_store_memory=5037192806 --plasma_directory=/tmp
-    # Longer arguments are elided with ... but all arguments from this instance
-    # are included, to provide a sense of what is in these.
-    # Indeed, we had to pull --gcs_address to the front of each call to make
-    # this readable.
-    # As you can see, this is very long and complex, which is why we can't
-    # simply extract all the the arguments using regular expressions and
-    # present a dict as if we never lost track of these arguments, for
-    # example. Picking out --gcs_address below looks like it might grab the
-    # wrong thing, but double-checking that we're finding the correct process
-    # by checking that the contents look like we expect would probably be prone
-    # to choking in unexpected ways.
-
-    pids = psutil.pids()
-    gcs_addresses = set()
-    for pid in pids:
-        try:
-            proc = psutil.Process(pid)
-            # HACK: Workaround for UNIX idiosyncrasy
-            # Normally, cmdline() is supposed to return the argument list.
-            # But it in some cases (such as when setproctitle is called),
-            # an arbitrary string resembling a command-line is stored in
-            # the first argument.
-            # Explanation: https://unix.stackexchange.com/a/432681
-            # More info: https://github.com/giampaolo/psutil/issues/1179
-            cmdline = proc.cmdline()
-            # NOTE(kfstorm): To support Windows, we can't use
-            # `os.path.basename(cmdline[0]) == "raylet"` here.
-            if len(cmdline) > 0 and "raylet" in os.path.basename(cmdline[0]):
-                for arglist in cmdline:
-                    # Given we're merely seeking --redis-address, we just split
-                    # every argument on spaces for now.
-                    for arg in arglist.split(" "):
-                        # TODO(ekl): Find a robust solution for locating Redis.
-                        if arg.startswith("--gcs_address="):
-                            proc_addr = arg.split("=")[1]
-                            gcs_addresses.add(proc_addr)
-        except psutil.AccessDenied:
-            pass
-        except psutil.NoSuchProcess:
-            pass
-    return gcs_addresses
-
-
-def _find_gcs_address_or_die():
-    """Find one GCS address unambiguously, or raise an error.
-
-    Callers outside of this module should use get_ray_address_to_use_or_die()
-    """
-    gcs_addresses = find_gcs_address()
-    if len(gcs_addresses) > 1:
-        raise ConnectionError(
-            f"Found multiple active Ray instances: {gcs_addresses}. "
-            "Please specify the one to connect to by setting `--address` flag "
-            "or `RAY_ADDRESS` environment variable.")
-        sys.exit(1)
-    elif not gcs_addresses:
-        raise ConnectionError(
-            "Could not find any running Ray instance. "
-            "Please specify the one to connect to by setting `--address` flag "
-            "or `RAY_ADDRESS` environment variable.")
-    return gcs_addresses.pop()
-
-
-def bootstrap_with_gcs() -> bool:
-    """Returns whether bootstrapping should be done with GCS."""
-    return os.environ.get("RAY_bootstrap_with_gcs") not in \
-        [None, "0", "false"]
-
-
-def get_ray_address_to_use_or_die():
-    """
-    Attempts to find an address for an existing Ray cluster if it is not
-    already specified as an environment variable.
-    Returns:
-        A string to pass into `ray.init(address=...)`
-    """
-    return os.environ.get(
-        ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE,
-        _find_gcs_address_or_die()
-        if bootstrap_with_gcs() else _find_redis_address_or_die())
 
 
 def wait_for_node(redis_address,
@@ -474,33 +367,32 @@ def remaining_processes_alive():
     return ray.worker._global_node.remaining_processes_alive()
 
 
-def validate_bootstrap_address(addr):
-    """Validates address parameter, and extract the host and IP.
+def validate_redis_address(address):
+    """Validates address parameter.
 
     Returns:
-        bootstrap_address: string containing the full <host:port> address for
-            bootstrapping.
-        ip: string representing the host portion of the address.
-        port: integer representing the port portion of the address.
+        redis_address: string containing the full <host:port> address.
+        redis_ip: string representing the host portion of the address.
+        redis_port: integer representing the port portion of the address.
     """
 
-    if addr == "auto":
-        addr = get_ray_address_to_use_or_die()
-    bootstrap_address = address_to_ip(addr)
+    if address == "auto":
+        address = find_redis_address_or_die()
+    redis_address = address_to_ip(address)
 
-    address_parts = bootstrap_address.split(":")
-    if len(address_parts) != 2:
+    redis_address_parts = redis_address.split(":")
+    if len(redis_address_parts) != 2:
         raise ValueError("Malformed address. Expected '<host>:<port>'.")
-    ip = address_parts[0]
+    redis_ip = redis_address_parts[0]
     try:
-        port = int(address_parts[1])
+        redis_port = int(redis_address_parts[1])
     except ValueError:
         raise ValueError("Malformed address port. Must be an integer.")
-    if port < 1024 or port > 65535:
-        raise ValueError("Invalid address port. Must be between 1024 and "
-                         "65535 (inclusive).")
+    if redis_port < 1024 or redis_port > 65535:
+        raise ValueError("Invalid address port. Must "
+                         "be between 1024 and 65535.")
 
-    return bootstrap_address, ip, port
+    return redis_address, redis_ip, redis_port
 
 
 def address_to_ip(address):
@@ -589,7 +481,7 @@ def create_redis_client(redis_address, password=None):
             except Exception:
                 create_redis_client.instances.pop(redis_address)
 
-    _, redis_ip_address, redis_port = validate_bootstrap_address(redis_address)
+    _, redis_ip_address, redis_port = validate_redis_address(redis_address)
     # For this command to work, some other client (on the same machine
     # as Redis) must have run "CONFIG SET protected-mode no".
     create_redis_client.instances[redis_address] = redis.StrictRedis(

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -27,8 +27,10 @@ def memory_summary(address=None,
                    stats_only=False,
                    num_entries=None):
     from ray.dashboard.memory_utils import memory_summary
-    if not address or address == "auto":
+    if not address:
         address = services.get_ray_address_to_use_or_die()
+    if address == "auto":
+        address = services.find_redis_address_or_die()
 
     state = GlobalState()
     state._initialize_global_state(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -841,18 +841,16 @@ def init(
     raylet_ip_address = node_ip_address
 
     if address:
-        bootstrap_address, _, _ = services.validate_bootstrap_address(address)
+        redis_address, _, _ = services.validate_redis_address(address)
     else:
-        bootstrap_address = None
-    redis_address = None if services.bootstrap_with_gcs(
-    ) else bootstrap_address
+        redis_address = None
 
     if configure_logging:
         setup_logger(logging_level, logging_format)
 
-    if bootstrap_address is not None:
-        logger.info("Connecting to existing Ray cluster at address: "
-                    f"{bootstrap_address}")
+    if redis_address is not None:
+        logger.info(
+            f"Connecting to existing Ray cluster at address: {redis_address}")
 
     if local_mode:
         driver_mode = LOCAL_MODE
@@ -875,10 +873,9 @@ def init(
         raise TypeError("The _system_config must be a dict.")
 
     global _global_node
-    if bootstrap_address is None:
+    if redis_address is None:
         # In this case, we need to start a new cluster.
         ray_params = ray._private.parameter.RayParams(
-            bootstrap_address=bootstrap_address,
             redis_address=redis_address,
             node_ip_address=node_ip_address,
             raylet_ip_address=raylet_ip_address,


### PR DESCRIPTION
…erver / client in GCS bootstrapping mode (#21115)"

This reverts commit 0e7c0b491b6d459349f8b7bf9777c0ec4c04b8f5.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

The previous change tries to resolve "auto" address on Ray startup and leads to ray init failure.


```
Traceback (most recent call last):
  File "wait_cluster.py", line 6, in <module>
    ray.init(address="auto")
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/client_mode_hook.py", line 105, in wrapper
    return func(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/worker.py", line 844, in init
    bootstrap_address, _, _ = services.validate_bootstrap_address(address)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/services.py", line 489, in validate_bootstrap_address
    bootstrap_address = address_to_ip(addr)
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/services.py", line 521, in address_to_ip
    ip_address = socket.gethostbyname(address_parts[0])
socket.gaierror: [Errno -3] Temporary failure in name resolution
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
