### PR TITLE
[RLlib] Extend CQL perf test to 1hr.

### DIFF
--- a/release/rllib_tests/performance_tests/performance_tests.yaml
+++ b/release/rllib_tests/performance_tests/performance_tests.yaml
@@ -57,7 +57,7 @@ cql-halfcheetahbulletenv-v0:
     run: CQL
     frameworks: [ "tf", "tf2", "torch" ]
     stop:
-        time_total_s: 1800
+        time_total_s: 3600
     config:
         # Use input produced by expert SAC algo.
         input: ["~/halfcheetah_expert_sac.zip"]


### PR DESCRIPTION
## Why are these changes needed?

I notice that in our weekly test, CQL does get to 400 reward in 1hr.
Maybe that's all we need, and it is actually working.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
