### PR TITLE
Unskipped test and bumped wait time to avoid race conditions

### DIFF
--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -286,7 +286,6 @@ def test_reconfigure_with_exception(serve_instance):
     wait_for_condition(rolled_back)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_handle", [True, False])
 def test_redeploy_single_replica(serve_instance, use_handle):
     # Tests that redeploying a deployment with a single replica waits for the
@@ -337,7 +336,7 @@ def test_redeploy_single_replica(serve_instance, use_handle):
 
     # ref2 will block until the signal is sent.
     ref2 = call.remote(block=True)
-    assert len(ray.wait([ref2], timeout=0.1)[0]) == 0
+    assert len(ray.wait([ref2], timeout=2.1)[0]) == 0
 
     # Redeploy new version. This should not go through until the old version
     # replica completely stops.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I have explained the reasoning in a review comment below.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
