### PR TITLE
[Serve] [CI] pin uvicorn to 0.16.0 to fix serve

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -34,6 +34,6 @@ tabulate
 tensorflow==2.0.1
 torch
 torchvision
-uvicorn
+uvicorn==0.16.0
 werkzeug
 xlrd

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -30,7 +30,7 @@ sphinx-book-theme==0.0.42
 sphinxcontrib.yt
 starlette
 tabulate
-uvicorn
+uvicorn==0.16.0
 werkzeug
 git+https://github.com/ray-project/tune-sklearn@master#tune-sklearn
 git+https://github.com/ray-project/xgboost_ray@master#egg=xgboost_ray

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -40,7 +40,7 @@ pandas>=1.2.0; python_version >= '3.7'
 scipy==1.4.1
 tabulate
 tensorboardX >= 1.9
-uvicorn
+uvicorn==0.16.0
 dataclasses; python_version < '3.7'
 starlette
 aiorwlock

--- a/python/setup.py
+++ b/python/setup.py
@@ -213,7 +213,9 @@ if setup_spec.type == SetupType.RAY:
             "prometheus_client >= 0.7.1",
             "smart_open"
         ],
-        "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
+        "serve": [
+            "uvicorn==0.16.0", "requests", "starlette", "fastapi", "aiorwlock"
+        ],
         "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests"],
         "k8s": ["kubernetes", "urllib3"],
         "observability": [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes broken Serve tests in CI. Uvicorn 0.17.0 was released 13 hours ago.

```


(HTTPProxyActor pid=39356) Traceback (most recent call last):
--
  | (HTTPProxyActor pid=39356)   File "/usr/local/opt/miniconda/lib/python3.6/site-packages/uvicorn/protocols/http/h11_impl.py", line 378, in run_asgi
  | (HTTPProxyActor pid=39356)     await self.send_500_response()
  | (HTTPProxyActor pid=39356)   File "/usr/local/opt/miniconda/lib/python3.6/site-packages/uvicorn/protocols/http/h11_impl.py", line 404, in send_500_response
  | (HTTPProxyActor pid=39356)     (b"connection", b"close"),
  | (HTTPProxyActor pid=39356)   File "/usr/local/opt/miniconda/lib/python3.6/site-packages/uvicorn/protocols/http/h11_impl.py", line 416, in send
  | (HTTPProxyActor pid=39356)     if self.flow.write_paused and not self.disconnected:
  | (HTTPProxyActor pid=39356) AttributeError: 'NoneType' object has no attribute 'write_paused'


```
<img width="483" alt="Screen Shot 2022-01-14 at 3 45 59 PM" src="https://user-images.githubusercontent.com/5459654/149598994-6cbba956-1084-4937-95dd-e47899feb68f.png">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
