### PR TITLE
[RLlib] Discussion 4351: Conv2d default filter tests and add default setting for 96x96 image obs space.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1209,6 +1209,13 @@ py_test(
 )
 
 py_test(
+    name = "test_conv2d_default_stacks",
+    tags = ["team:ml", "models"],
+    size = "medium",
+    srcs = ["models/tests/test_conv2d_default_stacks.py"]
+)
+
+py_test(
     name = "test_convtranspose2d_stack",
     tags = ["team:ml", "models"],
     size = "small",

--- a/rllib/models/tests/test_conv2d_default_stacks.py
+++ b/rllib/models/tests/test_conv2d_default_stacks.py
@@ -1,0 +1,56 @@
+import gym
+import unittest
+
+from ray.rllib.models.catalog import ModelCatalog, MODEL_DEFAULTS
+from ray.rllib.models.tf.visionnet import VisionNetwork
+from ray.rllib.models.torch.visionnet import VisionNetwork as TorchVision
+from ray.rllib.utils.framework import try_import_torch, try_import_tf
+from ray.rllib.utils.test_utils import framework_iterator
+
+torch, nn = try_import_torch()
+tf1, tf, tfv = try_import_tf()
+
+
+class TestConv2DDefaultStacks(unittest.TestCase):
+    """Tests our ConvTranspose2D Stack modules/layers."""
+
+    def test_conv2d_default_stacks(self):
+        """Tests, whether conv2d defaults are available for img obs spaces.
+        """
+        action_space = gym.spaces.Discrete(2)
+
+        shapes = [
+            (480, 640, 3),
+            (240, 320, 3),
+            (96, 96, 3),
+            (84, 84, 3),
+            (42, 42, 3),
+            (10, 10, 3),
+        ]
+        for shape in shapes:
+            print(f"shape={shape}")
+            obs_space = gym.spaces.Box(-1.0, 1.0, shape=shape)
+            for fw in framework_iterator():
+                model = ModelCatalog.get_model_v2(
+                    obs_space,
+                    action_space,
+                    2,
+                    MODEL_DEFAULTS.copy(),
+                    framework=fw)
+                self.assertTrue(
+                    isinstance(model, (VisionNetwork, TorchVision)))
+                if fw == "torch":
+                    output, _ = model({
+                        "obs": torch.from_numpy(obs_space.sample()[None])
+                    })
+                else:
+                    output, _ = model({"obs": obs_space.sample()[None]})
+                # B x [action logits]
+                self.assertTrue(output.shape == (1, 2))
+                print("ok")
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -73,7 +73,6 @@ def get_filter_config(shape):
         List[list]: The Conv2D filter configuration usable as `conv_filters`
             inside a model config dict.
     """
-    shape = list(shape)
     # VizdoomGym (large 480x640).
     filters_480x640 = [
         [16, [24, 32], [14, 18]],
@@ -85,6 +84,12 @@ def get_filter_config(shape):
         [16, [12, 16], [7, 9]],
         [32, [6, 6], 4],
         [256, [9, 9], 1],
+    ]
+    # 96x96x3 (e.g. CarRacing-v0).
+    filters_96x96 = [
+        [16, [8, 8], 4],
+        [32, [4, 4], 2],
+        [256, [11, 11], 2],
     ]
     # Atari.
     filters_84x84 = [
@@ -103,12 +108,17 @@ def get_filter_config(shape):
         [16, [5, 5], 2],
         [32, [5, 5], 2],
     ]
+
+    shape = list(shape)
     if len(shape) in [2, 3] and (shape[:2] == [480, 640]
                                  or shape[1:] == [480, 640]):
         return filters_480x640
     elif len(shape) in [2, 3] and (shape[:2] == [240, 320]
                                    or shape[1:] == [240, 320]):
         return filters_240x320
+    elif len(shape) in [2, 3] and (shape[:2] == [96, 96]
+                                   or shape[1:] == [96, 96]):
+        return filters_96x96
     elif len(shape) in [2, 3] and (shape[:2] == [84, 84]
                                    or shape[1:] == [84, 84]):
         return filters_84x84


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Discussion 4351: Conv2d default filter tests and add default setting for 96x96 image obs space.

See also this discussion here:
https://discuss.ray.io/t/use-gym-wrappers-for-training/4351

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
