### PR TITLE
[Core] Fix invalid to specify concurrency group at runtime.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1666,7 +1666,9 @@ cdef class CoreWorker:
             return_refs = CCoreWorkerProcess.GetCoreWorker().SubmitActorTask(
                 c_actor_id,
                 ray_function,
-                args_vector, CTaskOptions(name, num_returns, c_resources, concurrency_group_name))
+                args_vector,
+                CTaskOptions(
+                    name, num_returns, c_resources, concurrency_group_name))
             if return_refs.has_value():
                 return VectorToObjectRefs(return_refs.value())
             else:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1642,7 +1642,8 @@ cdef class CoreWorker:
                           args,
                           c_string name,
                           int num_returns,
-                          double num_method_cpus):
+                          double num_method_cpus,
+                          c_string concurrency_group_name):
 
         cdef:
             CActorID c_actor_id = actor_id.native()
@@ -1665,7 +1666,7 @@ cdef class CoreWorker:
             return_refs = CCoreWorkerProcess.GetCoreWorker().SubmitActorTask(
                 c_actor_id,
                 ray_function,
-                args_vector, CTaskOptions(name, num_returns, c_resources))
+                args_vector, CTaskOptions(name, num_returns, c_resources, concurrency_group_name))
             if return_refs.has_value():
                 return VectorToObjectRefs(return_refs.value())
             else:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -162,7 +162,8 @@ class ActorMethod:
                 args=args,
                 kwargs=kwargs,
                 name=name,
-                num_returns=num_returns)
+                num_returns=num_returns,
+                concurrency_group_name=concurrency_group)
 
         # Apply the decorator if there is one.
         if self._decorator is not None:
@@ -967,7 +968,8 @@ class ActorHandle:
                            args=None,
                            kwargs=None,
                            name="",
-                           num_returns=None):
+                           num_returns=None,
+                           concurrency_group_name=None):
         """Method execution stub for an actor handle.
 
         This is the function that executes when
@@ -1013,7 +1015,8 @@ class ActorHandle:
 
         object_refs = worker.core_worker.submit_actor_task(
             self._ray_actor_language, self._ray_actor_id, function_descriptor,
-            list_args, name, num_returns, self._ray_actor_method_cpus)
+            list_args, name, num_returns, self._ray_actor_method_cpus,
+            concurrency_group_name if concurrency_group_name is not None else b"")
 
         if len(object_refs) == 1:
             object_refs = object_refs[0]

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1016,7 +1016,8 @@ class ActorHandle:
         object_refs = worker.core_worker.submit_actor_task(
             self._ray_actor_language, self._ray_actor_id, function_descriptor,
             list_args, name, num_returns, self._ray_actor_method_cpus,
-            concurrency_group_name if concurrency_group_name is not None else b"")
+            concurrency_group_name
+            if concurrency_group_name is not None else b"")
 
         if len(object_refs) == 1:
             object_refs = object_refs[0]

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -249,7 +249,8 @@ cdef extern from "ray/core_worker/common.h" nogil:
     cdef cppclass CTaskOptions "ray::core::TaskOptions":
         CTaskOptions()
         CTaskOptions(c_string name, int num_returns,
-                     unordered_map[c_string, double] &resources)
+                     unordered_map[c_string, double] &resources,
+                     c_string concurrency_group_name)
         CTaskOptions(c_string name, int num_returns,
                      unordered_map[c_string, double] &resources,
                      c_string concurrency_group_name,

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -72,7 +72,8 @@ def test_basic():
 
     # It also has the ability to specify it at runtime.
     # This task will be invoked in the `compute` thread pool.
-    a.f2.options(concurrency_group="compute").remote()
+    result = ray.get(a.f2.options(concurrency_group="compute").remote())
+    assert result == f3_thread_id
 
 
 # The case tests that the asyncio count down works well in one concurrency


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We fix the issue that it's unable to specify the concurrency group name of an actor task at runtime with the following usage:
```python
a.f2.options(concurrency_group="compute").remote()
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Close #21190
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
