### PR TITLE
[docs] integrate algolia docsearch, move to sphinx panels

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -41,8 +41,7 @@ sphinx-copybutton==0.4.0
 sphinxemoji==0.2.0
 sphinx-gallery==0.10.0
 sphinx-jsonschema==1.17.2
-# spinx-panels==0.6.0
-sphinx-tabs==3.2.0
+spinx-panels==0.6.0
 sphinx-version-warning==1.1.2
 sphinx-book-theme==0.1.7
 sphinx-external-toc==0.2.3

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -41,7 +41,7 @@ sphinx-copybutton==0.4.0
 sphinxemoji==0.2.0
 sphinx-gallery==0.10.0
 sphinx-jsonschema==1.17.2
-spinx-panels==0.6.0
+sphinx-panels==0.6.0
 sphinx-version-warning==1.1.2
 sphinx-book-theme==0.1.7
 sphinx-external-toc==0.2.3

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -1,6 +1,15 @@
 /* For Algolia search box to flow-over horizontally into main content*/
 #site-navigation { overflow-y: visible; }
 
+/* Center the algolia search bar*/
+#search-input {
+    text-align: center;
+}
+.algolia-autocomplete {
+    width: 100%;
+    margin: auto;
+}
+
 /* sphinx-panels overrides the content width to 1140 for large displays.*/
 @media (min-width: 1200px) {
     .container, .container-lg, .container-md, .container-sm, .container-xl {

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -1,5 +1,12 @@
-/* For Algolia*/
-/*#site-navigation { overflow: visible; }*/
+/* For Algolia search box to flow-over horizontally into main content*/
+#site-navigation { overflow-y: visible; }
+
+/* sphinx-panels overrides the content width to 1140 for large displays.*/
+@media (min-width: 1200px) {
+    .container, .container-lg, .container-md, .container-sm, .container-xl {
+        max-width: 1400px !important;
+    }
+}
 
 /*Extends the docstring signature box.*/
 .rst-content dl:not(.docutils) dt {

--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -96,42 +96,8 @@ parts:
         title: Getting Started
       - file: ray-core/using-ray
         title: "User Guide"
-        sections:
-          - file: ray-core/starting-ray
-          - file: ray-core/actors
-          - file: ray-core/namespaces
-          - file: ray-core/handling-dependencies
-          - file: ray-core/async_api
-          - file: ray-core/concurrency_group_api
-          - file: ray-core/using-ray-with-gpus
-          - file: ray-core/serialization
-          - file: ray-core/memory-management
-          - file: ray-core/placement-group
-          - file: ray-core/troubleshooting
-          - file: ray-core/fault-tolerance
-          - file: ray-core/advanced
-          - file: ray-core/cross-language
-          - file: ray-core/using-ray-with-tensorflow
-          - file: ray-core/using-ray-with-pytorch
-          - file: ray-core/using-ray-with-jupyter
       - file: ray-core/examples/overview
         title: "Tutorials and Examples"
-        sections:
-          - file: ray-core/examples/tips-for-first-time
-          - file: ray-core/examples/testing-tips
-          - file: ray-core/examples/progress_bar
-          - file: ray-core/examples/plot_streaming
-          - file: ray-core/examples/placement-group
-          - file: ray-core/examples/plot_parameter_server
-          - file: ray-core/examples/plot_hyperparameter
-          - file: ray-core/examples/plot_lbfgs
-          - file: ray-core/examples/plot_example-lm
-          - file: ray-core/examples/plot_newsreader
-          - file: ray-core/examples/dask_xgboost/dask_xgboost
-          - file: ray-core/examples/modin_xgboost/modin_xgboost
-          - file: ray-core/examples/plot_pong_example
-          - file: ray-core/examples/plot_example-a3c
-          - file: ray-core/examples/using-ray-with-pytorch-lightning
 
   - caption: Deploying Ray Clusters
     chapters:

--- a/doc/source/cluster/cloud.rst
+++ b/doc/source/cluster/cloud.rst
@@ -23,168 +23,167 @@ Ray with cloud providers
 
     /cluster/aws-tips.rst
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed::  AWS
 
-        First, install boto (``pip install boto3``) and configure your AWS credentials in ``~/.aws/credentials``,
-        as described in `the boto docs <http://boto3.readthedocs.io/en/latest/guide/configuration.html>`__.
+    First, install boto (``pip install boto3``) and configure your AWS credentials in ``~/.aws/credentials``,
+    as described in `the boto docs <http://boto3.readthedocs.io/en/latest/guide/configuration.html>`__.
 
-        Once boto is configured to manage resources on your AWS account, you should be ready to launch your cluster. The provided `ray/python/ray/autoscaler/aws/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/aws/example-full.yaml>`__ cluster config file will create a small cluster with an m5.large head node (on-demand) configured to autoscale up to two m5.large `spot workers <https://aws.amazon.com/ec2/spot/>`__.
+    Once boto is configured to manage resources on your AWS account, you should be ready to launch your cluster. The provided `ray/python/ray/autoscaler/aws/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/aws/example-full.yaml>`__ cluster config file will create a small cluster with an m5.large head node (on-demand) configured to autoscale up to two m5.large `spot workers <https://aws.amazon.com/ec2/spot/>`__.
 
-        Test that it works by running the following commands from your local machine:
+    Test that it works by running the following commands from your local machine:
 
-        .. code-block:: bash
+    .. code-block:: bash
 
-            # Create or update the cluster. When the command finishes, it will print
-            # out the command that can be used to SSH into the cluster head node.
-            $ ray up ray/python/ray/autoscaler/aws/example-full.yaml
+        # Create or update the cluster. When the command finishes, it will print
+        # out the command that can be used to SSH into the cluster head node.
+        $ ray up ray/python/ray/autoscaler/aws/example-full.yaml
 
-            # Get a remote screen on the head node.
-            $ ray attach ray/python/ray/autoscaler/aws/example-full.yaml
-            $ # Try running a Ray program with 'ray.init(address="auto")'.
+        # Get a remote screen on the head node.
+        $ ray attach ray/python/ray/autoscaler/aws/example-full.yaml
+        $ # Try running a Ray program with 'ray.init(address="auto")'.
 
-            # Tear down the cluster.
-            $ ray down ray/python/ray/autoscaler/aws/example-full.yaml
+        # Tear down the cluster.
+        $ ray down ray/python/ray/autoscaler/aws/example-full.yaml
 
 
-        See :ref:`aws-cluster` for recipes on customizing AWS clusters.
-    .. group-tab:: Azure
+    See :ref:`aws-cluster` for recipes on customizing AWS clusters.
+.. tabbed:: Azure
 
-        First, install the Azure CLI (``pip install azure-cli``) then login using (``az login``).
+    First, install the Azure CLI (``pip install azure-cli``) then login using (``az login``).
 
-        Set the subscription to use from the command line (``az account set -s <subscription_id>``) or by modifying the provider section of the config provided e.g: `ray/python/ray/autoscaler/azure/example-full.yaml`
+    Set the subscription to use from the command line (``az account set -s <subscription_id>``) or by modifying the provider section of the config provided e.g: `ray/python/ray/autoscaler/azure/example-full.yaml`
 
-        Once the Azure CLI is configured to manage resources on your Azure account, you should be ready to launch your cluster. The provided `ray/python/ray/autoscaler/azure/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/azure/example-full.yaml>`__ cluster config file will create a small cluster with a Standard DS2v3 head node (on-demand) configured to autoscale up to two Standard DS2v3 `spot workers <https://docs.microsoft.com/en-us/azure/virtual-machines/windows/spot-vms>`__. Note that you'll need to fill in your resource group and location in those templates.
+    Once the Azure CLI is configured to manage resources on your Azure account, you should be ready to launch your cluster. The provided `ray/python/ray/autoscaler/azure/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/azure/example-full.yaml>`__ cluster config file will create a small cluster with a Standard DS2v3 head node (on-demand) configured to autoscale up to two Standard DS2v3 `spot workers <https://docs.microsoft.com/en-us/azure/virtual-machines/windows/spot-vms>`__. Note that you'll need to fill in your resource group and location in those templates.
 
-        Test that it works by running the following commands from your local machine:
+    Test that it works by running the following commands from your local machine:
 
-        .. code-block:: bash
+    .. code-block:: bash
 
-            # Create or update the cluster. When the command finishes, it will print
-            # out the command that can be used to SSH into the cluster head node.
-            $ ray up ray/python/ray/autoscaler/azure/example-full.yaml
+        # Create or update the cluster. When the command finishes, it will print
+        # out the command that can be used to SSH into the cluster head node.
+        $ ray up ray/python/ray/autoscaler/azure/example-full.yaml
 
-            # Get a remote screen on the head node.
-            $ ray attach ray/python/ray/autoscaler/azure/example-full.yaml
-            # test ray setup
-            $ python -c 'import ray; ray.init(address="auto")'
-            $ exit
-            # Tear down the cluster.
-            $ ray down ray/python/ray/autoscaler/azure/example-full.yaml
+        # Get a remote screen on the head node.
+        $ ray attach ray/python/ray/autoscaler/azure/example-full.yaml
+        # test ray setup
+        $ python -c 'import ray; ray.init(address="auto")'
+        $ exit
+        # Tear down the cluster.
+        $ ray down ray/python/ray/autoscaler/azure/example-full.yaml
 
-        **Azure Portal**:
-        Alternatively, you can deploy a cluster using Azure portal directly. Please note that autoscaling is done using Azure VM Scale Sets and not through
-        the Ray autoscaler. This will deploy `Azure Data Science VMs (DSVM) <https://azure.microsoft.com/en-us/services/virtual-machines/data-science-virtual-machines/>`_
-        for both the head node and the auto-scalable cluster managed by `Azure Virtual Machine Scale Sets <https://azure.microsoft.com/en-us/services/virtual-machine-scale-sets/>`_.
-        The head node conveniently exposes both SSH as well as JupyterLab.
+    **Azure Portal**:
+    Alternatively, you can deploy a cluster using Azure portal directly. Please note that autoscaling is done using Azure VM Scale Sets and not through
+    the Ray autoscaler. This will deploy `Azure Data Science VMs (DSVM) <https://azure.microsoft.com/en-us/services/virtual-machines/data-science-virtual-machines/>`_
+    for both the head node and the auto-scalable cluster managed by `Azure Virtual Machine Scale Sets <https://azure.microsoft.com/en-us/services/virtual-machine-scale-sets/>`_.
+    The head node conveniently exposes both SSH as well as JupyterLab.
 
-        .. image:: https://aka.ms/deploytoazurebutton
-           :target: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fray-project%2Fray%2Fmaster%2Fdoc%2Fazure%2Fazure-ray-template.json
-           :alt: Deploy to Azure
+    .. image:: https://aka.ms/deploytoazurebutton
+       :target: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fray-project%2Fray%2Fmaster%2Fdoc%2Fazure%2Fazure-ray-template.json
+       :alt: Deploy to Azure
 
-        Once the template is successfully deployed the deployment Outputs page provides the ssh command to connect and the link to the JupyterHub on the head node (username/password as specified on the template input).
-        Use the following code in a Jupyter notebook (using the conda environment specified in the template input, py38_tensorflow by default) to connect to the Ray cluster.
+    Once the template is successfully deployed the deployment Outputs page provides the ssh command to connect and the link to the JupyterHub on the head node (username/password as specified on the template input).
+    Use the following code in a Jupyter notebook (using the conda environment specified in the template input, py38_tensorflow by default) to connect to the Ray cluster.
 
-        .. code-block:: python
+    .. code-block:: python
 
-            import ray
-            ray.init(address='auto')
+        import ray
+        ray.init(address='auto')
 
-        Note that on each node the `azure-init.sh <https://github.com/ray-project/ray/blob/master/doc/azure/azure-init.sh>`_ script is executed and performs the following actions:
+    Note that on each node the `azure-init.sh <https://github.com/ray-project/ray/blob/master/doc/azure/azure-init.sh>`_ script is executed and performs the following actions:
 
-        1. Activates one of the conda environments available on DSVM
-        2. Installs Ray and any other user-specified dependencies
-        3. Sets up a systemd task (``/lib/systemd/system/ray.service``) to start Ray in head or worker mode
+    1. Activates one of the conda environments available on DSVM
+    2. Installs Ray and any other user-specified dependencies
+    3. Sets up a systemd task (``/lib/systemd/system/ray.service``) to start Ray in head or worker mode
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        First, install the Google API client (``pip install google-api-python-client``), set up your GCP credentials, and create a new GCP project.
+    First, install the Google API client (``pip install google-api-python-client``), set up your GCP credentials, and create a new GCP project.
 
-        Once the API client is configured to manage resources on your GCP account, you should be ready to launch your cluster. The provided `ray/python/ray/autoscaler/gcp/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/gcp/example-full.yaml>`__ cluster config file will create a small cluster with a n1-standard-2 head node (on-demand) configured to autoscale up to two n1-standard-2 `preemptible workers <https://cloud.google.com/preemptible-vms/>`__. Note that you'll need to fill in your project id in those templates.
+    Once the API client is configured to manage resources on your GCP account, you should be ready to launch your cluster. The provided `ray/python/ray/autoscaler/gcp/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/gcp/example-full.yaml>`__ cluster config file will create a small cluster with a n1-standard-2 head node (on-demand) configured to autoscale up to two n1-standard-2 `preemptible workers <https://cloud.google.com/preemptible-vms/>`__. Note that you'll need to fill in your project id in those templates.
 
-        Test that it works by running the following commands from your local machine:
+    Test that it works by running the following commands from your local machine:
 
-        .. code-block:: bash
+    .. code-block:: bash
 
-            # Create or update the cluster. When the command finishes, it will print
-            # out the command that can be used to SSH into the cluster head node.
-            $ ray up ray/python/ray/autoscaler/gcp/example-full.yaml
+        # Create or update the cluster. When the command finishes, it will print
+        # out the command that can be used to SSH into the cluster head node.
+        $ ray up ray/python/ray/autoscaler/gcp/example-full.yaml
 
-            # Get a remote screen on the head node.
-            $ ray attach ray/python/ray/autoscaler/gcp/example-full.yaml
-            $ # Try running a Ray program with 'ray.init(address="auto")'.
+        # Get a remote screen on the head node.
+        $ ray attach ray/python/ray/autoscaler/gcp/example-full.yaml
+        $ # Try running a Ray program with 'ray.init(address="auto")'.
 
-            # Tear down the cluster.
-            $ ray down ray/python/ray/autoscaler/gcp/example-full.yaml
+        # Tear down the cluster.
+        $ ray down ray/python/ray/autoscaler/gcp/example-full.yaml
 
-    .. group-tab:: Staroid Kubernetes Engine (contributed)
+.. tabbed:: Staroid Kubernetes Engine (contributed)
 
-        The Ray Cluster Launcher can be used to start Ray clusters on an existing Staroid Kubernetes Engine (SKE) cluster.
+    The Ray Cluster Launcher can be used to start Ray clusters on an existing Staroid Kubernetes Engine (SKE) cluster.
 
-        First, install the staroid client package (``pip install staroid``) then get `access token <https://staroid.com/settings/accesstokens>`_.
-        Once you have an access token, you should be ready to launch your cluster.
+    First, install the staroid client package (``pip install staroid``) then get `access token <https://staroid.com/settings/accesstokens>`_.
+    Once you have an access token, you should be ready to launch your cluster.
 
-        The provided `ray/python/ray/autoscaler/staroid/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/staroid/example-full.yaml>`__ cluster config file will create a cluster with
+    The provided `ray/python/ray/autoscaler/staroid/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/staroid/example-full.yaml>`__ cluster config file will create a cluster with
 
-        - a Jupyter notebook running on head node.
-          (Staroid management console -> Kubernetes -> ``<your_ske_name>`` -> ``<ray_cluster_name>`` -> Click "notebook")
-        - a shared nfs volume across all ray nodes mounted under ``/nfs`` directory.
+    - a Jupyter notebook running on head node.
+      (Staroid management console -> Kubernetes -> ``<your_ske_name>`` -> ``<ray_cluster_name>`` -> Click "notebook")
+    - a shared nfs volume across all ray nodes mounted under ``/nfs`` directory.
 
-        Test that it works by running the following commands from your local machine:
+    Test that it works by running the following commands from your local machine:
 
-        .. code-block:: bash
+    .. code-block:: bash
 
-            # Configure access token through environment variable.
-            $ export STAROID_ACCESS_TOKEN=<your access token>
+        # Configure access token through environment variable.
+        $ export STAROID_ACCESS_TOKEN=<your access token>
 
-            # Create or update the cluster. When the command finishes,
-            # you can attach a screen to the head node.
-            $ ray up ray/python/ray/autoscaler/staroid/example-full.yaml
+        # Create or update the cluster. When the command finishes,
+        # you can attach a screen to the head node.
+        $ ray up ray/python/ray/autoscaler/staroid/example-full.yaml
 
-            # Get a remote screen on the head node.
-            $ ray attach ray/python/ray/autoscaler/staroid/example-full.yaml
-            $ # Try running a Ray program with 'ray.init(address="auto")'.
+        # Get a remote screen on the head node.
+        $ ray attach ray/python/ray/autoscaler/staroid/example-full.yaml
+        $ # Try running a Ray program with 'ray.init(address="auto")'.
 
-            # Tear down the cluster
-            $ ray down ray/python/ray/autoscaler/staroid/example-full.yaml
+        # Tear down the cluster
+        $ ray down ray/python/ray/autoscaler/staroid/example-full.yaml
 
-    .. group-tab:: Aliyun
+.. tabbed:: Aliyun
 
-        First, install the aliyun client package (``pip install aliyun-python-sdk-core aliyun-python-sdk-ecs``). Obtain the AccessKey pair of the Aliyun account as described in `the docs <https://www.alibabacloud.com/help/en/doc-detail/175967.htm>`__ and grant AliyunECSFullAccess/AliyunVPCFullAccess permissions to the RAM user. Finally, set the AccessKey pair in your cluster config file.
+    First, install the aliyun client package (``pip install aliyun-python-sdk-core aliyun-python-sdk-ecs``). Obtain the AccessKey pair of the Aliyun account as described in `the docs <https://www.alibabacloud.com/help/en/doc-detail/175967.htm>`__ and grant AliyunECSFullAccess/AliyunVPCFullAccess permissions to the RAM user. Finally, set the AccessKey pair in your cluster config file.
 
-        Once the above is done, you should be ready to launch your cluster. The provided `aliyun/example-full.yaml </ray/python/ray/autoscaler/aliyun/example-full.yaml>`__ cluster config file will create a small cluster with an ``ecs.n4.large`` head node (on-demand) configured to autoscale up to two ``ecs.n4.2xlarge`` nodes.
+    Once the above is done, you should be ready to launch your cluster. The provided `aliyun/example-full.yaml </ray/python/ray/autoscaler/aliyun/example-full.yaml>`__ cluster config file will create a small cluster with an ``ecs.n4.large`` head node (on-demand) configured to autoscale up to two ``ecs.n4.2xlarge`` nodes.
 
-        Make sure your account balance is not less than 100 RMB, otherwise you will receive a `InvalidAccountStatus.NotEnoughBalance` error.
+    Make sure your account balance is not less than 100 RMB, otherwise you will receive a `InvalidAccountStatus.NotEnoughBalance` error.
 
-        Test that it works by running the following commands from your local machine:
+    Test that it works by running the following commands from your local machine:
 
-        .. code-block:: bash
+    .. code-block:: bash
 
-            # Create or update the cluster. When the command finishes, it will print
-            # out the command that can be used to SSH into the cluster head node.
-            $ ray up ray/python/ray/autoscaler/aliyun/example-full.yaml
+        # Create or update the cluster. When the command finishes, it will print
+        # out the command that can be used to SSH into the cluster head node.
+        $ ray up ray/python/ray/autoscaler/aliyun/example-full.yaml
 
-            # Get a remote screen on the head node.
-            $ ray attach ray/python/ray/autoscaler/aliyun/example-full.yaml
-            $ # Try running a Ray program with 'ray.init(address="auto")'.
+        # Get a remote screen on the head node.
+        $ ray attach ray/python/ray/autoscaler/aliyun/example-full.yaml
+        $ # Try running a Ray program with 'ray.init(address="auto")'.
 
-            # Tear down the cluster.
-            $ ray down ray/python/ray/autoscaler/aliyun/example-full.yaml
+        # Tear down the cluster.
+        $ ray down ray/python/ray/autoscaler/aliyun/example-full.yaml
 
-        Aliyun Node Provider Maintainer: zhuangzhuang131419, chenk008
+    Aliyun Node Provider Maintainer: zhuangzhuang131419, chenk008
 
-    .. group-tab:: Custom
+.. tabbed:: Custom
 
-        Ray also supports external node providers (check `node_provider.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/node_provider.py>`__ implementation).
-        You can specify the external node provider using the yaml config:
+    Ray also supports external node providers (check `node_provider.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/node_provider.py>`__ implementation).
+    You can specify the external node provider using the yaml config:
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            provider:
-                type: external
-                module: mypackage.myclass
+        provider:
+            type: external
+            module: mypackage.myclass
 
-        The module needs to be in the format ``package.provider_class`` or ``package.sub_package.provider_class``.
+    The module needs to be in the format ``package.provider_class`` or ``package.sub_package.provider_class``.
 
 
 .. _cluster-private-setup:
@@ -208,61 +207,60 @@ There are two ways of running private clusters:
         $ ssh-keygen
         $ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 
-.. tabs::
-
-    .. group-tab:: Manually Managed
-
-        You can get started by filling out the fields in the provided `ray/python/ray/autoscaler/local/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/local/example-full.yaml>`__.
-        Be sure to specify the proper ``head_ip``, list of ``worker_ips``, and the ``ssh_user`` field.
-
-        Test that it works by running the following commands from your local machine:
-
-        .. code-block:: bash
-
-            # Create or update the cluster. When the command finishes, it will print
-            # out the command that can be used to get a remote shell into the head node.
-            $ ray up ray/python/ray/autoscaler/local/example-full.yaml
-
-            # Get a remote screen on the head node.
-            $ ray attach ray/python/ray/autoscaler/local/example-full.yaml
-            $ # Try running a Ray program with 'ray.init(address="auto")'.
-
-            # Tear down the cluster
-            $ ray down ray/python/ray/autoscaler/local/example-full.yaml
-
-    .. group-tab:: Automatically Managed
+.. tabbed:: Manually Managed
 
 
-        Start by launching the coordinator server that will manage all the on prem clusters. This server also makes sure to isolate the resources between different users. The script for running the coordinator server is `ray/python/ray/autoscaler/local/coordinator_server.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/local/coordinator_server.py>`__. To launch the coordinator server run:
+    You can get started by filling out the fields in the provided `ray/python/ray/autoscaler/local/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/local/example-full.yaml>`__.
+    Be sure to specify the proper ``head_ip``, list of ``worker_ips``, and the ``ssh_user`` field.
 
-        .. code-block:: bash
+    Test that it works by running the following commands from your local machine:
 
-            $ python coordinator_server.py --ips <list_of_node_ips> --port <PORT>
+    .. code-block:: bash
 
-        where ``list_of_node_ips`` is a comma separated list of all the available nodes on the private cluster. For example, ``160.24.42.48,160.24.42.49,...`` and ``<PORT>`` is the port that the coordinator server will listen on.
-        After running the coordinator server it will print the address of the coordinator server. For example:
+        # Create or update the cluster. When the command finishes, it will print
+        # out the command that can be used to get a remote shell into the head node.
+        $ ray up ray/python/ray/autoscaler/local/example-full.yaml
 
-        .. code-block:: bash
+        # Get a remote screen on the head node.
+        $ ray attach ray/python/ray/autoscaler/local/example-full.yaml
+        $ # Try running a Ray program with 'ray.init(address="auto")'.
 
-          >> INFO:ray.autoscaler.local.coordinator_server:Running on prem coordinator server
-                on address <Host:PORT>
+        # Tear down the cluster
+        $ ray down ray/python/ray/autoscaler/local/example-full.yaml
 
-        Next, the user only specifies the ``<Host:PORT>`` printed above in the ``coordinator_address`` entry instead of specific head/worker ips in the provided `ray/python/ray/autoscaler/local/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/local/example-full.yaml>`__.
+.. tabbed:: Automatically Managed
 
-        Now we can test that it works by running the following commands from your local machine:
 
-        .. code-block:: bash
+    Start by launching the coordinator server that will manage all the on prem clusters. This server also makes sure to isolate the resources between different users. The script for running the coordinator server is `ray/python/ray/autoscaler/local/coordinator_server.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/local/coordinator_server.py>`__. To launch the coordinator server run:
 
-            # Create or update the cluster. When the command finishes, it will print
-            # out the command that can be used to get a remote shell into the head node.
-            $ ray up ray/python/ray/autoscaler/local/example-full.yaml
+    .. code-block:: bash
 
-            # Get a remote screen on the head node.
-            $ ray attach ray/python/ray/autoscaler/local/example-full.yaml
-            $ # Try running a Ray program with 'ray.init(address="auto")'.
+        $ python coordinator_server.py --ips <list_of_node_ips> --port <PORT>
 
-            # Tear down the cluster
-            $ ray down ray/python/ray/autoscaler/local/example-full.yaml
+    where ``list_of_node_ips`` is a comma separated list of all the available nodes on the private cluster. For example, ``160.24.42.48,160.24.42.49,...`` and ``<PORT>`` is the port that the coordinator server will listen on.
+    After running the coordinator server it will print the address of the coordinator server. For example:
+
+    .. code-block:: bash
+
+      >> INFO:ray.autoscaler.local.coordinator_server:Running on prem coordinator server
+            on address <Host:PORT>
+
+    Next, the user only specifies the ``<Host:PORT>`` printed above in the ``coordinator_address`` entry instead of specific head/worker ips in the provided `ray/python/ray/autoscaler/local/example-full.yaml <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/local/example-full.yaml>`__.
+
+    Now we can test that it works by running the following commands from your local machine:
+
+    .. code-block:: bash
+
+        # Create or update the cluster. When the command finishes, it will print
+        # out the command that can be used to get a remote shell into the head node.
+        $ ray up ray/python/ray/autoscaler/local/example-full.yaml
+
+        # Get a remote screen on the head node.
+        $ ray attach ray/python/ray/autoscaler/local/example-full.yaml
+        $ # Try running a Ray program with 'ray.init(address="auto")'.
+
+        # Tear down the cluster
+        $ ray down ray/python/ray/autoscaler/local/example-full.yaml
 
 
 .. _manual-cluster:
@@ -397,8 +395,7 @@ Running a Ray program on the Ray cluster
 
 To run a distributed Ray program, you'll need to execute your program on the same machine as one of the nodes.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     Within your program/script, you must call ``ray.init`` and add the ``address`` parameter to ``ray.init`` (like ``ray.init(address=...)``). This causes Ray to connect to the existing cluster. For example:
 
@@ -406,7 +403,7 @@ To run a distributed Ray program, you'll need to execute your program on the sam
 
         ray.init(address="auto")
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     You need to add the ``ray.address`` parameter to your command line (like ``-Dray.address=...``).
 
@@ -420,7 +417,7 @@ To run a distributed Ray program, you'll need to execute your program on the sam
 
     .. note:: Specifying ``auto`` as the address hasn't been implemented in Java yet. You need to provide the actual address. You can find the address of the server from the output of the ``ray up`` command.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     You need to add the ``RAY_ADDRESS`` env var to your command line (like ``RAY_ADDRESS=...``).
 

--- a/doc/source/cluster/config.rst
+++ b/doc/source/cluster/config.rst
@@ -74,79 +74,76 @@ Docker
 Auth
 ~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. parsed-literal::
+    .. parsed-literal::
 
-            :ref:`ssh_user <cluster-configuration-ssh-user>`: str
-            :ref:`ssh_private_key <cluster-configuration-ssh-private-key>`: str
+        :ref:`ssh_user <cluster-configuration-ssh-user>`: str
+        :ref:`ssh_private_key <cluster-configuration-ssh-private-key>`: str
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        .. parsed-literal::
+    .. parsed-literal::
 
-            :ref:`ssh_user <cluster-configuration-ssh-user>`: str
-            :ref:`ssh_private_key <cluster-configuration-ssh-private-key>`: str
-            :ref:`ssh_public_key <cluster-configuration-ssh-public-key>`: str
+        :ref:`ssh_user <cluster-configuration-ssh-user>`: str
+        :ref:`ssh_private_key <cluster-configuration-ssh-private-key>`: str
+        :ref:`ssh_public_key <cluster-configuration-ssh-public-key>`: str
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        .. parsed-literal::
+    .. parsed-literal::
 
-            :ref:`ssh_user <cluster-configuration-ssh-user>`: str
-            :ref:`ssh_private_key <cluster-configuration-ssh-private-key>`: str
+        :ref:`ssh_user <cluster-configuration-ssh-user>`: str
+        :ref:`ssh_private_key <cluster-configuration-ssh-private-key>`: str
 
 .. _cluster-configuration-provider-type:
 
 Provider
 ~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. parsed-literal::
+    .. parsed-literal::
 
-            :ref:`type <cluster-configuration-type>`: str
-            :ref:`region <cluster-configuration-region>`: str
-            :ref:`availability_zone <cluster-configuration-availability-zone>`: str
-            :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
-            :ref:`security_group <cluster-configuration-security-group>`:
-                :ref:`Security Group <cluster-configuration-security-group-type>`
+        :ref:`type <cluster-configuration-type>`: str
+        :ref:`region <cluster-configuration-region>`: str
+        :ref:`availability_zone <cluster-configuration-availability-zone>`: str
+        :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
+        :ref:`security_group <cluster-configuration-security-group>`:
+            :ref:`Security Group <cluster-configuration-security-group-type>`
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        .. parsed-literal::
+    .. parsed-literal::
 
-            :ref:`type <cluster-configuration-type>`: str
-            :ref:`location <cluster-configuration-location>`: str
-            :ref:`resource_group <cluster-configuration-resource-group>`: str
-            :ref:`subscription_id <cluster-configuration-subscription-id>`: str
-            :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
+        :ref:`type <cluster-configuration-type>`: str
+        :ref:`location <cluster-configuration-location>`: str
+        :ref:`resource_group <cluster-configuration-resource-group>`: str
+        :ref:`subscription_id <cluster-configuration-subscription-id>`: str
+        :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        .. parsed-literal::
+    .. parsed-literal::
 
-            :ref:`type <cluster-configuration-type>`: str
-            :ref:`region <cluster-configuration-region>`: str
-            :ref:`availability_zone <cluster-configuration-availability-zone>`: str
-            :ref:`project_id <cluster-configuration-project-id>`: str
-            :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
+        :ref:`type <cluster-configuration-type>`: str
+        :ref:`region <cluster-configuration-region>`: str
+        :ref:`availability_zone <cluster-configuration-availability-zone>`: str
+        :ref:`project_id <cluster-configuration-project-id>`: str
+        :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
 
 .. _cluster-configuration-security-group-type:
 
 Security Group
 ~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. parsed-literal::
+    .. parsed-literal::
 
-            :ref:`GroupName <cluster-configuration-group-name>`: str
-            :ref:`IpPermissions <cluster-configuration-ip-permissions>`:
-                - `IpPermission <https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html>`_
+        :ref:`GroupName <cluster-configuration-group-name>`: str
+        :ref:`IpPermissions <cluster-configuration-ip-permissions>`:
+            - `IpPermission <https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html>`_
 
 .. _cluster-configuration-node-types-type:
 
@@ -186,18 +183,17 @@ Cloud-specific configuration for nodes of a given node type.
 Modifying the ``node_config`` and updating with :ref:`ray up<ray-up-doc>` will cause the autoscaler to scale down all existing nodes of the node type;
 nodes with the newly applied ``node_config`` will then be created according to cluster configuration and Ray resource demands.
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        A YAML object which conforms to the EC2 ``create_instances`` API in `the AWS docs <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances>`_.
+    A YAML object which conforms to the EC2 ``create_instances`` API in `the AWS docs <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances>`_.
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        A YAML object as defined in `the deployment template <https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/virtualmachines>`_ whose resources are defined in `the Azure docs <https://docs.microsoft.com/en-us/azure/templates/>`_.
+    A YAML object as defined in `the deployment template <https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/virtualmachines>`_ whose resources are defined in `the Azure docs <https://docs.microsoft.com/en-us/azure/templates/>`_.
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        A YAML object as defined in `the GCP docs <https://cloud.google.com/compute/docs/reference/rest/v1/instances>`_.
+    A YAML object as defined in `the GCP docs <https://cloud.google.com/compute/docs/reference/rest/v1/instances>`_.
 
 .. _cluster-configuration-node-docker-type:
 
@@ -353,27 +349,26 @@ Each node type is identified by a user-specified key.
 * **Type:** :ref:`Node types <cluster-configuration-node-types-type>`
 * **Default:**
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-          available_node_types:
-            ray.head.default:
-                node_config:
-                  InstanceType: m5.large
-                  BlockDeviceMappings:
-                      - DeviceName: /dev/sda1
-                        Ebs:
-                            VolumeSize: 100
-                resources: {"CPU": 2}
-            ray.worker.default:
-                node_config:
-                  InstanceType: m5.large
-                  InstanceMarketOptions:
-                      MarketType: spot
-                resources: {"CPU": 2}
-                min_workers: 0
+      available_node_types:
+        ray.head.default:
+            node_config:
+              InstanceType: m5.large
+              BlockDeviceMappings:
+                  - DeviceName: /dev/sda1
+                    Ebs:
+                        VolumeSize: 100
+            resources: {"CPU": 2}
+        ray.worker.default:
+            node_config:
+              InstanceType: m5.large
+              InstanceMarketOptions:
+                  MarketType: spot
+            resources: {"CPU": 2}
+            min_workers: 0
 
 .. _cluster-configuration-head-node-type:
 
@@ -469,15 +464,14 @@ A list of commands to run to set up nodes. These commands will always run on the
 * **Type:** List of String
 * **Default:**
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            # Default setup_commands:
-            setup_commands:
-              - echo 'export PATH="$HOME/anaconda3/envs/tensorflow_p36/bin:$PATH"' >> ~/.bashrc
-              - pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
+        # Default setup_commands:
+        setup_commands:
+          - echo 'export PATH="$HOME/anaconda3/envs/tensorflow_p36/bin:$PATH"' >> ~/.bashrc
+          - pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
 
 - Setup commands should ideally be *idempotent* (i.e., can be run multiple times without changing the result); this allows Ray to safely update nodes after they have been created. You can usually make commands idempotent with small modifications, e.g. ``git clone foo`` can be rewritten as ``test -e foo || git clone foo`` which checks if the repo is already cloned first.
 
@@ -530,14 +524,13 @@ Commands to start ray on the head node. You don't need to change this.
 * **Type:** List of String
 * **Default:**
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            head_start_ray_commands:
-              - ray stop
-              - ulimit -n 65536; ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+        head_start_ray_commands:
+          - ray stop
+          - ulimit -n 65536; ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
 
 .. _cluster-configuration-worker-start-ray-commands:
 
@@ -551,14 +544,13 @@ Command to start ray on worker nodes. You don't need to change this.
 * **Type:** List of String
 * **Default:**
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            worker_start_ray_commands:
-              - ray stop
-              - ulimit -n 65536; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+        worker_start_ray_commands:
+          - ray stop
+          - ulimit -n 65536; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
 
 .. _cluster-configuration-image:
 
@@ -701,234 +693,225 @@ The user that Ray will authenticate with when launching new nodes.
 ``auth.ssh_private_key``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        The path to an existing private key for Ray to use. If not configured, Ray will create a new private keypair (default behavior). If configured, the key must be added to the project-wide metadata and ``KeyName`` has to be defined in the :ref:`node configuration <cluster-configuration-node-config>`.
+    The path to an existing private key for Ray to use. If not configured, Ray will create a new private keypair (default behavior). If configured, the key must be added to the project-wide metadata and ``KeyName`` has to be defined in the :ref:`node configuration <cluster-configuration-node-config>`.
 
-        * **Required:** No
-        * **Importance:** Low
-        * **Type:** String
+    * **Required:** No
+    * **Importance:** Low
+    * **Type:** String
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The path to an existing private key for Ray to use.
+    The path to an existing private key for Ray to use.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
 
-        You may use ``ssh-keygen -t rsa -b 4096`` to generate a new ssh keypair.
+    You may use ``ssh-keygen -t rsa -b 4096`` to generate a new ssh keypair.
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The path to an existing private key for Ray to use. If not configured, Ray will create a new private keypair (default behavior). If configured, the key must be added to the project-wide metadata and ``KeyName`` has to be defined in the :ref:`node configuration <cluster-configuration-node-config>`.
+    The path to an existing private key for Ray to use. If not configured, Ray will create a new private keypair (default behavior). If configured, the key must be added to the project-wide metadata and ``KeyName`` has to be defined in the :ref:`node configuration <cluster-configuration-node-config>`.
 
-        * **Required:** No
-        * **Importance:** Low
-        * **Type:** String
+    * **Required:** No
+    * **Importance:** Low
+    * **Type:** String
 
 .. _cluster-configuration-ssh-public-key:
 
 ``auth.ssh_public_key``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        Not available.
+    Not available.
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The path to an existing public key for Ray to use.
+    The path to an existing public key for Ray to use.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        Not available.
+    Not available.
 
 .. _cluster-configuration-type:
 
 ``provider.type``
 ~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        The cloud service provider. For AWS, this must be set to ``aws``.
+    The cloud service provider. For AWS, this must be set to ``aws``.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The cloud service provider. For Azure, this must be set to ``azure``.
+    The cloud service provider. For Azure, this must be set to ``azure``.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The cloud service provider. For GCP, this must be set to ``gcp``.
+    The cloud service provider. For GCP, this must be set to ``gcp``.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
 
 .. _cluster-configuration-region:
 
 ``provider.region``
 ~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        The region to use for deployment of the Ray cluster.
+    The region to use for deployment of the Ray cluster.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
-        * **Default:** us-west-2
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
+    * **Default:** us-west-2
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        Not available.
+    Not available.
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The region to use for deployment of the Ray cluster.
+    The region to use for deployment of the Ray cluster.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
-        * **Default:** us-west1
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
+    * **Default:** us-west1
 
 .. _cluster-configuration-availability-zone:
 
 ``provider.availability_zone``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        A string specifying a comma-separated list of availability zone(s) that nodes may be launched in.
-        Nodes will be launched in the first listed availability zone and will be tried in the following availability
-        zones if launching fails.
+    A string specifying a comma-separated list of availability zone(s) that nodes may be launched in.
+    Nodes will be launched in the first listed availability zone and will be tried in the following availability
+    zones if launching fails.
 
-        * **Required:** No
-        * **Importance:** Low
-        * **Type:** String
-        * **Default:** us-west-2a,us-west-2b
+    * **Required:** No
+    * **Importance:** Low
+    * **Type:** String
+    * **Default:** us-west-2a,us-west-2b
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        Not available.
+    Not available.
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        A string specifying a comma-separated list of availability zone(s) that nodes may be launched in.
+    A string specifying a comma-separated list of availability zone(s) that nodes may be launched in.
 
-        * **Required:** No
-        * **Importance:** Low
-        * **Type:** String
-        * **Default:** us-west1-a
+    * **Required:** No
+    * **Importance:** Low
+    * **Type:** String
+    * **Default:** us-west1-a
 
 .. _cluster-configuration-location:
 
 ``provider.location``
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        Not available.
+    Not available.
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The location to use for deployment of the Ray cluster.
+    The location to use for deployment of the Ray cluster.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
-        * **Default:** westus2
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
+    * **Default:** westus2
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        Not available.
+    Not available.
 
 .. _cluster-configuration-resource-group:
 
 ``provider.resource_group``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        Not available.
+    Not available.
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The resource group to use for deployment of the Ray cluster.
+    The resource group to use for deployment of the Ray cluster.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** String
-        * **Default:** ray-cluster
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** String
+    * **Default:** ray-cluster
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        Not available.
+    Not available.
 
 .. _cluster-configuration-subscription-id:
 
 ``provider.subscription_id``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        Not available.
+    Not available.
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The subscription ID to use for deployment of the Ray cluster. If not specified, Ray will use the default from the Azure CLI.
+    The subscription ID to use for deployment of the Ray cluster. If not specified, Ray will use the default from the Azure CLI.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** String
-        * **Default:** ``""``
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** String
+    * **Default:** ``""``
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        Not available.
+    Not available.
 
 .. _cluster-configuration-project-id:
 
 ``provider.project_id``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        Not available.
+    Not available.
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        Not available.
+    Not available.
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The globally unique project ID to use for deployment of the Ray cluster.
+    The globally unique project ID to use for deployment of the Ray cluster.
 
-        * **Required:** Yes
-        * **Importance:** Low
-        * **Type:** String
-        * **Default:** ``null``
+    * **Required:** Yes
+    * **Importance:** Low
+    * **Type:** String
+    * **Default:** ``null``
 
 .. _cluster-configuration-cache-stopped-nodes:
 
@@ -948,22 +931,21 @@ If enabled, nodes will be *stopped* when the cluster scales down. If disabled, n
 ``provider.security_group``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        A security group that can be used to specify custom inbound rules.
+    A security group that can be used to specify custom inbound rules.
 
-        * **Required:** No
-        * **Importance:** Medium
-        * **Type:** :ref:`Security Group <cluster-configuration-security-group-type>`
+    * **Required:** No
+    * **Importance:** Medium
+    * **Type:** :ref:`Security Group <cluster-configuration-security-group-type>`
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        Not available.
+    Not available.
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        Not available.
+    Not available.
 
 
 .. _cluster-configuration-group-name:
@@ -1061,30 +1043,29 @@ A list of commands to run to set up worker nodes of this type. These commands wi
 ``available_node_types.<node_type_name>.node_type.resources.CPU``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        The number of CPUs made available by this node. If not configured, Autoscaler can automatically detect them only for AWS/Kubernetes cloud providers.
+    The number of CPUs made available by this node. If not configured, Autoscaler can automatically detect them only for AWS/Kubernetes cloud providers.
 
-        * **Required:** Yes (except for AWS/K8s)
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** Yes (except for AWS/K8s)
+    * **Importance:** High
+    * **Type:** Integer
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The number of CPUs made available by this node.
+    The number of CPUs made available by this node.
 
-        * **Required:** Yes
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** Yes
+    * **Importance:** High
+    * **Type:** Integer
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The number of CPUs made available by this node.
+    The number of CPUs made available by this node.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** Integer
 
 
 .. _cluster-configuration-gpu:
@@ -1092,90 +1073,87 @@ A list of commands to run to set up worker nodes of this type. These commands wi
 ``available_node_types.<node_type_name>.node_type.resources.GPU``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        The number of GPUs made available by this node. If not configured, Autoscaler can automatically detect them only for AWS/Kubernetes cloud providers.
+    The number of GPUs made available by this node. If not configured, Autoscaler can automatically detect them only for AWS/Kubernetes cloud providers.
 
-        * **Required:** No
-        * **Importance:** Low
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** Low
+    * **Type:** Integer
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The number of GPUs made available by this node.
+    The number of GPUs made available by this node.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** Integer
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The number of GPUs made available by this node.
+    The number of GPUs made available by this node.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** Integer
-        
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** Integer
+
 .. _cluster-configuration-memory:
 
 ``available_node_types.<node_type_name>.node_type.resources.memory``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        The memory in bytes allocated for python worker heap memory on the node. If not configured, Autoscaler will automatically detect the amount of RAM on the node for AWS/Kubernetes and allocate 70% of it for the heap.
+    The memory in bytes allocated for python worker heap memory on the node. If not configured, Autoscaler will automatically detect the amount of RAM on the node for AWS/Kubernetes and allocate 70% of it for the heap.
 
-        * **Required:** No
-        * **Importance:** Low
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** Low
+    * **Type:** Integer
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The memory in bytes allocated for python worker heap memory on the node.
+    The memory in bytes allocated for python worker heap memory on the node.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** Integer
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The memory in bytes allocated for python worker heap memory on the node.
+    The memory in bytes allocated for python worker heap memory on the node.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** Integer
         
  .. _cluster-configuration-object-store-memory:
 
 ``available_node_types.<node_type_name>.node_type.resources.object-store-memory``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        The memory in bytes allocated for the object store on the node. If not configured, Autoscaler will automatically detect the amount of RAM on the node for AWS/Kubernetes and allocate 30% of it for the object store.
+    The memory in bytes allocated for the object store on the node. If not configured, Autoscaler will automatically detect the amount of RAM on the node for AWS/Kubernetes and allocate 30% of it for the object store.
 
-        * **Required:** No
-        * **Importance:** Low
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** Low
+    * **Type:** Integer
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        The memory in bytes allocated for the object store on the node.
+    The memory in bytes allocated for the object store on the node.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** Integer
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        The memory in bytes allocated for the object store on the node.
+    The memory in bytes allocated for the object store on the node.
 
-        * **Required:** No
-        * **Importance:** High
-        * **Type:** Integer
+    * **Required:** No
+    * **Importance:** High
+    * **Type:** Integer
 
 .. _cluster-configuration-node-docker:
 
@@ -1195,40 +1173,38 @@ Examples
 Minimal configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. literalinclude:: ../../../python/ray/autoscaler/aws/example-minimal.yaml
-            :language: yaml
+    .. literalinclude:: ../../../python/ray/autoscaler/aws/example-minimal.yaml
+        :language: yaml
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        .. literalinclude:: ../../../python/ray/autoscaler/azure/example-minimal.yaml
-            :language: yaml
+    .. literalinclude:: ../../../python/ray/autoscaler/azure/example-minimal.yaml
+        :language: yaml
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        .. literalinclude:: ../../../python/ray/autoscaler/gcp/example-minimal.yaml
-            :language: yaml
-            
+    .. literalinclude:: ../../../python/ray/autoscaler/gcp/example-minimal.yaml
+        :language: yaml
+
 Full configuration
 ~~~~~~~~~~~~~~~~~~
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. literalinclude:: ../../../python/ray/autoscaler/aws/example-full.yaml
-            :language: yaml
+    .. literalinclude:: ../../../python/ray/autoscaler/aws/example-full.yaml
+        :language: yaml
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        .. literalinclude:: ../../../python/ray/autoscaler/azure/example-full.yaml
-            :language: yaml
+    .. literalinclude:: ../../../python/ray/autoscaler/azure/example-full.yaml
+        :language: yaml
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        .. literalinclude:: ../../../python/ray/autoscaler/gcp/example-full.yaml
-            :language: yaml
+    .. literalinclude:: ../../../python/ray/autoscaler/gcp/example-full.yaml
+        :language: yaml
 
 TPU Configuration
 ~~~~~~~~~~~~~~~~~
@@ -1237,9 +1213,7 @@ It is possible to use `TPU VMs <https://cloud.google.com/tpu/docs/users-guide-tp
 
 Before using a config with TPUs, ensure that the `TPU API is enabled for your GCP project <https://cloud.google.com/tpu/docs/users-guide-tpu-vm#enable_the_cloud_tpu_api>`_.
 
-.. tabs::
+.. tabbed:: GCP
 
-    .. group-tab:: GCP
-
-        .. literalinclude:: ../../../python/ray/autoscaler/gcp/tpu.yaml
-            :language: yaml
+    .. literalinclude:: ../../../python/ray/autoscaler/gcp/tpu.yaml
+        :language: yaml

--- a/doc/source/cluster/quickstart.rst
+++ b/doc/source/cluster/quickstart.rst
@@ -31,39 +31,37 @@ Setup
 
 Before we start, you will need to install some Python dependencies as follows:
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. code-block:: shell
+    .. code-block:: shell
 
-            $ pip install -U "ray[default]" boto3
+        $ pip install -U "ray[default]" boto3
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        .. code-block:: shell
+    .. code-block:: shell
 
-            $ pip install -U "ray[default]" azure-cli azure-core
+        $ pip install -U "ray[default]" azure-cli azure-core
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        .. code-block:: shell
+    .. code-block:: shell
 
-            $ pip install -U "ray[default]" google-api-python-client
+        $ pip install -U "ray[default]" google-api-python-client
 
 Next, if you're not set up to use your cloud provider from the command line, you'll have to configure your credentials:
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        Configure your credentials in ``~/.aws/credentials`` as described in `the AWS docs <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_.
+    Configure your credentials in ``~/.aws/credentials`` as described in `the AWS docs <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_.
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        Log in using ``az login``, then configure your credentials with ``az account set -s <subscription_id>``.
+    Log in using ``az login``, then configure your credentials with ``az account set -s <subscription_id>``.
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        Set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable as described in `the GCP docs <https://cloud.google.com/docs/authentication/getting-started>`_.
+    Set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable as described in `the GCP docs <https://cloud.google.com/docs/authentication/getting-started>`_.
 
 Create a (basic) Python application
 -----------------------------------
@@ -156,52 +154,51 @@ To start a Ray Cluster, first we need to define the cluster configuration. The c
 
 A minimal sample cluster configuration file looks as follows:
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            # An unique identifier for the head node and workers of this cluster.
-            cluster_name: minimal
+        # An unique identifier for the head node and workers of this cluster.
+        cluster_name: minimal
 
-            # Cloud-provider specific configuration.
-            provider:
-                type: aws
-                region: us-west-2
+        # Cloud-provider specific configuration.
+        provider:
+            type: aws
+            region: us-west-2
 
-    .. group-tab:: Azure
+.. tabbed:: Azure
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            # An unique identifier for the head node and workers of this cluster.
-            cluster_name: minimal
+        # An unique identifier for the head node and workers of this cluster.
+        cluster_name: minimal
 
-            # Cloud-provider specific configuration.
-            provider:
-                type: azure
-                location: westus2
-                resource_group: ray-cluster
+        # Cloud-provider specific configuration.
+        provider:
+            type: azure
+            location: westus2
+            resource_group: ray-cluster
 
-            # How Ray will authenticate with newly launched nodes.
-            auth:
-                ssh_user: ubuntu
-                # you must specify paths to matching private and public key pair files
-                # use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair
-                ssh_private_key: ~/.ssh/id_rsa
-                # changes to this should match what is specified in file_mounts
-                ssh_public_key: ~/.ssh/id_rsa.pub
+        # How Ray will authenticate with newly launched nodes.
+        auth:
+            ssh_user: ubuntu
+            # you must specify paths to matching private and public key pair files
+            # use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair
+            ssh_private_key: ~/.ssh/id_rsa
+            # changes to this should match what is specified in file_mounts
+            ssh_public_key: ~/.ssh/id_rsa.pub
 
-    .. group-tab:: GCP
+.. tabbed:: GCP
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            # A unique identifier for the head node and workers of this cluster.
-            cluster_name: minimal
+        # A unique identifier for the head node and workers of this cluster.
+        cluster_name: minimal
 
-            # Cloud-provider specific configuration.
-            provider:
-                type: gcp
-                region: us-west1
+        # Cloud-provider specific configuration.
+        provider:
+            type: gcp
+            region: us-west1
 
 Save this configuration file as ``config.yaml``. You can specify a lot more details in the configuration file: instance types to use, minimum and maximum number of workers to start, autoscaling strategy, files to sync, and more. For a full reference on the available configuration properties, please refer to the :ref:`cluster YAML configuration options reference <cluster-config>`.
 

--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -85,31 +85,30 @@ Ensure that the Ray Client port on the head node is reachable from your local ma
 This means opening that port up by configuring security groups or other access controls (on  `EC2 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html>`_)
 or proxying from your local machine to the cluster (on `K8s <https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/#forward-a-local-port-to-a-port-on-the-pod>`_).
 
-.. tabs::
-    .. group-tab:: AWS
+.. tabbed:: AWS
 
-        With the Ray cluster launcher, you can configure the security group
-        to allow inbound access by defining :ref:`cluster-configuration-security-group`
-        in your `cluster.yaml`.
+    With the Ray cluster launcher, you can configure the security group
+    to allow inbound access by defining :ref:`cluster-configuration-security-group`
+    in your `cluster.yaml`.
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            # An unique identifier for the head node and workers of this cluster.
-            cluster_name: minimal_security_group
+        # An unique identifier for the head node and workers of this cluster.
+        cluster_name: minimal_security_group
 
-            # Cloud-provider specific configuration.
-            provider:
-                type: aws
-                region: us-west-2
-                security_group:
-                    GroupName: ray_client_security_group
-                    IpPermissions:
-                          - FromPort: 10001
-                            ToPort: 10001
-                            IpProtocol: TCP
-                            IpRanges:
-                                # This will enable inbound access from ALL IPv4 addresses.
-                                - CidrIp: 0.0.0.0/0
+        # Cloud-provider specific configuration.
+        provider:
+            type: aws
+            region: us-west-2
+            security_group:
+                GroupName: ray_client_security_group
+                IpPermissions:
+                      - FromPort: 10001
+                        ToPort: 10001
+                        IpProtocol: TCP
+                        IpRanges:
+                            # This will enable inbound access from ALL IPv4 addresses.
+                            - CidrIp: 0.0.0.0/0
 
 Step 3: Run Ray code
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -52,19 +52,12 @@ import ray
 
 # -- General configuration ------------------------------------------------
 
-# If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
+    "sphinx_panels",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx_click.ext",
-    # "sphinx_panels",
-    "sphinx_tabs.tabs",
     "sphinx-jsonschema",
     "sphinx_gallery.gen_gallery",
     "sphinxemoji.sphinxemoji",
@@ -255,19 +248,6 @@ html_favicon = "_static/favicon.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# TODO: this adds algolia search. can activate this once sphinx-tabs has been
-# replaced by sphinx-panels.
-# html_css_files = [
-#     "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css",
-# ]
-#
-# html_js_files = [
-#     (
-#         "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js",
-#         {"defer": "defer"},
-#     ),
-#     ("docsearch.sbt.js", {"defer": "defer"}),
-# ]
 html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
@@ -402,7 +382,11 @@ autodoc_member_order = "bysource"
 def setup(app):
     app.connect("html-page-context", update_context)
     # Custom CSS
-    app.add_css_file("css/custom.css")
+    app.add_css_file("css/custom.css", priority=800)
+    app.add_css_file("https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css")
+    # Custom JS
+    app.add_js_file("https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js", defer="defer")
+    app.add_js_file("docsearch.sbt.js", defer="defer")
     # Custom Sphinx directives
     app.add_directive("customgalleryitem", CustomGalleryItemDirective)
     # Custom docstring processor

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -383,9 +383,13 @@ def setup(app):
     app.connect("html-page-context", update_context)
     # Custom CSS
     app.add_css_file("css/custom.css", priority=800)
-    app.add_css_file("https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css")
+    app.add_css_file(
+        "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+    )
     # Custom JS
-    app.add_js_file("https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js", defer="defer")
+    app.add_js_file(
+        "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js",
+        defer="defer")
     app.add_js_file("docsearch.sbt.js", defer="defer")
     # Custom Sphinx directives
     app.add_directive("customgalleryitem", CustomGalleryItemDirective)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,8 +11,7 @@ reinforcement learning, and distributed training.
 
 Ray provides Python, Java, and *EXPERIMENTAL* C++ API. And Ray uses Tasks (functions) and Actors (Classes) to allow you to parallelize your code.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -44,7 +43,7 @@ Ray provides Python, Java, and *EXPERIMENTAL* C++ API. And Ray uses Tasks (funct
         futures = [c.read.remote() for c in counters]
         print(ray.get(futures)) # [1, 1, 1, 1]
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     First, add the `ray-api <https://mvnrepository.com/artifact/io.ray/ray-api>`__ and `ray-runtime <https://mvnrepository.com/artifact/io.ray/ray-runtime>`__ dependencies in your project.
 
@@ -112,7 +111,7 @@ Ray provides Python, Java, and *EXPERIMENTAL* C++ API. And Ray uses Tasks (funct
           }
         }
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     | The C++ Ray API is currently experimental with limited support. You can track its development `here <https://github.com/ray-project/ray/milestone/17>`__ and report issues on GitHub.
     | Run the following commands to get started:

--- a/doc/source/ray-core/actors.rst
+++ b/doc/source/ray-core/actors.rst
@@ -12,8 +12,7 @@ Java demo code in this documentation can be found `here <https://github.com/ray-
 Creating an actor
 -----------------
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     You can convert a standard Python class into a Ray actor class as follows:
 
@@ -52,7 +51,7 @@ Creating an actor
 
       counter_actor = Counter.remote()
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     You can convert a standard Java class into a Ray actor class as follows:
 
@@ -88,7 +87,7 @@ Creating an actor
       // Create an actor with a factory method.
       Ray.actor(CounterFactory::createCounter).remote();
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     You can convert a standard C++ class into a Ray actor class as follows:
 
@@ -138,44 +137,49 @@ Actor Methods
 
 Methods of the actor can be called remotely.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    counter_actor = Counter.remote()
+    .. code-block:: python
 
-    assert ray.get(counter_actor.increment.remote()) == 1
+        counter_actor = Counter.remote()
 
-    @ray.remote
-    class Foo(object):
+        assert ray.get(counter_actor.increment.remote()) == 1
 
-        # Any method of the actor can return multiple object refs.
-        @ray.method(num_returns=2)
-        def bar(self):
-            return 1, 2
+        @ray.remote
+        class Foo(object):
 
-    f = Foo.remote()
+            # Any method of the actor can return multiple object refs.
+            @ray.method(num_returns=2)
+            def bar(self):
+                return 1, 2
 
-    obj_ref1, obj_ref2 = f.bar.remote()
-    assert ray.get(obj_ref1) == 1
-    assert ray.get(obj_ref2) == 2
+        f = Foo.remote()
 
-  .. code-tab:: java
+        obj_ref1, obj_ref2 = f.bar.remote()
+        assert ray.get(obj_ref1) == 1
+        assert ray.get(obj_ref2) == 2
 
-    ActorHandle<Counter> counterActor = Ray.actor(Counter::new).remote();
-    // Call an actor method with a return value
-    Assert.assertEquals((int) counterActor.task(Counter::increment).remote().get(), 1);
-    // Call an actor method without return value. In this case, the return type of `remote()` is void.
-    counterActor.task(Counter::reset, 10).remote();
-    Assert.assertEquals((int) counterActor.task(Counter::increment).remote().get(), 11);
+.. tabbed:: Java
 
-  .. code-tab:: c++
+    .. code-block:: java
 
-    ray::ActorHandle<Counter> counter_actor = ray::Actor(CreateCounter).Remote();
-    // Call an actor method with a return value
-    assert(*counter_actor.Task(&Counter::Increment).Remote().Get(), 1);
-    // Call an actor method without return value. In this case, the return type of `Remote()` is void.
-    counter_actor.Task(&Counter::Reset).Remote(10);
-    assert(*counter_actor.Task(&Counter::Increment).Remote().Get(), 11);
+        ActorHandle<Counter> counterActor = Ray.actor(Counter::new).remote();
+        // Call an actor method with a return value
+        Assert.assertEquals((int) counterActor.task(Counter::increment).remote().get(), 1);
+        // Call an actor method without return value. In this case, the return type of `remote()` is void.
+        counterActor.task(Counter::reset, 10).remote();
+        Assert.assertEquals((int) counterActor.task(Counter::increment).remote().get(), 11);
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        ray::ActorHandle<Counter> counter_actor = ray::Actor(CreateCounter).Remote();
+        // Call an actor method with a return value
+        assert(*counter_actor.Task(&Counter::Increment).Remote().Get(), 1);
+        // Call an actor method without return value. In this case, the return type of `Remote()` is void.
+        counter_actor.Task(&Counter::Reset).Remote(10);
+        assert(*counter_actor.Task(&Counter::Increment).Remote().Get(), 11);
 
 .. _actor-resource-guide:
 
@@ -184,8 +188,7 @@ Specifying Resources
 
 You can specify that an actor requires CPUs or GPUs in the decorator. While Ray has built-in support for CPUs and GPUs, Ray can also handle custom resources.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     When using GPUs, Ray will automatically set the environment variable ``CUDA_VISIBLE_DEVICES`` for the actor after instantiated. The actor will have access to a list of the IDs of the GPUs
     that it is allowed to use via ``ray.get_gpu_ids()``. This is a list of strings,
@@ -197,20 +200,20 @@ You can specify that an actor requires CPUs or GPUs in the decorator. While Ray 
       class GPUActor(object):
           pass
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
-    .. In Java, we always specify resources when creating actors. There's no annotation available to act like the Python decorator ``@ray.remote(...)``.
+    In Java, we always specify resources when creating actors. There's no annotation available to act like the Python decorator ``@ray.remote(...)``.
 
     .. code-block:: java
 
-      public class GpuActor {
-      }
+        public class GpuActor {
+        }
 
-      Ray.actor(GpuActor::new).setResource("CPU", 2.0).setResource("GPU", 0.5).remote();
+        Ray.actor(GpuActor::new).setResource("CPU", 2.0).setResource("GPU", 0.5).remote();
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
-    .. In C++, we always specify resources when creating actors. There's no annotation available to act like the Python decorator ``@ray.remote(...)``.
+    In C++, we always specify resources when creating actors. There's no annotation available to act like the Python decorator ``@ray.remote(...)``.
 
     .. code-block:: c++
 
@@ -242,70 +245,80 @@ have these resources (see `configuration instructions
     decorator, then by default, the actor will not acquire any resources for its
     lifetime.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    @ray.remote(resources={'Resource2': 1})
-    class GPUActor(object):
-        pass
+    .. code-block:: python
 
-  .. code-tab:: java
+        @ray.remote(resources={'Resource2': 1})
+        class GPUActor(object):
+            pass
 
-    public class GpuActor {
-    }
+.. tabbed:: Java
 
-    Ray.actor(GpuActor::new).setResource("Resource2", 1.0).remote();
+    .. code-block:: java
 
-  .. code-tab:: c++
+        public class GpuActor {
+        }
 
-    class GpuActor {
-      static GpuActor* CreateGpuActor() {
-        return new GpuActor();
-      }
-    }
+        Ray.actor(GpuActor::new).setResource("Resource2", 1.0).remote();
 
-    ray::Actor(&GpuActor::CreateGpuActor).SetResource("Resource2", 1.0).Remote();
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        class GpuActor {
+          static GpuActor* CreateGpuActor() {
+            return new GpuActor();
+          }
+        }
+
+        ray::Actor(&GpuActor::CreateGpuActor).SetResource("Resource2", 1.0).Remote();
 
 
 If you need to instantiate many copies of the same actor with varying resource
 requirements, you can do so as follows.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    @ray.remote(num_cpus=4)
-    class Counter(object):
-        ...
+    .. code-block:: python
 
-    a1 = Counter.options(num_cpus=1, resources={"Custom1": 1}).remote()
-    a2 = Counter.options(num_cpus=2, resources={"Custom2": 1}).remote()
-    a3 = Counter.options(num_cpus=3, resources={"Custom3": 1}).remote()
+        @ray.remote(num_cpus=4)
+        class Counter(object):
+            ...
 
-  .. code-tab:: java
+        a1 = Counter.options(num_cpus=1, resources={"Custom1": 1}).remote()
+        a2 = Counter.options(num_cpus=2, resources={"Custom2": 1}).remote()
+        a3 = Counter.options(num_cpus=3, resources={"Custom3": 1}).remote()
 
-    public class Counter {
-      ...
-    }
+.. tabbed:: Java
 
-    ActorHandle<Counter> a1 = Ray.actor(Counter::new).setResource("CPU", 1.0)
-      .setResource("Custom1", 1.0).remote();
-    ActorHandle<Counter> a2 = Ray.actor(Counter::new).setResource("CPU", 2.0)
-      .setResource("Custom2", 1.0).remote();
-    ActorHandle<Counter> a3 = Ray.actor(Counter::new).setResource("CPU", 3.0)
-      .setResource("Custom3", 1.0).remote();
+    .. code-block:: java
 
-  .. code-tab:: c++
+        public class Counter {
+          ...
+        }
 
-    class Counter {
-      ...
-    }
+        ActorHandle<Counter> a1 = Ray.actor(Counter::new).setResource("CPU", 1.0)
+          .setResource("Custom1", 1.0).remote();
+        ActorHandle<Counter> a2 = Ray.actor(Counter::new).setResource("CPU", 2.0)
+          .setResource("Custom2", 1.0).remote();
+        ActorHandle<Counter> a3 = Ray.actor(Counter::new).setResource("CPU", 3.0)
+          .setResource("Custom3", 1.0).remote();
 
-    auto a1 = ray::Actor(&GpuActor::CreateGpuActor).SetResource("CPU", 1.0)
-      .SetResource("Custom1", 1.0).Remote();
-    auto a2 = ray::Actor(&GpuActor::CreateGpuActor).SetResource("CPU", 2.0)
-      .SetResource("Custom2", 1.0).Remote();
-    auto a3 = ray::Actor(&GpuActor::CreateGpuActor).SetResource("CPU", 3.0)
-      .SetResource("Custom3", 1.0).Remote();
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        class Counter {
+          ...
+        }
+
+        auto a1 = ray::Actor(&GpuActor::CreateGpuActor).SetResource("CPU", 1.0)
+          .SetResource("Custom1", 1.0).Remote();
+        auto a2 = ray::Actor(&GpuActor::CreateGpuActor).SetResource("CPU", 2.0)
+          .SetResource("Custom2", 1.0).Remote();
+        auto a3 = ray::Actor(&GpuActor::CreateGpuActor).SetResource("CPU", 3.0)
+          .SetResource("Custom3", 1.0).Remote();
 
 Note that to create these actors successfully, Ray will need to be started with
 sufficient CPU resources and the relevant custom resources.
@@ -322,8 +335,7 @@ Terminating Actors
 Automatic termination
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     Actor processes will be terminated automatically when the initial actor handle
     goes out of scope in Python. If we create an actor with ``actor_handle =
@@ -332,11 +344,11 @@ Automatic termination
     the original actor handle created for the actor and not to subsequent actor
     handles created by passing the actor handle to other tasks.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     Terminating an actor automatically when the initial actor handle goes out of scope hasn't been implemented in Java yet.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     Terminating an actor automatically when the initial actor handle goes out of scope hasn't been implemented in C++ yet.
 
@@ -346,30 +358,32 @@ Manual termination within the actor
 If necessary, you can manually terminate an actor from within one of the actor methods.
 This will kill the actor process and release resources associated/assigned to the actor.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
+
     .. code-block:: python
 
-      ray.actor.exit_actor()
+        ray.actor.exit_actor()
 
     This approach should generally not be necessary as actors are automatically garbage
     collected. The ``ObjectRef`` resulting from the task can be waited on to wait
     for the actor to exit (calling ``ray.get()`` on it will raise a ``RayActorError``).
 
-  .. group-tab:: Java
+.. tabbed:: Java
+
     .. code-block:: java
 
-      Ray.exitActor();
+        Ray.exitActor();
 
     Garbage collection for actors haven't been implemented yet, so this is currently the
     only way to terminate an actor gracefully. The ``ObjectRef`` resulting from the task
     can be waited on to wait for the actor to exit (calling ``ObjectRef::get`` on it will
     throw a ``RayActorException``).
 
-  .. group-tab:: C++
+.. tabbed:: C++
+
     .. code-block:: c++
 
-      ray::ExitActor();
+        ray::ExitActor();
 
     Garbage collection for actors haven't been implemented yet, so this is currently the
     only way to terminate an actor gracefully. The ``ObjectRef`` resulting from the task
@@ -384,37 +398,40 @@ Manual termination via an actor handle
 
 You can terminate an actor forcefully.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    ray.kill(actor_handle)
+    .. code-block:: python
 
-  .. code-tab:: java
+        ray.kill(actor_handle)
 
-    actorHandle.kill();
+.. tabbed:: Java
 
-  .. code-tab:: c++
+    .. code-block:: java
 
-    actor_handle.Kill();
+        actorHandle.kill();
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        actor_handle.Kill();
 
 This will call the exit syscall from within the actor, causing it to exit
 immediately and any pending tasks to fail.
 
-.. tabs::
-
-  .. group-tab:: Python
+.. tabbed:: Python
 
     This will not go through the normal
     Python sys.exit teardown logic, so any exit handlers installed in the actor using
     ``atexit`` will not be called.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     This will not go through the normal Java System.exit teardown logic, so any
     shutdown hooks installed in the actor using ``Runtime.addShutdownHook(...)`` will
     not be called.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     This will not go through the normal
     C++ std::exit teardown logic, so any exit handlers installed in the actor using
@@ -425,82 +442,92 @@ Passing Around Actor Handles
 
 Actor handles can be passed into other tasks. We can define remote functions (or actor methods) that use actor handles.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    import time
+    .. code-block:: python
 
-    @ray.remote
-    def f(counter):
-        for _ in range(1000):
-            time.sleep(0.1)
-            counter.increment.remote()
+        import time
 
-  .. code-tab:: java
+        @ray.remote
+        def f(counter):
+            for _ in range(1000):
+                time.sleep(0.1)
+                counter.increment.remote()
 
-    public static class MyRayApp {
+.. tabbed:: Java
 
-      public static void foo(ActorHandle<Counter> counter) throws InterruptedException {
-        for (int i = 0; i < 1000; i++) {
-          TimeUnit.MILLISECONDS.sleep(100);
-          counter.task(Counter::increment).remote();
+    .. code-block:: java
+
+        public static class MyRayApp {
+
+          public static void foo(ActorHandle<Counter> counter) throws InterruptedException {
+            for (int i = 0; i < 1000; i++) {
+              TimeUnit.MILLISECONDS.sleep(100);
+              counter.task(Counter::increment).remote();
+            }
+          }
         }
-      }
-    }
 
-  .. code-tab:: c++
+.. tabbed:: C++
 
-      void Foo(ray::ActorHandle<Counter> counter) {
-        for (int i = 0; i < 1000; i++) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(100));
-          counter.Task(&Counter::Increment).Remote();
+    .. code-block:: c++
+
+        void Foo(ray::ActorHandle<Counter> counter) {
+            for (int i = 0; i < 1000; i++) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                counter.Task(&Counter::Increment).Remote();
+            }
         }
-      }
 
 If we instantiate an actor, we can pass the handle around to various tasks.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    counter = Counter.remote()
+    .. code-block:: python
 
-    # Start some tasks that use the actor.
-    [f.remote(counter) for _ in range(3)]
+        counter = Counter.remote()
 
-    # Print the counter value.
-    for _ in range(10):
-        time.sleep(1)
-        print(ray.get(counter.get_counter.remote()))
+        # Start some tasks that use the actor.
+        [f.remote(counter) for _ in range(3)]
 
-  .. code-tab:: java
+        # Print the counter value.
+        for _ in range(10):
+            time.sleep(1)
+            print(ray.get(counter.get_counter.remote()))
 
-    ActorHandle<Counter> counter = Ray.actor(Counter::new).remote();
+.. tabbed:: Java
 
-    // Start some tasks that use the actor.
-    for (int i = 0; i < 3; i++) {
-      Ray.task(MyRayApp::foo, counter).remote();
-    }
+    .. code-block:: java
 
-    // Print the counter value.
-    for (int i = 0; i < 10; i++) {
-      TimeUnit.SECONDS.sleep(1);
-      System.out.println(counter.task(Counter::getCounter).remote().get());
-    }
+        ActorHandle<Counter> counter = Ray.actor(Counter::new).remote();
 
-  .. code-tab:: c++
+        // Start some tasks that use the actor.
+        for (int i = 0; i < 3; i++) {
+          Ray.task(MyRayApp::foo, counter).remote();
+        }
 
-    auto counter = ray::Actor(CreateCounter).Remote();
+        // Print the counter value.
+        for (int i = 0; i < 10; i++) {
+          TimeUnit.SECONDS.sleep(1);
+          System.out.println(counter.task(Counter::getCounter).remote().get());
+        }
 
-    // Start some tasks that use the actor.
-    for (int i = 0; i < 3; i++) {
-      ray::Task(Foo).Remote(counter);
-    }
+.. tabbed:: C++
 
-    // Print the counter value.
-    for (int i = 0; i < 10; i++) {
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-      std::cout << *counter.Task(&Counter::GetCounter).Remote().Get() << std::endl;
-    }
+    .. code-block:: c++
+
+        auto counter = ray::Actor(CreateCounter).Remote();
+
+        // Start some tasks that use the actor.
+        for (int i = 0; i < 3; i++) {
+          ray::Task(Foo).Remote(counter);
+        }
+
+        // Print the counter value.
+        for (int i = 0; i < 10; i++) {
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+          std::cout << *counter.Task(&Counter::GetCounter).Remote().Get() << std::endl;
+        }
 
 Named Actors
 ------------
@@ -513,61 +540,62 @@ access an actor launched by another driver.
 Note that the actor will still be garbage-collected if no handles to it
 exist. See :ref:`actor-lifetimes` for more details.
 
-.. tabs::
+.. tabbed:: Python
 
-  .. code-tab:: python
+    .. code-block:: python
 
-    # Create an actor with a name
-    counter = Counter.options(name="some_name").remote()
+        # Create an actor with a name
+        counter = Counter.options(name="some_name").remote()
 
-    ...
+        ...
 
-    # Retrieve the actor later somewhere
-    counter = ray.get_actor("some_name")
+        # Retrieve the actor later somewhere
+        counter = ray.get_actor("some_name")
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
-      // Create an actor with a name.
-      ActorHandle<Counter> counter = Ray.actor(Counter::new).setName("some_name").remote();
+        // Create an actor with a name.
+        ActorHandle<Counter> counter = Ray.actor(Counter::new).setName("some_name").remote();
 
-      ...
+        ...
 
-      // Retrieve the actor later somewhere
-      Optional<ActorHandle<Counter>> counter = Ray.getActor("some_name");
-      Assert.assertTrue(counter.isPresent());
+        // Retrieve the actor later somewhere
+        Optional<ActorHandle<Counter>> counter = Ray.getActor("some_name");
+        Assert.assertTrue(counter.isPresent());
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
-      // Create an actor with a globally unique name
-      ActorHandle<Counter> counter = ray::Actor(CreateCounter).SetGlobalName("some_name").Remote();
+        // Create an actor with a globally unique name
+        ActorHandle<Counter> counter = ray::Actor(CreateCounter).SetGlobalName("some_name").Remote();
 
-      ...
+        ...
 
-      // Retrieve the actor later somewhere
-      boost::optional<ray::ActorHandle<Counter>> counter = ray::GetGlobalActor("some_name");
+        // Retrieve the actor later somewhere
+        boost::optional<ray::ActorHandle<Counter>> counter = ray::GetGlobalActor("some_name");
 
     We also support non-global named actors in C++, which means that the actor name is only valid within the job and the actor cannot be accessed from another job
 
     .. code-block:: c++
 
-      // Create an actor with a job-scope-unique name
-      ActorHandle<Counter> counter = ray::Actor(CreateCounter).SetName("some_name").Remote();
+        // Create an actor with a job-scope-unique name
+        ActorHandle<Counter> counter = ray::Actor(CreateCounter).SetName("some_name").Remote();
 
-      ...
+        ...
 
-      // Retrieve the actor later somewhere in the same job
-      boost::optional<ray::ActorHandle<Counter>> counter = ray::GetActor("some_name");
+        // Retrieve the actor later somewhere in the same job
+        boost::optional<ray::ActorHandle<Counter>> counter = ray::GetActor("some_name");
 
 .. note::
 
      Named actors are only accessible in the same namespace.
 
-  .. tabs::
-    .. code-tab:: python
+.. tabbed:: Python
+
+    .. code-block:: python
 
         import ray
 
@@ -592,7 +620,9 @@ exist. See :ref:`actor-lifetimes` for more details.
         # This returns the "orange" actor we created in the first job.
         ray.get_actor("orange")
 
-    .. code-tab:: java
+.. tabbed:: Java
+
+    .. code-block:: java
 
         import ray
 
@@ -626,15 +656,14 @@ exist. See :ref:`actor-lifetimes` for more details.
 Actor Lifetimes
 ---------------
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     Separately, actor lifetimes can be decoupled from the job, allowing an actor to
     persist even after the driver process of the job exits.
 
     .. code-block:: python
 
-      counter = Counter.options(name="CounterActor", lifetime="detached").remote()
+        counter = Counter.options(name="CounterActor", lifetime="detached").remote()
 
     The CounterActor will be kept alive even after the driver running above script
     exits. Therefore it is possible to run the following script in a different
@@ -642,54 +671,53 @@ Actor Lifetimes
 
     .. code-block:: python
 
-      counter = ray.get_actor("CounterActor")
-      print(ray.get(counter.get_counter.remote()))
+        counter = ray.get_actor("CounterActor")
+        print(ray.get(counter.get_counter.remote()))
 
     Note that the lifetime option is decoupled from the name. If we only specified
     the name without specifying ``lifetime="detached"``, then the CounterActor can
     only be retrieved as long as the original driver is still running.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     Customizing lifetime of an actor hasn't been implemented in Java yet.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     Customizing lifetime of an actor hasn't been implemented in C++ yet.
 
 Actor Pool
 ----------
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     The ``ray.util`` module contains a utility class, ``ActorPool``.
     This class is similar to multiprocessing.Pool and lets you schedule Ray tasks over a fixed pool of actors.
 
     .. code-block:: python
 
-      from ray.util import ActorPool
+        from ray.util import ActorPool
 
-      @ray.remote
-      class Actor
+        @ray.remote
+        class Actor
         def double(self, n):
             return n * 2
 
-      a1, a2 = Actor.remote(), Actor.remote()
-      pool = ActorPool([a1, a2])
+        a1, a2 = Actor.remote(), Actor.remote()
+        pool = ActorPool([a1, a2])
 
-      # pool.map(..) returns a Python generator object ActorPool.map
-      gen = pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4]))
-      print([v for v in gen])
-      # [2, 4, 6, 8]
+        # pool.map(..) returns a Python generator object ActorPool.map
+        gen = pool.map(lambda a, v: a.double.remote(v), [1, 2, 3, 4]))
+        print([v for v in gen])
+        # [2, 4, 6, 8]
 
     See the `package reference <package-ref.html#ray.util.ActorPool>`_ for more information.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     Actor pool hasn't been implemented in Java yet.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     Actor pool hasn't been implemented in C++ yet.
 
