### PR TITLE
[GCP] Add `roles/iam.roleViewer`

### DIFF
--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -30,6 +30,8 @@ DEFAULT_SERVICE_ACCOUNT_CONFIG = {
 }
 
 # Those roles will be always added.
+# NOTE: `serviceAccountUser` allows the head node to create workers with
+# a serviceAccount. `roleViewer` allows the head node to run bootstrap_gcp.
 DEFAULT_SERVICE_ACCOUNT_ROLES = [
     "roles/storage.objectAdmin", "roles/compute.admin",
     "roles/iam.serviceAccountUser", "roles/iam.roleViewer"

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -32,7 +32,7 @@ DEFAULT_SERVICE_ACCOUNT_CONFIG = {
 # Those roles will be always added.
 DEFAULT_SERVICE_ACCOUNT_ROLES = [
     "roles/storage.objectAdmin", "roles/compute.admin",
-    "roles/iam.serviceAccountUser"
+    "roles/iam.serviceAccountUser", "roles/iam.roleViewer"
 ]
 # Those roles will only be added if there are TPU nodes defined in config.
 TPU_SERVICE_ACCOUNT_ROLES = ["roles/tpu.admin"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Allows `bootstrap_gcp` to be called from the Head Node. This is the case with Tune's DockerSyncClient. 
* NOTE: For existing clusters, either relaunch with `ray up --no-config-cache` or run the following command:
```
gcloud projects add-iam-policy-binding <PROJECT_ID> --member=serviceAccount:ray-autoscaler-sa-v1@<PROJECT_ID>.iam.gserviceaccount.com --role=roles/iam.roleViewer
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

* Closes https://github.com/ray-project/ray/issues/21696
* Closes https://github.com/ray-project/ray/issues/19875

<!-- For example: "Closes #1234" -->

## Checks
- Testing Strategy
  - [x] Manually tested by running `crm.projects().getIamPolicy(resource=project_id).execute()` before & after adding  `iam.roleViewer` to the `ray-autoscaler-sa-v1@PROJECT_ID.iam.gserviceaccount.com`.
