### PR TITLE
[RLlib] Discussion 2022: Fix batch_mode="complete_episodes" documentation inaccuracy.

### DIFF
--- a/doc/source/rllib/rllib-sample-collection.rst
+++ b/doc/source/rllib/rllib-sample-collection.rst
@@ -37,10 +37,12 @@ are determined by the following Trainer config keys:
      It does not matter, whether one or more episodes end within this rollout or whether
      the rollout starts in the middle of an already ongoing episode.
     *complete_episodes*:
-     Each rollout is exactly one episode long and always starts
-     at the beginning of an episode. It does not matter how long an episode lasts.
-     The ``rollout_fragment_length`` setting will be ignored. Note that you have to be
-     careful when chosing ``complete_episodes`` as batch_mode: If your environment does not
+     Each rollout always only contains completed episodes (at least one, but possibly more) and always starts
+     at the beginning of an episode. The ``rollout_fragment_length`` setting defines the minimum number of
+     timesteps that will be covered in the rollout. For example, if ``rollout_fragment_length=100`` and your episodes
+     are always 98 timesteps long, all rollouts will happen over two complete episodes
+     (98 < 100 -> too short; 98+98 >= 100 -> good).
+     Note that you have to be careful when chosing ``complete_episodes`` as batch_mode: If your environment does not
      terminate easily, this setting could lead to enormous batch sizes.
 
 **rollout_fragment_length [int]**:

--- a/doc/source/rllib/rllib-sample-collection.rst
+++ b/doc/source/rllib/rllib-sample-collection.rst
@@ -37,12 +37,11 @@ are determined by the following Trainer config keys:
      It does not matter, whether one or more episodes end within this rollout or whether
      the rollout starts in the middle of an already ongoing episode.
     *complete_episodes*:
-     Each rollout always only contains completed episodes (at least one, but possibly more) and always starts
-     at the beginning of an episode. The ``rollout_fragment_length`` setting defines the minimum number of
-     timesteps that will be covered in the rollout. For example, if ``rollout_fragment_length=100`` and your episodes
-     are always 98 timesteps long, all rollouts will happen over two complete episodes
-     (98 < 100 -> too short; 98+98 >= 100 -> good).
-     Note that you have to be careful when chosing ``complete_episodes`` as batch_mode: If your environment does not
+     Each rollout always only contains **full** episodes (from beginning to terminal), never any episode fragments. The number of episodes in the rollout is 1 or larger.
+     The ``rollout_fragment_length`` setting defines the minimum number of
+     timesteps that will be covered in the rollout.
+     For example, if ``rollout_fragment_length=100`` and your episodes are always 98 timesteps long, then rollouts will happen over two complete episodes and always be 196 timesteps long: 98 < 100 -> too short, keep rollout going; 98+98 >= 100 -> good, stop rollout after 2 episodes (196 timesteps).
+     Note that you have to be careful when choosing ``complete_episodes`` as batch_mode: If your environment does not
      terminate easily, this setting could lead to enormous batch sizes.
 
 **rollout_fragment_length [int]**:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix batch_mode="complete_episodes" documentation inaccuracy.

See also this discussion here:
https://discuss.ray.io/t/rllib-batch-size-for-complete-episodes-issue/2022/4

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
