### PR TITLE
Replace YAPF disables with Black disables

### DIFF
--- a/doc/source/data/_examples/doc_code/quick_start.py
+++ b/doc/source/data/_examples/doc_code/quick_start.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # __data_setup_begin__
 

--- a/doc/source/ray-core/_examples/doc_code/runtime_env_example.py
+++ b/doc/source/ray-core/_examples/doc_code/runtime_env_example.py
@@ -8,7 +8,7 @@ in the documentation.
 """
 import ray
 
-# yapf: disable
+# fmt: off
 
 # __runtime_env_conda_def_start__
 runtime_env = {

--- a/doc/source/ray-core/_examples/doc_code/tf_example.py
+++ b/doc/source/ray-core/_examples/doc_code/tf_example.py
@@ -7,7 +7,7 @@ but we put comments right after code blocks to prevent large white spaces
 in the documentation.
 """
 
-# yapf: disable
+# fmt: off
 # __tf_model_start__
 
 
@@ -28,9 +28,9 @@ def create_keras_model():
         metrics=[keras.metrics.categorical_accuracy])
     return model
 # __tf_model_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __ray_start__
 import ray
 import numpy as np
@@ -65,17 +65,17 @@ class Network(object):
         # Note that for simplicity this does not handle the optimizer state.
         self.model.set_weights(weights)
 # __ray_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __actor_start__
 NetworkActor = Network.remote()
 result_object_ref = NetworkActor.train.remote()
 ray.get(result_object_ref)
 # __actor_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __weight_average_start__
 NetworkActor2 = Network.remote()
 NetworkActor2.train.remote()

