### PR TITLE
[Xlang][Java] Fix Java overrided `default` method cannot be invoked.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/functionmanager/FunctionManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/functionmanager/FunctionManager.java
@@ -211,17 +211,9 @@ public class FunctionManager {
           clz = clz.getSuperclass();
         }
 
-        for (Executable e : executables) {
-          LOGGER.info("111=========methodName={}", e.getName());
-        }
-
         // Put interface methods ahead, so that in can be override by subclass methods in `map.put`
         for (Class baseInterface : clazz.getInterfaces()) {
           for (Method method : baseInterface.getDeclaredMethods()) {
-            LOGGER.info(
-                "222=================methodName={}, is_default={}",
-                method.getName(),
-                method.isDefault());
             if (method.isDefault()) {
               executables.add(method);
             }
@@ -239,31 +231,16 @@ public class FunctionManager {
               new RayFunction(
                   e, classLoader, new JavaFunctionDescriptor(className, methodName, signature));
           final boolean isDefault = e instanceof Method && ((Method) e).isDefault();
-          LOGGER.info(
-              "=============className={}, methodname={}, signature={}",
-              className,
-              methodName,
-              signature);
           map.put(
               ImmutablePair.of(methodName, signature), ImmutablePair.of(rayFunction, isDefault));
           // For cross language call java function without signature
           final Pair<String, String> emptyDescriptor = ImmutablePair.of(methodName, "");
           /// default method is not overloaded, so we should filter it.
           if (map.containsKey(emptyDescriptor) && !map.get(emptyDescriptor).getRight()) {
-            LOGGER.info(
-                "Mark this as overloaded =============className={}, methodname={}, signature={}",
-                className,
-                methodName,
-                signature);
             map.put(
                 emptyDescriptor,
                 ImmutablePair.of(null, false)); // Mark this function as overloaded.
           } else {
-            LOGGER.info(
-                "Not Mark this as overloaded =============className={}, methodname={}, signature={}",
-                className,
-                methodName,
-                signature);
             map.put(emptyDescriptor, ImmutablePair.of(rayFunction, isDefault));
           }
         }

--- a/java/runtime/src/main/java/io/ray/runtime/functionmanager/FunctionManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/functionmanager/FunctionManager.java
@@ -1,6 +1,5 @@
 package io.ray.runtime.functionmanager;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.ray.api.function.RayFunc;
 import io.ray.api.id.JobId;
@@ -166,7 +165,8 @@ public class FunctionManager {
     }
 
     RayFunction getFunction(JavaFunctionDescriptor descriptor) {
-      Map<Pair<String, String>, Pair<RayFunction, Boolean>> classFunctions = functions.get(descriptor.className);
+      Map<Pair<String, String>, Pair<RayFunction, Boolean>> classFunctions =
+          functions.get(descriptor.className);
       if (classFunctions == null) {
         synchronized (this) {
           classFunctions = functions.get(descriptor.className);
@@ -218,7 +218,10 @@ public class FunctionManager {
         // Put interface methods ahead, so that in can be override by subclass methods in `map.put`
         for (Class baseInterface : clazz.getInterfaces()) {
           for (Method method : baseInterface.getDeclaredMethods()) {
-            LOGGER.info("222=================methodName={}, is_default={}", method.getName(), method.isDefault());
+            LOGGER.info(
+                "222=================methodName={}, is_default={}",
+                method.getName(),
+                method.isDefault());
             if (method.isDefault()) {
               executables.add(method);
             }
@@ -236,16 +239,31 @@ public class FunctionManager {
               new RayFunction(
                   e, classLoader, new JavaFunctionDescriptor(className, methodName, signature));
           final boolean isDefault = e instanceof Method && ((Method) e).isDefault();
-          LOGGER.info("=============className={}, methodname={}, signature={}", className, methodName, signature);
-          map.put(ImmutablePair.of(methodName, signature), ImmutablePair.of(rayFunction, isDefault));
+          LOGGER.info(
+              "=============className={}, methodname={}, signature={}",
+              className,
+              methodName,
+              signature);
+          map.put(
+              ImmutablePair.of(methodName, signature), ImmutablePair.of(rayFunction, isDefault));
           // For cross language call java function without signature
           final Pair<String, String> emptyDescriptor = ImmutablePair.of(methodName, "");
           /// default method is not overloaded, so we should filter it.
           if (map.containsKey(emptyDescriptor) && !map.get(emptyDescriptor).getRight()) {
-            LOGGER.info("Mark this as overloaded =============className={}, methodname={}, signature={}", className, methodName, signature);
-            map.put(emptyDescriptor, ImmutablePair.of(null, false)); // Mark this function as overloaded.
+            LOGGER.info(
+                "Mark this as overloaded =============className={}, methodname={}, signature={}",
+                className,
+                methodName,
+                signature);
+            map.put(
+                emptyDescriptor,
+                ImmutablePair.of(null, false)); // Mark this function as overloaded.
           } else {
-            LOGGER.info("Not Mark this as overloaded =============className={}, methodname={}, signature={}", className, methodName, signature);
+            LOGGER.info(
+                "Not Mark this as overloaded =============className={}, methodname={}, signature={}",
+                className,
+                methodName,
+                signature);
             map.put(emptyDescriptor, ImmutablePair.of(rayFunction, isDefault));
           }
         }

--- a/java/runtime/src/test/java/io/ray/runtime/functionmanager/FunctionManagerTest.java
+++ b/java/runtime/src/test/java/io/ray/runtime/functionmanager/FunctionManagerTest.java
@@ -183,7 +183,7 @@ public class FunctionManagerTest {
   @Test
   public void testLoadFunctionTableForClass() {
     JobFunctionTable functionTable = new JobFunctionTable(getClass().getClassLoader());
-    Map<Pair<String, String>, RayFunction> res =
+    Map<Pair<String, String>, Pair<RayFunction, Boolean>> res =
         functionTable.loadFunctionsForClass(ChildClass.class.getName());
     // The result should be 4 entries:
     //   1, the constructor with signature
@@ -211,7 +211,7 @@ public class FunctionManagerTest {
                 overloadFunctionDescriptorDouble.signature)));
     Assert.assertTrue(res.containsKey(ImmutablePair.of(overloadFunctionDescriptorInt.name, "")));
     Pair<String, String> overloadKey = ImmutablePair.of(overloadFunctionDescriptorInt.name, "");
-    RayFunction func = res.get(overloadKey);
+    RayFunction func = res.get(overloadKey).getLeft();
     // The function is overloaded.
     Assert.assertTrue(res.containsKey(overloadKey));
     Assert.assertNull(func);

--- a/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
+++ b/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
@@ -396,4 +396,13 @@ public class CrossLanguageInvocationTest extends BaseTest {
 
     private byte[] value;
   }
+
+  public void testPyCallJavaOeveridedMethodWithDefault() {
+    ObjectRef<Object> res =
+      Ray.task(PyFunction.of(PYTHON_MODULE, "py_func_call_java_overrided_method_with_default_keyword", Object.class))
+        .remote();
+    System.out.println(res.get());
+    Assert.assertEquals("hi".getBytes(StandardCharsets.UTF_8), res.get());
+  }
+
 }

--- a/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
+++ b/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
@@ -399,10 +399,13 @@ public class CrossLanguageInvocationTest extends BaseTest {
 
   public void testPyCallJavaOeveridedMethodWithDefault() {
     ObjectRef<Object> res =
-      Ray.task(PyFunction.of(PYTHON_MODULE, "py_func_call_java_overrided_method_with_default_keyword", Object.class))
-        .remote();
+        Ray.task(
+                PyFunction.of(
+                    PYTHON_MODULE,
+                    "py_func_call_java_overrided_method_with_default_keyword",
+                    Object.class))
+            .remote();
     System.out.println(res.get());
     Assert.assertEquals("hi".getBytes(StandardCharsets.UTF_8), res.get());
   }
-
 }

--- a/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
+++ b/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
@@ -405,7 +405,6 @@ public class CrossLanguageInvocationTest extends BaseTest {
                     "py_func_call_java_overrided_method_with_default_keyword",
                     Object.class))
             .remote();
-    System.out.println(res.get());
-    Assert.assertEquals("hi".getBytes(StandardCharsets.UTF_8), res.get());
+    Assert.assertEquals("hi", res.get());
   }
 }

--- a/java/test/src/main/java/io/ray/test/ExampleImpl.java
+++ b/java/test/src/main/java/io/ray/test/ExampleImpl.java
@@ -1,0 +1,10 @@
+package io.ray.test;
+
+public class ExampleImpl implements ExampleInterface {
+
+  @Override
+  public String echo(String str) {
+    return str;
+  }
+
+}

--- a/java/test/src/main/java/io/ray/test/ExampleImpl.java
+++ b/java/test/src/main/java/io/ray/test/ExampleImpl.java
@@ -6,5 +6,4 @@ public class ExampleImpl implements ExampleInterface {
   public String echo(String str) {
     return str;
   }
-
 }

--- a/java/test/src/main/java/io/ray/test/ExampleInterface.java
+++ b/java/test/src/main/java/io/ray/test/ExampleInterface.java
@@ -1,0 +1,9 @@
+package io.ray.test;
+
+public interface ExampleInterface {
+
+   default String echo(String str) {
+     return "default" + str;
+   }
+
+}

--- a/java/test/src/main/java/io/ray/test/ExampleInterface.java
+++ b/java/test/src/main/java/io/ray/test/ExampleInterface.java
@@ -2,8 +2,7 @@ package io.ray.test;
 
 public interface ExampleInterface {
 
-   default String echo(String str) {
-     return "default" + str;
-   }
-
+  default String echo(String str) {
+    return "default" + str;
+  }
 }

--- a/java/test/src/main/resources/test_cross_language_invocation.py
+++ b/java/test/src/main/resources/test_cross_language_invocation.py
@@ -133,8 +133,7 @@ def py_func_get_and_invoke_named_actor():
     return b"true"
 
 @ray.remote
-def py_func_f():
+def py_func_call_java_overrided_method_with_default_keyword():
     cls = ray.java_actor_class("io.ray.test.ExampleImpl")
     handle = cls.remote()
-    print(ray.get(handle.echo.remote("hi")))
-    return b"ok"
+    return ray.get(handle.echo.remote("hi"))

--- a/java/test/src/main/resources/test_cross_language_invocation.py
+++ b/java/test/src/main/resources/test_cross_language_invocation.py
@@ -132,6 +132,7 @@ def py_func_get_and_invoke_named_actor():
     assert ray.get(java_named_actor.concat.remote(b"world")) == b"helloworld"
     return b"true"
 
+
 @ray.remote
 def py_func_call_java_overrided_method_with_default_keyword():
     cls = ray.java_actor_class("io.ray.test.ExampleImpl")

--- a/java/test/src/main/resources/test_cross_language_invocation.py
+++ b/java/test/src/main/resources/test_cross_language_invocation.py
@@ -131,3 +131,10 @@ def py_func_get_and_invoke_named_actor():
     java_named_actor = ray.get_actor("java_named_actor")
     assert ray.get(java_named_actor.concat.remote(b"world")) == b"helloworld"
     return b"true"
+
+@ray.remote
+def py_func_f():
+    cls = ray.java_actor_class("io.ray.test.ExampleImpl")
+    handle = cls.remote()
+    print(ray.get(handle.echo.remote("hi")))
+    return b"ok"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In Xlang(Python call Java), a Java method which overrides a `default` method of the super class is not able to be invoked successfully, due to we treat it as overloaded method instead of overrided method. This PR correctly handle it at the case it overrides a `default` method.

Before this PR, the following usage is not able to be invoked from Python -> Java.
```Java
public interface ExampleInterface {
  default String echo(String inp) {
    return inp;
  }
}
public class ExampleImpl implements ExampleInterface {
  @Override
  public String echo(String inp) {
    return inp + " echo";
  }
}
```
```python
/// Invoke it in Python.
cls = ray.java_actor_class("io.ray.serve.util.ExampleImpl")
handle = cls.remote()
print(ray.get(handle.echo.remote("hi")))
```





## Related issue number
Fix #21477
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
