### PR TITLE
[Core] Use const data for buffer where possible, fix: SharedMemoryBuffer should not be constructible from generic Buffer, only SharedMemoryBuffer

### DIFF
--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -203,7 +203,7 @@ Status TaskExecutor::ExecuteTask(
     auto result = *result_ptr;
     if (result != nullptr) {
       if (result->HasData()) {
-        memcpy(result->GetData()->Data(), data->data(), data_size);
+        memcpy(result->GetData()->MutableData(), data->data(), data_size);
       }
     }
 

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -124,7 +124,7 @@ class LocalMemoryBuffer : public Buffer {
   /// Whether this buffer holds a copy of data.
   bool has_data_copy_ = false;
   /// This is only valid when `should_copy` is true.
-  uint8_t *buffer_ = NULL;
+  uint8_t *buffer_ = nullptr;
 };
 
 /// Represents a byte buffer in shared memory.

--- a/src/ray/common/ray_object.cc
+++ b/src/ray/common/ray_object.cc
@@ -74,12 +74,12 @@ std::shared_ptr<ray::LocalMemoryBuffer> MakeSerializeErrorBuffer(
       std::make_unique<ray::LocalMemoryBuffer>(msgpack_serialized_exception.size() +
                                                kMessagePackOffset);
   // copy msgpack-serialized bytes
-  std::memcpy(final_buffer->Data() + kMessagePackOffset,
+  std::memcpy(final_buffer->MutableData() + kMessagePackOffset,
               msgpack_serialized_exception.data(), msgpack_serialized_exception.size());
   // copy offset
   msgpack::sbuffer msgpack_int;
   msgpack::pack(msgpack_int, msgpack_serialized_exception.size());
-  std::memcpy(final_buffer->Data(), msgpack_int.data(), msgpack_int.size());
+  std::memcpy(final_buffer->MutableData(), msgpack_int.data(), msgpack_int.size());
   RAY_CHECK(final_buffer->Data() != nullptr);
   RAY_CHECK(final_buffer->Size() != 0);
 

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -91,7 +91,7 @@ Status CoreWorkerPlasmaStoreProvider::Put(const RayObject &object,
   // not throw an error.
   if (data != nullptr) {
     if (object.HasData()) {
-      memcpy(data->Data(), object.GetData()->Data(), object.GetData()->Size());
+      memcpy(data->MutableData(), object.GetData()->Data(), object.GetData()->Size());
     }
     RAY_RETURN_NOT_OK(Seal(object_id));
     if (object_exists) {

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -61,7 +61,9 @@ class TrackedBuffer : public Buffer {
                 const std::shared_ptr<BufferTracker> &tracker, const ObjectID &object_id)
       : buffer_(buffer), tracker_(tracker), object_id_(object_id) {}
 
-  uint8_t *Data() const override { return buffer_->Data(); }
+  const uint8_t *Data() const override { return buffer_->Data(); }
+
+  uint8_t *MutableData() const override { return buffer_->MutableData(); }
 
   size_t Size() const override { return buffer_->Size(); }
 

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -229,7 +229,7 @@ ray::Status ObjectBufferPool::EnsureBufferExists(const ObjectID &object_id,
   }
 
   // Read object into store.
-  uint8_t *mutable_data = data->Data();
+  uint8_t *mutable_data = data->MutableData();
   uint64_t num_chunks = GetNumChunks(data_size);
   create_buffer_state_.emplace(
       std::piecewise_construct, std::forward_as_tuple(object_id),

--- a/streaming/src/channel/channel.cc
+++ b/streaming/src/channel/channel.cc
@@ -205,7 +205,8 @@ StreamingStatus StreamingQueueConsumer::ConsumeItemFromChannel(uint8_t *&data,
     return StreamingStatus::OK;
   }
 
-  data = item.Buffer()->Data();
+  // This is the previous behaviour (unsafe non-const cast) which we retain.
+  data = (uint8_t *)item.Buffer()->Data();
   data_size = item.Buffer()->Size();
 
   STREAMING_LOG(DEBUG) << "GetQueueItem qid: " << channel_info_.channel_id

--- a/streaming/src/queue/queue_handler.cc
+++ b/streaming/src/queue/queue_handler.cc
@@ -15,7 +15,8 @@ std::shared_ptr<DownstreamQueueMessageHandler>
 
 std::shared_ptr<Message> QueueMessageHandler::ParseMessage(
     std::shared_ptr<LocalMemoryBuffer> buffer) {
-  uint8_t *bytes = buffer->Data();
+  // This is the previous behaviour (unsafe non-const cast) which we retain.
+  uint8_t *bytes = const_cast<uint8_t *>(buffer->Data());
   uint8_t *p_cur = bytes;
   uint32_t *magic_num = (uint32_t *)p_cur;
   STREAMING_CHECK(*magic_num == Message::MagicNum)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Also, note that `SharedMemoryBuffer` does not own its data in any situation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

closes: https://github.com/ray-project/ray/issues/21632

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
