### PR TITLE
[Tune]  PTL replace deprecated `running_sanity_check` with `sanity_checking`

### DIFF
--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -174,7 +174,7 @@ class TuneReportCallback(TuneCallback):
 
     def _get_report_dict(self, trainer: Trainer, pl_module: LightningModule):
         # Don't report if just doing initial validation sanity checks.
-        if trainer.running_sanity_check:
+        if trainer.sanity_checking:
             return
         if not self._metrics:
             report_dict = {
@@ -228,7 +228,7 @@ class _TuneCheckpointCallback(TuneCallback):
         self._filename = filename
 
     def _handle(self, trainer: Trainer, pl_module: LightningModule):
-        if trainer.running_sanity_check:
+        if trainer.sanity_checking:
             return
         step = f"epoch={trainer.current_epoch}-step={trainer.global_step}"
         with tune.checkpoint_dir(step=step) as checkpoint_dir:


### PR DESCRIPTION
> Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.

I did but [getting involved](https://docs.ray.io/en/master/getting-involved.html) redirects to none? :)

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`running_sanity_check` was deprecated and removed in https://github.com/PyTorchLightning/pytorch-lightning/pull/9209 in favor of `sanity_checking`


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
