### PR TITLE
[resource-reporting 2/n]separate local resource manager from cluster_resource_scheduler

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -587,9 +587,10 @@ void NodeManager::FillResourceReport(rpc::ResourcesData &resources_data) {
   resources_data.set_node_manager_address(initial_config_.node_manager_address);
   // Update local cache from gcs remote cache, this is needed when gcs restart.
   // We should always keep the cache view consistent.
-  cluster_resource_scheduler_->UpdateLastResourceUsage(
+  cluster_resource_scheduler_->GetLocalResourceManager().UpdateLastResourceUsage(
       gcs_client_->NodeResources().GetLastResourceUsage());
-  cluster_resource_scheduler_->FillResourceUsage(resources_data);
+  cluster_resource_scheduler_->GetLocalResourceManager().FillResourceUsage(
+      resources_data);
   cluster_task_manager_->FillResourceUsage(
       resources_data, gcs_client_->NodeResources().GetLastResourceUsage());
   if (RayConfig::instance().gcs_actor_scheduling_enabled()) {
@@ -1572,8 +1573,8 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
     // up repeatedly starting the worker, then killing it because it idles for
     // too long. The downside is that we will be slower to schedule tasks that
     // could use a fraction of a CPU.
-    int64_t available_cpus =
-        static_cast<int64_t>(cluster_resource_scheduler_->GetLocalAvailableCpus());
+    int64_t available_cpus = static_cast<int64_t>(
+        cluster_resource_scheduler_->GetLocalResourceManager().GetLocalAvailableCpus());
     worker_pool_.PrestartWorkers(task_spec, request.backlog_size(), available_cpus);
   }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -713,7 +713,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// responsible for maintaining a view of the cluster state w.r.t resource
   /// usage. ClusterTaskManager is responsible for queuing, spilling back, and
   /// dispatching tasks.
-  std::shared_ptr<ClusterResourceSchedulerInterface> cluster_resource_scheduler_;
+  std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   std::shared_ptr<ClusterTaskManagerInterface> cluster_task_manager_;
 
   absl::flat_hash_map<ObjectID, std::unique_ptr<RayObject>> pinned_objects_;

--- a/src/ray/raylet/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/placement_group_resource_manager_test.cc
@@ -55,7 +55,9 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
   }
 
   void CheckAvailableResoueceEmpty(const std::string &resource) {
-    ASSERT_TRUE(cluster_resource_scheduler_->IsAvailableResourceEmpty(resource));
+    ASSERT_TRUE(
+        cluster_resource_scheduler_->GetLocalResourceManager().IsAvailableResourceEmpty(
+            resource));
   }
 
   void CheckRemainingResourceCorrect(NodeResources &node_resources) {
@@ -129,8 +131,9 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewCommitBundleResource) {
       "remaining", remaining_resources, *gcs_client_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
-  ASSERT_TRUE(remaining_resource_scheduler->AllocateLocalTaskResources(
-      unit_resource, resource_instances));
+  ASSERT_TRUE(
+      remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
+          unit_resource, resource_instances));
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetLocalNodeResources();
   CheckRemainingResourceCorrect(remaining_resource_instance);
@@ -200,8 +203,9 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
       "remaining", remaining_resources, *gcs_client_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
-  ASSERT_TRUE(remaining_resource_scheduler->AllocateLocalTaskResources(
-      init_unit_resource, resource_instances));
+  ASSERT_TRUE(
+      remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
+          init_unit_resource, resource_instances));
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetLocalNodeResources();
 
@@ -220,11 +224,12 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
                          {"bundle_group_" + group_id.Hex(), 2000}};
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
       "remaining", remaining_resources, *gcs_client_);
-  ASSERT_TRUE(remaining_resource_scheduler->AllocateLocalTaskResources(
-      {{"CPU_group_" + group_id.Hex(), 1.0},
-       {"CPU", 1.0},
-       {"bundle_group_" + group_id.Hex(), 1000}},
-      resource_instances));
+  ASSERT_TRUE(
+      remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
+          {{"CPU_group_" + group_id.Hex(), 1.0},
+           {"CPU", 1.0},
+           {"bundle_group_" + group_id.Hex(), 1000}},
+          resource_instances));
   remaining_resource_instance = remaining_resource_scheduler->GetLocalNodeResources();
   CheckRemainingResourceCorrect(remaining_resource_instance);
   /// 7. return first bundle.
@@ -259,8 +264,9 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithMultiPrepare)
       "remaining", remaining_resources, *gcs_client_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
-  ASSERT_TRUE(remaining_resource_scheduler->AllocateLocalTaskResources(
-      unit_resource, resource_instances));
+  ASSERT_TRUE(
+      remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
+          unit_resource, resource_instances));
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetLocalNodeResources();
   CheckRemainingResourceCorrect(remaining_resource_instance);
@@ -294,8 +300,9 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithRandomOrder) 
       "remaining", remaining_resources, *gcs_client_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
-  ASSERT_TRUE(remaining_resource_scheduler->AllocateLocalTaskResources(
-      unit_resource, resource_instances));
+  ASSERT_TRUE(
+      remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
+          unit_resource, resource_instances));
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetLocalNodeResources();
   CheckRemainingResourceCorrect(remaining_resource_instance);
@@ -370,8 +377,9 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestPreparedResourceBatched) {
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> allocating_resource;
   allocating_resource.insert({"CPU", 4.0});
-  ASSERT_TRUE(remaining_resource_scheduler->AllocateLocalTaskResources(
-      allocating_resource, resource_instances));
+  ASSERT_TRUE(
+      remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
+          allocating_resource, resource_instances));
   remaining_resource_instance = remaining_resource_scheduler->GetLocalNodeResources();
   RAY_LOG(INFO) << "The current local resource view: "
                 << cluster_resource_scheduler_->DebugString();
