### PR TITLE
[Test] allow `Cluster` to connect to a running cluster

### DIFF
--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -190,6 +190,8 @@ class Cluster:
         }
         ray_params = ray._private.parameter.RayParams(**node_args)
         ray_params.update_if_absent(**default_kwargs)
+        self.redis_password = node_args.get(
+            "redis_password", ray_constants.REDIS_DEFAULT_PASSWORD)
         with disable_client_hook():
             if self.head_node is None and self._bootstrap_address is None:
                 node = ray.node.Node(
@@ -230,9 +232,6 @@ class Cluster:
                     self.head_node = node
                 else:
                     self.worker_nodes.add(node)
-
-            self.redis_password = node_args.get(
-                "redis_password", ray_constants.REDIS_DEFAULT_PASSWORD)
 
             if wait:
                 # Wait for the node to appear in the client table. We do this

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -126,13 +126,15 @@ class Cluster:
         self.worker_nodes = set()
         self.redis_address = None
         self.gcs_address = None
+        self._bootstrap_address = None
         if bootstrap_address is not None:
+            self._bootstrap_address = \
+                ray._private.services.canonicalize_bootstrap_address(
+                    bootstrap_address)
             if use_gcs_for_bootstrap():
-                self.gcs_address = bootstrap_address
+                self.gcs_address = self._bootstrap_address
             else:
-                self.redis_address = bootstrap_address
-        # Just for indicating whether the bootstrap address is specified.
-        self._bootstrap_address = bootstrap_address
+                self.redis_address = self._bootstrap_address
         self.connected = False
         # Create a new global state accessor for fetching GCS table.
         self.global_state = ray.state.GlobalState()

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -176,8 +176,6 @@ class Node:
             session_name = self._internal_kv_get_with_retry(
                 "session_name", ray_constants.KV_NAMESPACE_SESSION)
             self.session_name = ray._private.utils.decode(session_name)
-            # setup gcs client
-            self.get_gcs_client()
 
         # Initialize webui url
         if head:

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -1177,12 +1177,11 @@ def run_session_command(sdk: AnyscaleSDK,
     return scd_id, result
 
 
-def wait_for_session_command_to_complete(create_session_command_result,
+def wait_for_session_command_to_complete(result,
                                          sdk: AnyscaleSDK,
                                          scd_id: str,
                                          stop_event: multiprocessing.Event,
                                          state_str: str = "CMD_RUN"):
-    result = create_session_command_result
     completed = result.result.finished_at is not None
     start_wait = time.time()
     next_report = start_wait + REPORT_S
@@ -1218,6 +1217,13 @@ def wait_for_session_command_to_complete(create_session_command_result,
         elif state_str == "CMD_PREPARE":
             raise PrepareCommandRuntimeError(
                 f"Prepare command returned non-success status: {status_code}")
+    else:
+        if state_str == "CMD_RUN":
+            logger.info("... Command succeeded after "
+                        f"({int(now - start_wait)} seconds) ...")
+        elif state_str == "CMD_PREPARE":
+            logger.info("... Prepare command succeeded after "
+                        f"({int(now - start_wait)} seconds) ...")
 
     return status_code, runtime
 

--- a/release/long_running_tests/long_running_tests.yaml
+++ b/release/long_running_tests/long_running_tests.yaml
@@ -6,7 +6,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/actor_deaths.py
     long_running: True
 
@@ -16,6 +16,7 @@
 
   app_env_vars:
     CLUSTER_ADDRESS: "127.0.0.1:6379"
+
 
 - name: apex
   team: ml
@@ -33,9 +34,6 @@
     run:
       timeout: 3600
 
-  app_env_vars:
-    CLUSTER_ADDRESS: "127.0.0.1:6379"
-
 
 - name: impala
   team: ml
@@ -52,8 +50,6 @@
     run:
       timeout: 3600
 
-  app_env_vars:
-    CLUSTER_ADDRESS: "127.0.0.1:6379"
 
 - name: many_actor_tasks
   team: core
@@ -63,7 +59,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/many_actor_tasks.py
     long_running: True
 
@@ -83,7 +79,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/many_drivers.py
     long_running: True
 
@@ -111,9 +107,6 @@
     run:
       timeout: 3600
 
-  app_env_vars:
-    CLUSTER_ADDRESS: "127.0.0.1:6379"
-
 
 - name: many_tasks
   team: core
@@ -123,7 +116,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/many_tasks.py
     long_running: True
 
@@ -143,7 +136,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/many_tasks_serialized_ids.py
     long_running: True
 
@@ -163,7 +156,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/node_failures.py
     long_running: True
 
@@ -183,7 +176,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/pbt.py
     long_running: True
 
@@ -203,7 +196,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/serve.py
     long_running: True
 
@@ -223,7 +216,7 @@
 
   run:
     timeout: 86400
-    prepare: pkill -7 raylet
+    prepare: while pkill -9 raylet; do sleep 1; done
     script: python workloads/serve_failure.py
     long_running: True
 

--- a/release/long_running_tests/long_running_tests.yaml
+++ b/release/long_running_tests/long_running_tests.yaml
@@ -6,7 +6,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/actor_deaths.py
     long_running: True
 
@@ -59,7 +59,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/many_actor_tasks.py
     long_running: True
 
@@ -79,7 +79,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/many_drivers.py
     long_running: True
 
@@ -116,7 +116,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/many_tasks.py
     long_running: True
 
@@ -136,7 +136,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/many_tasks_serialized_ids.py
     long_running: True
 
@@ -156,7 +156,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/node_failures.py
     long_running: True
 
@@ -176,7 +176,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/pbt.py
     long_running: True
 
@@ -196,7 +196,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/serve.py
     long_running: True
 
@@ -216,7 +216,7 @@
 
   run:
     timeout: 86400
-    prepare: while pkill -9 raylet; do sleep 1; done
+    prepare: $(while pkill -9 raylet; do sleep 1; done)
     script: python workloads/serve_failure.py
     long_running: True
 

--- a/release/long_running_tests/long_running_tests.yaml
+++ b/release/long_running_tests/long_running_tests.yaml
@@ -14,6 +14,9 @@
     run:
       timeout: 3600
 
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
 - name: apex
   team: ml
   cluster:
@@ -29,6 +32,9 @@
   smoke_test:
     run:
       timeout: 3600
+
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
 
 
 - name: impala
@@ -46,6 +52,9 @@
     run:
       timeout: 3600
 
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
 - name: many_actor_tasks
   team: core
   cluster:
@@ -61,6 +70,9 @@
   smoke_test:
     run:
       timeout: 3600
+
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
 
 
 - name: many_drivers
@@ -79,6 +91,9 @@
     run:
       timeout: 3600
 
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
 
 - name: many_ppo
   team: ml
@@ -96,6 +111,10 @@
     run:
       timeout: 3600
 
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
+
 - name: many_tasks
   team: core
   cluster:
@@ -112,6 +131,10 @@
     run:
       timeout: 3600
 
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
+
 - name: many_tasks_serialized_ids
   team: core
   cluster:
@@ -127,6 +150,9 @@
   smoke_test:
     run:
       timeout: 3600
+
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
 
 
 - name: node_failures
@@ -145,6 +171,10 @@
     run:
       timeout: 3600
 
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
+
 - name: pbt
   team: ml
   cluster:
@@ -160,6 +190,10 @@
   smoke_test:
     run:
       timeout: 3600
+
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
 
 - name: serve
   team: serve
@@ -177,6 +211,10 @@
     run:
       timeout: 3600
 
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"
+
+
 - name: serve_failure
   team: serve
   cluster:
@@ -192,3 +230,6 @@
   smoke_test:
     run:
       timeout: 3600
+
+  app_env_vars:
+    CLUSTER_ADDRESS: "127.0.0.1:6379"

--- a/release/long_running_tests/long_running_tests.yaml
+++ b/release/long_running_tests/long_running_tests.yaml
@@ -6,7 +6,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/actor_deaths.py
     long_running: True
 
@@ -54,7 +54,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/many_actor_tasks.py
     long_running: True
 
@@ -71,7 +71,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/many_drivers.py
     long_running: True
 
@@ -104,7 +104,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/many_tasks.py
     long_running: True
 
@@ -120,7 +120,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/many_tasks_serialized_ids.py
     long_running: True
 
@@ -137,7 +137,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/node_failures.py
     long_running: True
 
@@ -153,7 +153,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/pbt.py
     long_running: True
 
@@ -169,7 +169,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/serve.py
     long_running: True
 
@@ -185,7 +185,7 @@
 
   run:
     timeout: 86400
-    prepare: ray stop
+    prepare: pkill -7 raylet
     script: python workloads/serve_failure.py
     long_running: True
 

--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -30,7 +30,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -30,7 +30,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/apex.py
+++ b/release/long_running_tests/workloads/apex.py
@@ -16,7 +16,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-# cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+# cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 # for i in range(num_nodes):
 #     cluster.add_node(redis_port=6379 if i == 0 else None,
 #                      num_redis_shards=num_redis_shards if i == 0 else None,

--- a/release/long_running_tests/workloads/apex.py
+++ b/release/long_running_tests/workloads/apex.py
@@ -16,7 +16,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-# cluster = Cluster()
+# cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 # for i in range(num_nodes):
 #     cluster.add_node(redis_port=6379 if i == 0 else None,
 #                      num_redis_shards=num_redis_shards if i == 0 else None,

--- a/release/long_running_tests/workloads/impala.py
+++ b/release/long_running_tests/workloads/impala.py
@@ -18,7 +18,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-# cluster = Cluster()
+# cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 # for i in range(num_nodes):
 #     cluster.add_node(
 #         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/impala.py
+++ b/release/long_running_tests/workloads/impala.py
@@ -18,7 +18,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-# cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+# cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 # for i in range(num_nodes):
 #     cluster.add_node(
 #         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_actor_tasks.py
+++ b/release/long_running_tests/workloads/many_actor_tasks.py
@@ -29,7 +29,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_actor_tasks.py
+++ b/release/long_running_tests/workloads/many_actor_tasks.py
@@ -29,7 +29,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_drivers.py
+++ b/release/long_running_tests/workloads/many_drivers.py
@@ -28,7 +28,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_drivers.py
+++ b/release/long_running_tests/workloads/many_drivers.py
@@ -28,7 +28,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_tasks.py
+++ b/release/long_running_tests/workloads/many_tasks.py
@@ -29,7 +29,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_tasks.py
+++ b/release/long_running_tests/workloads/many_tasks.py
@@ -29,7 +29,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/release/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -31,7 +31,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/release/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -31,7 +31,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/node_failures.py
+++ b/release/long_running_tests/workloads/node_failures.py
@@ -28,7 +28,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/node_failures.py
+++ b/release/long_running_tests/workloads/node_failures.py
@@ -28,7 +28,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/pbt.py
+++ b/release/long_running_tests/workloads/pbt.py
@@ -18,7 +18,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/pbt.py
+++ b/release/long_running_tests/workloads/pbt.py
@@ -1,5 +1,5 @@
 # This workload tests running PBT
-
+import os
 import ray
 from ray.tune import run_experiments
 from ray.tune.schedulers import PopulationBasedTraining
@@ -18,7 +18,7 @@ assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
 
 # Simulate a cluster on one machine.
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/serve.py
+++ b/release/long_running_tests/workloads/serve.py
@@ -42,7 +42,7 @@ def update_progress(result):
         json.dump(result, f)
 
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(NUM_NODES):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/serve.py
+++ b/release/long_running_tests/workloads/serve.py
@@ -42,7 +42,7 @@ def update_progress(result):
         json.dump(result, f)
 
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(NUM_NODES):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -39,7 +39,7 @@ def update_progress(result):
         json.dump(result, f)
 
 
-cluster = Cluster()
+cluster = Cluster(bootstrap_address="127.0.0.1:6379")
 for i in range(NUM_NODES):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -39,7 +39,7 @@ def update_progress(result):
         json.dump(result, f)
 
 
-cluster = Cluster(bootstrap_address="127.0.0.1:6379")
+cluster = Cluster(bootstrap_address=os.environ.get("CLUSTER_ADDRESS"))
 for i in range(NUM_NODES):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Commands in `e2e.py` are ran with `ray job submit` on api server. But calling `ray stop` would kill the api server. This seems to make commands after `ray stop` unable to access the dashboard.

Instead, only kill the raylet started by default and use `Cluster` to connect to the existing cluster.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
