### PR TITLE
move slow test from small (timeout 60s) to medium (timeout 300s)

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -177,7 +177,7 @@ py_test_module_list(
   ],
   size = "medium",
   extra_srcs = SRCS,
-  tags = ["exclusive", "medium_size_python_tests", "team:serverless"],
+  tags = ["exclusive", "medium_size_python_tests_a_to_j", "team:serverless"],
   deps = ["//:ray_lib"],
 )
 
@@ -320,7 +320,7 @@ py_test(
     name = "test_serve_ray_minimal",
     size = "small",
     srcs = SRCS + ["test_serve_ray_minimal.py"],
-    tags = ["exclusive", "small_size_python_tests", "team:serve"],
+    tags = ["exclusive", "python_tests", "team:serve"],
     deps = ["//:ray_lib"],
 )
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -161,7 +161,6 @@ py_test_module_list(
     "test_client_terminate.py",
     "test_command_runner.py",
     "test_coordinator_server.py",
-    "test_dataclient_disconnect.py",
     "test_k8s_operator_unit_tests.py",
     "test_monitor.py",
     "test_response_cache.py",
@@ -169,6 +168,16 @@ py_test_module_list(
   size = "small",
   extra_srcs = SRCS,
   tags = ["exclusive", "small_size_python_tests", "team:serverless"],
+  deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+  files = [
+    "test_dataclient_disconnect.py",
+  ],
+  size = "medium",
+  extra_srcs = SRCS,
+  tags = ["exclusive", "medium_size_python_tests", "team:serverless"],
   deps = ["//:ray_lib"],
 )
 


### PR DESCRIPTION
This test is ranking high on https://flakey-tests.ray.io. For instance [here](https://buildkite.com/ray-project/ray-builders-branch/builds/5860#9ee8526b-e459-41ed-9071-0c23e434b683/3264-3384) it is timing out after 60 seconds. This is due to the bazel [test defaults](https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner) which use 60s for small, 300s for medium tests. Moving the test to medium should solve the problem. 

I created a new group for this with the new tag `medium_size_python_tests`