### PR TITLE
[tune] remove TrialExecutor.resume_trial.

### DIFF
--- a/python/ray/tune/tests/test_trial_runner_2.py
+++ b/python/ray/tune/tests/test_trial_runner_2.py
@@ -345,13 +345,6 @@ class TrialRunnerTest2(unittest.TestCase):
         runner.trial_executor.pause_trial(trials[0])
         self.assertEqual(trials[0].status, Trial.PAUSED)
 
-        runner.trial_executor.resume_trial(trials[0])
-        self.assertEqual(trials[0].status, Trial.RUNNING)
-        self.assertEqual(ray.get(trials[0].runner.get_info.remote()), 1)
-
-        runner.step()  # Process result
-        self.assertEqual(trials[0].status, Trial.TERMINATED)
-
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -126,11 +126,6 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
             logger.exception("Error pausing runner.")
             self.set_status(trial, Trial.ERROR)
 
-    def resume_trial(self, trial: Trial) -> None:
-        """Resumes PAUSED trials. This is a blocking call."""
-        assert trial.status == Trial.PAUSED, trial.status
-        self.start_trial(trial)
-
     @abstractmethod
     def reset_trial(self, trial: Trial, new_config: Dict,
                     new_experiment_tag: str) -> bool:


### PR DESCRIPTION
Dangling API.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
