### PR TITLE
[Train] Remove `run_dir` param from `BackendExecutor`

### DIFF
--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -337,7 +337,6 @@ class BackendExecutor:
     def start_training(
             self,
             train_func: Callable[[], T],
-            run_dir: Path,
             dataset: Optional[Union[RayDataset, Dict[str, RayDataset]]] = None,
             checkpoint: Optional[Dict] = None) -> None:
         """Executes a training function on all workers in a separate thread.
@@ -346,7 +345,6 @@ class BackendExecutor:
 
         Args:
             train_func (Callable): The training function to run on each worker.
-            run_dir (Path): The directory to use for this run.
             dataset (Optional[Union[Dataset, DatasetPipeline]])
                 Distributed Ray Dataset or DatasetPipeline to pass into
                 worker, which can be accessed from the training function via

--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from collections import defaultdict
-from pathlib import Path
 from typing import Callable, TypeVar, List, Optional, Dict, Union, Type, Tuple
 
 import ray

--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -95,7 +95,7 @@ class TestBackend(Backend):
         pass
 
 
-def test_start(ray_start_2_cpus, tmp_path):
+def test_start(ray_start_2_cpus):
     config = TestConfig()
     e = BackendExecutor(config, num_workers=2)
     with pytest.raises(InactiveWorkerGroupError):
@@ -104,7 +104,7 @@ def test_start(ray_start_2_cpus, tmp_path):
     assert len(e.worker_group) == 2
 
 
-def test_initialization_hook(ray_start_2_cpus, tmp_path):
+def test_initialization_hook(ray_start_2_cpus):
     config = TestConfig()
     e = BackendExecutor(config, num_workers=2)
 
@@ -122,7 +122,7 @@ def test_initialization_hook(ray_start_2_cpus, tmp_path):
     assert e.finish_training() == ["1", "1"]
 
 
-def test_shutdown(ray_start_2_cpus, tmp_path):
+def test_shutdown(ray_start_2_cpus):
     config = TestConfig()
     e = BackendExecutor(config, num_workers=2)
     e.start()
@@ -132,7 +132,7 @@ def test_shutdown(ray_start_2_cpus, tmp_path):
         e.start_training(lambda: 1)
 
 
-def test_train(ray_start_2_cpus, tmp_path):
+def test_train(ray_start_2_cpus):
     config = TestConfig()
     e = BackendExecutor(config, num_workers=2)
     e.start()
@@ -141,7 +141,7 @@ def test_train(ray_start_2_cpus, tmp_path):
     assert e.finish_training() == [1, 1]
 
 
-def test_local_ranks(ray_start_2_cpus, tmp_path):
+def test_local_ranks(ray_start_2_cpus):
     config = TestConfig()
     e = BackendExecutor(config, num_workers=2)
     e.start()
@@ -153,7 +153,7 @@ def test_local_ranks(ray_start_2_cpus, tmp_path):
     assert set(e.finish_training()) == {0, 1}
 
 
-def test_train_failure(ray_start_2_cpus, tmp_path):
+def test_train_failure(ray_start_2_cpus):
     config = TestConfig()
     e = BackendExecutor(config, num_workers=2)
     e.start()
@@ -175,7 +175,7 @@ def test_train_failure(ray_start_2_cpus, tmp_path):
     assert e.finish_training() == [1, 1]
 
 
-def test_worker_failure(ray_start_2_cpus, tmp_path):
+def test_worker_failure(ray_start_2_cpus):
     config = TestConfig()
     e = BackendExecutor(config, num_workers=2)
     e.start()
@@ -190,7 +190,7 @@ def test_worker_failure(ray_start_2_cpus, tmp_path):
             e.finish_training()
 
 
-def test_mismatch_checkpoint_report(ray_start_2_cpus, tmp_path):
+def test_mismatch_checkpoint_report(ray_start_2_cpus):
     def train_func():
         if (train.world_rank()) == 0:
             train.save_checkpoint(epoch=0)
@@ -205,7 +205,7 @@ def test_mismatch_checkpoint_report(ray_start_2_cpus, tmp_path):
         e.get_next_results()
 
 
-def test_tensorflow_start(ray_start_2_cpus, tmp_path):
+def test_tensorflow_start(ray_start_2_cpus):
     num_workers = 2
     tensorflow_config = TensorflowConfig()
     e = BackendExecutor(tensorflow_config, num_workers=num_workers)
@@ -228,7 +228,7 @@ def test_tensorflow_start(ray_start_2_cpus, tmp_path):
 
 
 @pytest.mark.parametrize("init_method", ["env", "tcp"])
-def test_torch_start_shutdown(ray_start_2_cpus, init_method, tmp_path):
+def test_torch_start_shutdown(ray_start_2_cpus, init_method):
     torch_config = TorchConfig(backend="gloo", init_method=init_method)
     e = BackendExecutor(torch_config, num_workers=2)
     e.start()
@@ -250,7 +250,7 @@ def test_torch_start_shutdown(ray_start_2_cpus, init_method, tmp_path):
 @pytest.mark.parametrize("worker_results", [(1, ["0"]), (2, ["0,1", "0,1"]),
                                             (3, ["0", "0,1", "0,1"]),
                                             (4, ["0,1", "0,1", "0,1", "0,1"])])
-def test_cuda_visible_devices(ray_2_node_2_gpu, worker_results, tmp_path):
+def test_cuda_visible_devices(ray_2_node_2_gpu, worker_results):
     config = TestConfig()
 
     def get_resources():
@@ -278,8 +278,7 @@ def test_cuda_visible_devices(ray_2_node_2_gpu, worker_results, tmp_path):
      (6, ["0", "0", "0,1", "0,1", "0,1", "0,1"]),
      (7, ["0,1", "0,1", "0,1", "0,1", "0,1", "0,1", "0,1"]),
      (8, ["0,1", "0,1", "0,1", "0,1", "0,1", "0,1", "0,1", "0,1"])])
-def test_cuda_visible_devices_fractional(ray_2_node_2_gpu, worker_results,
-                                         tmp_path):
+def test_cuda_visible_devices_fractional(ray_2_node_2_gpu, worker_results):
     config = TestConfig()
 
     def get_resources():
@@ -304,8 +303,7 @@ def test_cuda_visible_devices_fractional(ray_2_node_2_gpu, worker_results,
                          [(1, ["0,1"]), (2, ["0,1,2,3", "0,1,2,3"]),
                           (3, ["0,1", "0,1,2,3", "0,1,2,3"]),
                           (4, ["0,1,2,3", "0,1,2,3", "0,1,2,3", "0,1,2,3"])])
-def test_cuda_visible_devices_multiple(ray_2_node_4_gpu, worker_results,
-                                       tmp_path):
+def test_cuda_visible_devices_multiple(ray_2_node_4_gpu, worker_results):
     config = TestConfig()
 
     def get_resources():
@@ -356,7 +354,7 @@ def test_placement_group_spread(ray_4_node_4_cpu, num_workers):
 
 
 @pytest.mark.parametrize("placement_group_capture_child_tasks", [True, False])
-def test_placement_group_parent(ray_4_node_4_cpu, tmp_path,
+def test_placement_group_parent(ray_4_node_4_cpu,
                                 placement_group_capture_child_tasks):
     """Tests that parent placement group will be used."""
     num_workers = 2

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -627,7 +627,6 @@ class TrainingIterator:
         self._run_with_error_handling(
             lambda: ray.get(self._backend_executor_actor.start_training.remote(
                 train_func=train_func,
-                run_dir=run_dir,
                 dataset=dataset,
                 checkpoint=checkpoint_dict
             ))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The run_dir argument in ray.train.backend.BackendExecutor.start_training isn't used but is causing the following error: if your host computer and job cluster use different OS, then you get a pathlib error because, for e.g., you can't instantiate a pathlib.WindowsPath in a Linux system.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #21228 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