--- a/doc/source/ray-core/_examples/doc_code/torch_example.py
+++ b/doc/source/ray-core/_examples/doc_code/torch_example.py
@@ -6,7 +6,7 @@ It ignores yapf because yapf doesn't allow comments right after code blocks,
 but we put comments right after code blocks to prevent large white spaces
 in the documentation.
 """
-# yapf: disable
+# fmt: off
 # __torch_model_start__
 import argparse
 
@@ -35,9 +35,9 @@ class Model(nn.Module):
 
 
 # __torch_model_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __torch_helper_start__
 from filelock import FileLock
 from torchvision import datasets, transforms
@@ -112,9 +112,9 @@ def dataset_creator(use_cuda, data_dir):
 
 
 # __torch_helper_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __torch_net_start__
 import torch.optim as optim
 
@@ -155,9 +155,9 @@ args = parser.parse_args()
 net = Network(data_dir=args.data_dir)
 net.train()
 # __torch_net_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __torch_ray_start__
 import ray
 
@@ -167,18 +167,18 @@ RemoteNetwork = ray.remote(Network)
 # Use the below instead of `ray.remote(network)` to leverage the GPU.
 # RemoteNetwork = ray.remote(num_gpus=1)(Network)
 # __torch_ray_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __torch_actor_start__
 NetworkActor = RemoteNetwork.remote()
 NetworkActor2 = RemoteNetwork.remote()
 
 ray.get([NetworkActor.train.remote(), NetworkActor2.train.remote()])
 # __torch_actor_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __weight_average_start__
 weights = ray.get(
     [NetworkActor.get_weights.remote(),

--- a/doc/source/serve/_examples/doc_code/quick_start.py
+++ b/doc/source/serve/_examples/doc_code/quick_start.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # __serve_example_begin__
 import requests

--- a/python/ray/serve/examples/doc/tutorial_batch.py
+++ b/python/ray/serve/examples/doc/tutorial_batch.py
@@ -1,4 +1,4 @@
-# yapf: disable
+# fmt: off
 # __doc_import_begin__
 from typing import List
 import time
@@ -10,7 +10,7 @@ from starlette.requests import Request
 import ray
 from ray import serve
 # __doc_import_end__
-# yapf: enable
+# fmt: on
 
 
 # __doc_define_servable_begin__

--- a/python/ray/serve/examples/doc/tutorial_pytorch.py
+++ b/python/ray/serve/examples/doc/tutorial_pytorch.py
@@ -1,4 +1,4 @@
-# yapf: disable
+# fmt: off
 import ray
 # __doc_import_begin__
 from ray import serve
@@ -11,7 +11,7 @@ import torch
 from torchvision import transforms
 from torchvision.models import resnet18
 # __doc_import_end__
-# yapf: enable
+# fmt: on
 
 
 # __doc_define_servable_begin__

--- a/python/ray/serve/examples/doc/tutorial_sklearn.py
+++ b/python/ray/serve/examples/doc/tutorial_sklearn.py
@@ -1,4 +1,4 @@
-# yapf: disable
+# fmt: off
 import ray
 # __doc_import_begin__
 from ray import serve
@@ -14,7 +14,7 @@ from sklearn.datasets import load_iris
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.metrics import mean_squared_error
 # __doc_import_end__
-# yapf: enable
+# fmt: on
 
 # __doc_train_model_begin__
 # Load data

--- a/python/ray/serve/examples/doc/tutorial_tensorflow.py
+++ b/python/ray/serve/examples/doc/tutorial_tensorflow.py
@@ -1,4 +1,4 @@
-# yapf: disable
+# fmt: off
 import ray
 # __doc_import_begin__
 from ray import serve
@@ -8,7 +8,7 @@ import tempfile
 import numpy as np
 import requests
 # __doc_import_end__
-# yapf: enable
+# fmt: on
 
 # __doc_train_model_begin__
 TRAINED_MODEL_PATH = os.path.join(tempfile.gettempdir(), "mnist_model.h5")

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -289,7 +289,7 @@ def test_add_min_workers_nodes():
     # Formatting is disabled to prevent Black from erroring while formatting
     # this file. See https://github.com/ray-project/ray/issues/21313 for more
     # information.
-    # yapf: disable
+    # fmt: off
     assert _add_min_workers_nodes([],
                                   {},
                                   types, None, None, None) == \
@@ -336,7 +336,7 @@ def test_add_min_workers_nodes():
                                   }, {
                                       "gpubla": 10
                                   })
-    # yapf: enable
+    # fmt: on
 
 
 def test_get_nodes_to_launch_with_min_workers():

--- a/python/ray/train/examples/tensorflow_quick_start.py
+++ b/python/ray/train/examples/tensorflow_quick_start.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # __tf_setup_begin__
 

--- a/python/ray/train/examples/torch_quick_start.py
+++ b/python/ray/train/examples/torch_quick_start.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # __torch_setup_begin__
 import torch

--- a/python/ray/tune/examples/cifar10_pytorch.py
+++ b/python/ray/tune/examples/cifar10_pytorch.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # __import_begin__
 from functools import partial

--- a/python/ray/tune/examples/mnist_pytorch_lightning.py
+++ b/python/ray/tune/examples/mnist_pytorch_lightning.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # __import_lightning_begin__
 import math

--- a/python/ray/tune/examples/mnist_pytorch_trainable.py
+++ b/python/ray/tune/examples/mnist_pytorch_trainable.py
@@ -28,7 +28,7 @@ parser.add_argument(
 
 
 # Below comments are for documentation purposes only.
-# yapf: disable
+# fmt: off
 # __trainable_example_begin__
 class TrainMNIST(tune.Trainable):
     def setup(self, config):
@@ -57,7 +57,7 @@ class TrainMNIST(tune.Trainable):
 
 
 # __trainable_example_end__
-# yapf: enable
+# fmt: on
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # __tutorial_imports_begin__
 import argparse

--- a/python/ray/tune/result.py
+++ b/python/ray/tune/result.py
@@ -1,6 +1,6 @@
 import os
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 # (Optional/Auto-filled) training is terminated. Filled only if not provided.
 DONE = "done"
@@ -60,7 +60,7 @@ TIME_TOTAL_S = "time_total_s"
 # (Auto-filled) The index of this training iteration.
 TRAINING_ITERATION = "training_iteration"
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 DEFAULT_EXPERIMENT_INFO_KEYS = ("trainable_name", EXPERIMENT_TAG, TRIAL_ID)
 

--- a/python/ray/tune/tests/ext_pytorch.py
+++ b/python/ray/tune/tests/ext_pytorch.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-# yapf: disable
+# fmt: off
 
 # External PyTorch tutorial (https://github.com/pytorch/tutorials/pull/1066)
 # If this script fails, fix it and submit a PR to pytorch/tutorials.

--- a/python/ray/tune/tests/tutorial.py
+++ b/python/ray/tune/tests/tutorial.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # Original Code: https://github.com/pytorch/examples/blob/master/mnist/main.py
 
-# yapf: disable
+# fmt: off
 # __tutorial_imports_begin__
 import numpy as np
 import torch
@@ -14,10 +14,10 @@ import torch.nn.functional as F
 from ray import tune
 from ray.tune.schedulers import ASHAScheduler
 # __tutorial_imports_end__
-# yapf: enable
+# fmt: on
 
 
-# yapf: disable
+# fmt: off
 # __model_def_begin__
 class ConvNet(nn.Module):
     def __init__(self):
@@ -33,9 +33,9 @@ class ConvNet(nn.Module):
         x = self.fc(x)
         return F.log_softmax(x, dim=1)
 # __model_def_end__
-# yapf: enable
+# fmt: on
 
-# yapf: disable
+# fmt: off
 # __train_def_begin__
 
 # Change these values if you want the training to run quicker or slower.
@@ -111,7 +111,7 @@ def train_mnist(config):
             # This saves the model to the trial directory
             torch.save(model.state_dict(), "./model.pth")
 # __train_func_end__
-# yapf: enable
+# fmt: on
 
 # __eval_func_begin__
 search_space = {
@@ -145,14 +145,14 @@ analysis = tune.run(
 dfs = analysis.trial_dataframes
 # __run_scheduler_end__
 
-# yapf: disable
+# fmt: off
 # __plot_scheduler_begin__
 # Plot by epoch
 ax = None  # This plots everything on the same plot
 for d in dfs.values():
     ax = d.mean_accuracy.plot(ax=ax, legend=False)
 # __plot_scheduler_end__
-# yapf: enable
+# fmt: on
 
 # __run_searchalg_begin__
 from hyperopt import hp

--- a/python/ray/util/sgd/torch/examples/raysgd_torch_signatures.py
+++ b/python/ray/util/sgd/torch/examples/raysgd_torch_signatures.py
@@ -5,7 +5,7 @@ It ignores yapf because yapf doesn't allow comments right after code blocks,
 but we put comments right after code blocks to prevent large white spaces
 in the documentation.
 """
