### PR TITLE
fix "team:xxx" tag of cpp tests

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -134,7 +134,7 @@ cc_test(
     ]),
     copts = COPTS,
     linkstatic = False,
-    tags = ["team:serverless"],
+    tags = ["team:core"],
     deps = [
         "ray_api",
         "@boost//:filesystem",
@@ -160,7 +160,7 @@ cc_test(
         "src/ray/test/cluster/test_cross_language_invocation.py",
     ],
     linkstatic = True,
-    tags = ["team:serverless"],
+    tags = ["team:core"],
     deps = [
         "ray_api",
         "@com_google_googletest//:gtest_main",
@@ -206,7 +206,7 @@ cc_test(
         "simple_kv_store.so",
     ],
     linkstatic = True,
-    tags = ["team:serverless"],
+    tags = ["team:core"],
     deps = [
         ":ray_api",
     ],


### PR DESCRIPTION
## Why are these changes needed?
Cpp worker tests should be part of ray core.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
