### PR TITLE
[rllib] Registry should not contain a key when gcs client returns empty bytes

### DIFF
--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -154,7 +154,7 @@ class _Registry:
     def contains(self, category, key):
         if _internal_kv_initialized():
             value = _internal_kv_get(_make_key(self._prefix, category, key))
-            return value is not None
+            return value is not None and value != b''
         else:
             return (category, key) in self._to_flush
 


### PR DESCRIPTION
Registry should not contain a key when gcs client returns empty bytes

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #21734

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
