### PR TITLE
[CI] Pin pytest-asyncio version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -78,7 +78,7 @@ Pillow; platform_system != "Windows"
 pygments
 pyspark==3.1.2
 pytest==5.4.3
-pytest-asyncio
+pytest-asyncio==0.16.0
 pytest-rerunfailures
 pytest-sugar
 pytest-lazy-fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://pypi.org/project/pytest-asyncio/#history looks like there's a release 8 hours ago and break some of our tests. 

https://flakey-tests.ray.io/

The errors in  form of
```


File "/opt/miniconda/lib/python3.7/site-packages/pytest_asyncio/plugin.py", line 57, in pytest_addoption
--
  | default="legacy",
  | File "/opt/miniconda/lib/python3.7/site-packages/_pytest/config/argparsing.py", line 177, in addini
  | assert type in (None, "pathlist", "args", "linelist", "bool")
  | AssertionError


```
 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