@@ -413,8 +421,9 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestCommiteResourceBatched) {
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> allocating_resource;
   allocating_resource.insert({"CPU", 4.0});
-  ASSERT_TRUE(remaining_resource_scheduler->AllocateLocalTaskResources(
-      allocating_resource, resource_instances));
+  ASSERT_TRUE(
+      remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
+          allocating_resource, resource_instances));
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetLocalNodeResources();
   RAY_LOG(INFO) << "The current local resource view: "

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -193,20 +193,13 @@ class NodeResourceInstances {
 };
 
 struct Node {
-  Node(const NodeResources &resources)
-      : last_reported_(resources), local_view_(resources) {}
+  Node(const NodeResources &resources) : local_view_(resources) {}
 
   NodeResources *GetMutableLocalView() { return &local_view_; }
 
   const NodeResources &GetLocalView() const { return local_view_; }
 
  private:
-  /// The resource information according to the last heartbeat reported by
-  /// this node.
-  /// NOTE(swang): For the local node, this field should be ignored because
-  /// we do not receive heartbeats from ourselves and the local view is
-  /// therefore always the most up-to-date.
-  NodeResources last_reported_;
   /// Our local view of the remote node's resources. This may be dirty
   /// because it includes any resource requests that we allocated to this
   /// node through spillback since our last heartbeat tick. This view will

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -29,9 +29,13 @@ ClusterResourceScheduler::ClusterResourceScheduler(
       gcs_client_(&gcs_client) {
   scheduling_policy_ = std::make_unique<raylet_scheduling_policy::SchedulingPolicy>(
       local_node_id_, nodes_);
-  InitResourceUnitInstanceInfo();
+  local_resource_manager_ = std::make_unique<LocalResourceManager>(
+      local_node_id, string_to_int_map_, local_node_resources,
+      /*get_used_object_store_memory*/ nullptr, /*get_pull_manager_at_capacity*/ nullptr,
+      [&](const NodeResources &local_resource_update) {
+        this->AddOrUpdateNode(local_node_id_, local_resource_update);
+      });
   AddOrUpdateNode(local_node_id_, local_node_resources);
-  InitLocalResources(local_node_resources);
 }
 
 ClusterResourceScheduler::ClusterResourceScheduler(
@@ -39,18 +43,19 @@ ClusterResourceScheduler::ClusterResourceScheduler(
     const absl::flat_hash_map<std::string, double> &local_node_resources,
     gcs::GcsClient &gcs_client, std::function<int64_t(void)> get_used_object_store_memory,
     std::function<bool(void)> get_pull_manager_at_capacity)
-    : get_pull_manager_at_capacity_(get_pull_manager_at_capacity),
-      gcs_client_(&gcs_client) {
+    : gcs_client_(&gcs_client) {
   local_node_id_ = string_to_int_map_.Insert(local_node_id);
   scheduling_policy_ = std::make_unique<raylet_scheduling_policy::SchedulingPolicy>(
       local_node_id_, nodes_);
   NodeResources node_resources = ResourceMapToNodeResources(
       string_to_int_map_, local_node_resources, local_node_resources);
 
-  InitResourceUnitInstanceInfo();
+  local_resource_manager_ = std::make_unique<LocalResourceManager>(
+      local_node_id_, string_to_int_map_, node_resources, get_used_object_store_memory,
+      get_pull_manager_at_capacity, [&](const NodeResources &local_resource_update) {
+        this->AddOrUpdateNode(local_node_id_, local_resource_update);
+      });
   AddOrUpdateNode(local_node_id_, node_resources);
-  InitLocalResources(node_resources);
-  get_used_object_store_memory_ = get_used_object_store_memory;
 }
 
 bool ClusterResourceScheduler::NodeAlive(int64_t node_id) const {
@@ -64,31 +69,6 @@ bool ClusterResourceScheduler::NodeAlive(int64_t node_id) const {
   return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id_binary)) != nullptr;
 }
 
-void ClusterResourceScheduler::InitResourceUnitInstanceInfo() {
-  std::string predefined_unit_instance_resources =
-      RayConfig::instance().predefined_unit_instance_resources();
-  if (!predefined_unit_instance_resources.empty()) {
-    std::vector<std::string> results;
-    boost::split(results, predefined_unit_instance_resources, boost::is_any_of(","));
-    for (std::string &result : results) {
-      PredefinedResources resource = ResourceStringToEnum(result);
-      RAY_CHECK(resource < PredefinedResources_MAX)
-          << "Failed to parse predefined resource";
-      predefined_unit_instance_resources_.emplace(resource);
-    }
-  }
-  std::string custom_unit_instance_resources =
-      RayConfig::instance().custom_unit_instance_resources();
-  if (!custom_unit_instance_resources.empty()) {
-    std::vector<std::string> results;
-    boost::split(results, custom_unit_instance_resources, boost::is_any_of(","));
-    for (std::string &result : results) {
-      int64_t resource_id = string_to_int_map_.Insert(result);
-      custom_unit_instance_resources_.emplace(resource_id);
-    }
-  }
-}
-
 void ClusterResourceScheduler::AddOrUpdateNode(
     const std::string &node_id,
     const absl::flat_hash_map<std::string, double> &resources_total,
@@ -100,6 +80,8 @@ void ClusterResourceScheduler::AddOrUpdateNode(
 
 void ClusterResourceScheduler::AddOrUpdateNode(int64_t node_id,
                                                const NodeResources &node_resources) {
+  RAY_LOG(DEBUG) << "Update node info, node_id: " << node_id << ", node_resources: "
+                 << node_resources.DebugString(string_to_int_map_);
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     // This node is new, so add it to the map.
@@ -349,70 +331,6 @@ const StringIdMap &ClusterResourceScheduler::GetStringIdMap() const {
   return string_to_int_map_;
 }
 
-void ClusterResourceScheduler::AddLocalResourceInstances(
-    const std::string &resource_name, const std::vector<FixedPoint> &instances) {
-  ResourceInstanceCapacities *node_instances;
-  local_resources_.predefined_resources.resize(PredefinedResources_MAX);
-  if (kCPU_ResourceLabel == resource_name) {
-    node_instances = &local_resources_.predefined_resources[CPU];
-  } else if (kGPU_ResourceLabel == resource_name) {
-    node_instances = &local_resources_.predefined_resources[GPU];
-  } else if (kObjectStoreMemory_ResourceLabel == resource_name) {
-    node_instances = &local_resources_.predefined_resources[OBJECT_STORE_MEM];
-  } else if (kMemory_ResourceLabel == resource_name) {
-    node_instances = &local_resources_.predefined_resources[MEM];
-  } else {
-    string_to_int_map_.Insert(resource_name);
-    int64_t resource_id = string_to_int_map_.Get(resource_name);
-    node_instances = &local_resources_.custom_resources[resource_id];
-  }
-
-  if (node_instances->total.size() < instances.size()) {
-    node_instances->total.resize(instances.size());
-    node_instances->available.resize(instances.size());
-  }
-
-  for (size_t i = 0; i < instances.size(); i++) {
-    node_instances->available[i] += instances[i];
-    node_instances->total[i] += instances[i];
-  }
-  UpdateLocalAvailableResourcesFromResourceInstances();
-}
-
-bool ClusterResourceScheduler::IsAvailableResourceEmpty(
-    const std::string &resource_name) {
-  auto it = nodes_.find(local_node_id_);
-  if (it == nodes_.end()) {
-    RAY_LOG(WARNING) << "Can't find local node:[" << local_node_id_
-                     << "] when check local available resource.";
-    return true;
-  }
-
-  int idx = -1;
-  if (resource_name == ray::kCPU_ResourceLabel) {
-    idx = (int)CPU;
-  } else if (resource_name == ray::kGPU_ResourceLabel) {
-    idx = (int)GPU;
-  } else if (resource_name == ray::kObjectStoreMemory_ResourceLabel) {
-    idx = (int)OBJECT_STORE_MEM;
-  } else if (resource_name == ray::kMemory_ResourceLabel) {
-    idx = (int)MEM;
-  };
-
-  auto local_view = it->second.GetMutableLocalView();
-  if (idx != -1) {
-    return local_view->predefined_resources[idx].available <= 0;
-  }
-  string_to_int_map_.Insert(resource_name);
-  int64_t resource_id = string_to_int_map_.Get(resource_name);
-  auto itr = local_view->custom_resources.find(resource_id);
-  if (itr != local_view->custom_resources.end()) {
-    return itr->second.available <= 0;
-  } else {
-    return true;
-  }
-}
-
 void ClusterResourceScheduler::UpdateResourceCapacity(const std::string &node_id_string,
                                                       const std::string &resource_name,
                                                       double resource_total) {
@@ -471,13 +389,10 @@ void ClusterResourceScheduler::UpdateResourceCapacity(const std::string &node_id
   }
 }
 
-void ClusterResourceScheduler::DeleteLocalResource(const std::string &resource_name) {
-  DeleteResource(string_to_int_map_.Get(local_node_id_), resource_name);
-}
-
 void ClusterResourceScheduler::DeleteResource(const std::string &node_id_string,
                                               const std::string &resource_name) {
   int64_t node_id = string_to_int_map_.Get(node_id_string);
+
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     return;
@@ -498,99 +413,19 @@ void ClusterResourceScheduler::DeleteResource(const std::string &node_id_string,
     local_view->predefined_resources[idx].available = 0;
     local_view->predefined_resources[idx].total = 0;
 
-    if (node_id == local_node_id_) {
-      for (auto &total : local_resources_.predefined_resources[idx].total) {
-        total = 0;
-      }
-      for (auto &available : local_resources_.predefined_resources[idx].available) {
-        available = 0;
-      }
-    }
   } else {
     int64_t resource_id = string_to_int_map_.Get(resource_name);
     auto itr = local_view->custom_resources.find(resource_id);
     if (itr != local_view->custom_resources.end()) {
       local_view->custom_resources.erase(itr);
     }
-
-    auto c_itr = local_resources_.custom_resources.find(resource_id);
-    if (node_id == local_node_id_ && c_itr != local_resources_.custom_resources.end()) {
-      local_resources_.custom_resources[resource_id].total.clear();
-      local_resources_.custom_resources[resource_id].available.clear();
-      local_resources_.custom_resources.erase(c_itr);
-    }
   }
-}
-
-bool ClusterResourceScheduler::ResourcesExist(const std::string &resource_name) {
-  auto it = nodes_.find(local_node_id_);
-  if (it == nodes_.end()) {
-    RAY_LOG(WARNING) << "Can't find local node:[" << local_node_id_
-                     << "] when check local resource exists or not.";
-    return false;
-  }
-
-  int idx = -1;
-  if (resource_name == ray::kCPU_ResourceLabel) {
-    idx = (int)CPU;
-  } else if (resource_name == ray::kGPU_ResourceLabel) {
-    idx = (int)GPU;
-  } else if (resource_name == ray::kObjectStoreMemory_ResourceLabel) {
-    idx = (int)OBJECT_STORE_MEM;
-  } else if (resource_name == ray::kMemory_ResourceLabel) {
-    idx = (int)MEM;
-  };
-  if (idx != -1) {
-    // Return true directly for predefined resources as we always initialize this kind of
-    // resources at the beginning.
-    return true;
-  } else {
-    int64_t resource_id = string_to_int_map_.Get(resource_name);
-    const auto &it = local_resources_.custom_resources.find(resource_id);
-    return it != local_resources_.custom_resources.end();
-  }
-}
-
-std::string ClusterResourceScheduler::SerializedTaskResourceInstances(
-    std::shared_ptr<TaskResourceInstances> task_allocation) const {
-  bool has_added_resource = false;
-  std::stringstream buffer;
-  buffer << "{";
-  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    std::vector<FixedPoint> resource = task_allocation->predefined_resources[i];
-    if (resource.empty()) {
-      continue;
-    }
-    if (has_added_resource) {
-      buffer << ",";
-    }
-    std::string resource_name = ResourceEnumToString(static_cast<PredefinedResources>(i));
-    buffer << "\"" << resource_name << "\":";
-    bool is_unit_instance = predefined_unit_instance_resources_.find(i) !=
-                            predefined_unit_instance_resources_.end();
-    if (!is_unit_instance) {
-      buffer << resource[0];
-    } else {
-      buffer << "[";
-      for (size_t i = 0; i < resource.size(); i++) {
-        buffer << resource[i];
-        if (i < resource.size() - 1) {
-          buffer << ", ";
-        }
-      }
-      buffer << "]";
-    }
-    has_added_resource = true;
-  }
-  // TODO (chenk008): add custom_resources
-  buffer << "}";
-  return buffer.str();
 }
 
 std::string ClusterResourceScheduler::DebugString(void) const {
   std::stringstream buffer;
   buffer << "\nLocal id: " << local_node_id_;
-  buffer << " Local resources: " << local_resources_.DebugString(string_to_int_map_);
+  buffer << " Local resources: " << local_resource_manager_->DebugString();
   for (auto &node : nodes_) {
     buffer << "node id: " << node.first;
     buffer << node.second.GetLocalView().DebugString(string_to_int_map_);
@@ -598,390 +433,10 @@ std::string ClusterResourceScheduler::DebugString(void) const {
   return buffer.str();
 }
 
-uint64_t ClusterResourceScheduler::GetNumCpus() const {
-  auto it = nodes_.find(local_node_id_);
-  RAY_CHECK(it != nodes_.end());
-  return static_cast<uint64_t>(
-      it->second.GetLocalView().predefined_resources[CPU].total.Double());
-}
-
-void ClusterResourceScheduler::InitResourceInstances(
-    FixedPoint total, bool unit_instances, ResourceInstanceCapacities *instance_list) {
-  if (unit_instances) {
-    size_t num_instances = static_cast<size_t>(total.Double());
-    instance_list->total.resize(num_instances);
-    instance_list->available.resize(num_instances);
-    for (size_t i = 0; i < num_instances; i++) {
-      instance_list->total[i] = instance_list->available[i] = 1.0;
-    };
-  } else {
-    instance_list->total.resize(1);
-    instance_list->available.resize(1);
-    instance_list->total[0] = instance_list->available[0] = total;
-  }
-}
-
 std::string ClusterResourceScheduler::GetLocalResourceViewString() const {
   const auto &node_it = nodes_.find(local_node_id_);
   RAY_CHECK(node_it != nodes_.end());
   return node_it->second.GetLocalView().DictString(string_to_int_map_);
-}
-
-void ClusterResourceScheduler::InitLocalResources(const NodeResources &node_resources) {
-  local_resources_.predefined_resources.resize(PredefinedResources_MAX);
-
-  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    if (node_resources.predefined_resources[i].total > 0) {
-      // when we enable cpushare, the CPU will not be treat as unit_instance.
-      bool is_unit_instance = predefined_unit_instance_resources_.find(i) !=
-                              predefined_unit_instance_resources_.end();
-      InitResourceInstances(node_resources.predefined_resources[i].total,
-                            is_unit_instance, &local_resources_.predefined_resources[i]);
-    }
-  }
-
-  if (node_resources.custom_resources.size() == 0) {
-    return;
-  }
-
-  for (auto it = node_resources.custom_resources.begin();
-       it != node_resources.custom_resources.end(); ++it) {
-    if (it->second.total > 0) {
-      bool is_unit_instance = custom_unit_instance_resources_.find(it->first) !=
-                              custom_unit_instance_resources_.end();
-      ResourceInstanceCapacities instance_list;
-      InitResourceInstances(it->second.total, is_unit_instance, &instance_list);
-      local_resources_.custom_resources.emplace(it->first, instance_list);
-    }
-  }
-}
-
-std::vector<FixedPoint> ClusterResourceScheduler::AddAvailableResourceInstances(
-    std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances) {
-  std::vector<FixedPoint> overflow(available.size(), 0.);
-  for (size_t i = 0; i < available.size(); i++) {
-    resource_instances->available[i] = resource_instances->available[i] + available[i];
-    if (resource_instances->available[i] > resource_instances->total[i]) {
-      overflow[i] = (resource_instances->available[i] - resource_instances->total[i]);
-      resource_instances->available[i] = resource_instances->total[i];
-    }
-  }
-
-  return overflow;
-}
-
-std::vector<FixedPoint> ClusterResourceScheduler::SubtractAvailableResourceInstances(
-    std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances,
-    bool allow_going_negative) {
-  RAY_CHECK(available.size() == resource_instances->available.size());
-
-  std::vector<FixedPoint> underflow(available.size(), 0.);
-  for (size_t i = 0; i < available.size(); i++) {
-    if (resource_instances->available[i] < 0) {
-      if (allow_going_negative) {
-        resource_instances->available[i] =
-            resource_instances->available[i] - available[i];
-      } else {
-        underflow[i] = available[i];  // No change in the value in this case.
-      }
-    } else {
-      resource_instances->available[i] = resource_instances->available[i] - available[i];
-      if (resource_instances->available[i] < 0 && !allow_going_negative) {
-        underflow[i] = -resource_instances->available[i];
-        resource_instances->available[i] = 0;
-      }
-    }
-  }
-  return underflow;
-}
-
-namespace {
-/// Allocate enough capacity across the instances of a resource to satisfy "demand".
-/// If resource has multiple unit-capacity instances, we consider two cases.
-///
-/// 1) If the constraint is hard, allocate full unit-capacity instances until
-/// demand becomes fractional, and then satisfy the fractional demand using the
-/// instance with the smallest available capacity that can satisfy the fractional
-/// demand. For example, assume a resource conisting of 4 instances, with available
-/// capacities: (1., 1., .7, 0.5) and deman of 1.2. Then we allocate one full
-/// instance and then allocate 0.2 of the 0.5 instance (as this is the instance
-/// with the smalest available capacity that can satisfy the remaining demand of 0.2).
-/// As a result remaining available capacities will be (0., 1., .7, .3).
-/// Thus, if the constraint is hard, we will allocate a bunch of full instances and
-/// at most a fractional instance.
-///
-/// 2) If the constraint is soft, we can allocate multiple fractional resources,
-/// and even overallocate the resource. For example, in the previous case, if we
-/// have a demand of 1.8, we can allocate one full instance, the 0.5 instance, and
-/// 0.3 from the 0.7 instance. Furthermore, if the demand is 3.5, then we allocate
-/// all instances, and return success (true), despite the fact that the total
-/// available capacity of the rwsource is 3.2 (= 1. + 1. + .7 + .5), which is less
-/// than the demand, 3.5. In this case, the remaining available resource is
-/// (0., 0., 0., 0.)
-///
-/// \param demand: The resource amount to be allocated.
-/// \param available: List of available capacities of the instances of the resource.
-/// \param allocation: List of instance capacities allocated to satisfy the demand.
-/// This is a return parameter.
-///
-/// \return true, if allocation successful. In this case, the sum of the elements in
-/// "allocation" is equal to "demand".
-
-bool AllocateResourceInstances(FixedPoint demand, std::vector<FixedPoint> &available,
-                               std::vector<FixedPoint> *allocation) {
-  allocation->resize(available.size());
-  FixedPoint remaining_demand = demand;
-
-  if (available.size() == 1) {
-    // This resource has just an instance.
-    if (available[0] >= remaining_demand) {
-      available[0] -= remaining_demand;
-      (*allocation)[0] = remaining_demand;
-      return true;
-    } else {
-      // Not enough capacity.
-      return false;
-    }
-  }
-
-  // If resources has multiple instances, each instance has total capacity of 1.
-  //
-  // If this resource constraint is hard, as long as remaining_demand is greater than 1.,
-  // allocate full unit-capacity instances until the remaining_demand becomes fractional.
-  // Then try to find the best fit for the fractional remaining_resources. Best fist means
-  // allocating the resource instance with the smallest available capacity greater than
-  // remaining_demand
-  //
-  // If resource constraint is soft, allocate as many full unit-capacity resources and
-  // then distribute remaining_demand across remaining instances. Note that in case we can
-  // overallocate this resource.
-  if (remaining_demand >= 1.) {
-    for (size_t i = 0; i < available.size(); i++) {
-      if (available[i] == 1.) {
-        // Allocate a full unit-capacity instance.
-        (*allocation)[i] = 1.;
-        available[i] = 0;
-        remaining_demand -= 1.;
-      }
-      if (remaining_demand < 1.) {
-        break;
-      }
-    }
-  }
-
-  if (remaining_demand >= 1.) {
-    // Cannot satisfy a demand greater than one if no unit capacity resource is available.
-    return false;
-  }
-
-  // Remaining demand is fractional. Find the best fit, if exists.
-  if (remaining_demand > 0.) {
-    int64_t idx_best_fit = -1;
-    FixedPoint available_best_fit = 1.;
-    for (size_t i = 0; i < available.size(); i++) {
-      if (available[i] >= remaining_demand) {
-        if (idx_best_fit == -1 ||
-            (available[i] - remaining_demand < available_best_fit)) {
-          available_best_fit = available[i] - remaining_demand;
-          idx_best_fit = static_cast<int64_t>(i);
-        }
-      }
-    }
-    if (idx_best_fit == -1) {
-      return false;
-    } else {
-      (*allocation)[idx_best_fit] = remaining_demand;
-      available[idx_best_fit] -= remaining_demand;
-    }
-  }
-  return true;
-}
-}  // namespace
-
-bool ClusterResourceScheduler::AllocateTaskResourceInstances(
-    const ResourceRequest &resource_request,
-    std::shared_ptr<TaskResourceInstances> task_allocation) {
-  RAY_CHECK(task_allocation != nullptr);
-  if (nodes_.find(local_node_id_) == nodes_.end()) {
-    return false;
-  }
-  task_allocation->predefined_resources.resize(PredefinedResources_MAX);
-  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    if (resource_request.predefined_resources[i] > 0) {
-      if (!AllocateResourceInstances(resource_request.predefined_resources[i],
-                                     local_resources_.predefined_resources[i].available,
-                                     &task_allocation->predefined_resources[i])) {
-        // Allocation failed. Restore node's local resources by freeing the resources
-        // of the failed allocation.
-        FreeTaskResourceInstances(task_allocation);
-        return false;
-      }
-    }
-  }
-
-  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
-    auto it = local_resources_.custom_resources.find(task_req_custom_resource.first);
-    if (it != local_resources_.custom_resources.end()) {
-      if (task_req_custom_resource.second > 0) {
-        std::vector<FixedPoint> allocation;
-        bool success = AllocateResourceInstances(task_req_custom_resource.second,
-                                                 it->second.available, &allocation);
-        // Even if allocation failed we need to remember partial allocations to correctly
-        // free resources.
-        task_allocation->custom_resources.emplace(it->first, allocation);
-        if (!success) {
-          // Allocation failed. Restore node's local resources by freeing the resources
-          // of the failed allocation.
-          FreeTaskResourceInstances(task_allocation);
-          return false;
-        }
-      }
-    } else {
-      // Allocation failed because the custom resources don't exist in this local node.
-      // Restore node's local resources by freeing the resources
-      // of the failed allocation.
-      FreeTaskResourceInstances(task_allocation);
-      return false;
-    }
-  }
-  return true;
-}
-
-void ClusterResourceScheduler::UpdateLocalAvailableResourcesFromResourceInstances() {
-  auto it_local_node = nodes_.find(local_node_id_);
-  RAY_CHECK(it_local_node != nodes_.end());
-
-  auto local_view = it_local_node->second.GetMutableLocalView();
-  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    local_view->predefined_resources[i].available = 0;
-    local_view->predefined_resources[i].total = 0;
-    for (size_t j = 0; j < local_resources_.predefined_resources[i].available.size();
-         j++) {
-      local_view->predefined_resources[i].available +=
-          local_resources_.predefined_resources[i].available[j];
-      local_view->predefined_resources[i].total +=
-          local_resources_.predefined_resources[i].total[j];
-    }
-  }
-
-  for (auto &custom_resource : local_resources_.custom_resources) {
-    int64_t resource_name = custom_resource.first;
-    auto &instances = custom_resource.second;
-
-    FixedPoint available = std::accumulate(instances.available.begin(),
-                                           instances.available.end(), FixedPoint());
-    FixedPoint total =
-        std::accumulate(instances.total.begin(), instances.total.end(), FixedPoint());
-
-    local_view->custom_resources[resource_name].available = available;
-    local_view->custom_resources[resource_name].total = total;
-  }
-}
-
-void ClusterResourceScheduler::FreeTaskResourceInstances(
-    std::shared_ptr<TaskResourceInstances> task_allocation) {
-  RAY_CHECK(task_allocation != nullptr);
-  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    AddAvailableResourceInstances(task_allocation->predefined_resources[i],
-                                  &local_resources_.predefined_resources[i]);
-  }
-
-  for (const auto &task_allocation_custom_resource : task_allocation->custom_resources) {
-    auto it =
-        local_resources_.custom_resources.find(task_allocation_custom_resource.first);
-    if (it != local_resources_.custom_resources.end()) {
-      AddAvailableResourceInstances(task_allocation_custom_resource.second, &it->second);
-    }
-  }
-}
-
-std::vector<double> ClusterResourceScheduler::AddCPUResourceInstances(
-    std::vector<double> &cpu_instances) {
-  std::vector<FixedPoint> cpu_instances_fp =
-      VectorDoubleToVectorFixedPoint(cpu_instances);
-
-  if (cpu_instances.size() == 0) {
-    return cpu_instances;  // No overflow.
-  }
-  RAY_CHECK(nodes_.find(local_node_id_) != nodes_.end());
-
-  auto overflow = AddAvailableResourceInstances(
-      cpu_instances_fp, &local_resources_.predefined_resources[CPU]);
-  UpdateLocalAvailableResourcesFromResourceInstances();
-
-  return VectorFixedPointToVectorDouble(overflow);
-}
-
-std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
-    std::vector<double> &cpu_instances, bool allow_going_negative) {
-  std::vector<FixedPoint> cpu_instances_fp =
-      VectorDoubleToVectorFixedPoint(cpu_instances);
-
-  if (cpu_instances.size() == 0) {
-    return cpu_instances;  // No underflow.
-  }
-  RAY_CHECK(nodes_.find(local_node_id_) != nodes_.end());
-
-  auto underflow = SubtractAvailableResourceInstances(
-      cpu_instances_fp, &local_resources_.predefined_resources[CPU],
-      allow_going_negative);
-  UpdateLocalAvailableResourcesFromResourceInstances();
-
-  return VectorFixedPointToVectorDouble(underflow);
-}
-
-std::vector<double> ClusterResourceScheduler::AddGPUResourceInstances(
-    std::vector<double> &gpu_instances) {
-  std::vector<FixedPoint> gpu_instances_fp =
-      VectorDoubleToVectorFixedPoint(gpu_instances);
-
-  if (gpu_instances.size() == 0) {
-    return gpu_instances;  // No overflow.
-  }
-  RAY_CHECK(nodes_.find(local_node_id_) != nodes_.end());
-
-  auto overflow = AddAvailableResourceInstances(
-      gpu_instances_fp, &local_resources_.predefined_resources[GPU]);
-  UpdateLocalAvailableResourcesFromResourceInstances();
-
-  return VectorFixedPointToVectorDouble(overflow);
-}
-
-std::vector<double> ClusterResourceScheduler::SubtractGPUResourceInstances(
-    std::vector<double> &gpu_instances) {
-  std::vector<FixedPoint> gpu_instances_fp =
-      VectorDoubleToVectorFixedPoint(gpu_instances);
-
-  if (gpu_instances.size() == 0) {
-    return gpu_instances;  // No underflow.
-  }
-  RAY_CHECK(nodes_.find(local_node_id_) != nodes_.end());
-
-  auto underflow = SubtractAvailableResourceInstances(
-      gpu_instances_fp, &local_resources_.predefined_resources[GPU]);
-  UpdateLocalAvailableResourcesFromResourceInstances();
-
-  return VectorFixedPointToVectorDouble(underflow);
-}
-
-bool ClusterResourceScheduler::AllocateLocalTaskResources(
-    const ResourceRequest &resource_request,
-    std::shared_ptr<TaskResourceInstances> task_allocation) {
-  if (AllocateTaskResourceInstances(resource_request, task_allocation)) {
-    UpdateLocalAvailableResourcesFromResourceInstances();
-    return true;
-  }
-  return false;
-}
-
-bool ClusterResourceScheduler::AllocateLocalTaskResources(
-    const absl::flat_hash_map<std::string, double> &task_resources,
-    std::shared_ptr<TaskResourceInstances> task_allocation) {
-  RAY_CHECK(task_allocation != nullptr);
-  // We don't track object store memory demands so no need to allocate them.
-  ResourceRequest resource_request = ResourceMapToResourceRequest(
-      string_to_int_map_, task_resources, /*requires_object_store_memory=*/false);
-  return AllocateLocalTaskResources(resource_request, task_allocation);
 }
 
 std::string ClusterResourceScheduler::GetResourceNameFromIndex(int64_t res_idx) {
@@ -1006,136 +461,6 @@ bool ClusterResourceScheduler::AllocateRemoteTaskResources(
   auto node_id = string_to_int_map_.Insert(node_string);
   RAY_CHECK(node_id != local_node_id_);
   return SubtractRemoteNodeAvailableResources(node_id, resource_request);
-}
-
-void ClusterResourceScheduler::ReleaseWorkerResources(
-    std::shared_ptr<TaskResourceInstances> task_allocation) {
-  if (task_allocation == nullptr || task_allocation->IsEmpty()) {
-    return;
-  }
-  FreeTaskResourceInstances(task_allocation);
-  UpdateLocalAvailableResourcesFromResourceInstances();
-}
-
-void ClusterResourceScheduler::UpdateLastResourceUsage(
-    std::shared_ptr<SchedulingResources> gcs_resources) {
-  last_report_resources_ = std::make_unique<NodeResources>(ResourceMapToNodeResources(
-      string_to_int_map_, gcs_resources->GetTotalResources().GetResourceMap(),
-      gcs_resources->GetAvailableResources().GetResourceMap()));
-}
-
-void ClusterResourceScheduler::FillResourceUsage(rpc::ResourcesData &resources_data) {
-  NodeResources resources;
-
-  RAY_CHECK(GetNodeResources(local_node_id_, &resources))
-      << "Error: Populating heartbeat failed. Please file a bug report: "
-         "https://github.com/ray-project/ray/issues/new.";
-
-  // Initialize if last report resources is empty.
-  if (!last_report_resources_) {
-    NodeResources node_resources =
-        ResourceMapToNodeResources(string_to_int_map_, {{}}, {{}});
-    last_report_resources_.reset(new NodeResources(node_resources));
-  }
-
-  // Automatically report object store usage.
-  // XXX: this MUTATES the resources field, which is needed since we are storing
-  // it in last_report_resources_.
-  if (get_used_object_store_memory_ != nullptr) {
-    auto &capacity = resources.predefined_resources[OBJECT_STORE_MEM];
-    double used = get_used_object_store_memory_();
-    capacity.available = FixedPoint(capacity.total.Double() - used);
-  }
-
-  for (int i = 0; i < PredefinedResources_MAX; i++) {
-    const auto &label = ResourceEnumToString((PredefinedResources)i);
-    const auto &capacity = resources.predefined_resources[i];
-    const auto &last_capacity = last_report_resources_->predefined_resources[i];
-    // Note: available may be negative, but only report positive to GCS.
-    if (capacity.available != last_capacity.available && capacity.available > 0) {
-      resources_data.set_resources_available_changed(true);
-      (*resources_data.mutable_resources_available())[label] =
-          capacity.available.Double();
-    }
-    if (capacity.total != last_capacity.total) {
-      (*resources_data.mutable_resources_total())[label] = capacity.total.Double();
-    }
-  }
-  for (const auto &it : resources.custom_resources) {
-    uint64_t custom_id = it.first;
-    const auto &capacity = it.second;
-    const auto &last_capacity = last_report_resources_->custom_resources[custom_id];
-    const auto &label = string_to_int_map_.Get(custom_id);
-    // Note: available may be negative, but only report positive to GCS.
-    if (capacity.available != last_capacity.available && capacity.available > 0) {
-      resources_data.set_resources_available_changed(true);
-      (*resources_data.mutable_resources_available())[label] =
-          capacity.available.Double();
-    }
-    if (capacity.total != last_capacity.total) {
-      (*resources_data.mutable_resources_total())[label] = capacity.total.Double();
-    }
-  }
-
-  if (get_pull_manager_at_capacity_ != nullptr) {
-    resources.object_pulls_queued = get_pull_manager_at_capacity_();
-    if (last_report_resources_->object_pulls_queued != resources.object_pulls_queued) {
-      resources_data.set_object_pulls_queued(resources.object_pulls_queued);
-      resources_data.set_resources_available_changed(true);
-    }
-  }
-
-  if (resources != *last_report_resources_.get()) {
-    last_report_resources_.reset(new NodeResources(resources));
-  }
-
-  if (!RayConfig::instance().enable_light_weight_resource_report()) {
-    resources_data.set_resources_available_changed(true);
-  }
-}
-
-double ClusterResourceScheduler::GetLocalAvailableCpus() const {
-  NodeResources local_resources;
-  RAY_CHECK(GetNodeResources(local_node_id_, &local_resources));
-  auto &capacity = local_resources.predefined_resources[CPU];
-  return capacity.available.Double();
-}
-
-ray::gcs::NodeResourceInfoAccessor::ResourceMap
-ClusterResourceScheduler::GetResourceTotals(
-    const absl::flat_hash_map<std::string, double> &resource_map_filter) const {
-  ray::gcs::NodeResourceInfoAccessor::ResourceMap map;
-  auto it = nodes_.find(local_node_id_);
-  RAY_CHECK(it != nodes_.end());
-  const auto &local_resources = it->second.GetLocalView();
-  for (size_t i = 0; i < local_resources.predefined_resources.size(); i++) {
-    std::string resource_name = ResourceEnumToString(static_cast<PredefinedResources>(i));
-    double resource_total = local_resources.predefined_resources[i].total.Double();
-    if (!resource_map_filter.contains(resource_name)) {
-      continue;
-    }
-
-    if (resource_total > 0) {
-      auto data = std::make_shared<rpc::ResourceTableData>();
-      data->set_resource_capacity(resource_total);
-      map.emplace(resource_name, std::move(data));
-    }
-  }
-
-  for (auto entry : local_resources.custom_resources) {
-    std::string resource_name = string_to_int_map_.Get(entry.first);
-    double resource_total = entry.second.total.Double();
-    if (!resource_map_filter.contains(resource_name)) {
-      continue;
-    }
-
-    if (resource_total > 0) {
-      auto data = std::make_shared<rpc::ResourceTableData>();
-      data->set_resource_capacity(resource_total);
-      map.emplace(resource_name, std::move(data));
-    }
-  }
-  return map;
 }
 
 bool ClusterResourceScheduler::IsLocallySchedulable(

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -28,6 +28,7 @@
 #include "ray/raylet/scheduling/cluster_resource_data.h"
 #include "ray/raylet/scheduling/cluster_resource_scheduler_interface.h"
 #include "ray/raylet/scheduling/fixed_point.h"
+#include "ray/raylet/scheduling/local_resource_manager.h"
 #include "ray/raylet/scheduling/scheduling_ids.h"
 #include "ray/raylet/scheduling/scheduling_policy.h"
 #include "ray/util/logging.h"
@@ -113,26 +114,11 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
       bool requires_object_store_memory, bool actor_creation, bool force_spillback,
       int64_t *violations, bool *is_infeasible);
 
-  /// Get local node resources.
-  const NodeResources &GetLocalNodeResources() const;
-
   /// Get number of nodes in the cluster.
   int64_t NumNodes() const;
 
   /// Temporarily get the StringIDMap.
   const StringIdMap &GetStringIdMap() const;
-
-  /// Add a local resource that is available.
-  ///
-  /// \param resource_name: Resource which we want to update.
-  /// \param resource_total: New capacity of the resource.
-  void AddLocalResourceInstances(const std::string &resource_name,
-                                 const std::vector<FixedPoint> &instances);
-
-  /// Check whether the available resources are empty.
-  ///
-  /// \param resource_name: Resource which we want to check.
-  bool IsAvailableResourceEmpty(const std::string &resource_name);
 
   /// Update total capacity of a given resource of a given node.
   ///
@@ -142,11 +128,6 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   void UpdateResourceCapacity(const std::string &node_name,
                               const std::string &resource_name,
                               double resource_total) override;
-
-  /// Delete a given resource from the local node.
-  ///
-  /// \param resource_name: Resource we want to delete
-  void DeleteLocalResource(const std::string &resource_name);
 
   /// Delete a given resource from a given node.
   ///
@@ -163,79 +144,12 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   bool ResourcesExist(const std::string &resource_name);
 
   /// Return local resources.
-  NodeResourceInstances GetLocalResources() const { return local_resources_; };
+  NodeResourceInstances GetLocalResources() const {
+    return local_resource_manager_->GetLocalResources();
+  };
 
   /// Return local resources in human-readable string form.
   std::string GetLocalResourceViewString() const override;
-
-  /// Allocate local resources to satisfy a given request (resource_request).
-  ///
-  /// \param resource_request: Resources requested by a task.
-  /// \param task_allocation: Local resources allocated to satsify resource_request
-  /// demand.
-  ///
-  /// \return true, if allocation successful. If false, the caller needs to free the
-  /// allocated resources, i.e., task_allocation.
-  bool AllocateTaskResourceInstances(
-      const ResourceRequest &resource_request,
-      std::shared_ptr<TaskResourceInstances> task_allocation);
-
-  /// Free resources which were allocated with a task. The freed resources are
-  /// added back to the node's local available resources.
-  ///
-  /// \param task_allocation: Task's resources to be freed.
-  void FreeTaskResourceInstances(std::shared_ptr<TaskResourceInstances> task_allocation);
-
-  /// Increase the available CPU instances of this node.
-  ///
-  /// \param cpu_instances CPU instances to be added to available cpus.
-  ///
-  /// \return Overflow capacities of CPU instances after adding CPU
-  /// capacities in cpu_instances.
-  std::vector<double> AddCPUResourceInstances(std::vector<double> &cpu_instances);
-
-  /// Decrease the available CPU instances of this node.
-  ///
-  /// \param cpu_instances CPU instances to be removed from available cpus.
-  /// \param allow_going_negative Allow the values to go negative (disable underflow).
-  ///
-  /// \return Underflow capacities of CPU instances after subtracting CPU
-  /// capacities in cpu_instances.
-  std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances,
-                                                   bool allow_going_negative = false);
-
-  /// Increase the available GPU instances of this node.
-  ///
-  /// \param gpu_instances GPU instances to be added to available gpus.
-  ///
-  /// \return Overflow capacities of GPU instances after adding GPU
-  /// capacities in gpu_instances.
-  std::vector<double> AddGPUResourceInstances(std::vector<double> &gpu_instances);
-
-  /// Decrease the available GPU instances of this node.
-  ///
-  /// \param gpu_instances GPU instances to be removed from available gpus.
-  ///
-  /// \return Underflow capacities of GPU instances after subtracting GPU
-  /// capacities in gpu_instances.
-  std::vector<double> SubtractGPUResourceInstances(std::vector<double> &gpu_instances);
-
-  /// Subtract the resources required by a given resource request (resource_request) from
-  /// the local node. This function also updates the local node resources at the instance
-  /// granularity.
-  ///
-  /// \param resource_request Task for which we allocate resources.
-  /// \param task_allocation Resources allocated to the task at instance granularity.
-  /// This is a return parameter.
-  ///
-  /// \return True if local node has enough resources to satisfy the resource request.
-  /// False otherwise.
-  bool AllocateLocalTaskResources(
-      const absl::flat_hash_map<std::string, double> &task_resources,
-      std::shared_ptr<TaskResourceInstances> task_allocation);
-
-  bool AllocateLocalTaskResources(const ResourceRequest &resource_request,
-                                  std::shared_ptr<TaskResourceInstances> task_allocation);
 
   /// Subtract the resources required by a given resource request (resource_request) from
   /// a given remote node.
@@ -248,58 +162,8 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
       const std::string &node_id,
       const absl::flat_hash_map<std::string, double> &task_resources);
 
