### PR TITLE
Fix replace_symlinks_with_junctions for windows

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -378,7 +378,7 @@ def replace_symlinks_with_junctions():
 
     # Update this list if new symlinks are introduced to the source tree
     _LINKS = {
-        r"ray\new_dashboard": "../../dashboard",
+        r"ray\dashboard": "../../dashboard",
         r"ray\rllib": "../../rllib",
     }
     root_dir = os.path.dirname(__file__)
@@ -416,7 +416,7 @@ def replace_symlinks_with_junctions():
                 os.path.join(os.path.dirname(path), target))
             logger.info("Setting {} -> {}".format(link, target))
             subprocess.check_call(
-                f"MKLINK /J '{os.path.basename(link)}' '{target}'",
+                f'MKLINK /J "{os.path.basename(link)}" "{target}"',
                 shell=True,
                 cwd=os.path.dirname(path))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Windows cmd.exe doesn't interpret single quote correctly. See https://github.com/conda-forge/ray-packages-feedstock/pull/43

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
