### PR TITLE
[gcs/ha] Skip raydb test when it's gcs bootstrap mode

### DIFF
--- a/python/ray/data/tests/test_raydp_dataset.py
+++ b/python/ray/data/tests/test_raydp_dataset.py
@@ -33,6 +33,9 @@ def test_raydp_roundtrip(spark_on_ray_small):
     assert values == rows_2
 
 
+@pytest.mark.skipif(
+    ray._private.gcs_utils.use_gcs_for_bootstrap(),
+    reason="raydp need to be updated to work without redis.")
 def test_raydp_to_spark(spark_on_ray_small):
     spark = spark_on_ray_small
     n = 5


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
RayDP needs to be updated to work with redisless ray.
To be more specific this [line](https://github.com/oap-project/raydp/blob/c08a7867708224c25a73ae326d9244492b3f71fd/python/raydp/spark/ray_cluster_master.py#L146
) needs to be updated to using `node.address`

We should update this after the release with the feature being turned on by default.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
