### PR TITLE
WINDOWS: unskip passing runtime_env tests

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -175,7 +175,6 @@ test_python() {
       -python/ray/tests:test_resource_demand_scheduler
       -python/ray/tests:test_reference_counting  # too flaky 9/25/21
       -python/ray/tests:test_runtime_env_plugin # runtime_env not supported on Windows
-      -python/ray/tests:test_runtime_env_env_vars # runtime_env not supported on Windows
       -python/ray/tests:test_runtime_env_complicated # conda install slow leading to timeout
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -174,7 +174,6 @@ test_python() {
       -python/ray/tests:test_ray_init  # test_redis_port() seems to fail here, but pass in isolation
       -python/ray/tests:test_resource_demand_scheduler
       -python/ray/tests:test_reference_counting  # too flaky 9/25/21
-      -python/ray/tests:test_runtime_env_plugin # runtime_env not supported on Windows
       -python/ray/tests:test_runtime_env_complicated # conda install slow leading to timeout
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -43,8 +43,6 @@ def test_get_release_wheel_url():
                 assert requests.head(url).status_code == 200, url
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
 def test_decorator_task(start_cluster):
     cluster, address = start_cluster
     ray.init(address)
@@ -56,8 +54,6 @@ def test_decorator_task(start_cluster):
     assert ray.get(f.remote()) == "bar"
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
 def test_decorator_actor(start_cluster):
     cluster, address = start_cluster
     ray.init(address)
@@ -71,8 +67,6 @@ def test_decorator_actor(start_cluster):
     assert ray.get(a.g.remote()) == "bar"
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
 def test_decorator_complex(start_cluster):
     cluster, address = start_cluster
     ray.init(address, runtime_env={"env_vars": {"foo": "job"}})
@@ -127,7 +121,8 @@ def test_container_option_serialize():
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+    sys.platform == "win32",
+    reason="conda in runtime_env unsupported on Windows.")
 def test_invalid_conda_env(shutdown_only):
     ray.init()
 
@@ -161,8 +156,6 @@ def test_invalid_conda_env(shutdown_only):
     assert (time.time() - start) < (first_time / 2.0)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
 def test_no_spurious_worker_startup(shutdown_only):
     """Test that no extra workers start up during a long env installation."""
 
@@ -230,8 +223,7 @@ def runtime_env_local_dev_env_var():
     del os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"]
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+@pytest.mark.skipif(sys.platform == "win32", reason="very slow on Windows.")
 def test_runtime_env_no_spurious_resource_deadlock_msg(
         runtime_env_local_dev_env_var, ray_start_regular, error_pubsub):
     p = error_pubsub

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -53,7 +53,7 @@ def test_simple_env_modification_plugin(ray_start_regular):
         }).remote()
 
 
-    if os.name != 'nt':
+    if os.name != "nt":
         # Windows does not have a command-line nice
         output = ray.get(
             f.options(

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -52,7 +52,6 @@ def test_simple_env_modification_plugin(ray_start_regular):
             }
         }).remote()
 
-
     if os.name != "nt":
         # Windows does not have a command-line nice
         output = ray.get(
@@ -67,9 +66,13 @@ def test_simple_env_modification_plugin(ray_start_regular):
                             "prefix_command": "nice -n 19",
                         }
                     }
-            }).remote())
+                }).remote())
 
-        assert output == {"env_value": "42", "tmp_content": "hello", "nice": 19}
+        assert output == {
+            "env_value": "42",
+            "tmp_content": "hello",
+            "nice": 19,
+        }
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -52,21 +52,24 @@ def test_simple_env_modification_plugin(ray_start_regular):
             }
         }).remote()
 
-    output = ray.get(
-        f.options(
-            runtime_env={
-                "plugins": {
-                    MY_PLUGIN_CLASS_PATH: {
-                        "env_value": 42,
-                        "tmp_file": tmp_file_path,
-                        "tmp_content": "hello",
-                        # See https://en.wikipedia.org/wiki/Nice_(Unix)
-                        "prefix_command": "nice -n 19",
+
+    if os.name != 'nt':
+        # Windows does not have a command-line nice
+        output = ray.get(
+            f.options(
+                runtime_env={
+                    "plugins": {
+                        MY_PLUGIN_CLASS_PATH: {
+                            "env_value": 42,
+                            "tmp_file": tmp_file_path,
+                            "tmp_content": "hello",
+                            # See https://en.wikipedia.org/wiki/Nice_(Unix)
+                            "prefix_command": "nice -n 19",
+                        }
                     }
-                }
             }).remote())
 
-    assert output == {"env_value": "42", "tmp_content": "hello", "nice": 19}
+        assert output == {"env_value": "42", "tmp_content": "hello", "nice": 19}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Unskip passing runtime_env tests on windows, and rename the skips on other tests.