### PR TITLE
[PlacementGroup] Support using any available bundle in java api

### DIFF
--- a/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
+++ b/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
@@ -114,6 +114,17 @@ public class BaseActorCreator<T extends BaseActorCreator> {
     return self();
   }
 
+  /**
+   * Set the placement group to place this actor in, which may use any available bundle.
+   *
+   * @param group The placement group of the actor.
+   * @return self
+   * @see ActorCreationOptions.Builder#setPlacementGroup(PlacementGroup, int)
+   */
+  public T setPlacementGroup(PlacementGroup group) {
+    return setPlacementGroup(group, -1);
+  }
+
   @SuppressWarnings("unchecked")
   private T self() {
     return (T) this;

--- a/java/api/src/main/java/io/ray/api/call/BaseTaskCaller.java
+++ b/java/api/src/main/java/io/ray/api/call/BaseTaskCaller.java
@@ -64,6 +64,17 @@ public class BaseTaskCaller<T extends BaseTaskCaller<T>> {
     return self();
   }
 
+  /**
+   * Set the placement group to place this task in, which may use any available bundle.
+   *
+   * @param group The placement group of the task.
+   * @return self
+   * @see CallOptions.Builder#setPlacementGroup(PlacementGroup, int)
+   */
+  public T setPlacementGroup(PlacementGroup group) {
+    return setPlacementGroup(group, -1);
+  }
+
   @SuppressWarnings("unchecked")
   private T self() {
     return (T) this;

--- a/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
@@ -285,6 +285,7 @@ public class LocalModeTaskSubmitter implements TaskSubmitter {
     if (options != null) {
       if (options.group != null) {
         PlacementGroupImpl group = (PlacementGroupImpl) options.group;
+        // bundleIndex == -1 indicates using any available bundle.
         Preconditions.checkArgument(
             options.bundleIndex == -1
                 || options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),

--- a/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
@@ -286,7 +286,8 @@ public class LocalModeTaskSubmitter implements TaskSubmitter {
       if (options.group != null) {
         PlacementGroupImpl group = (PlacementGroupImpl) options.group;
         Preconditions.checkArgument(
-            options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),
+            options.bundleIndex == -1
+                || options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),
             String.format("Bundle index %s is invalid", options.bundleIndex));
       }
     }

--- a/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/LocalModeTaskSubmitter.java
@@ -289,7 +289,11 @@ public class LocalModeTaskSubmitter implements TaskSubmitter {
         Preconditions.checkArgument(
             options.bundleIndex == -1
                 || options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),
-            String.format("Bundle index %s is invalid", options.bundleIndex));
+            String.format(
+                "Bundle index %s is invalid, the correct bundle index should be "
+                    + "either in the range of 0 to the number of bundles "
+                    + "or -1 which means put the task to any available bundles.",
+                options.bundleIndex));
       }
     }
 

--- a/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
@@ -49,7 +49,11 @@ public class NativeTaskSubmitter implements TaskSubmitter {
         Preconditions.checkArgument(
             options.bundleIndex == -1
                 || options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),
-            String.format("Bundle index %s is invalid", options.bundleIndex));
+            String.format(
+                "Bundle index %s is invalid, the correct bundle index should be "
+                    + "either in the range of 0 to the number of bundles "
+                    + "or -1 which means put the task to any available bundles.",
+                options.bundleIndex));
       }
 
       if (StringUtils.isNotBlank(options.name)) {

--- a/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
@@ -46,7 +46,8 @@ public class NativeTaskSubmitter implements TaskSubmitter {
       if (options.group != null) {
         PlacementGroupImpl group = (PlacementGroupImpl) options.group;
         Preconditions.checkArgument(
-            options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),
+            options.bundleIndex == -1
+                || options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),
             String.format("Bundle index %s is invalid", options.bundleIndex));
       }
 

--- a/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
+++ b/java/runtime/src/main/java/io/ray/runtime/task/NativeTaskSubmitter.java
@@ -45,6 +45,7 @@ public class NativeTaskSubmitter implements TaskSubmitter {
     if (options != null) {
       if (options.group != null) {
         PlacementGroupImpl group = (PlacementGroupImpl) options.group;
+        // bundleIndex == -1 indicates using any available bundle.
         Preconditions.checkArgument(
             options.bundleIndex == -1
                 || options.bundleIndex >= 0 && options.bundleIndex < group.getBundles().size(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In python or C++, we can specify the bundle index as -1 to use any available bundle in the placement group. We should also enable it in Java to keep the API consistent across all languages.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
