### PR TITLE
[tune] Load experiment into searcher

### DIFF
--- a/python/ray/tune/suggest/dragonfly.py
+++ b/python/ray/tune/suggest/dragonfly.py
@@ -292,6 +292,24 @@ class DragonflySearch(Searcher):
             # If only a mode was passed, use anonymous metric
             self._metric = DEFAULT_METRIC
 
+    def add_evaluated_point(self,
+                            parameters: Dict,
+                            value: float,
+                            error: bool = False,
+                            pruned: bool = False,
+                            intermediate_values: Optional[List[float]] = None):
+        assert self._opt, "Optimizer must be set."
+        if intermediate_values:
+            logger.warning(
+                "dragonfly doesn't use intermediate_values. Ignoring.")
+        if not error and not pruned:
+            self._opt.tell(
+                [([parameters[par] for par in self._point_parameter_names],
+                  value)])
+        else:
+            logger.warning("Only non errored and non pruned points"
+                           " can be added to dragonfly.")
+
     def set_search_properties(self, metric: Optional[str], mode: Optional[str],
                               config: Dict, **spec) -> bool:
         if self._opt:

--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -36,13 +36,6 @@ class HEBOSearch(Searcher):
     by Huawei's Noah Ark. More info can be found here:
     https://github.com/huawei-noah/HEBO/tree/master/HEBO.
 
-    You will need to install HEBO via the following (dependencies are
-    pinned to avoid HEBO 0.1.0 errors):
-
-    .. code-block:: bash
-
-        pip install "scipy<1.7.0" "pymoo<0.5.0" "HEBO==0.1.0"
-
     `space` can either be a HEBO's `DesignSpace` object or a dict of Tune
     search spaces.
 
