### PR TITLE
Fixed MRO for `DerivedActorClass`

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -446,7 +446,9 @@ class ActorClass:
                     # if the exception raised by cls.__init__ is
                     # TypeError and not ActorClassInheritanceException(TypeError).
                     # In all other cases proceed with raise e.
-                    if isinstance(e, TypeError) and not isinstance(e, ActorClassInheritanceException):
+                    if isinstance(e, TypeError) and not isinstance(
+                        e, ActorClassInheritanceException
+                    ):
                         modified_class.__init__(self, *args, **kwargs)
                     else:
                         raise e

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -4,6 +4,7 @@ import numpy as np
 import os
 from ray import cloudpickle as pickle
 from ray import ray_constants
+from ray.actor import ActorClassInheritanceException
 
 try:
     import pytest_timeout
@@ -653,7 +654,8 @@ def test_actor_inheritance(ray_start_regular_shared):
 
     # Test that you can't inherit from an actor class.
     with pytest.raises(
-        TypeError, match="Inheriting from actor classes is not " "currently supported."
+        ActorClassInheritanceException,
+        match="Inheriting from actor classes is not " "currently supported.",
     ):
 
         class Derived(ActorBase):
@@ -1117,6 +1119,23 @@ def test_actor_autocomplete(ray_start_regular_shared):
     method_options = [fn for fn in dir(f.method_one) if not fn.startswith("_")]
 
     assert set(method_options) == {"options", "remote"}
+
+
+def test_actor_mro(ray_start_regular_shared):
+    @ray.remote
+    class Foo:
+        def __init__(self, x):
+            self.x = x
+
+        @classmethod
+        def factory_f(cls, x):
+            return cls(x)
+
+        def get_x(self):
+            return self.x
+
+    obj = Foo.factory_f(1)
+    assert obj.get_x() == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Comments to be noted from the discussion below,

https://github.com/ray-project/ray/pull/22113#discussion_r802512907

> Problem - We cannot always delegate call to cls.__init__ or modified_cls.__init__. Because if always delegate call to cls.__init__ from here, then user defined class's __init__ method will be ignore leading to issues like, https://github.com/ray-project/ray/issues/21868. If we always delegate call to modified_cls.__init__ then it will allow inheriting from actor classes leading to failure of test_actor_inheritance. So, I have added this if-else check to figure out which __init__ method should be called. If "__module__", "__qualname__" and "__init__" are present in args[-1] then it would mean an actor class is being inherited so cls.__init__ should be called. However, if no such signal is received in args then user defined class's __init__ i.e., modified_class.__init__ should be called.

https://github.com/ray-project/ray/pull/22113#discussion_r808696261

> So I noted that ActorClass.__init__ will anyway raise a TypeError whenever it will be inherited. To exactly figure out whether the exception is due to inheritance of ActorClass, I created a new class ActorClassInheritanceException(TypeError). Now, whenever this will be raised, then DerivedActorClass will get a clear signal about inheritance of ActorClass. In other cases, it will be safe to conclude (AFAICT) that user called __init__ method of their class and we will proceed normally. IMHO, this is a better and more robust solution which just depends on a simple signal i.e., raising a particular exception in a specific event. It doesn't matter how inheritance is prevented as in the end we just need to raise ActorClassInheritanceException and all other code will be able to detect that easily.

https://github.com/ray-project/ray/pull/22113#issuecomment-1048527387

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/21868

Closes 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
