### PR TITLE
[nightly] Enable GCS HA nightly test with bootstrap

### DIFF
--- a/benchmarks/benchmark_tests.yaml
+++ b/benchmarks/benchmark_tests.yaml
@@ -140,8 +140,9 @@
     script: python distributed/test_many_tasks.py --num-tasks=10000
 
   app_env_vars:
-    RAY_gcs_grpc_based_pubsub: "true"
+    RAY_gcs_grpc_based_pubsub: "1"
     RAY_gcs_storage: "memory"
+    RAY_bootstrap_with_gcs: "1"
 
   stable: false
 
@@ -160,8 +161,9 @@
     script: python distributed/test_many_actors.py
 
   app_env_vars:
-    RAY_gcs_grpc_based_pubsub: "true"
+    RAY_gcs_grpc_based_pubsub: "1"
     RAY_gcs_storage: "memory"
+    RAY_bootstrap_with_gcs: "1"
 
   stable: false
 
@@ -180,8 +182,9 @@
     script: python distributed/test_many_tasks.py --num-tasks=1000
 
   app_env_vars:
-    RAY_gcs_grpc_based_pubsub: "true"
+    RAY_gcs_grpc_based_pubsub: "1"
     RAY_gcs_storage: "memory"
+    RAY_bootstrap_with_gcs: "1"
 
   stable: false
 
@@ -200,7 +203,8 @@
     script: python distributed/test_many_pgs.py
 
   app_env_vars:
-    RAY_gcs_grpc_based_pubsub: "true"
+    RAY_gcs_grpc_based_pubsub: "1"
     RAY_gcs_storage: "memory"
+    RAY_bootstrap_with_gcs: "1"
 
   stable: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After https://github.com/ray-project/ray/pull/21232 we are able to start ray without redis. We need to bake the test for a while before turning on the flag by default.
This PR add tests for this.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
