### PR TITLE
[CI] [docker] Fix docker image name regex matching

### DIFF
--- a/ci/travis/build-docker-images.py
+++ b/ci/travis/build-docker-images.py
@@ -403,7 +403,7 @@ def push_and_tag_images(py_versions: List[str],
     date_tag = datetime.datetime.now().strftime("%Y-%m-%d")
     sha_tag = _get_commit_sha()
     if _release_build():
-        release_name = re.search("[0-9].\.[0-9].\.[0-9].*",
+        release_name = re.search("[0-9]+\.[0-9]+\.[0-9].*",
                                  _get_branch()).group(0)
         date_tag = release_name
         sha_tag = release_name


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Manually checked that both `1.9.0`, `1.9.0rc1`, and `1.10.0rc0` pass this regex match.  Previously `1.10.0rc0` did not pass.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/21400
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
