### PR TITLE
[Datasets] [Docs] Datasets library branding + positioning tweaks

### DIFF
--- a/doc/source/data/dataset-ml-preprocessing.rst
+++ b/doc/source/data/dataset-ml-preprocessing.rst
@@ -4,10 +4,10 @@
 Loading and Processing ML Data
 ==============================
 
-Datasets in Ray Data are designed to load and preprocess data for distributed :ref:`ML training pipelines <train-docs>`.
+Ray Datasets are designed to load and preprocess data for distributed :ref:`ML training pipelines <train-docs>`.
 Compared to other loading solutions, Datasets are more flexible (e.g., can express higher-quality `per-epoch global shuffles <examples/big_data_ingestion.html>`__) and provides `higher overall performance <https://www.anyscale.com/blog/why-third-generation-ml-platforms-are-more-performant>`__.
 
-Ray Data is not intended as a replacement for more general data processing systems.
+Datasets is not intended as a replacement for more general data processing systems.
 Its utility is as the last-mile bridge from ETL pipeline outputs to distributed applications and libraries in Ray:
 
 .. image:: images/dataset-loading-1.png
@@ -17,16 +17,16 @@ Its utility is as the last-mile bridge from ETL pipeline outputs to distributed 
 ..
   https://docs.google.com/presentation/d/1l03C1-4jsujvEFZUM4JVNy8Ju8jnY5Lc_3q7MBWi2PQ/edit
 
-Ray-integrated DataFrame libraries can also be seamlessly used with Ray Data, to enable running a full data to
+Ray-integrated DataFrame libraries can also be seamlessly used with Datasets, to enable running a full data to
 ML pipeline completely within Ray without requiring data to be materialized to external storage:
 
 .. image:: images/dataset-loading-2.png
    :width: 650px
    :align: center
 
-See the :ref:`ML preprocessing docs <datasets-ml-preprocessing>` for information on how to use Ray Data as the
+See the :ref:`ML preprocessing docs <datasets-ml-preprocessing>` for information on how to use Datasets as the
 last-mile bridge to model training and inference, and see :ref:`the Talks section <data-talks>` for more
-Ray Data ML use cases and benchmarks.
+Datasets ML use cases and benchmarks.
 
 
 --------------------

--- a/doc/source/data/dataset-ml-preprocessing.rst
+++ b/doc/source/data/dataset-ml-preprocessing.rst
@@ -1,8 +1,8 @@
 .. _datasets-ml-preprocessing:
 
-==============================
-Loading and Processing ML Data
-==============================
+==============================================
+Data Loading and Preprocessing for ML Training
+==============================================
 
 Ray Datasets are designed to load and preprocess data for distributed :ref:`ML training pipelines <train-docs>`.
 Compared to other loading solutions, Datasets are more flexible (e.g., can express higher-quality `per-epoch global shuffles <examples/big_data_ingestion.html>`__) and provides `higher overall performance <https://www.anyscale.com/blog/why-third-generation-ml-platforms-are-more-performant>`__.
