### PR TITLE
Unskip remaining tests in test_basic.py on Windows

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -214,7 +214,7 @@ def run_string_as_driver(driver_script: str, env: Dict = None):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        env=dict(os.environ, **env) if env else None,
+        env=env,
     )
     with proc:
         output = proc.communicate(driver_script.encode("ascii"))[0]
@@ -247,7 +247,7 @@ def run_string_as_driver_nonblocking(driver_script, env: Dict = None):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=dict(os.environ, **env) if env else None,
+        env=env,
     )
     proc.stdin.write(driver_script.encode("ascii"))
     proc.stdin.close()

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -214,7 +214,7 @@ def run_string_as_driver(driver_script: str, env: Dict = None):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        env=env,
+        env=dict(os.environ, **env) if env else None,
     )
     with proc:
         output = proc.communicate(driver_script.encode("ascii"))[0]
@@ -247,7 +247,8 @@ def run_string_as_driver_nonblocking(driver_script, env: Dict = None):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=env)
+        env=dict(os.environ, **env) if env else None,
+    )
     proc.stdin.write(driver_script.encode("ascii"))
     proc.stdin.close()
     return proc

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -208,13 +208,8 @@ print("local", ray._private.runtime_env.VAR)
 
 """
 
-    out = run_string_as_driver(
-        script,
-        dict(
-            os.environ, **{
-                "RAY_USER_SETUP_FUNCTION":
-                "ray._private.test_utils.set_setup_func"
-            }))
+    env = {"RAY_USER_SETUP_FUNCTION": "ray._private.test_utils.set_setup_func"}
+    out = run_string_as_driver(script, dict(os.environ, **env))
     (remote_out, local_out) = out.strip().splitlines()[-2:]
     assert remote_out == "remote hello world"
     assert local_out == "local hello world"

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -210,7 +210,10 @@ print("local", ray._private.runtime_env.VAR)
 
     out = run_string_as_driver(
         script,
-        {"RAY_USER_SETUP_FUNCTION": "ray._private.test_utils.set_setup_func"})
+        dict(
+            os.environ, **{
+                "RAY_USER_SETUP_FUNCTION": "ray._private.test_utils.set_setup_func"
+            }))
     (remote_out, local_out) = out.strip().splitlines()[-2:]
     assert remote_out == "remote hello world"
     assert local_out == "local hello world"
@@ -230,8 +233,10 @@ def check():
 print("remote", ray.get(check.remote()))
 """
 
-    run_string_as_driver(script,
-                         {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"})
+    run_string_as_driver(
+        script,
+        dict(os.environ,
+             **{"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}))
 
 
 def test_put_get(shutdown_only):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -194,7 +194,6 @@ def test_invalid_arguments(shutdown_only):
                 x = 1
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 def test_user_setup_function():
     script = """
 import ray
@@ -218,7 +217,6 @@ print("local", ray._private.runtime_env.VAR)
 
 
 # https://github.com/ray-project/ray/issues/17842
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")
 def test_disable_cuda_devices():
     script = """
 import ray

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -211,7 +211,7 @@ print("local", ray._private.runtime_env.VAR)
     out = run_string_as_driver(
         script,
         {"RAY_USER_SETUP_FUNCTION": "ray._private.test_utils.set_setup_func"})
-    (remote_out, local_out) = out.strip().split("\n")[-2:]
+    (remote_out, local_out) = out.strip().splitlines()[-2:]
     assert remote_out == "remote hello world"
     assert local_out == "local hello world"
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -212,7 +212,8 @@ print("local", ray._private.runtime_env.VAR)
         script,
         dict(
             os.environ, **{
-                "RAY_USER_SETUP_FUNCTION": "ray._private.test_utils.set_setup_func"
+                "RAY_USER_SETUP_FUNCTION":
+                "ray._private.test_utils.set_setup_func"
             }))
     (remote_out, local_out) = out.strip().splitlines()[-2:]
     assert remote_out == "remote hello world"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

What happened here is the run_string_as_driver function was not letting the driver inherit the environment (just setting it from scratch). That screwed up things on windows, since the random number generator doesn't work with an empty environment, see https://stackoverflow.com/a/64706392

The error was
```
Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python
--
  | Python runtime state: preinitialized
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
