### PR TITLE
[RFC] [Core] Support disabling log redirection via `RAY_LOG_TO_STDERR` environment variable.

### DIFF
--- a/doc/source/ray-observability/ray-logging.rst
+++ b/doc/source/ray-observability/ray-logging.rst
@@ -144,6 +144,17 @@ Redirecting Ray logs to stderr
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 By default, Ray logs are written to files under the ``/tmp/ray/session_*/logs`` directory. If you wish to redirect all internal Ray logging and your own logging within tasks/actors to stderr of the host nodes, you can do so by ensuring that the ``RAY_LOG_TO_STDERR=1`` environment variable is set on the driver and on all Ray nodes. This is very useful if you are using a log aggregator that needs log records to be written to stderr in order for them to be captured.
 
+Redirecting logging to stderr will also cause a ``({component})`` prefix, e.g. ``(raylet)``, to be added to each of the log record messages.
+
+.. code-block:: bash
+
+    [2022-01-24 19:42:02,978 I 1829336 1829336] (gcs_server) grpc_server.cc:103: GcsServer server started, listening on port 50009.
+    [2022-01-24 19:42:06,696 I 1829415 1829415] (raylet) grpc_server.cc:103: ObjectManager server started, listening on port 40545.
+    2022-01-24 19:42:05,087 INFO (dashboard) dashboard.py:95 -- Setup static dir for dashboard: /mnt/data/workspace/ray/python/ray/dashboard/client/build
+    2022-01-24 19:42:07,500 INFO (dashboard_agent) agent.py:105 -- Dashboard agent grpc address: 0.0.0.0:49228
+
+This should make it easier to filter the stderr stream of logs down to the component of interest. Note that multi-line log records will **not** have this component marker at the beginning of each line.
+
 When running a local Ray cluster, this environment variable should be set before starting the local cluster:
 
 .. code-block:: python

--- a/doc/source/ray-observability/ray-logging.rst
+++ b/doc/source/ray-observability/ray-logging.rst
@@ -25,9 +25,9 @@ Let's look at a code example to see how this works.
     @ray.remote
     def task():
         print("task")
-    
+
     ray.get(task.remote())
-        
+
 You should be able to see the string `task` from your driver stdout. 
 
 When logs are printed, the process id (pid) and an IP address of the node that executes tasks/actors are printed together. Check out the output below.
@@ -59,10 +59,10 @@ Since Python logger module creates a singleton logger per process, loggers shoul
             # be streamed to stdout and stderr.
             # Set the severity to INFO so that info logs are printed to stdout.
             logging.basicConfig(level=logging.INFO)
-        
+
         def log(self, msg):
             logging.info(msg)
-    
+
     actor = Actor.remote()
     ray.get(actor.log.remote("A log message for an actor."))
 
@@ -70,7 +70,7 @@ Since Python logger module creates a singleton logger per process, loggers shoul
     def f(msg):
         logging.basicConfig(level=logging.INFO)
         logging.info(msg)
-    
+
     ray.get(f.remote("A log message for a task"))
 
 .. code-block:: bash
@@ -92,7 +92,7 @@ Runtime context APIs help you to add metadata to your logging messages, making y
     @ray.remote
     def task():
         print(f"task_id: {ray.get_runtime_context().task_id}")
-    
+
     ray.get(task.remote())
 
 .. code-block:: bash
@@ -103,30 +103,30 @@ Logging directory structure
 ---------------------------
 .. _logging-directory-structure:
 
-By default, Ray logs are stored in a `/tmp/ray/session_*/logs` directory. 
+By default, Ray logs are stored in a ``/tmp/ray/session_*/logs`` directory. 
 
 .. note::
 
-    The default temp directory is `/tmp/ray` (for Linux and Mac OS). If you'd like to change the temp directory, you can specify it when `ray start` or `ray.init()` is called. 
+    The default temp directory is ``/tmp/ray`` (for Linux and Mac OS). If you'd like to change the temp directory, you can specify it when ``ray start`` or ``ray.init()`` is called. 
 
