### PR TITLE
[Dashboard] Fix NPE when there is no GPU on the node

### DIFF
--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -208,7 +208,9 @@ const NodeInfo: React.FC<{}> = () => {
 
   // Show GPU features only if there is at least one GPU in cluster.
   const showGPUs =
-    nodes.map((n) => n.gpus).filter((gpus) => gpus !== undefined && gpus.length !== 0).length !== 0;
+    nodes
+      .map((n) => n.gpus)
+      .filter((gpus) => gpus !== undefined && gpus.length !== 0).length !== 0;
 
   // Don't show disk on Kubernetes. K8s node disk usage should be monitored
   // elsewhere.

--- a/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
+++ b/dashboard/client/src/pages/dashboard/node-info/NodeInfo.tsx
@@ -208,7 +208,7 @@ const NodeInfo: React.FC<{}> = () => {
 
   // Show GPU features only if there is at least one GPU in cluster.
   const showGPUs =
-    nodes.map((n) => n.gpus).filter((gpus) => gpus.length !== 0).length !== 0;
+    nodes.map((n) => n.gpus).filter((gpus) => gpus !== undefined && gpus.length !== 0).length !== 0;
 
   // Don't show disk on Kubernetes. K8s node disk usage should be monitored
   // elsewhere.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is an NPE bug that causes browser crash when no GPU on the node.
We can add a condition to fix it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
