### PR TITLE
remove deprecated unittest aliases

### DIFF
--- a/python/ray/tune/tests/test_cloud.py
+++ b/python/ray/tune/tests/test_cloud.py
@@ -50,8 +50,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.download(
                 local_path=self.local_dir, cloud_path=self.cloud_dir)
 
-        self.assertEquals(self.local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.local_dir, state["cmd"])
 
     def testDownloadDefaultLocal(self):
@@ -77,8 +77,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(cloud_path=self.cloud_dir)
 
-        self.assertEquals(self.local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.local_dir, state["cmd"])
 
         # Case: Both are passed
@@ -87,8 +87,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.download(
                 local_path=other_local_dir, cloud_path=self.cloud_dir)
 
-        self.assertEquals(other_local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(other_local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
         self.assertNotIn(self.local_dir, state["cmd"])
 
@@ -110,8 +110,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(local_path=self.local_dir)
 
-        self.assertEquals(self.local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.local_dir, state["cmd"])
 
         # Case: Cloud dir is passed
@@ -125,8 +125,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.download(
                 local_path=self.local_dir, cloud_path=other_cloud_dir)
 
-        self.assertEquals(self.local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_cloud_dir, state["cmd"])
         self.assertNotIn(self.cloud_dir, state["cmd"])
 
@@ -146,8 +146,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download()
 
-        self.assertEquals(self.local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.local_dir, state["cmd"])
 
         # Case: Local dir is passed
@@ -157,8 +157,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.download(local_path=other_local_dir)
 
-        self.assertEquals(other_local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(other_local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
         self.assertNotIn(self.local_dir, state["cmd"])
 
@@ -171,8 +171,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.download(
                 local_path=other_local_dir, cloud_path=other_cloud_dir)
 
-        self.assertEquals(other_local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(other_local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
         self.assertNotIn(self.local_dir, state["cmd"])
         self.assertIn(other_cloud_dir, state["cmd"])
@@ -205,8 +205,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.upload(
                 local_path=self.local_dir, cloud_path=self.cloud_dir)
 
-        self.assertEquals(self.cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.cloud_dir, state["cmd"])
 
     def testUploadDefaultLocal(self):
@@ -232,8 +232,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.upload(cloud_path=self.cloud_dir)
 
-        self.assertEquals(self.cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.cloud_dir, state["cmd"])
 
         # Case: Both are passed
@@ -242,8 +242,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.upload(
                 local_path=other_local_dir, cloud_path=self.cloud_dir)
 
-        self.assertEquals(self.cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
         self.assertNotIn(self.local_dir, state["cmd"])
 
@@ -265,8 +265,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.upload(local_path=self.local_dir)
 
-        self.assertEquals(self.cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.cloud_dir, state["cmd"])
 
         # Case: Cloud dir is passed
@@ -280,8 +280,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.upload(
                 local_path=self.local_dir, cloud_path=other_cloud_dir)
 
-        self.assertEquals(other_cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(other_cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_cloud_dir, state["cmd"])
         self.assertNotIn(self.cloud_dir, state["cmd"])
 
@@ -301,8 +301,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.upload()
 
-        self.assertEquals(self.cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.cloud_dir, state["cmd"])
 
         # Case: Local dir is passed
@@ -312,8 +312,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.upload(local_path=other_local_dir)
 
-        self.assertEquals(self.cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
         self.assertNotIn(self.local_dir, state["cmd"])
 
@@ -326,8 +326,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
             path = checkpoint.upload(
                 local_path=other_local_dir, cloud_path=other_cloud_dir)
 
-        self.assertEquals(other_cloud_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(other_cloud_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(other_local_dir, state["cmd"])
         self.assertNotIn(self.local_dir, state["cmd"])
         self.assertIn(other_cloud_dir, state["cmd"])
@@ -368,8 +368,8 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.save(self.local_dir, force_download=True)
 
-        self.assertEquals(self.local_dir, path)
-        self.assertEquals(state["cmd"][0], "aws")
+        self.assertEqual(self.local_dir, path)
+        self.assertEqual(state["cmd"][0], "aws")
         self.assertIn(self.cloud_dir, state["cmd"])
         self.assertIn(self.local_dir, state["cmd"])
 
@@ -380,9 +380,9 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("shutil.copytree", copytree):
             path = checkpoint.save(other_local_dir)
 
-        self.assertEquals(other_local_dir, path)
-        self.assertEquals(state["copy_source"], self.local_dir)
-        self.assertEquals(state["copy_dest"], other_local_dir)
+        self.assertEqual(other_local_dir, path)
+        self.assertEqual(state["copy_source"], self.local_dir)
+        self.assertEqual(state["copy_dest"], other_local_dir)
 
         # Case: Both default, no pass
         checkpoint = TrialCheckpoint(
@@ -391,7 +391,7 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.save()
 
-        self.assertEquals(self.local_dir, path)
+        self.assertEqual(self.local_dir, path)
         self.assertIn(self.cloud_dir, state["cmd"])
         self.assertIn(self.local_dir, state["cmd"])
 
@@ -402,10 +402,10 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("shutil.copytree", copytree):
             path = checkpoint.save(other_local_dir)
 
-        self.assertEquals(other_local_dir, path)
-        self.assertEquals(state["copy_source"], self.local_dir)
-        self.assertEquals(state["copy_dest"], other_local_dir)
-        self.assertEquals(checkpoint.local_path, self.local_dir)
+        self.assertEqual(other_local_dir, path)
+        self.assertEqual(state["copy_source"], self.local_dir)
+        self.assertEqual(state["copy_dest"], other_local_dir)
+        self.assertEqual(checkpoint.local_path, self.local_dir)
 
     def testSaveCloudTarget(self):
         state = {}
@@ -436,7 +436,7 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.save(self.cloud_dir)
 
-        self.assertEquals(self.cloud_dir, path)
+        self.assertEqual(self.cloud_dir, path)
         self.assertIn(self.cloud_dir, state["cmd"])
         self.assertIn(self.local_dir, state["cmd"])
 
@@ -449,7 +449,7 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.save(other_cloud_dir)
 
-        self.assertEquals(other_cloud_dir, path)
+        self.assertEqual(other_cloud_dir, path)
         self.assertIn(other_cloud_dir, state["cmd"])
         self.assertNotIn(self.local_dir, state["cmd"])  # Temp dir
 
@@ -460,7 +460,7 @@ class TrialCheckpointApiTest(unittest.TestCase):
         with patch("subprocess.check_call", check_call):
             path = checkpoint.save(other_cloud_dir)
 
-        self.assertEquals(other_cloud_dir, path)
+        self.assertEqual(other_cloud_dir, path)
         self.assertIn(other_cloud_dir, state["cmd"])
         self.assertIn(self.local_dir, state["cmd"])
 
@@ -554,11 +554,11 @@ class TrialCheckpointEndToEndTest(unittest.TestCase):
             self.assertTrue(os.path.exists(cp0.local_path))
 
             cp_content = _load_cp(other_local_dir)
-            self.assertEquals(cp_content["train_id"], 0)
-            self.assertEquals(cp_content["score"], 9)
+            self.assertEqual(cp_content["train_id"], 0)
+            self.assertEqual(cp_content["score"], 9)
 
             cp_content_2 = _load_cp(cp0.local_path)
-            self.assertEquals(cp_content, cp_content_2)
+            self.assertEqual(cp_content, cp_content_2)
 
             # Clean up
             shutil.rmtree(other_local_dir)
@@ -576,8 +576,8 @@ class TrialCheckpointEndToEndTest(unittest.TestCase):
             # Directory is not empty anymore
             self.assertTrue(os.listdir(cp1.local_path))
             cp_content = _load_cp(cp1.local_path)
-            self.assertEquals(cp_content["train_id"], 1)
-            self.assertEquals(cp_content["score"], 9)
+            self.assertEqual(cp_content["train_id"], 1)
+            self.assertEqual(cp_content["score"], 9)
 
             #######
             # Case: Checkpoint does not exist on local dir, download from cloud
@@ -593,8 +593,8 @@ class TrialCheckpointEndToEndTest(unittest.TestCase):
             # Directory still does not exist (as we save to other dir)
             self.assertFalse(os.path.exists(cp2.local_path))
             cp_content = _load_cp(other_local_dir)
-            self.assertEquals(cp_content["train_id"], 2)
-            self.assertEquals(cp_content["score"], 9)
+            self.assertEqual(cp_content["train_id"], 2)
+            self.assertEqual(cp_content["score"], 9)
 
             # Clean up
             shutil.rmtree(other_local_dir)
@@ -621,8 +621,8 @@ class TrialCheckpointEndToEndTest(unittest.TestCase):
             self.assertTrue(os.listdir(self.second_fake_cloud_dir))
 
             cp_content = _load_cp(self.second_fake_cloud_dir)
-            self.assertEquals(cp_content["train_id"], 3)
-            self.assertEquals(cp_content["score"], 9)
+            self.assertEqual(cp_content["train_id"], 3)
+            self.assertEqual(cp_content["score"], 9)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -260,8 +260,7 @@ class ExperimentAnalysisPropertySuite(unittest.TestCase):
             all(ea.best_dataframe["trial_id"] == trials[2].trial_id))
         self.assertEqual(ea.results_df.loc[trials[2].trial_id, "res"], 309)
         self.assertEqual(ea.best_result["res"], 309)
-        self.assertEqual(ea.best_result_df.loc[trials[2].trial_id, "res"],
-                          309)
+        self.assertEqual(ea.best_result_df.loc[trials[2].trial_id, "res"], 309)
 
     def testDataframeBestResult(self):
         def train(config):

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -67,7 +67,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         df = self.ea.dataframe(self.metric, mode="max")
 
         self.assertTrue(isinstance(df, pd.DataFrame))
-        self.assertEquals(df.shape[0], self.num_samples)
+        self.assertEqual(df.shape[0], self.num_samples)
 
     def testLoadJson(self):
         all_dataframes_via_csv = self.ea.fetch_trial_dataframes()
@@ -112,7 +112,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         self.assertTrue(logdir.startswith(self.test_path))
         logdir2 = self.ea.get_best_logdir(self.metric, mode="min")
         self.assertTrue(logdir2.startswith(self.test_path))
-        self.assertNotEquals(logdir, logdir2)
+        self.assertNotEqual(logdir, logdir2)
 
     def testBestLogdirNan(self):
         nan_ea = self.nan_test_exp()
@@ -216,7 +216,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
                     lambda spec: int(100 * random.random())),
             })
         df = analysis.dataframe(self.metric, mode="max")
-        self.assertEquals(df.shape[0], 1)
+        self.assertEqual(df.shape[0], 1)
 
     def testGetTrialCheckpointsPathsByPathWithSpecialCharacters(self):
         analysis = tune.run(
@@ -252,15 +252,15 @@ class ExperimentAnalysisPropertySuite(unittest.TestCase):
 
         trials = ea.trials
 
-        self.assertEquals(ea.best_trial, trials[2])
-        self.assertEquals(ea.best_config, trials[2].config)
-        self.assertEquals(ea.best_logdir, trials[2].logdir)
-        self.assertEquals(ea.best_checkpoint, trials[2].checkpoint.value)
+        self.assertEqual(ea.best_trial, trials[2])
+        self.assertEqual(ea.best_config, trials[2].config)
+        self.assertEqual(ea.best_logdir, trials[2].logdir)
+        self.assertEqual(ea.best_checkpoint, trials[2].checkpoint.value)
         self.assertTrue(
             all(ea.best_dataframe["trial_id"] == trials[2].trial_id))
-        self.assertEquals(ea.results_df.loc[trials[2].trial_id, "res"], 309)
-        self.assertEquals(ea.best_result["res"], 309)
-        self.assertEquals(ea.best_result_df.loc[trials[2].trial_id, "res"],
+        self.assertEqual(ea.results_df.loc[trials[2].trial_id, "res"], 309)
+        self.assertEqual(ea.best_result["res"], 309)
+        self.assertEqual(ea.best_result_df.loc[trials[2].trial_id, "res"],
                           309)
 
     def testDataframeBestResult(self):

--- a/python/ray/tune/tests/test_function_api.py
+++ b/python/ray/tune/tests/test_function_api.py
@@ -519,7 +519,7 @@ class FunctionApiTest(unittest.TestCase):
 
         trainable = tune.with_parameters(train_fn, extra=8)
         out = tune.run(trainable, metric="metric", mode="max")
-        self.assertEquals(out.best_result["metric"], 8)
+        self.assertEqual(out.best_result["metric"], 8)
 
         self.tearDown()
         self.setUp()
@@ -529,7 +529,7 @@ class FunctionApiTest(unittest.TestCase):
 
         trainable = tune.with_parameters(train_fn_2, extra=9)
         out = tune.run(trainable, metric="metric", mode="max")
-        self.assertEquals(out.best_result["metric"], 9)
+        self.assertEqual(out.best_result["metric"], 9)
 
     def testWithParametersTwoRuns2(self):
         # Makes sure two runs in the same script
@@ -545,8 +545,8 @@ class FunctionApiTest(unittest.TestCase):
 
         out1 = tune.run(trainable1, metric="metric", mode="max")
         out2 = tune.run(trainable2, metric="metric", mode="max")
-        self.assertEquals(out1.best_result["metric"], 8)
-        self.assertEquals(out2.best_result["metric"], 9)
+        self.assertEqual(out1.best_result["metric"], 8)
+        self.assertEqual(out2.best_result["metric"], 9)
 
     def testReturnAnonymous(self):
         def train(config):

--- a/python/ray/tune/tests/test_run_experiment.py
+++ b/python/ray/tune/tests/test_run_experiment.py
@@ -282,7 +282,7 @@ class RunExperimentTest(unittest.TestCase):
                     lambda t: "{}_{}_321".format(t.trainable_name, t.trial_id)
             }
         })
-        self.assertEquals(
+        self.assertEqual(
             str(trial), "{}_{}_321".format(trial.trainable_name,
                                            trial.trial_id))
 

--- a/python/ray/tune/tests/test_sync.py
+++ b/python/ray/tune/tests/test_sync.py
@@ -428,11 +428,11 @@ class TestSyncFunctionality(unittest.TestCase):
         self.assertTrue(isinstance(syncer_callback, SyncerCallback))
 
         # Sync function should be false (no sync to driver)
-        self.assertEquals(syncer_callback._sync_function, False)
+        self.assertEqual(syncer_callback._sync_function, False)
 
         # Sync to driver is disabled, so this should be no-op
         trial_syncer = syncer_callback._get_trial_syncer(trial)
-        self.assertEquals(trial_syncer.sync_client, NOOP)
+        self.assertEqual(trial_syncer.sync_client, NOOP)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_trainable_util.py
+++ b/python/ray/tune/tests/test_trainable_util.py
@@ -49,7 +49,7 @@ class TrainableUtilTest(unittest.TestCase):
                                        "0/my/nested/chkpt")
         os.makedirs(checkpoint_path)
         found_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
-        self.assertEquals(self.checkpoint_dir, found_dir)
+        self.assertEqual(self.checkpoint_dir, found_dir)
 
         with self.assertRaises(FileNotFoundError):
             parent = os.path.dirname(found_dir)
@@ -71,7 +71,7 @@ class TrainableUtilTest(unittest.TestCase):
 
         for i in range(5):
             path = os.path.join(self.checkpoint_dir, str(i))
-            self.assertEquals(loaded["data"][str(i)], open(path, "rb").read())
+            self.assertEqual(loaded["data"][str(i)], open(path, "rb").read())
 
 
 class FlattenDictTest(unittest.TestCase):

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -722,7 +722,7 @@ class BOHBSuite(unittest.TestCase):
         self.assertEqual(decision, TrialScheduler.STOP)
         sched.choose_trial_to_run(runner)
         self.assertTrue("hyperband_info" in spy_result)
-        self.assertEquals(spy_result["hyperband_info"]["budget"], 1)
+        self.assertEqual(spy_result["hyperband_info"]["budget"], 1)
 
     def testCheckTrialInfoUpdateMin(self):
         def result(score, ts):
@@ -750,7 +750,7 @@ class BOHBSuite(unittest.TestCase):
         self.assertEqual(decision, TrialScheduler.CONTINUE)
         sched.choose_trial_to_run(runner)
         self.assertTrue("hyperband_info" in spy_result)
-        self.assertEquals(spy_result["hyperband_info"]["budget"], 1)
+        self.assertEqual(spy_result["hyperband_info"]["budget"], 1)
 
     def testPauseResumeChooseTrial(self):
         def result(score, ts):

--- a/python/ray/util/sgd/tests/test_torch_runner.py
+++ b/python/ray/util/sgd/tests/test_torch_runner.py
@@ -190,16 +190,16 @@ class TestLocalDistributedRunner(unittest.TestCase):
         self.assertTrue(mock_runner._set_cuda_device.called)
         local_device = mock_runner._set_cuda_device.call_args[0][0]
         env_set_device = os.environ["CUDA_VISIBLE_DEVICES"]
-        self.assertEquals(len(env_set_device), 1)
+        self.assertEqual(len(env_set_device), 1)
 
         if preset_devices:
             visible_devices = preset_devices.split(",")
             self.assertIn(env_set_device, visible_devices)
             device_int = int(local_device)
             self.assertLess(device_int, len(visible_devices))
-            self.assertEquals(len(os.environ["CUDA_VISIBLE_DEVICES"]), 1)
+            self.assertEqual(len(os.environ["CUDA_VISIBLE_DEVICES"]), 1)
         else:
-            self.assertEquals(local_device, env_set_device)
+            self.assertEqual(local_device, env_set_device)
 
     def testNoVisibleWithInitialized(self):
         with patch("torch.cuda.is_initialized") as init_mock:
@@ -252,7 +252,7 @@ class TestLocalDistributedRunner(unittest.TestCase):
         mock_runner = MagicMock()
         mock_runner._is_set = False
         LocalDistributedRunner._set_cuda_device(mock_runner, "123")
-        self.assertEquals(mock_runner.local_cuda_device, "123")
+        self.assertEqual(mock_runner.local_cuda_device, "123")
         self.assertTrue(set_mock.called)
         set_mock.assert_called_with(123)
 
@@ -263,7 +263,7 @@ class TestLocalDistributedRunner(unittest.TestCase):
         LocalDistributedRunner._try_reserve_and_set_resources(
             mock_runner, 4, 0)
         remaining = ray.available_resources()["CPU"]
-        self.assertEquals(int(remaining), 6)
+        self.assertEqual(int(remaining), 6)
 
     def testV2ReserveCPUResources(self):
         mock_runner = MagicMock()
@@ -272,4 +272,4 @@ class TestLocalDistributedRunner(unittest.TestCase):
         LocalDistributedRunner._try_reserve_and_set_resources(
             mock_runner, 4, 1)
         remaining = ray.available_resources()["CPU"]
-        self.assertEquals(int(remaining), 6)
+        self.assertEqual(int(remaining), 6)

--- a/rllib/agents/impala/tests/test_vtrace.py
+++ b/rllib/agents/impala/tests/test_vtrace.py
@@ -332,7 +332,7 @@ class VtraceTest(unittest.TestCase):
                     "bootstrap_value": Box(-1.0, 1.0, (7, )).sample()
                 }
             with self.assertRaisesRegex((ValueError, AssertionError),
-                                         "must have rank 2"):
+                                        "must have rank 2"):
                 vtrace.from_importance_weights(**inputs_)
 
 

--- a/rllib/agents/impala/tests/test_vtrace.py
+++ b/rllib/agents/impala/tests/test_vtrace.py
@@ -331,7 +331,7 @@ class VtraceTest(unittest.TestCase):
                     # Should be [15, 42].
                     "bootstrap_value": Box(-1.0, 1.0, (7, )).sample()
                 }
-            with self.assertRaisesRegexp((ValueError, AssertionError),
+            with self.assertRaisesRegex((ValueError, AssertionError),
                                          "must have rank 2"):
                 vtrace.from_importance_weights(**inputs_)
 

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -208,7 +208,7 @@ class TestTrainer(unittest.TestCase):
             # Setup trainer w/o evaluation worker set and still call
             # evaluate() -> Expect error.
             trainer_wo_env_on_driver = a3c.A3CTrainer(config=config)
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 ValueError, "Cannot evaluate w/o an evaluation worker set",
                 trainer_wo_env_on_driver.evaluate)
             trainer_wo_env_on_driver.stop()

--- a/rllib/tests/test_nested_observation_spaces.py
+++ b/rllib/tests/test_nested_observation_spaces.py
@@ -325,7 +325,7 @@ class NestedObservationSpacesTest(unittest.TestCase):
 
     def test_invalid_model(self):
         ModelCatalog.register_custom_model("invalid", InvalidModel)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Subclasses of TorchModelV2 must also inherit from nn.Module",
             lambda: PGTrainer(
@@ -339,7 +339,7 @@ class NestedObservationSpacesTest(unittest.TestCase):
 
     def test_invalid_model2(self):
         ModelCatalog.register_custom_model("invalid2", InvalidModel2)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, "State output is not a list",
             lambda: PGTrainer(
                 env="CartPole-v0", config={


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In a [recent review](https://discuss.python.org/t/experience-with-python-3-11-in-fedora/12911) of the experience of the Fedora team porting packages to the upcoming python 3.11, they remarked that most of the work was in removing deprecated aliases in unittest. I came across a few of these when looking at unrelated test failures, the DeprecationWarnings caught my eye. So a made a quick sweep of the code, using `git grep` to find occurances of the deprecated aliases:

old | new
---|---
assertEquals | assertEqual
assertNotEquals | assertNotEqual
assertRaisesRegexp | assertRaisesRegex


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None that I know of
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Edit: add the link to the fedora report