@@ -29,9 +29,9 @@ last-mile bridge to model training and inference, and see :ref:`the Talks sectio
 Datasets ML use cases and benchmarks.
 
 
---------------------
-Preprocessing for ML
---------------------
+-----------------------
+Last-mile Preprocessing
+-----------------------
 
 Datasets supports data preprocessing transformations commonly performed just before model training and model inference, which we refer to as **last-mile preprocessing**. These transformations are carried out via a few key operations: mapping, groupbys + aggregations, and random shuffling.
 

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -2,22 +2,22 @@
 
 .. note::
 
-    Before you proceed, note that Ray Data is available as **beta** in Ray 1.8+.
+    Before you proceed, note that Ray Datasets is available as **beta** in Ray 1.8+.
     Please file feature requests and bug reports on GitHub Issues or join the discussion
     on the `Ray Slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`__.
 
 ==============================================
-Ray Data: Distributed Data Loading and Compute
+Ray Datasets: Distributed Data Loading and Compute
 ==============================================
 
-Ray Data is a library for loading and processing large datasets.
+Ray Datasets is a library for loading and processing large datasets.
 Its key abstraction is that of a Dataset.
 Datasets are the standard way to load and exchange data in Ray libraries and applications.
 They provide basic distributed data transformations such as ``map``, ``filter``, and ``repartition``,
 and are compatible with a variety of file formats, data sources, and distributed frameworks.
 
 Here's an overview of the integrations with other processing frameworks, file formats, and supported operations,
-as well as glimpse at the Ray Data API.
+as well as glimpse at the Ray Datasets API.
 Check our :ref:`compatibility matrix<data-compatibility>` to see if your favorite format is supported already.
 
 .. image:: images/dataset.svg
@@ -25,7 +25,7 @@ Check our :ref:`compatibility matrix<data-compatibility>` to see if your favorit
 ..
   https://docs.google.com/drawings/d/16AwJeBNR46_TsrkOmMbGaBK7u-OPsf_V8fHjU-d2PPQ/edit
 
-Ray Data simplifies general purpose parallel GPU and CPU compute in Ray,
+Ray Datasets simplifies general purpose parallel GPU and CPU compute in Ray,
 for instance for `GPU batch inference <dataset.html#transforming-datasets>`__).
 It provides a higher level API for Ray tasks and actors in such embarrassingly parallel compute situations,
 internally handling operations like batching, pipelining, and memory management.
@@ -34,16 +34,16 @@ internally handling operations like batching, pipelining, and memory management.
    :width: 500px
    :align: center
 
-As part of the Ray ecosystem, Ray Data can leverage the full functionality of Ray's distributed scheduler,
+As part of the Ray ecosystem, Ray Datasets can leverage the full functionality of Ray's distributed scheduler,
 e.g., using actors for optimizing setup time and GPU scheduling.
 
 ----------------------
 Where to Go from Here?
 ----------------------
 
-As new user of Ray Data, you may want to start with our :ref:`Getting Started Guide<data_getting_started>`.
-If you've run your first examples already, you might want to dive into Ray Data's key concepts or our User Guide instead.
-Advanced users can utilize the Ray Data API reference for their projects.
+As new user of Ray Datasets, you may want to start with our :ref:`Getting Started Guide<data_getting_started>`.
+If you've run your first examples already, you might want to dive into Ray Datasets' key concepts or our User Guide instead.
+Advanced users can utilize the Ray Datasets API reference for their projects.
 
 .. panels::
     :container: text-center
@@ -55,21 +55,21 @@ Advanced users can utilize the Ray Data API reference for their projects.
 
     Start with our quick start tutorials for :ref:`working with Datasets<ray_data_quick_start>`
     and :ref:`Dataset Pipelines<data_pipelines_quick_start>`.
-    These concrete examples will give you an idea of how to use Ray Data.
+    These concrete examples will give you an idea of how to use Ray Datasets.
 
     +++
-    .. link-button:: data_getting_started
+    .. link-button:: datasets_getting_started
         :type: ref
-        :text: Get Started with Ray Data
+        :text: Get Started with Ray Datasets
         :classes: btn-outline-info btn-block
     ---
 
     Key Concepts
     ^^^
 
-    Understand the key concepts behind Ray Data.
+    Understand the key concepts behind Ray Datasets.
     Learn what :ref:`Datasets<dataset_concept>` and :ref:`Dataset Pipelines<dataset_pipeline_concept>` are
-    and :ref:`how they get executed<dataset_execution_concept>` in Ray Data.
+    and :ref:`how they get executed<dataset_execution_concept>` in Ray Datasets.
 
     +++
     .. link-button:: data_key_concepts
@@ -84,19 +84,19 @@ Advanced users can utilize the Ray Data API reference for their projects.
     Learn how to :ref:`load and process data for ML<datasets-ml-preprocessing>`,
     work with :ref:`tensor data<datasets_tensor_support>`, or :ref:`use pipelines<data_pipeline_usage>`.
     Run your first :ref:`Dask <dask-on-ray>`, :ref:`Spark <spark-on-ray>`, :ref:`Mars <mars-on-ray>`
-    and :ref:`Modin <modin-on-ray>` examples on Ray Data.
+    and :ref:`Modin <modin-on-ray>` examples on Ray Datasets.
 
     +++
     .. link-button:: data_user_guide
         :type: ref
