### PR TITLE
[GCS][Bootstrap 3/n] Refactor to support GCS bootstrap

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -206,9 +206,10 @@ class JobSupervisor:
                 "runtime_env": self._runtime_env,
                 "metadata": self._metadata,
             })
-            ray_address = ray._private.services.get_ray_address_to_use_or_die()
+            # Set RAY_ADDRESS to local Ray address, if it is not set.
             os.environ[
-                ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE] = ray_address
+                ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE] = \
+                ray._private.services.get_ray_address_from_environment()
 
             log_path = self._log_client.get_log_file_path(self._job_id)
             child_process = self._exec_entrypoint(log_path)

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -439,21 +439,21 @@ def extract_ip_port(bootstrap_address: str):
     return ip, port
 
 
-def address_to_ip(addr: str):
+def address_to_ip(address: str):
     """Convert a hostname to a numerical IP addresses in an address.
 
     This should be a no-op if address already contains an actual numerical IP
     address.
 
     Args:
-        addr: This can be either a string containing a hostname (or an IP
+        address: This can be either a string containing a hostname (or an IP
             address) and a port or it can be just an IP address.
 
     Returns:
         The same address but with the hostname replaced by a numerical IP
             address.
     """
-    address_parts = addr.split(":")
+    address_parts = address.split(":")
     ip_address = socket.gethostbyname(address_parts[0])
     # Make sure localhost isn't resolved to the loopback ip
     if ip_address == "127.0.0.1":

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -315,7 +315,7 @@ def get_ray_address_from_environment():
         A string to pass into `ray.init(address=...)`, e.g. ip:port, `auto`.
     """
     addr = os.environ.get(ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE)
-    if not addr or addr == "auto":
+    if addr is None or addr == "auto":
         # TODO(mwtian): support _find_gcs_address_or_die()
         addr = _find_redis_address_or_die()
     return addr
@@ -413,7 +413,7 @@ def canonicalize_bootstrap_address(addr: str):
     Returns:
         Ray cluster address string in <host:port> format.
     """
-    if not addr or addr == "auto":
+    if addr is None or addr == "auto":
         addr = get_ray_address_from_environment()
     try:
         bootstrap_address = address_to_ip(addr)

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -548,7 +548,7 @@ def init_error_pubsub():
     """Initialize redis error info pub/sub"""
     if gcs_pubsub_enabled():
         s = GcsErrorSubscriber(
-            channel=ray.worker.global_worker.gcs_channel.channel())
+            address=ray.worker.global_worker.gcs_client.address)
         s.subscribe()
     else:
         s = ray.worker.global_worker.redis_client.pubsub(
@@ -590,7 +590,7 @@ def init_log_pubsub():
     """Initialize redis error info pub/sub"""
     if gcs_pubsub_enabled():
         s = GcsLogSubscriber(
-            channel=ray.worker.global_worker.gcs_channel.channel())
+            address=ray.worker.global_worker.gcs_client.address)
         s.subscribe()
     else:
         s = ray.worker.global_worker.redis_client.pubsub(

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -27,10 +27,7 @@ def memory_summary(address=None,
                    stats_only=False,
                    num_entries=None):
     from ray.dashboard.memory_utils import memory_summary
-    if not address:
-        address = services.get_ray_address_to_use_or_die()
-    if address == "auto":
-        address = services.find_redis_address_or_die()
+    address = services.canonicalize_bootstrap_address(address)
 
     state = GlobalState()
     state._initialize_global_state(

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -276,8 +276,9 @@ class Node:
 
         # Makes sure the Node object has valid addresses after setup.
         self.validate_ip_port(self.address)
-        self.validate_ip_port(self.redis_address)
         self.validate_ip_port(self.gcs_address)
+        if not use_gcs_for_bootstrap():
+            self.validate_ip_port(self.redis_address)
 
     @staticmethod
     def validate_ip_port(ip_port):
@@ -540,7 +541,7 @@ class Node:
         return {
             "node_ip_address": self._node_ip_address,
             "raylet_ip_address": self._raylet_ip_address,
-            "redis_address": self._redis_address,
+            "redis_address": self.redis_address,
             "object_store_address": self._plasma_store_socket_name,
             "raylet_socket_name": self._raylet_socket_name,
             "webui_url": self._webui_url,
@@ -556,7 +557,7 @@ class Node:
     def create_redis_client(self):
         """Create a redis client."""
         return ray._private.services.create_redis_client(
-            self._redis_address, self._ray_params.redis_password)
+            self.redis_address, self._ray_params.redis_password)
 
     def get_gcs_client(self):
         if self._gcs_client is None:
@@ -570,12 +571,12 @@ class Node:
                             self.create_redis_client())
                     break
                 except Exception as e:
+                    logger.debug(f"Connecting to GCS: {e}")
                     time.sleep(1)
-                    logger.debug(f"Waiting for gcs up {e}")
-            assert self._gcs_client is not None
+            assert self._gcs_client is not None, \
+                f"Failed to connect to GCS at {self._gcs_address}"
             ray.experimental.internal_kv._initialize_internal_kv(
                 self._gcs_client)
-
         return self._gcs_client
 
     def get_temp_dir_path(self):
@@ -803,7 +804,7 @@ class Node:
             ]
 
     def start_redis(self):
