### PR TITLE
[tune] Fix dtype coercion in `tune.choice`

### DIFF
--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -376,7 +376,11 @@ class Categorical(Domain):
                    random_state: "RandomState" = None):
             if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
-            items = random_state.choice(domain.categories, size=size).tolist()
+            # do not use .choice() directly on domain.categories
+            # as that will coerce them to a single dtype
+            indices = random_state.choice(
+                np.arange(0, len(domain.categories)), size=size)
+            items = [domain.categories[index] for index in indices]
             return items if len(items) > 1 else domain.cast(items[0])
 
     default_sampler_cls = _Uniform

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -402,6 +402,14 @@ class SearchSpaceTest(unittest.TestCase):
         samples = tune.sample.Float(0, 33).quantized(3).sample(size=1000)
         self.assertTrue(all(0 <= s <= 33 for s in samples))
 
+    def testCategoricalDtype(self):
+        dist = tune.choice([1.0, "str"])
+
+        np.random.seed(1000)
+        sample = dist.sample(size=100)
+        self.assertTrue(
+            all((x, type(x)) in [(1.0, float), ("str", str)] for x in sample))
+
     def testCategoricalSeedInTrainingLoop(self):
         def train(config):
             return 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a list with mixed types is passed to `tune.choice`, they will be coerced to a single dtype during sampling (due to `numpy.choice` converting to an array internally). This behaviour is unintentional and surprising. This PR fixes this issue. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
