### PR TITLE
[GCS][Bootstrap 2/n] Fix tests to enable using GCS address for bootstrapping

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -206,10 +206,9 @@ class JobSupervisor:
                 "runtime_env": self._runtime_env,
                 "metadata": self._metadata,
             })
-            ray_redis_address = ray._private.services.find_redis_address_or_die(  # noqa: E501
-            )
-            os.environ[ray_constants.
-                       RAY_ADDRESS_ENVIRONMENT_VARIABLE] = ray_redis_address
+            ray_address = ray._private.services.get_ray_address_to_use_or_die()
+            os.environ[
+                ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE] = ray_address
 
             log_path = self._log_client.get_log_file_path(self._job_id)
             child_process = self._exec_entrypoint(log_path)

--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -377,6 +377,40 @@ class GcsFunctionKeySubscriber(_SyncSubscriber):
             return self._pop_function_key(self._queue)
 
 
+class GcsActorSubscriber(_SyncSubscriber):
+    """Subscriber to actor updates. Thread safe.
+
+    Usage example:
+        subscriber = GcsActorSubscriber()
+        # Subscribe to the actor channel.
+        subscriber.subscribe()
+        ...
+        while running:
+            actor_data = subscriber.poll()
+            ......
+        # Unsubscribe from the channel.
+        subscriber.close()
+    """
+
+    def __init__(
+            self,
+            address: str = None,
+            channel: grpc.Channel = None,
+    ):
+        super().__init__(pubsub_pb2.GCS_ACTOR_CHANNEL, address, channel)
+
+    def poll(self, timeout=None) -> Optional[bytes]:
+        """Polls for new actor messages.
+
+        Returns:
+            A byte string of function key.
+            None if polling times out or subscriber closed.
+        """
+        with self._lock:
+            self._poll_locked(timeout=timeout)
+            return self._pop_actor(self._queue)
+
+
 class GcsAioPublisher(_PublisherBase):
     """Publisher to GCS. Uses async io."""
 

--- a/python/ray/_private/gcs_utils.py
+++ b/python/ray/_private/gcs_utils.py
@@ -169,10 +169,11 @@ class GcsChannel:
         self._aio = aio
 
     def connect(self):
-        if self._redis_client is not None:
-            self._gcs_address = get_gcs_address_from_redis(self._redis_client)
-
-        gcs_address = self._gcs_address
+        if self._gcs_address is None:
+            assert self._redis_client is not None
+            gcs_address = get_gcs_address_from_redis(self._redis_client)
+        else:
+            gcs_address = self._gcs_address
         self._channel = create_gcs_channel(gcs_address, self._aio)
 
     def channel(self):

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -12,10 +12,6 @@ class RayParams:
     """A class used to store the parameters used by Ray.
 
     Attributes:
-        external_addresses (str): The address of external Redis server to
-            connect to, in format of "ip1:port1,ip2:port2,...".  If this
-            address is provided, then ray won't start Redis instances in the
-            head node but use external Redis server(s) instead.
         redis_address (str): The address of the Redis server to connect to. If
             this address is not provided, then this command will start Redis, a
             raylet, a plasma store, a plasma manager, and some workers.
@@ -60,6 +56,10 @@ class RayParams:
             manner. However, the same ID should not be used for different jobs.
         redirect_output (bool): True if stdout and stderr for non-worker
             processes should be redirected to files and false otherwise.
+        external_addresses (str): The address of external Redis server to
+            connect to, in format of "ip1:port1,ip2:port2,...".  If this
+            address is provided, then ray won't start Redis instances in the
+            head node but use external Redis server(s) instead.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
         redis_max_clients: If provided, attempt to configure Redis with this
@@ -120,7 +120,6 @@ class RayParams:
     """
 
     def __init__(self,
-                 external_addresses=None,
                  redis_address=None,
                  gcs_address=None,
                  num_cpus=None,
@@ -143,6 +142,7 @@ class RayParams:
                  object_ref_seed=None,
                  driver_mode=None,
                  redirect_output=None,
+                 external_addresses=None,
                  num_redis_shards=None,
                  redis_max_clients=None,
                  redis_password=ray_constants.REDIS_DEFAULT_PASSWORD,
@@ -171,8 +171,6 @@ class RayParams:
                  tracing_startup_hook=None,
                  no_monitor=False,
                  env_vars=None):
-        self.object_ref_seed = object_ref_seed
-        self.external_addresses = external_addresses
         self.redis_address = redis_address
         self.gcs_address = gcs_address
         self.num_cpus = num_cpus
@@ -194,6 +192,7 @@ class RayParams:
         self.ray_client_server_port = ray_client_server_port
         self.driver_mode = driver_mode
         self.redirect_output = redirect_output
