### PR TITLE
[Cleanup] Use `mkstemp` 

### DIFF
--- a/python/ray/autoscaler/_private/cluster_dump.py
+++ b/python/ray/autoscaler/_private/cluster_dump.py
@@ -409,7 +409,7 @@ def create_and_get_archive_from_remote_node(remote_node: Node,
     cat = "node" if not remote_node.is_head else "head"
 
     cli_logger.print(f"Collecting data from remote node: {remote_node.host}")
-    _, tmp = tempfile.mkstemp(
+    tmp = tempfile.mkstemp(
         prefix=f"ray_{cat}_{remote_node.host}_", suffix=".tar.gz")[1]
     with open(tmp, "wb") as fp:
         try:

--- a/python/ray/autoscaler/_private/cluster_dump.py
+++ b/python/ray/autoscaler/_private/cluster_dump.py
@@ -84,8 +84,8 @@ class Archive:
     """
 
     def __init__(self, file: Optional[str] = None):
-        self.file = file or tempfile.mktemp(
-            prefix="ray_logs_", suffix=".tar.gz")
+        self.file = file or tempfile.mkstemp(
+            prefix="ray_logs_", suffix=".tar.gz")[1]
         self.tar = None
         self._lock = threading.Lock()
 
@@ -409,8 +409,8 @@ def create_and_get_archive_from_remote_node(remote_node: Node,
     cat = "node" if not remote_node.is_head else "head"
 
     cli_logger.print(f"Collecting data from remote node: {remote_node.host}")
-    tmp = tempfile.mktemp(
-        prefix=f"ray_{cat}_{remote_node.host}_", suffix=".tar.gz")
+    _, tmp = tempfile.mkstemp(
+        prefix=f"ray_{cat}_{remote_node.host}_", suffix=".tar.gz")[1]
     with open(tmp, "wb") as fp:
         try:
             subprocess.check_call(cmd, stdout=fp, stderr=sys.stderr)

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -62,7 +62,7 @@ class AutoscalingCluster:
         ray.init("auto").
         """
         subprocess.check_call(["ray", "stop", "--force"])
-        fake_config = tempfile.mktemp()
+        _, fake_config = tempfile.mkstemp()
         with open(fake_config, "w") as f:
             f.write(json.dumps(self._config))
         cmd = [

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -172,7 +172,7 @@ def test_fastapi_features(serve_instance):
             })
 
     def run_background(background_tasks: BackgroundTasks):
-        path = tempfile.mktemp()
+        _, path = tempfile.mkstemp()
 
         def write_to_file(p):
             with open(p, "w") as f:

--- a/python/ray/tune/tests/test_checkpoint_manager.py
+++ b/python/ray/tune/tests/test_checkpoint_manager.py
@@ -136,7 +136,7 @@ class CheckpointManagerTest(unittest.TestCase):
 
         tmpfiles = []
         for i in range(3):
-            tmpfile = tempfile.mktemp()
+            _, tmpfile = tempfile.mkstemp()
             with open(tmpfile, "wt") as fp:
                 fp.write("")
             tmpfiles.append(tmpfile)

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -2094,7 +2094,7 @@ class AsyncHyperBandSuite(unittest.TestCase):
             TrialScheduler.STOP)
 
     def testAsyncHBSaveRestore(self):
-        tmpfile = tempfile.mktemp()
+        _, tmpfile = tempfile.mkstemp()
 
         scheduler = AsyncHyperBandScheduler(
             metric="episode_reward_mean",

--- a/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
+++ b/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
@@ -389,7 +389,7 @@ def fetch_remote_directory_content(
         local_dir: str,
 ):
     def _pack(dir: str):
-        tmpfile = tempfile.mktemp()
+        _, tmpfile = tempfile.mkstemp()
         with tarfile.open(tmpfile, "w:gz") as tar:
             tar.add(dir, arcname="")
 
@@ -399,7 +399,7 @@ def fetch_remote_directory_content(
         return stream
 
     def _unpack(stream: str, dir: str):
-        tmpfile = tempfile.mktemp()
+        _, tmpfile = tempfile.mkstemp()
 
         with open(tmpfile, "wb") as f:
             f.write(stream)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* `tempfile.mktemp` is technically deprecated in favor of `tempfile.mkstemp` ([here](https://docs.python.org/3/library/tempfile.html#deprecated-functions-and-variables)).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