-        """Start the Redis servers."""
+        """Start the Redis server."""
         assert self._redis_address is None
         redis_log_files = []
         if self._ray_params.external_addresses is None:
@@ -889,7 +890,7 @@ class Node:
         stdout_file, stderr_file = self.get_log_file_handles(
             "gcs_server", unique=True)
         process_info = ray._private.services.start_gcs_server(
-            self._redis_address,
+            self.redis_address,
             self._logs_dir,
             stdout_file=stdout_file,
             stderr_file=stderr_file,
@@ -930,7 +931,7 @@ class Node:
         stdout_file, stderr_file = self.get_log_file_handles(
             "raylet", unique=True)
         process_info = ray._private.services.start_raylet(
-            self._redis_address,
+            self.redis_address,
             self.gcs_address,
             self._node_ip_address,
             self._ray_params.node_manager_port,
@@ -986,7 +987,7 @@ class Node:
         stdout_file, stderr_file = self.get_log_file_handles(
             "monitor", unique=True)
         process_info = ray._private.services.start_monitor(
-            self._redis_address,
+            self.redis_address,
             self.gcs_address,
             self._logs_dir,
             stdout_file=stdout_file,
@@ -1005,7 +1006,7 @@ class Node:
         stdout_file, stderr_file = self.get_log_file_handles(
             "ray_client_server", unique=True)
         process_info = ray._private.services.start_ray_client_server(
-            self.redis_address,
+            self.address,
             self._node_ip_address,
             self._ray_params.ray_client_server_port,
             stdout_file=stdout_file,
@@ -1040,6 +1041,7 @@ class Node:
         assert self._gcs_client is None
 
         # If this is the head node, start the relevant head node processes.
+        # TODO(mwtian): guard with `if not use_gcs_for_bootstrap():`
         self.start_redis()
         assert self._redis_address is not None
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -535,6 +535,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
                 port = s.getsockname()[1]
 
         # Set bootstrap port.
+        # TODO(mwtian): set bootstrap port as GCS server port.
         ray_params.redis_port = port
 
         if not use_gcs_for_bootstrap():

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -16,6 +16,7 @@ from socket import socket
 
 import ray
 import psutil
+from ray._private.gcs_utils import use_gcs_for_bootstrap
 import ray._private.services as services
 import ray.ray_constants as ray_constants
 import ray._private.utils
@@ -175,8 +176,7 @@ def format_table(table):
     help="Override the address to connect to.")
 def debug(address):
     """Show all active breakpoints and exceptions in the Ray debugger."""
-    if not address:
-        address = services.get_ray_address_to_use_or_die()
+    address = services.canonicalize_bootstrap_address(address)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address, log_to_driver=False)
     while True:
@@ -242,6 +242,7 @@ def debug(address):
     "--port",
     type=int,
     required=False,
+    default=ray_constants.DEFAULT_PORT,
     help=f"the port of the head ray process. If not provided, defaults to "
     f"{ray_constants.DEFAULT_PORT}; if port is set to 0, we will"
     f" allocate an available port.")
@@ -463,9 +464,11 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
           system_config, enable_object_reconstruction, metrics_export_port,
           no_monitor, tracing_startup_hook, ray_debugger_external):
     """Start Ray processes manually on the local machine."""
