### PR TITLE
[release] Fix broken `pip_download_test.sh` script for non-M1 Macs

### DIFF
--- a/release/util/pip_download_test.sh
+++ b/release/util/pip_download_test.sh
@@ -34,7 +34,7 @@ source "$(conda info --base)/etc/profile.d/conda.sh"
 if [[ $(uname -m) == 'arm64' ]] && [[ $OSTYPE == "darwin"* ]]; then
   PYTHON_VERSIONS=( "3.8" "3.9" )
 else
-  PYTHON_VERSION=( "3.6" "3.7" "3.8" "3.9" )
+  PYTHON_VERSIONS=( "3.6" "3.7" "3.8" "3.9" )
 fi
 
 for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fixes a typo that caused the script to exit early without running any sanity checks when not using an M1 Mac.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually tested on 1.10.0rc0
