### PR TITLE
[Train] Replace `abc.ABCMeta` with `abc.ABC` in callbacks

### DIFF
--- a/python/ray/train/callbacks/callback.py
+++ b/python/ray/train/callbacks/callback.py
@@ -2,7 +2,7 @@ import abc
 from typing import List, Dict
 
 
-class TrainingCallback(metaclass=abc.ABCMeta):
+class TrainingCallback(abc.ABC):
     """Abstract Train callback class."""
 
     def handle_result(self, results: List[Dict], **info):

--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -40,7 +40,7 @@ class TrainingLogdirMixin:
 
 
 class TrainingSingleFileLoggingCallback(
-        TrainingLogdirMixin, TrainingCallback, metaclass=abc.ABCMeta):
+        TrainingLogdirMixin, TrainingCallback, abc.ABC):
     """Abstract Train logging callback class.
 
     Args:
@@ -143,7 +143,7 @@ class JsonLoggerCallback(TrainingSingleFileLoggingCallback):
 
 
 class TrainingSingleWorkerLoggingCallback(
-        TrainingLogdirMixin, TrainingCallback, metaclass=abc.ABCMeta):
+        TrainingLogdirMixin, TrainingCallback, abc.ABC):
     """Abstract Train logging callback class.
 
     Allows only for single-worker logging.

--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -39,8 +39,8 @@ class TrainingLogdirMixin:
         return Path(self._logdir_path)
 
 
-class TrainingSingleFileLoggingCallback(
-        TrainingLogdirMixin, TrainingCallback, abc.ABC):
+class TrainingSingleFileLoggingCallback(TrainingLogdirMixin, TrainingCallback,
+                                        abc.ABC):
     """Abstract Train logging callback class.
 
     Args:
@@ -142,8 +142,8 @@ class JsonLoggerCallback(TrainingSingleFileLoggingCallback):
                 loaded_results + [results_to_log], f, cls=SafeFallbackEncoder)
 
 
-class TrainingSingleWorkerLoggingCallback(
-        TrainingLogdirMixin, TrainingCallback, abc.ABC):
+class TrainingSingleWorkerLoggingCallback(TrainingLogdirMixin,
+                                          TrainingCallback, abc.ABC):
     """Abstract Train logging callback class.
 
     Allows only for single-worker logging.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Inheriting from `abc.ABC` is more readable than setting the meta class to `abc.ABCMeta`.

Relevant snippet from the Python 3.4 release notes:
> New class ABC has ABCMeta as its meta class. Using ABC as a base class has essentially the same effect as specifying metaclass=abc.ABCMeta, but is simpler to type and easier to read. (Contributed by Bruno Dupuis in bpo-16049.)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
