### PR TITLE
[client] Move ClientObjectRef and ClientActorRef into py code

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -90,6 +90,7 @@ cdef class ObjectRef(BaseID):
 
     cdef CObjectID native(self)
 
+
 cdef class ActorID(BaseID):
     cdef CActorID data
 
@@ -97,13 +98,6 @@ cdef class ActorID(BaseID):
 
     cdef size_t hash(self)
 
-cdef class ClientActorRef(ActorID):
-    cdef object _mutex
-    cdef object _id_future
-    cdef object _worker
-
-    cdef _set_id(self, id)
-    cdef inline _wait_for_id(self, timeout=None)
 
 cdef class CoreWorker:
     cdef:

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -90,14 +90,6 @@ cdef class ObjectRef(BaseID):
 
     cdef CObjectID native(self)
 
-cdef class ClientObjectRef(ObjectRef):
-    cdef object _mutex
-    cdef object _id_future
-    cdef object _worker
-
-    cdef _set_id(self, id)
-    cdef inline _wait_for_id(self, timeout=None)
-
 cdef class ActorID(BaseID):
     cdef CActorID data
 

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -9,6 +9,7 @@ from typing import Callable, Any, Union
 
 import ray
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
+import cython
 import ray.util.client as client
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,7 @@ cdef class ObjectRef(BaseID):
         return self
 
 
+@cython.no_gc_clear
 cdef class ClientObjectRef(ObjectRef):
 
     def __init__(self, id: Union[bytes, concurrent.futures.Future]):

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -40,8 +40,7 @@ cdef class ObjectRef(BaseID):
     def __init__(
             self, id, owner_addr="", call_site_data="",
             skip_adding_local_ref=False):
-        check_id(id)
-        self.data = CObjectID.FromBinary(<c_string>id)
+        self._set_id(id)
         self.owner_addr = owner_addr
         self.in_core_worker = False
         self.call_site_data = call_site_data
@@ -100,6 +99,10 @@ cdef class ObjectRef(BaseID):
     def size(self):
         return CObjectID.Size()
 
+    def _set_id(self, id):
+        check_id(id)
+        self.data = CObjectID.FromBinary(<c_string>id)
+
     @classmethod
     def nil(cls):
         return cls(CObjectID.Nil().Binary())
@@ -148,129 +151,3 @@ cdef class ObjectRef(BaseID):
         core_worker = ray.worker.global_worker.core_worker
         core_worker.set_get_async_callback(self, py_callback)
         return self
-
-
-# Prevent tp_clear to avoid self._worker being cleared before __dealloc__
-@cython.no_gc_clear
-cdef class ClientObjectRef(ObjectRef):
-
-    def __init__(self, id: Union[bytes, concurrent.futures.Future]):
-        self.in_core_worker = False
-        self._mutex = threading.Lock()
-        self._worker = client.ray.get_context().client_worker
-        if isinstance(id, bytes):
-            self._set_id(id)
-        elif isinstance(id, concurrent.futures.Future):
-            self._id_future = id
-        else:
-            raise TypeError("Unexpected type for id {}".format(id))
-
-    def __dealloc__(self):
-        # This function is necessary, since within `__dealloc__`, we are not
-        # supposed to do any python related operations. It's for C related
-        # resource cleanup.
-        # Besides, we can't use `__del__` here, since cython won't call this
-        # unless it's > 3.0.
-        def _connected():
-            try:
-                return client is not None and self._worker is not None \
-                    and self._worker.is_connected()
-            except Exception:
-                return False
-
-        if _connected():
-            try:
-                self._wait_for_id()
-            # cython would suppress this exception as well, but it tries to
-            # print out the exception which may crash. Log a simpler message
-            # instead.
-            except Exception:
-                logger.info(
-                    "Exception in ObjectRef is ignored in destructor. "
-                    "To receive this exception in application code, call "
-                    "a method on the actor reference before its destructor "
-                    "is run.")
-            if not self.data.IsNil():
-                self._worker.call_release(self.id)
-
-    cdef CObjectID native(self):
-        self._wait_for_id()
-        return self.data
-
-    def binary(self):
-        self._wait_for_id()
-        return self.data.Binary()
-
-    def hex(self):
-        self._wait_for_id()
-        return decode(self.data.Hex())
-
-    def is_nil(self):
-        self._wait_for_id()
-        return self.data.IsNil()
-
-    cdef size_t hash(self):
-        self._wait_for_id()
-        return self.data.Hash()
-
-    def task_id(self):
-        self._wait_for_id()
-        return TaskID(self.data.TaskId().Binary())
-
-    @property
-    def id(self):
-        return self.binary()
-
-    def future(self) -> concurrent.futures.Future:
-        fut = concurrent.futures.Future()
-
-        def set_future(data: Any) -> None:
-            """Schedules a callback to set the exception or result
-            in the Future."""
-
-            if isinstance(data, Exception):
-                fut.set_exception(data)
-            else:
-                fut.set_result(data)
-
-        self._on_completed(set_future)
-
-        # Prevent this object ref from being released.
-        fut.object_ref = self
-        return fut
-
-    def _on_completed(self, py_callback: Callable[[Any], None]) -> None:
-        """Register a callback that will be called after Object is ready.
-        If the ObjectRef is already ready, the callback will be called soon.
-        The callback should take the result as the only argument. The result
-        can be an exception object in case of task error.
-        """
-        from ray.util.client.client_pickler import loads_from_server
-
-        def deserialize_obj(resp: Union[ray_client_pb2.DataResponse,
-                                        Exception]) -> None:
-            if isinstance(resp, Exception):
-                data = resp
-            else:
-                obj = resp.get
-                data = None
-                if not obj.valid:
-                    data = loads_from_server(resp.get.error)
-                else:
-                    data = loads_from_server(resp.get.data)
-
-            py_callback(data)
-
-        self._worker.register_callback(self, deserialize_obj)
-
-    cdef _set_id(self, id):
-        check_id(id)
-        self.data = CObjectID.FromBinary(<c_string>id)
-        self._worker.call_retain(id)
-
-    cdef inline _wait_for_id(self, timeout=None):
-        if self._id_future:
-            with self._mutex:
-                if self._id_future:
-                    self._set_id(self._id_future.result(timeout=timeout))
-                    self._id_future = None

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -150,6 +150,7 @@ cdef class ObjectRef(BaseID):
         return self
 
 
