### PR TITLE
[Test] Fix dask on ray test on K8s 

### DIFF
--- a/release/nightly_tests/dask_on_ray/large_scale_test.py
+++ b/release/nightly_tests/dask_on_ray/large_scale_test.py
@@ -436,7 +436,7 @@ def main():
     data_save_path = args.data_save_path
     if not os.path.exists(data_save_path):
         os.makedirs(data_save_path, mode=0o777, exist_ok=True)
-    os.chmod(data_save_path, mode=0o777)
+    # os.chmod(data_save_path, mode=0o777)
 
     # Lazily construct Xarrays
     xarray_filename_pairs = lazy_create_xarray_filename_pairs(test_spec)

--- a/release/nightly_tests/dask_on_ray/large_scale_test.py
+++ b/release/nightly_tests/dask_on_ray/large_scale_test.py
@@ -436,7 +436,6 @@ def main():
     data_save_path = args.data_save_path
     if not os.path.exists(data_save_path):
         os.makedirs(data_save_path, mode=0o777, exist_ok=True)
-    # os.chmod(data_save_path, mode=0o777)
 
     # Lazily construct Xarrays
     xarray_filename_pairs = lazy_create_xarray_filename_pairs(test_spec)

--- a/release/nightly_tests/nightly_tests.yaml
+++ b/release/nightly_tests/nightly_tests.yaml
@@ -166,6 +166,7 @@
 #     script: python shuffle/shuffle_test.py --num-partitions=5000 --partition-size=200e6 --no-streaming
 
 - name: k8s_dask_on_ray_large_scale_test_no_spilling
+  team: core
   cluster:
     app_config: dask_on_ray/large_scale_dask_on_ray_app_config.yaml
     compute_template: dask_on_ray/dask_on_ray_stress_compute_k8s.yaml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix dash on ray large scale test on K8s. Basically, chmod requires a root access, which we don't have it by default in the k8s cluster. We don't need chmod I think (I verified the test passes without it). 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
