### PR TITLE
Fix zero gradients for ppo-clipped vf

### DIFF
--- a/rllib/agents/ppo/ppo_torch_policy.py
+++ b/rllib/agents/ppo/ppo_torch_policy.py
@@ -144,21 +144,14 @@ class PPOTorchPolicy(TorchPolicy, LearningRateSchedule, EntropyCoeffSchedule):
 
         # Compute a value function loss.
         if self.config["use_critic"]:
-            prev_value_fn_out = train_batch[SampleBatch.VF_PREDS]
             value_fn_out = model.value_function()
-            vf_loss1 = torch.pow(
+            vf_loss = torch.pow(
                 value_fn_out - train_batch[Postprocessing.VALUE_TARGETS], 2.0
             )
-            vf_clipped = prev_value_fn_out + torch.clamp(
-                value_fn_out - prev_value_fn_out,
-                -self.config["vf_clip_param"],
-                self.config["vf_clip_param"],
+            vf_loss_clipped = torch.clamp(
+                vf_loss, -self.config["vf_clip_param"], self.config["vf_clip_param"]
             )
-            vf_loss2 = torch.pow(
-                vf_clipped - train_batch[Postprocessing.VALUE_TARGETS], 2.0
-            )
-            vf_loss = torch.max(vf_loss1, vf_loss2)
-            mean_vf_loss = reduce_mean_valid(vf_loss)
+            mean_vf_loss = reduce_mean_valid(vf_loss_clipped)
         # Ignore the value function.
         else:
             vf_loss = mean_vf_loss = 0.0

--- a/rllib/agents/ppo/ppo_torch_policy.py
+++ b/rllib/agents/ppo/ppo_torch_policy.py
@@ -154,11 +154,11 @@ class PPOTorchPolicy(TorchPolicy, LearningRateSchedule, EntropyCoeffSchedule):
             mean_vf_loss = reduce_mean_valid(vf_loss_clipped)
         # Ignore the value function.
         else:
-            vf_loss = mean_vf_loss = 0.0
+            vf_loss_clipped = mean_vf_loss = 0.0
 
         total_loss = reduce_mean_valid(
             -surrogate_loss
-            + self.config["vf_loss_coeff"] * vf_loss
+            + self.config["vf_loss_coeff"] * vf_loss_clipped
             - self.entropy_coeff * curr_entropy
         )
 

--- a/rllib/agents/ppo/ppo_torch_policy.py
+++ b/rllib/agents/ppo/ppo_torch_policy.py
@@ -148,9 +148,7 @@ class PPOTorchPolicy(TorchPolicy, LearningRateSchedule, EntropyCoeffSchedule):
             vf_loss = torch.pow(
                 value_fn_out - train_batch[Postprocessing.VALUE_TARGETS], 2.0
             )
-            vf_loss_clipped = torch.clamp(
-                vf_loss, -self.config["vf_clip_param"], self.config["vf_clip_param"]
-            )
+            vf_loss_clipped = torch.clamp(vf_loss, 0, self.config["vf_clip_param"])
             mean_vf_loss = reduce_mean_valid(vf_loss_clipped)
         # Ignore the value function.
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The PPO value loss calculation returns a zero-gradient when clipping is applied and `vf_loss2` is selected, because `prev_value_fn_out` is from the `SampleBatch` which doesn't track gradients. Furthermore, the logic itself is a bit convoluted. See the related issue for a more in-depth description.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #19291

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
