### PR TITLE
[RLlib] Fix LSTM padding for torch model

### DIFF
--- a/rllib/examples/cartpole_lstm.py
+++ b/rllib/examples/cartpole_lstm.py
@@ -33,6 +33,9 @@ parser.add_argument(
 parser.add_argument(
     "--stop-reward", type=float, default=150.0, help="Reward at which we stop training."
 )
+parser.add_argument(
+    "--max-seq-len", type=int, default=20, help="Maximum length sequence for BPTT"
+)
 
 if __name__ == "__main__":
     import ray
@@ -68,6 +71,7 @@ if __name__ == "__main__":
                 "lstm_cell_size": 256,
                 "lstm_use_prev_action": args.use_prev_action,
                 "lstm_use_prev_reward": args.use_prev_reward,
+                "max_seq_len": args.max_seq_len,
             },
             "framework": args.framework,
             # Run with tracing enabled for tfe/tf2?


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The recurrent states used by the torch LSTM model include padding. This will decrease model accuracy if a sequence is less than `max_seq_len`, as the recurrent state at `seq_len` is not used -- the LSTM will see `max_seq_len - seq_len` inputs of zero-padding. See the related issue for an in-depth description.

This should fix this issue, and should potentially increase model accuracy when BPTT spans multiple batches (where the recurrent states are added to the `SampleBatch` to be used in the next training iteration).

## Related issue number
Closes https://github.com/ray-project/ray/issues/21392

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I ran `for i in {1..2}; do python rllib/examples/cartpole_lstm.py --framework torch --seq-len 19; done` without this fix (red and light blue lines) and with this fix (orange and dark blue) and obtained the following results:

<img width="343" alt="Screen Shot 2022-02-01 at 8 37 31 PM" src="https://user-images.githubusercontent.com/1743889/152047902-310000a2-40b7-4c60-a6a9-b094dcd6486a.png">