-A new Ray instance creates a new session ID to the temp directory. The latest session ID is symlinked to `/tmp/ray/session_latest`.
+A new Ray instance creates a new session ID to the temp directory. The latest session ID is symlinked to ``/tmp/ray/session_latest``.
 
-Here's a Ray log directory structure. Note that `.out` is logs from stdout/stderr and `.err` is logs from stderr. The backward compatibility of log directories is not maintained.
+Here's a Ray log directory structure. Note that ``.out`` is logs from stdout/stderr and ``.err`` is logs from stderr. The backward compatibility of log directories is not maintained.
 
-- `dashboard.log`: A log file of a Ray dashboard.
-- `dashboard_agent.log`: Every Ray node has one dashboard agent. This is a log file of the agent.
-- `gcs_server.[out|err]`: The GCS server is a stateless server that manages business logic that needs to be performed on GCS (Redis). It exists only in the head node.
-- `log_monitor.log`: The log monitor is in charge of streaming logs to the driver.
-- `monitor.log`: Ray's cluster launcher is operated with a monitor process. It also manages the autoscaler.
-- `monitor.[out|err]`: Stdout and stderr of a cluster launcher.
-- `plasma_store.[out|err]`: Deprecated.
-- `python-core-driver-[worker_id]_[pid].log`: Ray drivers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
-- `python-core-worker-[worker_id]_[pid].log`: Ray workers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
-- `raylet.[out|err]`: A log file of raylets.
-- `redis-shard_[shard_index].[out|err]`: A log file of GCS (Redis by default) shards.
-- `redis.[out|err]`: A log file of GCS (Redis by default).
-- `worker-[worker_id]-[job_id]-[pid].[out|err]`: Python/Java part of Ray drivers and workers. All of stdout and stderr from tasks/actors are streamed here. Note that job_id is an id of the driver.
-- `io-worker-[worker_id]-[pid].[out|err]`: Ray creates IO workers to spill/restore objects to external storage by default from Ray 1.3+. This is a log file of IO workers.
+- ``dashboard.log``: A log file of a Ray dashboard.
+- ``dashboard_agent.log``: Every Ray node has one dashboard agent. This is a log file of the agent.
+- ``gcs_server.[out|err]``: The GCS server is a stateless server that manages business logic that needs to be performed on GCS (Redis). It exists only in the head node.
+- ``log_monitor.log``: The log monitor is in charge of streaming logs to the driver.
+- ``monitor.log``: Ray's cluster launcher is operated with a monitor process. It also manages the autoscaler.
+- ``monitor.[out|err]``: Stdout and stderr of a cluster launcher.
+- ``plasma_store.[out|err]``: Deprecated.
+- ``python-core-driver-[worker_id]_[pid].log``: Ray drivers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
+- ``python-core-worker-[worker_id]_[pid].log``: Ray workers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
+- ``raylet.[out|err]``: A log file of raylets.
+- ``redis-shard_[shard_index].[out|err]``: A log file of GCS (Redis by default) shards.
+- ``redis.[out|err]``: A log file of GCS (Redis by default).
+- ``worker-[worker_id]-[job_id]-[pid].[out|err]``: Python/Java part of Ray drivers and workers. All of stdout and stderr from tasks/actors are streamed here. Note that job_id is an id of the driver.
+- ``io-worker-[worker_id]-[pid].[out|err]``: Ray creates IO workers to spill/restore objects to external storage by default from Ray 1.3+. This is a log file of IO workers.
 
 Log rotation
 ------------
@@ -140,3 +140,38 @@ If you'd like to change the log rotation configuration, you can do it by specify
     RAY_ROTATION_MAX_BYTES=1024; ray start --head # Start a ray instance with maxBytes 1KB.
     RAY_ROTATION_BACKUP_COUNT=1; ray start --head # Start a ray instance with backupCount 1.
 
