### PR TITLE
[autoscaler] Pass on provider.internal_ip() exceptions during scale down

### DIFF
--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -54,6 +54,8 @@ class DrainNodeOutcome(str, Enum):
     GenericRpcError = "GenericRpcError"
     # Raise a generic unexpected exception.
     GenericException = "GenericException"
+    # Tell the autoscaler to fail finding ips during drain
+    FailedToFindIp = "FailedToFindIp"
 
 
 class MockRpcException(grpc.RpcError):
@@ -115,7 +117,9 @@ class MockNodeInfoStub():
         # All but the last.
         not_all_drained_status = all_nodes_drained_status[:-1]
 
-        if self.drain_node_outcome == DrainNodeOutcome.Succeeded:
+        if self.drain_node_outcome in [
+                DrainNodeOutcome.Succeeded, DrainNodeOutcome.FailedToFindIp
+        ]:
             drain_node_status = all_nodes_drained_status
         elif self.drain_node_outcome == DrainNodeOutcome.NotAllDrained:
             drain_node_status = not_all_drained_status
@@ -294,6 +298,7 @@ class MockProvider(NodeProvider):
         self.ready_to_create.set()
         self.cache_stopped = cache_stopped
         self.unique_ips = unique_ips
+        self.fail_to_fetch_ip = False
         # Many of these functions are called by node_launcher or updater in
         # different threads. This can be treated as a global lock for
         # everything.
@@ -345,6 +350,8 @@ class MockProvider(NodeProvider):
             return self.mock_nodes[node_id].tags
 
     def internal_ip(self, node_id):
+        if self.fail_to_fetch_ip:
+            raise Exception("Failed to fetch ip on purpose.")
         if node_id is None:
             # Circumvent test-cases where there's no head node.
             return "mock"
@@ -401,6 +408,10 @@ class MockAutoscaler(StandardAutoscaler):
     autoscaler update issues at most one provider.non_terminated_nodes call.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fail_to_find_ip_during_drain = False
+
     def _update(self):
         # Only works with MockProvider
         assert isinstance(self.provider, MockProvider)
@@ -411,6 +422,12 @@ class MockAutoscaler(StandardAutoscaler):
         # Strict inequality if update is called twice within the throttling
         # interval `self.update_interval_s`
         assert end_calls <= start_calls + 1
+
+    def drain_nodes_via_gcs(self, provider_node_ids_to_drain):
+        if self.fail_to_find_ip_during_drain:
+            self.provider.fail_to_fetch_ip = True
+        super().drain_nodes_via_gcs(provider_node_ids_to_drain)
+        self.provider.fail_to_fetch_ip = False
 
 
 SMALL_CLUSTER = {
@@ -1425,6 +1442,9 @@ class AutoscalingTest(unittest.TestCase):
         assert mock_metrics.worker_create_node_time.observe.call_count == 5
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
+    def testMissingIpDuringScaleDown(self):
+        pass
+
     # Parameterization functionality in the unittest module is not great.
     # To test scale-down behavior, we parameterize the DynamicScaling test
     # manually over outcomes for the DrainNode RPC call.
@@ -1443,6 +1463,9 @@ class AutoscalingTest(unittest.TestCase):
     def testDynamicScaling5(self):
         self.helperDynamicScaling(DrainNodeOutcome.GenericException)
 
+    def testDynamicScaling6(self):
+        self.helperDynamicScaling(DrainNodeOutcome.FailedToFindIp)
+
     def helperDynamicScaling(self, drain_node_outcome: DrainNodeOutcome):
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
         mock_node_info_stub = MockNodeInfoStub(drain_node_outcome)
@@ -1452,21 +1475,25 @@ class AutoscalingTest(unittest.TestCase):
 
         # Make assertions about DrainNode error handling during scale-down.
 
-        # DrainNode call was made.
-        assert mock_node_info_stub.drain_node_call_count > 0
         if drain_node_outcome == DrainNodeOutcome.Succeeded:
+            # DrainNode call was made.
+            mock_node_info_stub.drain_node_call_count > 0
             # No drain node exceptions.
             assert mock_metrics.drain_node_exceptions.inc.call_count == 0
             # Each drain node call succeeded.
             assert (mock_node_info_stub.drain_node_reply_success ==
                     mock_node_info_stub.drain_node_call_count)
         elif drain_node_outcome == DrainNodeOutcome.Unimplemented:
+            # DrainNode call was made.
+            mock_node_info_stub.drain_node_call_count > 0
             # All errors were supressed.
             assert mock_metrics.drain_node_exceptions.inc.call_count == 0
             # Every call failed.
             assert mock_node_info_stub.drain_node_reply_success == 0
         elif drain_node_outcome in (DrainNodeOutcome.GenericRpcError,
                                     DrainNodeOutcome.GenericException):
+            # DrainNode call was made.
+            mock_node_info_stub.drain_node_call_count > 0
 
             # We encountered an exception.
             assert mock_metrics.drain_node_exceptions.inc.call_count > 0
@@ -1474,6 +1501,12 @@ class AutoscalingTest(unittest.TestCase):
             assert (mock_metrics.drain_node_exceptions.inc.call_count ==
                     mock_node_info_stub.drain_node_call_count)
             assert mock_node_info_stub.drain_node_reply_success == 0
+        elif drain_node_outcome == DrainNodeOutcome.FailedToFindIp:
+            # We never called the drain node api because we were unable to
+            # fetch ips
+            assert mock_node_info_stub.drain_node_call_count == 0
+            # We encountered an exception fetching ip.
+            assert mock_metrics.drain_node_exceptions.inc.call_count > 0
 
     def _helperDynamicScaling(self, mock_metrics, mock_node_info_stub):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -1497,6 +1530,9 @@ class AutoscalingTest(unittest.TestCase):
             process_runner=runner,
             update_interval_s=0,
             prom_metrics=mock_metrics)
+        if (mock_node_info_stub.drain_node_outcome ==
+                DrainNodeOutcome.FailedToFindIp):
+            autoscaler.fail_to_find_ip_during_drain = True
         self.waitForNodes(0, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         autoscaler.update()
         self.waitForNodes(2, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -1442,9 +1442,6 @@ class AutoscalingTest(unittest.TestCase):
         assert mock_metrics.worker_create_node_time.observe.call_count == 5
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
-    def testMissingIpDuringScaleDown(self):
-        pass
-
     # Parameterization functionality in the unittest module is not great.
     # To test scale-down behavior, we parameterize the DynamicScaling test
     # manually over outcomes for the DrainNode RPC call.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Treats failures of `provider.internal_ip` during node drain as non-fatal.
For example, if a node is deleted by a third party between the time it's scheduled for termination and drained, there will now be no error on GCP. 

Closes https://github.com/ray-project/ray/issues/21151

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
