### PR TITLE
[Datasets] [Docs] Add API docs links to I/O compatibility matrix

### DIFF
--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -73,49 +73,49 @@ Datasource Compatibility Matrices
      - Read API
      - Status
    * - CSV File Format
-     - ``ray.data.read_csv()``
+     - :func:`ray.data.read_csv()`
      - ✅
    * - JSON File Format
-     - ``ray.data.read_json()``
+     - :func:`ray.data.read_json()`
      - ✅
    * - Parquet File Format
-     - ``ray.data.read_parquet()``
+     - :func:`ray.data.read_parquet()`
      - ✅
    * - Numpy File Format
-     - ``ray.data.read_numpy()``
+     - :func:`ray.data.read_numpy()`
      - ✅
    * - Text Files
-     - ``ray.data.read_text()``
+     - :func:`ray.data.read_text()`
      - ✅
    * - Binary Files
-     - ``ray.data.read_binary_files()``
+     - :func:`ray.data.read_binary_files()`
      - ✅
    * - Python Objects
-     - ``ray.data.from_items()``
+     - :func:`ray.data.from_items()`
      - ✅
    * - Spark Dataframe
-     - ``ray.data.from_spark()``
+     - :func:`ray.data.from_spark()`
      - ✅
    * - Dask Dataframe
-     - ``ray.data.from_dask()``
+     - :func:`ray.data.from_dask()`
      - ✅
    * - Modin Dataframe
-     - ``ray.data.from_modin()``
+     - :func:`ray.data.from_modin()`
      - ✅
    * - MARS Dataframe
-     - ``ray.data.from_mars()``
+     - :func:`ray.data.from_mars()`
      - (todo)
    * - Pandas Dataframe Objects
-     - ``ray.data.from_pandas()``
+     - :func:`ray.data.from_pandas()`
      - ✅
    * - NumPy ndarray Objects
-     - ``ray.data.from_numpy()``
+     - :func:`ray.data.from_numpy()`
      - ✅
    * - Arrow Table Objects
-     - ``ray.data.from_arrow()``
+     - :func:`ray.data.from_arrow()`
      - ✅
    * - Custom Datasource
-     - ``ray.data.read_datasource()``
+     - :func:`ray.data.read_datasource()`
      - ✅
 
 
@@ -126,55 +126,55 @@ Datasource Compatibility Matrices
      - Dataset API
      - Status
    * - CSV File Format
-     - ``ds.write_csv()``
+     - :meth:`ds.write_csv() <ray.data.Dataset.write_csv>`
      - ✅
    * - JSON File Format
-     - ``ds.write_json()``
+     - :meth:`ds.write_json() <ray.data.Dataset.write_json>`
      - ✅
    * - Parquet File Format
-     - ``ds.write_parquet()``
+     - :meth:`ds.write_parquet() <ray.data.Dataset.write_parquet>`
      - ✅
    * - Numpy File Format
-     - ``ds.write_numpy()``
+     - :meth:`ds.write_numpy() <ray.data.Dataset.write_numpy>`
      - ✅
    * - Spark Dataframe
-     - ``ds.to_spark()``
+     - :meth:`ds.to_spark() <ray.data.Dataset.to_spark>`
      - ✅
    * - Dask Dataframe
-     - ``ds.to_dask()``
+     - `:meth:`ds.to_dask() <ray.data.Dataset.to_dask>`
      - ✅
    * - Modin Dataframe
-     - ``ds.to_modin()``
+     - :meth:`ds.to_modin() <ray.data.Dataset.to_modin>`
      - ✅
    * - MARS Dataframe
-     - ``ds.to_mars()``
+     - :meth:`ds.to_mars() <ray.data.Dataset.to_mars>`
      - (todo)
    * - Arrow Table Objects
-     - ``ds.to_arrow_refs()``
+     - :meth:`ds.to_arrow_refs() <ray.data.Dataset.to_arrow_refs>`
      - ✅
    * - Arrow Table Iterator
-     - ``ds.iter_batches(batch_format="pyarrow")``
+     - :meth:`ds.iter_batches(batch_format="pyarrow") <ray.data.Dataset.iter_batches>`
      - ✅
    * - Single Pandas Dataframe
-     - ``ds.to_pandas()``
+     - :meth:`ds.to_pandas() <ray.data.Dataset.to_pandas>`
      - ✅
    * - Pandas Dataframe Objects
-     - ``ds.to_pandas_refs()``
+     - :meth:`ds.to_pandas_refs() <ray.data.Dataset.to_pandas_refs>`
      - ✅
    * - NumPy ndarray Objects
-     - ``ds.to_numpy_refs()``
+     - :meth:`ds.to_numpy_refs() <ray.data.Dataset.to_numpy_refs>`
      - ✅
    * - Pandas Dataframe Iterator
-     - ``ds.iter_batches(batch_format="pandas")``
+     - :meth:`ds.iter_batches(batch_format="pandas") <ray.data.Dataset.iter_batches>`
      - ✅
    * - PyTorch Iterable Dataset
-     - ``ds.to_torch()``
+     - :meth:`ds.to_torch() <ray.data.Dataset.to_torch>`
      - ✅
    * - TensorFlow Iterable Dataset
-     - ``ds.to_tf()``
+     - :meth:`ds.to_tf() <ray.data.Dataset.to_tf>`
      - ✅
    * - Custom Datasource
-     - ``ds.write_datasource()``
+     - :meth:`ds.write_datasource() <ray.data.Dataset.write_datasource>`
      - ✅
 
 

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -141,7 +141,7 @@ Datasource Compatibility Matrices
      - :meth:`ds.to_spark() <ray.data.Dataset.to_spark>`
      - ✅
    * - Dask Dataframe
-     - `:meth:`ds.to_dask() <ray.data.Dataset.to_dask>`
+     - :meth:`ds.to_dask() <ray.data.Dataset.to_dask>`
      - ✅
    * - Modin Dataframe
      - :meth:`ds.to_modin() <ray.data.Dataset.to_modin>`


### PR DESCRIPTION
This should allow the user to click on any of the I/O functions/methods in the compatibility matrix and jump to the corresponding API docs, which should greatly improve the landing page docs flow for new users.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
