### PR TITLE
[Train] `_WrappedDataLoader` yield tuples

### DIFF
--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -120,6 +120,11 @@ training.
         -       X = X.to_device(device)
         -       y = y.to_device(device)
 
+    .. note::
+       You can choose not to use the ``prepare_model`` or ``prepare_data_loader``. However, if you choose not to
+       do so, then you are responsible for moving the model & data to the right devices, adding ``DistributedSampler``
+       to your ``DataLoader`` and wrapping the model in ``DistributedDataParallel`` in your training function.
+
   .. group-tab:: TensorFlow
 
     .. note::

--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -67,6 +67,10 @@ training.
     Ray Train will set up your distributed process group for you and also provides utility methods
     to automatically prepare your model and data for distributed training.
 
+    .. note::
+       Ray Train will still work even if you don't use the ``prepare_model`` and ``prepare_data_loader`` utilities below,
+       and instead handle the logic directly inside your training function.
+
     First, use the ``prepare_model`` function to automatically move your model to the right device and wrap it in
     ``DistributedDataParallel``
 
@@ -119,11 +123,6 @@ training.
             for X, y in data_loader:
         -       X = X.to_device(device)
         -       y = y.to_device(device)
-
-    .. note::
-       You can choose not to use the ``prepare_model`` or ``prepare_data_loader``. However, if you choose not to
-       do so, then you are responsible for moving the model & data to the right devices, adding ``DistributedSampler``
-       to your ``DataLoader`` and wrapping the model in ``DistributedDataParallel`` in your training function.
 
   .. group-tab:: TensorFlow
 

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -28,6 +28,7 @@ def ray_start_4_cpus_2_gpus():
 
 def test_torch_prepare_model(ray_start_4_cpus_2_gpus):
     """Tests if ``prepare_model`` correctly wraps in DDP."""
+
     def train_fn():
         model = torch.nn.Linear(1, 1)
 
@@ -67,6 +68,7 @@ def test_torch_prepare_dataloader(ray_start_4_cpus_2_gpus):
     trainer.start()
     trainer.run(train_fn)
     trainer.shutdown()
+
 
 def test_torch_auto_gpu_to_cpu(ray_start_4_cpus_2_gpus):
     """Tests if GPU tensors are auto converted to CPU on driver."""

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -1,8 +1,12 @@
 import os
 import pytest
+
 import torch
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.data import DataLoader, DistributedSampler
 
 import ray
+import ray.train as train
 from ray.train import Trainer, TrainingCallback
 from ray.train.examples.horovod.horovod_example import train_func as \
     horovod_torch_train_func
@@ -10,6 +14,7 @@ from ray.train.examples.tensorflow_mnist_example import train_func as \
     tensorflow_mnist_train_func
 from ray.train.examples.train_fashion_mnist_example import train_func \
     as fashion_mnist_train_func
+from ray.train.examples.train_linear_example import LinearDataset
 from test_tune import torch_fashion_mnist, tune_tensorflow_mnist
 
 
@@ -20,6 +25,48 @@ def ray_start_4_cpus_2_gpus():
     # The code after the yield will run as teardown code.
     ray.shutdown()
 
+
+def test_torch_prepare_model(ray_start_4_cpus_2_gpus):
+    """Tests if ``prepare_model`` correctly wraps in DDP."""
+    def train_fn():
+        model = torch.nn.Linear(1, 1)
+
+        # Wrap in DDP.
+        model = train.torch.prepare_model(model)
+
+        # Make sure model is wrapped in DDP.
+        assert isinstance(model, DistributedDataParallel)
+
+        # Make sure model is on cuda.
+        assert next(model.parameters()).is_cuda
+
+    trainer = Trainer("torch", num_workers=2, use_gpu=True)
+    trainer.start()
+    trainer.run(train_fn)
+    trainer.shutdown()
+
+
+def test_torch_prepare_dataloader(ray_start_4_cpus_2_gpus):
+    data_loader = DataLoader(LinearDataset(a=1, b=2, size=10))
+
+    def train_fn():
+        wrapped_data_loader = train.torch.prepare_data_loader(data_loader)
+
+        # Check that DistributedSampler has been added to the data loader.
+        assert isinstance(wrapped_data_loader.sampler, DistributedSampler)
+
+        # Make sure you can properly iterate through the DataLoader.
+        for batch in wrapped_data_loader:
+            X = batch[0]
+            y = batch[1]
+
+            # Make sure the data is on the correct device.
+            assert X.is_cuda and y.is_cuda
+
+    trainer = Trainer("torch", num_workers=2, use_gpu=True)
+    trainer.start()
+    trainer.run(train_fn)
+    trainer.shutdown()
 
 def test_torch_auto_gpu_to_cpu(ray_start_4_cpus_2_gpus):
     """Tests if GPU tensors are auto converted to CPU on driver."""

