### PR TITLE
fixes to allow tune/tests/test_commands.py to run on windows

### DIFF
--- a/python/ray/tune/commands.py
+++ b/python/ray/tune/commands.py
@@ -1,8 +1,9 @@
 import click
 import logging
-import os
-import subprocess
 import operator
+import os
+import shutil
+import subprocess
 from datetime import datetime
 
 import pandas as pd
@@ -30,11 +31,7 @@ DEFAULT_PROJECT_INFO_KEYS = (
     "last_updated",
 )
 
-try:
-    TERM_HEIGHT, TERM_WIDTH = subprocess.check_output(["stty", "size"]).split()
-    TERM_HEIGHT, TERM_WIDTH = int(TERM_HEIGHT), int(TERM_WIDTH)
-except subprocess.CalledProcessError:
-    TERM_HEIGHT, TERM_WIDTH = 100, 100
+TERM_WIDTH, TERM_HEIGHT = shutil.get_terminal_size(fallback=(100, 100))
 
 OPERATORS = {
     "<": operator.lt,

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1848,8 +1848,9 @@ class Trainer(Trainable):
     @override(Trainable)
     def cleanup(self) -> None:
         # Stop all workers.
-        if hasattr(self, "workers"):
-            self.workers.stop()
+        workers = getattr(self, "workers", None)
+        if workers:
+            workers.stop()
         # Stop all optimizers.
         if hasattr(self, "optimizer") and self.optimizer:
             self.optimizer.stop()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`tune` does not run smoothly on Windows. This cleans up some blockers:
- use cross-platform `shutils.get_terminal_size` instead of `Popen(stty`)
- somehow `Trainer.workers` is None at the end of `test_commands.py`, so the cleanup command was erroring. The error was not fatal, but was printing in the logs.
- if run locally, the log files are all written to the same location, so the `rync`-based syncing solution is not needed. This is the real fix for issue #20747
## Related issue number
Closes #20747

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Should I add python/ray/tune/tests/test_commands.py which passes to the windows CI?