### PR TITLE
[autoscaler][core] Debug flag to log resource message in autoscaler

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -31,6 +31,7 @@ from ray.autoscaler._private.constants import AUTOSCALER_MAX_RESOURCE_DEMAND_VEC
 from ray.autoscaler._private.util import format_readonly_node_type
 
 from ray.core.generated import gcs_service_pb2, gcs_service_pb2_grpc
+from ray.core.generated import gcs_pb2
 import ray.ray_constants as ray_constants
 from ray._private.ray_logging import setup_component_logger
 from ray._private.gcs_pubsub import gcs_pubsub_enabled, GcsPublisher
@@ -268,6 +269,7 @@ class Monitor:
         request = gcs_service_pb2.GetAllResourceUsageRequest()
         response = self.gcs_node_resources_stub.GetAllResourceUsage(request, timeout=60)
         resources_batch_data = response.resource_usage_data
+        log_resource_batch_data_if_desired(resources_batch_data)
 
         # Tell the readonly node provider what nodes to report.
         if self.readonly_config:
@@ -511,6 +513,12 @@ class Monitor:
             self._handle_failure(traceback.format_exc())
             raise
 
+
+def log_resource_batch_data_if_desired(resources_batch_data: gcs_pb2.ResourceUsageBatchData) -> None:
+    if os.getenv("AUTOSCALER_LOG_RESOURCE_BATCH_DATA") == "1":
+        logger.info("Logging raw resource message pulled from GCS.")
+        logger.info(resources_batch_data)
+        logger.info("Done logging raw resource message.")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We've had multiple issues that manifest as unexpected autoscaler logs about resource demands.

To make it easier to debug such issues, this PR adds a debug flag to allow logging the entire resource message used by the autoscaler as its source of truth about the Ray internals' resource usage. 

If the env `AUTOSCALER_LOG_RESOURCE_BATCH_DATA=1` is set, the autoscaler will log the resource message.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
Manually checked using fake node provider that the log appears when the env is set and does not appear when the env is not set.
