### PR TITLE
[ci/multinode] Build multinode image with OpenSSH before running tests

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -237,10 +237,12 @@
     - mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.0.1/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose
     - pip install -U docker aws_requests_auth boto3
     - python ./ci/travis/build-docker-images.py --py-versions py37 --device-types cpu --build-type LOCAL --build-base
+    - python ./ci/travis/build-multinode-image.py rayproject/ray:nightly-py37-cpu rayproject/ray:multinode-py37
     - bazel test --config=ci $(./scripts/bazel_export_options) --build_tests_only
       --test_tag_filters=multinode,-example,-flaky,-py37,-soft_imports,-gpu_only,-rllib
       python/ray/tune/...
-      --test_env=RAY_DOCKER_IMAGE="rayproject/ray:nightly-py37-cpu"
+      --test_env=RAY_HAS_SSH="1"
+      --test_env=RAY_DOCKER_IMAGE="rayproject/ray:multinode-py37"
       --test_env=RAY_TEMPDIR="/ray-mount"
       --test_env=RAY_HOSTDIR="/ray"
       --test_env=RAY_TESTHOST="dind-daemon"

--- a/ci/travis/build-multinode-image.py
+++ b/ci/travis/build-multinode-image.py
@@ -1,0 +1,35 @@
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+
+
+def build_multinode_image(source_image: str, target_image: str):
+    """Build docker image from source_image.
+
+    This docker image will contain packages needed for the fake multinode
+    docker cluster to work.
+    """
+    tempdir = tempfile.mkdtemp()
+
+    dockerfile = os.path.join(tempdir, "Dockerfile")
+    with open(dockerfile, "wt") as f:
+        f.write(f"FROM {source_image}\n")
+        f.write("RUN sudo apt update\n")
+        f.write("RUN sudo apt install -y openssh-server\n")
+        f.write("RUN sudo service ssh start\n")
+
+    subprocess.check_output(
+        f"docker build -t {target_image} .", shell=True, cwd=tempdir)
+
+    shutil.rmtree(tempdir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_image", type=str)
+    parser.add_argument("target_image", type=str)
+    args = parser.parse_args()
+
+    build_multinode_image(args.source_image, args.target_image)

--- a/doc/source/fake-autoscaler.rst
+++ b/doc/source/fake-autoscaler.rst
@@ -194,11 +194,17 @@ For the Ray OSS Buildkite environment, we thus set some environment variables:
   variable.
 
 Lastly, docker-compose obviously requires a docker image. The default docker image is ``rayproject/ray:nightly``.
-However, on our Ray OSS Buildkite environment, we want to test changes from the respective PR or Branch. Thus, we set
+The docker image requires ``openssh-server`` to be installed and enabled. In Buildkite we build a new image from
+``rayproject/ray:nightly-py37-cpu`` to avoid installing this on the fly for every node (which is the default way).
+This base image is built in one of the previous build steps.
 
-* ``RAY_DOCKER_IMAGE="rayproject/ray:nightly-py37-cpu"``
+Thus, we set
 
-which is the name of the docker image we build in one of the previous build steps.
+* ``RAY_DOCKER_IMAGE="rayproject/ray:multinode-py37"``
+
+* ``RAY_HAS_SSH=1``
+
+to use this docker image and inform our multinode infrastructure that SSH is already installed.
 
 Local development
 -----------------

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import subprocess
+import sys
 from threading import RLock
 import time
 from types import ModuleType
@@ -57,8 +58,7 @@ DOCKER_HEAD_CMD = (
     "sudo chmod 600 ~/.ssh/authorized_keys && "
     "sudo chmod 600 ~/ray_bootstrap_key.pem && "
     "sudo chown ray:users ~/.ssh ~/.ssh/authorized_keys && "
-    "((sudo apt update && sudo apt install -y openssh-server && "
-    "sudo service ssh start) || true) && "
+    "{ensure_ssh} && "
     "sleep 1 && "
     "RAY_FAKE_CLUSTER=1 ray start --head "
     "--autoscaling-config=~/ray_bootstrap_config.yaml "
@@ -76,8 +76,7 @@ DOCKER_WORKER_CMD = (
     "sudo chmod 700 ~/.ssh && "
     "sudo chmod 600 ~/.ssh/authorized_keys && "
     "sudo chown ray:users ~/.ssh ~/.ssh/authorized_keys && "
-    "((sudo apt update && sudo apt install -y openssh-server && "
-    "sudo service ssh start) || true) && "
+    "{ensure_ssh} && "
     "sleep 1 && "
     f"ray start --address={FAKE_HEAD_NODE_ID}:6379 "
     "--object-manager-port=8076 "
@@ -130,7 +129,12 @@ def create_node_spec(head: bool,
 
     resources = resources or {}
 
+    ensure_ssh = ("((sudo apt update && sudo apt install -y openssh-server && "
+                  "sudo service ssh start) || true)") if not bool(
+                      int(os.environ.get("RAY_HAS_SSH", "0"))) else "true"
+
     cmd_kwargs = dict(
+        ensure_ssh=ensure_ssh,
         num_cpus=num_cpus,
         num_gpus=num_gpus,
         resources=json.dumps(resources, indent=None),
@@ -147,7 +151,12 @@ def create_node_spec(head: bool,
         else:
             local_ray_dir = fake_cluster_dev_dir
         os.environ["FAKE_CLUSTER_DEV"] = local_ray_dir
-        docker_ray_dir = "/home/ray/anaconda3/lib/python3.7/site-packages/ray"
+
+        mj = sys.version_info.major
+        mi = sys.version_info.minor
+
+        docker_ray_dir = (f"/home/ray/anaconda3/lib"
+                          f"/python{mj}.{mi}/site-packages/ray")
         node_spec["volumes"] += [
             f"{local_ray_dir}/autoscaler:{docker_ray_dir}/autoscaler:ro",
         ]
@@ -191,6 +200,7 @@ def create_node_spec(head: bool,
 
     # Pass these environment variables (to the head node)
     # These variables are propagated by the `docker compose` command.
+    env_vars.setdefault("RAY_HAS_SSH", os.environ.get("RAY_HAS_SSH", ""))
     env_vars.setdefault("RAY_TEMPDIR", os.environ.get("RAY_TEMPDIR", ""))
     env_vars.setdefault("RAY_HOSTDIR", os.environ.get("RAY_HOSTDIR", ""))
 

--- a/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
@@ -16,6 +16,8 @@ from ray.util.ml_utils.dict import deep_update
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_DOCKER_IMAGE = "rayproject/ray:nightly-py{major}{minor}-cpu"
+
 
 class DockerCluster:
     """Docker cluster wrapper.
@@ -142,7 +144,7 @@ class DockerCluster:
                 mj = sys.version_info.major
                 mi = sys.version_info.minor
 
-                docker_image = f"rayproject/ray:nightly-py{mj}{mi}-cpu"
+                docker_image = DEFAULT_DOCKER_IMAGE.format(major=mj, minor=mi)
 
             self._docker_image = docker_image
 

--- a/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from typing import Dict, Any, Optional
@@ -134,7 +135,16 @@ class DockerCluster:
 
         if not config.get("provider", {}).get("image"):
             # No image specified, trying to parse from buildkite
-            self._docker_image = os.environ.get("RAY_DOCKER_IMAGE", None)
+            docker_image = os.environ.get("RAY_DOCKER_IMAGE", None)
+
+            if not docker_image:
+                # If still no docker image, use one according to Python version
+                mj = sys.version_info.major
+                mi = sys.version_info.minor
+
+                docker_image = f"rayproject/ray:nightly-py{mj}{mi}-cpu"
+
+            self._docker_image = docker_image
 
         with open(self._base_config_file, "rt") as f:
             cluster_config = yaml.safe_load(f)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently we install OpenSSH on the fly in fake multinode docker testing. Instead we can speed testing up a fair bit by building a Docker image which includes OpenSSH first and then run tests with this image.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
