### PR TITLE
[Core] Remove unused flag put_small_object_in_memory_store

### DIFF
--- a/python/ray/_private/ray_client_microbenchmark.py
+++ b/python/ray/_private/ray_client_microbenchmark.py
@@ -95,9 +95,6 @@ def main(results=None):
     results = results or []
 
     ray_config = {
-        "_system_config": {
-            "put_small_object_in_memory_store": True
-        },
         "logging_level": logging.WARNING
     }
 

--- a/python/ray/_private/ray_client_microbenchmark.py
+++ b/python/ray/_private/ray_client_microbenchmark.py
@@ -94,9 +94,7 @@ def benchmark_simple_actor(ray, results):
 def main(results=None):
     results = results or []
 
-    ray_config = {
-        "logging_level": logging.WARNING
-    }
+    ray_config = {"logging_level": logging.WARNING}
 
     def ray_connect_handler(job_config=None, **ray_init_kwargs):
         from ray._private.client_mode_hook import disable_client_hook

--- a/python/ray/_private/ray_perf.py
+++ b/python/ray/_private/ray_perf.py
@@ -96,7 +96,7 @@ def main(results=None):
 
     print("Tip: set TESTS_TO_RUN='pattern' to run a subset of benchmarks")
 
-    ray.init(_system_config={"put_small_object_in_memory_store": True})
+    ray.init()
 
     value = ray.put(0)
 
@@ -121,7 +121,7 @@ def main(results=None):
     results += timeit("multi client put calls", put_multi_small, 1000)
 
     ray.shutdown()
-    ray.init(_system_config={"put_small_object_in_memory_store": False})
+    ray.init()
 
     value = ray.put(0)
     arr = np.zeros(100 * 1024 * 1024, dtype=np.int64)

--- a/python/ray/_private/ray_perf.py
+++ b/python/ray/_private/ray_perf.py
@@ -103,12 +103,8 @@ def main(results=None):
     def get_small():
         ray.get(value)
 
-    results += timeit("single client get calls", get_small)
-
     def put_small():
         ray.put(0)
-
-    results += timeit("single client put calls", put_small)
 
     @ray.remote
     def do_put_small():
@@ -118,12 +114,6 @@ def main(results=None):
     def put_multi_small():
         ray.get([do_put_small.remote() for _ in range(10)])
 
-    results += timeit("multi client put calls", put_multi_small, 1000)
-
-    ray.shutdown()
-    ray.init()
-
-    value = ray.put(0)
     arr = np.zeros(100 * 1024 * 1024, dtype=np.int64)
 
     results += timeit("single client get calls (Plasma Store)", get_small)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1278,7 +1278,6 @@ cdef class CoreWorker:
             shared_ptr[CBuffer] data_buf
             shared_ptr[CBuffer] metadata_buf
             int64_t put_threshold
-            c_bool put_small_object_in_memory_store
             c_vector[CObjectID] c_object_id_vector
             unique_ptr[CAddress] c_owner_address
         # TODO(suquark): This method does not support put objects to
@@ -1317,16 +1316,12 @@ cdef class CoreWorker:
             shared_ptr[CBuffer] data
             shared_ptr[CBuffer] metadata
             int64_t put_threshold
-            c_bool put_small_object_in_memory_store
             unique_ptr[CAddress] c_owner_address
             c_vector[CObjectID] contained_object_ids
             c_vector[CObjectReference] contained_object_refs
 
         metadata = string_to_buffer(serialized_object.metadata)
         put_threshold = RayConfig.instance().max_direct_call_object_size()
-        put_small_object_in_memory_store = (
-            RayConfig.instance().put_small_object_in_memory_store() and
-            inline_small_object)
         total_bytes = serialized_object.total_bytes
         contained_object_ids = ObjectRefsToVector(
                 serialized_object.contained_object_refs)
@@ -1339,8 +1334,7 @@ cdef class CoreWorker:
             if total_bytes > 0:
                 (<SerializedObject>serialized_object).write_to(
                     Buffer.make(data))
-            if self.is_local_mode or (put_small_object_in_memory_store
-               and <int64_t>total_bytes < put_threshold):
+            if self.is_local_mode or inline_small_object:
                 contained_object_refs = (
                         CCoreWorkerProcess.GetCoreWorker().
                         GetObjectRefs(contained_object_ids))

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1334,7 +1334,7 @@ cdef class CoreWorker:
             if total_bytes > 0:
                 (<SerializedObject>serialized_object).write_to(
                     Buffer.make(data))