-  void ReleaseWorkerResources(std::shared_ptr<TaskResourceInstances> task_allocation);
-
-  /// Update the available resources of the local node given
-  /// the available instances of each resource of the local node.
-  /// Basically, this means computing the available resources
-  /// by adding up the available quantities of each instance of that
-  /// resources.
-  ///
-  /// Example: Assume the local node has four GPU instances with the
-  /// following availabilities: 0.2, 0.3, 0.1, 1. Then the total GPU
-  // resources availabile at that node is 0.2 + 0.3 + 0.1 + 1. = 1.6
-  void UpdateLocalAvailableResourcesFromResourceInstances();
-
-  /// Populate the relevant parts of the heartbeat table. This is intended for
-  /// sending resource usage of raylet to gcs. In particular, this should fill in
-  /// resources_available and resources_total.
-  ///
-  /// \param Output parameter. `resources_available` and `resources_total` are the only
-  /// fields used.
-  void FillResourceUsage(rpc::ResourcesData &resources_data) override;
-
-  /// Populate a UpdateResourcesRequest. This is inteneded to update the
-  /// resource totals on a node when a custom resource is created or deleted
-  /// (e.g. during the placement group lifecycle).
-  ///
-  /// \param resource_map_filter When returning the resource map, the returned result will
-  /// only contain the keys in the filter. Note that only the key of the map is used.
-  /// \return The total resource capacity of the node.
-  ray::gcs::NodeResourceInfoAccessor::ResourceMap GetResourceTotals(
-      const absl::flat_hash_map<std::string, double> &resource_map_filter) const override;
-
-  /// Update last report resources local cache from gcs cache,
-  /// this is needed when gcs fo.
-  ///
-  /// \param gcs_resources: The remote cache from gcs.
-  void UpdateLastResourceUsage(
-      const std::shared_ptr<SchedulingResources> gcs_resources) override;
-
-  double GetLocalAvailableCpus() const override;
-
-  /// Serialize task resource instances to json string.
-  ///
-  /// \param task_allocation Allocated resource instances for a task.
-  /// \return The task resource instances json string
-  std::string SerializedTaskResourceInstances(
-      std::shared_ptr<TaskResourceInstances> task_allocation) const;
-
   /// Return human-readable string for this scheduler state.
   std::string DebugString() const;
