### PR TITLE
[Datasets] Tie `_DesignatedBlockOwner` lifetime to context creator

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -59,8 +59,11 @@ class DatasetContext:
                     enable_pandas_block=DEFAULT_ENABLE_PANDAS_BLOCK,
                 )
 
-            if _default_context.block_owner is None:
-                owner = _DesignatedBlockOwner.options(lifetime="detached").remote()
+            if (
+                _default_context.block_splitting_enabled
+                and _default_context.block_owner is None
+            ):
+                owner = _DesignatedBlockOwner.remote()
                 ray.get(owner.ping.remote())
 
                 # Clear the actor handle after Ray reinits since it's no longer


### PR DESCRIPTION
Instead of using a detached lifetime, tie the lifetime of `_DesignatedBlockOwner` to the lifetime of the context creator. Also, only create a `_DesignatedBlockOwner` if dynamic block splitting is enabled.

## Related issue number

Closes #21999 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