+Redirecting Ray logs to stderr
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, Ray logs are written to files under the ``/tmp/ray/session_*/logs`` directory. If you wish to redirect all internal Ray logging and your own logging within tasks/actors to stderr of the host nodes, you can do so by ensuring that the ``RAY_LOG_TO_STDERR=1`` environment variable is set on the driver and on all Ray nodes. This is very useful if you are using a log aggregator that needs log records to be written to stderr in order for them to be captured.
+
+When running a local Ray cluster, this environment variable should be set before starting the local cluster:
+
+.. code-block:: python
+
+    os.environ["RAY_LOG_TO_STDERR"] = "1"
+    ray.init()
+
+When starting a local cluster via the CLI or when starting nodes in a multi-node Ray cluster, this environment variable should be set before starting up each node:
+
+.. code-block:: bash
+
+    env RAY_LOG_TO_STDERR=1 ray start
+
+If using the Ray cluster launcher, you would specify this environment variable in the Ray start commands:
+
+.. code-block:: bash
+
+    head_start_ray_commands:
+        - ray stop
+        - env RAY_LOG_TO_STDERR=1 ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+
+    worker_start_ray_commands:
+        - ray stop
+        - env RAY_LOG_TO_STDERR=1 ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+
+When connecting to the cluster, be sure to set the environment variable before connecting:
+
+.. code-block:: python
+
+    os.environ["RAY_LOG_TO_STDERR"] = "1"
+    ray.init(address="auto")

--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -35,7 +35,7 @@ def setup_component_logger(*,
                            filename,
                            max_bytes,
                            backup_count,
-                           logger_name=""):
+                           logger_name=None):
     """Configure the root logger that is used for Ray's python components.
 
     For example, it should be used for monitor, dashboard, and log monitor.
@@ -44,8 +44,10 @@ def setup_component_logger(*,
     Args:
         logging_level(str | int): Logging level in string or logging enum.
         logging_format(str): Logging format string.
-        log_dir(str): Log directory path.
-        filename(str): Name of the file to write logs.
+        log_dir(str): Log directory path. If empty, logs will go to
+            stderr.
+        filename(str): Name of the file to write logs. If empty, logs will go
+            to stderr.
         max_bytes(int): Same argument as RotatingFileHandler's maxBytes.
         backup_count(int): Same argument as RotatingFileHandler's backupCount.
         logger_name(str, optional): used to create or get the correspoding
@@ -56,12 +58,13 @@ def setup_component_logger(*,
     logger = logging.getLogger(logger_name)
     if type(logging_level) is str:
         logging_level = logging.getLevelName(logging_level.upper())
-    assert filename, "filename argument should not be None."
-    assert log_dir, "log_dir should not be None."
-    handler = logging.handlers.RotatingFileHandler(
-        os.path.join(log_dir, filename),
-        maxBytes=max_bytes,
-        backupCount=backup_count)
+    if not filename or not log_dir:
+        handler = logging.StreamHandler()
+    else:
+        handler = logging.handlers.RotatingFileHandler(
+            os.path.join(log_dir, filename),
+            maxBytes=max_bytes,
+            backupCount=backup_count)
     handler.setLevel(logging_level)
     logger.setLevel(logging_level)
     handler.setFormatter(logging.Formatter(logging_format))

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1224,6 +1224,10 @@ def start_log_monitor(redis_address,
         # If not redirecting logging to files, unset log filename.
         # This will cause log records to go to stderr.
         command.append("--logging-filename=")
+        # Use stderr log format with the component name as a message prefix.
+        logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+            component=ray_constants.PROCESS_TYPE_LOG_MONITOR)
+        command.append(f"--logging-format={logging_format}")
         # Inherit stdout/stderr streams.
         stdout_file = None
         stderr_file = None
@@ -1336,6 +1340,10 @@ def start_dashboard(require_dashboard,
             # If not redirecting logging to files, unset log filename.
             # This will cause log records to go to stderr.
             command.append("--logging-filename=")
+            # Use stderr log format with the component name as a message prefix.
+            logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+                component=ray_constants.PROCESS_TYPE_DASHBOARD)
+            command.append(f"--logging-format={logging_format}")
             # Inherit stdout/stderr streams.
             stdout_file = None
             stderr_file = None
@@ -1670,6 +1678,10 @@ def start_raylet(redis_address,
             # If not redirecting logging to files, unset log filename.
             # This will cause log records to go to stderr.
             agent_command.append("--logging-filename=")
+            # Use stderr log format with the component name as a message prefix.
+            logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+                component=ray_constants.PROCESS_TYPE_DASHBOARD_AGENT)
+            agent_command.append(f"--logging-format={logging_format}")
 
         if redis_password is not None and len(redis_password) != 0:
             agent_command.append("--redis-password={}".format(redis_password))
@@ -2060,6 +2072,10 @@ def start_monitor(redis_address,
         # If not redirecting logging to files, unset log filename.
         # This will cause log records to go to stderr.
         command.append("--logging-filename=")
+        # Use stderr log format with the component name as a message prefix.
+        logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+            component=ray_constants.PROCESS_TYPE_MONITOR)
+        command.append(f"--logging-format={logging_format}")
     if autoscaling_config:
         command.append("--autoscaling-config=" + str(autoscaling_config))
     if redis_password:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1185,32 +1185,30 @@ def _start_redis_instance(executable,
 def start_log_monitor(redis_address,
                       gcs_address,
                       logs_dir,
-                      stdout_file=None,
-                      stderr_file=None,
                       redis_password=None,
                       fate_share=None,
                       max_bytes=0,
-                      backup_count=0):
+                      backup_count=0,
+                      redirect_logging=True):
     """Start a log monitor process.
 
     Args:
         redis_address (str): The address of the Redis instance.
         logs_dir (str): The directory of logging files.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
         redis_password (str): The password of the redis server.
         max_bytes (int): Log rotation parameter. Corresponding to
             RotatingFileHandler's maxBytes.
         backup_count (int): Log rotation parameter. Corresponding to
             RotatingFileHandler's backupCount.