-
-  /// Get the number of cpus on this node.
-  uint64_t GetNumCpus() const;
 
   /// Check whether a task request is schedulable on a the local node. A node is
   /// schedulable if it has the available resources needed to execute the task.
@@ -307,29 +171,10 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// \param shape The resource demand's shape.
   bool IsLocallySchedulable(const absl::flat_hash_map<std::string, double> &shape);
 
+  LocalResourceManager &GetLocalResourceManager() { return *local_resource_manager_; }
+
  private:
-  /// Create instances for each resource associated with the local node, given
-  /// the node's resources.
-  ///
-  /// \param local_resources: Total resources of the node.
-  void InitLocalResources(const NodeResources &local_resources);
-
-  /// Initialize the instances of a given resource given the resource's total capacity.
-  /// If unit_instances is true we split the resources in unit-size instances. For
-  /// example, if total = 10, then we create 10 instances, each with caoacity 1.
-  /// Otherwise, we create a single instance of capacity equal to the resource's capacity.
-  ///
-  /// \param total: Total resource capacity.
-  /// \param unit_instances: If true, we split the resource in unit-size instances.
-  /// If false, we create a single instance of capacity "total".
-  /// \param instance_list: The list of capacities this resource instances.
-  void InitResourceInstances(FixedPoint total, bool unit_instances,
-                             ResourceInstanceCapacities *instance_list);
-
   bool NodeAlive(int64_t node_id) const;
-
-  /// Init the information about which resources are unit_instance.
-  void InitResourceUnitInstanceInfo();
 
   /// Decrease the available resources of a node when a resource request is
   /// scheduled on the given node.
@@ -372,28 +217,8 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// If node_id not found, return false; otherwise return true.
   bool GetNodeResources(int64_t node_id, NodeResources *ret_resources) const;
 
-  /// Increase the available capacities of the instances of a given resource.
-  ///
-  /// \param available A list of available capacities for resource's instances.
-  /// \param resource_instances List of the resource instances being updated.
-  ///
-  /// \return Overflow capacities of "resource_instances" after adding instance
-  /// capacities in "available", i.e.,
-  /// min(available + resource_instances.available, resource_instances.total)
-  std::vector<FixedPoint> AddAvailableResourceInstances(
-      std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances);
-
-  /// Decrease the available capacities of the instances of a given resource.
-  ///
-  /// \param free A list of capacities for resource's instances to be freed.
-  /// \param resource_instances List of the resource instances being updated.
-  /// \param allow_going_negative Allow the values to go negative (disable underflow).
-  /// \return Underflow of "resource_instances" after subtracting instance
-  /// capacities in "available", i.e.,.
-  /// max(available - reasource_instances.available, 0)
-  std::vector<FixedPoint> SubtractAvailableResourceInstances(
-      std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances,
-      bool allow_going_negative = false);
+  /// Get local node resources; test only.
+  const NodeResources &GetLocalNodeResources() const;
 
   /// List of nodes in the clusters and their resources organized as a map.
   /// The key of the map is the node ID.
@@ -405,25 +230,12 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
   /// Resources of local node.
-  NodeResourceInstances local_resources_;
+  std::unique_ptr<LocalResourceManager> local_resource_manager_;
   /// Keep the mapping between node and resource IDs in string representation
   /// to integer representation. Used for improving map performance.
   StringIdMap string_to_int_map_;
-  /// Cached resources, used to compare with newest one in light heartbeat mode.
-  std::unique_ptr<NodeResources> last_report_resources_;
-  /// Function to get used object store memory.
-  std::function<int64_t(void)> get_used_object_store_memory_;
-  /// Function to get whether the pull manager is at capacity.
-  std::function<bool(void)> get_pull_manager_at_capacity_;
-
   /// Gcs client. It's not owned by this class.
   gcs::GcsClient *gcs_client_;
-
-  // Specify predefine resources that consists of unit-size instances.
-  std::unordered_set<int64_t> predefined_unit_instance_resources_{};
-
-  // Specify custom resources that consists of unit-size instances.
-  std::unordered_set<int64_t> custom_unit_instance_resources_{};
 
   friend class ClusterResourceSchedulerTest;
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingDeleteClusterNodeTest);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -136,13 +136,6 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   void DeleteResource(const std::string &node_name,
                       const std::string &resource_name) override;
 
-  /// Check whether the specific resource exists or not in local node.
-  ///
-  /// \param resource_name: the specific resource name.
-  ///
-  /// \return true, if exist. otherwise, false.
-  bool ResourcesExist(const std::string &resource_name);
-
   /// Return local resources.
   NodeResourceInstances GetLocalResources() const {
     return local_resource_manager_->GetLocalResources();
@@ -172,6 +165,9 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   bool IsLocallySchedulable(const absl::flat_hash_map<std::string, double> &shape);
 
   LocalResourceManager &GetLocalResourceManager() { return *local_resource_manager_; }
+
+  /// Get local node resources; test only.
+  const NodeResources &GetLocalNodeResources() const;
 
  private:
   bool NodeAlive(int64_t node_id) const;
@@ -217,9 +213,6 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// If node_id not found, return false; otherwise return true.
   bool GetNodeResources(int64_t node_id, NodeResources *ret_resources) const;
 
-  /// Get local node resources; test only.
-  const NodeResources &GetLocalNodeResources() const;
-
   /// List of nodes in the clusters and their resources organized as a map.
   /// The key of the map is the node ID.
   absl::flat_hash_map<int64_t, Node> nodes_;
@@ -249,6 +242,7 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   FRIEND_TEST(ClusterResourceSchedulerTest, ResourceUsageReportTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, AvailableResourceInstancesOpsTest);
+  FRIEND_TEST(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources);
 };
 
 }  // end namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
@@ -23,13 +23,6 @@ class ClusterResourceSchedulerInterface {
  public:
   virtual ~ClusterResourceSchedulerInterface() = default;
 
-  /// Add a local resource that is available.
-  ///
-  /// \param resource_name: Resource which we want to update.
-  /// \param resource_total: New capacity of the resource.
-  void AddLocalResourceInstances(const std::string &resource_name,
-                                 std::vector<FixedPoint> instances);
-
   /// Remove node from the cluster data structure. This happens
   /// when a node fails or it is removed from the cluster.
   ///
@@ -56,33 +49,6 @@ class ClusterResourceSchedulerInterface {
   /// \param resource_name: Resource we want to delete
   virtual void DeleteResource(const std::string &node_id_string,
                               const std::string &resource_name) = 0;
-
-  /// Update last report resources local cache from gcs cache,
-  /// this is needed when gcs fo.
-  ///
-  /// \param gcs_resources: The remote cache from gcs.
-  virtual void UpdateLastResourceUsage(
-      const std::shared_ptr<SchedulingResources> gcs_resources) {}
-
-  /// Populate the relevant parts of the heartbeat table. This is intended for
-  /// sending raylet <-> gcs heartbeats. In particular, this should fill in
-  /// resources_available and resources_total.
-  ///
-  /// \param Output parameter. `resources_available` and `resources_total` are the only
-  /// fields used.
-  virtual void FillResourceUsage(rpc::ResourcesData &data) = 0;
-
-  virtual double GetLocalAvailableCpus() const = 0;
-
-  /// Populate a UpdateResourcesRequest. This is inteneded to update the
-  /// resource totals on a node when a custom resource is created or deleted
-  /// (e.g. during the placement group lifecycle).
-  ///
-  /// \param resource_map_filter When returning the resource map, the returned result will
-  /// only contain the keys in the filter. Note that only the key of the map is used.
-  /// \return The total resource capacity of the node.
-  virtual ray::gcs::NodeResourceInfoAccessor::ResourceMap GetResourceTotals(
-      const absl::flat_hash_map<std::string, double> &resource_map_filter) const = 0;
 
   /// Return local resources in human-readable string form.
   virtual std::string GetLocalResourceViewString() const = 0;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -370,8 +370,8 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
     NodeResources nr1, nr2;
     ASSERT_TRUE(resource_scheduler.GetNodeResources(node_id, &nr1));
     auto task_allocation = std::make_shared<TaskResourceInstances>();
-    ASSERT_TRUE(
-        resource_scheduler.AllocateLocalTaskResources(resource_request, task_allocation));
+    ASSERT_TRUE(resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+        resource_request, task_allocation));
     ASSERT_TRUE(resource_scheduler.GetNodeResources(node_id, &nr2));
 
     for (size_t i = 0; i < PRED_CUSTOM_LEN; i++) {
@@ -401,8 +401,10 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest) {
   ClusterResourceScheduler resource_scheduler(
       NodeID::FromRandom().Binary(), initial_resources, *gcs_client_, nullptr, nullptr);
 
-  resource_scheduler.AddLocalResourceInstances(ray::kCPU_ResourceLabel, {0, 1, 1});
-  resource_scheduler.AddLocalResourceInstances("custom", {0, 1, 1});
+  resource_scheduler.GetLocalResourceManager().AddLocalResourceInstances(
+      ray::kCPU_ResourceLabel, {0, 1, 1});
+  resource_scheduler.GetLocalResourceManager().AddLocalResourceInstances("custom",
+                                                                         {0, 1, 1});
 
   const auto &predefined_resources =
       resource_scheduler.GetLocalNodeResources().predefined_resources;
@@ -642,19 +644,19 @@ TEST_F(ClusterResourceSchedulerTest, AvailableResourceInstancesOpsTest) {
   ResourceInstanceCapacities old_instances = instances;
 
   std::vector<FixedPoint> a{1., 1., 1.};
-  cluster.AddAvailableResourceInstances(a, &instances);
-  cluster.SubtractAvailableResourceInstances(a, &instances);
+  cluster.GetLocalResourceManager().AddAvailableResourceInstances(a, &instances);
+  cluster.GetLocalResourceManager().SubtractAvailableResourceInstances(a, &instances);
 
   ASSERT_EQ(EqualVectors(instances.available, old_instances.available), true);
 
   a = {10., 1., 1.};
-  cluster.AddAvailableResourceInstances(a, &instances);
+  cluster.GetLocalResourceManager().AddAvailableResourceInstances(a, &instances);
   std::vector<FixedPoint> expected_available{6., 3., 6.};
 
   ASSERT_EQ(EqualVectors(instances.available, expected_available), true);
 
   a = {10., 1., 1.};
-  cluster.SubtractAvailableResourceInstances(a, &instances);
+  cluster.GetLocalResourceManager().SubtractAvailableResourceInstances(a, &instances);
   expected_available = {0., 2., 5.};
   ASSERT_EQ(EqualVectors(instances.available, expected_available), true);
 }
@@ -677,12 +679,14 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
 
     std::shared_ptr<TaskResourceInstances> task_allocation =
         std::make_shared<TaskResourceInstances>();
-    bool success = resource_scheduler.AllocateTaskResourceInstances(resource_request,
-                                                                    task_allocation);
+    bool success =
+        resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+            resource_request, task_allocation);
 
     ASSERT_EQ(success, true);
 
-    resource_scheduler.FreeTaskResourceInstances(task_allocation);
+    resource_scheduler.GetLocalResourceManager().FreeTaskResourceInstances(
+        task_allocation);
 
     ASSERT_EQ((resource_scheduler.GetLocalResources() == old_local_resources), true);
   }
@@ -703,8 +707,9 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
     std::shared_ptr<TaskResourceInstances> task_allocation =
         std::make_shared<TaskResourceInstances>();
