### PR TITLE
[train] Fix `start_training` in logging callbacks

### DIFF
--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -236,7 +236,7 @@ class MLflowLoggerCallback(TrainingSingleWorkerLoggingCallback):
         self.save_artifact = save_artifact
         self.mlflow_util = MLflowLoggerUtil()
 
-    def start_training(self, logdir: str, **info):
+    def start_training(self, logdir: str, config: Dict, **info):
         super().start_training(logdir=logdir, **info)
 
         tracking_uri = self.tracking_uri or os.path.join(

--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -87,7 +87,7 @@ class TrainingSingleFileLoggingCallback(TrainingLogdirMixin, TrainingCallback,
         return logdir_path.joinpath(Path(filename))
 
     def start_training(self, logdir: str, **info):
-        super().start_training(logdir=logdir, **info)
+        TrainingLogdirMixin.start_training(logdir=logdir)
 
         if not self._filename:
             filename = self._default_filename
@@ -237,7 +237,7 @@ class MLflowLoggerCallback(TrainingSingleWorkerLoggingCallback):
         self.mlflow_util = MLflowLoggerUtil()
 
     def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir=logdir, **info)
+        super().start_training(logdir=logdir, config=config, **info)
 
         tracking_uri = self.tracking_uri or os.path.join(
             str(self.logdir), "mlruns")

--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -87,7 +87,7 @@ class TrainingSingleFileLoggingCallback(TrainingLogdirMixin, TrainingCallback,
         return logdir_path.joinpath(Path(filename))
 
     def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir, config, **info)
+        super().start_training(logdir=logdir, config=config, **info)
 
         if not self._filename:
             filename = self._default_filename
@@ -120,7 +120,7 @@ class JsonLoggerCallback(TrainingSingleFileLoggingCallback):
     _default_filename: Union[str, Path] = RESULT_FILE_JSON
 
     def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir, config, **info)
+        super().start_training(logdir=logdir, config=config, **info)
 
         # Create a JSON file with an empty list
         # that will be latter appended to
@@ -237,7 +237,7 @@ class MLflowLoggerCallback(TrainingSingleWorkerLoggingCallback):
         self.mlflow_util = MLflowLoggerUtil()
 
     def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir, config, **info)
+        super().start_training(logdir=logdir, config=config, **info)
 
         tracking_uri = self.tracking_uri or os.path.join(
             str(self.logdir), "mlruns")
@@ -282,7 +282,7 @@ class TBXLoggerCallback(TrainingSingleWorkerLoggingCallback):
     IGNORE_KEYS: Set[str] = {PID, TIMESTAMP, TIME_TOTAL_S, TRAINING_ITERATION}
 
     def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir, config, **info)
+        super().start_training(logdir=logdir, config=config, **info)
 
         try:
             from tensorboardX import SummaryWriter

--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -19,8 +19,10 @@ from ray.util.ml_utils.mlflow import MLflowLoggerUtil
 logger = logging.getLogger(__name__)
 
 
-class TrainingLogdirMixin:
-    def start_training(self, logdir: str, **info):
+class TrainingLogdirCallback(TrainingCallback, abc.ABC):
+    """Abstract Train callback class with logging directory."""
+
+    def start_training(self, logdir: str, config: Dict, **info):
         if self._logdir:
             logdir_path = Path(self._logdir)
         else:
@@ -39,8 +41,7 @@ class TrainingLogdirMixin:
         return Path(self._logdir_path)
 
 
-class TrainingSingleFileLoggingCallback(TrainingLogdirMixin, TrainingCallback,
-                                        abc.ABC):
+class TrainingSingleFileLoggingCallback(TrainingLogdirCallback, abc.ABC):
     """Abstract Train logging callback class.
 
     Args:
@@ -87,7 +88,7 @@ class TrainingSingleFileLoggingCallback(TrainingLogdirMixin, TrainingCallback,
         return logdir_path.joinpath(Path(filename))
 
     def start_training(self, logdir: str, **info):
-        TrainingLogdirMixin.start_training(logdir=logdir)
+        super().start_training(logdir=logdir, **info)
 
         if not self._filename:
             filename = self._default_filename
@@ -142,8 +143,7 @@ class JsonLoggerCallback(TrainingSingleFileLoggingCallback):
                 loaded_results + [results_to_log], f, cls=SafeFallbackEncoder)
 
 
-class TrainingSingleWorkerLoggingCallback(TrainingLogdirMixin,
-                                          TrainingCallback, abc.ABC):
+class TrainingSingleWorkerLoggingCallback(TrainingLogdirCallback, abc.ABC):
     """Abstract Train logging callback class.
 
     Allows only for single-worker logging.

