### PR TITLE
[gcs/ha] Enable HA flags by default

### DIFF
--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -18,41 +18,40 @@ a2c-breakoutnoframeskip-v4:
             [20000000, 0.000000000001],
         ]
 
-# a3c-pongdeterministic-v4:
-#    env: PongDeterministic-v4
-#    run: A3C
-#    # Minimum reward and total ts (in given time_total_s) to pass this test.
-#    pass_criteria:
-#        episode_reward_mean: 18.0
-#        timesteps_total: 5000000
-#    stop:
-#        time_total_s: 3600
-#    config:
-#        ignore_worker_failures: true
-#        num_gpus: 0
-#        num_workers: 16
-#        rollout_fragment_length: 20
-#        vf_loss_coeff: 0.5
-#        entropy_coeff: 0.01
-#        gamma: 0.99
-#        grad_clip: 40.0
-#        lambda: 1.0
-#        lr: 0.0001
-#        observation_filter: NoFilter
-#        preprocessor_pref: rllib
-#        model:
-#            use_lstm: true
-#            conv_activation: elu
-#            dim: 42
-#            grayscale: true
-#            zero_mean: false
-#            # Reduced channel depth and kernel size from default.
-#            conv_filters: [
-#                [32, [3, 3], 2],
-#                [32, [3, 3], 2],
-#                [32, [3, 3], 2],
-#                [32, [3, 3], 2],
-#            ]
+a3c-pongdeterministic-v4:
+    env: PongDeterministic-v4
+    run: A3C
+    # Minimum reward and total ts (in given time_total_s) to pass this test.
+    pass_criteria:
+        episode_reward_mean: 18.0
+        timesteps_total: 5000000
+    stop:
+        time_total_s: 3600
+    config:
+        num_gpus: 0
+        num_workers: 16
+        rollout_fragment_length: 20
+        vf_loss_coeff: 0.5
+        entropy_coeff: 0.01
+        gamma: 0.99
+        grad_clip: 40.0
+        lambda: 1.0
+        lr: 0.0001
+        observation_filter: NoFilter
+        preprocessor_pref: rllib
+        model:
+            use_lstm: true
+            conv_activation: elu
+            dim: 42
+            grayscale: true
+            zero_mean: false
+            # Reduced channel depth and kernel size from default.
+            conv_filters: [
+                [32, [3, 3], 2],
+                [32, [3, 3], 2],
+                [32, [3, 3], 2],
+                [32, [3, 3], 2],
+            ]
 
 apex-breakoutnoframeskip-v4:
     env: BreakoutNoFrameskip-v4

--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -18,40 +18,41 @@ a2c-breakoutnoframeskip-v4:
             [20000000, 0.000000000001],
         ]
 
-a3c-pongdeterministic-v4:
-    env: PongDeterministic-v4
-    run: A3C
-    # Minimum reward and total ts (in given time_total_s) to pass this test.
-    pass_criteria:
-        episode_reward_mean: 18.0
-        timesteps_total: 5000000
-    stop:
-        time_total_s: 3600
-    config:
-        num_gpus: 0
-        num_workers: 16
-        rollout_fragment_length: 20
-        vf_loss_coeff: 0.5
-        entropy_coeff: 0.01
-        gamma: 0.99
-        grad_clip: 40.0
-        lambda: 1.0
-        lr: 0.0001
-        observation_filter: NoFilter
-        preprocessor_pref: rllib
-        model:
-            use_lstm: true
-            conv_activation: elu
-            dim: 42
-            grayscale: true
-            zero_mean: false
-            # Reduced channel depth and kernel size from default.
-            conv_filters: [
-                [32, [3, 3], 2],
-                [32, [3, 3], 2],
-                [32, [3, 3], 2],
-                [32, [3, 3], 2],
-            ]
+# a3c-pongdeterministic-v4:
+#    env: PongDeterministic-v4
+#    run: A3C
+#    # Minimum reward and total ts (in given time_total_s) to pass this test.
+#    pass_criteria:
+#        episode_reward_mean: 18.0
+#        timesteps_total: 5000000
+#    stop:
+#        time_total_s: 3600
+#    config:
+#        ignore_worker_failures: true
+#        num_gpus: 0
+#        num_workers: 16
+#        rollout_fragment_length: 20
+#        vf_loss_coeff: 0.5
+#        entropy_coeff: 0.01
+#        gamma: 0.99
+#        grad_clip: 40.0
+#        lambda: 1.0
+#        lr: 0.0001
+#        observation_filter: NoFilter
+#        preprocessor_pref: rllib
+#        model:
+#            use_lstm: true
+#            conv_activation: elu
+#            dim: 42
+#            grayscale: true
+#            zero_mean: false
+#            # Reduced channel depth and kernel size from default.
+#            conv_filters: [
+#                [32, [3, 3], 2],
+#                [32, [3, 3], 2],
+#                [32, [3, 3], 2],
+#                [32, [3, 3], 2],
+#            ]
 
 apex-breakoutnoframeskip-v4:
     env: BreakoutNoFrameskip-v4

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -285,9 +285,9 @@ RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
 // Feature flag to enable grpc based pubsub in GCS.
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, true)
 // The storage backend to use for the GCS. It can be either 'redis' or 'memory'.
-RAY_CONFIG(std::string, gcs_storage, "redis")
+RAY_CONFIG(std::string, gcs_storage, "memory")
 // Feature flag to enable GCS based bootstrapping.
-RAY_CONFIG(bool, bootstrap_with_gcs, false)
+RAY_CONFIG(bool, bootstrap_with_gcs, true)
 
 /// Duration to sleep after failing to put an object in plasma because it is full.
 RAY_CONFIG(uint32_t, object_store_full_delay_ms, 10)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
PR to enable all three flags for GCS HA:
- RAY_bootstrap_with_gcs=1 
- RAY_gcs_grpc_based_pubsub=1 
- RAY_gcs_storage=memory

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