+# Prevent tp_clear to avoid self._worker being cleared before __dealloc__
 @cython.no_gc_clear
 cdef class ClientObjectRef(ObjectRef):
 

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -321,6 +321,7 @@ cdef class ActorID(BaseID):
         return <CActorID>self.data
 
 
+# Prevent tp_clear to avoid self._worker being cleared before __dealloc__
 @cython.no_gc_clear
 cdef class ClientActorRef(ActorID):
 

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -7,7 +7,6 @@ See https://github.com/ray-project/ray/issues/3721.
 # WARNING: Any additional ID types defined in this file must be added to the
 # _ID_TYPES list at the bottom of this file.
 
-from concurrent.futures import Future
 import logging
 import os
 
@@ -275,8 +274,7 @@ cdef class WorkerID(UniqueID):
 cdef class ActorID(BaseID):
 
     def __init__(self, id):
-        check_id(id, CActorID.Size())
-        self.data = CActorID.FromBinary(<c_string>id)
+        self._set_id(id)
 
     @classmethod
     def of(cls, job_id, parent_task_id, parent_task_counter):
@@ -301,6 +299,10 @@ cdef class ActorID(BaseID):
     def size(self):
         return CActorID.Size()
 
+    def _set_id(self, id):
+        check_id(id, CActorID.Size())
+        self.data = CActorID.FromBinary(<c_string>id)
+
     @property
     def job_id(self):
         return JobID(self.data.JobId().Binary())
@@ -320,84 +322,6 @@ cdef class ActorID(BaseID):
     cdef CActorID native(self):
         return <CActorID>self.data
 
-
-# Prevent tp_clear to avoid self._worker being cleared before __dealloc__
-@cython.no_gc_clear
-cdef class ClientActorRef(ActorID):
-
-    def __init__(self, id: Union[bytes, concurrent.futures.Future]):
-        self._mutex = threading.Lock()
-        self._worker = client.ray.get_context().client_worker
-        if isinstance(id, bytes):
-            self._set_id(id)
-        elif isinstance(id, Future):
-            self._id_future = id
-        else:
-            raise TypeError("Unexpected type for id {}".format(id))
-
-    def __dealloc__(self):
-        # This function is necessary, since within `__dealloc__`, we are not
-        # supposed to do any python related operations. It's for C related
-        # resource cleanup.
-        # Besides, we can't use `__del__` here, since cython won't call this
-        # unless it's > 3.0.
-        def _connected():
-            try:
-                return client is not None and \
-                    self._worker is not None and self._worker.is_connected()
-            except Exception:
-                return False
-
-        if _connected():
-            try:
-                self._wait_for_id()
-            # cython would suppress this exception as well, but it tries to
-            # print out the exception which may crash. Log a simpler message
-            # instead.
-            except Exception:
-                logger.info(
-                    "Exception from actor creation is ignored in destructor. "
-                    "To receive this exception in application code, call "
-                    "a method on the actor reference before its destructor "
-                    "is run.")
-            if not self.data.IsNil():
-                self._worker.call_release(self.id)
-
-    def binary(self):
-        self._wait_for_id()
-        return self.data.Binary()
-
-    def hex(self):
-        self._wait_for_id()
-        return decode(self.data.Hex())
-
-    def is_nil(self):
-        self._wait_for_id()
-        return self.data.IsNil()
-
-    cdef size_t hash(self):
-        self._wait_for_id()
-        return self.data.Hash()
-
-    cdef CActorID native(self):
-        self._wait_for_id()
-        return <CActorID>self.data
-
-    @property
-    def id(self):
-        return self.binary()
-
-    cdef _set_id(self, id):
-        check_id(id, CActorID.Size())
-        self.data = CActorID.FromBinary(<c_string>id)
-        self._worker.call_retain(id)
-
-    cdef _wait_for_id(self, timeout=None):
-        if self._id_future:
-            with self._mutex:
-                if self._id_future:
-                    self._set_id(self._id_future.result(timeout=timeout))
-                    self._id_future = None
 
 cdef class FunctionID(UniqueID):
 

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -321,6 +321,7 @@ cdef class ActorID(BaseID):
         return <CActorID>self.data
 
 