@@ -718,8 +746,7 @@ better off using tasks.
 Concurrency within an actor
 ---------------------------
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     Within a single actor process, it is possible to execute concurrent threads.
 
@@ -730,10 +757,10 @@ Concurrency within an actor
 
     See the above links for more details.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     Actor-level concurrency hasn't been implemented in Java yet.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     Actor-level concurrency hasn't been implemented in C++ yet.

--- a/doc/source/ray-core/concurrency_group_api.rst
+++ b/doc/source/ray-core/concurrency_group_api.rst
@@ -12,8 +12,7 @@ Defining Concurrency Groups
 
 You can define concurrency groups for asyncio actors using the ``concurrency_groups`` decorator argument:
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     This defines two concurrency groups, "io" with max_concurrency=2 and
     "compute" with max_concurrency=4.  The methods ``f1`` and ``f2`` are
@@ -63,8 +62,7 @@ Default Concurrency Group
 By default, methods are placed in a default concurrency group which has a concurrency limit of 1000.
 The concurrency of the default group can be changed by setting the ``max_concurrency`` actor option.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     The following AsyncIOActor has 2 concurrency groups: "io" and "default".
     The max concurrency of "io" is 2, and the max concurrency of "default" is 10.
@@ -86,8 +84,7 @@ Setting the Concurrency Group at Runtime
 
 You can also dispatch actor methods into a specific concurrency group at runtime using the ``.options`` method:
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     The following snippet demonstrates setting the concurrency group of the
     ``f2`` method dynamically at runtime.

