### PR TITLE
WINDOWS: re-enable runtime_env tests, skip cluster tests in serve

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -167,8 +167,6 @@ test_python() {
       -python/ray/tests:test_resource_demand_scheduler
       -python/ray/tests:test_reference_counting  # too flaky 9/25/21
       -python/ray/tests:test_runtime_env_plugin # runtime_env not supported on Windows
-      -python/ray/tests:test_runtime_env_env_vars # runtime_env not supported on Windows
-      -python/ray/tests:test_runtime_env_complicated # conda install slow leading to timeout
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_operator_unit_tests

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -166,7 +166,7 @@ test_python() {
       -python/ray/tests:test_ray_init  # test_redis_port() seems to fail here, but pass in isolation
       -python/ray/tests:test_resource_demand_scheduler
       -python/ray/tests:test_reference_counting  # too flaky 9/25/21
-      -python/ray/tests:test_runtime_env_plugin # runtime_env not supported on Windows
+      -python/ray/tests:test_runtime_env_complicated # requires conda
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_operator_unit_tests

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -15,7 +15,7 @@ import requests
 
 import ray
 from ray import serve
-from ray.cluster_utils import Cluster
+from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.serve.constants import SERVE_ROOT_URL_ENV_KEY, SERVE_PROXY_NAME
 from ray.serve.exceptions import RayServeException
 from ray.serve.utils import (block_until_http_ready, get_all_node_ids,
@@ -34,6 +34,8 @@ from ray.tests.conftest import ray_start_with_dashboard  # noqa: F401
 
 @pytest.fixture
 def ray_cluster():
+    if cluster_not_supported:
+        pytest.skip("Cluster not supported")
     cluster = Cluster()
     yield Cluster()
     serve.shutdown()

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -43,8 +43,6 @@ def test_get_release_wheel_url():
                 assert requests.head(url).status_code == 200, url
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
 def test_decorator_task(start_cluster):
     cluster, address = start_cluster
     ray.init(address)
@@ -56,8 +54,6 @@ def test_decorator_task(start_cluster):
     assert ray.get(f.remote()) == "bar"
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
 def test_decorator_actor(start_cluster):
     cluster, address = start_cluster
     ray.init(address)
@@ -71,8 +67,6 @@ def test_decorator_actor(start_cluster):
     assert ray.get(a.g.remote()) == "bar"
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
 def test_decorator_complex(start_cluster):
     cluster, address = start_cluster
     ray.init(address, runtime_env={"env_vars": {"foo": "job"}})
@@ -127,7 +121,8 @@ def test_container_option_serialize():
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+    sys.platform == "win32",
+    reason="conda in runtime_env unsupported on Windows.")
 def test_invalid_conda_env(shutdown_only):
     ray.init()
 
@@ -230,8 +225,7 @@ def runtime_env_local_dev_env_var():
     del os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"]
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows.")
+@pytest.mark.skipif(sys.platform == "win32", reason="very slow on Windows.")
 def test_runtime_env_no_spurious_resource_deadlock_msg(
         runtime_env_local_dev_env_var, ray_start_regular, error_pubsub):
     p = error_pubsub

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -52,21 +52,26 @@ def test_simple_env_modification_plugin(ray_start_regular):
             }
         }).remote()
 
-    output = ray.get(
-        f.options(
-            runtime_env={
-                "plugins": {
-                    MY_PLUGIN_CLASS_PATH: {
-                        "env_value": 42,
-                        "tmp_file": tmp_file_path,
-                        "tmp_content": "hello",
-                        # See https://en.wikipedia.org/wiki/Nice_(Unix)
-                        "prefix_command": "nice -n 19",
+    if os.name != "nt":
+        output = ray.get(
+            f.options(
+                runtime_env={
+                    "plugins": {
+                        MY_PLUGIN_CLASS_PATH: {
+                            "env_value": 42,
+                            "tmp_file": tmp_file_path,
+                            "tmp_content": "hello",
+                            # See https://en.wikipedia.org/wiki/Nice_(Unix)
+                            "prefix_command": "nice -n 19",
+                        }
                     }
-                }
-            }).remote())
+                }).remote())
 
-    assert output == {"env_value": "42", "tmp_content": "hello", "nice": 19}
+        assert output == {
+            "env_value": "42",
+            "tmp_content": "hello",
+            "nice": 19
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After enabling tests of test_runtime_env_plugin and test_runtime_env_env_vars (PR #21252) and python/ray/serve:* tests (PR #21107), the analysis at flaky-tests.ray.io starting showing failing tests in the windows://python/ray/test/serv:test_standalone. PR #21352 reverted 21252 (runtime_env tests), but the problem was more likely in the serve tests. Specifically  `test_standalone` has a test that uses Cluster, which should be skipped on windows because it is flaky. So this PR
- re-enables the runtime_env tests for windows
- skips the Cluster test in serve/tests/test_standalone.py
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #21393
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
