### PR TITLE
Revert "[e2e] Remove unnecessary logic around copying results (#22034)"

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -2207,22 +2207,23 @@ def run_test_config(
 
         out_dir = os.path.expanduser(GLOBAL_CONFIG["RELEASE_RESULTS_DIR"])
 
-        logger.info(f"Moving results dir {temp_dir} to persistent location {out_dir}")
+        logger.info(
+            f"Moving results dir {temp_dir} to persistent location " f"{out_dir}"
+        )
 
         try:
-            # out_dir is cleared in run_e2e.sh, but it may exist when running
-            # e2e.py directly.
-            if os.path.exists(out_dir):
-                shutil.rmtree(out_dir)
-                logger.info(f"Destination {out_dir} is cleared")
+            shutil.rmtree(out_dir)
         except Exception:
-            logger.info(
-                f"Ran into error when clearing the destination: {out_dir}",
-                exc_info=True,
+            logger.exception(
+                f"Ran into error when clearing the destination dir: {out_dir}"
             )
 
         try:
-            shutil.cptree(temp_dir, out_dir)
+            # Use distutils.dir_util.copy_tree() instead of shutil.cptree(),
+            # which allows existing output directory.
+            from distutils.dir_util import copy_tree
+
+            copy_tree(temp_dir, out_dir)
         except Exception:
             logger.exception(
                 "Ran into error when copying results dir to persistent "


### PR DESCRIPTION
This reverts commit 92d7e9bf988e3b482ad54847fa1d33fa6451db68.
It breaks release tests.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