--- a/doc/source/ray-core/cross-language.rst
+++ b/doc/source/ray-core/cross-language.rst
@@ -10,41 +10,37 @@ Setup the driver
 
 We need to set :ref:`code_search_path` in your driver.
 
-.. tabs::
-
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
       ray.init(job_config=ray.job_config.JobConfig(code_search_path="/path/to/code"))
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: bash
 
-      java -classpath <classpath> \
-        -Dray.address=<address> \
-        -Dray.job.code-search-path=/path/to/code/ \
-        <classname> <args>
+        java -classpath <classpath> \
+            -Dray.address=<address> \
+            -Dray.job.code-search-path=/path/to/code/ \
+            <classname> <args>
 
 You may want to include multiple directories to load both Python and Java code for workers, if they are placed in different directories.
 
-.. tabs::
-
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
       ray.init(job_config=ray.job_config.JobConfig(code_search_path="/path/to/jars:/path/to/pys"))
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: bash
 
-      java -classpath <classpath> \
-        -Dray.address=<address> \
-        -Dray.job.code-search-path=/path/to/jars:/path/to/pys \
-        <classname> <args>
+        java -classpath <classpath> \
+            -Dray.address=<address> \
+            -Dray.job.code-search-path=/path/to/jars:/path/to/pys \
+            <classname> <args>
 
 Python calling Java
 -------------------