-        :text: Start Using Ray Data
+        :text: Start Using Ray Datasets
         :classes: btn-outline-info btn-block
     ---
 
     API
     ^^^
 
-    Get more in-depth information about the Ray Data API.
+    Get more in-depth information about the Ray Datasets API.
 
     +++
     .. link-button:: data_api
@@ -111,7 +111,7 @@ Advanced users can utilize the Ray Data API reference for their projects.
 Datasource Compatibility
 ------------------------
 
-Ray Data supports reading and writing many formats.
+Ray Datasets supports reading and writing many formats.
 The following two compatibility matrices will help you understand which formats are currently available.
 
 Supported Input Formats
@@ -245,7 +245,7 @@ Learn More
 Contribute
 ----------
 
-Contributions to Ray Data are `welcome <https://docs.ray.io/en/master/development.html#python-develop>`__!
+Contributions to Ray Datasets are `welcome <https://docs.ray.io/en/master/development.html#python-develop>`__!
 There are many potential improvements, including:
 
 - Supporting more data sources and transforms.

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -6,13 +6,11 @@
     Please file feature requests and bug reports on GitHub Issues or join the discussion
     on the `Ray Slack <https://forms.gle/9TSdDYUgxYs8SA9e8>`__.
 
-==============================================
+==================================================
 Ray Datasets: Distributed Data Loading and Compute
-==============================================
+==================================================
 
-Ray Datasets is a library for loading and processing large datasets.
-Its key abstraction is that of a Dataset.
-Datasets are the standard way to load and exchange data in Ray libraries and applications.
+Ray Datasets are the standard way to load and exchange data in Ray libraries and applications.
 They provide basic distributed data transformations such as ``map``, ``filter``, and ``repartition``,
 and are compatible with a variety of file formats, data sources, and distributed frameworks.
 
@@ -25,8 +23,7 @@ Check our :ref:`compatibility matrix<data-compatibility>` to see if your favorit
 ..
   https://docs.google.com/drawings/d/16AwJeBNR46_TsrkOmMbGaBK7u-OPsf_V8fHjU-d2PPQ/edit
 
-Ray Datasets simplifies general purpose parallel GPU and CPU compute in Ray,
-for instance for `GPU batch inference <dataset.html#transforming-datasets>`__).
+Ray Datasets simplifies general purpose parallel GPU and CPU compute in Ray; for instance, for `GPU batch inference <dataset.html#transforming-datasets>`__.
 It provides a higher level API for Ray tasks and actors in such embarrassingly parallel compute situations,
 internally handling operations like batching, pipelining, and memory management.
 
@@ -36,6 +33,16 @@ internally handling operations like batching, pipelining, and memory management.
 
 As part of the Ray ecosystem, Ray Datasets can leverage the full functionality of Ray's distributed scheduler,
 e.g., using actors for optimizing setup time and GPU scheduling.
+
+----------------------------------------------
+Data Loading and Preprocessing for ML Training
+----------------------------------------------
+
+Ray Datasets are designed to load and preprocess data for distributed :ref:`ML training pipelines <train-docs>`.
+Compared to other loading solutions, Datasets are more flexible (e.g., can express higher-quality `per-epoch global shuffles <examples/big_data_ingestion.html>`__) and provides `higher overall performance <https://www.anyscale.com/blog/why-third-generation-ml-platforms-are-more-performant>`__.
+
+Ray Datasets is not intended as a replacement for more general data processing systems.
+:ref:`Learn more about how Ray Datasets works with other ETL systems <datasets-ml-preprocessing>`.
 
 ----------------------
 Where to Go from Here?

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -48,7 +48,7 @@ Ray Datasets is not intended as a replacement for more general data processing s
 Where to Go from Here?
 ----------------------
 
-As new user of Ray Datasets, you may want to start with our :ref:`Getting Started Guide<data_getting_started>`.
+As new user of Ray Datasets, you may want to start with our :ref:`Getting Started Guide<datasets_getting_started>`.
 If you've run your first examples already, you might want to dive into Ray Datasets' key concepts or our User Guide instead.
 Advanced users can utilize the Ray Datasets API reference for their projects.
 
@@ -60,8 +60,8 @@ Advanced users can utilize the Ray Datasets API reference for their projects.
     Getting Started
     ^^^
 
