### PR TITLE
[CI] deflake linter issues

### DIFF
--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1969,12 +1969,12 @@ def test_iter_batches_basic(ray_start_regular_shared):
 
     # Batch size larger than dataset.
     batch_size = 15
-    batches = list(
-        ds.iter_batches(batch_size=batch_size, batch_format="pandas"))
+    batches = list(ds.iter_batches(batch_size=batch_size, batch_format="pandas"))
     assert all(len(batch) == ds.count() for batch in batches)
     assert len(batches) == 1
-    assert pd.concat(
-        batches, ignore_index=True).equals(pd.concat(dfs, ignore_index=True))
+    assert pd.concat(batches, ignore_index=True).equals(
+        pd.concat(dfs, ignore_index=True)
+    )
 
     # Batch size drop partial.
     batch_size = 5


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

linter is[ failing on master](https://buildkite.com/ray-project/ray-builders-branch/builds/5797#08c4b36d-0a74-40a0-ad6f-0f2067ef03e8) with following errors. Address them.
```


diff --git a/python/ray/data/tests/test_dataset.py b/python/ray/data/tests/test_dataset.py
--
  | index 35d9be2c1..9e468b98f 100644
  | --- a/python/ray/data/tests/test_dataset.py
  | +++ b/python/ray/data/tests/test_dataset.py
  | @@ -1969,12 +1969,12 @@ def test_iter_batches_basic(ray_start_regular_shared):
  |  
  | # Batch size larger than dataset.
  | batch_size = 15
  | -    batches = list(
  | -        ds.iter_batches(batch_size=batch_size, batch_format="pandas"))
  | +    batches = list(ds.iter_batches(batch_size=batch_size, batch_format="pandas"))
  | assert all(len(batch) == ds.count() for batch in batches)
  | assert len(batches) == 1
  | -    assert pd.concat(
  | -        batches, ignore_index=True).equals(pd.concat(dfs, ignore_index=True))
  | +    assert pd.concat(batches, ignore_index=True).equals(
  | +        pd.concat(dfs, ignore_index=True)
  | +    )
  |  
  | # Batch size drop partial.
  | batch_size = 5
  | Reformatted changed files. Please review and stage the changes.
  | Files updated:


````


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
