### PR TITLE
[release] Fix Ray commit mismatch by uninstalling Ray before installing new Ray version

### DIFF
--- a/release/long_running_tests/app_config.yaml
+++ b/release/long_running_tests/app_config.yaml
@@ -19,5 +19,5 @@ post_build_cmds:
   - pip3 install ray[all]
   # TODO (Alex): Ideally we would install all the dependencies from the new
   # version too, but pip won't be able to find the new version of ray-cpp.
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall ray -y && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Reusing the fix from https://github.com/ray-project/ray/pull/21119 on a different app config that was failing to build for the same reason.  The fix is to unininstall Ray before installing the correct version.

This should fix the failures observed here  https://buildkite.com/ray-project/periodic-ci/builds/2010# for:
- Actor deaths
- many_actor_tasks
- many_drivers
- many_tasks
- many_tasks_serialized_ids
- node_failures

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/21096
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
