### PR TITLE
Fix datasets leaking worker processes due to closure capture of stats actor handle

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -223,7 +223,7 @@ def read_datasource(
     stats_uuid = uuid.uuid4()
     stats_actor.record_start.remote(stats_uuid)
 
-    def remote_read(i: int, task: ReadTask) -> MaybeBlockPartition:
+    def remote_read(i: int, task: ReadTask, stats_actor) -> MaybeBlockPartition:
         DatasetContext._set_current(context)
         stats = BlockExecStats.builder()
 
@@ -268,7 +268,7 @@ def read_datasource(
         calls.append(
             lambda i=i, task=task, resources=next(resource_iter): remote_read.options(
                 **ray_remote_args, resources=resources
-            ).remote(i, task)
+            ).remote(i, task, stats_actor)
         )
         metadata.append(task.get_metadata())
 

--- a/release/long_running_tests/workloads/many_drivers.py
+++ b/release/long_running_tests/workloads/many_drivers.py
@@ -78,6 +78,9 @@ for _ in range(5):
         actor = Actor._remote(args=[], kwargs={{}}, resources={{str(i): 1}})
         assert ray.get(actor.method.remote()) == 1
 
+# Tests datasets doesn't leak workers.
+ray.data.range(100).map(lambda x: x).show()
+
 print("success")
 """.format(
     cluster.address, num_nodes

--- a/release/long_running_tests/workloads/many_drivers.py
+++ b/release/long_running_tests/workloads/many_drivers.py
@@ -79,7 +79,7 @@ for _ in range(5):
         assert ray.get(actor.method.remote()) == 1
 
 # Tests datasets doesn't leak workers.
-ray.data.range(100).map(lambda x: x).show()
+ray.data.range(100).map(lambda x: x).take()
 
 print("success")
 """.format(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It looks like an actor handle was closure captured in one of the remote tasks. This prevents the workers of those tasks from exiting once the job finishes, since the reference counter is seeing live references.

This PR changes Datasets to avoid this code path. Separately @stephanie-wang I think ReferenceCounter::DrainAndShutdown() may need to be changed to ignore references that don't have any remote borrowers (in this case, an entry in the function table holding an actor reference doesn't seem like a reason to hold up shutdown).

## Related issue number

Closes https://github.com/ray-project/ray/issues/22154