### PR TITLE
[GCS] reenable test_client_reconnect.py for GCS HA builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -347,7 +347,7 @@
       --test_env=RAY_gcs_grpc_based_pubsub=1
       --test_env=RAY_bootstrap_with_gcs=1
       --test_env=RAY_gcs_storage=memory
-      -- python/ray/tests/... -//python/ray/tests:test_client_reconnect
+      -- python/ray/tests/...
 - label: ":redis: HA GCS (Large)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   parallelism: 3

--- a/python/ray/tests/test_client_reconnect.py
+++ b/python/ray/tests/test_client_reconnect.py
@@ -3,7 +3,6 @@ import contextlib
 import os
 import threading
 import sys
-from ray.util.client.common import CLIENT_SERVER_MAX_THREADS, GRPC_OPTIONS
 import grpc
 
 import time
@@ -12,11 +11,12 @@ import pytest
 from typing import Any, Callable, Optional
 from unittest.mock import patch
 
+import ray
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
-
+from ray.util.client.common import CLIENT_SERVER_MAX_THREADS, GRPC_OPTIONS
 import ray.util.client.server.server as ray_client_server
-import ray
+from ray._private.client_mode_hook import disable_client_hook
 
 # At a high level, these tests rely on an extra RPC server sitting
 # between the client and the real Ray server to inject errors, drop responses
@@ -266,9 +266,16 @@ def start_middleman_server(on_log_response=None,
     finally:
         ray._inside_client_test = False
         ray.util.disconnect()
-        server.stop(0)
         if middleman:
             middleman.stop(0)
+        server.stop(0)
+        del server
+        start = time.monotonic()
+        with disable_client_hook():
+            while ray.is_initialized():
+                time.sleep(1)
+                if time.monotonic() - start > 30:
+                    raise RuntimeError("Failed to terminate Ray")
 
 
 def test_disconnect_during_get():
@@ -294,7 +301,6 @@ def test_disconnect_during_get():
         disconnect_thread.join()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on windows")
 def test_valid_actor_state():
     """
     Repeatedly inject errors in the middle of mutating actor calls. Check
@@ -333,9 +339,6 @@ def test_valid_actor_state():
         assert ray.get(ref) == 100
 
 
-# TODO(ckw017): investigate why test is flaking on HA GCS
-# details: https://github.com/ray-project/ray/issues/20907
-@pytest.mark.skipif(True, reason="Flaky on Windows and HA GCS")
 def test_valid_actor_state_2():
     """
     Do a full disconnect (cancel channel) every 11 requests. Failure
@@ -374,7 +377,6 @@ def test_valid_actor_state_2():
         assert ray.get(ref) == 100
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on windows")
 def test_noisy_puts():
     """
     Randomly kills the data channel with 10% chance when receiving response


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In `test_client_reconnect.py`, each test case starts a Ray cluster via client server's `default_connect_handler()`. The Ray cluster shuts down implicitly when the `start_middleman_server()` ended and Python GC'es the client server. After turning on GCS pubsub, the time when client server is GC'ed changes. Sometimes the Ray cluster from a previous test cases stays alive after the next test case starts and shuts down later, leading to test failures due to lost data or crashes (race during worker shutdown, will be investigated separately).

This PR makes sure each test case shuts down its Ray cluster.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
