### PR TITLE
[RLlib] Fix time dimension shaping for PyTorch RNN models.

### DIFF
--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -185,6 +185,7 @@ def add_time_dimension(
     if framework in ["tf2", "tf", "tfe"]:
         assert time_major is False, "time-major not supported yet for tf!"
         padded_batch_size = tf.shape(padded_inputs)[0]
+        max_seq_len = tf.constant(max_seq_len, dtype=tf.shape(padded_inputs).dtype)
         # Dynamically reshape the padded batch to introduce a time dimension.
         new_batch_size = padded_batch_size // max_seq_len
         new_shape = tf.squeeze(

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -206,8 +206,7 @@ def add_time_dimension(
 
         # Dynamically reshape the padded batch to introduce a time dimension.
         new_batch_size = padded_batch_size // max_seq_len
-        batch_major_shape = \
-            (new_batch_size, max_seq_len) + padded_inputs.shape[1:]
+        batch_major_shape = (new_batch_size, max_seq_len) + padded_inputs.shape[1:]
         padded_outputs = padded_inputs.view(batch_major_shape)
 
         if time_major:

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -206,11 +206,12 @@ def add_time_dimension(
 
         # Dynamically reshape the padded batch to introduce a time dimension.
         new_batch_size = padded_batch_size // max_seq_len
+        batch_major_shape = (new_batch_size, max_seq_len) + padded_inputs.shape[1:]
+        padded_outputs = padded_inputs.view(batch_major_shape)
+
         if time_major:
-            new_shape = (max_seq_len, new_batch_size) + padded_inputs.shape[1:]
-        else:
-            new_shape = (new_batch_size, max_seq_len) + padded_inputs.shape[1:]
-        return torch.reshape(padded_inputs, new_shape)
+            padded_outputs = padded_outputs.transpose(0, 1)  # swap the batch and time dimensions
+        return padded_outputs
 
 
 @DeveloperAPI

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -206,11 +206,13 @@ def add_time_dimension(
 
         # Dynamically reshape the padded batch to introduce a time dimension.
         new_batch_size = padded_batch_size // max_seq_len
-        batch_major_shape = (new_batch_size, max_seq_len) + padded_inputs.shape[1:]
+        batch_major_shape = \
+            (new_batch_size, max_seq_len) + padded_inputs.shape[1:]
         padded_outputs = padded_inputs.view(batch_major_shape)
 
         if time_major:
-            padded_outputs = padded_outputs.transpose(0, 1)  # swap the batch and time dimensions
+            # Swap the batch and time dimensions
+            padded_outputs = padded_outputs.transpose(0, 1)
         return padded_outputs
 
 

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -185,7 +185,6 @@ def add_time_dimension(
     if framework in ["tf2", "tf", "tfe"]:
         assert time_major is False, "time-major not supported yet for tf!"
         padded_batch_size = tf.shape(padded_inputs)[0]
-        max_seq_len = tf.constant(max_seq_len, dtype=tf.shape(padded_inputs).dtype)
         # Dynamically reshape the padded batch to introduce a time dimension.
         new_batch_size = padded_batch_size // max_seq_len
         new_shape = tf.squeeze(

--- a/rllib/policy/tests/test_rnn_sequencing.py
+++ b/rllib/policy/tests/test_rnn_sequencing.py
@@ -2,10 +2,18 @@ import numpy as np
 import unittest
 
 import ray
-from ray.rllib.policy.rnn_sequencing import pad_batch_to_sequences_of_same_size
+from ray.rllib.policy.rnn_sequencing import (
+    pad_batch_to_sequences_of_same_size,
+    add_time_dimension,
+)
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.view_requirement import ViewRequirement
+from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.test_utils import check
+
+
+tf1, tf, tfv = try_import_tf()
+torch, nn = try_import_torch()
 
 
 class TestRNNSequencing(unittest.TestCase):
@@ -88,6 +96,47 @@ class TestRNNSequencing(unittest.TestCase):
         check(s1.max_seq_len, max_seq_len)
         check(s1["a"].shape[0], max_seq_len * num_seqs)
         check(s1["b"].shape[0], max_seq_len * num_seqs)
+
+    def test_add_time_dimension(self):
+        """Test add_time_dimension gives sequential data along the time dimension"""
+
+        B, T, F = np.random.choice(list(range(8, 32)), size=3, replace=False)
+
+        inputs_numpy = np.repeat(np.arange(B * T)[:, np.newaxis], repeats=F,
+                                 axis=-1).astype(np.int64)
+        check(inputs_numpy.shape, (B * T, F))
+
+        time_shift_diff_batch_major = np.ones(shape=(B, T - 1, F), dtype=np.int64)
+        time_shift_diff_time_major = np.ones(shape=(T - 1, B, F), dtype=np.int64)
+
+        if tf is not None:
+            # Test tensorflow batch-major
+            padded_inputs = tf.constant(inputs_numpy)
+            batch_major_outputs = add_time_dimension(
+                padded_inputs, max_seq_len=T, framework="tf", time_major=False
+            )
+            check(batch_major_outputs.shape.as_list(), [B, T, F])
+            time_shift_diff = batch_major_outputs[:, 1:] - batch_major_outputs[:, :-1]
+            check(time_shift_diff, time_shift_diff_batch_major)
+
+        if torch is not None:
+            # Test torch batch-major
+            padded_inputs = torch.from_numpy(inputs_numpy)
+            batch_major_outputs = add_time_dimension(
+                padded_inputs, max_seq_len=T, framework="torch", time_major=False
+            )
+            check(batch_major_outputs.shape, (B, T, F))
+            time_shift_diff = batch_major_outputs[:, 1:] - batch_major_outputs[:, :-1]
+            check(time_shift_diff, time_shift_diff_batch_major)
+
+            # Test torch time-major
+            padded_inputs = torch.from_numpy(inputs_numpy)
+            time_major_outputs = add_time_dimension(
+                padded_inputs, max_seq_len=T, framework="torch", time_major=True
+            )
+            check(time_major_outputs.shape, (T, B, F))
+            time_shift_diff = time_major_outputs[1:] - time_major_outputs[:-1]
+            check(time_shift_diff, time_shift_diff_time_major)
 
 
 if __name__ == "__main__":

--- a/rllib/policy/tests/test_rnn_sequencing.py
+++ b/rllib/policy/tests/test_rnn_sequencing.py
@@ -104,11 +104,11 @@ class TestRNNSequencing(unittest.TestCase):
 
         inputs_numpy = np.repeat(
             np.arange(B * T)[:, np.newaxis], repeats=F, axis=-1
-        ).astype(np.int64)
+        ).astype(np.int32)
         check(inputs_numpy.shape, (B * T, F))
 
-        time_shift_diff_batch_major = np.ones(shape=(B, T - 1, F), dtype=np.int64)
-        time_shift_diff_time_major = np.ones(shape=(T - 1, B, F), dtype=np.int64)
+        time_shift_diff_batch_major = np.ones(shape=(B, T - 1, F), dtype=np.int32)
+        time_shift_diff_time_major = np.ones(shape=(T - 1, B, F), dtype=np.int32)
 
         if tf is not None:
             # Test tensorflow batch-major

--- a/rllib/policy/tests/test_rnn_sequencing.py
+++ b/rllib/policy/tests/test_rnn_sequencing.py
@@ -102,8 +102,9 @@ class TestRNNSequencing(unittest.TestCase):
 
         B, T, F = np.random.choice(list(range(8, 32)), size=3, replace=False)
 
-        inputs_numpy = np.repeat(np.arange(B * T)[:, np.newaxis], repeats=F,
-                                 axis=-1).astype(np.int64)
+        inputs_numpy = np.repeat(
+            np.arange(B * T)[:, np.newaxis], repeats=F, axis=-1
+        ).astype(np.int64)
         check(inputs_numpy.shape, (B * T, F))
 
         time_shift_diff_batch_major = np.ones(shape=(B, T - 1, F), dtype=np.int64)

--- a/rllib/policy/tests/test_rnn_sequencing.py
+++ b/rllib/policy/tests/test_rnn_sequencing.py
@@ -100,7 +100,11 @@ class TestRNNSequencing(unittest.TestCase):
     def test_add_time_dimension(self):
         """Test add_time_dimension gives sequential data along the time dimension"""
 
-        B, T, F = np.random.choice(list(range(8, 32)), size=3, replace=False)
+        B, T, F = np.random.choice(
+            np.asarray(list(range(8, 32)), dtype=np.int32),  # use int32 for seq_lens
+            size=3,
+            replace=False,
+        )
 
         inputs_numpy = np.repeat(
             np.arange(B * T)[:, np.newaxis], repeats=F, axis=-1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

- Fix `tensor.reshape` to `tensor.transpose` when storing data in time-major format. See https://github.com/ray-project/ray/issues/13075#issuecomment-1017425289 for more details.
- Use `tensor.view` instead of `tensor.reshape`, which will not create a new tensor instance.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #13075

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