-    bool success = resource_scheduler.AllocateTaskResourceInstances(resource_request,
-                                                                    task_allocation);
+    bool success =
+        resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+            resource_request, task_allocation);
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((resource_scheduler.GetLocalResources() == old_local_resources), true);
@@ -727,12 +732,14 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
     std::shared_ptr<TaskResourceInstances> task_allocation =
         std::make_shared<TaskResourceInstances>();
-    bool success = resource_scheduler.AllocateTaskResourceInstances(resource_request,
-                                                                    task_allocation);
+    bool success =
+        resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+            resource_request, task_allocation);
 
     ASSERT_EQ(success, true);
 
-    resource_scheduler.FreeTaskResourceInstances(task_allocation);
+    resource_scheduler.GetLocalResourceManager().FreeTaskResourceInstances(
+        task_allocation);
 
     ASSERT_EQ((resource_scheduler.GetLocalResources() == old_local_resources), true);
   }
@@ -754,8 +761,9 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
     std::shared_ptr<TaskResourceInstances> task_allocation =
         std::make_shared<TaskResourceInstances>();
-    bool success = resource_scheduler.AllocateTaskResourceInstances(resource_request,
-                                                                    task_allocation);
+    bool success =
+        resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+            resource_request, task_allocation);
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((resource_scheduler.GetLocalResources() == old_local_resources), true);
@@ -781,7 +789,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesAllocationFailureTest)
   std::shared_ptr<TaskResourceInstances> task_allocation =
       std::make_shared<TaskResourceInstances>();
   bool success =
-      resource_scheduler.AllocateTaskResourceInstances(resource_request, task_allocation);
+      resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+          resource_request, task_allocation);
 
   ASSERT_EQ(success, false);
   // resource_scheduler.FreeTaskResourceInstances(task_allocation);
@@ -804,14 +813,16 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest2) {
 
     std::shared_ptr<TaskResourceInstances> task_allocation =
         std::make_shared<TaskResourceInstances>();
-    bool success = resource_scheduler.AllocateTaskResourceInstances(resource_request,
-                                                                    task_allocation);
+    bool success =
+        resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+            resource_request, task_allocation);
 
     NodeResourceInstances old_local_resources = resource_scheduler.GetLocalResources();
     ASSERT_EQ(success, true);
     std::vector<double> cpu_instances = task_allocation->GetCPUInstancesDouble();
-    resource_scheduler.AddCPUResourceInstances(cpu_instances);
-    resource_scheduler.SubtractCPUResourceInstances(cpu_instances);
+    resource_scheduler.GetLocalResourceManager().AddCPUResourceInstances(cpu_instances);
+    resource_scheduler.GetLocalResourceManager().SubtractCPUResourceInstances(
+        cpu_instances);
 
     ASSERT_EQ((resource_scheduler.GetLocalResources() == old_local_resources), true);
   }
@@ -848,7 +859,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskGPUResourceInstancesTest) {
     ClusterResourceScheduler resource_scheduler(0, node_resources, *gcs_client_);
 
     std::vector<double> allocate_gpu_instances{0.5, 0.5, 0.5, 0.5};
-    resource_scheduler.SubtractGPUResourceInstances(allocate_gpu_instances);
+    resource_scheduler.GetLocalResourceManager().SubtractGPUResourceInstances(
+        allocate_gpu_instances);
     std::vector<double> available_gpu_instances = resource_scheduler.GetLocalResources()
                                                       .GetAvailableResourceInstances()
                                                       .GetGPUInstancesDouble();
@@ -856,7 +868,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskGPUResourceInstancesTest) {
     ASSERT_TRUE(std::equal(available_gpu_instances.begin(), available_gpu_instances.end(),
                            expected_available_gpu_instances.begin()));
 
-    resource_scheduler.AddGPUResourceInstances(allocate_gpu_instances);
+    resource_scheduler.GetLocalResourceManager().AddGPUResourceInstances(
+        allocate_gpu_instances);
     available_gpu_instances = resource_scheduler.GetLocalResources()
                                   .GetAvailableResourceInstances()
                                   .GetGPUInstancesDouble();
@@ -866,7 +879,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskGPUResourceInstancesTest) {
 
     allocate_gpu_instances = {1.5, 1.5, .5, 1.5};
     std::vector<double> underflow =
-        resource_scheduler.SubtractGPUResourceInstances(allocate_gpu_instances);
+        resource_scheduler.GetLocalResourceManager().SubtractGPUResourceInstances(
+            allocate_gpu_instances);
     std::vector<double> expected_underflow{.5, .5, 0., .5};
     ASSERT_TRUE(
         std::equal(underflow.begin(), underflow.end(), expected_underflow.begin()));
@@ -879,7 +893,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskGPUResourceInstancesTest) {
 
     allocate_gpu_instances = {1.0, .5, 1., .5};
     std::vector<double> overflow =
-        resource_scheduler.AddGPUResourceInstances(allocate_gpu_instances);
+        resource_scheduler.GetLocalResourceManager().AddGPUResourceInstances(
+            allocate_gpu_instances);
     std::vector<double> expected_overflow{.0, .0, .5, 0.};
     ASSERT_TRUE(std::equal(overflow.begin(), overflow.end(), expected_overflow.begin()));
     available_gpu_instances = resource_scheduler.GetLocalResources()
@@ -905,7 +920,8 @@ TEST_F(ClusterResourceSchedulerTest,
       std::vector<double> allocate_gpu_instances{0.5, 0.5, 2, 0.5};
       // SubtractGPUResourceInstances() calls
       // UpdateLocalAvailableResourcesFromResourceInstances() under the hood.
-      resource_scheduler.SubtractGPUResourceInstances(allocate_gpu_instances);
+      resource_scheduler.GetLocalResourceManager().SubtractGPUResourceInstances(
+          allocate_gpu_instances);
       std::vector<double> available_gpu_instances = resource_scheduler.GetLocalResources()
                                                         .GetAvailableResourceInstances()
                                                         .GetGPUInstancesDouble();
@@ -923,7 +939,8 @@ TEST_F(ClusterResourceSchedulerTest,
       std::vector<double> allocate_gpu_instances{1.5, 0.5, 2, 0.3};
       // SubtractGPUResourceInstances() calls
       // UpdateLocalAvailableResourcesFromResourceInstances() under the hood.
-      resource_scheduler.AddGPUResourceInstances(allocate_gpu_instances);
+      resource_scheduler.GetLocalResourceManager().AddGPUResourceInstances(
+          allocate_gpu_instances);
       std::vector<double> available_gpu_instances = resource_scheduler.GetLocalResources()
                                                         .GetAvailableResourceInstances()
                                                         .GetGPUInstancesDouble();
@@ -954,7 +971,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstanceWithHardRequestTest) {
   std::shared_ptr<TaskResourceInstances> task_allocation =
       std::make_shared<TaskResourceInstances>();
   bool success =
-      resource_scheduler.AllocateTaskResourceInstances(resource_request, task_allocation);
+      resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+          resource_request, task_allocation);
 
   ASSERT_EQ(success, true);
 
@@ -979,7 +997,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstanceWithoutCpuUnitTest) {
   std::shared_ptr<TaskResourceInstances> task_allocation =
       std::make_shared<TaskResourceInstances>();
   bool success =
-      resource_scheduler.AllocateTaskResourceInstances(resource_request, task_allocation);
+      resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+          resource_request, task_allocation);
 
   ASSERT_EQ(success, true);
 
@@ -1040,7 +1059,7 @@ TEST_F(ClusterResourceSchedulerTest, ResourceUsageReportTest) {
 
   {  // Cluster is idle.
     rpc::ResourcesData data;
-    resource_scheduler.FillResourceUsage(data);
+    resource_scheduler.GetLocalResourceManager().FillResourceUsage(data);
 
     auto available = data.resources_available();
     auto total = data.resources_total();
@@ -1076,10 +1095,12 @@ TEST_F(ClusterResourceSchedulerTest, ResourceUsageReportTest) {
         {"CPU", 0.1},
         {"1", 0.1},
     });
-    resource_scheduler.AllocateLocalTaskResources(allocation_map, allocations);
+    resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+        allocation_map, allocations);
     rpc::ResourcesData data;
-    resource_scheduler.UpdateLastResourceUsage(std::make_shared<SchedulingResources>());
-    resource_scheduler.FillResourceUsage(data);
+    resource_scheduler.GetLocalResourceManager().UpdateLastResourceUsage(
+        std::make_shared<SchedulingResources>());
+    resource_scheduler.GetLocalResourceManager().FillResourceUsage(data);
 
     auto available = data.resources_available();
     auto total = data.resources_total();
@@ -1121,7 +1142,7 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
 
   {
     rpc::ResourcesData data;
-    resource_scheduler.FillResourceUsage(data);
+    resource_scheduler.GetLocalResourceManager().FillResourceUsage(data);
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 750 * 1024 * 1024);
@@ -1131,7 +1152,7 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
   used_object_store_memory = 450 * 1024 * 1024;
   {
     rpc::ResourcesData data;
-    resource_scheduler.FillResourceUsage(data);
+    resource_scheduler.GetLocalResourceManager().FillResourceUsage(data);
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 550 * 1024 * 1024);
@@ -1140,7 +1161,7 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
   used_object_store_memory = 0;
   {
     rpc::ResourcesData data;
-    resource_scheduler.FillResourceUsage(data);
+    resource_scheduler.GetLocalResourceManager().FillResourceUsage(data);
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 1000 * 1024 * 1024);
@@ -1149,7 +1170,7 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
   used_object_store_memory = 9999999999;
   {
     rpc::ResourcesData data;
-    resource_scheduler.FillResourceUsage(data);
+    resource_scheduler.GetLocalResourceManager().FillResourceUsage(data);
     auto available = data.resources_available();
     auto total = data.resources_total();
     ASSERT_EQ(available["object_store_memory"], 0);
@@ -1167,13 +1188,16 @@ TEST_F(ClusterResourceSchedulerTest, DirtyLocalViewTest) {
   // resources are available.
   std::shared_ptr<TaskResourceInstances> task_allocation =
       std::make_shared<TaskResourceInstances>();
-  ASSERT_TRUE(resource_scheduler.AllocateLocalTaskResources(task_spec, task_allocation));
+  ASSERT_TRUE(resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+      task_spec, task_allocation));
   task_allocation = std::make_shared<TaskResourceInstances>();
-  ASSERT_FALSE(resource_scheduler.AllocateLocalTaskResources(task_spec, task_allocation));
+  ASSERT_FALSE(resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+      task_spec, task_allocation));
   // View of local resources is not affected by resource usage report.
   rpc::ResourcesData data;
-  resource_scheduler.FillResourceUsage(data);
-  ASSERT_FALSE(resource_scheduler.AllocateLocalTaskResources(task_spec, task_allocation));
+  resource_scheduler.GetLocalResourceManager().FillResourceUsage(data);
+  ASSERT_FALSE(resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+      task_spec, task_allocation));
 
   for (int num_slots_available = 0; num_slots_available <= 2; num_slots_available++) {
     rpc::ResourcesData data;
@@ -1198,7 +1222,8 @@ TEST_F(ClusterResourceSchedulerTest, DirtyLocalViewTest) {
                         task_spec, scheduling_strategy, false, false, true, &t,
                         &is_infeasible));
       ASSERT_FALSE(
-          resource_scheduler.AllocateLocalTaskResources(task_spec, task_allocation));
+          resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+              task_spec, task_allocation));
       ASSERT_FALSE(resource_scheduler.AllocateRemoteTaskResources(remote, task_spec));
     }
   }
@@ -1218,7 +1243,8 @@ TEST_F(ClusterResourceSchedulerTest, DynamicResourceTest) {
       resource_request, scheduling_strategy, false, false, false, &t, &is_infeasible);
   ASSERT_TRUE(result.empty());
 
-  resource_scheduler.AddLocalResourceInstances("custom123", {0., 1.0, 1.0});
+  resource_scheduler.GetLocalResourceManager().AddLocalResourceInstances("custom123",
+                                                                         {0., 1.0, 1.0});
 
   result = resource_scheduler.GetBestSchedulableNode(
       resource_request, scheduling_strategy, false, false, false, &t, &is_infeasible);
@@ -1229,12 +1255,13 @@ TEST_F(ClusterResourceSchedulerTest, DynamicResourceTest) {
       resource_request, scheduling_strategy, false, false, false, &t, &is_infeasible);
   ASSERT_TRUE(result.empty());
 
-  resource_scheduler.AddLocalResourceInstances("custom123", {1.0});
+  resource_scheduler.GetLocalResourceManager().AddLocalResourceInstances("custom123",
+                                                                         {1.0});
   result = resource_scheduler.GetBestSchedulableNode(
       resource_request, scheduling_strategy, false, false, false, &t, &is_infeasible);
   ASSERT_FALSE(result.empty());
 
-  resource_scheduler.DeleteLocalResource("custom123");
+  resource_scheduler.GetLocalResourceManager().DeleteLocalResource("custom123");
   result = resource_scheduler.GetBestSchedulableNode(
       resource_request, scheduling_strategy, false, false, false, &t, &is_infeasible);
   ASSERT_TRUE(result.empty());
@@ -1246,9 +1273,11 @@ TEST_F(ClusterResourceSchedulerTest, AvailableResourceEmptyTest) {
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> resource_request = {{"custom123", 5}};
   bool allocated =
-      resource_scheduler.AllocateLocalTaskResources(resource_request, resource_instances);
+      resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+          resource_request, resource_instances);
   ASSERT_TRUE(allocated);
-  ASSERT_TRUE(resource_scheduler.IsAvailableResourceEmpty("custom123"));
+  ASSERT_TRUE(
+      resource_scheduler.GetLocalResourceManager().IsAvailableResourceEmpty("custom123"));
 }
 
 TEST_F(ClusterResourceSchedulerTest, TestForceSpillback) {
@@ -1311,18 +1340,19 @@ TEST_F(ClusterResourceSchedulerTest, CustomResourceInstanceTest) {
   std::shared_ptr<TaskResourceInstances> task_allocation =
       std::make_shared<TaskResourceInstances>();
   bool success =
-      resource_scheduler.AllocateTaskResourceInstances(resource_request, task_allocation);
+      resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+          resource_request, task_allocation);
   ASSERT_TRUE(success) << resource_scheduler.DebugString();
 
-  success =
-      resource_scheduler.AllocateTaskResourceInstances(resource_request, task_allocation);
+  success = resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+      resource_request, task_allocation);
   ASSERT_TRUE(success) << resource_scheduler.DebugString();
 
   ResourceRequest fail_resource_request;
   vector<FixedPoint> fail_cust_demands{0.5};
   initResourceRequest(fail_resource_request, pred_demands, cust_ids, fail_cust_demands);
-  success = resource_scheduler.AllocateTaskResourceInstances(fail_resource_request,
-                                                             task_allocation);
+  success = resource_scheduler.GetLocalResourceManager().AllocateTaskResourceInstances(
+      fail_resource_request, task_allocation);
   ASSERT_FALSE(success) << resource_scheduler.DebugString();
 }
 
