### PR TITLE
[e2e] use alternative `copy tree` function to tolerate output directory that already exists

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -2126,11 +2126,14 @@ def run_test_config(
 
         try:
             shutil.rmtree(out_dir, ignore_errors=True)
-            shutil.copytree(temp_dir, out_dir)
+            # Use distutils.dir_util.copy_tree() instead of shutil.cptree(),
+            # which allows existing output directory.
+            from distutils.dir_util import copy_tree
+            copy_tree(temp_dir, out_dir)
             logger.info(f"Dir contents: {os.listdir(out_dir)}")
         except Exception as e:
-            logger.error(
-                f"Ran into error when copying results dir to persistent "
+            logger.exception(
+                "Ran into error when copying results dir to persistent "
                 f"location: {str(e)}")
 
     return result


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Many release tests have error messages when copying results with `shutil.copytree()`. e.g.
https://buildkite.com/ray-project/periodic-ci/builds/2511#131c0d22-61a3-4dcf-b80a-de37b68ec591/139-450

This PR tries to make the copying process tolerate existing destination directory. There is logic to remove the destination directory, but I'm not sure why it failed.

This error should not be failing the tests though.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
