### PR TITLE
Reduced memory requirements in `python/ray/tests/test_reference_counting_2.py`

### DIFF
--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -73,7 +73,7 @@ def test_recursively_nest_ids(one_worker_100MiB, use_ray_put, failure):
 
     max_depth = 5
     array_oid = put_object(
-        np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+        np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
     nested_oid = array_oid
     for _ in range(max_depth):
         nested_oid = ray.put([nested_oid])
@@ -116,7 +116,7 @@ def test_return_object_ref(one_worker_100MiB, use_ray_put, failure):
     def return_an_id():
         return [
             put_object(
-                np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+                np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
         ]
 
     @ray.remote(max_retries=1)
@@ -153,7 +153,7 @@ def test_pass_returned_object_ref(one_worker_100MiB, use_ray_put, failure):
     def return_an_id():
         return [
             put_object(
-                np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+                np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
         ]
 
     # TODO(edoakes): this fails with an ActorError with max_retries=1.
@@ -201,7 +201,7 @@ def test_recursively_pass_returned_object_ref(one_worker_100MiB, use_ray_put,
     @ray.remote
     def return_an_id():
         return put_object(
-            np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
+            np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
 
     @ray.remote(max_retries=1)
     def recursive(ref, signal, max_depth, depth=0):
@@ -267,7 +267,7 @@ def test_recursively_return_borrowed_object_ref(one_worker_100MiB, use_ray_put,
     def recursive(num_tasks_left):
         if num_tasks_left == 0:
             return put_object(
-                np.zeros(20 * 1024 * 1024, dtype=np.uint8),
+                np.zeros(20 * 256 * 512, dtype=np.uint8),
                 use_ray_put), os.getpid()
 
         return ray.get(recursive.remote(num_tasks_left - 1))
@@ -338,7 +338,7 @@ def test_borrowed_id_failure(one_worker_100MiB, failure):
     borrower = Borrower.remote()
     ray.get(borrower.ping.remote())
 
-    obj = ray.put(np.zeros(20 * 1024 * 1024, dtype=np.uint8))
+    obj = ray.put(np.zeros(20 * 256 * 512, dtype=np.uint8))
     if failure:
         with pytest.raises(ray.exceptions.RayActorError):
             ray.get(parent.pass_ref.remote([obj], borrower))

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -54,7 +54,6 @@ def _fill_object_store_and_get(obj, succeed=True, object_MiB=20,
 
 # Test that an object containing object refs within it pins the inner IDs
 # recursively and for submitted tasks.
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_ray_put,failure", [(False, False), (False, True),
                                                  (True, False), (True, True)])
 def test_recursively_nest_ids(one_worker_100MiB, use_ray_put, failure):
@@ -108,7 +107,6 @@ def test_recursively_nest_ids(one_worker_100MiB, use_ray_put, failure):
 
 # Test that serialized ObjectRefs returned from remote tasks are pinned until
 # they go out of scope on the caller side.
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_ray_put,failure", [(False, False), (False, True),
                                                  (True, False), (True, True)])
 def test_return_object_ref(one_worker_100MiB, use_ray_put, failure):
@@ -258,7 +256,6 @@ def test_recursively_pass_returned_object_ref(one_worker_100MiB, use_ray_put,
 # returns the same ObjectRef by calling ray.get() on its submitted task and
 # returning the result. The reference should still exist while the driver has a
 # reference to the final task's ObjectRef.
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize("use_ray_put,failure", [(False, False), (False, True),
                                                  (True, False), (True, True)])
 def test_recursively_return_borrowed_object_ref(one_worker_100MiB, use_ray_put,
@@ -624,7 +621,6 @@ def test_return_nested_ids(shutdown_only, inline_args):
     ray.get(test.remote())
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_actor_constructor_borrowed_refs(shutdown_only):
     ray.init(object_store_memory=100 * 1024 * 1024)
 
@@ -646,7 +642,6 @@ def test_actor_constructor_borrowed_refs(shutdown_only):
         time.sleep(1)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_deep_nested_refs(shutdown_only):
     ray.init(object_store_memory=100 * 1024 * 1024)
 
@@ -665,7 +660,6 @@ def test_deep_nested_refs(shutdown_only):
         r = ray.get(r)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_forward_nested_ref(shutdown_only):
     ray.init(object_store_memory=100 * 1024 * 1024)
 

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -113,8 +113,7 @@ def test_return_object_ref(one_worker_100MiB, use_ray_put, failure):
     @ray.remote
     def return_an_id():
         return [
-            put_object(
-                np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
+            put_object(np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
         ]
 
     @ray.remote(max_retries=1)
@@ -150,8 +149,7 @@ def test_pass_returned_object_ref(one_worker_100MiB, use_ray_put, failure):
     @ray.remote
     def return_an_id():
         return [
-            put_object(
-                np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
+            put_object(np.zeros(20 * 256 * 512, dtype=np.uint8), use_ray_put)
         ]
 
     # TODO(edoakes): this fails with an ActorError with max_retries=1.


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