+        self.external_addresses = external_addresses
         self.num_redis_shards = num_redis_shards
         self.redis_max_clients = redis_max_clients
         self.redis_password = redis_password
@@ -216,6 +215,7 @@ class RayParams:
         self.metrics_export_port = metrics_export_port
         self.tracing_startup_hook = tracing_startup_hook
         self.no_monitor = no_monitor
+        self.object_ref_seed = object_ref_seed
         self.start_initial_python_workers_for_first_job = (
             start_initial_python_workers_for_first_job)
         self.ray_debugger_external = ray_debugger_external

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -96,6 +96,8 @@ class FakeMultiNodeProvider(NodeProvider):
                 resources=resources,
                 redis_address="{}:6379".format(
                     ray._private.services.get_node_ip_address()),
+                gcs_address="{}:6379".format(
+                    ray._private.services.get_node_ip_address()),
                 env_vars={
                     "RAY_OVERRIDE_NODE_ID_FOR_TESTING": next_id,
                     "RAY_OVERRIDE_RESOURCES": json.dumps(resources),

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -96,8 +96,6 @@ class FakeMultiNodeProvider(NodeProvider):
                 resources=resources,
                 redis_address="{}:6379".format(
                     ray._private.services.get_node_ip_address()),
-                gcs_address="{}:6379".format(
-                    ray._private.services.get_node_ip_address()),
                 env_vars={
                     "RAY_OVERRIDE_NODE_ID_FOR_TESTING": next_id,
                     "RAY_OVERRIDE_RESOURCES": json.dumps(resources),

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -142,10 +142,8 @@ class Cluster:
 
     @property
     def address(self):
-        if use_gcs_for_bootstrap():
-            return self.gcs_address
-        else:
-            return self.redis_address
+        # TODO(mwtian): use self.gcs_address when use_gcs_for_bootstrap():
+        return self.redis_address
 
     def connect(self, namespace=None):
         """Connect the driver to the cluster."""

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -136,20 +136,25 @@ class Cluster:
 
     @property
     def gcs_address(self):
+        if self.head_node is None:
+            return None
         return self.head_node.gcs_address
 
     @property
     def address(self):
-        return self.redis_address
+        if use_gcs_for_bootstrap():
+            return self.gcs_address
+        else:
+            return self.redis_address
 
     def connect(self, namespace=None):
         """Connect the driver to the cluster."""
-        assert self.redis_address is not None
+        assert self.address is not None
         assert not self.connected
         output_info = ray.init(
             namespace=namespace,
             ignore_reinit_error=True,
-            address=self.redis_address,
+            address=self.address,
             _redis_password=self.redis_password)
         logger.info(output_info)
         self.connected = True

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -225,7 +225,8 @@ class Node:
             if gcs_server_port:
                 ray_params.update_if_absent(gcs_server_port=gcs_server_port)
             if ray_params.gcs_server_port is None:
-                ray_params.gcs_server_port = self._get_unused_port()
+                ray_params.gcs_server_port = self._get_cached_port(
+                    "gcs_server_port")
             self._gcs_server_port = ray_params.gcs_server_port
 
         if not connect_only and spawn_reaper and not self.kernel_fate_share:

--- a/python/ray/serve/tests/test_persistence.py
+++ b/python/ray/serve/tests/test_persistence.py
@@ -15,7 +15,7 @@ def driver():
     return "OK!"
 
 driver.deploy()
-""".format(ray.worker._global_node._redis_address)
+""".format(ray.worker._global_node.address)
     run_string_as_driver(script)
 
     handle = serve.get_deployment("driver").get_handle()

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -480,7 +480,7 @@ def test_serve_controller_namespace(ray_shutdown, namespace: Optional[str],
 def test_checkpoint_isolation_namespace(ray_shutdown):
     info = ray.init(namespace="test_namespace1")
 
-    address = info["redis_address"]
+    address = info["address"]
 
     driver_template = """
 import ray

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -613,7 +613,7 @@ def test_calling_put_on_actor_handle(ray_start_regular):
 
 
 def test_named_but_not_detached(ray_start_regular):
-    redis_address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     driver_script = """
 import ray
@@ -629,7 +629,7 @@ assert ray.get(actor.ping.remote()) == "pong"
 handle = ray.get_actor("actor")
 assert ray.util.list_named_actors() == ["actor"]
 assert ray.get(handle.ping.remote()) == "pong"
-""".format(redis_address)
+""".format(address)
 
     # Creates and kills actor once the driver exits.
     run_string_as_driver(driver_script)
@@ -687,7 +687,7 @@ def test_detached_actor(ray_start_regular):
     with pytest.raises(ValueError, match="Please use a different name"):
         DetachedActor._remote(lifetime="detached", name="d_actor")
 
-    redis_address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     get_actor_name = "d_actor"
     create_actor_name = "DetachedActor"
@@ -720,7 +720,7 @@ class DetachedActor:
 
 actor = DetachedActor._remote(lifetime="detached", name="{}")
 ray.get(actor.ping.remote())
-""".format(redis_address, get_actor_name, create_actor_name)
+""".format(address, get_actor_name, create_actor_name)
 
     run_string_as_driver(driver_script)
     assert len(ray.util.list_named_actors()) == 2
@@ -773,7 +773,7 @@ def test_detached_actor_cleanup(ray_start_regular):
     # name should have been cleaned up from GCS.
     create_and_kill_actor(dup_actor_name)
 
-    redis_address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
     driver_script = """
 import ray
 import ray._private.gcs_utils as gcs_utils
@@ -801,7 +801,7 @@ while actor_status["State"] != convert_actor_state(gcs_utils.ActorTableData.DEAD
     if wait_time >= max_wait_time:
         assert None, (
             "It took too much time to kill an actor")
-""".format(redis_address, dup_actor_name)
+""".format(address, dup_actor_name)
 
     run_string_as_driver(driver_script)
     # Make sure we can create a detached actor created/killed

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -809,7 +809,7 @@ obj = normal_task.remote(large, large)
 print(ray.get(obj))
 """
     driver_script = driver_template.format(
-        address=ray_start_regular["redis_address"])
+        address=ray_start_regular["address"])
     driver_proc = run_string_as_driver_nonblocking(driver_script)
     try:
         driver_proc.wait(10)

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -462,12 +462,28 @@ def test_ray_address_environment_variable(ray_start_cluster):
     # ray cluster and connecting to an existing one.
 
     # Make sure we connect to an existing cluster if
-    # RAY_ADDRESS is set.
+    # RAY_ADDRESS is set to the cluster address.
     os.environ["RAY_ADDRESS"] = address
     ray.init()
     assert "CPU" not in ray.state.cluster_resources()
-    del os.environ["RAY_ADDRESS"]
     ray.shutdown()
+    del os.environ["RAY_ADDRESS"]
+
+    # Make sure we connect to an existing cluster if
+    # RAY_ADDRESS is set to "auto".
+    os.environ["RAY_ADDRESS"] = "auto"
+    ray.init()
+    assert "CPU" not in ray.state.cluster_resources()
+    ray.shutdown()
+    del os.environ["RAY_ADDRESS"]
+
+    # Prefer `address` parameter to the `RAY_ADDRESS` environment variable,
+    # when `address` is not `auto`.
+    os.environ["RAY_ADDRESS"] = "test"
+    ray.init(address=address)
+    assert "CPU" not in ray.state.cluster_resources()
+    ray.shutdown()
+    del os.environ["RAY_ADDRESS"]
 
     # Make sure we start a new cluster if RAY_ADDRESS is not set.
     ray.init()

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -355,7 +355,6 @@ def test_ray_options(shutdown_only):
 def test_fetch_local(ray_start_cluster_head):
     cluster = ray_start_cluster_head
     cluster.add_node(num_cpus=2, object_store_memory=75 * 1024 * 1024)
-
     signal_actor = SignalActor.remote()
 
     @ray.remote

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -694,8 +694,7 @@ if __name__ == "__main__":
         test_driver = os.path.join(tmpdir, "test_load_code_from_local.py")
         with open(test_driver, "w") as f:
             f.write(
-                code_test.format(
-                    repr(ray_start_regular_shared["redis_address"])))
+                code_test.format(repr(ray_start_regular_shared["address"])))
         output = subprocess.check_output([sys.executable, test_driver])
         assert b"OK" in output
 

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -469,7 +469,7 @@ def test_ray_submit(configure_lang, configure_aws, _unlink_test_ssh_key):
 
 def test_ray_status():
     import ray
-    address = ray.init(num_cpus=3).get("redis_address")
+    address = ray.init(num_cpus=3).get("address")
     runner = CliRunner()
 
     def output_ready():

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -22,7 +22,7 @@ def start_ray_and_proxy_manager(n_ports=2):
     ray_instance = ray.init(_redis_password="test")
     agent_port = ray.worker.global_worker.node.metrics_agent_port
     pm = proxier.ProxyManager(
-        ray_instance["redis_address"],
+        ray_instance["address"],
         session_dir=ray_instance["session_dir"],
         redis_password="test",
         runtime_env_agent_port=agent_port)
@@ -165,7 +165,7 @@ def test_delay_in_rewriting_environment(shutdown_only):
     ray_instance = ray.init()
     server = proxier.serve_proxier(
         "localhost:25010",
-        ray_instance["redis_address"],
+        ray_instance["address"],
         session_dir=ray_instance["session_dir"])
 
     def delay_in_rewrite(_input: JobConfig):
@@ -202,7 +202,7 @@ def test_startup_error_yields_clean_result(shutdown_only):
     ray_instance = ray.init()
     server = proxier.serve_proxier(
         "localhost:25030",
-        ray_instance["redis_address"],
+        ray_instance["address"],
         session_dir=ray_instance["session_dir"])
 
     def raise_not_rewrite(input: JobConfig):

--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -77,7 +77,7 @@ def test_dying_driver_get(ray_start_regular):
 import ray
 ray.init("{}")
 ray.get(ray.ObjectRef(ray._private.utils.hex_to_binary("{}")))
-""".format(address_info["redis_address"], x_id.hex())
+""".format(address_info["address"], x_id.hex())
 
     p = run_string_as_driver_nonblocking(driver)
     # Make sure the driver is running.
@@ -156,7 +156,7 @@ def test_dying_driver_wait(ray_start_regular):
 import ray
 ray.init("{}")
 ray.wait([ray.ObjectRef(ray._private.utils.hex_to_binary("{}"))])
-""".format(address_info["redis_address"], x_id.hex())
+""".format(address_info["address"], x_id.hex())
 
     p = run_string_as_driver_nonblocking(driver)
     # Make sure the driver is running.

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -11,7 +11,7 @@ import ray._private.utils
 import ray._private.gcs_utils as gcs_utils
 import ray.ray_constants as ray_constants
 from ray.exceptions import RayTaskError, RayActorError, GetTimeoutError
-from ray._private.gcs_pubsub import gcs_pubsub_enabled, GcsPublisher
+from ray._private.gcs_pubsub import GcsPublisher
 from ray._private.test_utils import (wait_for_condition, SignalActor,
                                      init_error_pubsub, get_error_message,
                                      convert_actor_state)
@@ -65,13 +65,15 @@ def test_unhandled_errors(ray_start_regular):
 
 def test_publish_error_to_driver(ray_start_regular, error_pubsub):
     address_info = ray_start_regular
-    address = address_info["redis_address"]
-    redis_client = ray._private.services.create_redis_client(
-        address, password=ray.ray_constants.REDIS_DEFAULT_PASSWORD)
+    address = address_info["address"]
+    redis_client = None
     gcs_publisher = None
-    if gcs_pubsub_enabled():
-        gcs_publisher = GcsPublisher(
-            address=gcs_utils.get_gcs_address_from_redis(redis_client))
+    if gcs_utils.use_gcs_for_bootstrap():
+        gcs_publisher = GcsPublisher(address=address)
+    else:
+        redis_client = ray._private.services.create_redis_client(
+            address, password=ray.ray_constants.REDIS_DEFAULT_PASSWORD)
+
     error_message = "Test error message"
     ray._private.utils.publish_error_to_driver(
         ray_constants.DASHBOARD_AGENT_DIED_ERROR,

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -11,7 +11,7 @@ import ray._private.utils
 import ray._private.gcs_utils as gcs_utils
 import ray.ray_constants as ray_constants
 from ray.exceptions import RayTaskError, RayActorError, GetTimeoutError
-from ray._private.gcs_pubsub import GcsPublisher
+from ray._private.gcs_pubsub import gcs_pubsub_enabled, GcsPublisher
 from ray._private.test_utils import (wait_for_condition, SignalActor,
                                      init_error_pubsub, get_error_message,
                                      convert_actor_state)
@@ -65,14 +65,14 @@ def test_unhandled_errors(ray_start_regular):
 
 def test_publish_error_to_driver(ray_start_regular, error_pubsub):
     address_info = ray_start_regular
-    address = address_info["address"]
     redis_client = None
     gcs_publisher = None
-    if gcs_utils.use_gcs_for_bootstrap():
-        gcs_publisher = GcsPublisher(address=address)
+    if gcs_pubsub_enabled():
+        gcs_publisher = GcsPublisher(address=address_info["gcs_address"])
     else:
         redis_client = ray._private.services.create_redis_client(
-            address, password=ray.ray_constants.REDIS_DEFAULT_PASSWORD)
+            address_info["redis_address"],
+            password=ray.ray_constants.REDIS_DEFAULT_PASSWORD)
 
     error_message = "Test error message"
     ray._private.utils.publish_error_to_driver(

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -19,6 +19,7 @@ from ray.core.generated import gcs_service_pb2
 from ray.core.generated import gcs_service_pb2_grpc
 from ray._private.test_utils import (init_error_pubsub, get_error_message,
                                      run_string_as_driver, wait_for_condition)
+from ray._private.gcs_utils import use_gcs_for_bootstrap
 from ray.exceptions import LocalRayletDiedError
 import ray.experimental.internal_kv as internal_kv
 
@@ -384,9 +385,12 @@ def test_gcs_drain(ray_start_cluster_head, error_pubsub):
     Test batch drain.
     """
     # Prepare requests.
-    redis_cli = ray._private.services.create_redis_client(
-        cluster.address, password=ray_constants.REDIS_DEFAULT_PASSWORD)
-    gcs_server_addr = redis_cli.get("GcsServerAddress").decode("utf-8")
+    if use_gcs_for_bootstrap():
+        gcs_server_addr = cluster.address
+    else:
+        redis_cli = ray._private.services.create_redis_client(
+            cluster.address, password=ray_constants.REDIS_DEFAULT_PASSWORD)
+        gcs_server_addr = redis_cli.get("GcsServerAddress").decode("utf-8")
     options = (("grpc.enable_http_proxy", 0), )
     channel = grpc.insecure_channel(gcs_server_addr, options)
     stub = gcs_service_pb2_grpc.NodeInfoGcsServiceStub(channel)

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -386,11 +386,12 @@ def test_gcs_drain(ray_start_cluster_head, error_pubsub):
     """
     # Prepare requests.
     if use_gcs_for_bootstrap():
-        gcs_server_addr = cluster.address
+        gcs_server_addr = cluster.gcs_address
     else:
         redis_cli = ray._private.services.create_redis_client(
-            cluster.address, password=ray_constants.REDIS_DEFAULT_PASSWORD)
-        gcs_server_addr = redis_cli.get("GcsServerAddress").decode("utf-8")
+            cluster.redis_address,
+            password=ray_constants.REDIS_DEFAULT_PASSWORD)
+        gcs_server_addr = redis_cli.get("GcsServerAddress").decode()
     options = (("grpc.enable_http_proxy", 0), )
     channel = grpc.insecure_channel(gcs_server_addr, options)
     stub = gcs_service_pb2_grpc.NodeInfoGcsServiceStub(channel)

--- a/python/ray/tests/test_list_actors.py
+++ b/python/ray/tests/test_list_actors.py
@@ -89,7 +89,7 @@ def test_list_named_actors_ray_kill(ray_start_regular):
 
 def test_list_named_actors_detached(ray_start_regular):
     """Verify that names are returned for detached actors until killed."""
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     driver_script = """
 import ray
@@ -115,7 +115,7 @@ assert "sad" in ray.util.list_named_actors()
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 def test_list_named_actors_namespace(ray_start_regular):
     """Verify that actor names are filtered on namespace by default."""
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     driver_script_1 = """
 import ray

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -69,7 +69,7 @@ def count(memory_str, substr):
         "_system_config": ray_config
     }], indirect=True)
 def test_driver_put_ref(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
     info = memory_summary(address)
     assert num_objects(info) == 0, info
     x_id = ray.put("HI")
@@ -88,7 +88,7 @@ def test_driver_put_ref(ray_start_regular):
         "_system_config": ray_config
     }], indirect=True)
 def test_worker_task_refs(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     @ray.remote
     def f(y):
@@ -131,7 +131,7 @@ def test_worker_task_refs(ray_start_regular):
         "_system_config": ray_config
     }], indirect=True)
 def test_actor_task_refs(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     @ray.remote
     class Actor:
@@ -183,7 +183,7 @@ def test_actor_task_refs(ray_start_regular):
         "_system_config": ray_config
     }], indirect=True)
 def test_nested_object_refs(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
     x_id = ray.put(np.zeros(100000))
     y_id = ray.put([x_id])
     z_id = ray.put([y_id])
@@ -201,7 +201,7 @@ def test_nested_object_refs(ray_start_regular):
         "_system_config": ray_config
     }], indirect=True)
 def test_pinned_object_call_site(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
     # Local ref only.
     x_id = ray.put(np.zeros(100000))
     info = memory_summary(address)
@@ -270,7 +270,7 @@ def test_multi_node_stats(shutdown_only):
         "_system_config": ray_config
     }], indirect=True)
 def test_group_by_sort_by(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     @ray.remote
     def f(y):
@@ -300,7 +300,7 @@ def test_group_by_sort_by(ray_start_regular):
         "_system_config": ray_config
     }], indirect=True)
 def test_memory_used_output(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
     import numpy as np
     _ = ray.put(np.ones(8 * 1024 * 1024, dtype=np.int8))
 

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -12,6 +12,7 @@ import ray
 from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
 from ray.ray_constants import PROMETHEUS_SERVICE_DISCOVERY_FILE
 from ray._private.metrics_agent import PrometheusServiceDiscoveryWriter
+from ray._private.gcs_utils import use_gcs_for_bootstrap
 from ray.util.metrics import Counter, Histogram, Gauge
 from ray._private.test_utils import (wait_for_condition, SignalActor,
                                      fetch_prometheus, get_log_batch)
@@ -27,7 +28,6 @@ except ImportError:
 # NOTE: Commented out metrics are not available in this test.
 # TODO(Clark): Find ways to trigger commented out metrics in cluster setup.
 _METRICS = [
-    "ray_gcs_latency_sum",
     "ray_object_store_available_memory",
     "ray_object_store_used_memory",
     "ray_object_store_num_local_objects",
@@ -73,6 +73,10 @@ _METRICS = [
     "ray_gcs_new_resource_creation_latency_ms_sum",
     "ray_gcs_actors_count",
 ]
+
+# ray_gcs_latency_sum is a metric in redis context
+if not use_gcs_for_bootstrap():
+    _METRICS.append("ray_gcs_latency_sum")
 
 # This list of metrics should be kept in sync with
 # ray/python/ray/autoscaler/_private/prom_metrics.py

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -161,7 +161,7 @@ def test_connecting_in_local_case(ray_start_regular):
 import ray
 ray.init(address="{}")
 print("success")
-""".format(address_info["redis_address"])
+""".format(address_info["address"])
 
     out = run_string_as_driver(driver_script)
     # Make sure the other driver succeeded.
@@ -205,7 +205,7 @@ tune.run_experiments({{
     }}
 }})
 print("success")
