### PR TITLE
[release] Uninstall old ray in all release test app configs to fix commit mismatch error

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -82,6 +82,7 @@ A notable one is the `RAY_WHEELS` variable which points to the wheels that
 should be tested (e.g. latest master wheels). You might want to include
 something like this in your `post_build_cmds`:
 
+  - pip3 uninstall ray -y || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
 
 If you want to force rebuilds, consider using something like

--- a/release/horovod_tests/app_config_master.yaml
+++ b/release/horovod_tests/app_config_master.yaml
@@ -10,6 +10,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
+  - pip3 uninstall ray -y || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install 'ray[tune]'
   - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_PYTORCH=1 pip3 install -U horovod

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -20,5 +20,6 @@ post_build_cmds:
     - pip3 install ray[all]
     # TODO (Alex): Ideally we would install all the dependencies from the new
     # version too, but pip won't be able to find the new version of ray-cpp.
+    - pip3 uninstall ray -y || true
     - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
     - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/ml_user_tests/horovod/app_config.yaml
+++ b/release/ml_user_tests/horovod/app_config.yaml
@@ -10,6 +10,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
+  - pip3 uninstall ray -y || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install 'ray[tune]'
   - pip3 install torch torchvision

--- a/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
@@ -6,6 +6,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
+  - pip3 uninstall ray -y || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip install -U git+https://github.com/ray-project/ray_shuffling_data_loader.git@add-embedding-model
   - pip install ray[default]

--- a/release/nightly_tests/dataset/pipelined_training_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_app.yaml
@@ -6,6 +6,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
+  - pip3 uninstall ray -y || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip install -U git+https://github.com/ray-project/ray_shuffling_data_loader.git@add-embedding-model
   - pip install ray[default]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
  Some new release tests newly started to fail with the same commit check assertion failure as seen before in #21096, e.g. `impala`: https://buildkite.com/ray-project/periodic-ci/builds/2019#6db8fd7d-a6e1-4241-90b3-c06978ec1cbb/138-248

This PR applies the fix from #21119 to all app configs used in all release tests that install specific commits from from `env["RAY_WHEELS"]`.  This PR also adds it as an instruction to e2e.py to help people creating new app configs for new release tests.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