--- a/doc/source/ray-core/namespaces.rst
+++ b/doc/source/ray-core/namespaces.rst
@@ -9,8 +9,7 @@ named, its name must be unique within the namespace.
 In order to set your applications namespace, it should be specified when you
 first connect to the cluster.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -18,90 +17,93 @@ first connect to the cluster.
       # or using ray client
       ray.init("ray://<head_node_host>:10001", namespace="world")
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
       System.setProperty("ray.job.namespace", "hello"); // set it before Ray.init()
       Ray.init();
 
-    Please refer to `Driver Options <configure.html#driver-options>`__ for ways of configuring a Java application.
+Please refer to `Driver Options <configure.html#driver-options>`__ for ways of configuring a Java application.
 
 Named actors are only accessible within their namespaces.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    # `ray start --head` has been run to launch a local cluster.
-    import ray
+    .. code-block:: python
 
-    @ray.remote
-    class Actor:
-      pass
+        # `ray start --head` has been run to launch a local cluster.
+        import ray
 
-    # Job 1 creates two actors, "orange" and "purple" in the "colors" namespace.
-    with ray.init("ray://localhost:10001", namespace="colors"):
-      Actor.options(name="orange", lifetime="detached")
-      Actor.options(name="purple", lifetime="detached")
+        @ray.remote
+        class Actor:
+            pass
 
