### PR TITLE
[jobs] Monitor jobs in the background to avoid requiring clients to poll

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -115,11 +115,8 @@ class JobSupervisor:
         # fire and forget call from outer job manager to this actor
         self._stop_event = asyncio.Event()
 
-    def ready(self):
-        """Dummy object ref. Return of this function represents job supervisor
-        actor stated successfully with runtime_env configured, and is ready to
-        move on to running state.
-        """
+    def ping(self):
+        """Used to check the health of the actor."""
         pass
 
     def _exec_entrypoint(self, logs_path: str) -> subprocess.Popen:
@@ -193,8 +190,10 @@ class JobSupervisor:
             variables.
         3) Handle concurrent events of driver execution and
         """
-        cur_status = self._get_status()
-        assert cur_status.status == JobStatus.PENDING, "Run should only be called once."
+        curr_status = self._status_client.get_status(self._job_id)
+        assert (
+            curr_status.status == JobStatus.PENDING
+        ), "Run should only be called once."
 
         if _start_signal_actor:
             # Block in PENDING state until start signal received.
@@ -269,9 +268,6 @@ class JobSupervisor:
             # clean up actor after tasks are finished
             ray.actor.exit_actor()
 
-    def _get_status(self) -> Optional[JobStatusInfo]:
-        return self._status_client.get_status(self._job_id)
-
     def stop(self):
         """Set step_event and let run() handle the rest in its asyncio.wait()."""
         self._stop_event.set()
@@ -288,17 +284,91 @@ class JobManager:
     # Time that we will sleep while tailing logs if no new log line is
     # available.
     LOG_TAIL_SLEEP_S = 1
+    JOB_MONITOR_LOOP_PERIOD_S = 1
 
     def __init__(self):
         self._status_client = JobStatusStorageClient()
         self._log_client = JobLogStorageClient()
         self._supervisor_actor_cls = ray.remote(JobSupervisor)
 
+        self._running_jobs: Dict[str, JobStatusInfo] = dict()
+        self._recover_running_jobs()
+
+    def _recover_running_jobs(self):
+        """Recovers all running jobs from the status client.
+
+        Each will be added to self._running_jobs and reconciled.
+        """
+        all_jobs = self._status_client.get_all_jobs()
+        for job_id, status_info in all_jobs.items():
+            if not status_info.status.is_terminal():
+                self._running_jobs[job_id] = status_info
+                self._create_job_monitor_task(job_id)
+                create_task(self._monitor_job(job_id))
+
     def _get_actor_for_job(self, job_id: str) -> Optional[ActorHandle]:
         try:
             return ray.get_actor(self.JOB_ACTOR_NAME.format(job_id=job_id))
         except ValueError:  # Ray returns ValueError for nonexistent actor.
             return None
+
+    async def _monitor_job(
+        self, job_id: str, job_supervisor: Optional[ActorHandle] = None
+    ):
+        """Monitors the specified job until it enters a terminal state.
+
+        This is necessary because we need to handle the case where the
+        JobSupervisor dies unexpectedly.
+        """
+        is_alive = True
+        if job_supervisor is None:
+            job_supervisor = self._get_actor_for_job(job_id)
+
+            if job_supervisor is None:
+                logger.error(f"Failed to get job supervisor for job {job_id}.")
+                self._status_client.put_status(
+                    job_id,
+                    JobStatusInfo(
+                        status=JobStatus.FAILED,
+                        message=(
+                            "Unexpected error occurred: Failed to get job supervisor."
+                        ),
+                    ),
+                )
+                is_alive = False
+
+        while is_alive:
+            try:
+                await job_supervisor.ping.remote()
+                asyncio.sleep(self.JOB_MONITOR_LOOP_PERIOD_S)
+            except Exception as e:
+                is_alive = False
+                if self._status_client.get_status(job_id).status.is_terminal():
+                    # If the job is already in a terminal state, then the actor
+                    # exiting is expected.
+                    pass
+                elif isinstance(e, RuntimeEnvSetupError):
+                    logger.info(f"Failed to set up runtime_env for job {job_id}.")
+                    self._status_client.put_status(
+                        job_id,
+                        JobStatusInfo(
+                            status=JobStatus.FAILED,
+                            message=(f"runtime_env setup failed: {e}"),
+                        ),
+                    )
+                else:
+                    logger.error(f"Job supervisor failed unexpectedly {job_id}: {e}.")
+                    self._status_client.put_status(
+                        job_id,
+                        JobStatusInfo(
+                            status=JobStatus.FAILED,
+                            message=f"Unexpected error occurred: {e}",
+                        ),
+                    )
+
+        # Kill the actor defensively to avoid leaking actors in unexpected error cases.
+        if job_supervisor is not None:
+            ray.kill(job_supervisor, no_restart=True)
 
     def _get_current_node_resource_key(self) -> str:
         """Get the Ray resource key for current node.
