### PR TITLE
[GCS] use separate event loop for GCS pubsub

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -218,6 +218,7 @@ void GcsServer::Stop() {
     // Shutdown the rpc server
     rpc_server_.Shutdown();
 
+    pubsub_handler_->Stop();
     kv_manager_.reset();
 
     is_stopped_ = true;
@@ -455,7 +456,8 @@ void GcsServer::InitKVManager() {
 }
 
 void GcsServer::InitPubSubHandler() {
-  pubsub_handler_ = std::make_unique<InternalPubSubHandler>(gcs_publisher_);
+  pubsub_handler_ =
+      std::make_unique<InternalPubSubHandler>(pubsub_io_service_, gcs_publisher_);
   pubsub_service_ = std::make_unique<rpc::InternalPubSubGrpcService>(pubsub_io_service_,
                                                                      *pubsub_handler_);
   // Register service.

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -43,7 +43,7 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
                            RayConfig::instance().gcs_server_rpc_client_thread_num()),
       raylet_client_pool_(
           std::make_shared<rpc::NodeManagerClientPool>(client_call_manager_)),
-      pubsub_periodical_runner_(main_service_),
+      pubsub_periodical_runner_(pubsub_io_service_),
       periodical_runner_(main_service),
       is_started_(false),
       is_stopped_(false) {
@@ -454,11 +454,10 @@ void GcsServer::InitKVManager() {
   rpc_server_.RegisterService(*kv_service_);
 }
 
-// TODO: Investigating optimal threading for PubSub, e.g. separate io_context.
 void GcsServer::InitPubSubHandler() {
   pubsub_handler_ = std::make_unique<InternalPubSubHandler>(gcs_publisher_);
-  pubsub_service_ =
-      std::make_unique<rpc::InternalPubSubGrpcService>(main_service_, *pubsub_handler_);
+  pubsub_service_ = std::make_unique<rpc::InternalPubSubGrpcService>(pubsub_io_service_,
+                                                                     *pubsub_handler_);
   // Register service.
   rpc_server_.RegisterService(*pubsub_service_);
 }

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -175,6 +175,8 @@ class GcsServer {
   /// The io service used by heartbeat manager in case of node failure detector being
   /// blocked by main thread.
   instrumented_io_context heartbeat_manager_io_service_;
+  /// The io service used by Pubsub, for isolation from other workload.
+  instrumented_io_context pubsub_io_service_;
   /// The grpc server
   rpc::GrpcServer rpc_server_;
   /// The `ClientCallManager` object that is shared by all `NodeManagerWorkerClient`s.

--- a/src/ray/gcs/gcs_server/pubsub_handler.cc
+++ b/src/ray/gcs/gcs_server/pubsub_handler.cc
@@ -14,8 +14,26 @@
 
 #include "ray/gcs/gcs_server/pubsub_handler.h"
 
+#include "absl/synchronization/notification.h"
+
 namespace ray {
 namespace gcs {
+
+InternalPubSubHandler::InternalPubSubHandler(
+    instrumented_io_context &io_service,
+    const std::shared_ptr<gcs::GcsPublisher> &gcs_publisher)
+    : io_service_(io_service), gcs_publisher_(gcs_publisher) {
+  io_service_thread_ = std::make_unique<std::thread>([this] {
+    SetThreadName("pubsub");
+    /// The asio work to keep io_service_ alive.
+    boost::asio::io_service::work io_service_work_(io_service_);
+    io_service_.run();
+  });
+
+  absl::Notification notif;
+  io_service_.post([&notif]() { notif.Notify(); }, "InternalPubSubHandler.Constructor");
+  notif.WaitForNotification();
+}
 
 void InternalPubSubHandler::HandleGcsPublish(const rpc::GcsPublishRequest &request,
                                              rpc::GcsPublishReply *reply,
@@ -91,6 +109,13 @@ void InternalPubSubHandler::HandleGcsSubscriberCommandBatch(
     }
   }
   send_reply_callback(Status::OK(), nullptr, nullptr);
+}
+
+void InternalPubSubHandler::Stop() {
+  io_service_.stop();
+  if (io_service_thread_->joinable()) {
+    io_service_thread_->join();
+  }
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/pubsub_handler.cc
+++ b/src/ray/gcs/gcs_server/pubsub_handler.cc
@@ -14,8 +14,6 @@
 
 #include "ray/gcs/gcs_server/pubsub_handler.h"
 
-#include "absl/synchronization/notification.h"
-
 namespace ray {
 namespace gcs {
 
@@ -25,14 +23,10 @@ InternalPubSubHandler::InternalPubSubHandler(
     : io_service_(io_service), gcs_publisher_(gcs_publisher) {
   io_service_thread_ = std::make_unique<std::thread>([this] {
     SetThreadName("pubsub");
-    /// The asio work to keep io_service_ alive.
+    // Keep io_service_ alive.
     boost::asio::io_service::work io_service_work_(io_service_);
     io_service_.run();
   });
-
-  absl::Notification notif;
-  io_service_.post([&notif]() { notif.Notify(); }, "InternalPubSubHandler.Constructor");
-  notif.WaitForNotification();
 }
 
 void InternalPubSubHandler::HandleGcsPublish(const rpc::GcsPublishRequest &request,

--- a/src/ray/gcs/gcs_server/pubsub_handler.h
+++ b/src/ray/gcs/gcs_server/pubsub_handler.h
@@ -26,8 +26,8 @@ namespace gcs {
 /// de-registering subscribers.
 class InternalPubSubHandler : public rpc::InternalPubSubHandler {
  public:
-  explicit InternalPubSubHandler(const std::shared_ptr<gcs::GcsPublisher> &gcs_publisher)
-      : gcs_publisher_(gcs_publisher) {}
+  InternalPubSubHandler(instrumented_io_context &io_service,
+                        const std::shared_ptr<gcs::GcsPublisher> &gcs_publisher);
 
   void HandleGcsPublish(const rpc::GcsPublishRequest &request,
                         rpc::GcsPublishReply *reply,
@@ -42,9 +42,15 @@ class InternalPubSubHandler : public rpc::InternalPubSubHandler {
       rpc::GcsSubscriberCommandBatchReply *reply,
       rpc::SendReplyCallback send_reply_callback) final;
 
+  // Stops the event loop and the thread of the pubsub handler.
+  void Stop();
+
   std::string DebugString() const;
 
  private:
+  /// Not owning the io service, to allow sharing it with pubsub::Publisher.
+  instrumented_io_context &io_service_;
+  std::unique_ptr<std::thread> io_service_thread_;
   std::shared_ptr<gcs::GcsPublisher> gcs_publisher_;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Use a separate event loop for pubsub work, to provide some isolation from other workload. There is no benchmark result but the downside, if there is any, should not be large.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
