### PR TITLE
[e2e] improve output dir handling

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -2125,16 +2125,22 @@ def run_test_config(
                     f"{out_dir}")
 
         try:
-            shutil.rmtree(out_dir, ignore_errors=True)
+            shutil.rmtree(out_dir)
+        except Exception:
+            logger.exception(
+                f"Ran into error when clearing the destination dir: {out_dir}")
+
+        try:
             # Use distutils.dir_util.copy_tree() instead of shutil.cptree(),
             # which allows existing output directory.
             from distutils.dir_util import copy_tree
             copy_tree(temp_dir, out_dir)
-            logger.info(f"Dir contents: {os.listdir(out_dir)}")
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "Ran into error when copying results dir to persistent "
-                f"location: {str(e)}")
+                f"location: {out_dir}")
+
+        logger.info(f"Dir contents: {os.listdir(out_dir)}")
 
     return result
 

--- a/release/run_e2e.sh
+++ b/release/run_e2e.sh
@@ -119,6 +119,8 @@ while [ "$RETRY_NUM" -lt "$MAX_RETRIES" ]; do
     sleep ${SLEEP_TIME}
   fi
 
+  sudo rm -rf /tmp/ray_release_test_artifacts || true
+
   python e2e.py "$@"
   EXIT_CODE=$?
   REASON=$(reason "${EXIT_CODE}")

--- a/release/run_e2e.sh
+++ b/release/run_e2e.sh
@@ -119,8 +119,6 @@ while [ "$RETRY_NUM" -lt "$MAX_RETRIES" ]; do
     sleep ${SLEEP_TIME}
   fi
 
-  sudo rm -rf /tmp/ray_release_test_artifacts || true
-
   python e2e.py "$@"
   EXIT_CODE=$?
   REASON=$(reason "${EXIT_CODE}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Try to clear the result dir before running the `e2e.py` script, to avoid failures where the directory already exists, or a file cannot be overwritten due to permission issue.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