-    # Job 2 is now connecting to a different namespace.
-    with ray.init("ray://localhost:10001", namespace="fruits")
-      # This fails because "orange" was defined in the "colors" namespace.
-      ray.get_actor("orange")
-      # This succceeds because the name "orange" is unused in this namespace.
-      Actor.options(name="orange", lifetime="detached")
-      Actor.options(name="watermelon", lifetime="detached")
+        # Job 1 creates two actors, "orange" and "purple" in the "colors" namespace.
+        with ray.init("ray://localhost:10001", namespace="colors"):
+            Actor.options(name="orange", lifetime="detached")
+            Actor.options(name="purple", lifetime="detached")
 
-    # Job 3 connects to the original "colors" namespace
-    context = ray.init("ray://localhost:10001", namespace="colors")
-    # This fails because "watermelon" was in the fruits namespace.
-    ray.get_actor("watermelon")
-    # This returns the "orange" actor we created in the first job, not the second.
-    ray.get_actor("orange")
-    context.disconnect()
-    # We are manually managing the scope of the connection in this example.
+        # Job 2 is now connecting to a different namespace.
+        with ray.init("ray://localhost:10001", namespace="fruits")
+            # This fails because "orange" was defined in the "colors" namespace.
+            ray.get_actor("orange")
+            # This succceeds because the name "orange" is unused in this namespace.
+            Actor.options(name="orange", lifetime="detached")
+            Actor.options(name="watermelon", lifetime="detached")
 
-  .. code-tab:: java
+        # Job 3 connects to the original "colors" namespace
+        context = ray.init("ray://localhost:10001", namespace="colors")
+        # This fails because "watermelon" was in the fruits namespace.
+        ray.get_actor("watermelon")
+        # This returns the "orange" actor we created in the first job, not the second.
+        ray.get_actor("orange")
+        context.disconnect()
+        # We are manually managing the scope of the connection in this example.
 
-    // `ray start --head` has been run to launch a local cluster.
+.. tabbed:: Java
 
-    // Job 1 creates two actors, "orange" and "purple" in the "colors" namespace.
-    System.setProperty("ray.address", "localhost:10001");
-    System.setProperty("ray.job.namespace", "colors");
-    try {
-      Ray.init();
-      Ray.actor(Actor::new).setName("orange").remote();
-      Ray.actor(Actor::new).setName("purple").remote();
-    } finally {
-      Ray.shutdown();
-    }
+    .. code-block:: java
 
