### PR TITLE
Revert "[Nightly Test] Add more metadata to test result (#21990)"

### DIFF
--- a/release/alerts/default.py
+++ b/release/alerts/default.py
@@ -13,11 +13,6 @@ def handle_result(
     artifacts: Dict,
     last_logs: str,
     team: str,
-    commit_url: str,
-    session_url: str,
-    runtime: float,
-    stable: bool,
-    return_code: int,
 ) -> Optional[str]:
 
     if not status == "finished":

--- a/release/alerts/long_running_tests.py
+++ b/release/alerts/long_running_tests.py
@@ -13,11 +13,6 @@ def handle_result(
     artifacts: Dict,
     last_logs: str,
     team: str,
-    commit_url: str,
-    session_url: str,
-    runtime: float,
-    stable: bool,
-    return_code: int,
 ) -> Optional[str]:
     assert test_suite == "long_running_tests"
 

--- a/release/alerts/rllib_tests.py
+++ b/release/alerts/rllib_tests.py
@@ -13,11 +13,6 @@ def handle_result(
     artifacts: Dict,
     last_logs: str,
     team: str,
-    commit_url: str,
-    session_url: str,
-    runtime: float,
-    stable: bool,
-    return_code: int,
 ) -> Optional[str]:
     assert test_suite == "rllib_tests"
 

--- a/release/alerts/tune_tests.py
+++ b/release/alerts/tune_tests.py
@@ -13,11 +13,6 @@ def handle_result(
     artifacts: Dict,
     last_logs: str,
     team: str,
-    commit_url: str,
-    session_url: str,
-    runtime: float,
-    stable: bool,
-    return_code: int,
 ) -> Optional[str]:
     assert test_suite == "tune_tests"
 

--- a/release/alerts/xgboost_tests.py
+++ b/release/alerts/xgboost_tests.py
@@ -13,11 +13,6 @@ def handle_result(
     artifacts: Dict,
     last_logs: str,
     team: str,
-    commit_url: str,
-    session_url: str,
-    runtime: float,
-    stable: bool,
-    return_code: int,
 ) -> Optional[str]:
     assert test_suite == "xgboost_tests"
 

--- a/release/e2e.py
+++ b/release/e2e.py
@@ -725,11 +725,6 @@ def report_result(
     artifacts: Dict[Any, Any],
     category: str,
     team: str,
-    commit_url: str,
-    session_url: str,
-    runtime: float,
-    stable: bool,
-    return_code: int,
 ):
     #   session_url: str, commit_url: str,
     #   runtime: float, stable: bool, frequency: str, return_code: int):
@@ -1631,11 +1626,10 @@ def run_test_config(
             )
 
         # Add these metadata here to avoid changing SQL schema.
-        is_stable = test_config.get("stable", True)
         results["_runtime"] = runtime
         results["_session_url"] = session_url
         results["_commit_url"] = commit_url
-        results["_stable"] = is_stable
+        results["_stable"] = test_config.get("stable", True)
         result_queue.put(
             State(
                 "END",
@@ -1645,10 +1639,6 @@ def run_test_config(
                     "last_logs": logs,
                     "results": results,
                     "artifacts": saved_artifacts,
-                    "runtime": runtime,
-                    "session_url": session_url,
-                    "commit_url": commit_url,
-                    "stable": is_stable,
                 },
             )
         )
@@ -1966,12 +1956,11 @@ def run_test_config(
                     exit_code = ExitCode.UNKNOWN
 
                 # Add these metadata here to avoid changing SQL schema.
-                is_stable = test_config.get("stable", True)
                 results = {}
                 results["_runtime"] = runtime
                 results["_session_url"] = session_url
                 results["_commit_url"] = commit_url
-                results["_stable"] = is_stable
+                results["_stable"] = test_config.get("stable", True)
                 result_queue.put(
                     State(
                         "END",
@@ -1981,10 +1970,6 @@ def run_test_config(
                             "last_logs": logs,
                             "results": results,
                             "exit_code": exit_code.value,
-                            "runtime": runtime,
-                            "session_url": session_url,
-                            "commit_url": commit_url,
-                            "stable": is_stable,
                         },
                     )
                 )
@@ -2375,11 +2360,6 @@ def run_test(
             artifacts=result.get("artifacts", {}),
             category=category,
             team=team,
-            commit_url=result.get("commit_url", ""),
-            session_url=result.get("session_url", ""),
-            runtime=result.get("runtime", -1),
-            stable=result.get("stable", True),
-            exit_code=result.get("exit_code", ExitCode.UNKNOWN),
         )
 
         if not has_errored(result):


### PR DESCRIPTION
This reverts commit fd20cf3239d18af344c6f9cbfb150587fb0f23c1.

Looks like this PR breaks nightly tests now. https://buildkite.com/ray-project/periodic-ci/builds/2618#cdfa6335-a92e-4787-a114-c6c67215d6c7

I will create a PR again 

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
