### PR TITLE
[tune] Resume additional epochs on completed trials

### DIFF
--- a/python/ray/tune/tests/test_additional_epochs.py
+++ b/python/ray/tune/tests/test_additional_epochs.py
@@ -1,0 +1,243 @@
+"""
+This is for testing the capability of training additional epochs on completed trials.
+The tuning example is adopted from pytorch hp tuning with ray tune:
+https://pytorch.org/tutorials/beginner/hyperparameter_tuning_tutorial.html
+
+Author: Peishi Jiang
+"""
+
+
+from functools import partial
+import numpy as np
+import os
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torch.utils.data import random_split
+import torchvision
+import torchvision.transforms as transforms
+import ray
+from ray import tune
+from ray.tune import CLIReporter
+
+
+# Define a nn model
+class Net(nn.Module):
+    def __init__(self, l1=120, l2=84):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, l1)
+        self.fc2 = nn.Linear(l1, l2)
+        self.fc3 = nn.Linear(l2, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+# Loss function
+def loss_fct(x, y):
+    return F.cross_entropy(x, y.flatten())
+
+# Generate artificial training/validation data
+def load_data(data_dir="./data"):
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+    ])
+
+    trainset = torchvision.datasets.CIFAR10(
+        root=data_dir, train=True, download=True, transform=transform)
+
+    testset = torchvision.datasets.CIFAR10(
+        root=data_dir, train=False, download=True, transform=transform)
+
+    return trainset, testset
+
+# Function for model training
+def train_cifar(config, checkpoint_dir=None, data_dir=None):
+    net = Net(config["l1"], config["l2"])
+
+    device = "cpu"
+    if torch.cuda.is_available():
+        device = "cuda:0"
+        if torch.cuda.device_count() > 1:
+            net = nn.DataParallel(net)
+    net.to(device)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=config["lr"], momentum=0.9)
+
+    if checkpoint_dir:
+        model_state, optimizer_state = torch.load(
+            os.path.join(checkpoint_dir, "checkpoint"))
+        net.load_state_dict(model_state)
+        optimizer.load_state_dict(optimizer_state)
+
+    trainset, testset = load_data(data_dir)
+
+    test_abs = int(len(trainset) * 0.8)
+    train_subset, val_subset = random_split(
+        trainset, [test_abs, len(trainset) - test_abs])
+
+    trainloader = torch.utils.data.DataLoader(
+        train_subset,
+        batch_size=int(config["batch_size"]),
+        shuffle=True,
+        num_workers=8)
+    valloader = torch.utils.data.DataLoader(
+        val_subset,
+        batch_size=int(config["batch_size"]),
+        shuffle=True,
+        num_workers=8)
+
+    for epoch in range(10):  # loop over the dataset multiple times
+        running_loss = 0.0
+        epoch_steps = 0
+        for i, data in enumerate(trainloader, 0):
+            # get the inputs; data is a list of [inputs, labels]
+            inputs, labels = data
+            inputs, labels = inputs.to(device), labels.to(device)
+
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            epoch_steps += 1
+            if i % 2000 == 1999:  # print every 2000 mini-batches
+                print("[%d, %5d] loss: %.3f" % (epoch + 1, i + 1,
+                                                running_loss / epoch_steps))
+                running_loss = 0.0
+
+        # Validation loss
+        val_loss = 0.0
+        val_steps = 0
+        total = 0
+        correct = 0
+        for i, data in enumerate(valloader, 0):
+            with torch.no_grad():
+                inputs, labels = data
+                inputs, labels = inputs.to(device), labels.to(device)
+
+                outputs = net(inputs)
+                _, predicted = torch.max(outputs.data, 1)
+                total += labels.size(0)
+                correct += (predicted == labels).sum().item()
+
+                loss = criterion(outputs, labels)
+                val_loss += loss.cpu().numpy()
+                val_steps += 1
+
+        with tune.checkpoint_dir(epoch) as checkpoint_dir:
+            path = os.path.join(checkpoint_dir, "checkpoint")
+            torch.save((net.state_dict(), optimizer.state_dict()), path)
+
+        tune.report(loss=(val_loss / val_steps), accuracy=correct / total)
+    print("Finished Training")
+
+
+# # Function for computing accuracy
+# def test_accuracy(net, device="cpu"):
+#     trainset, testset = load_data()
+
+#     testloader = torch.utils.data.DataLoader(
+#         testset, batch_size=4, shuffle=False, num_workers=2)
+
+#     correct = 0
+#     total = 0
+#     with torch.no_grad():
+#         for data in testloader:
+#             images, labels = data
+#             images, labels = images.to(device), labels.to(device)
+#             outputs = net(images)
+#             _, predicted = torch.max(outputs.data, 1)
+#             total += labels.size(0)
+#             correct += (predicted == labels).sum().item()
+
+#     return correct / total
+
+
+def test_gridsearch():
+    root = 'gridsearch_cifar_nn'
+    if not os.path.isdir(root):
+        os.mkdir(root)
+
+    data_dir = os.path.join(root, "data")
+
+    # Downloading the data
+    print('Downloading the data ...')
+    load_data(data_dir)
+
+    # Tuning configuration
+    config = {
+        # "l1": tune.grid_search([10, 12]),
+        "l1": tune.grid_search([10]),
+        "l2": tune.grid_search([10]),
+        # "lr": tune.grid_search([1e-4, 1e-1]),
+        "lr": tune.grid_search([1e-4]),
+        "batch_size": tune.choice([64])
+    }
+
+    reporter = CLIReporter(
+        # parameter_columns=["l1", "l2", "lr", "batch_size"],
+        metric_columns=["loss", "accuracy", "training_iteration"])
+
+    # Perform ray tune search
+    print('Tuning starts...')
+    result = tune.run(
+        partial(train_cifar, data_dir=data_dir),
+        resources_per_trial={"cpu": 2, "gpu": 1},
+        config=config,
+        local_dir=root,
+        name='gridsearch',
+        # scheduler=scheduler,
+        stop={"training_iteration": 2},
+        progress_reporter=reporter
+    )
+    print('Training ends ...')
+
+    assert all(result.dataframe()['training_iteration'] == 2)
+    
+    # del result
+    if ray.is_initialized():
+        print('Ray is initialized...')
+        print("Now, let's shut it down...")
+        del result
+        ray.shutdown()
+
+    # Continue ray tune search
+    print('Tuning restarts...')
+    result = tune.run(
+        partial(train_cifar, data_dir=data_dir),
+        resources_per_trial={"cpu": 2, "gpu": 1},
+        config=config,
+        local_dir=root,
+        name='gridsearch',
+        # scheduler=scheduler,
+        stop={"training_iteration": 3},
+        resume=True,
+        progress_reporter=reporter
+    )
+    print('Training ends ...')
+
+    assert all(result.dataframe()['training_iteration'] == 3)
+
+    # Clean up the data/training
+    os.rmdir(root)
+
+if __name__ == '__main__':
+    test_gridsearch()

