### PR TITLE
Give rnnsac_stateless cartpole gpu, increase timeout

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1240,7 +1240,7 @@ py_test(
 py_test(
     name = "test_preprocessors",
     tags = ["team:ml", "models"],
-    size = "medium",
+    size = "large",
     srcs = ["models/tests/test_preprocessors.py"]
 )
 
@@ -2571,7 +2571,7 @@ py_test(
 py_test(
     name = "examples/rnnsac_stateless_cartpole",
     tags = ["team:ml", "gpu"],
-    size = "large",
+    size = "enormous",
     srcs = ["examples/rnnsac_stateless_cartpole.py"]
 )
 

--- a/rllib/examples/rnnsac_stateless_cartpole.py
+++ b/rllib/examples/rnnsac_stateless_cartpole.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import ray
@@ -27,6 +28,7 @@ config = {
     "mode": "max",
     "verbose": 2,
     "config": {
+        "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": "torch",
         "num_workers": 4,
         "num_envs_per_worker": 1,


### PR DESCRIPTION
- Increase rnnsac_stateless_cartpole and test_preprocessors runtimes
- gpu access was enabled for rnnsac_stateless_cartpole, but enabled
  its ussage inside of the launch file
