### PR TITLE
[Core] Improve ray stop

### DIFF
--- a/python/ray/autoscaler/_private/cli_logger.py
+++ b/python/ray/autoscaler/_private/cli_logger.py
@@ -389,7 +389,13 @@ class _CliLogger:
         """Print a line feed."""
         self.print("")
 
-    def _print(self, msg: str, _level_str: str = "INFO", _linefeed: bool = True):
+    def _print(
+        self,
+        msg: str,
+        _level_str: str = "INFO",
+        _linefeed: bool = True,
+        end: str = None,
+    ):
         """Proxy for printing messages.
 
         Args:
@@ -435,7 +441,8 @@ class _CliLogger:
             stream.flush()
             return
 
-        print(rendered_message, file=stream)
+        kwargs = {"end": end}
+        print(rendered_message, file=stream, **kwargs)
 
     def indented(self):
         """Context manager that starts an indented block of output."""
@@ -557,12 +564,19 @@ class _CliLogger:
         self._error(*args, _level_str="PANIC", **kwargs)
 
     # Fine to expose _level_str here, since this is a general log function.
-    def print(self, msg: str, *args: Any, _level_str: str = "INFO", **kwargs: Any):
+    def print(
+        self,
+        msg: str,
+        *args: Any,
+        _level_str: str = "INFO",
+        end: str = None,
+        **kwargs: Any
+    ):
         """Prints a message.
 
         For arguments, see `_format_msg`.
         """
-        self._print(_format_msg(msg, *args, **kwargs), _level_str=_level_str)
+        self._print(_format_msg(msg, *args, **kwargs), _level_str=_level_str, end=end)
 
     def abort(
         self, msg: Optional[str] = None, *args: Any, exc: Any = None, **kwargs: Any


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I’d like to make a small proposal to change the behavior of ray stop

### Status quo
It basically just sends a SIGTERM and finish asynchronously. It is vulnerable to have leaked processes or port conflict when you run ray stop && ray start I feel like the right behavior is as follow;

### New
- Send sigterm and wait for processes to terminate
- Display the progress to users
- If procs are not terminated by X seconds, send SIGKILL.

### API change
We will add `--grace-period` flag. The default is ray `stop --grace-period=X (10 seconds by default)`

And if users don’t want to be blocked, they can use ray stop --force (which already exists. It just sends SIGKILL, so procs are guaranteed to be terminated)

### Tests
I am not sure what's the best way to test it. I"d love to hear recommendation! 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
