### PR TITLE
[Dask-on-Ray] Add support for Dask annotations.

### DIFF
--- a/doc/source/data/dask-on-ray.rst
+++ b/doc/source/data/dask-on-ray.rst
@@ -144,7 +144,7 @@ annotation API <https://docs.dask.org/en/stable/api.html#dask.annotate>`__. This
 annotation context manager can be used to attach resource requests (or any other Ray task
 option) to specific Dask operations, with the annotations funneling down to the
 underlying Ray tasks. Resource requests and other Ray task options can also be specified
-globally via the ``.compute(resources={...}, ray_remote_args={...})`` API, which will
+globally via the ``.compute(ray_remote_args={...})`` API, which will
 serve as a default for all Ray tasks launched via the Dask workload. Annotations on
 individual Dask operations will override this global default.
 

--- a/doc/source/data/dask-on-ray.rst
+++ b/doc/source/data/dask-on-ray.rst
@@ -121,7 +121,7 @@ Persist
 Dask-on-Ray patches `dask.persist()
 <https://docs.dask.org/en/latest/api.html#dask.persist>`__  in order to match `Dask
 Distributed's persist semantics
-<https://distributed.dask.org/en/latest/manage-computation.html#client-persist>`; namely, calling `dask.persist()` with a Dask-on-Ray
+<https://distributed.dask.org/en/latest/manage-computation.html#client-persist>`__; namely, calling `dask.persist()` with a Dask-on-Ray
 scheduler will submit the tasks to the Ray cluster and return Ray futures inlined in the
 Dask collection. This is nice if you wish to compute some base collection (such as
 a Dask array), followed by multiple different downstream computations (such as
@@ -133,12 +133,33 @@ via shared memory.
     :language: python
 
 
+Annotations, Resources, and Task Options
+----------------------------------------
+
+.. _dask-on-ray-annotations:
+
+
+Dask-on-Ray supports specifying resources or any other Ray task option via `Dask's
+annotation API <https://docs.dask.org/en/stable/api.html#dask.annotate>`__. This
+annotation context manager can be used to attach resource requests (or any other Ray task
+option) to specific Dask operations, with the annotations funneling down to the
+underlying Ray tasks. Resource requests and other Ray task options can also be specified
+globally via the ``.compute(resources={...}, ray_remote_args={...})`` API, which will
+serve as a default for all Ray tasks launched via the Dask workload. Annotations on
+individual Dask operations will override this global default.
+
+.. literalinclude:: ../../../python/ray/util/dask/examples/dask_ray_annotate_example.py
+    :language: python
+
+Note that you may need to disable graph optimizations since it can break annotations,
+see `this Dask issue <https://github.com/dask/dask/issues/7036>`__.
+
 Custom optimization for Dask DataFrame shuffling
 ------------------------------------------------
 
 .. _dask-on-ray-shuffle-optimization:
 
-Dask on Ray provides a Dask DataFrame optimizer that leverages Ray's ability to
+Dask-on-Ray provides a Dask DataFrame optimizer that leverages Ray's ability to
 execute multiple-return tasks in order to speed up shuffling by as much as 4x on Ray.
 Simply set the `dataframe_optimize` configuration option to our optimizer function, similar to how you specify the Dask-on-Ray scheduler:
 

--- a/python/ray/util/dask/examples/dask_ray_annotate_example.py
+++ b/python/ray/util/dask/examples/dask_ray_annotate_example.py
@@ -1,0 +1,45 @@
+import ray
+from ray.util.dask import enable_dask_on_ray
+import dask
+import dask.array as da
+
+# Start Ray.
+# Tip: If connecting to an existing cluster, use ray.init(address="auto").
+ray.init()
+
+# Use our Dask config helper to set the scheduler to ray_dask_get globally,
+# without having to specify it on each compute call.
+enable_dask_on_ray()
+
+# All Ray tasks that underly the Dask operations performed in an annotation
+# context will require the indicated resources: 2 CPUs and 0.01 of the custom
+# resource.
+with dask.annotate(num_cpus=2, resources={"custom_resource": 0.01}):
+    d_arr = da.ones(100)
+
+# Operations on the same collection can have different annotations.
+with dask.annotate(resources={"other_custom_resource": 0.01}):
+    d_arr = 2 * d_arr
+
+# This happens outside of the annotation context, so no resource constraints
+# will be attached to the underlying Ray tasks for the sum() operation.
+sum_ = d_arr.sum()
+
+# Compute the result, passing in a default resource request that will be
+# applied to all operations that aren't already annotated with a resource
+# request. In this case, only the sum() operation will get this default
+# resource request.
+# We also give ray_remote_args, which will be given to every Ray task that
+# Dask-on-Ray submits; note that this can also be overridden for individual
+# Dask operations via the dask.annotate API.
+# NOTE: We disable graph optimization since it can break annotations,
+# see this issue: https://github.com/dask/dask/issues/7036.
+result = sum_.compute(
+    resources={"another_custom_resource": 0.01},
+    ray_remote_args={"max_retries": 5},
+    optimize_graph=False,
+)
+print(result)
+# 200
+
+ray.shutdown()

--- a/python/ray/util/dask/examples/dask_ray_annotate_example.py
+++ b/python/ray/util/dask/examples/dask_ray_annotate_example.py
@@ -14,11 +14,13 @@ enable_dask_on_ray()
 # All Ray tasks that underly the Dask operations performed in an annotation
 # context will require the indicated resources: 2 CPUs and 0.01 of the custom
 # resource.
-with dask.annotate(num_cpus=2, resources={"custom_resource": 0.01}):
+with dask.annotate(
+    ray_remote_args=dict(num_cpus=2, resources={"custom_resource": 0.01})
+):
     d_arr = da.ones(100)
 
 # Operations on the same collection can have different annotations.
-with dask.annotate(resources={"other_custom_resource": 0.01}):
+with dask.annotate(ray_remote_args=dict(resources={"other_custom_resource": 0.01})):
     d_arr = 2 * d_arr
 
 # This happens outside of the annotation context, so no resource constraints
@@ -35,8 +37,7 @@ sum_ = d_arr.sum()
 # NOTE: We disable graph optimization since it can break annotations,
 # see this issue: https://github.com/dask/dask/issues/7036.
 result = sum_.compute(
-    resources={"another_custom_resource": 0.01},
-    ray_remote_args={"max_retries": 5},
+    ray_remote_args=dict(max_retries=5, resources={"another_custom_resource": 0.01}),
     optimize_graph=False,
 )
 print(result)

--- a/python/ray/util/dask/examples/dask_ray_persist_example.py
+++ b/python/ray/util/dask/examples/dask_ray_persist_example.py
@@ -1,5 +1,5 @@
 import ray
-from ray.util.dask import ray_dask_get
+from ray.util.dask import enable_dask_on_ray
 import dask
 import dask.array as da
 
@@ -7,9 +7,9 @@ import dask.array as da
 # Tip: If connecting to an existing cluster, use ray.init(address="auto").
 ray.init()
 
-# Set the scheduler to ray_dask_get in your config so you don't
-# have to specify it on each compute call.
-dask.config.set(scheduler=ray_dask_get)
+# Use our Dask config helper to set the scheduler to ray_dask_get globally,
+# without having to specify it on each compute call.
+enable_dask_on_ray()
 
 d_arr = da.ones(100)
 print(dask.base.collections_to_dsk([d_arr]))

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -21,6 +21,13 @@ default_pool = None
 pools = defaultdict(dict)
 pools_lock = threading.Lock()
 
+DASK_TO_RAY_RESOURCES = [
+    ("CPU", "num_cpus"),
+    ("GPU", "num_gpus"),
+    ("memory", "memory"),
+    ("object_store_memory", "object_store_memory"),
+]
+
 
 def enable_dask_on_ray(
     shuffle: Optional[str] = "tasks",
@@ -135,6 +142,18 @@ def ray_dask_get(dsk, keys, **kwargs):
     persist = kwargs.pop("ray_persist", False)
     enable_progress_bar = kwargs.pop("_ray_enable_progress_bar", None)
 
+    # Handle Ray remote args and resource annotations.
+    ray_remote_args = kwargs.pop("ray_remote_args", {})
+    resources = kwargs.pop("resources", ray_remote_args.pop("resources", {}))
+    try:
+        annotations = dask.config.get("annotations")
+    except KeyError:
+        annotations = {}
+
+    scoped_ray_remote_args = _build_key_scoped_ray_remote_args(
+        dsk, annotations, resources, ray_remote_args
+    )
+
     with local_ray_callbacks(ray_callbacks) as ray_callbacks:
         # Unpack the Ray-specific callbacks.
         (
@@ -155,6 +174,7 @@ def ray_dask_get(dsk, keys, **kwargs):
                 ray_postsubmit_cbs,
                 ray_pretask_cbs,
                 ray_posttask_cbs,
+                scoped_ray_remote_args,
             ),
             len(pool._pool),
             dsk,
@@ -235,6 +255,7 @@ def _rayify_task_wrapper(
     ray_postsubmit_cbs,
     ray_pretask_cbs,
     ray_posttask_cbs,
+    scoped_ray_remote_args,
 ):
     """
     The core Ray-Dask task execution wrapper, to be given to the thread pool's
@@ -253,6 +274,7 @@ def _rayify_task_wrapper(
         ray_postsubmit_cbs (callable): Post-task submission callbacks.
         ray_pretask_cbs (callable): Pre-task execution callbacks.
         ray_posttask_cbs (callable): Post-task execution callbacks.
+        scoped_ray_remote_args (dict): Ray task options for each key.
 
     Returns:
         A 3-tuple of the task's key, a literal or a Ray object reference for a
@@ -268,6 +290,7 @@ def _rayify_task_wrapper(
             ray_postsubmit_cbs,
             ray_pretask_cbs,
             ray_posttask_cbs,
+            scoped_ray_remote_args.get(key, {}),
         )
         id = get_id()
         result = dumps((result, id))
@@ -286,6 +309,7 @@ def _rayify_task(
     ray_postsubmit_cbs,
     ray_pretask_cbs,
     ray_posttask_cbs,
+    ray_remote_args,
 ):
     """
     Rayifies the given task, submitting it as a Ray task to the Ray cluster.
@@ -299,6 +323,7 @@ def _rayify_task(
         ray_postsubmit_cbs (callable): Post-task submission callbacks.
         ray_pretask_cbs (callable): Pre-task execution callbacks.
         ray_posttask_cbs (callable): Post-task execution callbacks.
+        ray_remote_args (dict): Ray task options.
 
     Returns:
         A literal, a Ray object reference representing a submitted task, or a
@@ -316,6 +341,7 @@ def _rayify_task(
                 ray_postsubmit_cbs,
                 ray_pretask_cbs,
                 ray_posttask_cbs,
+                ray_remote_args,
             )
             for t in task
         ]
@@ -345,6 +371,7 @@ def _rayify_task(
             num_returns=(
                 1 if not isinstance(func, MultipleReturnFunc) else func.num_returns
             ),
+            **ray_remote_args,
         ).remote(
             func,
             repack,
@@ -566,3 +593,52 @@ class MultipleReturnFunc:
 
 def multiple_return_get(multiple_returns, idx):
     return multiple_returns[idx]
+
+
+def _build_key_scoped_ray_remote_args(dsk, annotations, resources, ray_remote_args):
+    # Handle per-layer annotations.
+    if not isinstance(dsk, dask.highlevelgraph.HighLevelGraph):
+        dsk = dask.highlevelgraph.HighLevelGraph.from_collections(
+            id(dsk), dsk, dependencies=()
+        )
+    # Build key-scoped annotations.
+    scoped_annotations = {}
+    layers = [(name, dsk.layers[name]) for name in dsk._toposort_layers()]
+    for id_, layer in layers:
+        layer_annotations = layer.annotations
+        if layer_annotations is None:
+            layer_annotations = annotations
+        for key in layer.get_output_keys():
+            layer_annotations_for_key = annotations.copy()
+            # Layer annotations override global annotations.
+            layer_annotations_for_key.update(layer_annotations)
+            # Let same-key annotations earlier in the topological sort take precedence.
+            layer_annotations_for_key.update(scoped_annotations.get(key, {}))
+            scoped_annotations[key] = layer_annotations_for_key
+    # Build key-scoped Ray remote args.
+    scoped_ray_remote_args = {}
+    for key, annotations in scoped_annotations.items():
+        # Layer resources override global resources given in the compute call.
+        # The override is a full overwrite, with no merging.
+        try:
+            layer_resources = annotations["resources"]
+        except KeyError:
+            layer_resources = resources
+        layer_ray_remote_args = ray_remote_args.copy()
+        # Layer Ray remote args overriide global Ray remote args given in the compute
+        # call.
+        layer_ray_remote_args.update(annotations.get("ray_remote_args", {}))
+        # Map Dask resources to the equivalent top-level Ray resources.
+        for dask_resource, ray_resource in DASK_TO_RAY_RESOURCES:
+            try:
+                layer_ray_remote_args[ray_resource] = layer_resources.pop(dask_resource)
+            except KeyError:
+                pass
+            # Support special Ray resources as top-level annotations.
+            try:
+                layer_ray_remote_args[ray_resource] = annotations[ray_resource]
+            except KeyError:
+                pass
+        layer_ray_remote_args["resources"] = layer_resources
+        scoped_ray_remote_args[key] = layer_ray_remote_args
+    return scoped_ray_remote_args


### PR DESCRIPTION
This PR adds support for Dask annotations, allowing users to specify Ray-level resource requests (or any other Ray task options) for both individual Dask operations, using the `dask.annotate` API, or for the Dask workload as a whole by passing in `.compute(resources={...}, ray_remote_args={...})` at compute time.

See https://github.com/ray-project/ray/issues/21536 for more details on this feature.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #21536 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
