### PR TITLE
Fix native Progress Bar/tqdm for Ray #9233

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1238,6 +1238,13 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
         else:
             return colorama.Fore.CYAN
 
+    def end_for(line: str) -> str:
+        if sys.platform == "win32":
+            return "\n"
+        if line.endswith("\r"):
+            return ""
+        return "\n"
+
     if data.get("pid") == "autoscaler":
         pid = "scheduler +{}".format(time_string())
         lines = filter_autoscaler_events(data.get("lines", []))
@@ -1257,6 +1264,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     line,
                 ),
                 file=print_file,
+                end=end_for(line),
             )
     else:
         for line in lines:
@@ -1271,6 +1279,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     line,
                 ),
                 file=print_file,
+                end=end_for(line),
             )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR fixes the pyramid output for the native progress bar and tqdm shown below, by avoiding adding `\n` to the end when the line is ended with `\r` for all the platform systems but Windows.

> ```
>   0%|▎                                                                                                          | 1/400 [01:37<10:48:44, 97.56s/it]
>   0%|▌                                                                                                           | 2/400 [01:38<7:35:18, 68.64s/it]
>   1%|▊                                                                                                           | 3/400 [01:39<5:20:10, 48.39s/it]
>   1%|█                                                                                                           | 4/400 [01:41<3:46:10, 34.27s/it]
>   1%|█▎                                                                                                          | 5/400 [01:42<2:40:40, 24.41s/it]
>   2%|█▌                                                                                                          | 6/400 [01:43<1:54:41, 17.47s/it]
>   2%|█▉                                                                                                          | 7/400 [01:45<1:22:43, 12.63s/it]
>   2%|██▏                                                                                                           | 8/400 [01:46<59:54,  9.17s/it]
>   2%|██▍                                                                                                           | 9/400 [01:47<44:45,  6.87s/it]
>   2%|██▋                                                                                                          | 10/400 [01:49<33:55,  5.22s/it]
>   3%|██▉                                                                                                          | 11/400 [01:50<25:45,  3.97s/it]
>   3%|███▎                                                                                                         | 12/400 [01:52<21:26,  3.31s/it]
>   3%|███▌                                                                                                         | 13/400 [01:53<17:06,  2.65s/it]
>   4%|███▊                                                                                                         | 14/400 [01:54<14:31,  2.26s/it]
>   4%|████                                                                                                         | 15/400 [01:55<12:43,  1.98s/it]
>   4%|████▎                                                                                                        | 16/400 [01:57<11:32,  1.80s/it]
>   4%|████▋                                                                                                        | 17/400 [01:58<10:14,  1.60s/it]
>   4%|████▉                                                                                                        | 18/400 [01:59<10:00,  1.57s/it]
>   5%|█████▏                                                                                                       | 19/400 [02:00<09:06,  1.43s/it]
>   5%|█████▍                                                                                                       | 20/400 [02:02<08:46,  1.38s/it]
>   5%|█████▋                                                                                                       | 21/400 [02:03<09:22,  1.48s/it]
>   6%|█████▉                                                                                                       | 22/400 [02:05<08:59,  1.43s/it]
>   6%|██████▎                                                                                                      | 23/400 [02:06<08:18,  1.32s/it]
>   6%|██████▌                                                                                                      | 24/400 [02:07<07:59,  1.27s/it]
>   6%|██████▊                                                                                                      | 25/400 [02:08<08:19,  1.33s/it]
>   6%|███████                                                                                                      | 26/400 [02:10<08:50,  1.42s/it]
>   7%|███████▎                                                                                                     | 27/400 [02:11<08:12,  1.32s/it]
>   7%|███████▋                                                                                                     | 28/400 [02:13<08:38,  1.40s/it]
>   7%|███████▉                                                                                                     | 29/400 [02:14<08:45,  1.42s/it]
>   8%|████████▏                                                                                                    | 30/400 [02:15<08:00,  1.30s/it]
>   8%|████████▍                                                                                                    | 31/400 [02:17<08:02,  1.31s/it]
> ```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #9233

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
