### PR TITLE
[RLlib] Issue 21991: Fix `SampleBatch` slicing for `SampleBatch.INFOS` in RNN cases

### DIFF
--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -734,6 +734,7 @@ class SimpleListCollector(SampleCollector):
                 if data_col
                 in [
                     SampleBatch.OBS,
+                    SampleBatch.INFOS,
                     SampleBatch.ENV_ID,
                     SampleBatch.EPS_ID,
                     SampleBatch.AGENT_INDEX,

--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -734,7 +734,6 @@ class SimpleListCollector(SampleCollector):
                 if data_col
                 in [
                     SampleBatch.OBS,
-                    SampleBatch.INFOS,
                     SampleBatch.ENV_ID,
                     SampleBatch.EPS_ID,
                     SampleBatch.AGENT_INDEX,

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -115,7 +115,7 @@ def pad_batch_to_sequences_of_same_size(
         elif (
             not feature_keys
             and not k.startswith("state_out_")
-            and k not in ["infos", SampleBatch.SEQ_LENS]
+            and k not in [SampleBatch.INFOS, SampleBatch.SEQ_LENS]
         ):
             feature_keys_.append(k)
 

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -936,26 +936,30 @@ class SampleBatch(dict):
             # Build our slice-map, if not done already.
             if not self._slice_map:
                 sum_ = 0
-                for i, l in enumerate(self[SampleBatch.SEQ_LENS]):
-                    for _ in range(l):
-                        self._slice_map.append((i, sum_))
-                    sum_ += l
+                for i, l in enumerate(map(int, self[SampleBatch.SEQ_LENS])):
+                    self._slice_map.extend([(i, sum_)] * l)
+                    sum_ = sum_ + l
                 # In case `stop` points to the very end (lengths of this
                 # batch), return the last sequence (the -1 here makes sure we
                 # never go beyond it; would result in an index error below).
                 self._slice_map.append((len(self[SampleBatch.SEQ_LENS]), sum_))
 
-            start_seq_len, start = self._slice_map[start]
-            stop_seq_len, stop = self._slice_map[stop]
+            start_seq_len, start_unpadded = self._slice_map[start]
+            stop_seq_len, stop_unpadded = self._slice_map[stop]
+            start_padded = start_unpadded
+            stop_padded = stop_unpadded
             if self.zero_padded:
-                start = start_seq_len * self.max_seq_len
-                stop = stop_seq_len * self.max_seq_len
+                start_padded = start_seq_len * self.max_seq_len
+                stop_padded = stop_seq_len * self.max_seq_len
 
             def map_(path, value):
                 if path[0] != SampleBatch.SEQ_LENS and not path[0].startswith(
                     "state_in_"
                 ):
-                    return value[start:stop]
+                    if path[0] != SampleBatch.INFOS:
+                        return value[start_padded:stop_padded]
+                    else:
+                        return value[start_unpadded:stop_unpadded]
                 else:
                     return value[start_seq_len:stop_seq_len]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

1. In RNN cases, the sample batch will be padded and stacked into `torch.Tensor` before feeding into method `model.forward` and `model.custom_loss`, except `INFOS` and `SEQ_LENS`:

    https://github.com/ray-project/ray/blob/b73a007ccde13d809b20252478f086b4ad997e72/rllib/policy/rnn_sequencing.py#L109-L120

    The keys `SampleBatch.INFOS`, `SampleBatch.SEQ_LENS`, and `"state_*"` will not be padded.

    Therefore key `SampleBatch.INFOS` needs to be specially treated as well during batch slicing (`batch[start:end]`).

    https://github.com/ray-project/ray/blob/9c95b9a5fae5882b6b89cd80cbc2a55b4b50c405/rllib/policy/sample_batch.py#L924-L930

2. In `SampleBatch._slice_map`:

    https://github.com/ray-project/ray/blob/9c95b9a5fae5882b6b89cd80cbc2a55b4b50c405/rllib/policy/sample_batch.py#L906-L916

    The value for key `SampleBatch.SEQ_LENS` is a tensor. And variable `l` is an integer tensor instead of a Python `int`. The instance `sum_` can be a tensor and will be reused. Because in-place operator `+=` is used.

    ![Screenshot debugger](https://user-images.githubusercontent.com/16078332/152170512-9c831baf-4a37-461c-86c5-7c3a68bdb35c.png)

    ![Screenshot watch](https://user-images.githubusercontent.com/16078332/152170550-6269a2a9-216c-4b6b-91ef-4330711be687.png)

3. See https://github.com/ray-project/ray/pull/22050#discussion_r803769472

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes #21991

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [X] Release tests
   - [ ] This PR is not tested :(
