### PR TITLE
[Train] Decorate `get_device` with `PublicAPI`

### DIFF
--- a/doc/source/train/api.rst
+++ b/doc/source/train/api.rst
@@ -155,11 +155,6 @@ train.world_size
 
 .. autofunction:: ray.train.world_size
 
-train.get_device
-~~~~~~~~~~~~~~~~
-
-.. autofunction:: ray.train.get_device
-
 .. _train-api-torch-utils:
 
 PyTorch Training Function Utilities

--- a/doc/source/train/api.rst
+++ b/doc/source/train/api.rst
@@ -155,6 +155,11 @@ train.world_size
 
 .. autofunction:: ray.train.world_size
 
+train.get_device
+~~~~~~~~~~~~~~~~
+
+.. autofunction:: ray.train.get_device
+
 .. _train-api-torch-utils:
 
 PyTorch Training Function Utilities

--- a/python/ray/train/torch.py
+++ b/python/ray/train/torch.py
@@ -210,6 +210,7 @@ class _WrappedDataLoader(DataLoader):
             yield self._move_to_device(item)
 
 
+@PublicAPI(stability="beta")
 def get_device() -> torch.device:
     """Gets the correct torch device to use for training."""
     if torch.cuda.is_available():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`get_device` is part of the public API, but it isn't decorated as such.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
