### PR TITLE
[Rllib] fix range() in torch `attention_net.py`

### DIFF
--- a/rllib/models/torch/attention_net.py
+++ b/rllib/models/torch/attention_net.py
@@ -378,9 +378,8 @@ class AttentionWrapper(TorchModelV2, nn.Module):
                                 prev_n_actions[:, i].float(),
                                 space=self.action_space))
                 elif isinstance(self.action_space, MultiDiscrete):
-                    for i in range(
-                            self.use_n_prev_actions,
-                            step=self.action_space.shape[0]):
+                    for i in range(0, self.use_n_prev_actions,
+                                   self.action_space.shape[0]):
                         prev_a_r.append(
                             one_hot(
                                 prev_n_actions[:, i:i +


### PR DESCRIPTION
## Why are these changes needed?

This is the same bug as reported in #17502, the tf version of `attention.py` fixed it but somehow the same bug appeared in the torch version slips through the cracks.

## Related issue number

#17502, #17477

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
