### PR TITLE
[train] fix fashion mnist example

### DIFF
--- a/python/ray/train/examples/train_fashion_mnist_example.py
+++ b/python/ray/train/examples/train_fashion_mnist_example.py
@@ -144,18 +144,9 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Enables GPU training")
-    parser.add_argument(
-        "--smoke-test",
-        action="store_true",
-        default=False,
-        help="Finish quickly for testing.")
 
     args, _ = parser.parse_known_args()
 
     import ray
-
-    if args.smoke_test:
-        ray.init()
-    else:
-        ray.init(address=args.address)
+    ray.init(address=args.address)
     train_fashion_mnist(num_workers=args.num_workers, use_gpu=args.use_gpu)

--- a/python/ray/train/examples/train_fashion_mnist_example.py
+++ b/python/ray/train/examples/train_fashion_mnist_example.py
@@ -43,7 +43,8 @@ class NeuralNetwork(nn.Module):
 
 
 def train_epoch(dataloader, model, loss_fn, optimizer):
-    size = len(dataloader.dataset)
+    size = len(dataloader.dataset) // train.world_size()
+    model.train()
     for batch, (X, y) in enumerate(dataloader):
         # Compute prediction error
         pred = model(X)
@@ -60,7 +61,7 @@ def train_epoch(dataloader, model, loss_fn, optimizer):
 
 
 def validate_epoch(dataloader, model, loss_fn):
-    size = len(dataloader.dataset)
+    size = len(dataloader.dataset) // train.world_size()
     num_batches = len(dataloader)
     model.eval()
     test_loss, correct = 0, 0
@@ -82,9 +83,11 @@ def train_func(config: Dict):
     lr = config["lr"]
     epochs = config["epochs"]
 
+    worker_batch_size = batch_size // train.world_size()
+
     # Create data loaders.
-    train_dataloader = DataLoader(training_data, batch_size=batch_size)
-    test_dataloader = DataLoader(test_data, batch_size=batch_size)
+    train_dataloader = DataLoader(training_data, batch_size=worker_batch_size)
+    test_dataloader = DataLoader(test_data, batch_size=worker_batch_size)
 
     train_dataloader = train.torch.prepare_data_loader(train_dataloader)
     test_dataloader = train.torch.prepare_data_loader(test_dataloader)
@@ -152,7 +155,7 @@ if __name__ == "__main__":
     import ray
 
     if args.smoke_test:
-        ray.init(num_cpus=2)
+        ray.init()
     else:
         ray.init(address=args.address)
     train_fashion_mnist(num_workers=args.num_workers, use_gpu=args.use_gpu)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Making some minor fixes.

1. Update input `batch_size` to be global batch size. Introduce `worker_batch_size` so each iteration trains same global batch size.
2. Update dataset `size` calculation to only refer to the fraction of the data that is trained on each worker. This allows calculations (e.g. training progress, accuracy) to be correct.
3. Add `model.train()` for generality.
4. Remove `smoke-test` flag since it's not really being used.

## Related issue number

<!-- For example: "Closes #1234" -->
https://discuss.ray.io/t/train-fashion-mnist-example-accuracy-drops-when-num-workers-1/4735

## Checks

Successfully ran `python train_fashion_mnist_example.py --smoke-test --num-workers 4`

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