+        redirect_logging (bool): Whether we should redirect logging to
+            the provided log directory.
 
     Returns:
         ProcessInfo for the process that was started.
     """
     log_monitor_filepath = os.path.join(RAY_PATH, RAY_PRIVATE_DIR,
                                         "log_monitor.py")
+
     command = [
         sys.executable, "-u", log_monitor_filepath,
         f"--redis-address={redis_address}", f"--logs-dir={logs_dir}",
@@ -1218,8 +1216,19 @@ def start_log_monitor(redis_address,
         f"--logging-rotate-backup-count={backup_count}",
         f"--gcs-address={gcs_address}"
     ]
+    if redirect_logging:
+        # Avoid hanging due to fd inheritance.
+        stdout_file = subprocess.DEVNULL
+        stderr_file = subprocess.DEVNULL
+    else:
+        # If not redirecting logging to files, unset log filename.
+        # This will cause log records to go to stderr.
+        command.append("--logging-filename=")
+        # Inherit stdout/stderr streams.
+        stdout_file = None
+        stderr_file = None
     if redis_password:
-        command += ["--redis-password", redis_password]
+        command.append(f"--redis-password={redis_password}")
     process_info = start_ray_process(
         command,
         ray_constants.PROCESS_TYPE_LOG_MONITOR,
@@ -1236,12 +1245,11 @@ def start_dashboard(require_dashboard,
                     temp_dir,
                     logdir,
                     port=None,
-                    stdout_file=None,
-                    stderr_file=None,
                     redis_password=None,
                     fate_share=None,
                     max_bytes=0,
-                    backup_count=0):
+                    backup_count=0,
+                    redirect_logging=True):
     """Start a dashboard process.
 
     Args:
