### PR TITLE
upgrade cython to 0.29.26 for py310

### DIFF
--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -15,7 +15,7 @@ RUN set -x; apt update \
     && mv bazel.gpg /etc/apt/trusted.gpg.d/ \
     && echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
     && apt update && apt install bazel-3.7.2 -y \
-    && pip3 install cython==0.29.0 pytest pandas tree tabulate pexpect sklearn joblib yapf==0.23.0 flake8==3.9.1 mypy==0.782 flake8-quotes flake8-bugbear==21.9.2 setproctitle==1.1.10 psutil \
+    && pip3 install cython==0.29.26 pytest pandas tree tabulate pexpect sklearn joblib yapf==0.23.0 flake8==3.9.1 mypy==0.782 flake8-quotes flake8-bugbear==21.9.2 setproctitle==1.1.10 psutil \
     && python3 -c  'print("startup --output_base=/workspace/ray/.bazel-cache\nstartup --host_jvm_args=-Xmx1800m\nbuild --jobs=6")' > /etc/bazel.bazelrc
 
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3 30 \

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -189,8 +189,8 @@ def ray_deps_setup():
     auto_http_archive(
         name = "cython",
         build_file = True,
-        url = "https://github.com/cython/cython/archive/26cb654dcf4ed1b1858daf16b39fd13406b1ac64.tar.gz",
-        sha256 = "d21e155ac9a455831f81608bb06620e4a1d75012a630faf11f4c25ad10cfc9bb",
+        url = "https://github.com/cython/cython/archive/3028e8c7ac296bc848d996e397c3354b3dbbd431.tar.gz",
+        sha256 = "31ea23c2231ddee8572a2a5effd54952e16a1b44e9a4cb3eb645418f8accf20d",
     )
 
     auto_http_archive(

--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -2,7 +2,7 @@ aiohttp
 aiosignal
 blist
 boto3
-cython==0.29.0
+cython==0.29.26
 dataclasses; python_version < '3.7'
 dm-tree==0.1.5
 feather-format

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -67,7 +67,7 @@ For Ubuntu, run the following commands:
   sudo apt-get update
   sudo apt-get install -y build-essential curl unzip psmisc
 
-  pip install cython==0.29.0 pytest
+  pip install cython==0.29.26 pytest
 
 For RHELv8 (Redhat EL 8.0-64 Minimal), run the following commands:
 
@@ -76,7 +76,7 @@ For RHELv8 (Redhat EL 8.0-64 Minimal), run the following commands:
   sudo yum groupinstall 'Development Tools'
   sudo yum install psmisc
 
-  pip install cython==0.29.0 pytest
+  pip install cython==0.29.26 pytest
 
 Install bazel manually from link: https://docs.bazel.build/versions/main/install-redhat.html 
 
@@ -91,7 +91,7 @@ For MacOS, run the following commands:
   brew update
   brew install wget
 
-  pip install cython==0.29.0 pytest
+  pip install cython==0.29.26 pytest
 
 Ray can be built from the repository as follows.
 
@@ -193,7 +193,7 @@ Define an environment variable BAZEL_PATH to full exe path (example:
 
 .. code-block:: shell
 
-  pip install cython==0.29.0 pytest
+  pip install cython==0.29.26 pytest
 
 6. Download ray source code and build it.
 

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -52,7 +52,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     && $HOME/anaconda3/bin/conda clean -y --all \
     && $HOME/anaconda3/bin/pip install --no-cache-dir \
         flatbuffers \
-        cython==0.29.23 \
+        cython==0.29.26 \
         # Necessary for Dataset to work properly.
         numpy\>=1.20 \
         psutil \

--- a/docker/ray-worker-container/Dockerfile
+++ b/docker/ray-worker-container/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update -y && sudo apt-get upgrade -y \
     && $HOME/anaconda3/bin/conda clean -y --all \
     && $HOME/anaconda3/bin/pip install --no-cache-dir \
         flatbuffers \
-        cython==0.29.0 \
+        cython==0.29.26 \
         numpy==1.15.4 \
         psutil \
         blist \

--- a/python/build-wheel-macos-arm64.sh
+++ b/python/build-wheel-macos-arm64.sh
@@ -69,7 +69,7 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
     # Setuptools on CentOS is too old to install arrow 0.9.0, therefore we upgrade.
     # TODO: Unpin after https://github.com/pypa/setuptools/issues/2849 is fixed.
     $PIP_CMD install --upgrade setuptools==58.4
-    $PIP_CMD install -q cython==0.29.15
+    $PIP_CMD install -q cython==0.29.26
     # Install wheel to avoid the error "invalid command 'bdist_wheel'".
     $PIP_CMD install -q wheel
     # Set the commit SHA in __init__.py.

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -89,7 +89,7 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
     $PIP_CMD install -q setuptools_scm==3.1.0
     # Fix the numpy version because this will be the oldest numpy version we can
     # support.
-    $PIP_CMD install -q numpy=="$NUMPY_VERSION" cython==0.29.15
+    $PIP_CMD install -q numpy=="$NUMPY_VERSION" cython==0.29.26
     # Install wheel to avoid the error "invalid command 'bdist_wheel'".
     $PIP_CMD install -q wheel
     # Set the commit SHA in __init__.py.

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -80,7 +80,7 @@ for ((i=0; i<${#PYTHONS[@]}; ++i)); do
   pushd python
     # Fix the numpy version because this will be the oldest numpy version we can
     # support.
-    /opt/python/"${PYTHON}"/bin/pip install -q numpy=="${NUMPY_VERSION}" cython==0.29.15
+    /opt/python/"${PYTHON}"/bin/pip install -q numpy=="${NUMPY_VERSION}" cython==0.29.26
     # Set the commit SHA in __init__.py.
     if [ -n "$TRAVIS_COMMIT" ]; then
       sed -i.bak "s/{{RAY_COMMIT_SHA}}/$TRAVIS_COMMIT/g" ray/__init__.py && rm ray/__init__.py.bak

--- a/python/ray/autoscaler/aws/development-example.yaml
+++ b/python/ray/autoscaler/aws/development-example.yaml
@@ -98,7 +98,7 @@ setup_commands:
     - git clone https://github.com/ray-project/ray || true
     - ray/ci/travis/install-bazel.sh
     - cd ray/python/ray/dashboard/client; npm ci; npm run build
-    - pip install boto3==1.4.8 cython==0.29.0 aiohttp grpcio psutil setproctitle
+    - pip install boto3==1.4.8 cython==0.29.26 aiohttp grpcio psutil setproctitle
     - cd ray/python; pip install -e . --verbose
 
 # Custom commands that will be run on the head node after common setup.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -55,7 +55,7 @@ azure-mgmt-network==19.0.0
 azure-mgmt-resource==20.0.0
 msrestazure==0.6.4
 boto3
-cython >= 0.29.15
+cython >= 0.29.26
 dataclasses; python_version < '3.7'
 feather-format
 google-api-python-client

--- a/python/setup.py
+++ b/python/setup.py
@@ -706,7 +706,7 @@ setuptools.setup(
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
     install_requires=setup_spec.install_requires,
-    setup_requires=["cython >= 0.29.15", "wheel"],
+    setup_requires=["cython >= 0.29.26", "wheel"],
     extras_require=setup_spec.extras,
     entry_points={
         "console_scripts": [

--- a/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
@@ -5,7 +5,7 @@ python:
   pip_packages:
     - terminado
     - boto3
-    - cython==0.29.0
+    - cython==0.29.26
   conda_packages: []
 
 post_build_cmds:

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
         subprocess.run("sudo apt-get update".split(" "))
         subprocess.run("sudo apt-get install -y build-essential curl unzip "
                        "psmisc".split(" "))
-        subprocess.run("pip install cython==0.29.0 pytest".split(" "))
+        subprocess.run("pip install cython==0.29.26 pytest".split(" "))
         # Assume we are in the ray (git clone) directory.
         try:
             subprocess.run("pip uninstall -y ray".split(" "))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

cython versions needs to be updated to at least this commit: https://github.com/cython/cython/commit/d8e93b332fe7d15459433ea74cd29178c03186bd to work with py39 and later. The earliest cython version with this commit is 0.29.20. When upgrading mentions of cython version in our codebase, I noticed that we were using multiple cython versions. In lieu of this I decided to make all instances of cython versions consistent at the latest cython relaese of 0.29.26. This versions works all the way back to py36.

## Related issue number

<!-- For example: "Closes #1234" -->

Required before #21221 gets merged.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
