### PR TITLE
[Release] Disable caching for `ray_lightning`

### DIFF
--- a/release/ml_user_tests/ray-lightning/app_config.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config.yaml
@@ -15,4 +15,4 @@ post_build_cmds:
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the Ray Lightning version, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
-  - pip install -U ray-lightning
+  - pip3 install -U ray-lightning

--- a/release/ml_user_tests/ray-lightning/app_config.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config.yaml
@@ -13,4 +13,6 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - echo {{ env["TIMESTAMP"] }} # Trigger re-build of cluster env so we get most up to date ray lightning version.
+  # Upgrade the Ray Lightning version, otherwise it will be cached in the Anyscale Docker image.
+  - echo {{ env["TIMESTAMP"] }}
+  - pip install -U ray-lightning

--- a/release/ml_user_tests/ray-lightning/app_config.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config.yaml
@@ -13,3 +13,4 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
+  - echo {{ env["TIMESTAMP"] }} # Trigger re-build of cluster env so we get most up to date ray lightning version.

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -5,7 +5,6 @@ debian_packages:
 
 python:
   pip_packages:
-    - git+https://github.com/ray-project/ray_lightning#ray_lightning
     - tblib
   conda_packages: []
 
@@ -13,6 +12,6 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  # Upgrade the Ray Lightning version, otherwise it will be cached in the Anyscale Docker image.
+  # Upgrade the Ray Lightning version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
-  - pip install -U git+https://github.com/ray-project/ray_lightning#ray_lightning
+  - pip3 install -U git+https://github.com/ray-project/ray_lightning#ray_lightning

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -15,5 +15,4 @@ post_build_cmds:
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the Ray Lightning version, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
-  - pip install -U ray-lightning
   - pip install -U git+https://github.com/ray-project/ray_lightning#ray_lightning

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -6,6 +6,8 @@ debian_packages:
 python:
   pip_packages:
     - tblib
+    # Need to have in pip_packages so it is installed on the driver.
+    - git+https://github.com/ray-project/ray_lightning#ray_lightning
   conda_packages: []
 
 post_build_cmds:
@@ -14,4 +16,5 @@ post_build_cmds:
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the Ray Lightning version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
-  - pip3 install -U git+https://github.com/ray-project/ray_lightning#ray_lightning
+  - pip uninstall ray_lightning -y # Uninstall first so pip does a reinstall.
+  - pip3 install -U --no-cache-dir git+https://github.com/ray-project/ray_lightning#ray_lightning

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -13,3 +13,4 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
+  - echo {{ env["TIMESTAMP"] }} # Trigger re-build of cluster env so we get most up to date ray lightning version.

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -13,4 +13,7 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - echo {{ env["TIMESTAMP"] }} # Trigger re-build of cluster env so we get most up to date ray lightning version.
+  # Upgrade the Ray Lightning version, otherwise it will be cached in the Anyscale Docker image.
+  - echo {{ env["TIMESTAMP"] }}
+  - pip install -U ray-lightning
+  - pip install -U git+https://github.com/ray-project/ray_lightning#ray_lightning


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Passing tests: https://buildkite.com/ray-project/periodic-ci/builds/2560#_

Add an echo timestamp to the post build commands of the ray lightning release tests to trigger a cluster env rebuild and get the latest versions of ray lightning. Without this, the cluster env gets cached so an outdated version is installed on the cluster that is different than the one on the driver, resulting in the below failures.

Closes #21871 
Closes #21863 

Also reinstalls the dependencies in the post build commands so old versions are not cached in the Docker images

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
