### PR TITLE
[Core] [Releaser] Fix e2e.py help info for --report

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -2312,7 +2312,7 @@ if __name__ == "__main__":
         "--report",
         action="store_true",
         default=False,
-        help="Do not report any results or upload to S3")
+        help="Whether to report results and upload to S3")
     parser.add_argument(
         "--kick-off-only",
         action="store_true",


### PR DESCRIPTION
This momentarily confused me as to whether `--report` would enable or disable reporting.