-    // Job 2 is now connecting to a different namespace.
-    System.setProperty("ray.address", "localhost:10001");
-    System.setProperty("ray.job.namespace", "fruits");
-    try {
-      Ray.init();
-      // This fails because "orange" was defined in the "colors" namespace.
-      Ray.getActor("orange").isPresent(); // return false
-      // This succceeds because the name "orange" is unused in this namespace.
-      Ray.actor(Actor::new).setName("orange").remote();
-      Ray.actor(Actor::new).setName("watermelon").remote();
-    } finally {
-      Ray.shutdown();
-    }
+        // `ray start --head` has been run to launch a local cluster.
 
-    // Job 3 connects to the original "colors" namespace.
-    System.setProperty("ray.address", "localhost:10001");
-    System.setProperty("ray.job.namespace", "colors");
-    try {
-      Ray.init();
-      // This fails because "watermelon" was in the fruits namespace.
-      Ray.getActor("watermelon").isPresent(); // return false
-      // This returns the "orange" actor we created in the first job, not the second.
-      Ray.getActor("orange").isPresent(); // return true
-    } finally {
-      Ray.shutdown();
-    }
+        // Job 1 creates two actors, "orange" and "purple" in the "colors" namespace.
+        System.setProperty("ray.address", "localhost:10001");
+        System.setProperty("ray.job.namespace", "colors");
+        try {
+            Ray.init();
+            Ray.actor(Actor::new).setName("orange").remote();
+            Ray.actor(Actor::new).setName("purple").remote();
+        } finally {
+            Ray.shutdown();
+        }
+
+        // Job 2 is now connecting to a different namespace.
+        System.setProperty("ray.address", "localhost:10001");
+        System.setProperty("ray.job.namespace", "fruits");
+        try {
+            Ray.init();
+            // This fails because "orange" was defined in the "colors" namespace.
+            Ray.getActor("orange").isPresent(); // return false
+            // This succceeds because the name "orange" is unused in this namespace.
+            Ray.actor(Actor::new).setName("orange").remote();
+            Ray.actor(Actor::new).setName("watermelon").remote();
+        } finally {
+            Ray.shutdown();
+        }
+
+        // Job 3 connects to the original "colors" namespace.
+        System.setProperty("ray.address", "localhost:10001");
+        System.setProperty("ray.job.namespace", "colors");
+        try {
+            Ray.init();
+            // This fails because "watermelon" was in the fruits namespace.
+            Ray.getActor("watermelon").isPresent(); // return false
+            // This returns the "orange" actor we created in the first job, not the second.
+            Ray.getActor("orange").isPresent(); // return true
+        } finally {
+            Ray.shutdown();
+        }
 
 Anonymous namespaces
 --------------------
@@ -110,50 +112,53 @@ When a namespace is not specified, Ray will place your job in an anonymous
 namespace. In an anonymous namespace, your job will have its own namespace and
 will not have access to actors in other namespaces.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    # `ray start --head` has been run to launch a local cluster
+    .. code-block:: python
 
-    import ray
+        # `ray start --head` has been run to launch a local cluster
 
-    @ray.remote
-    class Actor:
-      pass
+        import ray
 
-    # Job 1 connects to an anonymous namespace by default
-    ctx = ray.init("ray://localhost:10001")
-    Actor.options(name="my_actor", lifetime="detached")
-    ctx.disconnect()
+        @ray.remote
+        class Actor:
+            pass
 
-    # Job 2 connects to a _different_ anonymous namespace by default
-    ctx = ray.init("ray://localhost:10001")
-    # This succeeds because the second job is in its own namespace.
-    Actor.options(name="my_actor", lifetime="detached")
-    ctx.disconnect()
+        # Job 1 connects to an anonymous namespace by default
+        ctx = ray.init("ray://localhost:10001")
+        Actor.options(name="my_actor", lifetime="detached")
+        ctx.disconnect()
 
-  .. code-tab:: java
+        # Job 2 connects to a _different_ anonymous namespace by default
+        ctx = ray.init("ray://localhost:10001")
+        # This succeeds because the second job is in its own namespace.
+        Actor.options(name="my_actor", lifetime="detached")
+        ctx.disconnect()
 
-    // `ray start --head` has been run to launch a local cluster.
+.. tabbed:: Java
 
-    // Job 1 connects to an anonymous namespace by default.
-    System.setProperty("ray.address", "localhost:10001");
-    try {
-      Ray.init();
-      Ray.actor(Actor::new).setName("my_actor").remote();
-    } finally {
-      Ray.shutdown();
-    }
+    .. code-block:: java
 
-    // Job 2 connects to a _different_ anonymous namespace by default
-    System.setProperty("ray.address", "localhost:10001");
-    try {
-      Ray.init();
-      // This succeeds because the second job is in its own namespace.
-      Ray.actor(Actor::new).setName("my_actor").remote();
-    } finally {
-      Ray.shutdown();
-    }
+        // `ray start --head` has been run to launch a local cluster.
+
+        // Job 1 connects to an anonymous namespace by default.
+        System.setProperty("ray.address", "localhost:10001");
+        try {
+            Ray.init();
+            Ray.actor(Actor::new).setName("my_actor").remote();
+        } finally {
+            Ray.shutdown();
+        }
+
+        // Job 2 connects to a _different_ anonymous namespace by default
+        System.setProperty("ray.address", "localhost:10001");
+        try {
+            Ray.init();
+            // This succeeds because the second job is in its own namespace.
+            Ray.actor(Actor::new).setName("my_actor").remote();
+        } finally {
+            Ray.shutdown();
+        }
 
 .. note::
 
@@ -166,21 +171,24 @@ Getting the current namespace
 -----------------------------
 You can access to the current namespace using :ref:`runtime_context APIs <runtime-context-apis>`.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    import ray
-    ray.init(address="auto", namespace="colors")
-    # Will print the information about "colors" namespace.
-    print(ray.get_runtime_context().namespace)
+    .. code-block:: python
 
-  .. code-tab:: java
+        import ray
+        ray.init(address="auto", namespace="colors")
+        # Will print the information about "colors" namespace.
+        print(ray.get_runtime_context().namespace)
 
-    System.setProperty("ray.job.namespace", "colors");
-    try {
-      Ray.init();
-      // Will print the information about "colors" namespace.
-      System.out.println(Ray.getRuntimeContext().getNamespace());
-    } finally {
-      Ray.shutdown();
-    }
+.. tabbed:: Java
+
+    .. code-block:: java
+
+        System.setProperty("ray.job.namespace", "colors");
+        try {
+            Ray.init();
+            // Will print the information about "colors" namespace.
+            System.out.println(Ray.getRuntimeContext().getNamespace());
+        } finally {
+            Ray.shutdown();
+        }

--- a/doc/source/ray-core/placement-group.rst
+++ b/doc/source/ray-core/placement-group.rst
@@ -39,8 +39,7 @@ Starting a placement group
 
 Ray placement group can be created via the ``ray.util.placement_group`` (Python) or ``PlacementGroups.createPlacementGroup`` (Java) API. Placement groups take in a list of bundles and a :ref:`placement strategy <pgroup-strategy>`:
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -60,7 +59,7 @@ Ray placement group can be created via the ``ray.util.placement_group`` (Python)
 
       pg = placement_group([bundle1, bundle2], strategy="STRICT_PACK")
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
@@ -80,7 +79,7 @@ Ray placement group can be created via the ``ray.util.placement_group`` (Python)
 
       PlacementGroup pg = PlacementGroups.createPlacementGroup(options);
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
@@ -100,8 +99,7 @@ Ray placement group can be created via the ``ray.util.placement_group`` (Python)
 
 Placement groups are atomically created - meaning that if there exists a bundle that cannot fit in any of the current nodes, then the entire placement group will not be ready.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -114,7 +112,7 @@ Placement groups are atomically created - meaning that if there exists a bundle 
       # You can look at placement group states using this API.
       print(placement_group_table(pg))
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
@@ -128,7 +126,7 @@ Placement groups are atomically created - meaning that if there exists a bundle 
         System.out.println(group);
       }
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
@@ -200,8 +198,7 @@ Let's create a placement group. Recall that each bundle is a collection of resou
 
   Once the placement group reserves resources, original resources are unavailable until the placement group is removed. For example:
 
-  .. tabs::
-    .. group-tab:: Python
+  .. tabbed:: Python
 
       .. code-block:: python
 
@@ -223,7 +220,7 @@ Let's create a placement group. Recall that each bundle is a collection of resou
         # Will be scheduled because 2 cpus are reserved by the placement group.
         f.options(placement_group=pg).remote()
 
-    .. group-tab:: Java
+  .. tabbed:: Java
 
       .. code-block:: java
 
@@ -267,7 +264,7 @@ Let's create a placement group. Recall that each bundle is a collection of resou
           .remote();
         Assert.assertEquals(obj.get(), "pong");
 
-    .. group-tab:: C++
+  .. tabbed:: C++
 
       .. code-block:: c++
 
@@ -323,8 +320,7 @@ Let's create a placement group. Recall that each bundle is a collection of resou
   and have the proper resources. Ray assumes that the placement group will be properly created and does *not*
   print a warning about infeasible tasks.
 
-  .. tabs::
-    .. group-tab:: Python
+  .. tabbed:: Python
 
       .. code-block:: python
 
@@ -340,7 +336,7 @@ Let's create a placement group. Recall that each bundle is a collection of resou
         # Wait until placement group is created.
         ray.get(pg.ready())
 
-    .. group-tab:: Java
+  .. tabbed:: Java
 
       .. code-block:: java
 
@@ -364,7 +360,7 @@ Let's create a placement group. Recall that each bundle is a collection of resou
         boolean isCreated = pg.wait(60);
         Assert.assertTrue(isCreated);
 
-    .. group-tab:: C++
+  .. tabbed:: C++
 
       .. code-block:: c++
 
@@ -383,8 +379,7 @@ Let's create a placement group. Recall that each bundle is a collection of resou
 
 Now let's define an actor that uses GPU. We'll also define a task that use ``extra_resources``.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -415,7 +410,7 @@ Now let's define an actor that uses GPU. We'll also define a task that use ``ext
           placement_group_bundle_index=1) # Index of extra_resource_bundle is 1.
       .remote() for _ in range(2)]
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
@@ -451,7 +446,7 @@ Now let's define an actor that uses GPU. We'll also define a task that use ``ext
           .remote().get();
       }
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
@@ -498,8 +493,7 @@ because they are scheduled on a placement group with the STRICT_PACK strategy.
   In order to fully utilize resources pre-reserved by the placement group,
   Ray automatically schedules children tasks/actors to the same placement group as its parent.
 
-  .. tabs::
-    .. group-tab:: Python
+  .. tabbed:: Python
 
       .. code-block:: python
 
@@ -529,14 +523,13 @@ because they are scheduled on a placement group with the STRICT_PACK strategy.
             # scheduled with the parent's placement group.
             ray.get(child.options(placement_group=None).remote())
 
