### PR TITLE
[ci/multinode] Add utilities to kill nodes in multi node testing

### DIFF
--- a/python/ray/tune/tests/test_multinode_sync.py
+++ b/python/ray/tune/tests/test_multinode_sync.py
@@ -51,6 +51,26 @@ class MultiNodeSyncTest(unittest.TestCase):
                     num_cpus=1, num_gpus=1, placement_group=pg).remote(5)))
 
         print("Autoscaling worked")
+        ray.util.remove_placement_group(pg)
+
+        time.sleep(1)  # Wait until nodes.json is updated
+
+        self.cluster.kill_node(num=2)
+        print("Killed GPU node.")
+        pg = ray.util.placement_group([{"CPU": 1, "GPU": 1}] * 2)
+
+        table = ray.util.placement_group_table(pg)
+        assert table["state"] == "PENDING"
+
+        timeout = time.monotonic() + 180
+        while table["state"] != "CREATED":
+            if time.monotonic() > timeout:
+                raise RuntimeError(
+                    "Re-starting killed node failed or too slow.")
+            time.sleep(1)
+            table = ray.util.placement_group_table(pg)
+
+        print("Node was restarted.")
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_multinode_sync.py
+++ b/python/ray/tune/tests/test_multinode_sync.py
@@ -53,7 +53,7 @@ class MultiNodeSyncTest(unittest.TestCase):
         print("Autoscaling worked")
         ray.util.remove_placement_group(pg)
 
-        time.sleep(1)  # Wait until nodes.json is updated
+        time.sleep(2)  # Give some time so nodes.json is updated
 
         self.cluster.kill_node(num=2)
         print("Killed GPU node.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Killing nodes enables advanced fault tolerance testing. This PR adds utilities and a test for this functionality in fake multinode docker mode.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
