### PR TITLE
[Core] Support UTF-8 Actor Creation Exceptions

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2148,8 +2148,8 @@ cdef class CoreWorker:
     def push_error(self, JobID job_id, error_type, error_message,
                    double timestamp):
         check_status(CCoreWorkerProcess.GetCoreWorker().PushError(
-            job_id.native(), error_type.encode("ascii"),
-            error_message.encode("ascii"), timestamp))
+            job_id.native(), error_type.encode("utf-8"),
+            error_message.encode("utf-8"), timestamp))
 
     def get_job_config(self):
         cdef CJobConfig c_job_config

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -728,6 +728,20 @@ def test_actor_failure_per_type(ray_start_cluster):
     print(exc_info._excinfo[1])
 
 
+def test_utf8_actor_exception(ray_start_regular):
+    @ray.remote
+    class FlakyActor:
+        def __init__(self):
+            raise RuntimeError("你好呀，祝你有个好心情！")
+
+        def ping(self):
+            return True
+
+    actor = FlakyActor.remote()
+    with pytest.raises(ray.exceptions.RayActorError):
+        ray.get(actor.ping.remote())
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

Now if an actor throws an exception containing non-ASCII characters, the actor won't die and will be alive.

This is because the following exception occurred during handling the user's exception:
```
  File "python/ray/_raylet.pyx", line 587, in ray._raylet.task_execution_handler
  File "python/ray/_raylet.pyx", line 434, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 551, in ray._raylet.execute_task
  File "/home/admin/.local/lib/python3.6/site-packages/ray/utils.py", line 96, in push_error_to_driver
    worker.core_worker.push_error(job_id, error_type, message, time.time())
  File "python/ray/_raylet.pyx", line 1636, in ray._raylet.CoreWorker.push_error
UnicodeEncodeError: 'ascii' codec can't encode characters in position 2597-2600: ordinal not in range(128)
An unexpected internal error occurred while the worker was executing a task.
```

This PR fixes this issue.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
