### PR TITLE
[Core] Fix 16GB mac perf issue by limit the plasma store size to 2GB

### DIFF
--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -166,6 +166,15 @@ class ResourceSpec(
             object_store_memory = int(
                 avail_memory *
                 ray_constants.DEFAULT_OBJECT_STORE_MEMORY_PROPORTION)
+
+            # Set the object_store_memory size to 2GB on Mac
+            # to avoid degraded performance.
+            # (https://github.com/ray-project/ray/issues/20388)
+            if sys.platform == "darwin":
+                object_store_memory = max(
+                    object_store_memory,
+                    ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT)
+
             max_cap = ray_constants.DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES
             # Cap by shm size by default to avoid low performance, but don't
             # go lower than REQUIRE_SHM_SIZE_THRESHOLD.

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -171,7 +171,7 @@ class ResourceSpec(
             # to avoid degraded performance.
             # (https://github.com/ray-project/ray/issues/20388)
             if sys.platform == "darwin":
-                object_store_memory = max(
+                object_store_memory = min(
                     object_store_memory,
                     ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT)
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1905,6 +1905,24 @@ def determine_plasma_store_config(object_store_memory,
                              object_store_memory,
                              ray_constants.OBJECT_STORE_MINIMUM_MEMORY_BYTES))
 
+    if sys.platform == "darwin" \
+            and object_store_memory > \
+            ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT \
+            and os.environ.get("RAY_OBJECT_STORE_ALLOW_MAC_LARGE_SIZE") != "1":
+        raise ValueError(
+            "The configured object store size ({:.4}GiB) exceeds "
+            "the optimal size on Mac ({:.4}GiB). "
+            "This will harm performance! There is a known issue where "
+            "Ray's performance degrades with object store size greater"
+            " than {:.4}GB on a Mac."
+            "To reduce the object store capacity, specify"
+            "`object_store_memory` when calling ray.init() or ray start."
+            "To ignore this warning, "
+            "set RAY_OBJECT_STORE_ALLOW_MAC_LARGE_SIZE=1.".format(
+                object_store_memory / 2**30,
+                ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT / 2**30,
+                ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT / 2**30))
+
     # Print the object store memory using two decimal places.
     logger.debug(
         "Determine to start the Plasma object store with {} GB memory "

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1908,7 +1908,7 @@ def determine_plasma_store_config(object_store_memory,
     if sys.platform == "darwin" \
             and object_store_memory > \
             ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT \
-            and os.environ.get("RAY_OBJECT_STORE_ALLOW_MAC_LARGE_SIZE") != "1":
+            and os.environ.get("RAY_ENABLE_MAC_LARGE_OBJECT_STORE") != "1":
         raise ValueError(
             "The configured object store size ({:.4}GiB) exceeds "
             "the optimal size on Mac ({:.4}GiB). "
@@ -1918,7 +1918,7 @@ def determine_plasma_store_config(object_store_memory,
             "To reduce the object store capacity, specify"
             "`object_store_memory` when calling ray.init() or ray start."
             "To ignore this warning, "
-            "set RAY_OBJECT_STORE_ALLOW_MAC_LARGE_SIZE=1.".format(
+            "set RAY_ENABLE_MAC_LARGE_OBJECT_STORE=1.".format(
                 object_store_memory / 2**30,
                 ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT / 2**30,
                 ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT / 2**30))

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1789,7 +1789,8 @@ class Dataset(Generic[T]):
                                             prefetch_blocks + 1):
             block_window = list(block_window)
             with self._stats.iter_wait_s.timer():
-                ray.wait(block_window, num_returns=1, fetch_local=True)
+                # Set timeout to 0 to trigger prefetching asynchronously.
+                ray.wait(block_window, num_returns=1, fetch_local=True, timeout=0)
             yield from batch_block(block_window[0])
 
         # Consume remainder of final block window.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1789,8 +1789,7 @@ class Dataset(Generic[T]):
                                             prefetch_blocks + 1):
             block_window = list(block_window)
             with self._stats.iter_wait_s.timer():
-                # Set timeout to 0 to trigger prefetching asynchronously.
-                ray.wait(block_window, num_returns=1, fetch_local=True, timeout=0)
+                ray.wait(block_window, num_returns=1, fetch_local=True)
             yield from batch_block(block_window[0])
 
         # Consume remainder of final block window.

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -44,6 +44,12 @@ REDIS_MINIMUM_MEMORY_BYTES = 10**7
 # Above this number of bytes, raise an error by default unless the user sets
 # RAY_ALLOW_SLOW_STORAGE=1. This avoids swapping with large object stores.
 REQUIRE_SHM_SIZE_THRESHOLD = 10**10
+# Mac with 16GB memory has degraded performance when the object store size is
+# greater than 2GB.
+# (see https://github.com/ray-project/ray/issues/20388 for details)
+# The workaround here is to limit capacity to 2GB for Mac by default,
+# and raise error if the capacity is overwritten by user.
+MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2**30
 # If a user does not specify a port for the primary Ray service,
 # we attempt to start the service running at this port.
 DEFAULT_PORT = 6379

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -367,6 +367,13 @@ def set_enable_auto_connect(enable_auto_connect: str = "0"):
         del os.environ["RAY_ENABLE_AUTO_CONNECT"]
 
 
+@pytest.fixture
+def enable_mac_large_object_store():
+    os.environ["RAY_ENABLE_MAC_LARGE_OBJECT_STORE"] = "1"
+    yield
+    del os.environ["RAY_ENABLE_MAC_LARGE_OBJECT_STORE"]
+
+
 @pytest.fixture()
 def two_node_cluster():
     system_config = {

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -356,7 +356,8 @@ def test_pull_bundles_pinning(ray_start_cluster):
 
 
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
-def test_pull_bundles_admission_control_dynamic(ray_start_cluster):
+def test_pull_bundles_admission_control_dynamic(enable_mac_large_object_store,
+                                                ray_start_cluster):
     # This test is the same as test_pull_bundles_admission_control, except that
     # the object store's capacity starts off higher and is later consumed
     # dynamically by concurrent workers.

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -16,7 +16,8 @@ from ray.util.scheduling_strategies import (
 
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Failing on Windows. Multi node.")
-def test_load_balancing_under_constrained_memory(ray_start_cluster):
+def test_load_balancing_under_constrained_memory(enable_mac_large_object_store,
+                                                 ray_start_cluster):
     # This test ensures that tasks are being assigned to all raylets in a
     # roughly equal manner even when the tasks have dependencies.
     cluster = ray_start_cluster


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Mac with 16GB memory has degraded performance when concurrently write to more than 2GB
sized mmaped region. (see https://github.com/ray-project/ray/issues/20388 for details)
The workaround here is to limit capacity to 2GB for 16GB Mac by default,
and raising warning if the capacity is overwritten by user.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