-    Start with our quick start tutorials for :ref:`working with Datasets<ray_data_quick_start>`
-    and :ref:`Dataset Pipelines<data_pipelines_quick_start>`.
+    Start with our quick start tutorials for :ref:`working with Datasets<ray_datasets_quick_start>`
+    and :ref:`Dataset Pipelines<dataset_pipelines_quick_start>`.
     These concrete examples will give you an idea of how to use Ray Datasets.
 
     +++

--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -1,8 +1,8 @@
 .. _datasets_getting_started:
 
-=============================
+=================================
 Getting Started with Ray Datasets
-=============================
+=================================
 
 In this tutorial you will learn how to:
 
@@ -12,9 +12,9 @@ In this tutorial you will learn how to:
 
 .. _ray_datasets_quick_start:
 
---------------------
+-------------------
 Dataset Quick Start
---------------------
+-------------------
 
 Ray Datasets implements `Distributed Arrow <https://arrow.apache.org/>`__.
 A Dataset consists of a list of Ray object references to *blocks*.
@@ -230,7 +230,7 @@ This is a common pattern useful for loading and splitting data between distribut
     # -> [650, 650, ...]
 
 
-.. _data_pipelines_quick_start:
+.. _dataset_pipelines_quick_start:
 
 -----------------------------
 Dataset Pipelines Quick Start

--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -1,7 +1,7 @@
-.. _data_getting_started:
+.. _datasets_getting_started:
 
 =============================
-Getting Started with Ray Data
+Getting Started with Ray Datasets
 =============================
 
 In this tutorial you will learn how to:
@@ -10,13 +10,13 @@ In this tutorial you will learn how to:
 - How to transform a ``Dataset`` and pass it into other Ray Tasks.
 - How to create a Ray ``DatasetPipeline`` and run transformations on it.
 
-.. _ray_data_quick_start:
+.. _ray_datasets_quick_start:
 
 --------------------
 Dataset Quick Start
 --------------------
 
-Ray Data implements `Distributed Arrow <https://arrow.apache.org/>`__.
+Ray Datasets implements `Distributed Arrow <https://arrow.apache.org/>`__.
 A Dataset consists of a list of Ray object references to *blocks*.
 Each block holds a set of items in either an `Arrow table <https://arrow.apache.org/docs/python/data.html#tables>`__
 or a Python list (for Arrow incompatible objects).

--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -239,7 +239,7 @@ Dataset Pipelines Quick Start
 Creating a DatasetPipeline
 ==========================
 
-A DatasetPipeline can be constructed in two ways: either by pipelining the execution of an existing Dataset (via ``Dataset.window``), or generating repeats of an existing Dataset (via ``Dataset.repeat``). Similar to Datasets, you can freely pass DatasetPipelines between Ray tasks, actors, and libraries. Get started with this synthetic data example:
+A `DatasetPipeline <package-ref.html#datasetpipeline-api>`__ can be constructed in two ways: either by pipelining the execution of an existing Dataset (via ``Dataset.window``), or generating repeats of an existing Dataset (via ``Dataset.repeat``). Similar to Datasets, you can freely pass DatasetPipelines between Ray tasks, actors, and libraries. Get started with this synthetic data example:
 
 .. code-block:: python
 

--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -44,7 +44,7 @@ Dataset Pipelines
 -----------------
 
 
-Datasets execute their transformations synchronously in blocking calls. However, it can be useful to overlap dataset computations with output. This can be done with a `DatasetPipeline <package-ref.html#datasetpipeline-api>`__.
+Datasets execute their transformations synchronously in blocking calls. However, it can be useful to overlap dataset computations with output. This can be done with a `DatasetPipeline <data-pipelines-quick-start>`__.
 
 A DatasetPipeline is an unified iterator over a (potentially infinite) sequence of Ray Datasets, each of which represents a *window* over the original data. Conceptually it is similar to a `Spark DStream <https://spark.apache.org/docs/latest/streaming-programming-guide.html#discretized-streams-dstreams>`__, but manages execution over a bounded amount of source data instead of an unbounded stream. Ray computes each dataset window on-demand and stitches their output together into a single logical data iterator. DatasetPipeline implements most of the same transformation and output methods as Datasets (e.g., map, filter, split, iter_rows, to_torch, etc.).
 

