### PR TITLE
[Core][nightly-test] better way of calculating num features

### DIFF
--- a/release/nightly_tests/dataset/ray_sgd_training.py
+++ b/release/nightly_tests/dataset/ray_sgd_training.py
@@ -664,12 +664,15 @@ if __name__ == "__main__":
             self.model = load_model_func().to(self.device)
 
         def __call__(self, batch) -> "pd.DataFrame":
-            tensor = torch.FloatTensor(batch.to_pandas().values).to(self.device)
-            return pd.DataFrame(self.model(tensor).cpu().detach().numpy())
+            tensor = torch.FloatTensor(batch.values).to(self.device)
+            return pd.DataFrame(
+                self.model(tensor).cpu().detach().numpy(), columns=["label"]
+            )
 
     inference_dataset = preprocessor.preprocess_inference_data(
         read_dataset(inference_path)
     )
+
     inference(
         inference_dataset,
         BatchInferModel(load_model_func),

--- a/release/nightly_tests/dataset/ray_sgd_training.py
+++ b/release/nightly_tests/dataset/ray_sgd_training.py
@@ -254,7 +254,9 @@ def train_epoch(dataset, model, device, criterion, optimizer, feature_size):
 
         # Forward + backward + optimize
         # check the input's shape matches the expectation
-        assert inputs.size()[1] == feature_size
+        assert (
+            inputs.size()[1] == feature_size
+        ), f"input size: {inputs.size()[1]}, expected: {feature_size}"
         outputs = model(inputs.float())
         loss = criterion(outputs, labels.float())
         loss.backward()
@@ -529,9 +531,13 @@ if __name__ == "__main__":
     preprocessing_end_time = timeit.default_timer()
     print("Preprocessing time (s): ", preprocessing_end_time - e2e_start_time)
 
-    num_columns = len(train_dataset.schema().names)
-    # remove label column and internal Arrow column.
-    num_features = num_columns - 2
+    # filter label column and internal Arrow column.
+    def is_feature_column(column_name):
+        return column_name != "label" and not column_name.startswith("__")
+
+    num_features = len(
+        list(filter(lambda name: is_feature_column(name), train_dataset.schema().names))
+    )
 
     BATCH_SIZE = 512
     NUM_HIDDEN = 50  # 200

--- a/release/nightly_tests/dataset/ray_sgd_training.py
+++ b/release/nightly_tests/dataset/ray_sgd_training.py
@@ -531,13 +531,11 @@ if __name__ == "__main__":
     preprocessing_end_time = timeit.default_timer()
     print("Preprocessing time (s): ", preprocessing_end_time - e2e_start_time)
 
-    # filter label column and internal Arrow column.
+    # filter label column and internal Arrow column (__index_level_0__).
     def is_feature_column(column_name):
         return column_name != "label" and not column_name.startswith("__")
 
-    num_features = len(
-        list(filter(lambda name: is_feature_column(name), train_dataset.schema().names))
-    )
+    num_features = len(list(filter(is_feature_column, train_dataset.schema().names)))
 
     BATCH_SIZE = 512
     NUM_HIDDEN = 50  # 200


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

previously, we use num_columns - 2 to calculate the feature size where we assumes both the "label" and arrow internal column `__index_level_0__` exists in the schema.

however, the `__index_level_0__` might not exist in the dataset's schema, which causes this check fail. 
in this pr, we use a better way to filter out arrow internal column and label column.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests https://console.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_xhpjT94JnGDwf9PnUjw78DJe
   - [ ] This PR is not tested :(