--- a/python/ray/train/torch.py
+++ b/python/ray/train/torch.py
@@ -191,9 +191,9 @@ class _WrappedDataLoader(DataLoader):
         iterator = iter(self._dataloader)
         if self._device is None:
             yield from iterator
-
-        for item in iterator:
-            yield self._move_to_device(item)
+        else:
+            for item in iterator:
+                yield self._move_to_device(item)
 
 
 def get_device() -> torch.device:

--- a/python/ray/train/torch.py
+++ b/python/ray/train/torch.py
@@ -178,13 +178,10 @@ class _WrappedDataLoader(DataLoader):
         self._device = device
 
     def _move_to_device(self, item):
-        return (i.to(self.device) for i in item)
+        return tuple(i.to(self.device) for i in item)
 
     def __len__(self):
         return len(self._dataloader)
-
-    def __getitem__(self, idx):
-        return self._move_to_device(self._dataloader[idx])
 
     @property
     def device(self) -> Optional[torch.device]:

--- a/python/ray/train/torch.py
+++ b/python/ray/train/torch.py
@@ -178,7 +178,15 @@ class _WrappedDataLoader(DataLoader):
         self.device = device
 
     def _move_to_device(self, item):
-        return tuple(i.to(self.device) for i in item)
+        def try_move_device(i):
+            try:
+                i = i.to(self.device)
+            except AttributeError:
+                logger.debug(f"Item {i} cannot be moved to device "
+                             f"{self.device}.")
+            return i
+
+        return tuple(try_move_device(i) for i in item)
 
     def __len__(self):
         return len(self.dataloader)

--- a/python/ray/train/torch.py
+++ b/python/ray/train/torch.py
@@ -174,26 +174,20 @@ class _WrappedDataLoader(DataLoader):
     def __init__(self, base_dataloader: DataLoader, device: torch.device):
 
         self.__dict__.update(getattr(base_dataloader, "__dict__", {}))
-        self._dataloader = base_dataloader
-        self._device = device
+        self.dataloader = base_dataloader
+        self.device = device
 
     def _move_to_device(self, item):
         return tuple(i.to(self.device) for i in item)
 
     def __len__(self):
-        return len(self._dataloader)
-
-    @property
-    def device(self) -> Optional[torch.device]:
-        return self._device
+        return len(self.dataloader)
 
     def __iter__(self):
-        iterator = iter(self._dataloader)
-        if self._device is None:
-            yield from iterator
-        else:
-            for item in iterator:
-                yield self._move_to_device(item)
+        iterator = iter(self.dataloader)
+
+        for item in iterator:
+            yield self._move_to_device(item)
 
 
 def get_device() -> torch.device:

--- a/python/ray/train/torch.py
+++ b/python/ray/train/torch.py
@@ -177,8 +177,14 @@ class _WrappedDataLoader(DataLoader):
         self._dataloader = base_dataloader
         self._device = device
 
+    def _move_to_device(self, item):
+        return (i.to(self.device) for i in item)
+
     def __len__(self):
         return len(self._dataloader)
+
+    def __getitem__(self, idx):
+        return self._move_to_device(self._dataloader[idx])
 
     @property
     def device(self) -> Optional[torch.device]:
@@ -190,7 +196,7 @@ class _WrappedDataLoader(DataLoader):
             yield from iterator
 
         for item in iterator:
-            yield (i.to(self.device) for i in item)
+            yield self._move_to_device(item)
 
 
 def get_device() -> torch.device:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fixes bug with `_WrappedDataLoader` that yields a generator instead of a tuple.

Addresses https://discuss.ray.io/t/ray-train-creates-typeerror-generator-object-is-not-subscriptable/4605/10

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