@@ -134,9 +127,10 @@ class HEBOSearch(Searcher):
             **kwargs):
         assert hebo is not None, (
             "HEBO must be installed! You can install HEBO with"
-            " the command: `pip install 'scipy<1.7.0' 'pymoo<0.5.0'"
-            " 'HEBO==0.1.0'`. This error may also be caused if HEBO"
-            " dependencies have bad versions.")
+            " the command: `pip install 'HEBO>=0.2.0'."
+            "This error may also be caused if HEBO"
+            " dependencies have bad versions. Try updating HEBO"
+            " first.")
         if mode:
             assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."
         assert isinstance(max_concurrent, int) and max_concurrent >= 1, (

--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -295,7 +295,11 @@ class HEBOSearch(Searcher):
             logger.warning("HEBO doesn't use intermediate_values. Ignoring.")
         if not error and not pruned:
             self._opt.observe(
-                pd.DataFrame([parameters]),
+                pd.DataFrame([{
+                    k: v
+                    for k, v in parameters.items()
+                    if k in self._opt.space.para_names
+                }]),
                 np.array([value]) * self._metric_op)
         else:
             logger.warning("Only non errored and non pruned points"

--- a/python/ray/tune/suggest/skopt.py
+++ b/python/ray/tune/suggest/skopt.py
@@ -219,6 +219,23 @@ class SkOptSearch(Searcher):
             # If only a mode was passed, use anonymous metric
             self._metric = DEFAULT_METRIC
 
+    def add_evaluated_point(self,
+                            parameters: Dict,
+                            value: float,
+                            error: bool = False,
+                            pruned: bool = False,
+                            intermediate_values: Optional[List[float]] = None):
+        assert self._skopt_opt, "Optimizer must be set."
+        if intermediate_values:
+            logger.warning("SkOpt doesn't use intermediate_values. Ignoring.")
+        if not error and not pruned:
+            self._skopt_opt.tell(
+                [parameters[par] for par in self._parameter_names], value)
+
+        else:
+            logger.warning("Only non errored and non pruned points"
+                           " can be added to SkOpt.")
+
     def set_search_properties(self, metric: Optional[str], mode: Optional[str],
                               config: Dict, **spec) -> bool:
         if self._skopt_opt:

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -2,10 +2,14 @@ import copy
 import glob
 import logging
 import os
-from typing import Dict, Optional, List
+import warnings
+from typing import Dict, Optional, List, Union, Any, TYPE_CHECKING
 
 from ray.tune.suggest.util import set_search_properties_backwards_compatible
 from ray.util.debug import log_once
+if TYPE_CHECKING:
+    from ray.tune.trial import Trial
+    from ray.tune.analysis import ExperimentAnalysis
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +215,63 @@ class Searcher:
 
         """
         raise NotImplementedError
+
+    def add_evaluated_trials(self, trials_or_analysis: Union["Trial", List[
+            "Trial"], "ExperimentAnalysis"], metric: str):
+        """Pass results from trials that have been evaluated separately.
+
+        This method allows for information from outside the
+        suggest - on_trial_complete loop to be passed to the search
+        algorithm.
+        This functionality depends on the underlying search algorithm
+        and may not be always available (same as ``add_evaluated_point``.)
+
+        Args:
+            trials_or_analysis (Trial|List[Trial]|ExperimentAnalysis):
+                Trials to pass results form to the searcher.
+            metric (str): Metric name reported by trials used for
+                determining the objective value.
+
+        """
+        if self.add_evaluated_point == Searcher.add_evaluated_point:
+            raise NotImplementedError
+
+        # lazy imports to avoid circular dependencies
+        from ray.tune.trial import Trial
+        from ray.tune.analysis import ExperimentAnalysis
+        from ray.tune.result import DONE
+
+        if isinstance(trials_or_analysis, Trial):
+            trials_or_analysis = [trials_or_analysis]
+        elif isinstance(trials_or_analysis, ExperimentAnalysis):
+            trials_or_analysis = trials_or_analysis.trials
+
+        any_trial_had_metric = False
+
+        def trial_to_points(trial: Trial) -> Dict[str, Any]:
+            nonlocal any_trial_had_metric
+            has_trial_been_pruned = (trial.status == Trial.TERMINATED and
+                                     not trial.last_result.get(DONE, False))
+            has_trial_finished = (trial.status == trial.TERMINATED
+                                  and trial.last_result.get(DONE, False))
+            if not any_trial_had_metric:
+                any_trial_had_metric = (metric in trial.last_result
+                                        and has_trial_finished)
+            return dict(
+                parameters=trial.config,
+                value=trial.last_result.get(metric, None),
+                error=trial.status == Trial.ERROR
+                or metric not in trial.last_result,
+                pruned=has_trial_been_pruned,
+                intermediate_values=None,  # we do not save those
+            )
+
+        if not any_trial_had_metric:
+            warnings.warn("No completed trial returned the specified metric. "
+                          "Make sure the name you have passed is correct. ")
+
+        for trial in trials_or_analysis:
+            self.add_evaluated_point(**trial_to_points(trial))
 
     def save(self, checkpoint_path: str):
         """Save state to path for this search algorithm.

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -15,8 +15,7 @@ gym[atari]>=0.21.0; python_version >= '3.7'
 gym[atari]==0.19.0; python_version < '3.7'
 h5py==3.1.0
 hpbandster==0.7.4
-pymoo<0.5.0  # this is a HEBO dependency, remove after https://github.com/huawei-noah/noah-research/issues/41 is fixed
-HEBO==0.1.0
+HEBO==0.3.2
 hyperopt==0.2.5
 jupyter==1.0.0
 kubernetes==17.17.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a new method to the `Searcher` class, `add_evaluated_trials`. This method wraps around `add_evaluated_point` and allows the user to pass a `Trial`, list of `Trial`s or `ExperimentAnalysis` to load into the searcher. Furthermore, this PR updates the HEBO version to the latest and removes outdated documentation, and adds `add_evaluated_point` methods to Dragonfly and SkOpt searchers.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/18847

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
