### PR TITLE
[autoscaler] Cap min and max workers for manually managed on-prem clusters.

### DIFF
--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -274,8 +274,6 @@ class AutoscalingConfigTest(unittest.TestCase):
         # Check that worker config numbers were clipped to 3.
         assert prepared_config == expected_prepared
 
-
-
     def testValidateNetworkConfig(self):
         web_yaml = "https://raw.githubusercontent.com/ray-project/ray/" \
             "master/python/ray/autoscaler/aws/example-full.yaml"

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -264,6 +264,18 @@ class AutoscalingConfigTest(unittest.TestCase):
             with pytest.raises(ClickException):
                 prepare_config(faulty_config)
 
+        too_many_workers_config = copy.deepcopy(base_config)
+
+        # More workers requested than the three available ips.
+        too_many_workers_config["max_workers"] = 10
+        too_many_workers_config["min_workers"] = 10
+        prepared_config = prepare_config(too_many_workers_config)
+
+        # Check that worker config numbers were clipped to 3.
+        assert prepared_config == expected_prepared
+
+
+
     def testValidateNetworkConfig(self):
         web_yaml = "https://raw.githubusercontent.com/ray-project/ray/" \
             "master/python/ray/autoscaler/aws/example-full.yaml"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Closes https://github.com/ray-project/ray/issues/19636 by capping min and max workers for manually managed on-prem clusters to the number of user-specified worker ips.

See https://github.com/ray-project/ray/issues/19636#issuecomment-1016664169 for additional context.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