@@ -1256,15 +1264,13 @@ def start_dashboard(require_dashboard,
         logdir (str): The log directory used to generate dashboard log.
         port (str): The port to bind the dashboard web server to.
             Defaults to 8265.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
         redis_password (str): The password of the redis server.
         max_bytes (int): Log rotation parameter. Corresponding to
             RotatingFileHandler's maxBytes.
         backup_count (int): Log rotation parameter. Corresponding to
             RotatingFileHandler's backupCount.
+        redirect_logging (bool): Whether we should redirect logging to
+            the provided log directory.
 
     Returns:
         ProcessInfo for the process that was started.
@@ -1312,6 +1318,7 @@ def start_dashboard(require_dashboard,
         dashboard_dir = "dashboard"
         dashboard_filepath = os.path.join(RAY_PATH, dashboard_dir,
                                           "dashboard.py")
+
         command = [
             sys.executable, "-u", dashboard_filepath, f"--host={host}",
             f"--port={port}", f"--port-retries={port_retries}",
@@ -1320,8 +1327,20 @@ def start_dashboard(require_dashboard,
             f"--logging-rotate-backup-count={backup_count}",
             f"--gcs-address={gcs_address}"
         ]
+
+        if redirect_logging:
+            # Avoid hanging due to fd inheritance.
+            stdout_file = subprocess.DEVNULL
+            stderr_file = subprocess.DEVNULL
+        else:
+            # If not redirecting logging to files, unset log filename.
+            # This will cause log records to go to stderr.
+            command.append("--logging-filename=")
+            # Inherit stdout/stderr streams.
+            stdout_file = None
+            stderr_file = None
         if redis_password is not None:
-            command += ["--redis-password", redis_password]
+            command.append(f"--redis-password={redis_password}")
         process_info = start_ray_process(
             command,
             ray_constants.PROCESS_TYPE_DASHBOARD,
@@ -1353,30 +1372,34 @@ def start_dashboard(require_dashboard,
             # so we need to poll often.
             time.sleep(0.1)
         if dashboard_url is None:
-            dashboard_log = os.path.join(logdir, "dashboard.log")
             returncode_str = (f", return code {dashboard_returncode}"
                               if dashboard_returncode is not None else "")
-            # Read last n lines of dashboard log. The log file may be large.
-            n = 10
-            lines = []
-            try:
-                with open(dashboard_log, "rb") as f:
-                    with mmap.mmap(
-                            f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
-                        end = mm.size()
-                        for _ in range(n):
-                            sep = mm.rfind(b"\n", 0, end - 1)
-                            if sep == -1:
-                                break
-                            lines.append(mm[sep + 1:end].decode("utf-8"))
-                            end = sep
-                lines.append(f" The last {n} lines of {dashboard_log}:")
-            except Exception as e:
-                raise Exception(f"Failed to read dashbord log: {e}")
+            err_msg = "Failed to start the dashboard" + returncode_str
+            if logdir:
+                dashboard_log = os.path.join(logdir, "dashboard.log")
+                # Read last n lines of dashboard log. The log file may be large.
+                n = 10
+                lines = []
+                try:
+                    with open(dashboard_log, "rb") as f:
+                        with mmap.mmap(
+                                f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                            end = mm.size()
+                            for _ in range(n):
+                                sep = mm.rfind(b"\n", 0, end - 1)
+                                if sep == -1:
+                                    break
+                                lines.append(mm[sep + 1:end].decode("utf-8"))
+                                end = sep
+                    lines.append(f" The last {n} lines of {dashboard_log}:")
+                except Exception as e:
+                    raise Exception(err_msg +
+                                    f"\nFailed to read dashboard log: {e}")
 
-            last_log_str = "\n".join(reversed(lines[-n:]))
-            raise Exception("Failed to start the dashboard"
-                            f"{returncode_str}.{last_log_str}")
+                last_log_str = "\n" + "\n".join(reversed(lines[-n:]))
+                raise Exception(err_msg + last_log_str)
+            else:
+                raise Exception(err_msg)
 
         logger.info("View the Ray dashboard at %s%shttp://%s%s%s",
                     colorama.Style.BRIGHT, colorama.Fore.GREEN, dashboard_url,
@@ -1643,6 +1666,10 @@ def start_raylet(redis_address,
             f"--logging-rotate-backup-count={backup_count}",
             f"--gcs-address={gcs_address}",
         ]
+        if stdout_file is None and stderr_file is None:
+            # If not redirecting logging to files, unset log filename.
+            # This will cause log records to go to stderr.
+            agent_command.append("--logging-filename=")
 
         if redis_password is not None and len(redis_password) != 0:
             agent_command.append("--redis-password={}".format(redis_password))
@@ -2017,6 +2044,7 @@ def start_monitor(redis_address,
         ProcessInfo for the process that was started.
     """
     monitor_path = os.path.join(RAY_PATH, AUTOSCALER_PRIVATE_DIR, "monitor.py")
+
     command = [
         sys.executable,
         "-u",
@@ -2027,6 +2055,11 @@ def start_monitor(redis_address,
         f"--logging-rotate-backup-count={backup_count}",
         f"--gcs-address={gcs_address}",
     ]
+
+    if stdout_file is None and stderr_file is None:
+        # If not redirecting logging to files, unset log filename.
+        # This will cause log records to go to stderr.
+        command.append("--logging-filename=")
     if autoscaling_config:
         command.append("--autoscaling-config=" + str(autoscaling_config))
     if redis_password:

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -649,6 +649,15 @@ class Node:
         raise FileExistsError(errno.EEXIST,
                               "No usable temporary filename found")
 
+    def should_redirect_logs(self):
+        redirect_output = self._ray_params.redirect_output
+        if redirect_output is None:
+            # Fall back to stderr redirect environment variable.
+            redirect_output = os.environ.get(
+                ray_constants.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE
+            ) != "1"
+        return redirect_output
+
     def get_log_file_handles(self, name, unique=False):
         """Open log files with partially randomized filenames, returning the
         file handles. If output redirection has been disabled, no files will
@@ -663,13 +672,7 @@ class Node:
             A tuple of two file handles for redirecting (stdout, stderr), or
             `(None, None)` if output redirection is disabled.
         """
-        redirect_output = self._ray_params.redirect_output
-
-        if redirect_output is None:
-            # Make the default behavior match that of glog.
-            redirect_output = os.getenv("GLOG_logtostderr") != "1"
-
-        if not redirect_output:
+        if not self.should_redirect_logs():
             return None, None
 
         log_stdout, log_stderr = self._get_log_file_names(name, unique=unique)
@@ -854,12 +857,11 @@ class Node:
             self.redis_address,
             self.gcs_address,
             self._logs_dir,
-            stdout_file=subprocess.DEVNULL,
-            stderr_file=subprocess.DEVNULL,
             redis_password=self._ray_params.redis_password,
             fate_share=self.kernel_fate_share,
             max_bytes=self.max_bytes,
-            backup_count=self.backup_count)
+            backup_count=self.backup_count,
+            redirect_logging=self.should_redirect_logs())
         assert ray_constants.PROCESS_TYPE_LOG_MONITOR not in self.all_processes
         self.all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] = [
             process_info,
@@ -880,13 +882,12 @@ class Node:
             self.gcs_address,
             self._temp_dir,
             self._logs_dir,
-            stdout_file=subprocess.DEVNULL,  # Avoid hang(fd inherit)
-            stderr_file=subprocess.DEVNULL,  # Avoid hang(fd inherit)
             redis_password=self._ray_params.redis_password,
             fate_share=self.kernel_fate_share,
             max_bytes=self.max_bytes,
             backup_count=self.backup_count,
-            port=self._ray_params.dashboard_port)
+            port=self._ray_params.dashboard_port,
+            redirect_logging=self.should_redirect_logs())
         assert ray_constants.PROCESS_TYPE_DASHBOARD not in self.all_processes
         if process_info is not None:
             self.all_processes[ray_constants.PROCESS_TYPE_DASHBOARD] = [

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -179,6 +179,13 @@ LOGGING_ROTATE_BYTES = 512 * 1024 * 1024  # 512MB.
 LOGGING_ROTATE_BACKUP_COUNT = 5  # 5 Backup files at max.
 
 LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
+# Logging format when logging stderr. This should be formatted with the
+# component before setting the formatter, e.g. via
+#   format = LOGGER_FORMAT_STDERR.format(component="dashboard")
+#   handler.setFormatter(logging.Formatter(format))
+LOGGER_FORMAT_STDERR = (
+    "%(asctime)s\t%(levelname)s ({component}) %(filename)s:%(lineno)s -- %(message)s"
+)
 
 # Constants used to define the different process types.
 PROCESS_TYPE_REAPER = "reaper"

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -178,6 +178,8 @@ LOGGER_LEVEL_HELP = ("The logging level threshold, choices=['debug', 'info',"
 LOGGING_ROTATE_BYTES = 512 * 1024 * 1024  # 512MB.
 LOGGING_ROTATE_BACKUP_COUNT = 5  # 5 Backup files at max.
 
+LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
+
 # Constants used to define the different process types.
 PROCESS_TYPE_REAPER = "reaper"
 PROCESS_TYPE_MONITOR = "monitor"

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1521,13 +1521,18 @@ def connect(node,
         job_config.set_runtime_env(runtime_env)
 
     serialized_job_config = job_config.serialize()
+    if not node.should_redirect_logs():
+        # Logging to stderr, so give core worker empty logs directory.
+        logs_dir = ""
+    else:
+        logs_dir = node.get_logs_dir_path()
     worker.core_worker = ray._raylet.CoreWorker(
         mode, node.plasma_store_socket_name, node.raylet_socket_name, job_id,
-        gcs_options, node.get_logs_dir_path(), node.node_ip_address,
-        node.node_manager_port, node.raylet_ip_address, (mode == LOCAL_MODE),
-        driver_name, log_stdout_file_path, log_stderr_file_path,
-        serialized_job_config, node.metrics_agent_port, runtime_env_hash,
-        worker_shim_pid, startup_token)
+        gcs_options, logs_dir, node.node_ip_address, node.node_manager_port,
+        node.raylet_ip_address, (mode == LOCAL_MODE), driver_name,
+        log_stdout_file_path, log_stderr_file_path, serialized_job_config,
+        node.metrics_agent_port, runtime_env_hash, worker_shim_pid,
+        startup_token)
 
     # Notify raylet that the core worker is ready.
     worker.core_worker.notify_raylet()


### PR DESCRIPTION
This PR adds the remaining support needed for disabling log redirection to files, i.e. for ensuring that all internal Ray logs and user logs within tasks/actors are directed to stderr. Namely, this PR adds support for directing logs to stderr for:
- dashboard
- dashboard agent
- log monitor
- driver core worker
- worker core worker
- autoscaler

All other Ray components, along with user logs within tasks/actors, already supported directing logs to stderr via the `GLOG_logtostderr=1` environment variable.

This PR also changes the environment variable for disabling log redirection to from `GLOG_logtostderr` to `RAY_LOG_TO_STDERR`, since (1) we no longer use glog after porting to spdlog, (2) this environment variable is more user friendly and Ray-native.

This PR also changes the log format when logging to stderr by adding a `({component})` prefix to the log record message. This should allow for easier component-based filtering on the stderr stream.

Finally, this PR adds documentation for using this environment variable to disable log redirection. This PR supersedes #21754.

## Future work

1. This PR **does not** expose a way to disable log redirection with the Python or CLI APIs. I think that we should add a `ray.init(..., redirect_logs=False)` API and a `ray start --no-redirect-logs` API, which would take priority over this environment variable. This can happen in a future PR.
2. This PR **does not** expose a directive for changing the log formatter such that log records are emitted in accordance with structured logging, i.e. as structured log records. This can happen in a future PR based on user feedback.

## Related issue number

Closes #18345 #21707 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
