### PR TITLE
[tune] Fix analysis without registered trainable

### DIFF
--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -3,11 +3,14 @@ import shutil
 import tempfile
 import random
 import os
+import pickle
 import pandas as pd
 from numpy import nan
 
 import ray
 from ray import tune
+from ray.tune import ExperimentAnalysis
+import ray.tune.registry
 from ray.tune.utils.mock_trainable import MyTrainableClass
 
 
@@ -299,6 +302,71 @@ class ExperimentAnalysisPropertySuite(unittest.TestCase):
         df = analysis.dataframe()
         var = df[df.loss == df.loss.min()]["config/var"].values[0]
         self.assertEqual(var, 1)
+
+
+class ExperimentAnalysisStubSuite(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.test_name = "analysis_exp"
+        self.num_samples = 2
+        self.metric = "episode_reward_mean"
+        self.test_path = os.path.join(self.test_dir, self.test_name)
+        self.run_test_exp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        ray.shutdown()
+
+    def run_test_exp(self):
+        def training_function(config, checkpoint_dir=None):
+            tune.report(episode_reward_mean=config["alpha"])
+
+        return tune.run(
+            training_function,
+            name=self.test_name,
+            local_dir=self.test_dir,
+            stop={"training_iteration": 1},
+            num_samples=self.num_samples,
+            config={
+                "alpha": tune.sample_from(
+                    lambda spec: 10 + int(90 * random.random())),
+            })
+
+    def testPickling(self):
+        analysis = self.run_test_exp()
+        pickle_path = os.path.join(self.test_dir, "analysis.pickle")
+        with open(pickle_path, "wb") as f:
+            pickle.dump(analysis, f)
+
+        self.assertTrue(
+            analysis.get_best_trial(metric=self.metric, mode="max"))
+
+        ray.shutdown()
+        ray.tune.registry._global_registry = ray.tune.registry._Registry(
+            prefix="global")
+
+        with open(pickle_path, "rb") as f:
+            analysis = pickle.load(f)
+
+        self.assertTrue(
+            analysis.get_best_trial(metric=self.metric, mode="max"))
+
+    def testFromPath(self):
+        self.run_test_exp()
+        analysis = ExperimentAnalysis(self.test_path)
+
+        self.assertTrue(
+            analysis.get_best_trial(metric=self.metric, mode="max"))
+
+        ray.shutdown()
+        ray.tune.registry._global_registry = ray.tune.registry._Registry(
+            prefix="global")
+
+        analysis = ExperimentAnalysis(self.test_path)
+
+        # This will be None if validate_trainable during loading fails
+        self.assertTrue(
+            analysis.get_best_trial(metric=self.metric, mode="max"))
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -776,7 +776,7 @@ class Trial:
         # Ensure that stub doesn't get overriden
         stub = state.pop("stub", True)
         self.__dict__.update(state)
-        self.stub = stub or self.stub
+        self.stub = stub or getattr(self, "stub", False)
 
         if not self.stub:
             validate_trainable(self.trainable_name)

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -773,7 +773,11 @@ class Trial:
         for key in self._nonjson_fields:
             state[key] = cloudpickle.loads(hex_to_binary(state[key]))
 
+        # Ensure that stub doesn't get overriden
+        stub = getattr(self, "stub", None)
         self.__dict__.update(state)
+        self.stub = stub if stub is not None else self.stub
+
         if not self.stub:
             validate_trainable(self.trainable_name)
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -774,9 +774,9 @@ class Trial:
             state[key] = cloudpickle.loads(hex_to_binary(state[key]))
 
         # Ensure that stub doesn't get overriden
-        stub = getattr(self, "stub", None)
+        stub = state.pop("stub", True)
         self.__dict__.update(state)
-        self.stub = stub if stub is not None else self.stub
+        self.stub = stub or self.stub
 
         if not self.stub:
             validate_trainable(self.trainable_name)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes issues with loading `ExperimentAnalysis` from path or pickle if the trainable used in the trials is not registered. Chiefly, it ensures that the `stub` attribute set in `load_trials_from_experiment_checkpoint` doesn't get overridden by the state of the loaded trial, and that when pickling, all trials in `ExperimentAnalysis` are turned into stubs if they aren't already. A test has also been added.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/21212

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
