### PR TITLE
[nit] remove decorator in test_cli.py

### DIFF
--- a/dashboard/modules/job/tests/test_cli.py
+++ b/dashboard/modules/job/tests/test_cli.py
@@ -81,7 +81,6 @@ def set_env_var(key: str, val: Optional[str] = None):
 
 
 class TestSubmit:
-    @pytest.mark.asyncio
     def test_address(self, mock_sdk_client):
         runner = CliRunner()
 


### PR DESCRIPTION
## Why are these changes needed?

Full context see https://github.com/ray-project/ray/issues/21791

pytest work for "some" environments for this test and on CI master, but this decorator is still unnecessary and was introduced by mistake. So just remove it and see what happens with the original issue.

## Related issue number

Closes #21791

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