-    .. group-tab:: Java
+  .. tabbed:: Java
 
       It's not implemented for Java APIs yet.
 
 You can remove a placement group at any time to free its allocated resources.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -559,7 +552,7 @@ You can remove a placement group at any time to free its allocated resources.
 
       ray.shutdown()
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
@@ -568,7 +561,7 @@ You can remove a placement group at any time to free its allocated resources.
       PlacementGroup removedPlacementGroup = PlacementGroups.getPlacementGroup(placementGroup.getId());
       Assert.assertEquals(removedPlacementGroup.getState(), PlacementGroupState.REMOVED);
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
@@ -588,8 +581,7 @@ access a placement group launched by another driver.
 Note that the placement group will still be destroyed if it's lifetime isn't `detached`.
 See :ref:`placement-group-lifetimes` for more details.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -606,7 +598,7 @@ See :ref:`placement-group-lifetimes` for more details.
       # Retrieve a placement group with a global name.
       pg = ray.util.get_placement_group("global_name")
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
@@ -630,7 +622,7 @@ See :ref:`placement-group-lifetimes` for more details.
       PlacementGroup group = PlacementGroups.getPlacementGroup("global_name");
       Assert.assertNotNull(group);
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
@@ -673,8 +665,7 @@ See :ref:`placement-group-lifetimes` for more details.
 Placement Group Lifetimes
 -------------------------
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     By default, the lifetimes of placement groups are not detached and will be destroyed
     when the driver is terminated (but, if it is created from a detached actor, it is 
@@ -702,7 +693,7 @@ Placement Group Lifetimes
     the name without specifying ``lifetime="detached"``, then the placement group can
     only be retrieved as long as the original driver is still running.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     The lifetime argument is not implemented for Java APIs yet.
 

--- a/doc/source/ray-core/starting-ray.rst
+++ b/doc/source/ray-core/starting-ray.rst
@@ -29,109 +29,118 @@ Calling ``ray.init()`` (without any ``address`` args) starts a Ray runtime on yo
 
   In recent versions of Ray (>=1.5), ``ray.init()`` will automatically be called on the first use of a Ray remote API.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    import ray
-    # Other Ray APIs will not work until `ray.init()` is called.
-    ray.init()
+    .. code-block:: python
 
-  .. code-tab:: java
+        import ray
+        # Other Ray APIs will not work until `ray.init()` is called.
+        ray.init()
 
-    import io.ray.api.Ray;
+.. tabbed:: Java
 
-    public class MyRayApp {
+    .. code-block:: java
 
-      public static void main(String[] args) {
-        // Other Ray APIs will not work until `Ray.init()` is called.
-        Ray.init();
-        ...
-      }
-    }
+        import io.ray.api.Ray;
 
-  .. code-tab:: c++
+        public class MyRayApp {
 
-    #include <ray/api.h>
-    // Other Ray APIs will not work until `ray::Init()` is called.
-    ray::Init()
+          public static void main(String[] args) {
+            // Other Ray APIs will not work until `Ray.init()` is called.
+            Ray.init();
+            ...
+          }
+        }
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        #include <ray/api.h>
+        // Other Ray APIs will not work until `ray::Init()` is called.
+        ray::Init()
 
 When the process calling ``ray.init()`` terminates, the Ray runtime will also terminate. To explicitly stop or restart Ray, use the shutdown API.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    import ray
-    ray.init()
-    ... # ray program
-    ray.shutdown()
+    .. code-block:: python
 
-  .. code-tab:: java
+        import ray
+        ray.init()
+        ... # ray program
+        ray.shutdown()
 
-    import io.ray.api.Ray;
+.. tabbed:: Java
 
-    public class MyRayApp {
+    .. code-block:: java
 
-      public static void main(String[] args) {
-        Ray.init();
+        import io.ray.api.Ray;
+
+        public class MyRayApp {
+
+          public static void main(String[] args) {
+            Ray.init();
+            ... // ray program
+            Ray.shutdown();
+          }
+        }
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        #include <ray/api.h>
+        ray::Init()
         ... // ray program
-        Ray.shutdown();
-      }
-    }
+        ray::Shutdown()
 
-  .. code-tab:: c++
-
-    #include <ray/api.h>
-    ray::Init()
-    ... // ray program
-    ray::Shutdown()
-
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     To check if Ray is initialized, you can call ``ray.is_initialized()``:
 
     .. code-block:: python
 
-      import ray
-      ray.init()
-      assert ray.is_initialized() == True
+        import ray
+        ray.init()
+        assert ray.is_initialized() == True
 
-      ray.shutdown()
-      assert ray.is_initialized() == False
+        ray.shutdown()
+        assert ray.is_initialized() == False
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     To check if Ray is initialized, you can call ``Ray.isInitialized()``:
 
     .. code-block:: java
 
-      import io.ray.api.Ray;
+        import io.ray.api.Ray;
 
-      public class MyRayApp {
+        public class MyRayApp {
 
         public static void main(String[] args) {
-          Ray.init();
-          Assert.assertTrue(Ray.isInitialized());
-          Ray.shutdown();
-          Assert.assertFalse(Ray.isInitialized());
+                Ray.init();
+                Assert.assertTrue(Ray.isInitialized());
+                Ray.shutdown();
+                Assert.assertFalse(Ray.isInitialized());
+            }
         }
-      }
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     To check if Ray is initialized, you can call ``ray::IsInitialized()``:
 
     .. code-block:: c++
 
-      #include <ray/api.h>
+        #include <ray/api.h>
 
-      int main(int argc, char **argv) {
-        ray::Init();
-        assert(ray::IsInitialized());
+        int main(int argc, char **argv) {
+            ray::Init();
+            assert(ray::IsInitialized());
 
-        ray::Shutdown();
-        assert(!ray::IsInitialized());
-      }
+            ray::Shutdown();
+            assert(!ray::IsInitialized());
+        }
 
 See the `Configuration <configure.html>`__ documentation for the various ways to configure Ray.
 
@@ -158,14 +167,14 @@ Use ``ray start`` from the CLI to start a 1 node ray runtime on a machine. This 
 
 You can connect to this Ray runtime by starting a driver process on the same node as where you ran ``ray start``:
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
+  .. code-block:: python
 
     # This must
     import ray
     ray.init(address='auto')
 
-  .. group-tab:: java
+.. tabbed:: java
 
     .. code-block:: java
 
@@ -185,7 +194,7 @@ You can connect to this Ray runtime by starting a driver process on the same nod
         -Dray.address=<address> \
         <classname> <args>
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
@@ -230,13 +239,13 @@ Local mode
 
 By default, Ray will parallelize its workload and run tasks on multiple processes and multiple nodes. However, if you need to debug your Ray program, it may be easier to do everything on a single process. You can force all Ray functions to occur on a single process by enabling local mode as the following:
 
-.. tabs::
+.. tabbed:: Python
 
-  .. code-tab:: python
+  .. code-block:: python
 
     ray.init(local_mode=True)
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: bash
 
@@ -246,7 +255,7 @@ By default, Ray will parallelize its workload and run tasks on multiple processe
 
     .. note:: If you just want to run your Java code in local mode, you can run it without Ray or even Python installed.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 

--- a/doc/source/ray-core/walkthrough.rst
+++ b/doc/source/ray-core/walkthrough.rst
@@ -17,18 +17,17 @@ Java demo code in this documentation can be found `here <https://github.com/ray-
 Installation
 ------------
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     To run this walkthrough, install Ray with ``pip install -U ray``. For the latest wheels (for a snapshot of ``master``), you can use these instructions at :ref:`install-nightlies`.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     To run this walkthrough, add `Ray API <https://mvnrepository.com/artifact/io.ray/ray-api>`_ and `Ray Runtime <https://mvnrepository.com/artifact/io.ray/ray-runtime>`_ as dependencies. Snapshot versions can be found in `sonatype repository <https://oss.sonatype.org/#nexus-search;quick~io.ray>`_.
 
     Note: To run your Ray Java application, you need to install Ray Python with `pip install -U ray` first. (For Ray Java snapshot versions, install nightly Ray Python wheels.) The versions of Ray Java and Ray Python must match.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     To run this walkthrough, install Ray with ``pip install -U ray[cpp]``. For the latest wheels (for a snapshot of ``master``), you can use these instructions at :ref:`install-nightlies`.
 
@@ -41,42 +40,47 @@ You can start Ray on a single machine by adding this to your code.
 
   In recent versions of Ray (>=1.5), ``ray.init()`` will automatically be called on the first use of a Ray remote API.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    import ray
+    .. code-block:: python
 
-    # Start Ray. If you're connecting to an existing cluster, you would use
-    # ray.init(address=<cluster-address>) instead.
-    ray.init()
+        import ray
 
-    ...
+        # Start Ray. If you're connecting to an existing cluster, you would use
+        # ray.init(address=<cluster-address>) instead.
+        ray.init()
 
-  .. code-tab:: java
-
-    import io.ray.api.Ray;
-
-    public class MyRayApp {
-
-      public static void main(String[] args) {
-        // Start Ray runtime. If you're connecting to an existing cluster, you can set
-        // the `-Dray.address=<cluster-address>` java system property.
-        Ray.init();
         ...
-      }
-    }
 
-  .. code-tab:: c++
+.. tabbed:: Java
 
-    // Run `ray cpp --show-library-path` to find headers and libraries.
-    #include <ray/api.h>
+    .. code-block:: java
 
-    int main(int argc, char **argv) {
-      // Start Ray runtime. If you're connecting to an existing cluster, you can set
-      // the `RAY_ADDRESS` env var.
-      ray::Init();
-      ...
-    }
+        import io.ray.api.Ray;
+
+        public class MyRayApp {
+
+            public static void main(String[] args) {
+                // Start Ray runtime. If you're connecting to an existing cluster, you can set
+                // the `-Dray.address=<cluster-address>` java system property.
+                Ray.init();
+                ...
+            }
+        }
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        // Run `ray cpp --show-library-path` to find headers and libraries.
+        #include <ray/api.h>
+
+        int main(int argc, char **argv) {
+            // Start Ray runtime. If you're connecting to an existing cluster, you can set
+            // the `RAY_ADDRESS` env var.
+            ray::Init();
+            ...
+        }
 
 
 Ray will then be able to utilize all cores of your machine. Find out how to configure the number of cores Ray will use at :ref:`configuring-ray`.
@@ -90,8 +94,7 @@ Remote functions (Tasks)
 
 Ray enables arbitrary functions to be executed asynchronously. These asynchronous Ray functions are called "remote functions". Here is an example.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     .. code:: python
 
@@ -126,9 +129,9 @@ Ray enables arbitrary functions to be executed asynchronously. These asynchronou
 
     See the `ray.remote package reference <package-ref.html>`__ page for specific documentation on how to use ``ray.remote``.
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
-    .. code:: java
+    .. code-block:: java
 
       public class MyRayApp {
         // A regular Java static method.
@@ -159,9 +162,9 @@ Ray enables arbitrary functions to be executed asynchronously. These asynchronou
         Ray.task(MyRayApp::slowFunction).remote();
       }
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
-    .. code:: c++
+    .. code-block:: c++
 
       // A regular C++ function.
       int MyFunction() {
@@ -198,49 +201,54 @@ Passing object refs to remote functions
 
 **Object refs** can also be passed into remote functions. When the function actually gets executed, **the argument will be a retrieved as a regular object**. For example, take this function:
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    @ray.remote
-    def function_with_an_argument(value):
-        return value + 1
+    .. code-block:: python
+
+        @ray.remote
+        def function_with_an_argument(value):
+            return value + 1
 
 
-    obj_ref1 = my_function.remote()
-    assert ray.get(obj_ref1) == 1
+        obj_ref1 = my_function.remote()
+        assert ray.get(obj_ref1) == 1
 
-    # You can pass an object ref as an argument to another Ray remote function.
-    obj_ref2 = function_with_an_argument.remote(obj_ref1)
-    assert ray.get(obj_ref2) == 2
+        # You can pass an object ref as an argument to another Ray remote function.
+        obj_ref2 = function_with_an_argument.remote(obj_ref1)
+        assert ray.get(obj_ref2) == 2
 
-  .. code-tab:: java
+.. tabbed:: Java
 
-    public class MyRayApp {
-      public static int functionWithAnArgument(int value) {
-        return value + 1;
-      }
-    }
+    .. code-block:: java
 
-    ObjectRef<Integer> objRef1 = Ray.task(MyRayApp::myFunction).remote();
-    Assert.assertTrue(objRef1.get() == 1);
+        public class MyRayApp {
+            public static int functionWithAnArgument(int value) {
+                return value + 1;
+            }
+        }
 
-    // You can pass an object ref as an argument to another Ray remote function.
-    ObjectRef<Integer> objRef2 = Ray.task(MyRayApp::functionWithAnArgument, objRef1).remote();
-    Assert.assertTrue(objRef2.get() == 2);
+        ObjectRef<Integer> objRef1 = Ray.task(MyRayApp::myFunction).remote();
+        Assert.assertTrue(objRef1.get() == 1);
 
-  .. code-tab:: c++
+        // You can pass an object ref as an argument to another Ray remote function.
+        ObjectRef<Integer> objRef2 = Ray.task(MyRayApp::functionWithAnArgument, objRef1).remote();
+        Assert.assertTrue(objRef2.get() == 2);
 
-    static int FunctionWithAnArgument(int value) {
-      return value + 1;
-    }
-    RAY_REMOTE(FunctionWithAnArgument);
+.. tabbed:: C++
 
-    auto obj_ref1 = ray::Task(MyFunction).Remote();
-    assert(*obj_ref1.Get() == 1);
+    .. code-block:: c++
 
-    // You can pass an object ref as an argument to another Ray remote function.
-    auto obj_ref2 = ray::Task(FunctionWithAnArgument).Remote(obj_ref1);
-    assert(*obj_ref2.Get() == 2);
+        static int FunctionWithAnArgument(int value) {
+            return value + 1;
+        }
+        RAY_REMOTE(FunctionWithAnArgument);
+
+        auto obj_ref1 = ray::Task(MyFunction).Remote();
+        assert(*obj_ref1.Get() == 1);
+
+        // You can pass an object ref as an argument to another Ray remote function.
+        auto obj_ref2 = ray::Task(FunctionWithAnArgument).Remote(obj_ref1);
+        assert(*obj_ref2.Get() == 2);
 
 Note the following behaviors:
 
@@ -260,45 +268,52 @@ one task may require a GPU). Ray will automatically
 detect the available GPUs and CPUs on the machine. However, you can override
 this default behavior by passing in specific resources.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
-    ``ray.init(num_cpus=8, num_gpus=4, resources={'Custom': 2})``
+    .. code-block:: python
 
-  .. group-tab:: Java
+        ray.init(num_cpus=8, num_gpus=4, resources={'Custom': 2})
+
+.. tabbed:: Java
 
     Set Java system property: ``-Dray.resources=CPU:8,GPU:4,Custom:2``.
 
 
-  .. code-tab:: c++
+.. tabbed:: C++
+    .. code-block:: c++
 
-    RayConfig config;
-    config.num_cpus = 8;
-    config.num_gpus = 4;
-    config.resources = {{"Custom", 2}};
-    ray::Init(config);
+        RayConfig config;
+        config.num_cpus = 8;
+        config.num_gpus = 4;
+        config.resources = {{"Custom", 2}};
+        ray::Init(config);
 
 Ray also allows specifying a task's resources requirements (e.g., CPU, GPU, and custom resources).
 The task will only run on a machine if there are enough resources
 available to execute the task.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    # Specify required resources.
-    @ray.remote(num_cpus=4, num_gpus=2)
-    def my_function():
-        return 1
+    .. code-block:: python
 
-  .. code-tab:: java
+        # Specify required resources.
+        @ray.remote(num_cpus=4, num_gpus=2)
+        def my_function():
+            return 1
 
-    // Specify required resources.
-    Ray.task(MyRayApp::myFunction).setResource("CPU", 1.0).setResource("GPU", 4.0).remote();
+.. tabbed:: Java
 
-  .. code-tab:: c++
+    .. code-block:: java
 
-    // Specify required resources.
-    ray::Task(MyFunction).SetResource("CPU", 1.0).SetResource("GPU", 4.0).Remote();
+        // Specify required resources.
+        Ray.task(MyRayApp::myFunction).setResource("CPU", 1.0).setResource("GPU", 4.0).remote();
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        // Specify required resources.
+        ray::Task(MyFunction).SetResource("CPU", 1.0).SetResource("GPU", 4.0).Remote();
 
 .. note::
 
@@ -318,28 +333,33 @@ resources.
 
 Below are more examples of resource specifications:
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    # Ray also supports fractional resource requirements.
-    @ray.remote(num_gpus=0.5)
-    def h():
-        return 1
+    .. code-block:: python
 
-    # Ray support custom resources too.
-    @ray.remote(resources={'Custom': 1})
-    def f():
-        return 1
+        # Ray also supports fractional resource requirements.
+        @ray.remote(num_gpus=0.5)
+        def h():
+            return 1
 
-  .. code-tab:: java
+        # Ray support custom resources too.
+        @ray.remote(resources={'Custom': 1})
+        def f():
+            return 1
 
-    // Ray aslo supports fractional and custom resources.
-    Ray.task(MyRayApp::myFunction).setResource("GPU", 0.5).setResource("Custom", 1.0).remote();
+.. tabbed:: Java
 
-  .. code-tab:: c++
+    .. code-block:: java
 
-    // Ray aslo supports fractional and custom resources.
-    ray::Task(MyFunction).SetResource("GPU", 0.5).SetResource("Custom", 1.0).Remote();
+        // Ray aslo supports fractional and custom resources.
+        Ray.task(MyRayApp::myFunction).setResource("GPU", 0.5).setResource("Custom", 1.0).remote();
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        // Ray aslo supports fractional and custom resources.
+        ray::Task(MyFunction).SetResource("GPU", 0.5).SetResource("Custom", 1.0).Remote();
 
 .. tip::
 
@@ -349,8 +369,7 @@ Below are more examples of resource specifications:
 Multiple returns
 ~~~~~~~~~~~~~~~~
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     Python remote functions can return multiple object refs.
 
@@ -362,19 +381,18 @@ Multiple returns
 
       a, b, c = return_multiple.remote()
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     Java remote functions doesn't support returning multiple objects.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     C++ remote functions doesn't support returning multiple objects.
 
 Cancelling tasks
 ~~~~~~~~~~~~~~~~
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     Remote functions can be canceled by calling ``ray.cancel`` (:ref:`docstring <ray-cancel-ref>`) on the returned Object ref. Remote actor functions can be stopped by killing the actor using the ``ray.kill`` interface.
 
@@ -394,11 +412,11 @@ Cancelling tasks
       except TaskCancelledError:
           print("Object reference was cancelled.")
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     Task cancellation hasn't been implemented in Java yet.
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     Task cancellation hasn't been implemented in C++ yet.
 
@@ -418,20 +436,22 @@ Object refs can be created in multiple ways.
   1. They are returned by remote function calls.
   2. They are returned by ``put`` (:ref:`docstring <ray-put-ref>`).
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
+  .. code-block:: python
 
     # Put an object in Ray's object store.
     y = 1
     object_ref = ray.put(y)
 
-  .. code-tab:: java
+.. tabbed:: Java
+  .. code-block:: java
 
     // Put an object in Ray's object store.
     int y = 1;
     ObjectRef<Integer> objectRef = Ray.put(y);
 
-  .. code-tab:: c++
+.. tabbed:: C++
+  .. code-block:: c++
 
     // Put an object in Ray's object store.
     int y = 1;
@@ -450,8 +470,7 @@ Fetching Results
 You can use the ``get`` method (:ref:`docstring <ray-get-ref>`) to fetch the result of a remote object from an object ref.
 If the current node's object store does not contain the object, the object is downloaded.
 
-.. tabs::
-  .. group-tab:: Python
+.. tabbed:: Python
 
     If the object is a `numpy array <https://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html>`__
     or a collection of numpy arrays, the ``get`` call is zero-copy and returns arrays backed by shared object store memory.
@@ -479,7 +498,7 @@ If the current node's object store does not contain the object, the object is do
       except GetTimeoutError:
           print("`get` timed out.")
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     .. code-block:: java
 
@@ -507,7 +526,7 @@ If the current node's object store does not contain the object, the object is do
       Assert.assertThrows(RayTimeoutException.class, 
         () -> Ray.get(Ray.task(MyRayApp::slowFunction).remote(), 3000));
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     .. code-block:: c++
 
@@ -530,18 +549,20 @@ After launching a number of tasks, you may want to know which ones have
 finished executing. This can be done with ``wait`` (:ref:`ray-wait-ref`). The function
 works as follows.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
+  .. code-block:: python
 
     ready_refs, remaining_refs = ray.wait(object_refs, num_returns=1, timeout=None)
 
-  .. code-tab:: java
+.. tabbed:: Java
+  .. code-block:: java
 
     WaitResult<Integer> waitResult = Ray.wait(objectRefs, /*num_returns=*/0, /*timeoutMs=*/1000);
     System.out.println(waitResult.getReady());  // List of ready objects.
     System.out.println(waitResult.getUnready());  // list of unready objects.
 
-  .. code-tab:: c++
+.. tabbed:: C++
+  .. code-block:: c++
 
     ray::WaitResult<int> wait_result = ray::Wait(object_refs, /*num_objects=*/0, /*timeout_ms=*/1000);
 
@@ -556,9 +577,7 @@ Remote Classes (Actors)
 
 Actors extend the Ray API from functions (tasks) to classes. An actor is essentially a stateful worker.
 
-.. tabs::
-
-  .. group-tab:: Python
+.. tabbed:: Python
 
     The ``ray.remote`` decorator indicates that instances of the ``Counter`` class will be actors. Each actor runs in its own Python process.
 
@@ -576,7 +595,7 @@ Actors extend the Ray API from functions (tasks) to classes. An actor is essenti
       # Create an actor from this class.
       counter = Counter.remote()
 
-  .. group-tab:: Java
+.. tabbed:: Java
 
     ``Ray.actor`` is used to create actors from regular Java classes.
 
@@ -599,7 +618,7 @@ Actors extend the Ray API from functions (tasks) to classes. An actor is essenti
       // as the argument.
       ActorHandle<Counter> counter = Ray.actor(Counter::new).remote();
 
-  .. group-tab:: C++
+.. tabbed:: C++
 
     ``ray::Actor`` is used to create actors from regular C++ classes.
 
@@ -637,23 +656,28 @@ Specifying required resources
 You can specify resource requirements in actors too (see the `Actors section
 <actors.html>`__ for more details.)
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    # Specify required resources for an actor.
-    @ray.remote(num_cpus=2, num_gpus=0.5)
-    class Actor(object):
-        pass
+    .. code-block:: python
 
-  .. code-tab:: java
+        # Specify required resources for an actor.
+        @ray.remote(num_cpus=2, num_gpus=0.5)
+        class Actor(object):
+            pass
 
-    // Specify required resources for an actor.
-    Ray.actor(Counter::new).setResource("CPU", 2.0).setResource("GPU", 0.5).remote();
+.. tabbed:: Java
 
-  .. code-tab:: c++
+    .. code-block:: java
 
-    // Specify required resources for an actor.
-    ray::Actor(CreateCounter).SetResource("CPU", 2.0).SetResource("GPU", 0.5).Remote();
+        // Specify required resources for an actor.
+        Ray.actor(Counter::new).setResource("CPU", 2.0).setResource("GPU", 0.5).remote();
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        // Specify required resources for an actor.
+        ray::Actor(CreateCounter).SetResource("CPU", 2.0).SetResource("GPU", 0.5).Remote();
 
 
 Calling the actor
@@ -663,99 +687,109 @@ We can interact with the actor by calling its methods with the ``remote``
 operator. We can then call ``get`` on the object ref to retrieve the actual
 value.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    # Call the actor.
-    obj_ref = counter.increment.remote()
-    assert ray.get(obj_ref) == 1
+    .. code-block:: python
 
-  .. code-tab:: java
+        # Call the actor.
+        obj_ref = counter.increment.remote()
+        assert ray.get(obj_ref) == 1
 
-    // Call the actor.
-    ObjectRef<Integer> objectRef = counter.task(&Counter::increment).remote();
-    Assert.assertTrue(objectRef.get() == 1);
+.. tabbed:: Java
 
-  .. code-tab:: c++
+    .. code-block:: java
 
-    // Call the actor.
-    auto object_ref = counter.Task(&Counter::increment).Remote();
-    assert(*object_ref.Get() == 1);
+        // Call the actor.
+        ObjectRef<Integer> objectRef = counter.task(&Counter::increment).remote();
+        Assert.assertTrue(objectRef.get() == 1);
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        // Call the actor.
+        auto object_ref = counter.Task(&Counter::increment).Remote();
+        assert(*object_ref.Get() == 1);
 
 Methods called on different actors can execute in parallel, and methods called on the same actor are executed serially in the order that they are called. Methods on the same actor will share state with one another, as shown below.
 
-.. tabs::
-  .. code-tab:: python
+.. tabbed:: Python
 
-    # Create ten Counter actors.
-    counters = [Counter.remote() for _ in range(10)]
+    .. code-block:: python
 
-    # Increment each Counter once and get the results. These tasks all happen in
-    # parallel.
-    results = ray.get([c.increment.remote() for c in counters])
-    print(results)  # prints [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        # Create ten Counter actors.
+        counters = [Counter.remote() for _ in range(10)]
 
-    # Increment the first Counter five times. These tasks are executed serially
-    # and share state.
-    results = ray.get([counters[0].increment.remote() for _ in range(5)])
-    print(results)  # prints [2, 3, 4, 5, 6]
+        # Increment each Counter once and get the results. These tasks all happen in
+        # parallel.
+        results = ray.get([c.increment.remote() for c in counters])
+        print(results)  # prints [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
-  .. code-tab:: java
+        # Increment the first Counter five times. These tasks are executed serially
+        # and share state.
+        results = ray.get([counters[0].increment.remote() for _ in range(5)])
+        print(results)  # prints [2, 3, 4, 5, 6]
 
-    // Create ten Counter actors.
-    List<ActorHandle<Counter>> counters = new ArrayList<>();
-    for (int i = 0; i < 10; i++) {
-      counters.add(Ray.actor(Counter::new).remote());
-    }
+.. tabbed:: Java
 
-    // Increment each Counter once and get the results. These tasks all happen in
-    // parallel.
-    List<ObjectRef<Integer>> objectRefs = new ArrayList<>();
-    for (ActorHandle<Counter> counterActor : counters) {
-      objectRefs.add(counterActor.task(Counter::increment).remote());
-    }
-    // prints [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    System.out.println(Ray.get(objectRefs));
+    .. code-block:: java
 
-    // Increment the first Counter five times. These tasks are executed serially
-    // and share state.
-    objectRefs = new ArrayList<>();
-    for (int i = 0; i < 5; i++) {
-      objectRefs.add(counters.get(0).task(Counter::increment).remote());
-    }
-    // prints [2, 3, 4, 5, 6]
-    System.out.println(Ray.get(objectRefs));
+        // Create ten Counter actors.
+        List<ActorHandle<Counter>> counters = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            counters.add(Ray.actor(Counter::new).remote());
+        }
 
