### PR TITLE
PoolActor now uses num_cpus=0 to avoid any deadlock

### DIFF
--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -46,6 +46,7 @@ def pool_4_processes_python_multiprocessing_lib():
     pool.terminate()
     pool.join()
 
+
 @pytest.fixture
 def ray_start_1_cpu():
     address_info = ray.init(num_cpus=1)

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -565,16 +565,17 @@ def test_maxtasksperchild(shutdown_only):
 
 def test_deadlock_avoidance_in_recursive_tasks():
     def poolit_a(_):
-        with Pool(ray_address='auto') as pool:
+        with Pool(ray_address="auto") as pool:
             return list(pool.map(math.sqrt, range(0, 2, 1)))
 
     def poolit_b():
-        with Pool(ray_address='auto') as pool:
+        with Pool(ray_address="auto") as pool:
             return list(pool.map(poolit_a, range(2, 4, 1)))
 
     ray.init(num_cpus=1)
     result = poolit_b()
-    assert result == [[0., 1.], [0., 1.]]
+    assert result == [[0.0, 1.0], [0.0, 1.0]]
+
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -6,6 +6,7 @@ import time
 import random
 from collections import defaultdict
 import queue
+import math
 
 import ray
 from ray._private.test_utils import SignalActor
@@ -561,6 +562,19 @@ def test_maxtasksperchild(shutdown_only):
     pool.terminate()
     pool.join()
 
+
+def test_deadlock_avoidance_in_recursive_tasks():
+    def poolit_a(_):
+        with Pool(ray_address='auto') as pool:
+            return list(pool.map(math.sqrt, range(0, 2, 1)))
+
+    def poolit_b():
+        with Pool(ray_address='auto') as pool:
+            return list(pool.map(poolit_a, range(2, 4, 1)))
+
+    ray.init(num_cpus=1)
+    result = poolit_b()
+    assert result == [[0., 1.], [0., 1.]]
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -435,7 +435,7 @@ class UnorderedIMapIterator(IMapIterator):
         return self._ready_objects.popleft()
 
 
-@ray.remote(num_cpus=1)
+@ray.remote(num_cpus=0)
 class PoolActor:
     """Actor used to process tasks submitted to a Pool."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/issues/21488#issuecomment-1027122177 :

> We discussed this issue in a bit more detail and came to the conclusion that we should set the CPU resource requirement for each actor in the actor pool to 0, to make the Ray Pool compatible/same behavior as the Python multiprocessing pool. Would that work for you @yogeveran ? (very similar to solution 4 mentioned above, but with 0.0 instead of 0.1, so it works in all cases).

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #21488 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
