### PR TITLE
[Bug][UT] fix python case `test_object_assign_owner` never run

### DIFF
--- a/python/ray/tests/test_object_assign_owner.py
+++ b/python/ray/tests/test_object_assign_owner.py
@@ -99,4 +99,10 @@ def test_owner_assign_when_put(ray_start_cluster, actor_resources):
     time.sleep(2)
     with pytest.raises(ray.exceptions.RayTaskError) as error:
         ray.get(borrower.get_object.remote(object_ref), timeout=2)
-    assert "ObjectLostError" in error.value.args[1]
+    assert "OwnerDiedError" in error.value.args[1]
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

We are syncing community code recently, and find bazel test never run this python test case `test_object_assign_owner`. This because I forget adding `if __name__ == '__main__'` in test file.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