@@ -326,26 +396,6 @@ class JobManager:
         """
         if result is None:
             return
-        elif isinstance(result, RuntimeEnvSetupError):
-            logger.info(f"Failed to set up runtime_env for job {job_id}.")
-            self._status_client.put_status(
-                job_id,
-                JobStatusInfo(
-                    status=JobStatus.FAILED,
-                    message=(f"runtime_env setup failed: {result}"),
-                ),
-            )
-        elif isinstance(result, Exception):
-            logger.error(f"Failed to start supervisor for job {job_id}: {result}.")
-            self._status_client.put_status(
-                job_id,
-                JobStatusInfo(
-                    status=JobStatus.FAILED,
-                    message=f"Error occurred while starting the job: {result}",
-                ),
-            )
-        else:
-            assert False, "This should not be reached."
 
     def submit_job(
         self,
@@ -394,9 +444,9 @@ class JobManager:
 
         # Wait for the actor to start up asynchronously so this call always
         # returns immediately and we can catch errors with the actor starting
-        # up. We may want to put this in an actor instead in the future.
+        # up.
         try:
-            actor = self._supervisor_actor_cls.options(
+            supervisor = self._supervisor_actor_cls.options(
                 lifetime="detached",
                 name=self.JOB_ACTOR_NAME.format(job_id=job_id),
                 num_cpus=0,
@@ -407,26 +457,26 @@ class JobManager:
                 },
                 runtime_env=runtime_env,
             ).remote(job_id, entrypoint, metadata or {})
-            actor.run.remote(_start_signal_actor=_start_signal_actor)
+            supervisor.run.remote(_start_signal_actor=_start_signal_actor)
 
-            def callback(result: Optional[Exception]):
-                return self._handle_supervisor_startup(job_id, result)
-
-            actor.ready.remote()._on_completed(callback)
+            # Monitor the job in the background so we can detect errors without
+            # requiring a client to poll.
+            create_task(self._monitor_job(job_id, supervisor))
         except Exception as e:
-            self._handle_supervisor_startup(job_id, e)
+            self._status_client.put_status(
+                job_id,
+                JobStatusInfo(
+                    status=JobStatus.FAILED,
+                    message=f"Failed to start job supervisor: {e}.",
+                ),
+            )
 
         return job_id
 
     def stop_job(self, job_id) -> bool:
-        """Request job to exit, fire and forget.
+        """Request a job to exit, fire and forget.
 
-        Args:
-            job_id: ID of the job.
-        Returns:
-            stopped:
-                True if there's running job
-                False if no running job found
+        Returns whether or not the job was running.
         """
         job_supervisor_actor = self._get_actor_for_job(job_id)
         if job_supervisor_actor is not None:
@@ -438,35 +488,15 @@ class JobManager:
             return False
 
     def get_job_status(self, job_id: str) -> Optional[JobStatus]:
