### PR TITLE
Revert "[jobs] Use `subprocess.list2cmdline` to properly handle quotes in CLI entrypoints"

### DIFF
--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import os
-from subprocess import list2cmdline
 import time
 from typing import Optional, Tuple
 import yaml
@@ -163,9 +162,7 @@ def job_submit(
         final_runtime_env["working_dir"] = working_dir
 
     job_id = client.submit_job(
-        entrypoint=list2cmdline(entrypoint),
-        job_id=job_id,
-        runtime_env=final_runtime_env,
+        entrypoint=" ".join(entrypoint), job_id=job_id, runtime_env=final_runtime_env
     )
 
     _log_big_success_msg(f"Job '{job_id}' submitted successfully")

--- a/dashboard/modules/job/tests/test_cli_integration.py
+++ b/dashboard/modules/job/tests/test_cli_integration.py
@@ -3,7 +3,7 @@ import os
 import logging
 import sys
 import subprocess
-from typing import Optional, Tuple
+from typing import Optional
 
 import pytest
 
@@ -48,35 +48,6 @@ def ray_cluster_manager():
         subprocess.check_output(["ray", "stop", "--force"])
 
 
-def _run_cmd(cmd: str, should_fail=False) -> Tuple[str, str]:
-    """Convenience wrapper for subprocess.run.
-
-    We always run with shell=True to simulate the CLI.
-
-    Asserts that the process succeeds/fails depending on should_fail.
-
-    Returns (stdout, stderr).
-    """
-    print(f"Running command: '{cmd}'")
-    p: subprocess.CompletedProcess = subprocess.run(
-        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    if p.returncode == 0:
-        print("Command succeeded.")
-        if should_fail:
-            raise RuntimeError(
-                f"Expected command to fail, but got exit code: {p.returncode}."
-            )
-    else:
-        print(f"Command failed with exit code: {p.returncode}.")
-        if not should_fail:
-            raise RuntimeError(
-                f"Expected command to succeed, but got exit code: {p.returncode}."
-            )
-
-    return p.stdout.decode("utf-8"), p.stderr.decode("utf-8")
-
-
 class TestRayAddress:
     """
     Integration version of job CLI test that ensures interaction with the
@@ -88,33 +59,49 @@ class TestRayAddress:
 
     def test_empty_ray_address(self, ray_start_stop):
         with set_env_var("RAY_ADDRESS", None):
-            _, stderr = _run_cmd("ray job submit -- echo hello", should_fail=True)
+            completed_process = subprocess.run(
+                ["ray", "job", "submit", "--", "echo hello"], stderr=subprocess.PIPE
+            )
+            stderr = completed_process.stderr.decode("utf-8")
+            # Current dashboard module that raises no exception from requests..
             assert (
                 "Address must be specified using either the "
                 "--address flag or RAY_ADDRESS environment"
             ) in stderr
 
     def test_ray_client_address(self, ray_start_stop):
-        stdout, _ = _run_cmd("ray job submit -- echo hello")
+        completed_process = subprocess.run(
+            ["ray", "job", "submit", "--", "echo hello"], stdout=subprocess.PIPE
+        )
+        stdout = completed_process.stdout.decode("utf-8")
         assert "hello" in stdout
         assert "succeeded" in stdout
 
     def test_valid_http_ray_address(self, ray_start_stop):
-        stdout, _ = _run_cmd("ray job submit -- echo hello")
+        completed_process = subprocess.run(
+            ["ray", "job", "submit", "--", "echo hello"], stdout=subprocess.PIPE
+        )
+        stdout = completed_process.stdout.decode("utf-8")
         assert "hello" in stdout
         assert "succeeded" in stdout
 
     def test_set_ray_http_address_first(self):
         with set_env_var("RAY_ADDRESS", "http://127.0.0.1:8265"):
             with ray_cluster_manager():
-                stdout, _ = _run_cmd("ray job submit -- echo hello")
+                completed_process = subprocess.run(
+                    ["ray", "job", "submit", "--", "echo hello"], stdout=subprocess.PIPE
+                )
+                stdout = completed_process.stdout.decode("utf-8")
                 assert "hello" in stdout
                 assert "succeeded" in stdout
 
     def test_set_ray_client_address_first(self):
         with set_env_var("RAY_ADDRESS", "127.0.0.1:8265"):
             with ray_cluster_manager():
-                stdout, _ = _run_cmd("ray job submit -- echo hello")
+                completed_process = subprocess.run(
+                    ["ray", "job", "submit", "--", "echo hello"], stdout=subprocess.PIPE
+                )
+                stdout = completed_process.stdout.decode("utf-8")
                 assert "hello" in stdout
                 assert "succeeded" in stdout
 
@@ -123,14 +110,20 @@ class TestJobSubmit:
     def test_basic_submit(self, ray_start_stop):
         """Should tail logs and wait for process to exit."""
         cmd = "sleep 1 && echo hello && sleep 1 && echo hello"
-        stdout, _ = _run_cmd(f"ray job submit -- bash -c '{cmd}'")
+        completed_process = subprocess.run(
+            ["ray", "job", "submit", "--", cmd], stdout=subprocess.PIPE
+        )
+        stdout = completed_process.stdout.decode("utf-8")
         assert "hello\nhello" in stdout
         assert "succeeded" in stdout
 
     def test_submit_no_wait(self, ray_start_stop):
         """Should exit immediately w/o printing logs."""
         cmd = "echo hello && sleep 1000"
-        stdout, _ = _run_cmd(f"ray job submit --no-wait -- bash -c '{cmd}'")
+        completed_process = subprocess.run(
+            ["ray", "job", "submit", "--no-wait", "--", cmd], stdout=subprocess.PIPE
+        )
+        stdout = completed_process.stdout.decode("utf-8")
         assert "hello" not in stdout
         assert "Tailing logs until the job exits" not in stdout
 
@@ -140,9 +133,14 @@ class TestJobStop:
         """Should wait until the job is stopped."""
         cmd = "sleep 1000"
         job_id = "test_basic_stop"
-        _run_cmd(f"ray job submit --no-wait --job-id={job_id} -- {cmd}")
+        completed_process = subprocess.run(
+            ["ray", "job", "submit", "--no-wait", f"--job-id={job_id}", "--", cmd]
+        )
 
-        stdout, _ = _run_cmd(f"ray job stop {job_id}")
+        completed_process = subprocess.run(
+            ["ray", "job", "stop", job_id], stdout=subprocess.PIPE
+        )
+        stdout = completed_process.stdout.decode("utf-8")
         assert "Waiting for job" in stdout
         assert f"Job '{job_id}' was stopped" in stdout
 
@@ -150,20 +148,16 @@ class TestJobStop:
         """Should not wait until the job is stopped."""
         cmd = "echo hello && sleep 1000"
         job_id = "test_stop_no_wait"
-        _run_cmd(f"ray job submit --no-wait --job-id={job_id} -- bash -c '{cmd}'")
+        completed_process = subprocess.run(
+            ["ray", "job", "submit", "--no-wait", f"--job-id={job_id}", "--", cmd]
+        )
 
-        stdout, _ = _run_cmd(f"ray job stop --no-wait {job_id}")
+        completed_process = subprocess.run(
+            ["ray", "job", "stop", "--no-wait", job_id], stdout=subprocess.PIPE
+        )
+        stdout = completed_process.stdout.decode("utf-8")
         assert "Waiting for job" not in stdout
         assert f"Job '{job_id}' was stopped" not in stdout
-
-
-def test_quote_escaping(ray_start_stop):
-    cmd = "echo \"hello 'world'\""
-    job_id = "test_quote_escaping"
-    stdout, _ = _run_cmd(
-        f"ray job submit --job-id={job_id} -- {cmd}",
-    )
-    assert "hello 'world'" in stdout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts ray-project/ray#22011

Breaks release tests and general ray jobs command execution:

```
ray job submit "echo test"
...
/bin/sh: 1: echo test: not found
```