### PR TITLE
[Serve Autoscaler] Raise warning if max_concurrent_queries < target_num_ongoing_requests

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -212,13 +212,6 @@ class Client:
         else:
             ray_actor_options["runtime_env"] = curr_job_env
 
-        if config.autoscaling_config is not None and \
-            config.max_concurrent_queries < \
-            config.autoscaling_config.target_num_ongoing_requests_per_replica:
-            logger.warning("Autoscaling will never happen, "
-                           "because 'max_concurrent_queries' is less than "
-                           "'target_num_ongoing_requests_per_replica' now.")
-
         replica_config = ReplicaConfig(
             deployment_def,
             init_args=init_args,
@@ -232,6 +225,13 @@ class Client:
         else:
             raise TypeError(
                 "config must be a DeploymentConfig or a dictionary.")
+
+        if deployment_config.autoscaling_config is not None and \
+            deployment_config.max_concurrent_queries < deployment_config. \
+                autoscaling_config.target_num_ongoing_requests_per_replica:
+            logger.warning("Autoscaling will never happen, "
+                           "because 'max_concurrent_queries' is less than "
+                           "'target_num_ongoing_requests_per_replica' now.")
 
         goal_id, updating = ray.get(
             self._controller.deploy.remote(name,

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -212,6 +212,13 @@ class Client:
         else:
             ray_actor_options["runtime_env"] = curr_job_env
 
+        if config.autoscaling_config is not None and \
+            config.max_concurrent_queries < \
+            config.autoscaling_config.target_num_ongoing_requests_per_replica:
+            logger.warning("Autoscaling will never happen, "
+                           "because 'max_concurrent_queries' is less than "
+                           "'target_num_ongoing_requests_per_replica' now.")
+
         replica_config = ReplicaConfig(
             deployment_def,
             init_args=init_args,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Raise warning if `max_concurrent_queries` < `target_num_ongoing_requests` to notify the user that scaling up will not occur.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #20946 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
