### PR TITLE
[Test] Fix wrong many_nodes_actor_test app config

### DIFF
--- a/release/nightly_tests/many_nodes_tests/app_config.yaml
+++ b/release/nightly_tests/many_nodes_tests/app_config.yaml
@@ -1,5 +1,5 @@
 base_image: "anyscale/ray:nightly-py37"
-env_vars: {"RAY_gcs_server_rpc_server_thread_num": "8", "RAY_GCS_ACTOR_SCHEDULING_ENABLED": "true"}
+env_vars: {"RAY_gcs_server_rpc_server_thread_num": "8"}
 debian_packages: []
 
 python:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
RAY_GCS_ACTOR_SCHEDULING_ENABLED is wrong should be RAY_gcs_actor_scheduling_enabled. Since gcs based actor scheduling is not enabled yet so I just removed this flag.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