-        """Get latest status of a job. If job supervisor actor is no longer
-        alive, it will also attempt to make adjustments needed to bring job
-        to correct terminiation state.
-
-        All job status is stored and read only from GCS.
-
-        Args:
-            job_id: ID of the job.
-        Returns:
-            job_status: Latest known job status
-        """
-        job_supervisor_actor = self._get_actor_for_job(job_id)
-        if job_supervisor_actor is None:
-            # Job actor either exited or failed, we need to ensure never
-            # left job in non-terminal status in case actor failed without
-            # updating GCS with latest status.
-            last_status = self._status_client.get_status(job_id)
-            if last_status and last_status.status in {
-                JobStatus.PENDING,
-                JobStatus.RUNNING,
-            }:
-                self._status_client.put_status(job_id, JobStatus.FAILED)
-
+        """Get latest status of a job."""
         return self._status_client.get_status(job_id)
 
     def get_job_logs(self, job_id: str) -> str:
+        """Get all logs produced by a job."""
         return self._log_client.get_logs(job_id)
 
     async def tail_job_logs(self, job_id: str) -> Iterator[str]:
+        """Return an iterator following the logs of a job."""
         if self.get_job_status(job_id) is None:
             raise RuntimeError(f"Job '{job_id}' does not exist.")
 

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -338,7 +338,7 @@ class JobManager:
 
         while is_alive:
             try:
-                result = await job_supervisor.ping.remote()
+                await job_supervisor.ping.remote()
                 await asyncio.sleep(self.JOB_MONITOR_LOOP_PERIOD_S)
             except Exception as e:
                 is_alive = False

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -291,18 +291,17 @@ class JobManager:
         self._log_client = JobLogStorageClient()
         self._supervisor_actor_cls = ray.remote(JobSupervisor)
 
-        self._running_jobs: Dict[str, JobStatusInfo] = dict()
         self._recover_running_jobs()
 
     def _recover_running_jobs(self):
         """Recovers all running jobs from the status client.
 
+        For each job, we will spawn a coroutine to monitor it.
         Each will be added to self._running_jobs and reconciled.
         """
         all_jobs = self._status_client.get_all_jobs()
         for job_id, status_info in all_jobs.items():
             if not status_info.status.is_terminal():
-                self._running_jobs[job_id] = status_info
                 create_task(self._monitor_job(job_id))
 
     def _get_actor_for_job(self, job_id: str) -> Optional[ActorHandle]:

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -377,6 +377,34 @@ def wait_for_condition(
     raise RuntimeError(message)
 
 
+async def async_wait_for_condition(
+    condition_predictor, timeout=10, retry_interval_ms=100, **kwargs: Any
+):
+    """Wait until a condition is met or time out with an exception.
+
+    Args:
+        condition_predictor: A function that predicts the condition.
+        timeout: Maximum timeout in seconds.
+        retry_interval_ms: Retry interval in milliseconds.
+
+    Raises:
+        RuntimeError: If the condition is not met before the timeout expires.
+    """
+    start = time.time()
+    last_ex = None
+    while time.time() - start <= timeout:
+        try:
+            if condition_predictor(**kwargs):
+                return
+        except Exception as ex:
+            last_ex = ex
+        await asyncio.sleep(retry_interval_ms / 1000.0)
+    message = "The condition wasn't met before the timeout expired."
+    if last_ex is not None:
+        message += f" Last exception: {last_ex}"
+    raise RuntimeError(message)
+
+
 def wait_until_succeeded_without_exception(
     func, exceptions, *args, timeout_ms=1000, retry_interval_ms=100, raise_last_ex=False
 ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As it stands, job supervisor actor failures are only detected when the client polls for status. This updates the logic to spawn an asyncio task to monitor each job actor so we can catch these in the background.

This simplifies the error handling logic & removes the need to use the private `ref._on_completed` interface as well.

Also adds ability to recover from failure in case the dashboard is restarted.

## Related issue number

Closes https://github.com/ray-project/ray/issues/22181

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
