### PR TITLE
[CI] [RLlib] Ignore E731 in `worker_set.py` and `sampler.py`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -41,3 +41,8 @@ ignore =
   B016
   B017
 avoid-escape = no
+# Error E731 is ignored because of the migration from YAPF to Black.
+# See https://github.com/ray-project/ray/issues/21315 for more information.
+per-file-ignores =
+    rllib/evaluation/worker_set.py:E731
+    rllib/evaluation/sampler.py:E731


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

These changes are necessary to prevent flake8 from failing once we've switched to Black.

For more information about why these changes are needed, see #21315. 

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #21315. Also see #21311.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