-    if gcs_server_port and not head:
+    if use_gcs_for_bootstrap() and gcs_server_port is not None:
+        cli_logger.abort("`{}` is deprecated. Specify {} instead.",
+                         cf.bold("--gcs-server-port"), cf.bold("--port"))
         raise ValueError(
-            "gcs_server_port can be only assigned when you specify --head.")
+            "`--gcs-server-port` is deprecated. Specify `--port` instead.")
 
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
@@ -495,7 +498,6 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         ray_client_server_port=ray_client_server_port,
         object_manager_port=object_manager_port,
         node_manager_port=node_manager_port,
-        gcs_server_port=gcs_server_port,
         memory=memory,
         object_store_memory=object_store_memory,
         redis_password=redis_password,
@@ -503,6 +505,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         num_cpus=num_cpus,
         num_gpus=num_gpus,
         resources=resources,
+        autoscaling_config=autoscaling_config,
         plasma_directory=plasma_directory,
         huge_pages=False,
         plasma_store_socket_name=plasma_store_socket_name,
@@ -519,11 +522,12 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         no_monitor=no_monitor,
         tracing_startup_hook=tracing_startup_hook,
         ray_debugger_external=ray_debugger_external)
-    if head:
-        # Use default if port is none, allocate an available port if port is 0
-        if port is None:
-            port = ray_constants.DEFAULT_PORT
 
+    if head:
+        # Start head node.
+
+        # TODO(mwtian): use a more robust mechanism to avoid collision,
+        # e.g. node._get_cached_port()
         if port == 0:
             with socket() as s:
                 s.bind(("", 0))
@@ -580,29 +584,30 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         ray_params.update_if_absent(
             node_ip_address=services.get_node_ip_address())
         cli_logger.labeled_value("Local node IP", ray_params.node_ip_address)
+
+        # Initialize Redis settings.
         ray_params.update_if_absent(
-            redis_port=port,
             redis_shard_ports=redis_shard_ports,
             redis_max_memory=redis_max_memory,
             num_redis_shards=num_redis_shards,
             redis_max_clients=None,
-            autoscaling_config=autoscaling_config,
         )
 
         # Fail early when starting a new cluster when one is already running
         if address is None:
             default_address = f"{ray_params.node_ip_address}:{port}"
-            redis_addresses = services.find_redis_address(default_address)
-            if len(redis_addresses) > 0:
+            bootstrap_addresses = services.find_bootstrap_address()
+            if default_address in bootstrap_addresses:
                 raise ConnectionError(
-                    f"Ray is already running at {default_address}. "
-                    f"Please specify a different port using the `--port`"
-                    f" command to `ray start`.")
+                    f"Ray is trying to start at {default_address}, "
+                    f"but is already running at {bootstrap_addresses}. "
+                    "Please specify a different port using the `--port`"
+                    " flag of `ray start` command.")
 
         node = ray.node.Node(
             ray_params, head=True, shutdown_at_exit=block, spawn_reaper=block)
 
-        redis_address = node.redis_address
+        bootstrap_addresses = node.address
         if temp_dir is None:
             # Default temp directory.
             temp_dir = ray._private.utils.get_user_temp_dir()
@@ -612,7 +617,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         # TODO: Consider using the custom temp_dir for this file across the
         # code base. (https://github.com/ray-project/ray/issues/16458)
         with open(current_cluster_path, "w") as f:
-            print(redis_address, file=f)
+            print(bootstrap_addresses, file=f)
 
         # this is a noop if new-style is not set, so the old logger calls
         # are still in place
@@ -628,7 +633,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             # NOTE(kfstorm): Java driver rely on this line to get the address
             # of the cluster. Please be careful when updating this line.
             cli_logger.print(
-                cf.bold("  ray start --address='{}'{}"), redis_address,
+                cf.bold("  ray start --address='{}'{}"), bootstrap_addresses,
                 f" --redis-password='{redis_password}'"
                 if redis_password else "")
             cli_logger.newline()
@@ -662,50 +667,58 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
             cli_logger.print("To terminate the Ray runtime, run")
             cli_logger.print(cf.bold("  ray stop"))
     else:
-        # Start Ray on a non-head node.
-        redis_address = None
-        if address is not None:
-            (redis_address, redis_address_ip,
-             redis_address_port) = services.validate_redis_address(address)
-        if not (port is None):
-            cli_logger.abort("`{}` should not be specified without `{}`.",
-                             cf.bold("--port"), cf.bold("--head"))
+        # Start worker node.
 
-            raise Exception("If --head is not passed in, --port is not "
-                            "allowed.")
-        if redis_shard_ports is not None:
-            cli_logger.abort("`{}` should not be specified without `{}`.",
-                             cf.bold("--redis-shard-ports"), cf.bold("--head"))
+        # Ensure `--address` flag is specified.
+        if address is None:
+            cli_logger.abort(
+                "`{}` is a required flag unless starting a head "
+                "node with `{}`.", cf.bold("--address"), cf.bold("--head"))
+            raise Exception("`--address` is a required flag unless starting a "
+                            "head node with `--head`.")
 
-            raise Exception("If --head is not passed in, --redis-shard-ports "
-                            "is not allowed.")
-        if redis_address is None:
-            cli_logger.abort("`{}` is required unless starting with `{}`.",
-                             cf.bold("--address"), cf.bold("--head"))
-
-            raise Exception("If --head is not passed in, --address must "
-                            "be provided.")
-        if include_dashboard:
-            cli_logger.abort("`{}` should not be specified without `{}`.",
-                             cf.bold("--include-dashboard"), cf.bold("--head"))
-
+        # Raise error if any head-only flag are specified.
+        head_only_flags = {
+            "--port": port,
+            "--redis-shard-ports": redis_shard_ports,
+            "--include-dashboard": include_dashboard
+        }
+        for flag, val in head_only_flags.items():
+            if val is None:
+                continue
+            cli_logger.abort(
+                "`{}` should only be specified when starting head "
+                "node with `{}`.", cf.bold(flag), cf.bold("--head"))
             raise ValueError(
-                "If --head is not passed in, the --include-dashboard"
-                "flag is not relevant.")
+                f"{flag} should only be specified when starting head node "
+                "with `--head`.")
 
-        # Wait for the Redis server to be started. And throw an exception if we
-        # can't connect to it.
-        # TODO(mwtian): wait only when using Redis to bootstrap.
-        services.wait_for_redis_to_start(
-            redis_address_ip, redis_address_port, password=redis_password)
+        # Start Ray on a non-head node.
+        bootstrap_address = services.canonicalize_bootstrap_address(address)
+
+        if bootstrap_address is None:
+            cli_logger.abort("Cannot canonicalize address `{}={}`.",
+                             cf.bold("--address"), cf.bold(address))
+            raise Exception("Cannot canonicalize address "
+                            f"`--address={address}`.")
+
+        # TODO(mwtian): set ray_params.gcs_address in GCS bootstrap mode.
+        ray_params.redis_address = bootstrap_address
+
+        address_ip, address_port = services.extract_ip_port(bootstrap_address)
+
+        if not use_gcs_for_bootstrap():
+            # Wait for the Redis server to be started. And throw an exception
+            # if we can't connect to it.
+            services.wait_for_redis_to_start(
+                address_ip, address_port, password=redis_password)
 
         # Get the node IP address if one is not provided.
         ray_params.update_if_absent(
-            node_ip_address=services.get_node_ip_address(redis_address))
+            node_ip_address=services.get_node_ip_address(address_ip))
 
         cli_logger.labeled_value("Local node IP", ray_params.node_ip_address)
 
