### PR TITLE
[Nightly Test] Fix broken scalability test

### DIFF
--- a/benchmarks/distributed/test_many_actors.py
+++ b/benchmarks/distributed/test_many_actors.py
@@ -47,6 +47,7 @@ ray.get(monitor_actor.stop_run.remote())
 used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
 print(f"Peak memory usage: {round(used_gb, 2)}GB")
 print(f"Peak memory usage per processes:\n {usage}")
+del monitor_actor
 test_utils.wait_for_condition(no_resource_leaks)
 
 rate = MAX_ACTORS_IN_CLUSTER / (end_time - start_time)

--- a/benchmarks/distributed/test_many_pgs.py
+++ b/benchmarks/distributed/test_many_pgs.py
@@ -73,6 +73,7 @@ ray.get(monitor_actor.stop_run.remote())
 used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
 print(f"Peak memory usage: {round(used_gb, 2)}GB")
 print(f"Peak memory usage per processes:\n {usage}")
+del monitor_actor
 test_utils.wait_for_condition(no_resource_leaks)
 
 rate = MAX_PLACEMENT_GROUPS / (end_time - start_time)

--- a/benchmarks/distributed/test_many_tasks.py
+++ b/benchmarks/distributed/test_many_tasks.py
@@ -62,6 +62,7 @@ def test(num_tasks):
     used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
     print(f"Peak memory usage: {round(used_gb, 2)}GB")
     print(f"Peak memory usage per processes:\n {usage}")
+    del monitor_actor
     test_utils.wait_for_condition(no_resource_leaks)
 
     rate = num_tasks / (end_time - start_time - sleep_time)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I added memory monitor to the scalability tests. This broke the tests because creating a memory monitor requires the node resources (to be scheduled on a head node), and that broke "resource leak" check. Ideally, this resource leak check should be more robust, but I fix the issue in an easier way for now. In the sooner future, memory monitor will become a fixture, and in that case, we should fix resource leak function code.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
