### PR TITLE
[Core] Disable formatting in `test_add_min_workers_nodes`

### DIFF
--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -380,6 +380,9 @@ def test_add_min_workers_nodes():
             "max_workers": 0,
         },
     }
+    # Formatting is disabled to prevent Black from erroring while formatting
+    # this file. See https://github.com/ray-project/ray/issues/21313 for more
+    # information.
     # yapf: disable
     assert _add_min_workers_nodes([],
                                   {},

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -380,6 +380,7 @@ def test_add_min_workers_nodes():
             "max_workers": 0,
         },
     }
+    # yapf: disable
     assert _add_min_workers_nodes([],
                                   {},
                                   types, None, None, None) == \
@@ -426,6 +427,7 @@ def test_add_min_workers_nodes():
                                   }, {
                                       "gpubla": 10
                                   })
+    # yapf: enable
 
 
 def test_get_nodes_to_launch_with_min_workers():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Black errors while formatting `test_resource_demand_scheduler.py`. The issue is caused by the [assertions](https://github.com/ray-project/ray/blob/master/python/ray/tests/test_resource_demand_scheduler.py#L383-L428) at the end of `test_add_min_workers_nodes`. 



To prevent `format.sh` from erroring once we switch to Black, I've disabled formatting around the assertions.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #21313. See also #21311.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
