### PR TITLE
[ci/multinode] Fix resource popping resulting in empty resource head …

### DIFF
--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -83,6 +83,8 @@ class FakeMultiNodeProvider(NodeProvider):
         raise AssertionError("Readonly node provider cannot be updated")
 
     def create_node_with_resources(self, node_config, tags, count, resources):
+        resources = resources.copy()
+
         with self.lock:
             node_type = tags[TAG_RAY_USER_NODE_TYPE]
             next_id = self._next_hex_node_id()


### PR DESCRIPTION
…nodes

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a small bug where we pop from the resources dict without making a copy, emptying the head node resources. This sometimes leads to empty head node resources.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
