### PR TITLE
[Core][nightly-test] enable debug log for dask_on_ray_* nightly test

### DIFF
--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -1,4 +1,5 @@
 base_image: "anyscale/ray:nightly-py37"
+env_vars: {"RAY_BACKEND_LOG_LEVEL": "debug"}
 debian_packages: []
 
 python:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We noticed a common pattern for those failures is worker failed to start up in time.
Given that we are not using runtime env, and the worker was alive during the timeout check, the another reason is gcs was busy thus the worker took longer time to register.

let's first enable debug log to see where the time spend.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