--- a/python/ray/tune/tests/test_additional_epochs.py
+++ b/python/ray/tune/tests/test_additional_epochs.py
@@ -10,6 +10,7 @@ Author: Peishi Jiang
 from functools import partial
 import numpy as np
 import os
+import shutil
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -237,7 +238,8 @@ def test_gridsearch():
     assert all(result.dataframe()['training_iteration'] == 3)
 
     # Clean up the data/training
-    os.rmdir(root)
+    # os.rmdir(root)
+    shutil.rmtree(root)
 
 if __name__ == '__main__':
     test_gridsearch()

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -267,9 +267,7 @@ class TrialRunner:
         metric=None,
         # Deprecate on next refactor
         driver_sync_trial_checkpoints=False,
-        # Start of edits by Peishi Jiang
         stopping_criterion=None,
-        # End of edits by Peishi Jiang
     ):
         self._search_alg = search_alg or BasicVariantGenerator()
         self._scheduler_alg = scheduler or FIFOScheduler()
@@ -277,13 +275,11 @@ class TrialRunner:
         self._insufficient_resources_manager = InsufficientResourcesManager()
         self._pending_trial_queue_times = {}
 
-        # Start of edits by Peishi Jiang
         if "training_iteration" not in stopping_criterion:
             raise Exception(
                 "training_iteration has to be in stopping_criterion of TrialRunner."
                 )
         self._stopping_criterion = stopping_criterion
-        # End of edits by Peishi Jiang
 
         # Set the number of maximum pending trials
         max_pending_trials = os.getenv("TUNE_MAX_PENDING_TRIALS_PG", "auto")
@@ -661,14 +657,12 @@ class TrialRunner:
             )
         )
 
-        # Start of edits by Peishi Jiang 
         # Here, we remove any potential old '_stopping_criterion' in runner_state["runner_data"]
         # because, it is not assumed to be saved there.
         # Note that: '_stopping_criterion' is saved in runner_state["runner_data"]
         #            when tuning and retuning at additional epochs are executed at the same script
         # if '_stopping_criterion' in runner_state["runner_data"]:
         runner_state["runner_data"].pop('_stopping_criterion', None)
-        # End of edits by Peishi Jiang
 
         self.__setstate__(runner_state["runner_data"])
         if self._search_alg.has_checkpoint(self._local_checkpoint_dir):
@@ -676,7 +670,6 @@ class TrialRunner:
 
         # trials = load_trials_from_experiment_checkpoint(runner_state)
 