-  .. code-tab:: c++
+        // Increment each Counter once and get the results. These tasks all happen in
+        // parallel.
+        List<ObjectRef<Integer>> objectRefs = new ArrayList<>();
+        for (ActorHandle<Counter> counterActor : counters) {
+            objectRefs.add(counterActor.task(Counter::increment).remote());
+        }
+        // prints [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        System.out.println(Ray.get(objectRefs));
 
-    // Create ten Counter actors.
-    std::vector<ray::ActorHandle<Counter>> counters;
-    for (int i = 0; i < 10; i++) {
-      counters.emplace_back(ray::Actor(CreateCounter).Remote());
-    }
+        // Increment the first Counter five times. These tasks are executed serially
+        // and share state.
+        objectRefs = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            objectRefs.add(counters.get(0).task(Counter::increment).remote());
+        }
+        // prints [2, 3, 4, 5, 6]
+        System.out.println(Ray.get(objectRefs));
 
-    // Increment each Counter once and get the results. These tasks all happen in
-    // parallel.
-    std::vector<ray::ObjectRef<int>> object_refs;
-    for (ray::ActorHandle<Counter> counter_actor : counters) {
-      object_refs.emplace_back(counter_actor.Task(&Counter::Increment).Remote());
-    }
-    // prints 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-    auto results = ray::Get(object_refs);
-    for (const auto &result : results) {
-      std::cout << *result;
-    }
+.. tabbed:: C++
 
-    // Increment the first Counter five times. These tasks are executed serially
-    // and share state.
-    object_refs.clear();
-    for (int i = 0; i < 5; i++) {
-      object_refs.emplace_back(counters[0].Task(&Counter::Increment).Remote());
-    }
-    // prints 2, 3, 4, 5, 6
-    results = ray::Get(object_refs);
-    for (const auto &result : results) {
-      std::cout << *result;
-    }
+    .. code-block:: c++
+
+        // Create ten Counter actors.
+        std::vector<ray::ActorHandle<Counter>> counters;
+        for (int i = 0; i < 10; i++) {
+            counters.emplace_back(ray::Actor(CreateCounter).Remote());
+        }
+
+        // Increment each Counter once and get the results. These tasks all happen in
+        // parallel.
+        std::vector<ray::ObjectRef<int>> object_refs;
+        for (ray::ActorHandle<Counter> counter_actor : counters) {
+            object_refs.emplace_back(counter_actor.Task(&Counter::Increment).Remote());
+        }
+        // prints 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+        auto results = ray::Get(object_refs);
+        for (const auto &result : results) {
+            std::cout << *result;
+        }
+
+        // Increment the first Counter five times. These tasks are executed serially
+        // and share state.
+        object_refs.clear();
+        for (int i = 0; i < 5; i++) {
+            object_refs.emplace_back(counters[0].Task(&Counter::Increment).Remote());
+        }
+        // prints 2, 3, 4, 5, 6
+        results = ray::Get(object_refs);
+        for (const auto &result : results) {
+            std::cout << *result;
+        }
 
 To learn more about Ray Actors, see the `Actors section <actors.html>`__.

--- a/doc/source/ray-observability/ray-tracing.rst
+++ b/doc/source/ray-observability/ray-tracing.rst
@@ -52,30 +52,29 @@ Below is an example tracing startup hook that sets up the default tracing provid
 
 For open-source users who want to experiment with tracing, Ray has a default tracing startup hook that exports spans to the folder ``/tmp/spans``. To run using this default hook, you can run the following code sample to set up tracing and trace a simple Ray task.
 
-.. tabs::
-    .. group-tab:: ray start
+.. tabbed:: ray start
 
-        .. code-block:: shell
+    .. code-block:: shell
 
-            $ ray start --head --tracing-startup-hook=ray.util.tracing.setup_local_tmp_tracing:setup_tracing
-            $ python
-            >>> ray.init(address="auto")
-            >>> @ray.remote
-                def my_function():
-                    return 1
+        $ ray start --head --tracing-startup-hook=ray.util.tracing.setup_local_tmp_tracing:setup_tracing
+        $ python
+        >>> ray.init(address="auto")
+        >>> @ray.remote
+            def my_function():
+                return 1
 
-                obj_ref = my_function.remote()
+            obj_ref = my_function.remote()
 
-    .. group-tab:: ray.init()
+.. tabbed:: ray.init()
 
-        .. code-block:: python
+    .. code-block:: python
 
-            >>> ray.init(_tracing_startup_hook="ray.util.tracing.setup_local_tmp_tracing:setup_tracing")
-            >>> @ray.remote
-                def my_function():
-                    return 1
+        >>> ray.init(_tracing_startup_hook="ray.util.tracing.setup_local_tmp_tracing:setup_tracing")
+        >>> @ray.remote
+            def my_function():
+                return 1
 
-                obj_ref = my_function.remote()
+            obj_ref = my_function.remote()
 
 If you want to provide your own custom tracing startup hook, provide your startup hook in the format of ``module:attribute`` where the attribute is the ``setup_tracing`` function to be run.
 

--- a/doc/source/train/train.rst
+++ b/doc/source/train/train.rst
@@ -55,9 +55,7 @@ Quick Start
 Ray Train abstracts away the complexity of setting up a distributed training
 system. Let's take following simple examples:
 
-.. tabs::
-
-  .. group-tab:: PyTorch
+.. tabbed:: PyTorch
 
     This example shows how you can use Ray Train with PyTorch.
 
@@ -106,7 +104,7 @@ system. Let's take following simple examples:
 
     See :ref:`train-porting-code` for a more comprehensive example.
 
-  .. group-tab:: TensorFlow
+.. tabbed:: TensorFlow
 
     This example shows how you can use Ray Train to set up `Multi-worker training
     with Keras <https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras>`_.

--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -60,9 +60,7 @@ Update training function
 First, you'll want to update your training function to support distributed
 training.
 
-.. tabs::
-
-  .. group-tab:: PyTorch
+.. tabbed:: PyTorch
 
     Ray Train will set up your distributed process group for you and also provides utility methods
     to automatically prepare your model and data for distributed training.
@@ -128,11 +126,11 @@ training.
        Keep in mind that ``DataLoader`` takes in a ``batch_size`` which is the batch size for each worker.
        The global batch size can be calculated from the worker batch size (and vice-versa) with the following equation:
 
-       .. code-block::
+        .. code-block::
 
             global_batch_size = worker_batch_size * train.world_size()
 
-  .. group-tab:: TensorFlow
+.. tabbed:: TensorFlow
 
     .. note::
        The current TensorFlow implementation supports
@@ -169,7 +167,7 @@ training.
         -batch_size = worker_batch_size
         +batch_size = worker_batch_size * train.world_size()
 
-  .. group-tab:: Horovod
+.. tabbed:: Horovod
 
     If you have a training function that already runs with the `Horovod Ray
     Executor <https://horovod.readthedocs.io/en/stable/ray_include.html#horovod-ray-executor>`_,
@@ -185,9 +183,7 @@ The ``Trainer`` is the primary Ray Train class that is used to manage state and
 execute training. You can create a simple ``Trainer`` for the backend of choice
 with one of the following:
 
-.. tabs::
-
-  .. group-tab:: PyTorch
+.. tabbed:: PyTorch
 
     .. code-block:: python
 
@@ -198,7 +194,7 @@ with one of the following:
         # trainer = Trainer(backend="torch", num_workers=2, use_gpu=True)
 
 
-  .. group-tab:: TensorFlow
+.. tabbed:: TensorFlow
 
     .. code-block:: python
 
@@ -208,7 +204,7 @@ with one of the following:
         # For GPU Training, set `use_gpu` to True.
         # trainer = Trainer(backend="tensorflow", num_workers=2, use_gpu=True)
 
-  .. group-tab:: Horovod
+.. tabbed:: Horovod
 
     .. code-block:: python
 
@@ -221,9 +217,7 @@ with one of the following:
 To customize the ``backend`` setup, you can replace the string argument with a
 :ref:`train-api-backend-config` object.
 
-.. tabs::
-
-  .. group-tab:: PyTorch
+.. tabbed:: PyTorch
 
     .. code-block:: python
 
@@ -233,7 +227,7 @@ To customize the ``backend`` setup, you can replace the string argument with a
         trainer = Trainer(backend=TorchConfig(...), num_workers=2)
 
 
-  .. group-tab:: TensorFlow
+.. tabbed:: TensorFlow
 
     .. code-block:: python
 
@@ -242,7 +236,7 @@ To customize the ``backend`` setup, you can replace the string argument with a
 
         trainer = Trainer(backend=TensorflowConfig(...), num_workers=2)
 
-  .. group-tab:: Horovod
+.. tabbed:: Horovod
 
     .. code-block:: python
 
@@ -578,9 +572,7 @@ The latest saved checkpoint can be accessed through the ``Trainer``'s
 Concrete examples are provided to demonstrate how checkpoints (model weights but not models) are saved
 appropriately in distributed training.
 
-.. tabs::
-
-  .. group-tab:: PyTorch
+.. tabbed:: PyTorch
 
     .. code-block:: python
         :emphasize-lines: 37, 38, 39
@@ -635,7 +627,7 @@ appropriately in distributed training.
         # {'epoch': 4, 'model_weights': OrderedDict([('bias', tensor([0.1533])), ('weight', tensor([[0.4529, 0.4618, 0.2730, 0.0190]]))]), '_timestamp': 1639117274}
 
 
-  .. group-tab:: TensorFlow
+.. tabbed:: TensorFlow
 
     .. code-block:: python
         :emphasize-lines: 24
@@ -764,9 +756,7 @@ Checkpoints can be loaded into the training function in 2 steps:
 2. The checkpoint to start training with can be bootstrapped by passing in a
    ``checkpoint`` to ``trainer.run()``.
 
-.. tabs::
-
-  .. group-tab:: PyTorch
+.. tabbed:: PyTorch
 
     .. code-block:: python
         :emphasize-lines: 24, 26, 27, 30, 31, 35
@@ -831,7 +821,7 @@ Checkpoints can be loaded into the training function in 2 steps:
         print(trainer.latest_checkpoint)
         # {'epoch': 3, 'model_weights': OrderedDict([('bias', tensor([-0.3304])), ('weight', tensor([[-0.0197, -0.3704,  0.2944,  0.3117]]))]), '_timestamp': 1639117865}
 
-  .. group-tab:: TensorFlow
+  .. tabbed:: TensorFlow
 
     .. code-block:: python
         :emphasize-lines: 16, 22, 23, 26, 27, 30

--- a/doc/source/tune/key-concepts.rst
+++ b/doc/source/tune/key-concepts.rst
@@ -24,42 +24,41 @@ To start, let's try to maximize this objective function:
 
 To use Tune, you will need to wrap this function in a lightweight :ref:`trainable API <trainable-docs>`. You can either use a :ref:`function-based version <tune-function-api>` or a :ref:`class-based version <tune-class-api>`.
 
-.. tabs::
-    .. group-tab:: Function API
+.. tabbed:: Function API
 
-        Here's an example of specifying the objective function using :ref:`the function-based Trainable API <tune-function-api>`:
+    Here's an example of specifying the objective function using :ref:`the function-based Trainable API <tune-function-api>`:
 
-        .. code-block:: python
+    .. code-block:: python
 
-            def trainable(config):
-                # config (dict): A dict of hyperparameters.
+        def trainable(config):
+            # config (dict): A dict of hyperparameters.
 
-                for x in range(20):
-                    score = objective(x, config["a"], config["b"])
+            for x in range(20):
+                score = objective(x, config["a"], config["b"])
 
-                    tune.report(score=score)  # This sends the score to Tune.
+                tune.report(score=score)  # This sends the score to Tune.
 
-    .. group-tab:: Class API
+.. tabbed:: Class API
 
-        Here's an example of specifying the objective function using the :ref:`class-based API <tune-class-api>`:
+    Here's an example of specifying the objective function using the :ref:`class-based API <tune-class-api>`:
 
-        .. code-block:: python
+    .. code-block:: python
 
-            from ray import tune
+        from ray import tune
 
-            class Trainable(tune.Trainable):
-                def setup(self, config):
-                    # config (dict): A dict of hyperparameters
-                    self.x = 0
-                    self.a = config["a"]
-                    self.b = config["b"]
+        class Trainable(tune.Trainable):
+            def setup(self, config):
+                # config (dict): A dict of hyperparameters
+                self.x = 0
+                self.a = config["a"]
+                self.b = config["b"]
 
-                def step(self):  # This is called iteratively.
-                    score = objective(self.x, self.a, self.b)
-                    self.x += 1
-                    return {"score": score}
+            def step(self):  # This is called iteratively.
+                score = objective(self.x, self.a, self.b)
+                self.x += 1
+                return {"score": score}
 
-        .. tip:: Do not use ``tune.report`` within a ``Trainable`` class.
+    .. tip:: Do not use ``tune.report`` within a ``Trainable`` class.
 
 See the documentation: :ref:`trainable-docs` and :ref:`examples <tune-general-examples>`.
 


### PR DESCRIPTION
Adds search-as-you-type search from Algolia and deprecates a dependency that stood in the way. Here's a preview:

https://ray--21814.org.readthedocs.build/en/21814/

Note that algolia crawls docs.ray.io, hence the search results point to 1.9.2.  This is not a blocking issue for now and can be configured in algolia properly.