### PR TITLE
[gcs/ha] Fix global_state_accessor_test to support redisless mode

### DIFF
--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -26,7 +26,7 @@ namespace ray {
 class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
  public:
   GlobalStateAccessorTest() {
-    if(GetParam()) {
+    if (GetParam()) {
       RayConfig::instance().bootstrap_with_gcs() = true;
       RayConfig::instance().gcs_storage() = "memory";
       RayConfig::instance().gcs_grpc_based_pubsub() = true;
@@ -36,13 +36,13 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
       RayConfig::instance().gcs_grpc_based_pubsub() = false;
     }
 
-    if(!RayConfig::instance().bootstrap_with_gcs()) {
+    if (!RayConfig::instance().bootstrap_with_gcs()) {
       TestSetupUtil::StartUpRedisServers(std::vector<int>());
     }
   }
 
   virtual ~GlobalStateAccessorTest() {
-    if(!RayConfig::instance().bootstrap_with_gcs()) {
+    if (!RayConfig::instance().bootstrap_with_gcs()) {
       TestSetupUtil::ShutDownRedisServers();
     }
   }
@@ -50,7 +50,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
     RayConfig::instance().gcs_max_active_rpcs_per_handler() = -1;
-    if(RayConfig::instance().bootstrap_with_gcs()) {
+    if (RayConfig::instance().bootstrap_with_gcs()) {
       config.grpc_server_port = 6379;
       config.grpc_pubsub_enabled = true;
     } else {
@@ -65,7 +65,6 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
     config.grpc_server_name = "MockedGcsServer";
     config.grpc_server_thread_num = 1;
 
-
     io_service_.reset(new instrumented_io_context());
     gcs_server_.reset(new gcs::GcsServer(config, *io_service_));
     gcs_server_->Start();
@@ -78,7 +77,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
     }
 
     // Create GCS client and global state.
-    if(RayConfig::instance().bootstrap_with_gcs()) {
+    if (RayConfig::instance().bootstrap_with_gcs()) {
       gcs::GcsClientOptions options("127.0.0.1:6379");
       gcs_client_ = std::make_unique<gcs::GcsClient>(options);
       global_state_ = std::make_unique<gcs::GlobalStateAccessor>(options);
@@ -101,7 +100,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
     gcs_client_.reset();
 
     gcs_server_->Stop();
-    if(!RayConfig::instance().bootstrap_with_gcs()) {
+    if (!RayConfig::instance().bootstrap_with_gcs()) {
       TestSetupUtil::FlushAllRedisServers();
     }
 
@@ -124,8 +123,6 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
   // Timeout waiting for GCS server reply, default is 2s.
   const std::chrono::milliseconds timeout_ms_{2000};
   std::unique_ptr<boost::asio::io_service::work> work_;
-
-
 };
 
 TEST_P(GlobalStateAccessorTest, TestJobTable) {
@@ -311,10 +308,8 @@ TEST_P(GlobalStateAccessorTest, TestPlacementGroupTable) {
   ASSERT_EQ(global_state_->GetAllPlacementGroupInfo().size(), 0);
 }
 
-INSTANTIATE_TEST_CASE_P(
-    RedisRemovalTest,
-    GlobalStateAccessorTest,
-    ::testing::Values(false, true));
+INSTANTIATE_TEST_CASE_P(RedisRemovalTest, GlobalStateAccessorTest,
+                        ::testing::Values(false, true));
 
 }  // namespace ray
 

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -23,22 +23,48 @@
 
 namespace ray {
 
-class GlobalStateAccessorTest : public ::testing::Test {
+class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
  public:
-  GlobalStateAccessorTest() { TestSetupUtil::StartUpRedisServers(std::vector<int>()); }
+  GlobalStateAccessorTest() {
+    if(GetParam()) {
+      RayConfig::instance().bootstrap_with_gcs() = true;
+      RayConfig::instance().gcs_storage() = "memory";
+      RayConfig::instance().gcs_grpc_based_pubsub() = true;
+    } else {
+      RayConfig::instance().bootstrap_with_gcs() = false;
+      RayConfig::instance().gcs_storage() = "redis";
+      RayConfig::instance().gcs_grpc_based_pubsub() = false;
+    }
 
-  virtual ~GlobalStateAccessorTest() { TestSetupUtil::ShutDownRedisServers(); }
+    if(!RayConfig::instance().bootstrap_with_gcs()) {
+      TestSetupUtil::StartUpRedisServers(std::vector<int>());
+    }
+  }
+
+  virtual ~GlobalStateAccessorTest() {
+    if(!RayConfig::instance().bootstrap_with_gcs()) {
+      TestSetupUtil::ShutDownRedisServers();
+    }
+  }
 
  protected:
   void SetUp() override {
     RayConfig::instance().gcs_max_active_rpcs_per_handler() = -1;
-    config.grpc_server_port = 0;
+    if(RayConfig::instance().bootstrap_with_gcs()) {
+      config.grpc_server_port = 6379;
+      config.grpc_pubsub_enabled = true;
+    } else {
+      config.grpc_server_port = 0;
+      config.redis_address = "127.0.0.1";
+      config.enable_sharding_conn = false;
+      config.grpc_pubsub_enabled = false;
+      config.redis_port = TEST_REDIS_SERVER_PORTS.front();
+    }
+
+    config.node_ip_address = "127.0.0.1";
     config.grpc_server_name = "MockedGcsServer";
     config.grpc_server_thread_num = 1;
-    config.redis_address = "127.0.0.1";
-    config.node_ip_address = "127.0.0.1";
-    config.enable_sharding_conn = false;
-    config.redis_port = TEST_REDIS_SERVER_PORTS.front();
+
 
     io_service_.reset(new instrumented_io_context());
     gcs_server_.reset(new gcs::GcsServer(config, *io_service_));
@@ -51,14 +77,19 @@ class GlobalStateAccessorTest : public ::testing::Test {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
-    // Create GCS client.
-    gcs::GcsClientOptions options(config.redis_address, config.redis_port,
-                                  config.redis_password);
-    gcs_client_ = std::make_unique<gcs::GcsClient>(options);
+    // Create GCS client and global state.
+    if(RayConfig::instance().bootstrap_with_gcs()) {
+      gcs::GcsClientOptions options("127.0.0.1:6379");
+      gcs_client_ = std::make_unique<gcs::GcsClient>(options);
+      global_state_ = std::make_unique<gcs::GlobalStateAccessor>(options);
+    } else {
+      gcs::GcsClientOptions options(config.redis_address, config.redis_port,
+                                    config.redis_password);
+      gcs_client_ = std::make_unique<gcs::GcsClient>(options);
+      global_state_ = std::make_unique<gcs::GlobalStateAccessor>(options);
+    }
     RAY_CHECK_OK(gcs_client_->Connect(*io_service_));
 
-    // Create global state.
-    global_state_ = std::make_unique<gcs::GlobalStateAccessor>(options);
     RAY_CHECK(global_state_->Connect());
   }
 
@@ -70,7 +101,9 @@ class GlobalStateAccessorTest : public ::testing::Test {
     gcs_client_.reset();
 
     gcs_server_->Stop();
-    TestSetupUtil::FlushAllRedisServers();
+    if(!RayConfig::instance().bootstrap_with_gcs()) {
+      TestSetupUtil::FlushAllRedisServers();
+    }
 
     io_service_->stop();
     thread_io_service_->join();
@@ -91,9 +124,11 @@ class GlobalStateAccessorTest : public ::testing::Test {
   // Timeout waiting for GCS server reply, default is 2s.
   const std::chrono::milliseconds timeout_ms_{2000};
   std::unique_ptr<boost::asio::io_service::work> work_;
+
+
 };
 
-TEST_F(GlobalStateAccessorTest, TestJobTable) {
+TEST_P(GlobalStateAccessorTest, TestJobTable) {
   int job_count = 100;
   ASSERT_EQ(global_state_->GetAllJobInfo().size(), 0);
   for (int index = 0; index < job_count; ++index) {
@@ -107,7 +142,7 @@ TEST_F(GlobalStateAccessorTest, TestJobTable) {
   ASSERT_EQ(global_state_->GetAllJobInfo().size(), job_count);
 }
 
-TEST_F(GlobalStateAccessorTest, TestNodeTable) {
+TEST_P(GlobalStateAccessorTest, TestNodeTable) {
   int node_count = 100;
   ASSERT_EQ(global_state_->GetAllNodeInfo().size(), 0);
   // It's useful to check if index value will be marked as address suffix.
@@ -129,7 +164,7 @@ TEST_F(GlobalStateAccessorTest, TestNodeTable) {
   }
 }
 
-TEST_F(GlobalStateAccessorTest, TestNodeResourceTable) {
+TEST_P(GlobalStateAccessorTest, TestNodeResourceTable) {
   int node_count = 100;
   ASSERT_EQ(global_state_->GetAllNodeInfo().size(), 0);
   for (int index = 0; index < node_count; ++index) {
@@ -165,7 +200,7 @@ TEST_F(GlobalStateAccessorTest, TestNodeResourceTable) {
   }
 }
 
-TEST_F(GlobalStateAccessorTest, TestGetAllResourceUsage) {
+TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   std::unique_ptr<std::string> resources = global_state_->GetAllResourceUsage();
   rpc::ResourceUsageBatchData resource_usage_batch_data;
   resource_usage_batch_data.ParseFromString(*resources.get());
@@ -235,7 +270,7 @@ TEST_F(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   ASSERT_EQ((*resources_data.mutable_resources_available())["GPU"], 5.0);
 }
 
-TEST_F(GlobalStateAccessorTest, TestProfileTable) {
+TEST_P(GlobalStateAccessorTest, TestProfileTable) {
   int profile_count = RayConfig::instance().maximum_profile_table_rows_count() + 1;
   ASSERT_EQ(global_state_->GetAllProfileInfo().size(), 0);
   for (int index = 0; index < profile_count; ++index) {
@@ -251,7 +286,7 @@ TEST_F(GlobalStateAccessorTest, TestProfileTable) {
             RayConfig::instance().maximum_profile_table_rows_count());
 }
 
-TEST_F(GlobalStateAccessorTest, TestWorkerTable) {
+TEST_P(GlobalStateAccessorTest, TestWorkerTable) {
   ASSERT_EQ(global_state_->GetAllWorkerInfo().size(), 0);
   // Add worker info
   auto worker_table_data = Mocker::GenWorkerTableData();
@@ -272,9 +307,14 @@ TEST_F(GlobalStateAccessorTest, TestWorkerTable) {
 }
 
 // TODO(sang): Add tests after adding asyncAdd
-TEST_F(GlobalStateAccessorTest, TestPlacementGroupTable) {
+TEST_P(GlobalStateAccessorTest, TestPlacementGroupTable) {
   ASSERT_EQ(global_state_->GetAllPlacementGroupInfo().size(), 0);
 }
+
+INSTANTIATE_TEST_CASE_P(
+    RedisRemovalTest,
+    GlobalStateAccessorTest,
+    ::testing::Values(false, true));
 
 }  // namespace ray
 

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -308,8 +308,8 @@ TEST_P(GlobalStateAccessorTest, TestPlacementGroupTable) {
   ASSERT_EQ(global_state_->GetAllPlacementGroupInfo().size(), 0);
 }
 
-INSTANTIATE_TEST_CASE_P(RedisRemovalTest, GlobalStateAccessorTest,
-                        ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(RedisRemovalTest, GlobalStateAccessorTest,
+                         ::testing::Values(false, true));
 
 }  // namespace ray
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR enables global_state_accessor_test to support redisless mode so that we can enable the flag by default in the future.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
