### PR TITLE
[Pubsub] improve error handling for GCS AIO subscribers in dashboard

### DIFF
--- a/dashboard/modules/node/node_head.py
+++ b/dashboard/modules/node/node_head.py
@@ -261,9 +261,11 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
 
         if self._dashboard_head.gcs_log_subscriber:
             while True:
-                log_batch = await \
-                    self._dashboard_head.gcs_log_subscriber.poll()
                 try:
+                    log_batch = await \
+                        self._dashboard_head.gcs_log_subscriber.poll()
+                    if log_batch is None:
+                        continue
                     process_log_batch(log_batch)
                 except Exception:
                     logger.exception("Error receiving log from GCS.")
@@ -304,9 +306,11 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
 
         if self._dashboard_head.gcs_error_subscriber:
             while True:
-                _, error_data = await \
-                    self._dashboard_head.gcs_error_subscriber.poll()
                 try:
+                    _, error_data = await \
+                        self._dashboard_head.gcs_error_subscriber.poll()
+                    if error_data is None:
+                        continue
                     process_error(error_data)
                 except Exception:
                     logger.exception("Error receiving error info from GCS.")

--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -108,6 +108,17 @@ class _SubscriberBase:
         return req
 
     @staticmethod
+    def _should_terminate_polling(e: grpc.RpcError) -> None:
+        # Caller only expects polling to be terminated after deadline exceeded.
+        if e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+            return True
+        # Could be a temporary connection issue. Suppress error.
+        # TODO: reconnect GRPC channel?
+        if e.code() == grpc.StatusCode.UNAVAILABLE:
+            return True
+        return False
+
+    @staticmethod
     def _pop_error_info(queue):
         if len(queue) == 0:
             return None, None
@@ -243,13 +254,7 @@ class _SyncSubscriber(_SubscriberBase):
                     # GRPC has not replied, continue waiting.
                     continue
                 except grpc.RpcError as e:
-                    # Choose to not raise deadline exceeded errors to the
-                    # caller. Instead return None. This can be revisited later.
-                    if e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
-                        return
-                    # Could be a temporary connection issue. Suppress error.
-                    # TODO: reconnect GRPC channel?
-                    if e.code() == grpc.StatusCode.UNAVAILABLE:
+                    if self._should_terminate_polling(e):
                         return
                     raise
 
@@ -514,9 +519,13 @@ class _AioSubscriber(_SubscriberBase):
             if poll not in done or close in done:
                 # Request timed out or subscriber closed.
                 break
-            # TODO(mwtian): Check for exception.
-            for msg in poll.result().pub_messages:
-                self._queue.append(msg)
+            try:
+                for msg in poll.result().pub_messages:
+                    self._queue.append(msg)
+            except grpc.RpcError as e:
+                if self._should_terminate_polling(e):
+                    return
+                raise
 
     async def close(self) -> None:
         """Closes the subscriber and its active subscription."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Tolerate GRPC deadline exceeded and transient failures in Python GCS AIO subscribers, which becomes consistent with Python GCS synchronous subscribers.
- Tolerate any exception in dashboard for subscribing to logs and error info, which becomes consistent with how dashboard handles GRPC errors for obtaining node stats.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