-        ray_params.update(redis_address=redis_address)
         node = ray.node.Node(
             ray_params, head=False, shutdown_at_exit=block, spawn_reaper=block)
 
@@ -1372,8 +1385,7 @@ def microbenchmark():
     help="Override the redis address to connect to.")
 def timeline(address):
     """Take a Chrome tracing timeline for a Ray cluster."""
-    if not address:
-        address = services.get_ray_address_to_use_or_die()
+    address = services.canonicalize_bootstrap_address(address)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     time = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
@@ -1437,8 +1449,7 @@ terminal width is less than 137 characters.")
 def memory(address, redis_password, group_by, sort_by, units, no_format,
            stats_only, num_entries):
     """Print object references held in a Ray cluster."""
-    if not address:
-        address = services.get_ray_address_to_use_or_die()
+    address = services.canonicalize_bootstrap_address(address)
     time = datetime.now()
     header = "=" * 8 + f" Object references status: {time} " + "=" * 8
     mem_stats = memory_summary(address, redis_password, group_by, sort_by,
@@ -1460,8 +1471,7 @@ def memory(address, redis_password, group_by, sort_by, units, no_format,
     help="Connect to ray with redis_password.")
 def status(address, redis_password):
     """Print cluster status, including autoscaling info."""
-    if not address:
-        address = services.get_ray_address_to_use_or_die()
+    address = services.canonicalize_bootstrap_address(address)
     redis_client = ray._private.services.create_redis_client(
         address, redis_password)
     gcs_client = ray._private.gcs_utils.GcsClient.create_from_redis(
@@ -1681,8 +1691,7 @@ def cluster_dump(cluster_config_file: Optional[str] = None,
     help="Override the address to connect to.")
 def global_gc(address):
     """Trigger Python garbage collection on all cluster workers."""
-    if not address:
-        address = services.get_ray_address_to_use_or_die()
+    address = services.canonicalize_bootstrap_address(address)
     logger.info(f"Connecting to Ray instance at {address}.")
     ray.init(address=address)
     ray.internal.internal_api.global_gc()
@@ -1714,10 +1723,7 @@ def healthcheck(address, redis_password, component):
     Health check a Ray or a specific component. Exit code 0 is healthy.
     """
 
-    if not address:
-        address = services.get_ray_address_to_use_or_die()
-    else:
-        address = services.address_to_ip(address)
+    address = services.canonicalize_bootstrap_address(address)
     redis_client = ray._private.services.create_redis_client(
         address, redis_password)
 
@@ -1728,7 +1734,7 @@ def healthcheck(address, redis_password, component):
         redis_client.ping()
         try:
             # TODO: add feature to ray._private.GcsClient to share channel
-            gcs_address = redis_client.get("GcsServerAddress").decode("utf-8")
+            gcs_address = redis_client.get("GcsServerAddress").decode()
             options = (("grpc.enable_http_proxy", 0), )
             channel = ray._private.utils.init_grpc_channel(
                 gcs_address, options)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -717,9 +717,9 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
         # TODO(mwtian): set ray_params.gcs_address in GCS bootstrap mode.
         ray_params.redis_address = bootstrap_address
 
-        address_ip, address_port = services.extract_ip_port(bootstrap_address)
-
         if not use_gcs_for_bootstrap():
+            address_ip, address_port = services.extract_ip_port(
+                bootstrap_address)
             # Wait for the Redis server to be started. And throw an exception
             # if we can't connect to it.
             services.wait_for_redis_to_start(
@@ -727,7 +727,7 @@ def start(node_ip_address, address, port, redis_password, redis_shard_ports,
 
         # Get the node IP address if one is not provided.
         ray_params.update_if_absent(
-            node_ip_address=services.get_node_ip_address(address_ip))
+            node_ip_address=services.get_node_ip_address(bootstrap_address))
 
         cli_logger.labeled_value("Local node IP", ray_params.node_ip_address)
 

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -109,7 +109,7 @@ def test_function_unique_export(ray_start_regular):
 
     if gcs_pubsub_enabled():
         subscriber = GcsFunctionKeySubscriber(
-            channel=ray.worker.global_worker.gcs_channel.channel())
+            address=ray.worker.global_worker.gcs_client.address)
         subscriber.subscribe()
 
         ray.get(g.remote())

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -505,7 +505,10 @@ def test_ray_status_multinode():
     def output_ready():
         result = runner.invoke(scripts.status)
         result.stdout
-        return not result.exception and "memory" in result.output
+        if not result.exception and "memory" in result.output:
+            return True
+        raise RuntimeError(f"result.exception={result.exception} "
+                           f"result.output={result.output}")
 
     wait_for_condition(output_ready)
 

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -144,7 +144,7 @@ for i in range(0, 5):
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
 
 
-def test_ray_start_non_head(call_ray_stop_only):
+def test_ray_start_non_head(call_ray_stop_only, monkeypatch):
 
     # Test that we can call ray start to connect to an existing cluster.
 
@@ -176,12 +176,11 @@ assert ray.get(f.options(resources={"res_1": 1}).remote()) == 1
 assert ray.get(f.options(resources={"res_2": 1}).remote()) == 1
 print("success")
 """
-    os.environ["RAY_ADDRESS"] = "auto"
+    monkeypatch.setenv("RAY_ADDRESS", "auto")
     out = run_string_as_driver(driver_script)
     # Make sure the driver succeeded.
     assert "success" in out
 
-    del os.environ["RAY_ADDRESS"]
     check_call_ray(["stop"])
 
 

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -13,8 +13,7 @@ from ray._private.test_utils import (
 def test_calling_start_ray_head(call_ray_stop_only):
 
     # Test that we can call ray start with various command line
-    # parameters. TODO(rkn): This test only tests the --head code path. We
-    # should also test the non-head node code path.
+    # parameters.
 
     # Test starting Ray with a redis port specified.
     check_call_ray(["start", "--head", "--port", "0"])
@@ -137,6 +136,47 @@ for i in range(0, 5):
     wait_for_children_of_pid_to_exit(blocked.pid, timeout=30)
     blocked.wait()
     assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
+
+
+def test_ray_start_non_head(call_ray_stop_only):
+
+    # Test that we can call ray start to connect to an existing cluster.
+
+    # Test starting Ray with a port specified.
+    check_call_ray(
+        ["start", "--head", "--port", "7298", "--resources", "{\"res_0\": 1}"])
+
+    # Test starting node connecting to the above cluster.
+    check_call_ray([
+        "start", "--address", "127.0.0.1:7298", "--resources", "{\"res_1\": 1}"
+    ])
+
+    # Test starting Ray with address `auto`.
+    check_call_ray(
+        ["start", "--address", "auto", "--resources", "{\"res_2\": 1}"])
+
+    # Run tasks to verify nodes with custom resources are available.
+    driver_script = """
+import ray
+ray.init()
+
+@ray.remote
+def f():
+    return 1
+
+assert ray.get(f.remote()) == 1
+assert ray.get(f.options(resources={"res_0": 1}).remote()) == 1
+assert ray.get(f.options(resources={"res_1": 1}).remote()) == 1
+assert ray.get(f.options(resources={"res_2": 1}).remote()) == 1
+print("success")
+"""
+    os.environ["RAY_ADDRESS"] = "auto"
+    out = run_string_as_driver(driver_script)
+    # Make sure the driver succeeded.
+    assert "success" in out
+
+    del os.environ["RAY_ADDRESS"]
+    check_call_ray(["stop"])
 
 
 @pytest.mark.parametrize(

--- a/python/ray/util/client/server/proxier.py
+++ b/python/ray/util/client/server/proxier.py
@@ -108,14 +108,14 @@ def _match_running_client_server(command: List[str]) -> bool:
 
 class ProxyManager():
     def __init__(self,
-                 redis_address: Optional[str],
+                 address: Optional[str],
                  *,
                  session_dir: Optional[str] = None,
                  redis_password: Optional[str] = None,
                  runtime_env_agent_port: int = 0):
         self.servers: Dict[str, SpecificServer] = dict()
         self.server_lock = RLock()
-        self._redis_address = redis_address
+        self._address = address
         self._redis_password = redis_password
         self._free_ports: List[int] = list(
             range(MIN_SPECIFIC_SERVER_PORT, MAX_SPECIFIC_SERVER_PORT))
@@ -152,27 +152,28 @@ class ProxyManager():
         raise RuntimeError("Unable to succeed in selecting a random port.")
 
     @property
-    def redis_address(self) -> str:
+    def address(self) -> str:
         """
-        Returns the provided Ray Redis address, or creates a new cluster.
+        Returns the provided Ray bootstrap address, or creates a new cluster.
         """
-        if self._redis_address:
-            return self._redis_address
+        if self._address:
+            return self._address
         # Start a new, locally scoped cluster.
         connection_tuple = ray.init()
-        self._redis_address = connection_tuple["redis_address"]
+        self._address = connection_tuple["address"]
         self._session_dir = connection_tuple["session_dir"]
-        return self._redis_address
+        return self._address
 
     @property
     def node(self) -> ray.node.Node:
         """Gets a 'ray.Node' object for this node (the head node).
-        If it does not already exist, one is created using the redis_address.
+        If it does not already exist, one is created using the bootstrap
+        address.
         """
         if self._node:
             return self._node
 
-        ray_params = RayParams(redis_address=self.redis_address)
+        ray_params = RayParams(redis_address=self.address)
         if self._redis_password:
             ray_params.redis_password = self._redis_password
 
@@ -282,7 +283,7 @@ class ProxyManager():
             )
 
         proc = start_ray_client_server(
-            self.redis_address,
+            self.address,
             self.node.node_ip_address,
             specific_server.port,
             stdout_file=output,
@@ -736,7 +737,7 @@ class LogstreamServicerProxy(ray_client_pb2_grpc.RayletLogStreamerServicer):
 
 
 def serve_proxier(connection_str: str,
-                  redis_address: Optional[str],
+                  address: Optional[str],
                   *,
                   redis_password: Optional[str] = None,
                   session_dir: Optional[str] = None,
@@ -745,16 +746,16 @@ def serve_proxier(connection_str: str,
     # before calling ray.init within the RayletServicers.
     # NOTE(edoakes): redis_address and redis_password should only be None in
     # tests.
-    if redis_address is not None and redis_password is not None:
+    if address is not None and redis_password is not None:
         gcs_cli = GcsClient.connect_to_gcs_by_redis_address(
-            redis_address, redis_password)
+            address, redis_password)
         ray.experimental.internal_kv._initialize_internal_kv(gcs_cli)
 
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=CLIENT_SERVER_MAX_THREADS),
         options=GRPC_OPTIONS)
     proxy_manager = ProxyManager(
-        redis_address,
+        address,
         session_dir=session_dir,
         redis_password=redis_password,
         runtime_env_agent_port=runtime_env_agent_port)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -840,17 +840,17 @@ def init(
         node_ip_address = services.address_to_ip(_node_ip_address)
     raylet_ip_address = node_ip_address
 
+    bootstrap_address, redis_address, gcs_address = None, None, None
     if address:
-        redis_address, _, _ = services.validate_redis_address(address)
-    else:
-        redis_address = None
+        bootstrap_address = services.canonicalize_bootstrap_address(address)
+        assert bootstrap_address is not None
+        # TODO(mwtian): bootstrap with GCS address
+        redis_address = bootstrap_address
+        logger.info("Connecting to existing Ray cluster at address: "
+                    f"{bootstrap_address}")
 
     if configure_logging:
         setup_logger(logging_level, logging_format)
-
-    if redis_address is not None:
-        logger.info(
-            f"Connecting to existing Ray cluster at address: {redis_address}")
 
     if local_mode:
         driver_mode = LOCAL_MODE
@@ -873,10 +873,10 @@ def init(
         raise TypeError("The _system_config must be a dict.")
 
     global _global_node
-    if redis_address is None:
+    if bootstrap_address is None:
         # In this case, we need to start a new cluster.
+        # Use a random port by not specifying Redis port / GCS server port.
         ray_params = ray._private.parameter.RayParams(
-            redis_address=redis_address,
             node_ip_address=node_ip_address,
             raylet_ip_address=raylet_ip_address,
             object_ref_seed=None,
@@ -943,6 +943,7 @@ def init(
         ray_params = ray._private.parameter.RayParams(
             node_ip_address=node_ip_address,
             raylet_ip_address=raylet_ip_address,
+            gcs_address=gcs_address,
             redis_address=redis_address,
             redis_password=_redis_password,
             object_ref_seed=None,
@@ -1368,9 +1369,10 @@ def connect(node,
     # The Redis client can safely be shared between threads. However,
     # that is not true of Redis pubsub clients. See the documentation at
     # https://github.com/andymccurdy/redis-py#thread-safety.
+    # TODo(mwtian): do not create Redis client when bootstrapping with GCS
     worker.redis_client = node.create_redis_client()
-    worker.gcs_channel = gcs_utils.GcsChannel(redis_client=worker.redis_client)
-    worker.gcs_client = gcs_utils.GcsClient(worker.gcs_channel)
+    worker.gcs_client = node.get_gcs_client()
+    assert worker.gcs_client is not None
     _initialize_internal_kv(worker.gcs_client)
     if gcs_utils.use_gcs_for_bootstrap():
         ray.state.state._initialize_global_state(
@@ -1382,14 +1384,13 @@ def connect(node,
     worker.gcs_pubsub_enabled = gcs_pubsub_enabled()
     worker.gcs_publisher = None
     if worker.gcs_pubsub_enabled:
-        worker.gcs_publisher = GcsPublisher(
-            channel=worker.gcs_channel.channel())
+        worker.gcs_publisher = GcsPublisher(address=worker.gcs_client.address)
         worker.gcs_error_subscriber = GcsErrorSubscriber(
-            channel=worker.gcs_channel.channel())
+            address=worker.gcs_client.address)
         worker.gcs_log_subscriber = GcsLogSubscriber(
-            channel=worker.gcs_channel.channel())
+            address=worker.gcs_client.address)
         worker.gcs_function_key_subscriber = GcsFunctionKeySubscriber(
-            channel=worker.gcs_channel.channel())
+            address=worker.gcs_client.address)
 
     # Initialize some fields.
     if mode in (WORKER_MODE, RESTORE_WORKER_MODE, SPILL_WORKER_MODE):
@@ -1452,7 +1453,6 @@ def connect(node,
         raise ValueError(
             "Invalid worker mode. Expected DRIVER, WORKER or LOCAL.")
 
-    redis_address, redis_port = node.redis_address.split(":")
     if gcs_utils.use_gcs_for_bootstrap():
         gcs_options = ray._raylet.GcsClientOptions.from_gcs_address(
             node.gcs_address)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR refactors several components to support switching to GCS address bootstrapping later:
- Treat address from `ray.init()` and `ray` CLI as bootstrap address instead of assuming it is Redis address.
- Ray client servers support `--address` flag instead of `--redis-address`.
- A few other miscellaneous cleanup.

Also, add a test for starting non-head node with `ray start`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
