### PR TITLE
[Core] [Hackathon] Affinity and anti-affinity prototype (1/n): Resource-based anti-affinity.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -318,8 +318,6 @@ cdef int prepare_resources(
     for key, value in resource_dict.items():
         if not (isinstance(value, int) or isinstance(value, float)):
             raise ValueError("Resource quantities may only be ints or floats.")
-        if value < 0:
-            raise ValueError("Resource quantities may not be negative.")
         if value > 0:
             if (value >= 1 and isinstance(value, float)
                     and not value.is_integer()):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2167,11 +2167,17 @@ def remote(*args, **kwargs):
             the remote function invocation.
         num_cpus (float): The quantity of CPU cores to reserve
             for this task or for the lifetime of the actor.
+            If negative, this task or actor will not be scheduled onto nodes
+            that have CPUs (anti-affinity).
         num_gpus (int): The quantity of GPUs to reserve
             for this task or for the lifetime of the actor.
+            If negative, this task or actor will not be scheduled onto nodes
+            that have GPUs (anti-affinity).
         resources (Dict[str, float]): The quantity of various custom resources
             to reserve for this task or for the lifetime of the actor.
             This is a dictionary mapping strings (resource names) to floats.
+            If negative, this task or actor will not be scheduled onto nodes
+            that have the corresponding resource (anti-affinity).
         accelerator_type: If specified, requires that the task or actor run
             on a node with the specified type of accelerator.
             See `ray.accelerators` for accelerator types.

--- a/src/ray/raylet/scheduling/cluster_resource_data.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_data.cc
@@ -227,7 +227,7 @@ bool NodeResources::IsAvailable(const ResourceRequest &resource_request,
   // First, check predefined resources.
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     if (i >= this->predefined_resources.size()) {
-      if (resource_request.predefined_resources[i] != 0) {
+      if (resource_request.predefined_resources[i] > 0) {
         return false;
       }
       continue;
@@ -239,6 +239,8 @@ bool NodeResources::IsAvailable(const ResourceRequest &resource_request,
     if (resource < demand) {
       RAY_LOG(DEBUG) << "At resource capacity";
       return false;
+    } else if (demand < 0 && this->predefined_resources[i].total > 0) {
+      return false;
     }
   }
 
@@ -248,6 +250,8 @@ bool NodeResources::IsAvailable(const ResourceRequest &resource_request,
     if (it == this->custom_resources.end()) {
       return false;
     } else if (resource_req_custom_resource.second > it->second.available) {
+      return false;
+    } else if (resource_req_custom_resource.second < 0 && it->second.total > 0) {
       return false;
     }
   }
@@ -259,7 +263,7 @@ bool NodeResources::IsFeasible(const ResourceRequest &resource_request) const {
   // First, check predefined resources.
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     if (i >= this->predefined_resources.size()) {
-      if (resource_request.predefined_resources[i] != 0) {
+      if (resource_request.predefined_resources[i] > 0) {
         return false;
       }
       continue;
@@ -268,6 +272,8 @@ bool NodeResources::IsFeasible(const ResourceRequest &resource_request) const {
     const auto &demand = resource_request.predefined_resources[i];
 
     if (resource < demand) {
+      return false;
+    } else if (demand < 0 && resource > 0) {
       return false;
     }
   }
@@ -278,6 +284,8 @@ bool NodeResources::IsFeasible(const ResourceRequest &resource_request) const {
     if (it == this->custom_resources.end()) {
       return false;
     } else if (resource_req_custom_resource.second > it->second.total) {
+      return false;
+    } else if (resource_req_custom_resource.second < 0 && it->second.total > 0) {
       return false;
     }
   }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -188,6 +188,9 @@ bool ClusterResourceScheduler::IsSchedulable(const ResourceRequest &resource_req
       // A hard constraint has been violated, so we cannot schedule
       // this resource request.
       return false;
+    } else if (resource_request.predefined_resources[i] < 0 &&
+               resources.predefined_resources[i].total > 0) {
+      return false;
     }
   }
 
@@ -202,6 +205,8 @@ bool ClusterResourceScheduler::IsSchedulable(const ResourceRequest &resource_req
     } else {
       if (task_req_custom_resource.second > it->second.available) {
         // Resource constraint is violated.
+        return false;
+      } else if (task_req_custom_resource.second < 0 && it->second.total > 0) {
         return false;
       }
     }


### PR DESCRIPTION
## Motivation
In addition to scheduling a task onto a node that **must have** a resource, users also want to be able to schedule a task onto a node that **must not have** a resource. This PR adds support for this by considering a negative resource request on a task to indicate that the task can **not** be scheduled onto a node that has that resource.

## Use case 1 - keeping CPU tasks off of GPU nodes

When trying to keep CPU-bound and GPU-bound work separate, it can be useful to ensure that CPU-bound work is only scheduled onto the non-GPU nodes.

```python
@ray.remote
def do_cpu_work(a):
    return a + 1

# Ensure task isn't scheduled onto a node that has GPUs.
result = do_cpu_work.options(num_gpus=-1).remote(1)
print(ray.get(result))
```
## Use case 2 - custom anti-affinity

Users may require a custom affinity and anti-affinity pattern when colocation of certain tasks/actors is (un)desirable; this can often be achieved using custom resources, with this PR implementing the anti-affinity side of this equation.

```python
@ray.remote(resources={"chill_vibes": 0.01})
class TiredActor:
    pass

@ray.remote
def loud_task(a):
    return a + 1

# Start a few tired actors on a specific node that has custom resource.
actors = [TiredActor.remote() for _ in range(5)]

# We don't want the load task to be colocated with the tired actors,
# so we avoid the custom resource.
result = loud_task.options(resources={"chill_vibes": -1}).remote(1)
print(ray.get(result))
```

## Total vs availability semantics

Currently, if a task has a `"foo": -1` anti-affinity to the `"foo"` resource, we consider a node with positive `"foo"` resource total (not available) to be infeasible. I.e., if the node was started with a positive `"foo"` resource allocation, it will always be infeasible for a task with `"foo"` anti-affinity.

An alternative semantics would be considering a node with positive `"foo"` resource **availability** (not total) to be infeasible, but otherwise considering a node with zero `"foo"` resource availability to be feasible. This means that a node that was started with a positive `"foo"` resource allocation could still be feasible for a task with `"foo"` anti-affinity if the node's `"foo"` resource is at 100% utilization. For the CPU/GPU workload isolation use case (use case 1), these semantics could be advantageous: if a GPU node is at 100% GPU utilization but has CPU cores sitting idle, this anti-affinity would allow for `.options(num_gpus=-1)` tasks to be scheduled onto such nodes, creating better utilization of the CPU cores on those nodes while still preventing CPU and GPU tasks from otherwise competing.

For now, I think that sticking with the former (total semantics) makes sense, since those semantics should be easier for users to reason about.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
