### PR TITLE
Don't advertise cpus on gpu nodes for pipelined ingestion tests

### DIFF
--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -17,8 +17,8 @@ head_node_type:
 worker_node_types:
     - name: memory_node
       instance_type: i3.8xlarge
-      min_workers: 16
-      max_workers: 16
+      min_workers: 20
+      max_workers: 20
       use_spot: false
     - name: gpu_node
       instance_type: i3.8xlarge

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -26,4 +26,5 @@ worker_node_types:
       max_workers: 4
       use_spot: false
       resources:
+        cpu: 0
         gpu: 4

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -286,7 +286,7 @@ if __name__ == "__main__":
 
     if args.debug:
         tasks = [
-            consume.options(num_gpus=1).remote(
+            consume.options(num_gpus=1, num_cpus=0).remote(
                 split, rank=idx, batch_size=args.batch_size)
             for idx, split in enumerate(splits)
         ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Prevent non-training tasks/actors from being scheduled onto the gpu nodes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
