### PR TITLE
Fix nightly shuffle_data_loader by pinning down dependencies versions

### DIFF
--- a/release/nightly_tests/shuffle_data_loader/shuffle_data_loader_app_config.yaml
+++ b/release/nightly_tests/shuffle_data_loader/shuffle_data_loader_app_config.yaml
@@ -2,7 +2,7 @@ base_image: "anyscale/ray:nightly-py37"
 debian_packages: []
 
 python:
-  pip_packages: [numpy, pandas, pyarrow, s3fs, botocore]
+  pip_packages: [numpy, pandas, pyarrow, s3fs, botocore==1.23.24, boto3==1.20.24, awscli==1.22.24]
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
See https://github.com/fsspec/s3fs/issues/588
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #22162
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
