### PR TITLE
Revert "[Release 1.11.0][Core] avoid unnecessary work during event st…

### DIFF
--- a/src/ray/common/event_stats.h
+++ b/src/ray/common/event_stats.h
@@ -94,7 +94,7 @@ struct StatsHandle {
 
 class EventTracker {
  public:
-  /// Initializes the global stats struct after calling the base constructor.
+  /// Initializes the global stats struct after calling the base contructor.
   EventTracker() : global_stats_(std::make_shared<GuardedGlobalStats>()) {}
 
   /// Sets the queueing start time, increments the current and cumulative counts and


### PR DESCRIPTION
…ats collection (#22054)"

This reverts commit 9ac3f6879d01dccc54ef9986f4224cfe86374f95.

Seems like this makes this test flaky, so I will revert it for now.

<img width="653" alt="Screen Shot 2022-02-05 at 6 06 17 AM" src="https://user-images.githubusercontent.com/18510752/152645204-c584993f-b105-47b4-9d68-39b53bdc20b0.png">


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
