### PR TITLE
[e2e] do not terminate in `serve_failure` smoke test

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -7,7 +7,7 @@ py_test(
     size = "medium",
     srcs = test_srcs,
     env = {
-        "IS_SMOKE_TEST": "1",
+        "RAY_UNIT_TEST": "1",
     },
     main = "serve_failure.py",
     tags = [

--- a/release/long_running_tests/long_running_tests.yaml
+++ b/release/long_running_tests/long_running_tests.yaml
@@ -191,4 +191,4 @@
 
   smoke_test:
     run:
-      timeout: 3600
+      timeout: 600

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -24,7 +24,7 @@ NUM_NODES = 4
 # RandomTest setup constants
 CPUS_PER_NODE = 10
 
-IS_SMOKE_TEST = "IS_SMOKE_TEST" in os.environ
+RAY_UNIT_TEST = "RAY_UNIT_TEST" in os.environ
 
 
 def update_progress(result):
@@ -149,7 +149,7 @@ class RandomTest:
             previous_time = new_time
             iteration += 1
 
-            if IS_SMOKE_TEST:
+            if RAY_UNIT_TEST:
                 break
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In smoke test mode, the script finishes after 1 iteration. Then it will also terminate its cluster including dashboard, which will prevent subsequent job submissions. Other long running e2e test scripts do not finish in smoke test mode, so make `serve_failure` behave the same by using a different variable to allow the script to finish in unit tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #21918
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
