### PR TITLE
[autoscaler] Ensure inital scaleup with high upscaling_speed isn't limited.

### DIFF
--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -401,7 +401,10 @@ class ResourceDemandScheduler:
             2) Calculates the pending nodes and gets the launching nodes.
             3) Limits the total number of pending + currently-launching +
                to-be-launched nodes to:
-               max(5, self.upscaling_speed * running_nodes[node_type]).
+                   max(
+                       5,
+                       self.upscaling_speed * max(running_nodes[node_type], 1)
+                   ).
 
         Args:
             to_launch: List of number of nodes to launch based on resource
@@ -429,7 +432,7 @@ class ResourceDemandScheduler:
             # running nodes.
             max_allowed_pending_nodes = max(
                 UPSCALING_INITIAL_NUM_NODES,
-                int(self.upscaling_speed * running_nodes[node_type]))
+                int(self.upscaling_speed * max(running_nodes[node_type], 1)))
             total_pending_nodes = pending_launches_nodes.get(
                 node_type, 0) + pending_nodes[node_type]
 

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -1005,29 +1005,35 @@ def test_get_concurrent_resource_demand_to_launch_with_upscaling_speed():
     slow_scheduler = ResourceDemandScheduler(
         create_provider(), node_types, 200, head_node_type="empty_node")
 
-    to_launch = slow_scheduler._get_concurrent_resource_demand_to_launch(
-        {"m4.large": 50}, [], slow_scheduler.provider.non_terminated_nodes({}),
-        {}, {}, {})
+    to_launch = slow_scheduler._get_concurrent_resource_demand_to_launch({
+        "m4.large": 50
+    }, [], slow_scheduler.provider.non_terminated_nodes({}), {}, {}, {})
     assert to_launch == {"m4.large": 5}
 
     # Test upscaling_speed is respected
     mid_scheduler = ResourceDemandScheduler(
-        create_provider(), node_types, 200, head_node_type="empty_node",
+        create_provider(),
+        node_types,
+        200,
+        head_node_type="empty_node",
         upscaling_speed=25)
 
-    to_launch = mid_scheduler._get_concurrent_resource_demand_to_launch(
-        {"m4.large": 50}, [], mid_scheduler.provider.non_terminated_nodes({}),
-        {}, {}, {})
+    to_launch = mid_scheduler._get_concurrent_resource_demand_to_launch({
+        "m4.large": 50
+    }, [], mid_scheduler.provider.non_terminated_nodes({}), {}, {}, {})
     assert to_launch == {"m4.large": 25}
 
     # Test high upscaling_speed
     fast_scheduler = ResourceDemandScheduler(
-        create_provider(), node_types, 200, head_node_type="empty_node",
+        create_provider(),
+        node_types,
+        200,
+        head_node_type="empty_node",
         upscaling_speed=9999)
 
-    to_launch = fast_scheduler._get_concurrent_resource_demand_to_launch(
-        {"m4.large": 50}, [], fast_scheduler.provider.non_terminated_nodes({}),
-        {}, {}, {})
+    to_launch = fast_scheduler._get_concurrent_resource_demand_to_launch({
+        "m4.large": 50
+    }, [], fast_scheduler.provider.non_terminated_nodes({}), {}, {}, {})
     assert to_launch == {"m4.large": 50}
 
 


### PR DESCRIPTION
PR to fix #19785 By ensuring the initial cluster scale up to max workers is repected for high `upscaling_speed`

## Why are these changes needed?

We regularly run tasks where we know our expected resource requirements at launch, so call request_resources with the required number of cpus. The number of machines doesn't scale back down as our tasks are finishing, and just sit idle. This is costing more in aws hosting costs than necessary. Fix suggested is to not call request_resources and have a high upscaling_speed to instantly scale up to the required resources.

 ## Related issue number

Closes #19785

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.  *N/A*
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x]  Tested manually on a cluster