### PR TITLE
[tune] deflake testBadParams5.

### DIFF
--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -449,7 +449,7 @@ class TrainableFunctionApiTest(unittest.TestCase):
 
     def testBadParams5(self):
         def f():
-            run_experiments({"foo": {"run": "PPO", "stop": {"asdf": 1}}})
+            run_experiments({"foo": {"run": "__fake", "stop": {"asdf": 1}}})
 
         self.assertRaises(TuneError, f)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test is timing out during actor creation and ends up not testing the code which is only triggered after a training result is returned back to driver.

```(RolloutWorker pid=74711) 2022-01-26 07:52:52,035	ERROR worker.py:432 -- Exception raised in creation task: The actor died because of an error raised in its creation task, ray::RolloutWorker.__init__() (pid=74711, ip=127.0.0.1, repr=<ray.rllib.evaluation.rollout_worker.RolloutWorker object at 0x7fd52192c130>)
(RolloutWorker pid=74711)   File "/Users/xwjiang/ray/python/ray/rllib/evaluation/rollout_worker.py", line 541, in __init__
(RolloutWorker pid=74711)     self.policy_dict = _determine_spaces_for_multi_agent_dict(
(RolloutWorker pid=74711)   File "/Users/xwjiang/ray/python/ray/rllib/evaluation/rollout_worker.py", line 1649, in _determine_spaces_for_multi_agent_dict
(RolloutWorker pid=74711)     raise ValueError(
(RolloutWorker pid=74711) ValueError: `observation_space` not provided in PolicySpec for default_policy and env does not have an observation space OR no spaces received from other workers' env(s) OR no `observation_space` specified in config!
```

Change to use a simpler Trainable.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