-        # Start of edits by Peishi Jiang
         # The goal is to resume the training when more iterations are needed
         checkpoints = [
             json.loads(cp, cls=TuneFunctionDecoder) if isinstance(cp, str) else cp
@@ -696,7 +689,6 @@ class TrialRunner:
             new_trial = Trial(trial_cp["trainable_name"], stub=False)
             new_trial.__setstate__(trial_cp)
             trials.append(new_trial)
-        # End of edits by Peishi Jiang
 
         for trial in sorted(trials, key=lambda t: t.last_update_time, reverse=True):
             if run_errored_only and trial.status == Trial.ERROR:

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -240,6 +240,9 @@ class TrialRunner:
             reported without this metric, an error will be raised. The error
             can be omitted by not providing a metric or by setting the env
             variable ``TUNE_DISABLE_STRICT_METRIC_CHECKING=0``
+        stopping_criterion (dict): The tuning stopping criterion used for
+            adjusting the training epochs. It is used to resume completed trials
+            on additional epochs. It has to follow {"training_iteration": ***}.
 
     """
 
@@ -264,12 +267,23 @@ class TrialRunner:
         metric=None,
         # Deprecate on next refactor
         driver_sync_trial_checkpoints=False,
+        # Start of edits by Peishi Jiang
+        stopping_criterion=None,
+        # End of edits by Peishi Jiang
     ):
         self._search_alg = search_alg or BasicVariantGenerator()
         self._scheduler_alg = scheduler or FIFOScheduler()
         self.trial_executor = trial_executor or RayTrialExecutor()
         self._insufficient_resources_manager = InsufficientResourcesManager()
         self._pending_trial_queue_times = {}
+
+        # Start of edits by Peishi Jiang
+        if "training_iteration" not in stopping_criterion:
+            raise Exception(
+                "training_iteration has to be in stopping_criterion of TrialRunner."
+                )
+        self._stopping_criterion = stopping_criterion
+        # End of edits by Peishi Jiang
 
         # Set the number of maximum pending trials
         max_pending_trials = os.getenv("TUNE_MAX_PENDING_TRIALS_PG", "auto")
@@ -647,11 +661,43 @@ class TrialRunner:
             )
         )
 
+        # Start of edits by Peishi Jiang 
+        # Here, we remove any potential old '_stopping_criterion' in runner_state["runner_data"]
+        # because, it is not assumed to be saved there.
+        # Note that: '_stopping_criterion' is saved in runner_state["runner_data"]
+        #            when tuning and retuning at additional epochs are executed at the same script
+        # if '_stopping_criterion' in runner_state["runner_data"]:
+        runner_state["runner_data"].pop('_stopping_criterion', None)
+        # End of edits by Peishi Jiang
+
         self.__setstate__(runner_state["runner_data"])
         if self._search_alg.has_checkpoint(self._local_checkpoint_dir):
             self._search_alg.restore_from_dir(self._local_checkpoint_dir)
 
-        trials = load_trials_from_experiment_checkpoint(runner_state)
+        # trials = load_trials_from_experiment_checkpoint(runner_state)
+
+        # Start of edits by Peishi Jiang
+        # The goal is to resume the training when more iterations are needed
+        checkpoints = [
+            json.loads(cp, cls=TuneFunctionDecoder) if isinstance(cp, str) else cp
+            for cp in runner_state["checkpoints"]
+        ]
+
+        if (self._stopping_criterion is not None) and ('training_iteration' in self._stopping_criterion):
+            for i in range(len(checkpoints)):
+                if self._stopping_criterion['training_iteration'] > checkpoints[i]['stopping_criterion']['training_iteration']:
+                    checkpoints[i]['stopping_criterion']['training_iteration'] = self._stopping_criterion['training_iteration']
+                    if checkpoints[i]['status'] == Trial.TERMINATED:
+                        checkpoints[i]['status'] = Trial.PENDING
+        del self._stopping_criterion # delete the variables to avoid that it is saved
+
+        trials = []
+        for trial_cp in checkpoints:
+            new_trial = Trial(trial_cp["trainable_name"], stub=False)
+            new_trial.__setstate__(trial_cp)
+            trials.append(new_trial)
+        # End of edits by Peishi Jiang
+
         for trial in sorted(trials, key=lambda t: t.last_update_time, reverse=True):
             if run_errored_only and trial.status == Trial.ERROR:
                 new_trial = trial.reset()

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -564,9 +564,7 @@ def run(
         # Driver should only sync trial checkpoints if
         # checkpoints are not synced to cloud
         driver_sync_trial_checkpoints=not bool(sync_config.upload_dir),
-        # start of edits by Peishi Jiang
         stopping_criterion=experiments[0].spec['stop']
-        # end of edits by Peishi Jiang
     )
 
     if not runner.resumed:

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -564,6 +564,9 @@ def run(
         # Driver should only sync trial checkpoints if
         # checkpoints are not synced to cloud
         driver_sync_trial_checkpoints=not bool(sync_config.upload_dir),
+        # start of edits by Peishi Jiang
+        stopping_criterion=experiments[0].spec['stop']
+        # end of edits by Peishi Jiang
     )
 
     if not runner.resumed:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This feature allows continuing training on additional epochs for completed trials. Minor changes are made on the following two files:
- `ray/python/ray/tune/tune.py`
- `ray/python/tune/trial_runner.py`

A test file is added and runs successfully using grid search: `ray/python/tune/tests/test_additional_epochs.py`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