@@ -1335,7 +1365,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesSerializedStringTest) 
   addTaskResourceInstances(true, {4.}, 1, cluster_resources.get());
   addTaskResourceInstances(true, {1., 1.}, 2, cluster_resources.get());
   std::string serialized_string =
-      resource_scheduler.SerializedTaskResourceInstances(cluster_resources);
+      resource_scheduler.GetLocalResourceManager().SerializedTaskResourceInstances(
+          cluster_resources);
   std::string expected_serialized_string =
       R"({"CPU":20000,"memory":40000,"GPU":[10000, 10000]})";
   ASSERT_EQ(serialized_string == expected_serialized_string, true);
@@ -1354,8 +1385,8 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesSerializedStringTest) 
   ClusterResourceScheduler resource_scheduler_cpu_instance(
       "local", {{"CPU", 4}, {"memory", 4}, {"GPU", 2}}, *gcs_client_);
   std::string instance_serialized_string =
-      resource_scheduler_cpu_instance.SerializedTaskResourceInstances(
-          cluster_instance_resources);
+      resource_scheduler_cpu_instance.GetLocalResourceManager()
+          .SerializedTaskResourceInstances(cluster_instance_resources);
   std::string expected_instance_serialized_string =
       R"({"CPU":[10000, 10000],"memory":40000,"GPU":[10000, 10000]})";
   ASSERT_EQ(instance_serialized_string == expected_instance_serialized_string, true);

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -427,24 +427,24 @@ TEST_F(ClusterTaskManagerTest, IdempotencyTest) {
   ASSERT_EQ(pool_.workers.size(), 0);
   ASSERT_EQ(node_info_calls_, 0);
 
-  ASSERT_EQ(scheduler_->GetLocalAvailableCpus(), 4.0);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 4.0);
 
   task_manager_.ReleaseCpuResourcesFromUnblockedWorker(worker);
   task_manager_.ReleaseCpuResourcesFromUnblockedWorker(worker);
 
-  ASSERT_EQ(scheduler_->GetLocalAvailableCpus(), 8.0);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 8.0);
 
   task_manager_.ReturnCpuResourcesToBlockedWorker(worker);
   task_manager_.ReturnCpuResourcesToBlockedWorker(worker);
 
-  ASSERT_EQ(scheduler_->GetLocalAvailableCpus(), 4.0);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 4.0);
 
   RayTask finished_task;
   task_manager_.TaskFinished(leased_workers_.begin()->second, &finished_task);
   task_manager_.TaskFinished(leased_workers_.begin()->second, &finished_task);
   ASSERT_EQ(finished_task.GetTaskSpecification().TaskId(),
             task.GetTaskSpecification().TaskId());
-  ASSERT_EQ(scheduler_->GetLocalAvailableCpus(), 8.0);
+  ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 8.0);
   AssertNoLeaks();
 }
 
@@ -1408,7 +1408,7 @@ TEST_F(ClusterTaskManagerTest, FeasibleToNonFeasible) {
 
   // Delete cpu resource of local node, then task 2 should be turned into
   // infeasible.
-  scheduler_->DeleteLocalResource(ray::kCPU_ResourceLabel);
+  scheduler_->GetLocalResourceManager().DeleteLocalResource(ray::kCPU_ResourceLabel);
 
   RayTask task2 = CreateTask({{ray::kCPU_ResourceLabel, 4}});
   rpc::RequestWorkerLeaseReply reply2;
@@ -1448,7 +1448,8 @@ TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) 
 
   auto allocated_instances = std::make_shared<TaskResourceInstances>();
   const absl::flat_hash_map<std::string, double> task_spec = {{"CPU", 1.}, {"GPU", 1.}};
-  ASSERT_TRUE(scheduler_->AllocateLocalTaskResources(task_spec, allocated_instances));
+  ASSERT_TRUE(scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
+      task_spec, allocated_instances));
   worker->SetAllocatedInstances(allocated_instances);
 
   // Check that the resoruces are allocated successfully.