--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class TrainingLogdirMixin:
-    def start_training(self, logdir: str):
+    def start_training(self, logdir: str, config: Dict, **info):
         if self._logdir:
             logdir_path = Path(self._logdir)
         else:
@@ -86,8 +86,8 @@ class TrainingSingleFileLoggingCallback(TrainingLogdirMixin, TrainingCallback,
             raise ValueError("filename cannot be None or empty.")
         return logdir_path.joinpath(Path(filename))
 
-    def start_training(self, logdir: str):
-        super().start_training(logdir)
+    def start_training(self, logdir: str, config: Dict, **info):
+        super().start_training(logdir, config, **info)
 
         if not self._filename:
             filename = self._default_filename
@@ -119,8 +119,8 @@ class JsonLoggerCallback(TrainingSingleFileLoggingCallback):
 
     _default_filename: Union[str, Path] = RESULT_FILE_JSON
 
-    def start_training(self, logdir: str, **info):
-        super().start_training(logdir)
+    def start_training(self, logdir: str, config: Dict, **info):
+        super().start_training(logdir, config, **info)
 
         # Create a JSON file with an empty list
         # that will be latter appended to
@@ -237,7 +237,7 @@ class MLflowLoggerCallback(TrainingSingleWorkerLoggingCallback):
         self.mlflow_util = MLflowLoggerUtil()
 
     def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir=logdir)
+        super().start_training(logdir, config, **info)
 
         tracking_uri = self.tracking_uri or os.path.join(
             str(self.logdir), "mlruns")
@@ -281,8 +281,8 @@ class TBXLoggerCallback(TrainingSingleWorkerLoggingCallback):
                                         np.int32, np.int64)
     IGNORE_KEYS: Set[str] = {PID, TIMESTAMP, TIME_TOTAL_S, TRAINING_ITERATION}
 
-    def start_training(self, logdir: str, **info):
-        super().start_training(logdir)
+    def start_training(self, logdir: str, config: Dict, **info):
+        super().start_training(logdir, config, **info)
 
         try:
             from tensorboardX import SummaryWriter

--- a/python/ray/train/callbacks/logging.py
+++ b/python/ray/train/callbacks/logging.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class TrainingLogdirMixin:
-    def start_training(self, logdir: str, config: Dict, **info):
+    def start_training(self, logdir: str, **info):
         if self._logdir:
             logdir_path = Path(self._logdir)
         else:
@@ -86,8 +86,8 @@ class TrainingSingleFileLoggingCallback(TrainingLogdirMixin, TrainingCallback,
             raise ValueError("filename cannot be None or empty.")
         return logdir_path.joinpath(Path(filename))
 
-    def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir=logdir, config=config, **info)
+    def start_training(self, logdir: str, **info):
+        super().start_training(logdir=logdir, **info)
 
         if not self._filename:
             filename = self._default_filename
@@ -119,8 +119,8 @@ class JsonLoggerCallback(TrainingSingleFileLoggingCallback):
 
     _default_filename: Union[str, Path] = RESULT_FILE_JSON
 
-    def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir=logdir, config=config, **info)
+    def start_training(self, logdir: str, **info):
+        super().start_training(logdir=logdir, **info)
 
         # Create a JSON file with an empty list
         # that will be latter appended to
@@ -236,8 +236,8 @@ class MLflowLoggerCallback(TrainingSingleWorkerLoggingCallback):
         self.save_artifact = save_artifact
         self.mlflow_util = MLflowLoggerUtil()
 
-    def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir=logdir, config=config, **info)
+    def start_training(self, logdir: str, **info):
+        super().start_training(logdir=logdir, **info)
 
         tracking_uri = self.tracking_uri or os.path.join(
             str(self.logdir), "mlruns")
@@ -281,8 +281,8 @@ class TBXLoggerCallback(TrainingSingleWorkerLoggingCallback):
                                         np.int32, np.int64)
     IGNORE_KEYS: Set[str] = {PID, TIMESTAMP, TIME_TOTAL_S, TRAINING_ITERATION}
 
-    def start_training(self, logdir: str, config: Dict, **info):
-        super().start_training(logdir=logdir, config=config, **info)
+    def start_training(self, logdir: str, **info):
+        super().start_training(logdir=logdir, **info)
 
         try:
             from tensorboardX import SummaryWriter


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes outdated `start_training` definitions and calls in Train logging callbacks & abstract classes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
