### PR TITLE
[Core]Add a task to detect if gcs thread hangs

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -456,6 +456,16 @@ RAY_CONFIG(uint64_t, gcs_actor_table_min_duration_ms, /*  5 min */ 60 * 1000 * 5
 /// Whether to enable GCS-based actor scheduling.
 RAY_CONFIG(bool, gcs_actor_scheduling_enabled, false);
 
+RAY_CONFIG(int64_t, gcs_main_thread_busy_detect_interval_ms,
+           getenv("GCS_MAIN_THREAD_BUSY_DETECT_INTERVAL_MS") != nullptr
+               ? std::stoull(getenv("GCS_MAIN_THREAD_BUSY_DETECT_INTERVAL_MS"))
+               : 1000);
+
+RAY_CONFIG(int64_t, gcs_main_thread_maximum_miss_detect_count,
+           getenv("GCS_MAIN_THREAD_MAXIMUM_MISS_DETECT_COUNT") != nullptr
+               ? std::stoull(getenv("GCS_MAIN_THREAD_MAXIMUM_MISS_DETECT_COUNT"))
+               : 3);
+
 RAY_CONFIG(uint32_t, max_error_msg_size_bytes, 512 * 1024)
 
 /// If enabled, raylet will report resources only when resources are changed.

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -159,6 +159,9 @@ class GcsServer {
   /// Get or connect to a redis server
   std::shared_ptr<RedisClient> GetOrConnectRedis();
 
+  /// Detect that if the main thread hangs.
+  void DetectHang();
+
   /// Gcs server configuration.
   GcsServerConfig config_;
   /// The main io service to drive event posted from grpc threads.
@@ -227,6 +230,8 @@ class GcsServer {
   /// The gcs table storage.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::unique_ptr<ray::RuntimeEnvManager> runtime_env_manager_;
+  /// The timer to detect if the main thread hangs.
+  boost::asio::steady_timer detect_hang_timer_;
   /// Gcs service state flag, which is used for ut.
   std::atomic<bool> is_started_;
   std::atomic<bool> is_stopped_;

--- a/src/ray/util/event_label.h
+++ b/src/ray/util/event_label.h
@@ -30,4 +30,6 @@ namespace ray {
 
 #define EL_RAY_CPP_TASK_FAILED "RAY_CPP_TASK_FAILED"
 
+#define EVENT_LABEL_GCS_MAIN_THREAD_BUSY "GCS_MAIN_THREAD_BUSY"
+
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The main thread of gcs is responsible for almost everything and sometimes it is very busy.
We add a random task in the main thread to detect how long the task will be scheduled and send a warning if it is blocked for a quite long time, which means the main thread is too busy to handle request at that moment.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
