### PR TITLE
[Dashboard] offload blocking work to a thread pool

### DIFF
--- a/dashboard/modules/actor/actor_head.py
+++ b/dashboard/modules/actor/actor_head.py
@@ -144,9 +144,11 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
             while True:
                 try:
                     actor_id, actor_table_data = await subscriber.poll()
-                    # Convert to lower case hex ID.
-                    actor_id = actor_id.hex()
-                    process_actor_data_from_pubsub(actor_id, actor_table_data)
+                    if actor_id is not None:
+                        # Convert to lower case hex ID.
+                        actor_id = actor_id.hex()
+                        process_actor_data_from_pubsub(actor_id,
+                                                       actor_table_data)
                 except Exception:
                     logger.exception("Error processing actor info from GCS.")
 

--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -1,3 +1,5 @@
+import asyncio
+import concurrent.futures
 from typing import Any, Dict, List, Optional
 import hashlib
 
@@ -25,9 +27,11 @@ class APIHead(dashboard_utils.DashboardHeadModule):
         self._gcs_job_info_stub = None
         self._gcs_actor_info_stub = None
         self._dashboard_head = dashboard_head
-
         assert _internal_kv_initialized()
         self._job_status_client = JobStatusStorageClient()
+        # For offloading CPU intensive work.
+        self._thread_pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="api_head")
 
     @routes.get("/api/actors/kill")
     async def kill_actor_gcs(self, req) -> aiohttp.web.Response:
@@ -160,32 +164,35 @@ class APIHead(dashboard_utils.DashboardHeadModule):
         # Serve wraps Ray's internal KV store and specially formats the keys.
         # These are the keys we are interested in:
         # SERVE_CONTROLLER_NAME(+ optional random letters):SERVE_SNAPSHOT_KEY
+        def get_deployments():
+            serve_keys = _internal_kv_list(
+                SERVE_CONTROLLER_NAME,
+                namespace=ray_constants.KV_NAMESPACE_SERVE)
+            serve_snapshot_keys = filter(
+                lambda k: SERVE_SNAPSHOT_KEY in str(k), serve_keys)
 
-        serve_keys = _internal_kv_list(
-            SERVE_CONTROLLER_NAME, namespace=ray_constants.KV_NAMESPACE_SERVE)
-        serve_snapshot_keys = filter(lambda k: SERVE_SNAPSHOT_KEY in str(k),
-                                     serve_keys)
+            deployments_per_controller: List[Dict[str, Any]] = []
+            for key in serve_snapshot_keys:
+                val_bytes = _internal_kv_get(
+                    key, namespace=ray_constants.KV_NAMESPACE_SERVE
+                ) or "{}".encode("utf-8")
+                deployments_per_controller.append(
+                    json.loads(val_bytes.decode("utf-8")))
+            # Merge the deployments dicts of all controllers.
+            deployments: Dict[str, Any] = {
+                k: v
+                for d in deployments_per_controller for k, v in d.items()
+            }
+            # Replace the keys (deployment names) with their hashes to prevent
+            # collisions caused by the automatic conversion to camelcase by the
+            # dashboard agent.
+            return {
+                hashlib.sha1(name.encode()).hexdigest(): info
+                for name, info in deployments.items()
+            }
 
-        deployments_per_controller: List[Dict[str, Any]] = []
-        for key in serve_snapshot_keys:
-            val_bytes = _internal_kv_get(
-                key, namespace=ray_constants.KV_NAMESPACE_SERVE
-            ) or "{}".encode("utf-8")
-            deployments_per_controller.append(
-                json.loads(val_bytes.decode("utf-8")))
-        # Merge the deployments dicts of all controllers.
-        deployments: Dict[str, Any] = {
-            k: v
-            for d in deployments_per_controller for k, v in d.items()
-        }
-        # Replace the keys (deployment names) with their hashes to prevent
-        # collisions caused by the automatic conversion to camelcase by the
-        # dashboard agent.
-        deployments = {
-            hashlib.sha1(name.encode()).hexdigest(): info
-            for name, info in deployments.items()
-        }
-        return deployments
+        return await asyncio.get_running_loop().run_in_executor(
+            executor=self._thread_pool, func=get_deployments)
 
     async def get_session_name(self):
         # TODO(yic): Use async version if performance is an issue

--- a/dashboard/modules/snapshot/tests/test_job_submission.py
+++ b/dashboard/modules/snapshot/tests/test_job_submission.py
@@ -54,8 +54,8 @@ def test_successful_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
                 assert job_entry["status"] in {
                     "PENDING", "RUNNING", "SUCCEEDED"
                 }
-                return job_entry["status"] == "SUCCEEDED"
                 assert job_entry["statusMessage"] is not None
+                return job_entry["status"] == "SUCCEEDED"
 
         return False
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, GCS KV client only has blocking API. Calling them from dashboard event loop can block other operations for many seconds, leading to failures such as taking too long (> 2min) to submit a job and making nightly tests fail (#21699). This PR offloads the blocking work to a separate thread. Implementing async GCS KV API will be done in the future.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
