### PR TITLE
Move ddpg to training_iteration: Refactor replay ops

### DIFF
--- a/rllib/agents/dqn/simple_q.py
+++ b/rllib/agents/dqn/simple_q.py
@@ -204,7 +204,6 @@ class SimpleQTrainer(Trainer):
 
         return StandardMetricsReporting(train_op, workers, config)
 
-
     def training_iteration(self) -> ResultDict:
         """Runs one iteration of training."""
         # Some shortcuts.

--- a/rllib/execution/replay_ops.py
+++ b/rllib/execution/replay_ops.py
@@ -51,10 +51,10 @@ class StoreToReplayBuffer:
 
 
 @ExperimentalAPI
-def store_to_replay_buffer(local_buffer: Optional[MultiAgentReplayBuffer]
-                           = None,
-                           actors: Optional[List[ActorHandle]] = None,
-                           batch: SampleBatchType = None):
+def store_to_replay_buffer(
+        local_buffer: Optional[MultiAgentReplayBuffer] = None,
+        actors: Optional[List[ActorHandle]] = None,
+        batch: SampleBatchType = None):
     """Store a batch into the given local buffer or one of the actors randomly.
 
     Args:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Refactor replay ops to not use the ray iterator pattern. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
