### PR TITLE
Two issues fix for GCS connecting logic in monitor.py and log_monitor.py

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -454,8 +454,11 @@ class Monitor:
             gcs_publisher=gcs_publisher)
 
     def _signal_handler(self, sig, frame):
-        self._handle_failure(f"Terminated with signal {sig}\n" +
-                             "".join(traceback.format_stack(frame)))
+        try:
+            self._handle_failure(f"Terminated with signal {sig}\n" +
+                                 "".join(traceback.format_stack(frame)))
+        except Exception:
+            logger.exception("Monitor: Failure in signal handler.")
         sys.exit(sig + 128)
 
     def run(self):


### PR DESCRIPTION
## Why are these changes needed?

This patch fixed two issues.

1. log_monitor.py can crash when gcs is not temporarily available. Added retry logic in gcs_pubsub.py.
2. it is possible that the signal handler can raise another exception during exception handling. 

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [X] Manually tested.