--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -4,8 +4,8 @@
 Key Concepts
 ============
 
-To work with Ray Data, you need to understand how Datasets and Dataset Pipelines work.
-You might also be interested to learn about the execution model of Ray Data operations
+To work with Ray Datasets, you need to understand how Datasets and Dataset Pipelines work.
+You might also be interested to learn about the execution model of Ray Datasets operations
 
 
 .. _dataset_concept:
@@ -14,7 +14,7 @@ You might also be interested to learn about the execution model of Ray Data oper
 Datasets
 --------
 
-Ray Data implements `Distributed Arrow <https://arrow.apache.org/>`__.
+Ray Datasets implements `Distributed Arrow <https://arrow.apache.org/>`__.
 A Dataset consists of a list of Ray object references to *blocks*.
 Each block holds a set of items in either an `Arrow table <https://arrow.apache.org/docs/python/data.html#tables>`__
 or a Python list (for Arrow incompatible objects).
@@ -28,12 +28,12 @@ The following figure visualizes a Dataset that has three Arrow table blocks, eac
 ..
   https://docs.google.com/drawings/d/1PmbDvHRfVthme9XD7EYM-LIHPXtHdOfjCbc1SCsM64k/edit
 
-Since a Ray Dataset is just a list of Ray object references, it can be freely passed between Ray tasks,
+Since a Dataset is just a list of Ray object references, it can be freely passed between Ray tasks,
 actors, and libraries like any other object reference.
-This flexibility is a unique characteristic of Ray Data.
+This flexibility is a unique characteristic of Ray Datasets.
 
 Compared to `Spark RDDs <https://spark.apache.org/docs/latest/rdd-programming-guide.html>`__
-and `Dask Bags <https://docs.dask.org/en/latest/bag.html>`__, Ray Data offers a more basic set of features,
+and `Dask Bags <https://docs.dask.org/en/latest/bag.html>`__, Ray Datasets offers a more basic set of features,
 and executes operations eagerly for simplicity.
 It is intended that users cast Datasets into more feature-rich dataframe types (e.g., ``ds.to_dask()``) for advanced operations.
 

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -1,6 +1,6 @@
 .. _data_api:
 
-Ray Data API
+Ray Datasets API
 ============
 
 Creating Datasets

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -1,7 +1,7 @@
 .. _data_api:
 
 Ray Datasets API
-============
+================
 
 Creating Datasets
 -----------------

--- a/doc/source/data/user-guide.rst
+++ b/doc/source/data/user-guide.rst
@@ -4,15 +4,15 @@
 User Guides
 ===========
 
-If you’re new to Ray Data, we recommend starting with the :ref:`Ray Data Quick Start <ray_data_quick_start>`.
-This user guide will help you navigate the Ray Data project and show you how achieve several tasks, for instance
+If you’re new to Ray Datasets, we recommend starting with the :ref:`Ray Datasets Quick Start <ray_datasets_quick_start>`.
+This user guide will help you navigate the Ray Datasets project and show you how achieve several tasks, for instance
 you will learn
 
 - how to load data and preprocess it for machine learning applications,
-- how to use Tensors with Ray Data,
+- how to use Tensors with Ray Datasets,
 - how to run Dataset Pipelines in common scenarios,
-- how to run Dask, Spark, Mars or Modin on Ray Data,
-- and how to tune your Ray Data applications for performance.
+- how to run Dask, Spark, Mars or Modin on Ray,
+- and how to tune your Ray Datasets applications for performance.
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
This PR restores the "Ray Datasets" library branding and makes a few tweaks around last-mile preprocessing positioning. Larger changes, such as:
1. Changing the landing page to give an overview of Ray's data ecosystem.
2. Create dedicated user guide pages for creating/saving datasets (I/O), transforming datasets, exchanging datasets with other frameworks, and pipelining operations.
3. Trim "Getting Started" down to a linear flow.
4. Change hierarchy to `Ray Data --> {Datasets, Third Party Integrations --> {Dask-on-Ray, Modin, etc.}}`.

will take place in a future PR.
