### PR TITLE
[tune/release] Demote xgboost_sweep to weekly testing

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -198,7 +198,6 @@ NIGHTLY_TESTS = {
         SmokeTest("network_overhead"),
         "result_throughput_cluster",
         "result_throughput_single_node",
-        "xgboost_sweep",
     ],
     "~/ray/release/xgboost_tests/xgboost_tests.yaml": [
         "train_small",
@@ -252,6 +251,7 @@ WEEKLY_TESTS = {
     "~/ray/release/tune_tests/scalability_tests/tune_tests.yaml": [
         "network_overhead",
         "long_running_large_checkpoints",
+        "xgboost_sweep",
     ],
     "~/ray/release/rllib_tests/rllib_tests.yaml": [
         "learning_tests",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

XGBoost functionality is tested daily in the xgboost release test suite. The expensive XGBoost sweep test can thus be run weekly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
