### PR TITLE
[Core] [Docs] Document redirecting Ray logs to stdout/stderr via `GLOG_logtostderr` environment variable

### DIFF
--- a/doc/source/ray-observability/ray-logging.rst
+++ b/doc/source/ray-observability/ray-logging.rst
@@ -103,30 +103,30 @@ Logging directory structure
 ---------------------------
 .. _logging-directory-structure:
 
-By default, Ray logs are stored in a `/tmp/ray/session_*/logs` directory. 
+By default, Ray logs are stored in a ``/tmp/ray/session_*/logs`` directory. 
 
 .. note::
 
-    The default temp directory is `/tmp/ray` (for Linux and Mac OS). If you'd like to change the temp directory, you can specify it when `ray start` or `ray.init()` is called. 
+    The default temp directory is ``/tmp/ray`` (for Linux and Mac OS). If you'd like to change the temp directory, you can specify it when ``ray start`` or ``ray.init()`` is called. 
 
-A new Ray instance creates a new session ID to the temp directory. The latest session ID is symlinked to `/tmp/ray/session_latest`.
+A new Ray instance creates a new session ID to the temp directory. The latest session ID is symlinked to ``/tmp/ray/session_latest``.
 
-Here's a Ray log directory structure. Note that `.out` is logs from stdout/stderr and `.err` is logs from stderr. The backward compatibility of log directories is not maintained.
+Here's a Ray log directory structure. Note that ``.out`` is logs from stdout/stderr and ``.err`` is logs from stderr. The backward compatibility of log directories is not maintained.
 
-- `dashboard.log`: A log file of a Ray dashboard.
-- `dashboard_agent.log`: Every Ray node has one dashboard agent. This is a log file of the agent.
-- `gcs_server.[out|err]`: The GCS server is a stateless server that manages business logic that needs to be performed on GCS (Redis). It exists only in the head node.
-- `log_monitor.log`: The log monitor is in charge of streaming logs to the driver.
-- `monitor.log`: Ray's cluster launcher is operated with a monitor process. It also manages the autoscaler.
-- `monitor.[out|err]`: Stdout and stderr of a cluster launcher.
-- `plasma_store.[out|err]`: Deprecated.
-- `python-core-driver-[worker_id]_[pid].log`: Ray drivers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
-- `python-core-worker-[worker_id]_[pid].log`: Ray workers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
-- `raylet.[out|err]`: A log file of raylets.
-- `redis-shard_[shard_index].[out|err]`: A log file of GCS (Redis by default) shards.
-- `redis.[out|err]`: A log file of GCS (Redis by default).
-- `worker-[worker_id]-[job_id]-[pid].[out|err]`: Python/Java part of Ray drivers and workers. All of stdout and stderr from tasks/actors are streamed here. Note that job_id is an id of the driver.
-- `io-worker-[worker_id]-[pid].[out|err]`: Ray creates IO workers to spill/restore objects to external storage by default from Ray 1.3+. This is a log file of IO workers.
+- ``dashboard.log``: A log file of a Ray dashboard.
+- ``dashboard_agent.log``: Every Ray node has one dashboard agent. This is a log file of the agent.
+- ``gcs_server.[out|err]``: The GCS server is a stateless server that manages business logic that needs to be performed on GCS (Redis). It exists only in the head node.
+- ``log_monitor.log``: The log monitor is in charge of streaming logs to the driver.
+- ``monitor.log``: Ray's cluster launcher is operated with a monitor process. It also manages the autoscaler.
+- ``monitor.[out|err]``: Stdout and stderr of a cluster launcher.
+- ``plasma_store.[out|err]``: Deprecated.
+- ``python-core-driver-[worker_id]_[pid].log``: Ray drivers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
+- ``python-core-worker-[worker_id]_[pid].log``: Ray workers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
+- ``raylet.[out|err]``: A log file of raylets.
+- ``redis-shard_[shard_index].[out|err]``: A log file of GCS (Redis by default) shards.
+- ``redis.[out|err]``: A log file of GCS (Redis by default).
+- ``worker-[worker_id]-[job_id]-[pid].[out|err]``: Python/Java part of Ray drivers and workers. All of stdout and stderr from tasks/actors are streamed here. Note that job_id is an id of the driver.
+- ``io-worker-[worker_id]-[pid].[out|err]``: Ray creates IO workers to spill/restore objects to external storage by default from Ray 1.3+. This is a log file of IO workers.
 
 Log rotation
 ------------
