### PR TITLE
[Dataset] Fix simple dataset sort generating only 1 non-empty block

### DIFF
--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -129,8 +129,8 @@ class SimpleBlockAccessor(BlockAccessor):
         # in descending order and we only need to count the number of items
         # *greater than* the boundary value instead.
         key_fn = key if key else lambda x: x
-        comp_fn = lambda x, b: key_fn(x) > b \
-            if descending else lambda x, b: key_fn(x) < b  # noqa E731
+        comp_fn = (lambda x, b: key_fn(x) > b) \
+            if descending else (lambda x, b: key_fn(x) < b)  # noqa E731
 
         # Compute the boundary indices in O(n) time via scan.
         boundary_indices = []

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3616,6 +3616,9 @@ def test_sort_simple(ray_start_regular_shared):
     random.shuffle(xs)
     ds = ray.data.from_items(xs, parallelism=parallelism)
     assert ds.sort().take(num_items) == list(range(num_items))
+    # Make sure we have rows in each block.
+    assert len(
+        [n for n in ds.sort()._block_num_rows() if n > 0]) == parallelism
     assert ds.sort(descending=True).take(num_items) == list(
         reversed(range(num_items)))
     assert ds.sort(key=lambda x: -x).take(num_items) == list(
@@ -3784,6 +3787,9 @@ def test_sort_arrow(ray_start_regular, num_items, parallelism):
                 for row in sorted_ds.iter_rows()] == list(expected_rows)
 
     assert_sorted(ds.sort(key="a"), zip(reversed(a), reversed(b)))
+    # Make sure we have rows in each block.
+    assert len([n for n in ds.sort(key="a")._block_num_rows()
+                if n > 0]) == parallelism
     assert_sorted(ds.sort(key="b"), zip(a, b))
     assert_sorted(ds.sort(key="a", descending=True), zip(a, b))
     assert_sorted(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`lamba x : 1 if y else lambda x: 2` generates a lambda that returns another lambda in the else case.

Couldn't find a flake8 rule to catch this in the future.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
