### PR TITLE
[Test] Fix flaky Drain node tests

### DIFF
--- a/python/ray/tests/test_autoscaler_drain_node_api.py
+++ b/python/ray/tests/test_autoscaler_drain_node_api.py
@@ -8,7 +8,7 @@ import ray
 from ray.autoscaler._private.fake_multi_node.node_provider import FakeMultiNodeProvider
 from ray.cluster_utils import AutoscalingCluster
 import ray.ray_constants as ray_constants
-from ray._private.test_utils import get_error_message, init_error_pubsub
+from ray._private.test_utils import get_error_message, init_error_pubsub, wait_for_condition
 
 logger = logging.getLogger(__name__)
 
@@ -82,12 +82,12 @@ def test_drain_api(shutdown_only):
         ray.get(f.remote())
 
         # Verify scale-up
-        assert ray.cluster_resources().get("GPU", 0) == 1
+        wait_for_condition(lambda: ray.cluster_resources().get("GPU", 0) == 1)
         # Sleep for double the idle timeout of 6 seconds.
         time.sleep(12)
 
         # Verify scale-down
-        assert ray.cluster_resources().get("GPU", 0) == 0
+        wait_for_condition(lambda :ray.cluster_resources().get("GPU", 0) == 0)
 
         # Check that no errors were raised while draining nodes.
         # (Logic copied from test_failure4::test_gcs_drain.)

--- a/python/ray/tests/test_autoscaler_drain_node_api.py
+++ b/python/ray/tests/test_autoscaler_drain_node_api.py
@@ -8,7 +8,11 @@ import ray
 from ray.autoscaler._private.fake_multi_node.node_provider import FakeMultiNodeProvider
 from ray.cluster_utils import AutoscalingCluster
 import ray.ray_constants as ray_constants
-from ray._private.test_utils import get_error_message, init_error_pubsub, wait_for_condition
+from ray._private.test_utils import (
+    get_error_message,
+    init_error_pubsub,
+    wait_for_condition,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +91,7 @@ def test_drain_api(shutdown_only):
         time.sleep(12)
 
         # Verify scale-down
-        wait_for_condition(lambda :ray.cluster_resources().get("GPU", 0) == 0)
+        wait_for_condition(lambda: ray.cluster_resources().get("GPU", 0) == 0)
 
         # Check that no errors were raised while draining nodes.
         # (Logic copied from test_failure4::test_gcs_drain.)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like the drain node test is flaky after 
<img width="714" alt="Screen Shot 2022-02-04 at 12 57 16 AM" src="https://user-images.githubusercontent.com/18510752/152500495-ecf1527f-0f72-4a7b-a510-637f4fbcb70b.png">

But this PR only adds resource metadata to the node information. So I think it is just due to the fact that we don't use wait_for_conditions (note that available_resources is not an API that guarantees the consistency. It can be stale). 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
