### PR TITLE
[Dask on Ray] Use spread as default scheduling for dask on ray

### DIFF
--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -347,6 +347,7 @@ def _rayify_task(
             name=f"dask:{key!s}",
             num_returns=(1 if not isinstance(func, MultipleReturnFunc) else
                          func.num_returns),
+            scheduling_strategy="SPREAD",
         ).remote(
             func,
             repack,

--- a/python/ray/util/dask/tests/test_dask_scheduler.py
+++ b/python/ray/util/dask/tests/test_dask_scheduler.py
@@ -86,7 +86,7 @@ def test_spread_scheduling(ray_start_cluster):
     cluster.add_node(num_cpus=4)
 
     def set_aggregate(x, y):
-        return set([x, y])
+        return {x, y}
 
     def get_ip():
         import time


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Dask on Ray works better with spread scheduling especially when data loading is involved. This PR uses the spread scheduling by default for dask on ray. 

There are times pack scheduling works better. This can be optimized in a different way in the future (better locality scheduling, or different scheduling strategy depending on function names)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
