### PR TITLE
[code owner] add runtime env code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,11 @@
 # Ray Client
 /src/ray/protobuf/ray_client.proto @ijrsvt @ameerhajali @ckw017 @mwtian
 
+# Runtime Env
+# TODO(SongGuyang): Add new items to guarantee runtime env API compatibility in multiple languages.
+/src/ray/protobuf/runtime_env_common.proto @SongGuyang @raulchen @edoakes @architkulkarni
+/src/ray/protobuf/runtime_env_agent.proto @SongGuyang @raulchen @edoakes @architkulkarni
+
 # ==== Libraries and frameworks ====
 
 # Ray tune.


### PR DESCRIPTION
## Why are these changes needed?

Add some code owners for runtime env. We need to add more items as we support multiple languages and cross-language API in future.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
