### PR TITLE
[Java] Change ActorLifetime API: DEFAULT -> NON_DETACHED

### DIFF
--- a/java/api/src/main/java/io/ray/api/options/ActorCreationOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/ActorCreationOptions.java
@@ -46,7 +46,7 @@ public class ActorCreationOptions extends BaseTaskOptions {
   /** The inner class for building ActorCreationOptions. */
   public static class Builder {
     private String name;
-    private ActorLifetime lifetime = ActorLifetime.DEFAULT;
+    private ActorLifetime lifetime = ActorLifetime.NON_DETACHED;
     private Map<String, Double> resources = new HashMap<>();
     private int maxRestarts = 0;
     private List<String> jvmOptions = new ArrayList<>();

--- a/java/api/src/main/java/io/ray/api/options/ActorLifetime.java
+++ b/java/api/src/main/java/io/ray/api/options/ActorLifetime.java
@@ -1,9 +1,9 @@
 package io.ray.api.options;
 
-/** The enumeration class is used for declaring lifetime of actors. It's non detached by default. */
+/** The enumeration class is used for declaring lifetime of actors. */
 public enum ActorLifetime {
-  DEFAULT("DEFAULT", 0),
-  DETACHED("DETACHED", 1);
+  DETACHED("DETACHED", 0),
+  NON_DETACHED("NON_DETACHED", 1);
 
   private String name;
   private int value;

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
@@ -164,7 +164,7 @@ inline ActorCreationOptions ToActorCreationOptions(JNIEnv *env,
     RAY_CHECK(java_actor_lifetime != nullptr);
     jint actor_lifetime_value =
         env->GetIntField(java_actor_lifetime, java_actor_lifetime_value);
-    is_detached = (actor_lifetime_value == 1);
+    is_detached = (actor_lifetime_value == 0);
     max_restarts =
         env->GetIntField(actorCreationOptions, java_actor_creation_options_max_restarts);
     jobject java_resources =


### PR DESCRIPTION
## Why are these changes needed?
This PR changes the enum value `ActorLifetime.DEFAULT` to `ActorLifetime.NON_DETACHED`. In our release versions, `ActorLifetime` was not introduced <= 1.9.2


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/21647
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
