### PR TITLE
[rllib] Give rnnsac_stateless cartpole gpu, increase timeout

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2571,7 +2571,7 @@ py_test(
 py_test(
     name = "examples/rnnsac_stateless_cartpole",
     tags = ["team:ml", "gpu"],
-    size = "enormous",
+    size = "large",
     srcs = ["examples/rnnsac_stateless_cartpole.py"]
 )
 

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1240,7 +1240,7 @@ py_test(
 py_test(
     name = "test_preprocessors",
     tags = ["team:ml", "models"],
-    size = "medium",
+    size = "large",
     srcs = ["models/tests/test_preprocessors.py"]
 )
 
@@ -2571,7 +2571,7 @@ py_test(
 py_test(
     name = "examples/rnnsac_stateless_cartpole",
     tags = ["team:ml", "gpu"],
-    size = "large",
+    size = "enormous",
     srcs = ["examples/rnnsac_stateless_cartpole.py"]
 )
 

--- a/rllib/examples/rnnsac_stateless_cartpole.py
+++ b/rllib/examples/rnnsac_stateless_cartpole.py
@@ -22,12 +22,13 @@ config = {
     "checkpoint_score_attr": "episode_reward_mean",
     "stop": {
         "episode_reward_mean": 65.0,
-        "timesteps_total": 100000,
+        "timesteps_total": 50000,
     },
     "metric": "episode_reward_mean",
     "mode": "max",
     "verbose": 2,
     "config": {
+        "seed": 42,
         "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": "torch",
         "num_workers": 4,

--- a/rllib/examples/rnnsac_stateless_cartpole.py
+++ b/rllib/examples/rnnsac_stateless_cartpole.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import ray
@@ -27,6 +28,7 @@ config = {
     "mode": "max",
     "verbose": 2,
     "config": {
+        "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
         "framework": "torch",
         "num_workers": 4,
         "num_envs_per_worker": 1,

--- a/rllib/models/tests/test_preprocessors.py
+++ b/rllib/models/tests/test_preprocessors.py
@@ -24,7 +24,7 @@ class TestPreprocessors(unittest.TestCase):
 
     def test_preprocessing_disabled(self):
         config = ppo.DEFAULT_CONFIG.copy()
-
+        config["seed"] = 42
         config["env"] = "ray.rllib.examples.env.random_env.RandomEnv"
         config["env_config"] = {
             "config": {


### PR DESCRIPTION
- Increase rnnsac_stateless_cartpole and test_preprocessors runtimes
- gpu access was enabled for rnnsac_stateless_cartpole, but enabled
  its ussage inside of the launch file