-            if self.is_local_mode or inline_small_object:
+            if self.is_local_mode:
                 contained_object_refs = (
                         CCoreWorkerProcess.GetCoreWorker().
                         GetObjectRefs(contained_object_ids))

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -53,8 +53,6 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         int64_t max_direct_call_object_size() const
 
-        c_bool put_small_object_in_memory_store() const
-
         int64_t task_rpc_inlined_bytes_limit() const
 
         uint32_t max_tasks_in_flight_per_worker() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -89,10 +89,6 @@ cdef class Config:
         return RayConfig.instance().maximum_gcs_deletion_batch_size()
 
     @staticmethod
-    def put_small_object_in_memory_store():
-        return RayConfig.instance().put_small_object_in_memory_store()
-
-    @staticmethod
     def max_tasks_in_flight_per_worker():
         return RayConfig.instance().max_tasks_in_flight_per_worker()
 

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -553,7 +553,6 @@ def test_future_resolution_skip_plasma(ray_start_cluster):
         _system_config={
             "worker_lease_timeout_milliseconds": 0,
             "max_direct_call_object_size": 100 * 1024,
-            "put_small_object_in_memory_store": True,
         },
     )
     cluster.add_node(num_cpus=1, resources={"pin_worker": 1})
@@ -591,7 +590,6 @@ def test_task_output_inline_bytes_limit(ray_start_cluster):
             "worker_lease_timeout_milliseconds": 0,
             "max_direct_call_object_size": 100 * 1024,
             "task_rpc_inlined_bytes_limit": 20,
-            "put_small_object_in_memory_store": True,
         },
     )
     cluster.add_node(num_cpus=1, resources={"pin_worker": 1})
@@ -629,7 +627,6 @@ def test_task_arguments_inline_bytes_limit(ray_start_cluster):
             # max_grpc_message_size, this test fails.
             "task_rpc_inlined_bytes_limit": 18 * 1024,
             "max_grpc_message_size": 20 * 1024,
-            "put_small_object_in_memory_store": True,
         },
     )
     cluster.add_node(num_cpus=1, resources={"pin_worker": 1})

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -323,9 +323,6 @@ RAY_CONFIG(int64_t, metrics_report_batch_size, 100)
 /// Whether or not we enable metrics collection.
 RAY_CONFIG(int64_t, enable_metrics_collection, true)
 
-/// Whether put small objects in the local memory store.
-RAY_CONFIG(bool, put_small_object_in_memory_store, false)
-
 // Max number bytes of inlined objects in a task rpc request/response.
 RAY_CONFIG(int64_t, task_rpc_inlined_bytes_limit, 10 * 1024 * 1024)
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -841,9 +841,7 @@ Status CoreWorker::Put(const RayObject &object,
                        const std::vector<ObjectID> &contained_object_ids,
                        const ObjectID &object_id, bool pin_object) {
   RAY_RETURN_NOT_OK(WaitForActorRegistered(contained_object_ids));
-  if (options_.is_local_mode ||
-      (RayConfig::instance().put_small_object_in_memory_store() &&
-       static_cast<int64_t>(object.GetSize()) < max_direct_call_object_size_)) {
+  if (options_.is_local_mode) {
     RAY_LOG(DEBUG) << "Put " << object_id << " in memory store";
     RAY_CHECK(memory_store_->Put(object, object_id));
     return Status::OK();
@@ -904,10 +902,7 @@ Status CoreWorker::CreateOwned(const std::shared_ptr<Buffer> &metadata,
     status = status_promise.get_future().get();
   }
 
-  if ((options_.is_local_mode ||
-       (RayConfig::instance().put_small_object_in_memory_store() &&
-        static_cast<int64_t>(data_size) < max_direct_call_object_size_)) &&
-      owned_by_us && inline_small_object) {
+  if (options_.is_local_mode && owned_by_us && inline_small_object) {
     *data = std::make_shared<LocalMemoryBuffer>(data_size);
   } else {
     if (status.ok()) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Since we have not been using `put_small_object_in_memory_store` flag for a long time, it's should be removed. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
