### PR TITLE
[ci/repro] Add SYS_PTRACE to docker container, use unique name

### DIFF
--- a/ci/repro-ci.py
+++ b/ci/repro-ci.py
@@ -606,7 +606,10 @@ def main(session_url: Optional[str],
         },
         script_command=("sed -E 's/"
                         "docker run/"
-                        "docker run --name ray_container -d/g' | "
+                        "docker run "
+                        "--cap-add=SYS_PTRACE "
+                        "--name ray_container "
+                        "-d/g' | "
                         "bash -l"))
 
     repro.create_new_ssh_client()
@@ -619,6 +622,14 @@ def main(session_url: Optional[str],
         repro.print_buildkite_command(skipped=True)
 
     repro.transfer_env_to_container()
+
+    # Print once more before attaching
+    click.secho("Instance ID: ", nl=False)
+    click.secho(repro.aws_instance_id, bold=True)
+    click.secho("Instance IP: ", nl=False)
+    click.secho(repro.aws_instance_ip, bold=True)
+    print("-" * 80)
+
     repro.attach_to_container()
 
     logger.info("You are now detached from the AWS instance.")

--- a/ci/repro-ci.py
+++ b/ci/repro-ci.py
@@ -103,7 +103,7 @@ class ReproSession:
 
     def __init__(self,
                  buildkite_token: str,
-                 instance_name: str = "repro-ci-dev",
+                 instance_name: Optional[str] = None,
                  logger: Optional[logging.Logger] = None):
         self.logger = logger or logging.getLogger(self.__class__.__name__)
 
@@ -164,6 +164,12 @@ class ReproSession:
 
     def aws_start_instance(self):
         assert self.env
+
+        if not self.aws_instance_name:
+            self.aws_instance_name = (
+                f"repro_ci_{self.build_id}_{self.job_id[:8]}")
+            self.logger.info(
+                f"No instance name provided, using {self.aws_instance_name}")
 
         instance_type = self.env["BUILDKITE_AGENT_META_DATA_AWS_INSTANCE_TYPE"]
         instance_ami = self.env["BUILDKITE_AGENT_META_DATA_AWS_AMI_ID"]
@@ -546,11 +552,11 @@ class ReproSession:
 
 @click.command()
 @click.argument("session_url", required=False)
-@click.option("-n", "--instance-name", default="repro-ci-dev")
+@click.option("-n", "--instance-name", default=None)
 @click.option("-c", "--commands", is_flag=True, default=False)
 @click.option("-f", "--filters", multiple=True, default=[])
 def main(session_url: Optional[str],
-         instance_name: str = "repro-ci-dev",
+         instance_name: Optional[str] = None,
          commands: bool = False,
          filters: Optional[List[str]] = None):
     random.seed(1235)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This will start repro docker containers with SYS_PTRACE capabilities to enable debugging e.g. via py-spy.

Additionally, default instance name tags for instance re-use will be generated using the buildkite build id and job id.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
