### PR TITLE
Revert "[Serve] [CI] pin uvicorn to 0.16.0 to fix serve"

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -34,6 +34,6 @@ tabulate
 tensorflow==2.0.1
 torch
 torchvision
-uvicorn==0.16.0
+uvicorn
 werkzeug
 xlrd

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -30,7 +30,7 @@ sphinx-book-theme==0.0.42
 sphinxcontrib.yt
 starlette
 tabulate
-uvicorn==0.16.0
+uvicorn
 werkzeug
 git+https://github.com/ray-project/tune-sklearn@master#tune-sklearn
 git+https://github.com/ray-project/xgboost_ray@master#egg=xgboost_ray

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -40,7 +40,7 @@ pandas>=1.2.0; python_version >= '3.7'
 scipy==1.4.1
 tabulate
 tensorboardX >= 1.9
-uvicorn==0.16.0
+uvicorn
 dataclasses; python_version < '3.7'
 starlette
 aiorwlock

--- a/python/setup.py
+++ b/python/setup.py
@@ -213,9 +213,7 @@ if setup_spec.type == SetupType.RAY:
             "prometheus_client >= 0.7.1",
             "smart_open"
         ],
-        "serve": [
-            "uvicorn==0.16.0", "requests", "starlette", "fastapi", "aiorwlock"
-        ],
+        "serve": ["uvicorn", "requests", "starlette", "fastapi", "aiorwlock"],
         "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests"],
         "k8s": ["kubernetes", "urllib3"],
         "observability": [


### PR DESCRIPTION
Reverts ray-project/ray#21612

Broke CI with Python 3.6

```


>       assert "uvicorn" in result  # from ray[serve]
--


E
       AssertionError: assert 'uvicorn' in ['pkg1', 'pandas', 
'tabulate', 'tensorboardX&gt;=1.9', 'requests', 'gpustat &gt;= 1.0.0b1',
 ...]
```