@@ -1756,7 +1757,8 @@ TEST_F(ClusterTaskManagerTest, PopWorkerExactlyOnce) {
 }
 
 TEST_F(ClusterTaskManagerTest, CapRunningOnDispatchQueue) {
-  scheduler_->AddLocalResourceInstances(ray::kGPU_ResourceLabel, {1, 1, 1});
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(ray::kGPU_ResourceLabel,
+                                                                  {1, 1, 1});
   RayTask task = CreateTask({{ray::kCPU_ResourceLabel, 4}, {ray::kGPU_ResourceLabel, 1}},
                             /*num_args=*/0, /*args=*/{});
   RayTask task2 = CreateTask({{ray::kCPU_ResourceLabel, 4}, {ray::kGPU_ResourceLabel, 1}},
@@ -1807,7 +1809,8 @@ TEST_F(ClusterTaskManagerTest, CapRunningOnDispatchQueue) {
 }
 
 TEST_F(ClusterTaskManagerTest, ZeroCPUTasks) {
-  scheduler_->AddLocalResourceInstances(ray::kGPU_ResourceLabel, {1, 1, 1});
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(ray::kGPU_ResourceLabel,
+                                                                  {1, 1, 1});
   RayTask task = CreateTask({{"GPU", 1}}, /*num_args=*/0, /*args=*/{});
   RayTask task2 = CreateTask({{"GPU", 1}}, /*num_args=*/0, /*args=*/{});
   RayTask task3 = CreateTask({{"GPU", 1}}, /*num_args=*/0, /*args=*/{});

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -37,6 +37,14 @@ class FixedPoint {
 
   FixedPoint(uint64_t i) : FixedPoint((double)i) {}  // NOLINT
 
+  static FixedPoint Sum(const std::vector<FixedPoint> &list) {
+    FixedPoint sum;
+    for (auto &value : list) {
+      sum += value;
+    }
+    return sum;
+  }
+
   FixedPoint operator+(FixedPoint const &ru) const {
     FixedPoint res;
     res.i_ = i_ + ru.i_;

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -1,0 +1,688 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/local_resource_manager.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include "ray/common/grpc_util.h"
+#include "ray/common/ray_config.h"
+
+namespace ray {
+
+LocalResourceManager::LocalResourceManager(
+    int64_t local_node_id, StringIdMap &resource_name_to_id,
+    const NodeResources &node_resources,
+    std::function<int64_t(void)> get_used_object_store_memory,
+    std::function<bool(void)> get_pull_manager_at_capacity,
+    std::function<void(const NodeResources &)> resource_change_subscriber)
+    : local_node_id_(local_node_id),
+      resource_name_to_id_(resource_name_to_id),
+      get_used_object_store_memory_(get_used_object_store_memory),
+      get_pull_manager_at_capacity_(get_pull_manager_at_capacity),
+      resource_change_subscriber_(resource_change_subscriber) {
+  InitResourceUnitInstanceInfo();
+  InitLocalResources(node_resources);
+  RAY_LOG(DEBUG) << "local resources: "
+                 << local_resources_.DebugString(resource_name_to_id);
+}
+
+void LocalResourceManager::InitResourceUnitInstanceInfo() {
+  std::string predefined_unit_instance_resources =
+      RayConfig::instance().predefined_unit_instance_resources();
+  if (!predefined_unit_instance_resources.empty()) {
+    std::vector<std::string> results;
+    boost::split(results, predefined_unit_instance_resources, boost::is_any_of(","));
+    for (std::string &result : results) {
+      PredefinedResources resource = ResourceStringToEnum(result);
+      RAY_CHECK(resource < PredefinedResources_MAX)
+          << "Failed to parse predefined resource";
+      predefined_unit_instance_resources_.emplace(resource);
+    }
+  }
+  std::string custom_unit_instance_resources =
+      RayConfig::instance().custom_unit_instance_resources();
+  if (!custom_unit_instance_resources.empty()) {
+    std::vector<std::string> results;
+    boost::split(results, custom_unit_instance_resources, boost::is_any_of(","));
+    for (std::string &result : results) {
+      int64_t resource_id = resource_name_to_id_.Insert(result);
+      custom_unit_instance_resources_.emplace(resource_id);
+    }
+  }
+}
+
+void LocalResourceManager::AddLocalResourceInstances(
+    const std::string &resource_name, const std::vector<FixedPoint> &instances) {
+  ResourceInstanceCapacities *node_instances;
+  local_resources_.predefined_resources.resize(PredefinedResources_MAX);
+  if (kCPU_ResourceLabel == resource_name) {
+    node_instances = &local_resources_.predefined_resources[CPU];
+  } else if (kGPU_ResourceLabel == resource_name) {
+    node_instances = &local_resources_.predefined_resources[GPU];
+  } else if (kObjectStoreMemory_ResourceLabel == resource_name) {
+    node_instances = &local_resources_.predefined_resources[OBJECT_STORE_MEM];
+  } else if (kMemory_ResourceLabel == resource_name) {
+    node_instances = &local_resources_.predefined_resources[MEM];
+  } else {
+    resource_name_to_id_.Insert(resource_name);
+    int64_t resource_id = resource_name_to_id_.Get(resource_name);
+    node_instances = &local_resources_.custom_resources[resource_id];
+  }
+
+  if (node_instances->total.size() < instances.size()) {
+    node_instances->total.resize(instances.size());
+    node_instances->available.resize(instances.size());
+  }
+
+  for (size_t i = 0; i < instances.size(); i++) {
+    node_instances->available[i] += instances[i];
+    node_instances->total[i] += instances[i];
+  }
+  OnResourceChanged();
+}
+
+void LocalResourceManager::DeleteLocalResource(const std::string &resource_name) {
+  int idx = -1;
+  if (resource_name == ray::kCPU_ResourceLabel) {
+    idx = (int)CPU;
+  } else if (resource_name == ray::kGPU_ResourceLabel) {
+    idx = (int)GPU;
+  } else if (resource_name == ray::kObjectStoreMemory_ResourceLabel) {
+    idx = (int)OBJECT_STORE_MEM;
+  } else if (resource_name == ray::kMemory_ResourceLabel) {
+    idx = (int)MEM;
+  };
+  if (idx != -1) {
+    for (auto &total : local_resources_.predefined_resources[idx].total) {
+      total = 0;
+    }
+    for (auto &available : local_resources_.predefined_resources[idx].available) {
+      available = 0;
+    }
+  } else {
+    int64_t resource_id = resource_name_to_id_.Get(resource_name);
+    auto c_itr = local_resources_.custom_resources.find(resource_id);
+    if (c_itr != local_resources_.custom_resources.end()) {
+      local_resources_.custom_resources[resource_id].total.clear();
+      local_resources_.custom_resources[resource_id].available.clear();
+      local_resources_.custom_resources.erase(c_itr);
+    }
+  }
+  OnResourceChanged();
+}
+
+bool LocalResourceManager::IsAvailableResourceEmpty(const std::string &resource_name) {
+  int idx = -1;
+  if (resource_name == ray::kCPU_ResourceLabel) {
+    idx = (int)CPU;
+  } else if (resource_name == ray::kGPU_ResourceLabel) {
+    idx = (int)GPU;
+  } else if (resource_name == ray::kObjectStoreMemory_ResourceLabel) {
+    idx = (int)OBJECT_STORE_MEM;
+  } else if (resource_name == ray::kMemory_ResourceLabel) {
+    idx = (int)MEM;
+  };
+
+  if (idx != -1) {
+    return FixedPoint::Sum(local_resources_.predefined_resources[idx].available) <= 0;
+  }
+  resource_name_to_id_.Insert(resource_name);
+  int64_t resource_id = resource_name_to_id_.Get(resource_name);
+  auto itr = local_resources_.custom_resources.find(resource_id);
+  if (itr != local_resources_.custom_resources.end()) {
+    return FixedPoint::Sum(itr->second.available) <= 0;
+  } else {
+    return true;
+  }
+}
+
+std::string LocalResourceManager::DebugString(void) const {
+  std::stringstream buffer;
+  buffer << local_resources_.DebugString(resource_name_to_id_);
+  return buffer.str();
+}
+
+uint64_t LocalResourceManager::GetNumCpus() const {
+  return static_cast<uint64_t>(
+      FixedPoint::Sum(local_resources_.predefined_resources[CPU].total).Double());
+}
+
+void LocalResourceManager::InitResourceInstances(
+    FixedPoint total, bool unit_instances, ResourceInstanceCapacities *instance_list) {
+  if (unit_instances) {
+    size_t num_instances = static_cast<size_t>(total.Double());
+    instance_list->total.resize(num_instances);
+    instance_list->available.resize(num_instances);
+    for (size_t i = 0; i < num_instances; i++) {
+      instance_list->total[i] = instance_list->available[i] = 1.0;
+    };
+  } else {
+    instance_list->total.resize(1);
+    instance_list->available.resize(1);
+    instance_list->total[0] = instance_list->available[0] = total;
+  }
+}
+
+void LocalResourceManager::InitLocalResources(const NodeResources &node_resources) {
+  local_resources_.predefined_resources.resize(PredefinedResources_MAX);
+
+  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
+    if (node_resources.predefined_resources[i].total > 0) {
+      // when we enable cpushare, the CPU will not be treat as unit_instance.
+      bool is_unit_instance = predefined_unit_instance_resources_.find(i) !=
+                              predefined_unit_instance_resources_.end();
+      InitResourceInstances(node_resources.predefined_resources[i].total,
+                            is_unit_instance, &local_resources_.predefined_resources[i]);
+    }
+  }
+
+  if (node_resources.custom_resources.size() == 0) {
+    return;
+  }
+
+  for (auto it = node_resources.custom_resources.begin();
+       it != node_resources.custom_resources.end(); ++it) {
+    if (it->second.total > 0) {
+      bool is_unit_instance = custom_unit_instance_resources_.find(it->first) !=
+                              custom_unit_instance_resources_.end();
+      ResourceInstanceCapacities instance_list;
+      InitResourceInstances(it->second.total, is_unit_instance, &instance_list);
+      local_resources_.custom_resources.emplace(it->first, instance_list);
+    }
+  }
+}
+
+std::vector<FixedPoint> LocalResourceManager::AddAvailableResourceInstances(
+    std::vector<FixedPoint> available,
+    ResourceInstanceCapacities *resource_instances) const {
+  std::vector<FixedPoint> overflow(available.size(), 0.);
+  for (size_t i = 0; i < available.size(); i++) {
+    resource_instances->available[i] = resource_instances->available[i] + available[i];
+    if (resource_instances->available[i] > resource_instances->total[i]) {
+      overflow[i] = (resource_instances->available[i] - resource_instances->total[i]);
+      resource_instances->available[i] = resource_instances->total[i];
+    }
+  }
+
+  return overflow;
+}
+
+std::vector<FixedPoint> LocalResourceManager::SubtractAvailableResourceInstances(
+    std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances,
+    bool allow_going_negative) const {
+  RAY_CHECK(available.size() == resource_instances->available.size());
+
+  std::vector<FixedPoint> underflow(available.size(), 0.);
+  for (size_t i = 0; i < available.size(); i++) {
+    if (resource_instances->available[i] < 0) {
+      if (allow_going_negative) {
+        resource_instances->available[i] =
+            resource_instances->available[i] - available[i];
+      } else {
+        underflow[i] = available[i];  // No change in the value in this case.
+      }
+    } else {
+      resource_instances->available[i] = resource_instances->available[i] - available[i];
+      if (resource_instances->available[i] < 0 && !allow_going_negative) {
+        underflow[i] = -resource_instances->available[i];
+        resource_instances->available[i] = 0;
+      }
+    }
+  }
+  return underflow;
+}
+
+bool LocalResourceManager::AllocateResourceInstances(
+    FixedPoint demand, std::vector<FixedPoint> &available,
+    std::vector<FixedPoint> *allocation) const {
+  allocation->resize(available.size());
+  FixedPoint remaining_demand = demand;
+
+  if (available.size() == 1) {
+    // This resource has just an instance.
+    if (available[0] >= remaining_demand) {
+      available[0] -= remaining_demand;
+      (*allocation)[0] = remaining_demand;
+      return true;
+    } else {
+      // Not enough capacity.
+      return false;
+    }
+  }
+
+  // If resources has multiple instances, each instance has total capacity of 1.
+  //
+  // If this resource constraint is hard, as long as remaining_demand is greater than 1.,
+  // allocate full unit-capacity instances until the remaining_demand becomes fractional.
+  // Then try to find the best fit for the fractional remaining_resources. Best fist means
+  // allocating the resource instance with the smallest available capacity greater than
+  // remaining_demand
+  //
+  // If resource constraint is soft, allocate as many full unit-capacity resources and
+  // then distribute remaining_demand across remaining instances. Note that in case we can
+  // overallocate this resource.
+  if (remaining_demand >= 1.) {
+    for (size_t i = 0; i < available.size(); i++) {
+      if (available[i] == 1.) {
+        // Allocate a full unit-capacity instance.
+        (*allocation)[i] = 1.;
+        available[i] = 0;
+        remaining_demand -= 1.;
+      }
+      if (remaining_demand < 1.) {
+        break;
+      }
+    }
+  }
+
+  if (remaining_demand >= 1.) {
+    // Cannot satisfy a demand greater than one if no unit capacity resource is available.
+    return false;
+  }
+
+  // Remaining demand is fractional. Find the best fit, if exists.
+  if (remaining_demand > 0.) {
+    int64_t idx_best_fit = -1;
+    FixedPoint available_best_fit = 1.;
+    for (size_t i = 0; i < available.size(); i++) {
+      if (available[i] >= remaining_demand) {
+        if (idx_best_fit == -1 ||
+            (available[i] - remaining_demand < available_best_fit)) {
+          available_best_fit = available[i] - remaining_demand;
+          idx_best_fit = static_cast<int64_t>(i);
+        }
+      }
+    }
+    if (idx_best_fit == -1) {
+      return false;
+    } else {
+      (*allocation)[idx_best_fit] = remaining_demand;
+      available[idx_best_fit] -= remaining_demand;
+    }
+  }
+  return true;
+}
+
+bool LocalResourceManager::AllocateTaskResourceInstances(
+    const ResourceRequest &resource_request,
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
+  RAY_CHECK(task_allocation != nullptr);
+  task_allocation->predefined_resources.resize(PredefinedResources_MAX);
+  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
+    if (resource_request.predefined_resources[i] > 0) {
+      if (!AllocateResourceInstances(resource_request.predefined_resources[i],
+                                     local_resources_.predefined_resources[i].available,
+                                     &task_allocation->predefined_resources[i])) {
+        // Allocation failed. Restore node's local resources by freeing the resources
+        // of the failed allocation.
+        FreeTaskResourceInstances(task_allocation);
+        return false;
+      }
+    }
+  }
+
+  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
+    auto it = local_resources_.custom_resources.find(task_req_custom_resource.first);
+    if (it != local_resources_.custom_resources.end()) {
+      if (task_req_custom_resource.second > 0) {
+        std::vector<FixedPoint> allocation;
+        bool success = AllocateResourceInstances(task_req_custom_resource.second,
+                                                 it->second.available, &allocation);
+        // Even if allocation failed we need to remember partial allocations to correctly
+        // free resources.
+        task_allocation->custom_resources.emplace(it->first, allocation);
+        if (!success) {
+          // Allocation failed. Restore node's local resources by freeing the resources
+          // of the failed allocation.
+          FreeTaskResourceInstances(task_allocation);
+          return false;
+        }
+      }
+    } else {
+      // Allocation failed because the custom resources don't exist in this local node.
+      // Restore node's local resources by freeing the resources
+      // of the failed allocation.
+      FreeTaskResourceInstances(task_allocation);
+      return false;
+    }
+  }
+
+  OnResourceChanged();
+  return true;
+}
+
+void LocalResourceManager::FreeTaskResourceInstances(
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
+  RAY_CHECK(task_allocation != nullptr);
+  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
+    AddAvailableResourceInstances(task_allocation->predefined_resources[i],
+                                  &local_resources_.predefined_resources[i]);
+  }
+
+  for (const auto &task_allocation_custom_resource : task_allocation->custom_resources) {
+    auto it =
+        local_resources_.custom_resources.find(task_allocation_custom_resource.first);
+    if (it != local_resources_.custom_resources.end()) {
+      AddAvailableResourceInstances(task_allocation_custom_resource.second, &it->second);
+    }
+  }
+  OnResourceChanged();
+}
+
+std::vector<double> LocalResourceManager::AddCPUResourceInstances(
+    std::vector<double> &cpu_instances) {
+  std::vector<FixedPoint> cpu_instances_fp =
+      VectorDoubleToVectorFixedPoint(cpu_instances);
+
+  if (cpu_instances.size() == 0) {
+    return cpu_instances;  // No overflow.
+  }
+
+  auto overflow = AddAvailableResourceInstances(
+      cpu_instances_fp, &local_resources_.predefined_resources[CPU]);
+  OnResourceChanged();
+
+  return VectorFixedPointToVectorDouble(overflow);
+}
+
+std::vector<double> LocalResourceManager::SubtractCPUResourceInstances(
+    std::vector<double> &cpu_instances, bool allow_going_negative) {
+  std::vector<FixedPoint> cpu_instances_fp =
+      VectorDoubleToVectorFixedPoint(cpu_instances);
+
+  if (cpu_instances.size() == 0) {
+    return cpu_instances;  // No underflow.
+  }
+
+  auto underflow = SubtractAvailableResourceInstances(
+      cpu_instances_fp, &local_resources_.predefined_resources[CPU],
+      allow_going_negative);
+  OnResourceChanged();
+
+  return VectorFixedPointToVectorDouble(underflow);
+}
+
+std::vector<double> LocalResourceManager::AddGPUResourceInstances(
+    std::vector<double> &gpu_instances) {
+  std::vector<FixedPoint> gpu_instances_fp =
+      VectorDoubleToVectorFixedPoint(gpu_instances);
+
+  if (gpu_instances.size() == 0) {
+    return gpu_instances;  // No overflow.
+  }
+
+  auto overflow = AddAvailableResourceInstances(
+      gpu_instances_fp, &local_resources_.predefined_resources[GPU]);
+  OnResourceChanged();
+
+  return VectorFixedPointToVectorDouble(overflow);
+}
+
+std::vector<double> LocalResourceManager::SubtractGPUResourceInstances(
+    std::vector<double> &gpu_instances) {
+  std::vector<FixedPoint> gpu_instances_fp =
+      VectorDoubleToVectorFixedPoint(gpu_instances);
+
+  if (gpu_instances.size() == 0) {
+    return gpu_instances;  // No underflow.
+  }
+
+  auto underflow = SubtractAvailableResourceInstances(
+      gpu_instances_fp, &local_resources_.predefined_resources[GPU]);
+  OnResourceChanged();
+
+  return VectorFixedPointToVectorDouble(underflow);
+}
+
+bool LocalResourceManager::AllocateLocalTaskResources(
+    const ResourceRequest &resource_request,
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
+  if (AllocateTaskResourceInstances(resource_request, task_allocation)) {
+    OnResourceChanged();
+    return true;
+  }
+  return false;
+}
+
+bool LocalResourceManager::AllocateLocalTaskResources(
+    const absl::flat_hash_map<std::string, double> &task_resources,
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
+  RAY_CHECK(task_allocation != nullptr);
+  // We don't track object store memory demands so no need to allocate them.
+  ResourceRequest resource_request = ResourceMapToResourceRequest(
+      resource_name_to_id_, task_resources, /*requires_object_store_memory=*/false);
+  return AllocateLocalTaskResources(resource_request, task_allocation);
+}
+
+void LocalResourceManager::ReleaseWorkerResources(
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
+  if (task_allocation == nullptr || task_allocation->IsEmpty()) {
+    return;
+  }
+  FreeTaskResourceInstances(task_allocation);
+  OnResourceChanged();
+}
+
+namespace {
+
+NodeResources ToNodeResources(const NodeResourceInstances &instance) {
+  NodeResources node_resources;
+  node_resources.predefined_resources.resize(PredefinedResources_MAX);
+  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
+    node_resources.predefined_resources[i].available = 0;
+    node_resources.predefined_resources[i].total = 0;
+    for (size_t j = 0; j < instance.predefined_resources[i].available.size(); j++) {
+      node_resources.predefined_resources[i].available +=
+          instance.predefined_resources[i].available[j];
+      node_resources.predefined_resources[i].total +=
+          instance.predefined_resources[i].total[j];
+    }
+  }
+
+  for (auto &custom_resource : instance.custom_resources) {
+    int64_t resource_name = custom_resource.first;
+    auto &instances = custom_resource.second;
+
+    FixedPoint available = std::accumulate(instances.available.begin(),
+                                           instances.available.end(), FixedPoint());
+    FixedPoint total =
+        std::accumulate(instances.total.begin(), instances.total.end(), FixedPoint());
+
+    node_resources.custom_resources[resource_name].available = available;
+    node_resources.custom_resources[resource_name].total = total;
+  }
+  return node_resources;
+}
+
+}  // namespace
+
+void LocalResourceManager::FillResourceUsage(rpc::ResourcesData &resources_data) {
+  NodeResources resources = ToNodeResources(local_resources_);
+
+  // Initialize if last report resources is empty.
+  if (!last_report_resources_) {
+    NodeResources node_resources =
+        ResourceMapToNodeResources(resource_name_to_id_, {{}}, {{}});
+    last_report_resources_.reset(new NodeResources(node_resources));
+  }
+
+  // Automatically report object store usage.
+  // XXX: this MUTATES the resources field, which is needed since we are storing
+  // it in last_report_resources_.
+  if (get_used_object_store_memory_ != nullptr) {
+    auto &capacity = resources.predefined_resources[OBJECT_STORE_MEM];
+    double used = get_used_object_store_memory_();
+    capacity.available = FixedPoint(capacity.total.Double() - used);
+  }
+
+  for (int i = 0; i < PredefinedResources_MAX; i++) {
+    const auto &label = ResourceEnumToString((PredefinedResources)i);
+    const auto &capacity = resources.predefined_resources[i];
+    const auto &last_capacity = last_report_resources_->predefined_resources[i];
+    // Note: available may be negative, but only report positive to GCS.
+    if (capacity.available != last_capacity.available && capacity.available > 0) {
+      resources_data.set_resources_available_changed(true);
+      (*resources_data.mutable_resources_available())[label] =
+          capacity.available.Double();
+    }
+    if (capacity.total != last_capacity.total) {
+      (*resources_data.mutable_resources_total())[label] = capacity.total.Double();
+    }
+  }
+  for (const auto &it : resources.custom_resources) {
+    uint64_t custom_id = it.first;
+    const auto &capacity = it.second;
+    const auto &last_capacity = last_report_resources_->custom_resources[custom_id];
+    const auto &label = resource_name_to_id_.Get(custom_id);
+    // Note: available may be negative, but only report positive to GCS.
+    if (capacity.available != last_capacity.available && capacity.available > 0) {
+      resources_data.set_resources_available_changed(true);
+      (*resources_data.mutable_resources_available())[label] =
+          capacity.available.Double();
+    }
+    if (capacity.total != last_capacity.total) {
+      (*resources_data.mutable_resources_total())[label] = capacity.total.Double();
+    }
+  }
+
+  if (get_pull_manager_at_capacity_ != nullptr) {
+    resources.object_pulls_queued = get_pull_manager_at_capacity_();
+    if (last_report_resources_->object_pulls_queued != resources.object_pulls_queued) {
+      resources_data.set_object_pulls_queued(resources.object_pulls_queued);
+      resources_data.set_resources_available_changed(true);
+    }
+  }
+
+  if (resources != *last_report_resources_.get()) {
+    last_report_resources_.reset(new NodeResources(resources));
+  }
+
+  if (!RayConfig::instance().enable_light_weight_resource_report()) {
+    resources_data.set_resources_available_changed(true);
+  }
+}
+
+double LocalResourceManager::GetLocalAvailableCpus() const {
+  auto &capacity = local_resources_.predefined_resources[CPU];
+  return FixedPoint::Sum(capacity.available).Double();
+}
+
+ray::gcs::NodeResourceInfoAccessor::ResourceMap LocalResourceManager::GetResourceTotals(
+    const absl::flat_hash_map<std::string, double> &resource_map_filter) const {
+  ray::gcs::NodeResourceInfoAccessor::ResourceMap map;
+  for (size_t i = 0; i < local_resources_.predefined_resources.size(); i++) {
+    std::string resource_name = ResourceEnumToString(static_cast<PredefinedResources>(i));
+    double resource_total =
+        FixedPoint::Sum(local_resources_.predefined_resources[i].total).Double();
+    if (!resource_map_filter.contains(resource_name)) {
+      continue;
+    }
+
+    if (resource_total > 0) {
+      auto data = std::make_shared<rpc::ResourceTableData>();
+      data->set_resource_capacity(resource_total);
+      map.emplace(resource_name, std::move(data));
+    }
+  }
+
+  for (auto entry : local_resources_.custom_resources) {
+    std::string resource_name = resource_name_to_id_.Get(entry.first);
+    double resource_total = FixedPoint::Sum(entry.second.total).Double();
+    if (!resource_map_filter.contains(resource_name)) {
+      continue;
+    }
+
+    if (resource_total > 0) {
+      auto data = std::make_shared<rpc::ResourceTableData>();
+      data->set_resource_capacity(resource_total);
+      map.emplace(resource_name, std::move(data));
+    }
+  }
+  return map;
+}
+
+void LocalResourceManager::OnResourceChanged() {
+  if (resource_change_subscriber_ == nullptr) {
+    return;
+  }
+  resource_change_subscriber_(ToNodeResources(local_resources_));
+}
+
+std::string LocalResourceManager::SerializedTaskResourceInstances(
+    std::shared_ptr<TaskResourceInstances> task_allocation) const {
+  bool has_added_resource = false;
+  std::stringstream buffer;
+  buffer << "{";
+  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
+    std::vector<FixedPoint> resource = task_allocation->predefined_resources[i];
+    if (resource.empty()) {
+      continue;
+    }
+    if (has_added_resource) {
+      buffer << ",";
+    }
+    std::string resource_name = ResourceEnumToString(static_cast<PredefinedResources>(i));
+    buffer << "\"" << resource_name << "\":";
+    bool is_unit_instance = predefined_unit_instance_resources_.find(i) !=
+                            predefined_unit_instance_resources_.end();
+    if (!is_unit_instance) {
+      buffer << resource[0];
+    } else {
+      buffer << "[";
+      for (size_t i = 0; i < resource.size(); i++) {
+        buffer << resource[i];
+        if (i < resource.size() - 1) {
+          buffer << ", ";
+        }
+      }
+      buffer << "]";
+    }
+    has_added_resource = true;
+  }
+  // TODO (chenk008): add custom_resources
+  buffer << "}";
+  return buffer.str();
+}
+
+void LocalResourceManager::UpdateLastResourceUsage(
+    std::shared_ptr<SchedulingResources> gcs_resources) {
+  last_report_resources_ = std::make_unique<NodeResources>(ResourceMapToNodeResources(
+      resource_name_to_id_, gcs_resources->GetTotalResources().GetResourceMap(),
+      gcs_resources->GetAvailableResources().GetResourceMap()));
+}
+
+bool LocalResourceManager::ResourcesExist(const std::string &resource_name) {
+  int idx = -1;
+  if (resource_name == ray::kCPU_ResourceLabel) {
+    idx = (int)CPU;
+  } else if (resource_name == ray::kGPU_ResourceLabel) {
+    idx = (int)GPU;
+  } else if (resource_name == ray::kObjectStoreMemory_ResourceLabel) {
+    idx = (int)OBJECT_STORE_MEM;
+  } else if (resource_name == ray::kMemory_ResourceLabel) {
+    idx = (int)MEM;
+  };
+  if (idx != -1) {
+    // Return true directly for predefined resources as we always initialize this kind of
+    // resources at the beginning.
+    return true;
+  } else {
+    int64_t resource_id = resource_name_to_id_.Get(resource_name);
+    const auto &it = local_resources_.custom_resources.find(resource_id);
+    return it != local_resources_.custom_resources.end();
+  }
+}
+
+}  // namespace ray

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -1,0 +1,297 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest_prod.h>
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ray/common/task/scheduling_resources.h"
+#include "ray/gcs/gcs_client/accessor.h"
+#include "ray/gcs/gcs_client/gcs_client.h"
+#include "ray/raylet/scheduling/cluster_resource_data.h"
+#include "ray/raylet/scheduling/cluster_resource_scheduler_interface.h"
+#include "ray/raylet/scheduling/fixed_point.h"
+#include "ray/raylet/scheduling/scheduling_ids.h"
+#include "ray/raylet/scheduling/scheduling_policy.h"
+#include "ray/util/logging.h"
+#include "src/ray/protobuf/gcs.pb.h"
+
+namespace ray {
+
+using rpc::HeartbeatTableData;
+
+/// Class manages the resources of the local node.
+class LocalResourceManager {
+ public:
+  LocalResourceManager(
+      int64_t local_node_id, StringIdMap &resource_name_to_id,
+      const NodeResources &node_resources,
+      std::function<int64_t(void)> get_used_object_store_memory,
+      std::function<bool(void)> get_pull_manager_at_capacity,
+      std::function<void(const NodeResources &)> resource_change_subscriber);
+
+  int64_t GetNodeId() const { return local_node_id_; }
+
+  /// Add a local resource that is available.
+  ///
+  /// \param resource_name: Resource which we want to update.
+  /// \param resource_total: New capacity of the resource.
+  void AddLocalResourceInstances(const std::string &resource_name,
+                                 const std::vector<FixedPoint> &instances);
+
+  /// Delete a given resource from the local node.
+  ///
+  /// \param resource_name: Resource we want to delete
+  void DeleteLocalResource(const std::string &resource_name);
+
+  /// Check whether the available resources are empty.
+  ///
+  /// \param resource_name: Resource which we want to check.
+  bool IsAvailableResourceEmpty(const std::string &resource_name);
+
+  /// Return local resources.
+  NodeResourceInstances GetLocalResources() const { return local_resources_; }
+
+  /// Allocate local resources to satisfy a given request (resource_request).
+  ///
+  /// \param resource_request: Resources requested by a task.
+  /// \param task_allocation: Local resources allocated to satsify resource_request
+  /// demand.
+  ///
+  /// \return true, if allocation successful. If false, the caller needs to free the
+  /// allocated resources, i.e., task_allocation.
+  bool AllocateTaskResourceInstances(
+      const ResourceRequest &resource_request,
+      std::shared_ptr<TaskResourceInstances> task_allocation);
+
+  /// Free resources which were allocated with a task. The freed resources are
+  /// added back to the node's local available resources.
+  ///
+  /// \param task_allocation: Task's resources to be freed.
+  void FreeTaskResourceInstances(std::shared_ptr<TaskResourceInstances> task_allocation);
+
+  /// Increase the available CPU instances of this node.
+  ///
+  /// \param cpu_instances CPU instances to be added to available cpus.
+  ///
+  /// \return Overflow capacities of CPU instances after adding CPU
+  /// capacities in cpu_instances.
+  std::vector<double> AddCPUResourceInstances(std::vector<double> &cpu_instances);
+
+  /// Decrease the available CPU instances of this node.
+  ///
+  /// \param cpu_instances CPU instances to be removed from available cpus.
+  /// \param allow_going_negative Allow the values to go negative (disable underflow).
+  ///
+  /// \return Underflow capacities of CPU instances after subtracting CPU
+  /// capacities in cpu_instances.
+  std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances,
+                                                   bool allow_going_negative = false);
+
+  /// Increase the available GPU instances of this node.
+  ///
+  /// \param gpu_instances GPU instances to be added to available gpus.
+  ///
+  /// \return Overflow capacities of GPU instances after adding GPU
+  /// capacities in gpu_instances.
+  std::vector<double> AddGPUResourceInstances(std::vector<double> &gpu_instances);
+
+  /// Decrease the available GPU instances of this node.
+  ///
+  /// \param gpu_instances GPU instances to be removed from available gpus.
+  ///
+  /// \return Underflow capacities of GPU instances after subtracting GPU
+  /// capacities in gpu_instances.
+  std::vector<double> SubtractGPUResourceInstances(std::vector<double> &gpu_instances);
+
+  /// Subtract the resources required by a given resource request (resource_request) from
+  /// the local node. This function also updates the local node resources at the instance
+  /// granularity.
+  ///
+  /// \param resource_request Task for which we allocate resources.
+  /// \param task_allocation Resources allocated to the task at instance granularity.
+  /// This is a return parameter.
+  ///
+  /// \return True if local node has enough resources to satisfy the resource request.
+  /// False otherwise.
+  bool AllocateLocalTaskResources(
+      const absl::flat_hash_map<std::string, double> &task_resources,
+      std::shared_ptr<TaskResourceInstances> task_allocation);
+
+  bool AllocateLocalTaskResources(const ResourceRequest &resource_request,
+                                  std::shared_ptr<TaskResourceInstances> task_allocation);
+
+  void ReleaseWorkerResources(std::shared_ptr<TaskResourceInstances> task_allocation);
+
+  /// Populate the relevant parts of the heartbeat table. This is intended for
+  /// sending resource usage of raylet to gcs. In particular, this should fill in
+  /// resources_available and resources_total.
+  ///
+  /// \param Output parameter. `resources_available` and `resources_total` are the only
+  /// fields used.
+  void FillResourceUsage(rpc::ResourcesData &resources_data);
+
+  /// Populate a UpdateResourcesRequest. This is inteneded to update the
+  /// resource totals on a node when a custom resource is created or deleted
+  /// (e.g. during the placement group lifecycle).
+  ///
+  /// \param resource_map_filter When returning the resource map, the returned result will
+  /// only contain the keys in the filter. Note that only the key of the map is used.
+  /// \return The total resource capacity of the node.
+  ray::gcs::NodeResourceInfoAccessor::ResourceMap GetResourceTotals(
+      const absl::flat_hash_map<std::string, double> &resource_map_filter) const;
+
+  double GetLocalAvailableCpus() const;
+
+  /// Return human-readable string for this scheduler state.
+  std::string DebugString() const;
+
+  /// Get the number of cpus on this node.
+  uint64_t GetNumCpus() const;
+
+  /// Serialize task resource instances to json string.
+  ///
+  /// \param task_allocation Allocated resource instances for a task.
+  /// \return The task resource instances json string
+  std::string SerializedTaskResourceInstances(
+      std::shared_ptr<TaskResourceInstances> task_allocation) const;
+
+  /// Update last report resources local cache from gcs cache,
+  /// this is needed when gcs fo.
+  ///
+  /// \param gcs_resources: The remote cache from gcs.
+  void UpdateLastResourceUsage(const std::shared_ptr<SchedulingResources> gcs_resources);
+
+  /// Check whether the specific resource exists or not in local node.
+  ///
+  /// \param resource_name: the specific resource name.
+  ///
+  /// \return true, if exist. otherwise, false.
+  bool ResourcesExist(const std::string &resource_name);
+
+ private:
+  /// Create instances for each resource associated with the local node, given
+  /// the node's resources.
+  ///
+  /// \param local_resources: Total resources of the node.
+  void InitLocalResources(const NodeResources &local_resources);
+
+  /// Initialize the instances of a given resource given the resource's total capacity.
+  /// If unit_instances is true we split the resources in unit-size instances. For
+  /// example, if total = 10, then we create 10 instances, each with caoacity 1.
+  /// Otherwise, we create a single instance of capacity equal to the resource's capacity.
+  ///
+  /// \param total: Total resource capacity.
+  /// \param unit_instances: If true, we split the resource in unit-size instances.
+  /// If false, we create a single instance of capacity "total".
+  /// \param instance_list: The list of capacities this resource instances.
+  void InitResourceInstances(FixedPoint total, bool unit_instances,
+                             ResourceInstanceCapacities *instance_list);
+
+  /// Init the information about which resources are unit_instance.
+  void InitResourceUnitInstanceInfo();
+
+  void OnResourceChanged();
+
+  /// Increase the available capacities of the instances of a given resource.
+  ///
+  /// \param available A list of available capacities for resource's instances.
+  /// \param resource_instances List of the resource instances being updated.
+  ///
+  /// \return Overflow capacities of "resource_instances" after adding instance
+  /// capacities in "available", i.e.,
+  /// min(available + resource_instances.available, resource_instances.total)
+  std::vector<FixedPoint> AddAvailableResourceInstances(
+      std::vector<FixedPoint> available,
+      ResourceInstanceCapacities *resource_instances) const;
+
+  /// Decrease the available capacities of the instances of a given resource.
+  ///
+  /// \param free A list of capacities for resource's instances to be freed.
+  /// \param resource_instances List of the resource instances being updated.
+  /// \param allow_going_negative Allow the values to go negative (disable underflow).
+  /// \return Underflow of "resource_instances" after subtracting instance
+  /// capacities in "available", i.e.,.
+  /// max(available - reasource_instances.available, 0)
+  std::vector<FixedPoint> SubtractAvailableResourceInstances(
+      std::vector<FixedPoint> available, ResourceInstanceCapacities *resource_instances,
+      bool allow_going_negative = false) const;
+
+  /// Allocate enough capacity across the instances of a resource to satisfy "demand".
+  /// If resource has multiple unit-capacity instances, we consider two cases.
+  ///
+  /// 1) If the constraint is hard, allocate full unit-capacity instances until
+  /// demand becomes fractional, and then satisfy the fractional demand using the
+  /// instance with the smallest available capacity that can satisfy the fractional
+  /// demand. For example, assume a resource conisting of 4 instances, with available
+  /// capacities: (1., 1., .7, 0.5) and deman of 1.2. Then we allocate one full
+  /// instance and then allocate 0.2 of the 0.5 instance (as this is the instance
+  /// with the smalest available capacity that can satisfy the remaining demand of 0.2).
+  /// As a result remaining available capacities will be (0., 1., .7, .3).
+  /// Thus, if the constraint is hard, we will allocate a bunch of full instances and
+  /// at most a fractional instance.
+  ///
+  /// 2) If the constraint is soft, we can allocate multiple fractional resources,
+  /// and even overallocate the resource. For example, in the previous case, if we
+  /// have a demand of 1.8, we can allocate one full instance, the 0.5 instance, and
+  /// 0.3 from the 0.7 instance. Furthermore, if the demand is 3.5, then we allocate
+  /// all instances, and return success (true), despite the fact that the total
+  /// available capacity of the rwsource is 3.2 (= 1. + 1. + .7 + .5), which is less
+  /// than the demand, 3.5. In this case, the remaining available resource is
+  /// (0., 0., 0., 0.)
+  ///
+  /// \param demand: The resource amount to be allocated.
+  /// \param available: List of available capacities of the instances of the resource.
+  /// \param allocation: List of instance capacities allocated to satisfy the demand.
+  /// This is a return parameter.
+  ///
+  /// \return true, if allocation successful. In this case, the sum of the elements in
+  /// "allocation" is equal to "demand".
+
+  bool AllocateResourceInstances(FixedPoint demand, std::vector<FixedPoint> &available,
+                                 std::vector<FixedPoint> *allocation) const;
+
+  /// Identifier of local node.
+  int64_t local_node_id_;
+  /// Keep the mapping between node and resource IDs in string representation
+  /// to integer representation. Used for improving map performance.
+  StringIdMap &resource_name_to_id_;
+  /// Resources of local node.
+  NodeResourceInstances local_resources_;
+  /// Cached resources, used to compare with newest one in light heartbeat mode.
+  std::unique_ptr<NodeResources> last_report_resources_;
+  /// Function to get used object store memory.
+  std::function<int64_t(void)> get_used_object_store_memory_;
+  /// Function to get whether the pull manager is at capacity.
+  std::function<bool(void)> get_pull_manager_at_capacity_;
+  /// Subscribes to resource changes.
+  std::function<void(const NodeResources &)> resource_change_subscriber_;
+
+  // Specify predefine resources that consists of unit-size instances.
+  std::unordered_set<int64_t> predefined_unit_instance_resources_{};
+
+  // Specify custom resources that consists of unit-size instances.
+  std::unordered_set<int64_t> custom_unit_instance_resources_{};
+
+  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest);
+  FRIEND_TEST(ClusterResourceSchedulerTest, AvailableResourceInstancesOpsTest);
+};
+
+}  // end namespace ray

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <vector>
 
 #include "ray/common/ray_config.h"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The cluster resource scheduler has 3 responsibilities: 

- local resource management: manages the resources on the local raylet
- cluster resource management: stores a view of the cluster resources.
- some scheduling logic: decide which node to schedule a resource request, based on the cluster resource view.

Mixing 3 responsibilities into a single class makes it hard to reason or change the code. 

In this PR, we separate the local resource manager from cluster resource scheduler. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
