### PR TITLE
[resource-reporting 4/n][wip] cluster-resource-manage agnostic of local_node_id

### DIFF
--- a/src/mock/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/mock/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -28,7 +28,8 @@ class MockClusterResourceScheduler : public ClusterResourceScheduler {
   MOCK_METHOD(void, DeleteResource,
               (const std::string &node_name, const std::string &resource_name),
               (override));
-  MOCK_METHOD(std::string, GetLocalResourceViewString, (), (const, override));
+  MOCK_METHOD(std::string, GetNodeResourceViewString, (const std::string &node_name),
+              (const, override));
   MOCK_METHOD(void, FillResourceUsage, (rpc::ResourcesData & resources_data), (override));
   MOCK_METHOD(ray::gcs::NodeResourceInfoAccessor::ResourceMap, GetResourceTotals,
               (const absl::flat_hash_map<std::string, double> &resource_map_filter),

--- a/src/mock/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
+++ b/src/mock/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
@@ -35,7 +35,8 @@ class MockClusterResourceSchedulerInterface : public ClusterResourceSchedulerInt
   MOCK_METHOD(ray::gcs::NodeResourceInfoAccessor::ResourceMap, GetResourceTotals,
               (const absl::flat_hash_map<std::string, double> &resource_map_filter),
               (const, override));
-  MOCK_METHOD(std::string, GetLocalResourceViewString, (), (const, override));
+  MOCK_METHOD(std::string, GetNodeResourceViewString, (const std::string &node_id_string),
+              (const, override));
 };
 
 }  // namespace ray

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -760,7 +760,7 @@ void NodeManager::WarnResourceDeadlock() {
         << exemplar.GetTaskSpecification().GetRequiredPlacementResources().ToString()
         << "\n"
         << "Available resources on this node: "
-        << cluster_resource_scheduler_->GetLocalResourceViewString()
+        << cluster_resource_scheduler_->GetNodeResourceViewString(self_node_id_.Binary())
         << " In total there are " << pending_tasks << " pending tasks and "
         << pending_actor_creations << " pending actors on this node.";
 
@@ -1593,7 +1593,8 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
                      << " actor_id = " << actor_id
                      << ", normal_task_resources = " << normal_task_resources.ToString()
                      << ", local_resoruce_view = "
-                     << cluster_resource_scheduler_->GetLocalResourceViewString();
+                     << cluster_resource_scheduler_->GetNodeResourceViewString(
+                            self_node_id_.Binary());
       auto resources_data = reply->mutable_resources_data();
       resources_data->set_node_id(self_node_id_.Binary());
       resources_data->set_resources_normal_task_changed(true);

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -1,0 +1,184 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest_prod.h>
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ray/common/task/scheduling_resources.h"
+#include "ray/gcs/gcs_client/accessor.h"
+#include "ray/gcs/gcs_client/gcs_client.h"
+#include "ray/raylet/scheduling/cluster_resource_data.h"
+#include "ray/raylet/scheduling/cluster_resource_scheduler_interface.h"
+#include "ray/raylet/scheduling/fixed_point.h"
+#include "ray/raylet/scheduling/local_resource_manager.h"
+#include "ray/raylet/scheduling/scheduling_ids.h"
+#include "ray/raylet/scheduling/scheduling_policy.h"
+#include "ray/util/logging.h"
+#include "src/ray/protobuf/gcs.pb.h"
+
+namespace ray {
+
+using rpc::HeartbeatTableData;
+
+/// Class encapsulating the cluster resources and the logic to assign
+/// tasks to nodes based on the task's constraints and the available
+/// resources at those nodes.
+class ClusterResourceManager {
+ public:
+  ClusterResourceManager() {}
+  /// Constructor initializing the resources associated with the local node.
+  ///
+  /// \param local_node_id: ID of local node,
+  /// \param local_node_resources: The total and the available resources associated
+  /// with the local node.
+  ClusterResourceManager(int64_t local_node_id,
+                           const NodeResources &local_node_resources,
+                           gcs::GcsClient &gcs_client);
+  ClusterResourceManager(
+      const std::string &local_node_id,
+      const absl::flat_hash_map<std::string, double> &local_node_resources,
+      gcs::GcsClient &gcs_client,
+      std::function<int64_t(void)> get_used_object_store_memory = nullptr,
+      std::function<bool(void)> get_pull_manager_at_capacity = nullptr);
+
+  // Mapping from predefined resource indexes to resource strings
+  std::string GetResourceNameFromIndex(int64_t res_idx);
+
+  /// Update node resources. This hanppens when a node resource usage udpated.
+  ///
+  /// \param node_id_string ID of the node which resoruces need to be udpated.
+  /// \param resource_data The node resource data.
+  bool UpdateNode(const std::string &node_id_string,
+                  const rpc::ResourcesData &resource_data) override;
+
+  /// Remove node from the cluster data structure. This happens
+  /// when a node fails or it is removed from the cluster.
+  ///
+  /// \param node_id_string ID of the node to be removed.
+  bool RemoveNode(const std::string &node_id_string) override;
+
+  /// Get number of nodes in the cluster.
+  int64_t NumNodes() const;
+
+  /// Temporarily get the StringIDMap.
+  const StringIdMap &GetStringIdMap() const;
+
+  /// Update total capacity of a given resource of a given node.
+  ///
+  /// \param node_name: Node whose resource we want to update.
+  /// \param resource_name: Resource which we want to update.
+  /// \param resource_total: New capacity of the resource.
+  void UpdateResourceCapacity(const std::string &node_name,
+                              const std::string &resource_name,
+                              double resource_total) override;
+
+  /// Delete a given resource from a given node.
+  ///
+  /// \param node_name: Node whose resource we want to delete.
+  /// \param resource_name: Resource we want to delete
+  void DeleteResource(const std::string &node_name,
+                      const std::string &resource_name) override;
+
+  /// Return local resources in human-readable string form.
+  std::string GetNodeResourceViewString(const std::string &node_name) const override;
+
+  /// Subtract the resources required by a given resource request (resource_request) from
+  /// a given remote node.
+  ///
+  /// \param node_id Remote node whose resources we allocate.
+  /// \param resource_request Task for which we allocate resources.
+  /// \return True if remote node has enough resources to satisfy the resource request.
+  /// False otherwise.
+  bool AllocateRemoteTaskResources(
+      const std::string &node_id,
+      const absl::flat_hash_map<std::string, double> &task_resources);
+
+  /// Return human-readable string for this scheduler state.
+  std::string DebugString() const;
+
+  LocalResourceManager &GetLocalResourceManager() { return *local_resource_manager_; }
+
+  const NodeResources &GetNodeResources(const std::string &node_name) const;
+
+  /// Decrease the available resources of a node when a resource request is
+  /// scheduled on the given node.
+  ///
+  /// \param node_id: ID of node on which request is being scheduled.
+  /// \param resource_request: resource request being scheduled.
+  ///
+  /// \return true, if resource_request can be indeed scheduled on the node,
+  /// and false otherwise.
+  bool SubtractRemoteNodeAvailableResources(int64_t node_id,
+                                            const ResourceRequest &resource_request);
+ private:
+
+  /// Add a new node or overwrite the resources of an existing node.
+  ///
+  /// \param node_id: Node ID.
+  /// \param node_resources: Up to date total and available resources of the node.
+  void AddOrUpdateNode(int64_t node_id, const NodeResources &node_resources);
+
+  void AddOrUpdateNode(
+      const std::string &node_id,
+      const absl::flat_hash_map<std::string, double> &resource_map_total,
+      const absl::flat_hash_map<std::string, double> &resource_map_available);
+
+  /// Remove node from the cluster data structure. This happens
+  /// when a node fails or it is removed from the cluster.
+  ///
+  /// \param node_id ID of the node to be removed.
+  bool RemoveNode(int64_t node_id);
+
+  /// Return resources associated to the given node_id in ret_resources.
+  /// If node_id not found, return false; otherwise return true.
+  bool GetNodeResources(int64_t node_id, NodeResources *ret_resources) const;
+
+  /// List of nodes in the clusters and their resources organized as a map.
+  /// The key of the map is the node ID.
+  absl::flat_hash_map<int64_t, Node> nodes_;
+  /// Resources of local node.
+  std::unique_ptr<LocalResourceManager> local_resource_manager_;
+  /// Keep the mapping between node and resource IDs in string representation
+  /// to integer representation. Used for improving map performance.
+  StringIdMap string_to_int_map_;
+
+  friend class ClusterResourceManagerTest;
+  FRIEND_TEST(ClusterResourceManagerTest, SchedulingDeleteClusterNodeTest);
+  FRIEND_TEST(ClusterResourceManagerTest, SchedulingModifyClusterNodeTest);
+  FRIEND_TEST(ClusterResourceManagerTest, SchedulingUpdateAvailableResourcesTest);
+  FRIEND_TEST(ClusterResourceManagerTest, SchedulingAddOrUpdateNodeTest);
+  FRIEND_TEST(ClusterResourceManagerTest, SpreadSchedulingStrategyTest);
+  FRIEND_TEST(ClusterResourceManagerTest, SchedulingResourceRequestTest);
+  FRIEND_TEST(ClusterResourceManagerTest, SchedulingUpdateTotalResourcesTest);
+  FRIEND_TEST(ClusterResourceManagerTest,
+              UpdateLocalAvailableResourcesFromResourceInstancesTest);
+  FRIEND_TEST(ClusterResourceManagerTest, ResourceUsageReportTest);
+  FRIEND_TEST(ClusterResourceManagerTest, DeadNodeTest);
+  FRIEND_TEST(ClusterResourceManagerTest, TestAlwaysSpillInfeasibleTask);
+  FRIEND_TEST(ClusterResourceManagerTest, ObjectStoreMemoryUsageTest);
+  FRIEND_TEST(ClusterResourceManagerTest, AvailableResourceInstancesOpsTest);
+  FRIEND_TEST(ClusterResourceManagerTest, DirtyLocalViewTest);
+  FRIEND_TEST(ClusterResourceManagerTest, DynamicResourceTest);
+  FRIEND_TEST(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources);
+  FRIEND_TEST(ClusterResourceManagerTest, TestForceSpillback);
+};
+
+}  // end namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_interface.h
@@ -51,6 +51,7 @@ class ClusterResourceSchedulerInterface {
                               const std::string &resource_name) = 0;
 
   /// Return local resources in human-readable string form.
-  virtual std::string GetLocalResourceViewString() const = 0;
+  virtual std::string GetNodeResourceViewString(
+      const std::string &node_id_string) const = 0;
 };
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -1500,8 +1500,8 @@ void ClusterTaskManager::SpillWaitingTasks() {
 
 bool ClusterTaskManager::IsLocallySchedulable(const RayTask &task) const {
   const auto &spec = task.GetTaskSpecification();
-  return cluster_resource_scheduler_->IsLocallySchedulable(
-      spec.GetRequiredResources().GetResourceMap());
+  return cluster_resource_scheduler_->IsSchedulableOnNode(
+      self_node_id_.Binary(), spec.GetRequiredResources().GetResourceMap());
 }
 
 ResourceSet ClusterTaskManager::CalcNormalTaskResources() const {

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -1433,7 +1433,7 @@ TEST_F(ClusterTaskManagerTest, FeasibleToNonFeasible) {
 }
 
 TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) {
-  const NodeResources &node_resources = scheduler_->GetLocalNodeResources();
+  const NodeResources &node_resources = scheduler_->GetLocalNodeResources(id_.Binary());
   ASSERT_EQ(node_resources.predefined_resources[PredefinedResources::CPU].available, 8);
   ASSERT_EQ(node_resources.predefined_resources[PredefinedResources::GPU].available, 4);
 

--- a/src/ray/raylet/scheduling/distributed_scheduler.cc
+++ b/src/ray/raylet/scheduling/distributed_scheduler.cc
@@ -1,0 +1,179 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/cluster_resource_scheduler.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include "ray/common/grpc_util.h"
+#include "ray/common/ray_config.h"
+
+namespace ray {
+
+DistributedScheduler::DistributedScheduler(
+    gcs::GcsClient &gcs_client)
+    : gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
+      gcs_client_(&gcs_client) {
+  scheduling_policy_ = std::make_unique<raylet_scheduling_policy::SchedulingPolicy>(
+      local_node_id_, nodes_);
+}
+
+bool DistributedScheduler::NodeAlive(int64_t node_id) const {
+  if (node_id == local_node_id_) {
+    return true;
+  }
+  if (node_id == -1) {
+    return false;
+  }
+  auto node_id_binary = string_to_int_map_.Get(node_id);
+  return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id_binary)) != nullptr;
+}
+
+bool DistributedScheduler::IsSchedulable(const ResourceRequest &resource_request,
+                                             int64_t node_id,
+                                             const NodeResources &resources) const {
+  if (resource_request.requires_object_store_memory && resources.object_pulls_queued &&
+      node_id != local_node_id_) {
+    // It's okay if the local node's pull manager is at capacity because we
+    // will eventually spill the task back from the waiting queue if its args
+    // cannot be pulled.
+    return false;
+  }
+
+  // First, check predefined resources.
+  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
+    if (resource_request.predefined_resources[i] >
+        resources.predefined_resources[i].available) {
+      // A hard constraint has been violated, so we cannot schedule
+      // this resource request.
+      return false;
+    }
+  }
+
+  // Now check custom resources.
+  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
+    auto it = resources.custom_resources.find(task_req_custom_resource.first);
+
+    if (it == resources.custom_resources.end()) {
+      // Requested resource doesn't exist at this node.
+      // This is a hard constraint so cannot schedule this resource request.
+      return false;
+    } else {
+      if (task_req_custom_resource.second > it->second.available) {
+        // Resource constraint is violated.
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+int64_t DistributedScheduler::GetBestSchedulableNode(
+    const ResourceRequest &resource_request,
+    const rpc::SchedulingStrategy &scheduling_strategy, bool actor_creation,
+    bool force_spillback, int64_t *total_violations, bool *is_infeasible) {
+  // The zero cpu actor is a special case that must be handled the same way by all
+  // scheduling policies.
+  if (actor_creation && resource_request.IsEmpty()) {
+    int64_t best_node = -1;
+    // This is an actor which requires no resources.
+    // Pick a random node to to avoid scheduling all actors on the local node.
+    if (nodes_.size() > 0) {
+      std::uniform_int_distribution<int> distribution(0, nodes_.size() - 1);
+      int idx = distribution(gen_);
+      auto iter = std::next(nodes_.begin(), idx);
+      for (size_t i = 0; i < nodes_.size(); ++i) {
+        // TODO(iycheng): Here is there are a lot of nodes died, the
+        // distribution might not be even.
+        if (NodeAlive(iter->first)) {
+          best_node = iter->first;
+          break;
+        }
+        ++iter;
+        if (iter == nodes_.end()) {
+          iter = nodes_.begin();
+        }
+      }
+    }
+    RAY_LOG(DEBUG) << "GetBestSchedulableNode, best_node = " << best_node
+                   << ", # nodes = " << nodes_.size()
+                   << ", resource_request = " << resource_request.DebugString();
+    return best_node;
+  }
+
+  // TODO (Alex): Setting require_available == force_spillback is a hack in order to
+  // remain bug compatible with the legacy scheduling algorithms.
+  int64_t best_node_id = scheduling_policy_->HybridPolicy(
+      resource_request,
+      scheduling_strategy.scheduling_strategy_case() ==
+              rpc::SchedulingStrategy::SchedulingStrategyCase::kSpreadSchedulingStrategy
+          ? 0.0
+          : RayConfig::instance().scheduler_spread_threshold(),
+      force_spillback, force_spillback,
+      [this](auto node_id) { return this->NodeAlive(node_id); });
+  *is_infeasible = best_node_id == -1 ? true : false;
+  if (!*is_infeasible) {
+    // TODO (Alex): Support soft constraints if needed later.
+    *total_violations = 0;
+  }
+
+  RAY_LOG(DEBUG) << "Scheduling decision. "
+                 << "forcing spillback: " << force_spillback
+                 << ". Best node: " << best_node_id << " "
+                 << (string_to_int_map_.Get(best_node_id) == "-1"
+                         ? NodeID::Nil()
+                         : NodeID::FromBinary(string_to_int_map_.Get(best_node_id)))
+                 << ", is infeasible: " << *is_infeasible;
+  return best_node_id;
+}
+
+std::string DistributedScheduler::GetBestSchedulableNode(
+    const absl::flat_hash_map<std::string, double> &task_resources,
+    const rpc::SchedulingStrategy &scheduling_strategy, bool requires_object_store_memory,
+    bool actor_creation, bool force_spillback, int64_t *total_violations,
+    bool *is_infeasible) {
+  ResourceRequest resource_request = ResourceMapToResourceRequest(
+      string_to_int_map_, task_resources, requires_object_store_memory);
+  int64_t node_id =
+      GetBestSchedulableNode(resource_request, scheduling_strategy, actor_creation,
+                             force_spillback, total_violations, is_infeasible);
+
+  if (node_id == -1) {
+    // This is not a schedulable node, so return empty string.
+    return "";
+  }
+  // Return the string name of the node.
+  return string_to_int_map_.Get(node_id);
+}
+
+bool DistributedScheduler::AllocateRemoteTaskResources(
+    const std::string &node_string,
+    const absl::flat_hash_map<std::string, double> &task_resources) {
+  ResourceRequest resource_request = ResourceMapToResourceRequest(
+      string_to_int_map_, task_resources, /*requires_object_store_memory=*/false);
+  auto node_id = string_to_int_map_.Insert(node_string);
+  RAY_CHECK(node_id != local_node_id_);
+  return cluster_resource_manager_->SubtractRemoteNodeAvailableResources(node_id, resource_request);
+}
+
+bool DistributedScheduler::IsSchedulableOnNode(
+    const std::string &node_name, const absl::flat_hash_map<std::string, double> &shape) {
+  int64_t node_id = string_to_int_map_.Get(node_name);
+  auto resource_request = ResourceMapToResourceRequest(
+      string_to_int_map_, shape, /*requires_object_store_memory=*/false);
+  return IsSchedulable(resource_request, node_id, GetNodeResources(node_name));
+}
+
+}  // namespace ray

--- a/src/ray/raylet/scheduling/distributed_scheduler.h
+++ b/src/ray/raylet/scheduling/distributed_scheduler.h
@@ -41,44 +41,16 @@ using rpc::HeartbeatTableData;
 /// Class encapsulating the cluster resources and the logic to assign
 /// tasks to nodes based on the task's constraints and the available
 /// resources at those nodes.
-class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
+class DistributedScheduler {
  public:
-  ClusterResourceScheduler() {}
+  DistributedScheduler() {}
   /// Constructor initializing the resources associated with the local node.
   ///
   /// \param local_node_id: ID of local node,
   /// \param local_node_resources: The total and the available resources associated
   /// with the local node.
-  ClusterResourceScheduler(int64_t local_node_id,
-                           const NodeResources &local_node_resources,
-                           gcs::GcsClient &gcs_client);
-  ClusterResourceScheduler(
-      const std::string &local_node_id,
-      const absl::flat_hash_map<std::string, double> &local_node_resources,
-      gcs::GcsClient &gcs_client,
-      std::function<int64_t(void)> get_used_object_store_memory = nullptr,
-      std::function<bool(void)> get_pull_manager_at_capacity = nullptr);
+  DistributedScheduler(gcs::GcsClient &gcs_client);
 
-  // Mapping from predefined resource indexes to resource strings
-  std::string GetResourceNameFromIndex(int64_t res_idx);
-
-  void AddOrUpdateNode(
-      const std::string &node_id,
-      const absl::flat_hash_map<std::string, double> &resource_map_total,
-      const absl::flat_hash_map<std::string, double> &resource_map_available);
-
-  /// Update node resources. This hanppens when a node resource usage udpated.
-  ///
-  /// \param node_id_string ID of the node which resoruces need to be udpated.
-  /// \param resource_data The node resource data.
-  bool UpdateNode(const std::string &node_id_string,
-                  const rpc::ResourcesData &resource_data) override;
-
-  /// Remove node from the cluster data structure. This happens
-  /// when a node fails or it is removed from the cluster.
-  ///
-  /// \param node_id_string ID of the node to be removed.
-  bool RemoveNode(const std::string &node_id_string) override;
 
   ///  Find a node in the cluster on which we can schedule a given resource request.
   ///  In hybrid mode, see `scheduling_policy.h` for a description of the policy.
@@ -114,31 +86,6 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
       bool requires_object_store_memory, bool actor_creation, bool force_spillback,
       int64_t *violations, bool *is_infeasible);
 
-  /// Get number of nodes in the cluster.
-  int64_t NumNodes() const;
-
-  /// Temporarily get the StringIDMap.
-  const StringIdMap &GetStringIdMap() const;
-
-  /// Update total capacity of a given resource of a given node.
-  ///
-  /// \param node_name: Node whose resource we want to update.
-  /// \param resource_name: Resource which we want to update.
-  /// \param resource_total: New capacity of the resource.
-  void UpdateResourceCapacity(const std::string &node_name,
-                              const std::string &resource_name,
-                              double resource_total) override;
-
-  /// Delete a given resource from a given node.
-  ///
-  /// \param node_name: Node whose resource we want to delete.
-  /// \param resource_name: Resource we want to delete
-  void DeleteResource(const std::string &node_name,
-                      const std::string &resource_name) override;
-
-  /// Return local resources in human-readable string form.
-  std::string GetLocalResourceViewString() const override;
-
   /// Subtract the resources required by a given resource request (resource_request) from
   /// a given remote node.
   ///
@@ -153,42 +100,16 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   /// Return human-readable string for this scheduler state.
   std::string DebugString() const;
 
-  /// Check whether a task request is schedulable on a the local node. A node is
+  /// Check whether a task request is schedulable on a given node. A node is
   /// schedulable if it has the available resources needed to execute the task.
   ///
+  /// \param node_name Name of the node.
   /// \param shape The resource demand's shape.
-  bool IsLocallySchedulable(const absl::flat_hash_map<std::string, double> &shape);
-
-  LocalResourceManager &GetLocalResourceManager() { return *local_resource_manager_; }
-
-  /// Get local node resources; test only.
-  const NodeResources &GetLocalNodeResources() const;
+  bool IsSchedulableOnNode(const std::string &node_name,
+                           const absl::flat_hash_map<std::string, double> &shape);
 
  private:
   bool NodeAlive(int64_t node_id) const;
-
-  /// Decrease the available resources of a node when a resource request is
-  /// scheduled on the given node.
-  ///
-  /// \param node_id: ID of node on which request is being scheduled.
-  /// \param resource_request: resource request being scheduled.
-  ///
-  /// \return true, if resource_request can be indeed scheduled on the node,
-  /// and false otherwise.
-  bool SubtractRemoteNodeAvailableResources(int64_t node_id,
-                                            const ResourceRequest &resource_request);
-
-  /// Add a new node or overwrite the resources of an existing node.
-  ///
-  /// \param node_id: Node ID.
-  /// \param node_resources: Up to date total and available resources of the node.
-  void AddOrUpdateNode(int64_t node_id, const NodeResources &node_resources);
-
-  /// Remove node from the cluster data structure. This happens
-  /// when a node fails or it is removed from the cluster.
-  ///
-  /// \param node_id ID of the node to be removed.
-  bool RemoveNode(int64_t node_id);
 
   /// Check whether a resource request can be scheduled given a node.
   ///
@@ -203,41 +124,35 @@ class ClusterResourceScheduler : public ClusterResourceSchedulerInterface {
   ///  \return: Whether the request can be scheduled.
   bool IsSchedulable(const ResourceRequest &resource_request, int64_t node_id,
                      const NodeResources &resources) const;
-
-  /// Return resources associated to the given node_id in ret_resources.
-  /// If node_id not found, return false; otherwise return true.
-  bool GetNodeResources(int64_t node_id, NodeResources *ret_resources) const;
-
-  /// List of nodes in the clusters and their resources organized as a map.
-  /// The key of the map is the node ID.
-  absl::flat_hash_map<int64_t, Node> nodes_;
-  /// Identifier of local node.
-  int64_t local_node_id_;
+  
   /// The scheduling policy to use.
   std::unique_ptr<raylet_scheduling_policy::SchedulingPolicy> scheduling_policy_;
+  /// The cluster resource manager.
+  std::unique_ptr<ClusterResourceManager> cluster_resource_manager_;
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
-  /// Resources of local node.
-  std::unique_ptr<LocalResourceManager> local_resource_manager_;
-  /// Keep the mapping between node and resource IDs in string representation
-  /// to integer representation. Used for improving map performance.
-  StringIdMap string_to_int_map_;
   /// Gcs client. It's not owned by this class.
   gcs::GcsClient *gcs_client_;
 
-  friend class ClusterResourceSchedulerTest;
-  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingDeleteClusterNodeTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingModifyClusterNodeTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingAddOrUpdateNodeTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingResourceRequestTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest,
+  friend class DistributedSchedulerTest;
+  FRIEND_TEST(DistributedSchedulerTest, SchedulingDeleteClusterNodeTest);
+  FRIEND_TEST(DistributedSchedulerTest, SchedulingModifyClusterNodeTest);
+  FRIEND_TEST(DistributedSchedulerTest, SchedulingUpdateAvailableResourcesTest);
+  FRIEND_TEST(DistributedSchedulerTest, SchedulingAddOrUpdateNodeTest);
+  FRIEND_TEST(DistributedSchedulerTest, SpreadSchedulingStrategyTest);
+  FRIEND_TEST(DistributedSchedulerTest, SchedulingResourceRequestTest);
+  FRIEND_TEST(DistributedSchedulerTest, SchedulingUpdateTotalResourcesTest);
+  FRIEND_TEST(DistributedSchedulerTest,
               UpdateLocalAvailableResourcesFromResourceInstancesTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, ResourceUsageReportTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest);
-  FRIEND_TEST(ClusterResourceSchedulerTest, AvailableResourceInstancesOpsTest);
+  FRIEND_TEST(DistributedSchedulerTest, ResourceUsageReportTest);
+  FRIEND_TEST(DistributedSchedulerTest, DeadNodeTest);
+  FRIEND_TEST(DistributedSchedulerTest, TestAlwaysSpillInfeasibleTask);
+  FRIEND_TEST(DistributedSchedulerTest, ObjectStoreMemoryUsageTest);
+  FRIEND_TEST(DistributedSchedulerTest, AvailableResourceInstancesOpsTest);
+  FRIEND_TEST(DistributedSchedulerTest, DirtyLocalViewTest);
+  FRIEND_TEST(DistributedSchedulerTest, DynamicResourceTest);
   FRIEND_TEST(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources);
+  FRIEND_TEST(DistributedSchedulerTest, TestForceSpillback);
 };
 
 }  // end namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
