### PR TITLE
[Core]limit body size instead of entry number in resources broadcasting

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -480,8 +480,8 @@ RAY_CONFIG(std::string, predefined_unit_instance_resources, "GPU")
 /// When set it to "FPGA", we will treat FPGA as unit_instance.
 RAY_CONFIG(std::string, custom_unit_instance_resources, "")
 
-// Maximum size of the batches when broadcasting resources to raylet.
-RAY_CONFIG(uint64_t, resource_broadcast_batch_size, 512);
+// Maximum size of the broadcasting resources to raylet.
+RAY_CONFIG(uint64_t, resource_broadcast_body_size, 100 * 1024);
 
 // If enabled and worker stated in container, the container will add
 // resource limit.

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -213,8 +213,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   absl::flat_hash_map<NodeID, int64_t> latest_resources_normal_task_timestamp_;
   /// The resources changed listeners.
   std::vector<std::function<void()>> resources_changed_listeners_;
-  /// Max batch size for broadcasting
-  size_t max_broadcasting_batch_size_;
+  /// Max size for broadcasting.
+  size_t max_broadcasting_body_size_;
 
   /// Debug info.
   enum CountType {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Limit resource size of broadcasting is important for redis/gcs robustness.
Now we only limit node size, but resource body of a node is not affirmatory because resource label will differ as we can set self define resource for nodes. So it's better to limit byte size instead of node size.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
