### PR TITLE
[RLlib] Issue 21552: `unsquash_action` and `clip_action` (when None) cause wrong actions computed by `Trainer.compute_single_action`.

### DIFF
--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1414,6 +1414,13 @@ class Trainer(Trainable):
                 error=False)
             unsquash_action = unsquash_actions
 
+        # `unsquash_action` is None: Use value of config['normalize_actions'].
+        if unsquash_action is None:
+            unsquash_action = self.config["normalize_actions"]
+        # `clip_action` is None: Use value of config['clip_actions'].
+        elif clip_action is None:
+            clip_action = self.config["clip_actions"]
+
         # User provided an input-dict: Assert that `obs`, `prev_a|r`, `state`
         # are all None.
         err_msg = "Provide either `input_dict` OR [`observation`, ...] as " \
@@ -1545,6 +1552,13 @@ class Trainer(Trainable):
                 new="Trainer.compute_actions(`unsquash_actions`=...)",
                 error=False)
             unsquash_actions = normalize_actions
+
+        # `unsquash_actions` is None: Use value of config['normalize_actions'].
+        if unsquash_actions is None:
+            unsquash_actions = self.config["normalize_actions"]
+        # `clip_actions` is None: Use value of config['clip_actions'].
+        elif clip_actions is None:
+            clip_actions = self.config["clip_actions"]
 
         # Preprocess obs and states.
         state_defined = state is not None

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -397,6 +397,11 @@ def check_compute_single_action(trainer,
             for si, so in zip(state_in, state_out):
                 check(list(si.shape), so.shape)
 
+        if unsquash is None:
+            unsquash = what.config["normalize_actions"]
+        if clip is None:
+            clip = what.config["clip_actions"]
+
         # Test whether unsquash/clipping works on the Trainer's
         # compute_single_action method: Both flags should force the action
         # to be within the space's bounds.
@@ -443,8 +448,9 @@ def check_compute_single_action(trainer,
                 for full_fetch in ([False, True]
                                    if what is trainer else [False]):
                     timestep = random.randint(0, 100000)
-                    for unsquash in [True, False]:
-                        for clip in ([False] if unsquash else [True, False]):
+                    for unsquash in [True, False, None]:
+                        for clip in ([False]
+                                     if unsquash else [True, False, None]):
                             _test(what, method_to_test, obs_space, full_fetch,
                                   explore, timestep, unsquash, clip)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

https://github.com/ray-project/ray/issues/21552

- Also enhanced the `check_compute_single_action` test utility function to cover the `unsquash_action/clip_action=None` cases.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/issues/21552

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/21552
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