-""".format(address_info["redis_address"])
+""".format(address_info["address"])
 
     for i in range(2):
         out = run_string_as_driver(driver_script)
@@ -329,7 +329,7 @@ print("success")
 
 def test_multi_driver_logging(ray_start_regular):
     address_info = ray_start_regular
-    address = address_info["redis_address"]
+    address = address_info["address"]
 
     # ray.init(address=address)
     driver1_wait = Semaphore.options(name="driver1_wait").remote(value=0)

--- a/python/ray/tests/test_multi_tenancy.py
+++ b/python/ray/tests/test_multi_tenancy.py
@@ -75,7 +75,7 @@ pids = set([ray.get(obj) for obj in pid_objs])
 print("PID:" + str.join(",", [str(_) for _ in pids]))
 
 ray.shutdown()
-    """.format(info["redis_address"])
+    """.format(info["address"])
 
     driver_count = 3
     processes = [
@@ -226,7 +226,7 @@ def foo():
 [foo.remote() for _ in range(100)]
 
 ray.shutdown()
-    """.format(info["redis_address"])
+    """.format(info["address"])
 
     before = len(get_workers())
     assert before == 1

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -12,7 +12,7 @@ from ray.cluster_utils import Cluster
 def test_isolation(shutdown_only):
     info = ray.init(namespace="namespace")
 
-    address = info["redis_address"]
+    address = info["address"]
 
     # First param of template is the namespace. Second is the redis address.
     driver_template = """
@@ -73,7 +73,7 @@ ray.get(actor.ping.remote())
 def test_placement_groups(shutdown_only):
     info = ray.init(namespace="namespace")
 
-    address = info["redis_address"]
+    address = info["address"]
 
     # First param of template is the namespace. Second is the redis address.
     driver_template = """
@@ -115,7 +115,7 @@ ray.get(pg.ready())
 def test_default_namespace(shutdown_only):
     info = ray.init(namespace="namespace")
 
-    address = info["redis_address"]
+    address = info["address"]
 
     # First param of template is the namespace. Second is the redis address.
     driver_template = """
@@ -145,7 +145,7 @@ def test_namespace_in_job_config(shutdown_only):
     job_config = ray.job_config.JobConfig(ray_namespace="namespace")
     info = ray.init(job_config=job_config)
 
-    address = info["redis_address"]
+    address = info["address"]
 
     # First param of template is the namespace. Second is the redis address.
     driver_template = """

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -265,8 +265,8 @@ def test_many_small_transfers(ray_start_cluster_with_resource):
 # (4) Allow the local object to be evicted.
 # (5) Try to get the object again. Now the retry timer should kick in and
 #     successfuly pull the remote object.
-def test_pull_request_retry(shutdown_only):
-    cluster = Cluster()
+def test_pull_request_retry(ray_start_cluster):
+    cluster = ray_start_cluster
     cluster.add_node(num_cpus=0, num_gpus=1, object_store_memory=100 * 2**20)
     cluster.add_node(num_cpus=1, num_gpus=0, object_store_memory=100 * 2**20)
     cluster.wait_for_nodes()
@@ -297,8 +297,8 @@ def test_pull_request_retry(shutdown_only):
 
 
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
-def test_pull_bundles_admission_control(shutdown_only):
-    cluster = Cluster()
+def test_pull_bundles_admission_control(ray_start_cluster):
+    cluster = ray_start_cluster
     object_size = int(6e6)
     num_objects = 10
     num_tasks = 10
@@ -331,8 +331,8 @@ def test_pull_bundles_admission_control(shutdown_only):
 
 
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
-def test_pull_bundles_pinning(shutdown_only):
-    cluster = Cluster()
+def test_pull_bundles_pinning(ray_start_cluster):
+    cluster = ray_start_cluster
     object_size = int(50e6)
     num_objects = 10
     # Head node can fit all of the objects at once.
@@ -356,11 +356,11 @@ def test_pull_bundles_pinning(shutdown_only):
 
 
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
-def test_pull_bundles_admission_control_dynamic(shutdown_only):
+def test_pull_bundles_admission_control_dynamic(ray_start_cluster):
     # This test is the same as test_pull_bundles_admission_control, except that
     # the object store's capacity starts off higher and is later consumed
     # dynamically by concurrent workers.
-    cluster = Cluster()
+    cluster = ray_start_cluster
     object_size = int(6e6)
     num_objects = 20
     num_tasks = 20
@@ -403,8 +403,8 @@ def test_pull_bundles_admission_control_dynamic(shutdown_only):
 
 
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
-def test_max_pinned_args_memory(shutdown_only):
-    cluster = Cluster()
+def test_max_pinned_args_memory(ray_start_cluster):
+    cluster = ray_start_cluster
     cluster.add_node(
         num_cpus=0,
         object_store_memory=200 * 1024 * 1024,
@@ -436,8 +436,8 @@ def test_max_pinned_args_memory(shutdown_only):
 
 
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
-def test_ray_get_task_args_deadlock(shutdown_only):
-    cluster = Cluster()
+def test_ray_get_task_args_deadlock(ray_start_cluster):
+    cluster = ray_start_cluster
     object_size = int(6e6)
     num_objects = 10
     # Head node can fit all of the objects at once.

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -14,6 +14,7 @@ from ray.tests.conftest import (file_system_object_spilling_config,
                                 mock_distributed_fs_object_spilling_config)
 from ray.external_storage import (create_url_with_offset,
                                   parse_url_with_offset)
+from ray._private.gcs_utils import use_gcs_for_bootstrap
 from ray._private.test_utils import wait_for_condition
 from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.internal.internal_api import memory_summary
@@ -43,9 +44,12 @@ def is_dir_empty(temp_folder,
 
 def assert_no_thrashing(address):
     state = ray.state.GlobalState()
-    state._initialize_global_state(
-        GcsClientOptions.from_redis_address(
-            address, ray.ray_constants.REDIS_DEFAULT_PASSWORD))
+    if use_gcs_for_bootstrap():
+        options = GcsClientOptions.from_gcs_address(address)
+    else:
+        options = GcsClientOptions.from_redis_address(
+            address, ray.ray_constants.REDIS_DEFAULT_PASSWORD)
+    state._initialize_global_state(options)
     summary = memory_summary(address=address, stats_only=True)
     restored_bytes = 0
     consumed_bytes = 0
@@ -171,7 +175,7 @@ def test_spilling_not_done_for_pinned_object(object_spilling_config,
     ref2 = ray.put(arr)  # noqa
 
     wait_for_condition(lambda: is_dir_empty(temp_folder))
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -257,7 +261,7 @@ def test_spill_objects_automatically(object_spilling_config, shutdown_only):
         solution = solution_buffer[index]
         sample = ray.get(ref, timeout=0)
         assert np.array_equal(sample, solution)
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -296,7 +300,7 @@ def test_unstable_spill_objects_automatically(unstable_spilling_config,
         solution = solution_buffer[index]
         sample = ray.get(ref, timeout=0)
         assert np.array_equal(sample, solution)
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -335,7 +339,7 @@ def test_slow_spill_objects_automatically(slow_spilling_config, shutdown_only):
         solution = solution_buffer[index]
         sample = ray.get(ref, timeout=0)
         assert np.array_equal(sample, solution)
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -368,7 +372,7 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
     x_id = f.remote()  # noqa
     ray.get(x_id)
-    s = memory_summary(address=address["redis_address"], stats_only=True)
+    s = memory_summary(address=address["address"], stats_only=True)
     assert "Plasma memory usage 50 MiB, 1 objects, 50.0% full" in s, s
     assert "Spilled 200 MiB, 4 objects" in s, s
     assert "Restored 150 MiB, 3 objects" in s, s
@@ -382,10 +386,10 @@ def test_spill_stats(object_spilling_config, shutdown_only):
 
     ray.get(func_with_ref.remote(obj))
 
-    s = memory_summary(address=address["redis_address"], stats_only=True)
+    s = memory_summary(address=address["address"], stats_only=True)
     # 50MB * 5 references + 30MB used for task execution.
     assert "Objects consumed by Ray tasks: 280 MiB." in s, s
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -447,7 +451,7 @@ async def test_spill_during_get(object_spilling_config, shutdown_only,
     assert duration <= timedelta(
         seconds=timeout_seconds
     ), "Concurrent gets took too long. Maybe IO workers are not started properly."  # noqa: E501
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -479,7 +483,7 @@ def test_spill_deadlock(object_spilling_config, shutdown_only):
                 ref = random.choice(replay_buffer)
                 sample = ray.get(ref, timeout=0)
                 assert np.array_equal(sample, arr)
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -40,7 +40,7 @@ def test_delete_objects(object_spilling_config, shutdown_only):
     del replay_buffer
     del ref
     wait_for_condition(lambda: is_dir_empty(temp_folder))
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -81,7 +81,7 @@ def test_delete_objects_delete_while_creating(object_spilling_config,
     del replay_buffer
     del ref
     wait_for_condition(lambda: is_dir_empty(temp_folder))
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -143,7 +143,7 @@ def test_delete_objects_on_worker_failure(object_spilling_config,
 
     # After all, make sure all objects are deleted upon worker failures.
     wait_for_condition(lambda: is_dir_empty(temp_folder))
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(
@@ -265,7 +265,7 @@ def test_fusion_objects(object_spilling_config, shutdown_only):
         if file_size >= min_spilling_size:
             is_test_passing = True
     assert is_test_passing
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 # https://github.com/ray-project/ray/issues/12912
@@ -301,7 +301,7 @@ def test_release_resource(object_spilling_config, shutdown_only):
     canary = sneaky_task_tries_to_steal_released_resources.remote()
     ready, _ = ray.wait([canary], timeout=2)
     assert not ready
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -71,7 +71,7 @@ def test_multiple_directories(tmp_path, shutdown_only):
     for temp_dir in temp_dirs:
         temp_folder = temp_dir
         wait_for_condition(lambda: is_dir_empty(temp_folder))
-    assert_no_thrashing(address["redis_address"])
+    assert_no_thrashing(address["address"])
 
     # Now kill ray and see all directories are deleted.
     print("Check directories are deleted...")

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -550,7 +550,7 @@ def test_automatic_cleanup_job(ray_start_cluster):
     driver_code = f"""
 import ray
 
-ray.init(address="{info["redis_address"]}")
+ray.init(address="{info["address"]}")
 
 def create_pg():
     pg = ray.util.placement_group(
@@ -618,7 +618,7 @@ def test_automatic_cleanup_detached_actors(ray_start_cluster):
     driver_code = f"""
 import ray
 
-ray.init(address="{info["redis_address"]}", namespace="default_test_namespace")
+ray.init(address="{info["address"]}", namespace="default_test_namespace")
 
 def create_pg():
     pg = ray.util.placement_group(

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -131,7 +131,7 @@ def test_detached_placement_group(ray_start_cluster):
     driver_code = f"""
 import ray
 
-ray.init(address="{info["redis_address"]}")
+ray.init(address="{info["address"]}")
 
 pg = ray.util.placement_group(
         [{{"CPU": 1}} for _ in range(2)],
@@ -245,7 +245,7 @@ def test_named_placement_group(ray_start_cluster):
     driver_code = f"""
 import ray
 
-ray.init(address="{info["redis_address"]}", namespace="default_test_namespace")
+ray.init(address="{info["address"]}", namespace="default_test_namespace")
 
 pg = ray.util.placement_group(
         [{{"CPU": 1}} for _ in range(2)],

--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -19,7 +19,7 @@ def _init_ray():
 
 def _check_spilled_mb(address, spilled=None, restored=None, fallback=None):
     def ok():
-        s = memory_summary(address=address["redis_address"], stats_only=True)
+        s = memory_summary(address=address["address"], stats_only=True)
         print(s)
         if restored:
             if "Restored {} MiB".format(restored) not in s:

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -146,7 +146,7 @@ def test_ray_debugger_recursive(shutdown_only):
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Failing on Windows.")
 def test_job_exit_cleanup(ray_start_regular):
-    address = ray_start_regular["redis_address"]
+    address = ray_start_regular["address"]
 
     driver_script = """
 import time

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -13,6 +13,7 @@ from ray.cluster_utils import Cluster
 from ray._private.test_utils import run_string_as_driver
 from ray._raylet import ClientObjectRef
 from ray.util.client.worker import Worker
+from ray._private.gcs_utils import use_gcs_for_bootstrap
 import grpc
 
 
@@ -25,6 +26,8 @@ def password():
 
 
 class TestRedisPassword:
+    @pytest.mark.skipif(
+        use_gcs_for_bootstrap(), reason="Not valid for gcs bootstrap")
     def test_redis_password(self, password, shutdown_only):
         @ray.remote
         def f():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR contains most of the fixes @iycheng made in #21232, to make tests pass with GCS bootstrapping by supporting both Redis and GCS address as the bootstrap address. The main change is to use `address_info["address"]` to obtain the bootstrap address to pass to `ray.init()`, instead of using `address_info["redis_address"]`. In a subsequent PR, `address_info["address"]` will return the Redis or GCS address depending on whether using GCS to bootstrap.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
