### PR TITLE
[Release 1.11.0rc0 Cherrypick] [ci/release] Increase step timeout in long running tests, fix artifacts copy

### DIFF
--- a/release/alerts/long_running_tests.py
+++ b/release/alerts/long_running_tests.py
@@ -21,15 +21,15 @@ def handle_result(created_on: datetime.datetime, category: str,
             "object_spilling_shuffle",
     ]:
         # Core tests
-        target_update_diff = 120
+        target_update_diff = 300
 
     elif test_name in ["apex", "impala", "many_ppo", "pbt"]:
         # Tune/RLLib style tests
-        target_update_diff = 360
+        target_update_diff = 480
     elif test_name in ["serve", "serve_failure"]:
         # Serve tests have workload logs every five minutes.
-        # Leave up to 60 seconds overhead.
-        target_update_diff = 360
+        # Leave up to 180 seconds overhead.
+        target_update_diff = 480
     else:
         return None
 

--- a/release/run_e2e.sh
+++ b/release/run_e2e.sh
@@ -90,6 +90,7 @@ done
 
 RAY_TEST_REPO=${RAY_TEST_REPO-https://github.com/ray-project/ray.git}
 RAY_TEST_BRANCH=${RAY_TEST_BRANCH-master}
+RELEASE_RESULTS_DIR=${RELEASE_RESULTS_DIR-/tmp/artifacts}
 
 export RAY_REPO RAY_BRANCH RAY_VERSION RAY_WHEELS RAY_TEST_REPO RAY_TEST_BRANCH RELEASE_RESULTS_DIR
 
@@ -119,6 +120,8 @@ while [ "$RETRY_NUM" -lt "$MAX_RETRIES" ]; do
     sleep ${SLEEP_TIME}
   fi
 
+  sudo rm -rf "${RELEASE_RESULTS_DIR}"/* || true
+
   python e2e.py "$@"
   EXIT_CODE=$?
   REASON=$(reason "${EXIT_CODE}")
@@ -140,7 +143,8 @@ while [ "$RETRY_NUM" -lt "$MAX_RETRIES" ]; do
 
 done
 
-sudo cp -rf /tmp/artifacts/* /tmp/ray_release_test_artifacts || true
+sudo rm -rf /tmp/ray_release_test_artifacts/* || true
+sudo cp -rf "${RELEASE_RESULTS_DIR}"/* /tmp/ray_release_test_artifacts/ || true
 
 echo "----------------------------------------"
 echo "e2e test finished with final exit code ${EXIT_CODE} after ${RETRY_NUM}/${MAX_RETRIES} tries"


### PR DESCRIPTION
This will simplify getting results from release tests, and potentially make the release tests more stable.

```
With the new job-based file copy, fetching results takes longer. We thus have to increase the long running update test check times in order not to run into bogus release test failures.
Also fixes artifact uploading issues.
```
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
