### PR TITLE
[event] redefine  "SetCustomFields" to "UpdateCustomFields"

### DIFF
--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/util/event.h"
+
 #include <boost/filesystem.hpp>
 
 #include "absl/base/call_once.h"
@@ -174,12 +175,12 @@ void RayEventContext::SetEventContext(
     rpc::Event_SourceType source_type,
     const std::unordered_map<std::string, std::string> &custom_fields) {
   SetSourceType(source_type);
-  SetCustomFields(custom_fields);
+  AddCustomFields(custom_fields);
 
   if (!global_context_started_setting_.fetch_or(1)) {
     global_context_ = std::make_unique<RayEventContext>();
     global_context_->SetSourceType(source_type);
-    global_context_->SetCustomFields(custom_fields);
+    global_context_->AddCustomFields(custom_fields);
     global_context_finished_setting_ = true;
   }
 }
@@ -191,17 +192,19 @@ void RayEventContext::ResetEventContext() {
   global_context_finished_setting_ = false;
 }
 
-void RayEventContext::SetCustomField(const std::string &key, const std::string &value) {
+void RayEventContext::AddCustomField(const std::string &key, const std::string &value) {
   // This method should be used while source type has been set.
   RAY_CHECK(GetInitialzed());
   custom_fields_[key] = value;
 }
 
-void RayEventContext::SetCustomFields(
+void RayEventContext::AddCustomFields(
     const std::unordered_map<std::string, std::string> &custom_fields) {
   // This method should be used while source type has been set.
   RAY_CHECK(GetInitialzed());
-  custom_fields_ = custom_fields;
+  for (const auto &pair : custom_fields) {
+    custom_fields_[pair.first] = pair.second;
+  }
 }
 ///
 /// RayEvent

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -175,12 +175,12 @@ void RayEventContext::SetEventContext(
     rpc::Event_SourceType source_type,
     const std::unordered_map<std::string, std::string> &custom_fields) {
   SetSourceType(source_type);
-  AddCustomFields(custom_fields);
+  UpdateCustomFields(custom_fields);
 
   if (!global_context_started_setting_.fetch_or(1)) {
     global_context_ = std::make_unique<RayEventContext>();
     global_context_->SetSourceType(source_type);
-    global_context_->AddCustomFields(custom_fields);
+    global_context_->UpdateCustomFields(custom_fields);
     global_context_finished_setting_ = true;
   }
 }
@@ -192,13 +192,14 @@ void RayEventContext::ResetEventContext() {
   global_context_finished_setting_ = false;
 }
 
-void RayEventContext::AddCustomField(const std::string &key, const std::string &value) {
+void RayEventContext::UpdateCustomField(const std::string &key,
+                                        const std::string &value) {
   // This method should be used while source type has been set.
   RAY_CHECK(GetInitialzed());
   custom_fields_[key] = value;
 }
 
-void RayEventContext::AddCustomFields(
+void RayEventContext::UpdateCustomFields(
     const std::unordered_map<std::string, std::string> &custom_fields) {
   // This method should be used while source type has been set.
   RAY_CHECK(GetInitialzed());

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -137,9 +137,15 @@ class RayEventContext final {
                        const std::unordered_map<std::string, std::string> &custom_fields =
                            std::unordered_map<std::string, std::string>());
 
-  void SetCustomField(const std::string &key, const std::string &value);
+  // Only for test, isn't thread-safe with SetEventContext.
+  void ResetEventContext();
 
-  void SetCustomFields(const std::unordered_map<std::string, std::string> &custom_fields);
+  // If the key already exists, replace the value. Otherwise, insert a new item.
+  void AddCustomField(const std::string &key, const std::string &value);
+
+  // Add the `custom_fields` into the existing items.
+  // If the key already exists, replace the value. Otherwise, insert a new item.
+  void AddCustomFields(const std::unordered_map<std::string, std::string> &custom_fields);
 
   inline void SetSourceType(rpc::Event_SourceType source_type) {
     source_type_ = source_type;
@@ -165,11 +171,6 @@ class RayEventContext final {
   RayEventContext(const RayEventContext &event_context) = delete;
 
   const RayEventContext &operator=(const RayEventContext &event_context) = delete;
-
-  // Only for test, isn't thread-safe with SetEventContext.
-  void ResetEventContext();
-
-  FRIEND_TEST(EVENT_TEST, MULTI_THREAD_CONTEXT_COPY);
 
   rpc::Event_SourceType source_type_ = rpc::Event_SourceType::Event_SourceType_COMMON;
   std::string source_hostname_ = boost::asio::ip::host_name();
@@ -243,9 +244,9 @@ class RayEvent {
   // Only for test
   static void SetLevel(const std::string &event_level);
 
-  FRIEND_TEST(EVENT_TEST, TEST_LOG_LEVEL);
+  FRIEND_TEST(EventTest, TestLogLevel);
 
-  FRIEND_TEST(EVENT_TEST, TEST_LOG_EVENT);
+  FRIEND_TEST(EventTest, TestLogEvent);
 
  private:
   rpc::Event_Severity severity_;

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -141,11 +141,12 @@ class RayEventContext final {
   void ResetEventContext();
 
   // If the key already exists, replace the value. Otherwise, insert a new item.
-  void AddCustomField(const std::string &key, const std::string &value);
+  void UpdateCustomField(const std::string &key, const std::string &value);
 
-  // Add the `custom_fields` into the existing items.
+  // Update the `custom_fields` into the existing items.
   // If the key already exists, replace the value. Otherwise, insert a new item.
-  void AddCustomFields(const std::unordered_map<std::string, std::string> &custom_fields);
+  void UpdateCustomFields(
+      const std::unordered_map<std::string, std::string> &custom_fields);
 
   inline void SetSourceType(rpc::Event_SourceType source_type) {
     source_type_ = source_type;

--- a/src/ray/util/event_test.cc
+++ b/src/ray/util/event_test.cc
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include "ray/util/event.h"
+
 #include <boost/filesystem.hpp>
 #include <boost/range.hpp>
 #include <csignal>
 #include <fstream>
 #include <set>
 #include <thread>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ray/util/event_label.h"
@@ -161,10 +163,21 @@ std::string GenerateLogDir() {
   return log_dir;
 }
 
-TEST(EVENT_TEST, TEST_BASIC) {
-  TestEventReporter::event_list.clear();
-  EventManager::Instance().ClearReporters();
+class EventTest : public ::testing::Test {
+ public:
+  virtual void SetUp() { log_dir = GenerateLogDir(); }
 
+  virtual void TearDown() {
+    TestEventReporter::event_list.clear();
+    boost::filesystem::remove_all(log_dir.c_str());
+    EventManager::Instance().ClearReporters();
+    ray::RayEventContext::Instance().ResetEventContext();
+  }
+
+  std::string log_dir;
+};
+
+TEST_F(EventTest, TestBasic) {
   RAY_EVENT(WARNING, "label") << "test for empty reporters";
 
   // If there are no reporters, it would not Publish event
@@ -181,12 +194,16 @@ TEST(EVENT_TEST, TEST_BASIC) {
 
   RAY_EVENT(INFO, "label 1") << "send message 1";
 
+  RayEventContext::Instance().ResetEventContext();
+
   RayEventContext::Instance().SetEventContext(
       rpc::Event_SourceType::Event_SourceType_RAYLET,
       std::unordered_map<std::string, std::string>(
           {{"node_id", "node 2"}, {"job_id", "job 2"}}));
   RAY_EVENT(ERROR, "label 2") << "send message 2 "
                               << "send message again";
+
+  RayEventContext::Instance().ResetEventContext();
 
   RayEventContext::Instance().SetEventContext(
       rpc::Event_SourceType::Event_SourceType_GCS);
@@ -208,10 +225,36 @@ TEST(EVENT_TEST, TEST_BASIC) {
   CheckEventDetail(result[3], "", "", "", "GCS", "FATAL", "", "");
 }
 
-TEST(EVENT_TEST, LOG_ONE_THREAD) {
-  std::string log_dir = GenerateLogDir();
+TEST_F(EventTest, TestAddCustomFields) {
+  EventManager::Instance().AddReporter(std::make_shared<TestEventReporter>());
 
-  EventManager::Instance().ClearReporters();
+  RayEventContext::Instance().SetEventContext(
+      rpc::Event_SourceType::Event_SourceType_CORE_WORKER,
+      std::unordered_map<std::string, std::string>(
+          {{"node_id", "node 1"}, {"job_id", "job 1"}}));
+
+  RAY_EVENT(INFO, "label 1") << "send message 1";
+
+  // Replace the value of existing key: "job_id"
+  // Insert new item of key: "task_id"
+  RayEventContext::Instance().AddCustomFields(
+      std::unordered_map<std::string, std::string>(
+          {{"node_id", "node 1"}, {"job_id", "job 2"}, {"task_id", "task 2"}}));
+  RAY_EVENT(ERROR, "label 2") << "send message 2 "
+                              << "send message again";
+
+  std::vector<rpc::Event> &result = TestEventReporter::event_list;
+
+  EXPECT_EQ(result.size(), 2);
+
+  CheckEventDetail(result[0], "job 1", "node 1", "", "CORE_WORKER", "INFO", "label 1",
+                   "send message 1");
+
+  CheckEventDetail(result[1], "job 2", "node 1", "task 2", "CORE_WORKER", "ERROR",
+                   "label 2", "send message 2 send message again");
+}
+
+TEST_F(EventTest, TestLogOneThread) {
   RayEventContext::Instance().SetEventContext(
       rpc::Event_SourceType::Event_SourceType_RAYLET,
       std::unordered_map<std::string, std::string>(
@@ -237,14 +280,10 @@ TEST(EVENT_TEST, LOG_ONE_THREAD) {
                      "label " + std::to_string(i + 1),
                      "send message " + std::to_string(i + 1));
   }
-
-  boost::filesystem::remove_all(log_dir.c_str());
 }
 
-TEST(EVENT_TEST, MULTI_THREAD_CONTEXT_COPY) {
+TEST_F(EventTest, TestMultiThreadContextCopy) {
   ray::RayEventContext::Instance().ResetEventContext();
-  TestEventReporter::event_list.clear();
-  ray::EventManager::Instance().ClearReporters();
   ray::EventManager::Instance().AddReporter(std::make_shared<TestEventReporter>());
   RAY_EVENT(INFO, "label 0") << "send message 0";
 
@@ -276,7 +315,7 @@ TEST(EVENT_TEST, MULTI_THREAD_CONTEXT_COPY) {
   std::thread private_thread_2 = std::thread(std::bind([&]() {
     ray::RayEventContext::Instance().SetSourceType(
         rpc::Event_SourceType::Event_SourceType_RAYLET);
-    ray::RayEventContext::Instance().SetCustomField("job_id", "job 1");
+    ray::RayEventContext::Instance().AddCustomField("job_id", "job 1");
     RAY_EVENT(INFO, "label 2") << "send message 2";
   }));
 
@@ -290,11 +329,7 @@ TEST(EVENT_TEST, MULTI_THREAD_CONTEXT_COPY) {
   CheckEventDetail(result[1], "", "", "", "COMMON", "INFO", "label 3", "send message 3");
 }
 
-TEST(EVENT_TEST, LOG_MULTI_THREAD) {
-  std::string log_dir = GenerateLogDir();
-
-  EventManager::Instance().ClearReporters();
-
+TEST_F(EventTest, TestLogMultiThread) {
   EventManager::Instance().AddReporter(std::make_shared<LogEventReporter>(
       rpc::Event_SourceType::Event_SourceType_GCS, log_dir));
   int nthreads = 80;
@@ -333,14 +368,9 @@ TEST(EVENT_TEST, LOG_MULTI_THREAD) {
   EXPECT_EQ(label_set.size(), print_times);
   EXPECT_EQ(*(label_set.begin()), "label 0");
   EXPECT_EQ(*(--label_set.end()), "label " + std::to_string(print_times - 1));
-
-  boost::filesystem::remove_all(log_dir.c_str());
 }
 
-TEST(EVENT_TEST, LOG_ROTATE) {
-  std::string log_dir = GenerateLogDir();
-
-  EventManager::Instance().ClearReporters();
+TEST_F(EventTest, TestLogRotate) {
   RayEventContext::Instance().SetEventContext(
       rpc::Event_SourceType::Event_SourceType_RAYLET,
       std::unordered_map<std::string, std::string>(
@@ -365,10 +395,7 @@ TEST(EVENT_TEST, LOG_ROTATE) {
   EXPECT_EQ(cnt, 21);
 }
 
-TEST(EVENT_TEST, WITH_FIELD) {
-  std::string log_dir = GenerateLogDir();
-
-  EventManager::Instance().ClearReporters();
+TEST_F(EventTest, TestWithField) {
   RayEventContext::Instance().SetEventContext(
       rpc::Event_SourceType::Event_SourceType_RAYLET,
       std::unordered_map<std::string, std::string>(
@@ -401,13 +428,9 @@ TEST(EVENT_TEST, WITH_FIELD) {
   EXPECT_EQ(double_value, 0.123);
   auto bool_value = custom_fields["bool"].get<bool>();
   EXPECT_EQ(bool_value, true);
-  boost::filesystem::remove_all(log_dir.c_str());
 }
 
-TEST(EVENT_TEST, TEST_RAY_CHECK_ABORT) {
-  std::string log_dir = GenerateLogDir();
-
-  ray::EventManager::Instance().ClearReporters();
+TEST_F(EventTest, TestRayCheckAbort) {
   auto custom_fields = std::unordered_map<std::string, std::string>();
   custom_fields.emplace("node_id", "node 1");
   custom_fields.emplace("job_id", "job 1");
@@ -432,14 +455,9 @@ TEST(EVENT_TEST, TEST_RAY_CHECK_ABORT) {
               testing::HasSubstr("Check failed: 1 < 0 incorrect test case"));
   EXPECT_THAT(ele_1.message(), testing::HasSubstr("*** StackTrace Information ***"));
   EXPECT_THAT(ele_1.message(), testing::HasSubstr("ray::RayLog::~RayLog()"));
-
-  boost::filesystem::remove_all(log_dir.c_str());
 }
 
-TEST(EVENT_TEST, TEST_RAY_EVENT_INIT) {
-  std::string log_dir = GenerateLogDir();
-
-  ray::EventManager::Instance().ClearReporters();
+TEST_F(EventTest, TestRayEventInit) {
   auto custom_fields = std::unordered_map<std::string, std::string>();
   custom_fields.emplace("node_id", "node 1");
   custom_fields.emplace("job_id", "job 1");
@@ -456,13 +474,9 @@ TEST(EVENT_TEST, TEST_RAY_EVENT_INIT) {
 
   CheckEventDetail(ele_1, "job 1", "node 1", "task 1", "RAYLET", "FATAL", "label",
                    "NULL");
-
-  boost::filesystem::remove_all(log_dir.c_str());
 }
 
-TEST(EVENT_TEST, TEST_LOG_LEVEL) {
-  TestEventReporter::event_list.clear();
-  EventManager::Instance().ClearReporters();
+TEST_F(EventTest, TestLogLevel) {
   EventManager::Instance().AddReporter(std::make_shared<TestEventReporter>());
   RayEventContext::Instance().SetEventContext(
       rpc::Event_SourceType::Event_SourceType_CORE_WORKER, {});
@@ -522,13 +536,9 @@ TEST(EVENT_TEST, TEST_LOG_LEVEL) {
   result.clear();
 }
 
-TEST(EVENT_TEST, TEST_LOG_EVENT) {
-  std::string log_dir = GenerateLogDir();
+TEST_F(EventTest, TestLogEvent) {
   // Initialize log level to error
   ray::RayLog::StartRayLog("event_test", ray::RayLogLevel::ERROR, log_dir);
-
-  TestEventReporter::event_list.clear();
-  EventManager::Instance().ClearReporters();
   EventManager::Instance().AddReporter(std::make_shared<TestEventReporter>());
   RayEventContext::Instance().SetEventContext(
       rpc::Event_SourceType::Event_SourceType_CORE_WORKER, {});
@@ -585,8 +595,6 @@ TEST(EVENT_TEST, TEST_LOG_EVENT) {
   EXPECT_THAT(vc[3], testing::HasSubstr(" E "));
   EXPECT_THAT(vc[3], testing::HasSubstr("Event"));
   EXPECT_THAT(vc[3], testing::HasSubstr("test fatal 2"));
-
-  boost::filesystem::remove_all(log_dir.c_str());
 }
 
 }  // namespace ray

--- a/src/ray/util/event_test.cc
+++ b/src/ray/util/event_test.cc
@@ -225,7 +225,7 @@ TEST_F(EventTest, TestBasic) {
   CheckEventDetail(result[3], "", "", "", "GCS", "FATAL", "", "");
 }
 
-TEST_F(EventTest, TestAddCustomFields) {
+TEST_F(EventTest, TestUpdateCustomFields) {
   EventManager::Instance().AddReporter(std::make_shared<TestEventReporter>());
 
   RayEventContext::Instance().SetEventContext(
@@ -237,7 +237,7 @@ TEST_F(EventTest, TestAddCustomFields) {
 
   // Replace the value of existing key: "job_id"
   // Insert new item of key: "task_id"
-  RayEventContext::Instance().AddCustomFields(
+  RayEventContext::Instance().UpdateCustomFields(
       std::unordered_map<std::string, std::string>(
           {{"node_id", "node 1"}, {"job_id", "job 2"}, {"task_id", "task 2"}}));
   RAY_EVENT(ERROR, "label 2") << "send message 2 "
@@ -315,7 +315,7 @@ TEST_F(EventTest, TestMultiThreadContextCopy) {
   std::thread private_thread_2 = std::thread(std::bind([&]() {
     ray::RayEventContext::Instance().SetSourceType(
         rpc::Event_SourceType::Event_SourceType_RAYLET);
-    ray::RayEventContext::Instance().AddCustomField("job_id", "job 1");
+    ray::RayEventContext::Instance().UpdateCustomField("job_id", "job 1");
     RAY_EVENT(INFO, "label 2") << "send message 2";
   }));
 


### PR DESCRIPTION
## Why are these changes needed?

In some cases, we need to add custom fields in different code path. `SetCustomFields` will cover all the existing items, which leads to custom fields losing. This PR redefine `SetCustomFields` to `UpdateCustomFields `.  `UpdateCustomFields ` could keep existing items and merge new items. If the key already exists, replace the value.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
