### PR TITLE
[Core] allow message in deprecation annotation

### DIFF
--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -86,12 +86,11 @@ def Deprecated(*args, **kwargs):
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         return Deprecated()(args[0])
 
+    message = "\n    DEPRECATED: This API is deprecated and may be removed " \
+              "in future Ray releases."
     if "message" in kwargs:
-        message = kwargs["message"]
+        message = message + " " + kwargs["message"]
         del kwargs["message"]
-    else:
-        message = "This API is deprecated and may be removed in future " \
-                  "Ray releases."
 
     if kwargs:
         raise ValueError("Unknown kwargs: {}".format(kwargs.keys()))
@@ -99,7 +98,7 @@ def Deprecated(*args, **kwargs):
     def inner(obj):
         if not obj.__doc__:
             obj.__doc__ = ""
-        obj.__doc__ += f"\n    DEPRECATED: {message}"
+        obj.__doc__ += f"{message}"
         return obj
 
     return inner

--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -64,19 +64,42 @@ def DeveloperAPI(obj):
     return obj
 
 
-def Deprecated(obj):
+def Deprecated(*args, **kwargs):
     """Annotation for documenting a deprecated API.
 
     Deprecated APIs may be removed in future releases of Ray.
+
+    Args:
+        message: a message to help users understand the reason for the
+            deprecation, and provide a migration path.
 
     Examples:
         >>> @Deprecated
         >>> def func(x):
         >>>     return x
-    """
 
-    if not obj.__doc__:
-        obj.__doc__ = ""
-    obj.__doc__ += ("\n    DEPRECATED: This API is deprecated and may be "
-                    "removed in future Ray releases.")
-    return obj
+        >>> @Deprecated(message="g() is deprecated because the API is error "
+        "prone. Please call h() instead.")
+        >>> def g(y):
+        >>>     return y
+    """
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return Deprecated()(args[0])
+
+    if "message" in kwargs:
+        message = kwargs["message"]
+        del kwargs["message"]
+    else:
+        message = "This API is deprecated and may be removed in future " \
+                  "Ray releases."
+
+    if kwargs:
+        raise ValueError("Unknown kwargs: {}".format(kwargs.keys()))
+
+    def inner(obj):
+        if not obj.__doc__:
+            obj.__doc__ = ""
+        obj.__doc__ += f"\n    DEPRECATED: {message}"
+        return obj
+
+    return inner

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -563,7 +563,7 @@ def get_resource_ids():
     return global_worker.core_worker.resource_ids()
 
 
-@Deprecated(message='Use ray.init()[\"webui_url\"] instead')
+@Deprecated(message="Use ray.init()['webui_url'] instead.")
 def get_dashboard_url():
     """Get the URL to access the Ray dashboard.
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -563,7 +563,7 @@ def get_resource_ids():
     return global_worker.core_worker.resource_ids()
 
 
-@Deprecated
+@Deprecated(message='Use ray.init()[\"webui_url\"] instead')
 def get_dashboard_url():
     """Get the URL to access the Ray dashboard.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This can make the deprecation annotation more useful for users, e.g. pointing out a migration path.
An alternative is to consolidate with the RLLib deprecation annotation: https://github.com/ray-project/ray/blob/3a3d0a4a2bf720d7857797e8d37f05a40854f458/rllib/utils/deprecation.py. But it requires message on all annotations.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