+@cython.no_gc_clear
 cdef class ClientActorRef(ActorID):
 
     def __init__(self, id: Union[bytes, concurrent.futures.Future]):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -828,6 +828,9 @@ def test_multiple_actors(ray_start_regular_shared):
         assert v == list(range(i + 1, num_increases + i + 1))
 
     # Reset the actor values.
+    # THere is a deadlock because we are running py code in dealloc
+    # Please refer to this for more details
+    #     https://github.com/ray-project/ray/issues/22082
     holder = [actor.reset.remote() for actor in actors]  # noqa
 
     # Interweave the method calls on the different actors.

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -828,7 +828,7 @@ def test_multiple_actors(ray_start_regular_shared):
         assert v == list(range(i + 1, num_increases + i + 1))
 
     # Reset the actor values.
-    [actor.reset.remote() for actor in actors]
+    holder = [actor.reset.remote() for actor in actors]  # noqa
 
     # Interweave the method calls on the different actors.
     results = []

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -86,7 +86,6 @@ CLIENT_SERVER_MAX_THREADS = float(os.getenv("RAY_CLIENT_SERVER_MAX_THREADS", 100
 
 # Aliases for compatibility.
 class ClientObjectRef(raylet.ObjectRef):
-
     def __init__(self, id: Union[bytes, Future]):
         self.in_core_worker = False
         self._mutex = threading.Lock()
@@ -109,7 +108,8 @@ class ClientObjectRef(raylet.ObjectRef):
                     "Exception in ObjectRef is ignored in destructor. "
                     "To receive this exception in application code, call "
                     "a method on the actor reference before its destructor "
-                    "is run.")
+                    "is run."
+                )
 
     def binary(self):
         self._wait_for_id()
@@ -160,9 +160,11 @@ class ClientObjectRef(raylet.ObjectRef):
         can be an exception object in case of task error.
         """
 
-        def deserialize_obj(resp: Union[ray_client_pb2.DataResponse,
-                                        Exception]) -> None:
+        def deserialize_obj(
+            resp: Union[ray_client_pb2.DataResponse, Exception]
+        ) -> None:
             from ray.util.client.client_pickler import loads_from_server
+
             if isinstance(resp, Exception):
                 data = resp
             else:
@@ -190,7 +192,6 @@ class ClientObjectRef(raylet.ObjectRef):
 
 
 class ClientActorRef(raylet.ActorID):
-
     def __init__(self, id: Union[bytes, Future]):
         self._mutex = threading.Lock()
         self._worker = ray.get_context().client_worker
@@ -212,7 +213,8 @@ class ClientActorRef(raylet.ActorID):
                     "Exception from actor creation is ignored in destructor. "
                     "To receive this exception in application code, call "
                     "a method on the actor reference before its destructor "
-                    "is run.")
+                    "is run."
+                )
 
     def binary(self):
         self._wait_for_id()

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -84,7 +84,7 @@ GRPC_OPTIONS = [
 
 CLIENT_SERVER_MAX_THREADS = float(os.getenv("RAY_CLIENT_SERVER_MAX_THREADS", 100))
 
-# Aliases for compatibility.
+
 class ClientObjectRef(raylet.ObjectRef):
     def __init__(self, id: Union[bytes, Future]):
         self.in_core_worker = False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For more details please refer to this https://github.com/ray-project/ray/issues/22082#issuecomment-1030562177

- Use `@cython.no_gc_clear` to avoid content being stolen by GC
- Prevent GC to avoid deadlock.

This is not the final solution. We need to make ClientObjectRef and ActorObjectRef being python objects to avoid the deadlock.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/22141
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
