### PR TITLE
Allow setting tolerations on the Kubernetes operator deployment

### DIFF
--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -63,4 +63,9 @@ spec:
           limits:
             memory: 2Gi
             cpu: 1
+      {{- if .Values.operatorTolerations }}
+      tolerations:
+        {{ toYaml .Values.operatorTolerations | nindent 8 }}
+      {{- end }}
+
 {{- end }}

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -64,4 +64,9 @@ spec:
           limits:
             memory: 2Gi
             cpu: 1
+      {{- if .Values.operatorTolerations }}
+      tolerations:
+        {{ .Values.operatorTolerations | nindent 8 }}
+      {{- end }}
+
 {{- end }}

--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -102,5 +102,7 @@ operatorImage: rayproject/ray:latest
 # For a particular official release version of Ray, use `rayproject/ray:1.x.y`.
 # For a specific master commit, use the first 6 characters of the commit SHA, e.g. `rayproject/ray:050a07`.
 # The operator and Ray cluster can use different Ray versions, provided both versions are >= 1.2.0
+# operatorTolerations - The tolerations that apply to the operator deployment
+operatorTolerations: []
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We're tainting all of Kubernetes nodes, so we need the ability to set tolerations on the Ray operator before it will schedule.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