-# yapf: disable
+# fmt: off
 
 # __torch_operator_start__
 import torch

--- a/python/ray/util/sgd/torch/examples/train_example.py
+++ b/python/ray/util/sgd/torch/examples/train_example.py
@@ -5,7 +5,7 @@ but we put comments right after code blocks to prevent large white spaces
 in the documentation.
 """
 
-# yapf: disable
+# fmt: off
 # __torch_train_example__
 import argparse
 import numpy as np

--- a/python/ray/util/sgd/torch/examples/tune_example.py
+++ b/python/ray/util/sgd/torch/examples/tune_example.py
@@ -1,4 +1,4 @@
-# yapf: disable
+# fmt: off
 """
 This file holds code for a Distributed Pytorch + Tune page in the docs.
 

--- a/python/ray/worker.pyi
+++ b/python/ray/worker.pyi
@@ -1,4 +1,4 @@
-# yapf: disable
+# fmt: off
 from typing import Any, Callable, Generic, Optional, TypeVar, Union, overload, Sequence, List
 
 from ray._raylet import ObjectRef

--- a/python/ray/workflow/api.pyi
+++ b/python/ray/workflow/api.pyi
@@ -1,4 +1,4 @@
-# yapf: disable
+# fmt: off
 from typing import Callable, Generic, Optional, TypeVar, Union, overload, Any
 from types import FunctionType
 

