### PR TITLE
[Test] First core nightly test migration to k8s

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -125,6 +125,7 @@ SERVE_NIGHTLY_TESTS = {
 
 CORE_DAILY_TESTS = {
     "~/ray/release/nightly_tests/nightly_tests.yaml": [
+        "k8s_dask_on_ray_large_scale_test_no_spilling",
         "dask_on_ray_large_scale_test_no_spilling",
         "dask_on_ray_large_scale_test_spilling",
         "pg_autoscaling_regression_test",

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute_k8s.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_stress_compute_k8s.yaml
@@ -1,0 +1,26 @@
+cloud_id: cld_HSrCZdMCYDe1NmMCJhYRgQ4p
+region: us-west-2
+
+aws:
+  TagSpecifications:
+    - ResourceType: "instance"
+      Tags:
+        - Key: anyscale-user
+          Value: '{{env["ANYSCALE_USER"]}}'
+        - Key: anyscale-expiration
+          Value: '{{env["EXPIRATION_1D"]}}'
+  BlockDeviceMappings:
+    - DeviceName: /dev/sda1
+      Ebs:
+        VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: m5.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.8xlarge
+      min_workers: 20
+      max_workers: 20
+      use_spot: false

--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -152,6 +152,18 @@
 #     prepare: python wait_cluster.py 20 900
 #     script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6 --no-streaming
 
+- name: k8s_dask_on_ray_large_scale_test_no_spilling
+  cluster:
+    app_config: dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+    compute_template: dask_on_ray/dask_on_ray_stress_compute_k8s.yaml
+    compute_on_k8s: True
+
+  run:
+    timeout: 7200
+    prepare: python wait_cluster.py 21 600
+    script: python dask_on_ray/large_scale_test.py --num_workers 20 --worker_obj_store_size_in_gb 20 --error_rate 0  --data_save_path /tmp/ray
+  stable: false
+
 # Test large scale dask on ray test without spilling.
 - name: dask_on_ray_large_scale_test_no_spilling
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The first migration of test into k8s. We are adopting a conservative approach (migrate slowly while we keep existing test suites). Once things are confirmed to be stable, we will migrate with more speed. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
