### PR TITLE
[train] Turn off TF autosharding internally

### DIFF
--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -938,23 +938,6 @@ Ray Train provides native support for :ref:`Ray Datasets <datasets>` to support 
 
 To get started, pass in a Ray Dataset (or multiple) into ``Trainer.run``. Underneath the hood, Ray Train will automatically shard the given dataset.
 
-.. warning::
-
-    If you are doing distributed training with TensorFlow, you will need to
-    disable TensorFlow's built-in autosharding as the data on each worker is
-    already sharded.
-
-    .. code-block:: python
-
-        def train_func():
-            ...
-            tf_dataset = ray.train.get_dataset_shard().to_tf()
-            options = tf.data.Options()
-            options.experimental_distribute.auto_shard_policy = \
-                tf.data.experimental.AutoShardPolicy.OFF
-            tf_dataset = tf_dataset.with_options(options)
-
-
 **Simple Dataset Example**
 
 .. code-block:: python

--- a/python/ray/train/session.py
+++ b/python/ray/train/session.py
@@ -314,12 +314,11 @@ def get_dataset_shard(dataset_name: Optional[str] = None,
 
         def new_to_tf(self, *args, **kwargs):
             import tensorflow as tf
-            tf_dataset = original_to_tf(self, *args, **kwargs)
+            tf_dataset = original_to_tf(*args, **kwargs)
             options = tf.data.Options()
             options.experimental_distribute.auto_shard_policy = \
                 tf.data.experimental.AutoShardPolicy.OFF
-            tf_dataset.with_options(options)
-            return tf_dataset
+            return tf_dataset.with_options(options)
 
         # overrides Dataset.to_tf()
         shard.to_tf = types.MethodType(new_to_tf, shard)

--- a/python/ray/train/session.py
+++ b/python/ray/train/session.py
@@ -313,10 +313,12 @@ def get_dataset_shard(dataset_name: Optional[str] = None,
         original_to_tf = shard.to_tf
 
         def new_to_tf(self, *args, **kwargs):
+            import tensorflow as tf
             tf_dataset = original_to_tf(self, *args, **kwargs)
-            # tf.data.experimental.AutoShardPolicy.OFF is -1.
-            # https://www.tensorflow.org/api_docs/python/tf/data/experimental/AutoShardPolicy
-            tf_dataset.options().experimental_distribute.auto_shard_policy = -1
+            options = tf.data.Options()
+            options.experimental_distribute.auto_shard_policy = \
+                tf.data.experimental.AutoShardPolicy.OFF
+            tf_dataset.with_options(options)
             return tf_dataset
 
         # overrides Dataset.to_tf()

--- a/python/ray/train/tests/test_session.py
+++ b/python/ray/train/tests/test_session.py
@@ -68,6 +68,7 @@ def test_get_dataset_shard():
     # test tf_autoshard_off is working appropriately
     tf_dataset = get_dataset_shard().to_tf()
     # tf.data.experimental.AutoShardPolicy.OFF is -1
+    # avoid importing tensorflow package
     assert tf_dataset.options().experimental_distribute.auto_shard_policy == -1
     shutdown_session()
 

--- a/python/ray/train/tests/test_session.py
+++ b/python/ray/train/tests/test_session.py
@@ -89,9 +89,10 @@ def test_get_dataset_shard_tf_autoshard_off():
     tf_dataset = get_dataset_shard().to_tf(
         label_column="y",
         output_signature=(tf.TensorSpec(shape=(None, 1), dtype=tf.float32),
-                          tf.TensorSpec(shape=(None,), dtype=tf.float32)))
+                          tf.TensorSpec(shape=(None, ), dtype=tf.float32)))
 
-    assert tf_dataset.options().experimental_distribute.auto_shard_policy == tf.data.experimental.AutoShardPolicy.OFF
+    assert tf_dataset.options(
+    ).experimental_distribute.auto_shard_policy == tf.data.experimental.AutoShardPolicy.OFF
     shutdown_session()
 
 

--- a/python/ray/train/tests/test_session.py
+++ b/python/ray/train/tests/test_session.py
@@ -64,9 +64,10 @@ def test_get_dataset_shard():
         local_rank=0,
         world_size=1,
         dataset_shard=dataset)
-    assert get_dataset_shard() == dataset
+    shard = get_dataset_shard()
+    assert shard == dataset
     # test tf_autoshard_off is working appropriately
-    tf_dataset = get_dataset_shard().to_tf()
+    tf_dataset = shard.to_tf()
     # tf.data.experimental.AutoShardPolicy.OFF is -1
     # avoid importing tensorflow package
     assert tf_dataset.options().experimental_distribute.auto_shard_policy == -1

--- a/python/ray/train/tests/test_session.py
+++ b/python/ray/train/tests/test_session.py
@@ -65,6 +65,10 @@ def test_get_dataset_shard():
         world_size=1,
         dataset_shard=dataset)
     assert get_dataset_shard() == dataset
+    # test tf_autoshard_off is working appropriately
+    tf_dataset = get_dataset_shard().to_tf()
+    # tf.data.experimental.AutoShardPolicy.OFF is -1
+    assert tf_dataset.options().experimental_distribute.auto_shard_policy == -1
     shutdown_session()
 
 

--- a/python/ray/train/tests/test_session.py
+++ b/python/ray/train/tests/test_session.py
@@ -91,8 +91,8 @@ def test_get_dataset_shard_tf_autoshard_off():
         output_signature=(tf.TensorSpec(shape=(None, 1), dtype=tf.float32),
                           tf.TensorSpec(shape=(None, ), dtype=tf.float32)))
 
-    assert tf_dataset.options(
-    ).experimental_distribute.auto_shard_policy == tf.data.experimental.AutoShardPolicy.OFF
+    assert tf_dataset.options().experimental_distribute.auto_shard_policy ==\
+           tf.data.experimental.AutoShardPolicy.OFF
     shutdown_session()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR disables TF autosharding internally but provides users with an option to turn it on.

## Related issue number

Closes #19324.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