--- a/rllib/agents/a3c/a3c.py
+++ b/rllib/agents/a3c/a3c.py
@@ -14,7 +14,7 @@ from ray.util.iter import LocalIterator
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # Should use a critic as a baseline (otherwise don't use value baseline;
@@ -46,7 +46,7 @@ DEFAULT_CONFIG = with_common_config({
     "sample_async": True,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class A3CTrainer(Trainer):

--- a/rllib/agents/ars/ars.py
+++ b/rllib/agents/ars/ars.py
@@ -35,7 +35,7 @@ Result = namedtuple(
     ],
 )
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     "action_noise_std": 0.0,
@@ -59,7 +59,7 @@ DEFAULT_CONFIG = with_common_config({
     },
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 @ray.remote

--- a/rllib/agents/bandit/bandit.py
+++ b/rllib/agents/bandit/bandit.py
@@ -9,7 +9,7 @@ from ray.rllib.utils.typing import TrainerConfigDict
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # No remote workers by default.
@@ -26,7 +26,7 @@ DEFAULT_CONFIG = with_common_config({
     "timesteps_per_iteration": 100,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class BanditLinTSTrainer(Trainer):

--- a/rllib/agents/cql/cql.py
+++ b/rllib/agents/cql/cql.py
@@ -26,7 +26,7 @@ tf1, tf, tfv = try_import_tf()
 tfp = try_import_tfp()
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 CQL_DEFAULT_CONFIG = merge_dicts(
     SAC_CONFIG, {
@@ -55,7 +55,7 @@ CQL_DEFAULT_CONFIG = merge_dicts(
         },
     })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class CQLTrainer(SACTrainer):

--- a/rllib/agents/ddpg/ddpg.py
+++ b/rllib/agents/ddpg/ddpg.py
@@ -11,7 +11,7 @@ from ray.rllib.utils.typing import TrainerConfigDict
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # === Twin Delayed DDPG (TD3) and Soft Actor-Critic (SAC) tricks ===
@@ -175,7 +175,7 @@ DEFAULT_CONFIG = with_common_config({
     "min_time_s_per_reporting": 1,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class DDPGTrainer(SimpleQTrainer):

--- a/rllib/agents/dqn/apex.py
+++ b/rllib/agents/dqn/apex.py
@@ -47,7 +47,7 @@ from ray.tune.trainable import Trainable
 from ray.tune.utils.placement_groups import PlacementGroupFactory
 from ray.util.iter import LocalIterator
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 APEX_DEFAULT_CONFIG = merge_dicts(
     # See also the options in dqn.py, which are also supported.
@@ -92,7 +92,7 @@ APEX_DEFAULT_CONFIG = merge_dicts(
     },
 )
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 # Update worker weights as they finish generating experiences.

--- a/rllib/agents/dqn/dqn.py
+++ b/rllib/agents/dqn/dqn.py
@@ -38,7 +38,7 @@ from ray.util.iter import LocalIterator
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = Trainer.merge_trainer_configs(
     SIMPLEQ_DEFAULT_CONFIG,
@@ -106,7 +106,7 @@ DEFAULT_CONFIG = Trainer.merge_trainer_configs(
     _allow_unknown_configs=True,
 )
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 def calculate_rr_weights(config: TrainerConfigDict) -> List[float]:

--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -11,7 +11,7 @@ from ray.rllib.utils.typing import TrainerConfigDict
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
     DQN_DEFAULT_CONFIG,  # See keys in impala.py, which are also supported.
@@ -70,7 +70,7 @@ R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
     _allow_unknown_configs=True,
 )
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 # Build an R2D2 trainer, which uses the framework specific Policy

--- a/rllib/agents/dqn/simple_q.py
+++ b/rllib/agents/dqn/simple_q.py
@@ -31,7 +31,7 @@ from ray.rllib.utils.typing import TrainerConfigDict
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # === Exploration Settings ===
@@ -110,7 +110,7 @@ DEFAULT_CONFIG = with_common_config({
     "min_time_s_per_reporting": 1,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class SimpleQTrainer(Trainer):

--- a/rllib/agents/dreamer/dreamer.py
+++ b/rllib/agents/dreamer/dreamer.py
@@ -17,7 +17,7 @@ from ray.rllib.utils.typing import SampleBatchType, TrainerConfigDict
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # PlaNET Model LR
@@ -78,7 +78,7 @@ DEFAULT_CONFIG = with_common_config({
     }
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class EpisodicBuffer(object):

--- a/rllib/agents/es/es.py
+++ b/rllib/agents/es/es.py
@@ -33,7 +33,7 @@ Result = namedtuple(
     ],
 )
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     "action_noise_std": 0.01,
@@ -58,7 +58,7 @@ DEFAULT_CONFIG = with_common_config({
     },
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 @ray.remote

--- a/rllib/agents/impala/impala.py
+++ b/rllib/agents/impala/impala.py
@@ -25,7 +25,7 @@ from ray.tune.utils.placement_groups import PlacementGroupFactory
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # V-trace params (see vtrace_tf/torch.py).
@@ -127,7 +127,7 @@ DEFAULT_CONFIG = with_common_config({
     "num_data_loader_buffers": DEPRECATED_VALUE,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 def make_learner_thread(local_worker, config):

--- a/rllib/agents/maml/maml.py
+++ b/rllib/agents/maml/maml.py
@@ -27,7 +27,7 @@ from ray.util.iter import from_actors, LocalIterator
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # If true, use the Generalized Advantage Estimator (GAE)
@@ -80,7 +80,7 @@ DEFAULT_CONFIG = with_common_config({
     "vf_share_layers": DEPRECATED_VALUE,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 # @mluo: TODO

--- a/rllib/agents/marwil/bc.py
+++ b/rllib/agents/marwil/bc.py
@@ -5,7 +5,7 @@ from ray.rllib.agents.marwil.marwil import (
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import TrainerConfigDict
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 BC_DEFAULT_CONFIG = MARWILTrainer.merge_trainer_configs(
     MARWIL_CONFIG, {
@@ -19,7 +19,7 @@ BC_DEFAULT_CONFIG = MARWILTrainer.merge_trainer_configs(
         "input_evaluation": [],
     })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class BCTrainer(MARWILTrainer):

--- a/rllib/agents/marwil/marwil.py
+++ b/rllib/agents/marwil/marwil.py
@@ -14,7 +14,7 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import TrainerConfigDict
 from ray.util.iter import LocalIterator
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # === Input settings ===
@@ -73,7 +73,7 @@ DEFAULT_CONFIG = with_common_config({
     "num_workers": 0,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class MARWILTrainer(Trainer):

--- a/rllib/agents/mbmpo/mbmpo.py
+++ b/rllib/agents/mbmpo/mbmpo.py
@@ -35,7 +35,7 @@ from ray.util.iter import from_actors, LocalIterator
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 
 # Adds the following updates to the (base) `Trainer` config in
@@ -115,7 +115,7 @@ DEFAULT_CONFIG = with_common_config({
     "vf_share_layers": DEPRECATED_VALUE,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 # Select Metric Keys for MAML Stats Tracing
 METRICS_KEYS = ["episode_reward_mean", "episode_reward_min", "episode_reward_max"]

--- a/rllib/agents/pg/default_config.py
+++ b/rllib/agents/pg/default_config.py
@@ -1,6 +1,6 @@
 from ray.rllib.agents.trainer import with_common_config
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 
 # Add the following (PG-specific) updates to the (base) `Trainer` config in
@@ -20,4 +20,4 @@ DEFAULT_CONFIG = with_common_config({
 })
 
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on

--- a/rllib/agents/ppo/appo.py
+++ b/rllib/agents/ppo/appo.py
@@ -25,7 +25,7 @@ from ray.rllib.execution.common import (
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import PartialTrainerConfigDict, TrainerConfigDict
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 
 # Adds the following updates to the `IMPALATrainer` config in
@@ -85,7 +85,7 @@ DEFAULT_CONFIG = impala.ImpalaTrainer.merge_trainer_configs(
 )
 
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class UpdateTargetAndKL:

--- a/rllib/agents/ppo/ddppo.py
+++ b/rllib/agents/ppo/ddppo.py
@@ -43,7 +43,7 @@ from ray.util.iter import LocalIterator
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 
 # Adds the following updates to the `PPOTrainer` config in
@@ -93,7 +93,7 @@ DEFAULT_CONFIG = Trainer.merge_trainer_configs(
 )
 
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class DDPPOTrainer(PPOTrainer):

--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -34,7 +34,7 @@ from ray.util.iter import LocalIterator
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 
 # Adds the following updates to the (base) `Trainer` config in
@@ -101,7 +101,7 @@ DEFAULT_CONFIG = with_common_config({
 })
 
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class UpdateKL:

--- a/rllib/agents/qmix/qmix.py
+++ b/rllib/agents/qmix/qmix.py
@@ -18,7 +18,7 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import TrainerConfigDict
 from ray.util.iter import LocalIterator
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # === QMix ===
@@ -107,7 +107,7 @@ DEFAULT_CONFIG = with_common_config({
     "framework": "torch",
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class QMixTrainer(SimpleQTrainer):

--- a/rllib/agents/sac/sac.py
+++ b/rllib/agents/sac/sac.py
@@ -26,7 +26,7 @@ OPTIMIZER_SHARED_CONFIGS = [
     "learning_starts",
 ]
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 
 # Adds the following updates to the (base) `Trainer` config in
@@ -173,7 +173,7 @@ DEFAULT_CONFIG = with_common_config({
     "_use_beta_distribution": False,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 class SACTrainer(DQNTrainer):

--- a/rllib/agents/slateq/slateq.py
+++ b/rllib/agents/slateq/slateq.py
@@ -46,7 +46,7 @@ ALL_SLATEQ_STRATEGIES = [
     "QL",
 ]
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # === Model ===
@@ -135,7 +135,7 @@ DEFAULT_CONFIG = with_common_config({
     "recsim_embedding_size": 20,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 def calculate_round_robin_weights(config: TrainerConfigDict) -> List[float]:

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -115,7 +115,7 @@ logger = logging.getLogger(__name__)
 # times in a row since that would indicate a persistent cluster issue.
 MAX_WORKER_FAILURE_RETRIES = 3
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 COMMON_CONFIG: TrainerConfigDict = {
     # === Settings for Rollout Worker processes ===
@@ -646,7 +646,7 @@ COMMON_CONFIG: TrainerConfigDict = {
     "collect_metrics_timeout": DEPRECATED_VALUE,
 }
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 @DeveloperAPI

--- a/rllib/contrib/alpha_zero/core/alpha_zero_trainer.py
+++ b/rllib/contrib/alpha_zero/core/alpha_zero_trainer.py
@@ -48,7 +48,7 @@ class AlphaZeroDefaultCallbacks(DefaultCallbacks):
         episode.user_data["initial_state"] = state
 
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # Size of batches collected from each worker
@@ -121,7 +121,7 @@ DEFAULT_CONFIG = with_common_config({
 
 
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 def alpha_zero_loss(policy, model, dist_class, train_batch):

--- a/rllib/contrib/maddpg/maddpg.py
+++ b/rllib/contrib/maddpg/maddpg.py
@@ -25,7 +25,7 @@ from ray.rllib.utils.typing import TrainerConfigDict
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # === Framework to run the algorithm ===
@@ -123,7 +123,7 @@ DEFAULT_CONFIG = with_common_config({
     "min_time_s_per_reporting": 0,
 })
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 def before_learn_on_batch(multi_agent_batch, policies, train_batch_size):

--- a/rllib/contrib/random_agent/random_agent.py
+++ b/rllib/contrib/random_agent/random_agent.py
@@ -5,7 +5,7 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import TrainerConfigDict
 
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 class RandomAgent(Trainer):
     """Trainer that produces random actions and never learns."""

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -233,7 +233,7 @@ class MultiAgentEnv(gym.Env):
         # By default, do nothing.
         pass
 
-    # yapf: disable
+    # fmt: off
     # __grouping_doc_begin__
     @ExperimentalAPI
     def with_agent_groups(
@@ -279,7 +279,7 @@ class MultiAgentEnv(gym.Env):
         return GroupAgentsWrapper(self, groups, obs_space, act_space)
 
     # __grouping_doc_end__
-    # yapf: enable
+    # fmt: on
 
     @PublicAPI
     def to_base_env(

--- a/rllib/evaluation/collectors/sample_collector.py
+++ b/rllib/evaluation/collectors/sample_collector.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 class SampleCollector(metaclass=ABCMeta):
     """Collects samples for all policies and agents from a multi-agent env.

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -48,7 +48,7 @@ torch, _ = try_import_torch()
 
 logger = logging.getLogger(__name__)
 
-# yapf: disable
+# fmt: off
 # __sphinx_doc_begin__
 MODEL_DEFAULTS: ModelConfigDict = {
     # Experimental flag.
@@ -188,7 +188,7 @@ MODEL_DEFAULTS: ModelConfigDict = {
     "lstm_use_prev_action_reward": DEPRECATED_VALUE,
 }
 # __sphinx_doc_end__
-# yapf: enable
+# fmt: on
 
 
 @PublicAPI

--- a/rllib/utils/exploration/exploration.py
+++ b/rllib/utils/exploration/exploration.py
@@ -80,7 +80,7 @@ class Exploration:
         """
         pass
 
-    # yapf: disable
+    # fmt: off
     # __sphinx_doc_begin_get_exploration_action__
 
     @DeveloperAPI
@@ -112,7 +112,7 @@ class Exploration:
         pass
 
     # __sphinx_doc_end_get_exploration_action__
-    # yapf: enable
+    # fmt: on
 
     @DeveloperAPI
     def on_episode_start(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

These changes are motivated by #21318.

The only changes in this PR are replacing `# yapf: enable` with `# fmt: on`, and replacing `# yapf: disable` with `# fmt: off`.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #21318.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
