### PR TITLE
fix memory leak in MARWIL

### DIFF
--- a/rllib/agents/marwil/marwil_torch_policy.py
+++ b/rllib/agents/marwil/marwil_torch_policy.py
@@ -40,6 +40,10 @@ def marwil_loss(policy: Policy, model: ModelV2, dist_class: ActionDistribution,
         rate = policy.config["moving_average_sqd_adv_norm_update_rate"]
         policy._moving_average_sqd_adv_norm.add_(
             rate * (adv_squared_mean - policy._moving_average_sqd_adv_norm))
+
+        # detach to get rid of the growing memory occupancy by grad fn chain.
+        policy._moving_average_sqd_adv_norm = policy._moving_average_sqd_adv_norm.detach()
+
         # Exponentially weighted advantages.
         exp_advs = torch.exp(
             policy.config["beta"] *


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
MARWIL (torch version) had a memory leak which didn't allow for long training.
The policy variable "_moving_average_sqd_adv_norm" is updated during loss calculation.
It caused keeping gradient function chains in memory that increased with each iteration and resulted in memory overflow.

Detaching _moving_average_sqd_adv_norm fixes the problem. This term is used only for normalization and doesn't require gradients to learn.

## Related issue number
Closes #16670 and #11754
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