@@ -140,3 +140,43 @@ If you'd like to change the log rotation configuration, you can do it by specify
     RAY_ROTATION_MAX_BYTES=1024; ray start --head # Start a ray instance with maxBytes 1KB.
     RAY_ROTATION_BACKUP_COUNT=1; ray start --head # Start a ray instance with backupCount 1.
 
+Redirecting Ray logs to stdout/stderr
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, Ray logs are written to files under the ``/tmp/ray/session_*/logs`` directory. If you wish to redirect all internal Ray logging and your own logging within tasks/actors to stdout/stderr of the host nodes, you can do so by ensuring that the ``GLOG_logtostderr=1`` environment variable is set on the driver and on all Ray nodes. This is very useful if you are using a log aggregator that needs log records to be written to stdout/stderr in order for them to be captured.
+
+When running a local Ray cluster, this environment variable should be set before starting the local cluster:
+
+.. code-block:: python
+
+    os.environ["GLOG_logtostderr"] = "1"
+    ray.init()
+
+When starting a local cluster via the CLI or when starting nodes in a multi-node Ray cluster, this environment variable should be set before starting up each node:
+
+.. code-block:: bash
+
+    env GLOG_logtostderr=1 ray start
+
+If using the Ray cluster launcher, you would specify this environment variable in the Ray start commands:
+
+.. code-block:: bash
+
+    head_start_ray_commands:
+        - ray stop
+        - env GLOG_logtostderr=1 ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+    
+    worker_start_ray_commands:
+        - ray stop
+        - env GLOG_logtostderr=1 ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+ 
+When connecting to the cluster, be sure to set the environment variable before connecting:
+
+.. code-block:: python
+
+    os.environ["GLOG_logtostderr"] = "1"
+    ray.init(address="auto")
+    
+Caveats
+-------
+
+This feature does not yet have complete coverage, i.e. there are some Ray components that will still log to files even if this environment variable is set. See the following issue for the current status of this feature: https://github.com/ray-project/ray/issues/21707

--- a/doc/source/ray-observability/ray-logging.rst
+++ b/doc/source/ray-observability/ray-logging.rst
@@ -141,7 +141,7 @@ If you'd like to change the log rotation configuration, you can do it by specify
     RAY_ROTATION_BACKUP_COUNT=1; ray start --head # Start a ray instance with backupCount 1.
 
 Redirecting Ray logs to stdout/stderr
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 By default, Ray logs are written to files under the ``/tmp/ray/session_*/logs`` directory. If you wish to redirect all internal Ray logging and your own logging within tasks/actors to stdout/stderr of the host nodes, you can do so by ensuring that the ``GLOG_logtostderr=1`` environment variable is set on the driver and on all Ray nodes. This is very useful if you are using a log aggregator that needs log records to be written to stdout/stderr in order for them to be captured.
 
 When running a local Ray cluster, this environment variable should be set before starting the local cluster:


### PR DESCRIPTION
We currently support redirecting the logs of application code (user code in tasks/actors) and most Ray components via the `GLOG_logtostderr` environment variable. This PR adds documentation for this feature.

Note that not all Ray components properly redirect to stdout/stderr when this environment variable is set. The linked issue will be updated to contain a tracking list of the missing coverage.

## Drivebys

- Changed italicized file paths and inlined code in the "Logging directory structure" section to be formatted as inline code, which I believe was the original intention.

## Related issue number

Towards #21707 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
