### PR TITLE
[autoscaler][core] Kludge for compatibility.

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -560,14 +560,24 @@ if __name__ == "__main__":
     logger.info(f"Ray version: {ray.__version__}")
     logger.info(f"Ray commit: {ray.__commit__}")
     logger.info(f"Monitor started with command: {sys.argv}")
+    print(args)
 
     if args.autoscaling_config:
         autoscaling_config = os.path.expanduser(args.autoscaling_config)
     else:
         autoscaling_config = None
 
+    # Kludge introduced for compatibility: In no-redis mode, interpret
+    # the `--redis-address` argument as the gcs address.
+    if use_gcs_for_bootstrap() and not args.gcs_address:
+        assert args.redis_address
+        gcs_address = args.redis_address
+    elif use_gcs_for_bootstrap() and args.gcs_address:
+        # The common case.
+        gcs_address = args.gcs_address
+
     monitor = Monitor(
-        args.gcs_address if use_gcs_for_bootstrap() else args.redis_address,
+        gcs_address if use_gcs_for_bootstrap() else args.redis_address,
         autoscaling_config,
         redis_password=args.redis_password,
         monitor_ip=args.monitor_ip)

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -560,7 +560,6 @@ if __name__ == "__main__":
     logger.info(f"Ray version: {ray.__version__}")
     logger.info(f"Ray commit: {ray.__commit__}")
     logger.info(f"Monitor started with command: {sys.argv}")
-    print(args)
 
     if args.autoscaling_config:
         autoscaling_config = os.path.expanduser(args.autoscaling_config)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In certain legacy systems, it's awkward to change the command line arguments of the monitor.py entry-point.
Thus when in "no-redis" mode we may need to interpret the `--redis-address` argument as the gcs address.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
