### PR TITLE
[Datasets] Add `.iter_batches()` test for batch size larger than dataset.

### DIFF
--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -48,7 +48,7 @@ class ArrowBlockBuilder(TableBlockBuilder[T]):
     def __init__(self):
         if pyarrow is None:
             raise ImportError("Run `pip install pyarrow` for Arrow support")
-        TableBlockBuilder.__init__(self, pyarrow.Table)
+        super().__init__(pyarrow.Table)
 
     def _table_from_pydict(self, columns: Dict[str, List[Any]]) -> Block:
         return pyarrow.Table.from_pydict(columns)
@@ -65,7 +65,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def __init__(self, table: "pyarrow.Table"):
         if pyarrow is None:
             raise ImportError("Run `pip install pyarrow` for Arrow support")
-        TableBlockAccessor.__init__(self, table)
+        super().__init__(table)
 
     def _create_table_row(self, row: "pyarrow.Table") -> ArrowRow:
         return ArrowRow(row)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1883,6 +1883,15 @@ def test_iter_batches_basic(ray_start_regular_shared):
     assert pd.concat(
         batches, ignore_index=True).equals(pd.concat(dfs, ignore_index=True))
 
+    # Batch size larger than dataset.
+    batch_size = 15
+    batches = list(
+        ds.iter_batches(batch_size=batch_size, batch_format="pandas"))
+    assert all(len(batch) == ds.count() for batch in batches)
+    assert len(batches) == 1
+    assert pd.concat(
+        batches, ignore_index=True).equals(pd.concat(dfs, ignore_index=True))
+
     # Batch size drop partial.
     batch_size = 5
     batches = list(


### PR DESCRIPTION
Adds an `.iter_batches()` test for batch sizes larger than the dataset.

## Drivebys

Use `super()` instead of explicit parent class reference.

## Related issues

Closes #21980 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
