### PR TITLE
[WIP] Enable all Windows runtime env tests

### DIFF
--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -45,8 +45,9 @@ steps:
 
 - label: ":windows: Post-wheel-build Tests"
   commands:
-      - *prelude_commands
+    - *prelude_commands
     - export WINDOWS_WHEELS="1"
     - . ./ci/travis/ci.sh init
     - . ./ci/travis/ci.sh build
-    - . ./ci/travis/ci.sh test_post_wheel_build    
+    - . ./ci/travis/ci.sh test_post_wheel_build
+  

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -42,3 +42,11 @@ steps:
     - . ./ci/travis/ci.sh init
     - . ./ci/travis/ci.sh build
     - *upload_wheels_if_needed
+
+- label: ":windows: Post-wheel-build Tests"
+  commands:
+      - *prelude_commands
+    - export WINDOWS_WHEELS="1"
+    - . ./ci/travis/ci.sh init
+    - . ./ci/travis/ci.sh build
+    - . ./ci/travis/ci.sh test_post_wheel_build    

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -140,7 +140,6 @@ test_python() {
     args+=(
       python/ray/serve/...
       python/ray/tests/...
-      -python/ray/serve:conda_env # pip field in runtime_env not supported
       -python/ray/tests:test_actor_advanced  # crashes in shutdown
       -python/ray/tests:test_autoscaler # We don't support Autoscaler on Windows
       -python/ray/tests:test_autoscaler_aws
@@ -157,7 +156,6 @@ test_python() {
       -python/ray/tests:test_multi_node_3
       -python/ray/tests:test_object_manager # OOM on test_object_directory_basic
       -python/ray/tests:test_resource_demand_scheduler
-      -python/ray/tests:test_runtime_env_complicated # requires conda
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_operator_unit_tests

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -183,6 +183,19 @@ test_python() {
   fi
 }
 
+test_post_wheel_build() {
+  bazel test --config=ci "$(./scripts/bazel_export_options)" \
+      --test_tag_filters=post_wheel_build \
+      --test_env=CONDA_EXE \
+      --test_env=CONDA_PYTHON_EXE \
+      --test_env=CONDA_SHLVL \
+      --test_env=CONDA_PREFIX \
+      --test_env=CONDA_DEFAULT_ENV \
+      --test_env=CI \
+      --test_env=RAY_CI_POST_WHEEL_TESTS=True \
+      python/ray/tests/... python/ray/serve/... python/ray/tune/... rllib/... doc/...
+}
+
 # For running large Python tests on Linux and MacOS.
 test_large() {
   bazel test --config=ci "$(./scripts/bazel_export_options)" --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE \

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -87,13 +87,7 @@ def parse_and_validate_conda(conda: Union[str, dict]) -> Union[str, dict]:
     assert conda is not None
 
     result = None
-    if sys.platform == "win32":
-        raise NotImplementedError(
-            "The 'conda' field in runtime_env "
-            "is not currently supported on "
-            "Windows."
-        )
-    elif isinstance(conda, str):
+    if isinstance(conda, str):
         yaml_file = Path(conda)
         if yaml_file.suffix in (".yaml", ".yml"):
             if not yaml_file.is_file():
@@ -192,13 +186,7 @@ def parse_and_validate_pip(pip: Union[str, List[str]]) -> Optional[List[str]]:
     assert pip is not None
 
     pip_list = None
-    if sys.platform == "win32":
-        raise NotImplementedError(
-            "The 'pip' field in runtime_env "
-            "is not currently supported on "
-            "Windows."
-        )
-    elif isinstance(pip, str):
+    if isinstance(pip, str):
         # We have been given a path to a requirements.txt file.
         pip_file = Path(pip)
         if not pip_file.is_file():

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-import sys
+
 from typing import Any, Dict, List, Optional, Set, Union
 from pkg_resources import Requirement
 from collections import OrderedDict

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -48,7 +48,6 @@ def tmp_dir():
 
 
 @pytest.mark.parametrize("use_ray_client", [False, True])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_failure_condition(ray_start, tmp_dir, use_ray_client):
     # Verify that the test conditions fail without passing the working dir.
     with open("hello", "w") as f:
@@ -93,7 +92,6 @@ def connect_with_working_dir(use_ray_client: bool, ray_client_addr: str):
 
 
 @pytest.mark.parametrize("use_ray_client", [False, True])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_working_dir_basic(ray_start, tmp_dir, use_ray_client):
     with open("hello", "w") as f:
         f.write("world")
@@ -126,7 +124,6 @@ assert ray.get(handle.remote()) == "world"
 
 
 @pytest.mark.parametrize("use_ray_client", [False, True])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_working_dir_connect_from_new_driver(ray_start, tmp_dir, use_ray_client):
     with open("hello", "w") as f:
         f.write("world")
@@ -181,7 +178,6 @@ Test.delete()
 
 
 @pytest.mark.parametrize("use_ray_client", [False, True])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_working_dir_scale_up_in_new_driver(ray_start, tmp_dir, use_ray_client):
     with open("hello", "w") as f:
         f.write("world")
@@ -247,7 +243,6 @@ Test.delete()
 
 
 @pytest.mark.parametrize("use_ray_client", [False, True])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_working_dir_deploy_new_version(ray_start, tmp_dir, use_ray_client):
     with open("hello", "w") as f:
         f.write("world")
@@ -310,9 +305,6 @@ Test.delete()
 
 
 @pytest.mark.parametrize("use_ray_client", [False, True])
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Runtime env unsupported on Windows"
-)
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="Post-wheel-build test is only run on linux CI machines.",

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -424,6 +424,4 @@ def test_runtime_env_log_msg(
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -120,9 +120,6 @@ def test_container_option_serialize():
     assert job_config_serialized.count(b"--name=test") == 1
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="conda in runtime_env unsupported on Windows."
-)
 def test_invalid_conda_env(shutdown_only):
     ray.init()
 
@@ -162,9 +159,6 @@ def test_invalid_conda_env(shutdown_only):
     assert (time.time() - start) < (first_time / 2.0)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows."
-)
 def test_no_spurious_worker_startup(shutdown_only):
     """Test that no extra workers start up during a long env installation."""
 
@@ -231,7 +225,6 @@ def runtime_env_local_dev_env_var():
     del os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="very slow on Windows.")
 def test_runtime_env_no_spurious_resource_deadlock_msg(
     runtime_env_local_dev_env_var, ray_start_regular, error_pubsub
 ):
@@ -411,9 +404,6 @@ def enable_dev_mode(local_env_var_enabled):
     del os.environ["RAY_RUNTIME_ENV_LOG_TO_DRIVER_ENABLED"]
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="conda in runtime_env unsupported on Windows."
-)
 @pytest.mark.parametrize("local_env_var_enabled", [False, True])
 def test_runtime_env_log_msg(
     local_env_var_enabled, enable_dev_mode, ray_start_cluster_head, log_pubsub

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import time
 from typing import List
-from unittest import mock, skipIf
+from unittest import mock
 import yaml
 
 import ray
@@ -494,7 +494,6 @@ def test_pip_job_config(shutdown_only, pip_as_str, tmp_path):
     assert ray.get(f.remote())
 
 
-@skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package(shutdown_only):
     ray.init(num_cpus=2)
     pkg = ray.experimental.load_package(
@@ -508,7 +507,6 @@ def test_experimental_package(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
-@skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package_lazy(shutdown_only):
     pkg = ray.experimental.load_package(
         os.path.join(
@@ -522,7 +520,6 @@ def test_experimental_package_lazy(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
-@skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package_github(shutdown_only):
     ray.init(num_cpus=2)
     pkg = ray.experimental.load_package(

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -120,10 +120,6 @@ context.disconnect()
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment",
 )
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize(
     "call_ray_start",
     ["ray start --head --ray-client-server-port 24001 --port 0"],
@@ -150,10 +146,6 @@ def test_client_tasks_and_actors_inherit_from_driver(conda_envs, call_ray_start)
 @pytest.mark.skipif(
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment",
-)
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
 )
 def test_task_actor_conda_env(conda_envs, shutdown_only):
     ray.init()
@@ -192,10 +184,6 @@ def test_task_actor_conda_env(conda_envs, shutdown_only):
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment",
 )
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_job_config_conda_env(conda_envs, shutdown_only):
     for package_version in REQUEST_VERSIONS:
         runtime_env = {"conda": f"package-{package_version}"}
@@ -207,10 +195,6 @@ def test_job_config_conda_env(conda_envs, shutdown_only):
 @pytest.mark.skipif(
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment",
-)
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
 )
 def test_job_eager_install(shutdown_only):
     # Test enable eager install. This flag is set to True by default.
@@ -270,10 +254,6 @@ def test_get_conda_env_dir(tmp_path):
         assert env_dir == str(tmp_path / "envs" / "tf2")
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_conda_create_task(shutdown_only):
     """Tests dynamic creation of a conda env in a task's runtime env."""
     ray.init()
@@ -296,10 +276,6 @@ def test_conda_create_task(shutdown_only):
     assert ray.get(f.options(runtime_env=runtime_env).remote())
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_conda_create_job_config(shutdown_only):
     """Tests dynamic conda env creation in a runtime env in the JobConfig."""
 
@@ -358,10 +334,6 @@ def test_inject_dependencies():
         assert output == outputs[i], error_msg
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize(
     "call_ray_start",
     ["ray start --head --ray-client-server-port 24001 --port 0"],
@@ -393,10 +365,6 @@ def test_conda_create_ray_client(call_ray_start):
             ray.get(f.remote())
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize("pip_as_str", [True, False])
 def test_pip_task(shutdown_only, pip_as_str, tmp_path):
     """Tests pip installs in the runtime env specified in f.options()."""
@@ -429,10 +397,6 @@ def test_pip_task(shutdown_only, pip_as_str, tmp_path):
     assert ray.get(f.options(runtime_env=runtime_env).remote())
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize("option", ["conda", "pip"])
 def test_conda_pip_extras_ray_serve(shutdown_only, option):
     """Tests that ray[extras] can be included as a conda/pip dependency."""
@@ -460,10 +424,6 @@ def test_conda_pip_extras_ray_serve(shutdown_only, option):
     assert ray.get(f.options(runtime_env=runtime_env).remote())
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize("pip_as_str", [True, False])
 def test_pip_job_config(shutdown_only, pip_as_str, tmp_path):
     """Tests dynamic installation of pip packages in a task's runtime env."""
@@ -531,10 +491,6 @@ def test_experimental_package_github(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize(
     "call_ray_start",
     ["ray start --head --ray-client-server-port 24001 --port 0"],
@@ -579,10 +535,6 @@ def test_client_working_dir_filepath(call_ray_start, tmp_path):
             assert ray.get(f.remote())
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize(
     "call_ray_start",
     ["ray start --head --ray-client-server-port 24001 --port 0"],
@@ -653,10 +605,6 @@ time.sleep(5)
 """
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_env_installation_nonblocking(shutdown_only):
     """Test fix for https://github.com/ray-project/ray/issues/16226."""
     env1 = {"pip": ["pip-install-test==0.5"]}
@@ -697,10 +645,6 @@ def test_env_installation_nonblocking(shutdown_only):
     proc.wait()
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_simultaneous_install(shutdown_only):
     """Test that two envs can be installed without affecting each other."""
     ray.init()
@@ -733,10 +677,6 @@ def test_simultaneous_install(shutdown_only):
 CLIENT_SERVER_PORT = 24001
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize(
     "call_ray_start",
     [f"ray start --head --ray-client-server-port {CLIENT_SERVER_PORT}" " --port 0"],
@@ -875,10 +815,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
         assert ray.get(a.test.remote()) == "Hello"
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_runtime_env_override(call_ray_start):
     # https://github.com/ray-project/ray/issues/16481
 
@@ -932,10 +868,6 @@ def test_runtime_env_override(call_ray_start):
         ray.shutdown()
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_runtime_env_logging_to_driver(ray_start_regular_shared, log_pubsub):
     @ray.remote(runtime_env={"pip": [f"requests=={REQUEST_VERSIONS[0]}"]})
     def func():
@@ -952,6 +884,4 @@ def test_runtime_env_logging_to_driver(ray_start_regular_shared, log_pubsub):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip.py
@@ -66,10 +66,6 @@ def test_get_conda_dict_with_ray_inserted_m1_wheel(monkeypatch):
     }
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
-)
 @pytest.mark.parametrize("field", ["conda", "pip"])
 def test_requirements_files(start_cluster, field):
     """Test the use of requirements.txt and environment.yaml.
@@ -118,10 +114,6 @@ def test_requirements_files(start_cluster, field):
 
 
 class TestGC:
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason="Needs PR wheels built in CI, so only run on linux CI machines.",
-    )
     @pytest.mark.parametrize("field", ["conda", "pip"])
     @pytest.mark.parametrize("spec_format", ["file", "python_object"])
     def test_job_level_gc(
@@ -165,10 +157,6 @@ class TestGC:
 
         assert ray.get(f.remote())
 
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason=("Requires PR wheels built in CI, so only run on linux CI " "machines."),
-    )
     @pytest.mark.parametrize("field", ["conda", "pip"])
     @pytest.mark.parametrize("spec_format", ["file", "python_object"])
     def test_detached_actor_gc(
@@ -207,10 +195,6 @@ class TestGC:
 
         wait_for_condition(lambda: check_local_files_gced(cluster), timeout=30)
 
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason=("Requires PR wheels built in CI, so only run on linux CI " "machines."),
-    )
     @pytest.mark.parametrize("field", ["conda", "pip"])
     @pytest.mark.parametrize("spec_format", ["file", "python_object"])
     def test_actor_level_gc(

--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -19,10 +19,6 @@ if not os.environ.get("CI"):
 
 
 class TestGC:
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason="Needs PR wheels built in CI, so only run on linux CI machines.",
-    )
     @pytest.mark.parametrize("field", ["conda", "pip"])
     @pytest.mark.parametrize("spec_format", ["file", "python_object"])
     def test_actor_level_gc(
@@ -52,10 +48,6 @@ class TestGC:
             ray.kill(actors[i])
         wait_for_condition(lambda: check_local_files_gced(cluster))
 
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason="Needs PR wheels built in CI, so only run on linux CI machines.",
-    )
     @pytest.mark.parametrize(
         "ray_start_cluster",
         [
@@ -160,10 +152,6 @@ def skip_local_gc():
 
 
 class TestSkipLocalGC:
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason="Requires PR wheels built in CI, so only run on linux CI " "machines.",
-    )
     @pytest.mark.parametrize("field", ["conda", "pip"])
     def test_skip_local_gc_env_var(self, skip_local_gc, start_cluster, field, tmp_path):
         cluster, address = start_cluster

--- a/python/ray/tests/test_runtime_env_fork_process.py
+++ b/python/ray/tests/test_runtime_env_fork_process.py
@@ -9,9 +9,6 @@ import ray
 from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Fork API is not supported on Windows"
-)
 def test_fork_process_in_runtime_env(ray_start_cluster):
     cluster = ray_start_cluster
     directory = os.path.dirname(os.path.realpath(__file__))
@@ -46,9 +43,6 @@ def test_fork_process_in_runtime_env(ray_start_cluster):
     assert result == 1
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Fork API is not supported on Windows"
-)
 def test_fork_process_job_config_from_env_var(ray_start_cluster):
 
     os.environ[RAY_JOB_CONFIG_JSON_ENV_VAR] = json.dumps(

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -89,7 +89,6 @@ def random_zip_file_with_top_level_dir():
         yield str(path / ARCHIVE_NAME)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestGetURIForDirectory:
     def test_invalid_directory(self):
         with pytest.raises(ValueError):
@@ -142,7 +141,6 @@ class TestGetURIForDirectory:
         assert len(hex_hash) == 16
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestUploadPackageIfNeeded:
     def test_create_upload_once(self, empty_dir, random_dir, ray_start_regular):
         uri = get_uri_for_directory(random_dir)
@@ -161,7 +159,6 @@ class TestUploadPackageIfNeeded:
         assert uploaded
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestGetTopLevelDirFromCompressedPackage:
     def test_get_top_level_valid(self, random_zip_file_with_top_level_dir):
         top_level_dir_name = get_top_level_dir_from_compressed_package(
@@ -176,7 +173,6 @@ class TestGetTopLevelDirFromCompressedPackage:
         assert top_level_dir_name is None
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestRemoveDirFromFilepaths:
     def test_valid_removal(self, random_zip_file_with_top_level_dir):
         # This test copies the TOP_LEVEL_DIR_NAME directory, and then it
@@ -206,7 +202,6 @@ class TestRemoveDirFromFilepaths:
         assert len(dcmp.right_only) == 0
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("remove_top_level_directory", [False, True])
 @pytest.mark.parametrize("unlink_zip", [False, True])
 class TestUnzipPackage:
@@ -285,7 +280,6 @@ class TestUnzipPackage:
             )
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_travel():
     with tempfile.TemporaryDirectory() as tmp_dir:
         dir_paths = set()

--- a/python/ray/tests/test_runtime_env_ray_minimal.py
+++ b/python/ray/tests/test_runtime_env_ray_minimal.py
@@ -34,9 +34,6 @@ def _test_task_and_actor(capsys):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows."
-)
-@pytest.mark.skipif(
     os.environ.get("RAY_MINIMAL") != "1",
     reason="This test is only run in CI with a minimal Ray installation.",
 )
@@ -51,9 +48,6 @@ def test_ray_client_task_actor(call_ray_start, capsys):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows."
-)
-@pytest.mark.skipif(
     os.environ.get("RAY_MINIMAL") != "1",
     reason="This test is only run in CI with a minimal Ray installation.",
 )
@@ -62,9 +56,6 @@ def test_task_actor(shutdown_only, capsys):
     _test_task_and_actor(capsys)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows."
-)
 @pytest.mark.skipif(
     os.environ.get("RAY_MINIMAL") != "1",
     reason="This test is only run in CI with a minimal Ray installation.",
@@ -79,9 +70,6 @@ def test_ray_init(shutdown_only, capsys):
     assert ray.get(f.remote()) == 1
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows."
-)
 @pytest.mark.skipif(
     os.environ.get("RAY_MINIMAL") != "1",
     reason="This test is only run in CI with a minimal Ray installation.",

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -145,9 +145,6 @@ class TestValidateExcludes:
         assert ParsedRuntimeEnv({"excludes": []}) == {}
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Conda option not supported on Windows."
-)
 class TestValidateConda:
     def test_validate_conda_invalid_types(self):
         with pytest.raises(TypeError):
@@ -186,9 +183,6 @@ class TestValidateConda:
         assert parse_and_validate_conda(CONDA_DICT) == CONDA_DICT
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Pip option not supported on Windows."
-)
 class TestValidatePip:
     def test_validate_pip_invalid_types(self):
         with pytest.raises(TypeError):
@@ -247,9 +241,6 @@ class TestParsedRuntimeEnv:
     def test_empty(self):
         assert ParsedRuntimeEnv({}) == {}
 
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="Pip option not supported on Windows."
-    )
     def test_serialization(self):
         env1 = ParsedRuntimeEnv(
             {"pip": ["requests"], "env_vars": {"hi1": "hi1", "hi2": "hi2"}}
@@ -276,10 +267,6 @@ class TestParsedRuntimeEnv:
         with pytest.raises(ValueError):
             ParsedRuntimeEnv({"pip": ["requests"], "conda": "env_name"})
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="Conda and pip options not supported on Windows.",
-    )
     def test_ray_commit_injection(self):
         # Should not be injected if no pip and conda.
         result = ParsedRuntimeEnv({"env_vars": {"hi": "hi"}})

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -30,7 +30,6 @@ S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
 GS_PACKAGE_URI = "gs://public-runtime-env-test/test_module.zip"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_create_delete_size_equal(tmpdir, ray_start_regular):
     """Tests that `create` and `delete_uri` return the same size for a URI."""
 
@@ -58,7 +57,6 @@ def test_create_delete_size_equal(tmpdir, ray_start_regular):
 @pytest.mark.parametrize(
     "option", ["failure", "working_dir", "working_dir_zip", "py_modules"]
 )
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_lazy_reads(start_cluster, tmp_working_dir, option: str):
     """Tests the case where we lazily read files or import inside a task/actor.
 
@@ -155,7 +153,6 @@ def test_lazy_reads(start_cluster, tmp_working_dir, option: str):
 
 
 @pytest.mark.parametrize("option", ["failure", "working_dir", "py_modules"])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_captured_import(start_cluster, tmp_working_dir, option: str):
     """Tests importing a module in the driver and capturing it in a task/actor.
 
@@ -220,7 +217,6 @@ def test_captured_import(start_cluster, tmp_working_dir, option: str):
         assert ray.get(a.test_import.remote()) == 1
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_empty_working_dir(start_cluster):
     """Tests the case where we pass an empty directory as the working_dir."""
     cluster, address = start_cluster
@@ -248,7 +244,6 @@ def test_empty_working_dir(start_cluster):
 
 
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_input_validation(start_cluster, option: str):
     """Tests input validation for working_dir and py_modules."""
     cluster, address = start_cluster
@@ -293,7 +288,6 @@ def test_input_validation(start_cluster, option: str):
 
 
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 def test_exclusion(start_cluster, tmp_working_dir, option):
     """Tests various forms of the 'excludes' parameter."""
     cluster, address = start_cluster

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -53,7 +53,6 @@ def URI_cache_10_MB():
         yield
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 def test_inheritance(start_cluster, option: str):
     """Tests that child tasks/actors inherit URIs properly."""
@@ -103,7 +102,6 @@ def test_inheritance(start_cluster, option: str):
             EnvGetter.options(runtime_env=env).remote()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 def test_large_file_boundary(shutdown_only, option: str):
     """Check that packages just under the max size work as expected."""
@@ -127,7 +125,6 @@ def test_large_file_boundary(shutdown_only, option: str):
         assert ray.get(t.get_size.remote()) == size
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 def test_large_file_error(shutdown_only, option: str):
     with tempfile.TemporaryDirectory() as tmp_dir, chdir(tmp_dir):
@@ -147,7 +144,6 @@ def test_large_file_error(shutdown_only, option: str):
                 ray.init(runtime_env={"py_modules": ["."]})
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 def test_large_dir_upload_message(start_cluster, option):
     cluster, address = start_cluster
@@ -269,7 +265,6 @@ def check_internal_kv_gced():
 
 
 class TestGC:
-    @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
     @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
     @pytest.mark.parametrize(
         "source", [S3_PACKAGE_URI, lazy_fixture("tmp_working_dir")]
@@ -324,7 +319,6 @@ class TestGC:
         wait_for_condition(check_internal_kv_gced)
         wait_for_condition(lambda: check_local_files_gced(cluster))
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
     @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
     def test_actor_level_gc(
         self, start_cluster, runtime_env_disable_URI_cache, option: str
@@ -359,7 +353,6 @@ class TestGC:
             ray.kill(actors[i])
         wait_for_condition(lambda: check_local_files_gced(cluster))
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
     @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
     @pytest.mark.parametrize(
         "source", [S3_PACKAGE_URI, lazy_fixture("tmp_working_dir")]
@@ -418,7 +411,6 @@ class TestGC:
         wait_for_condition(check_internal_kv_gced)
         wait_for_condition(lambda: check_local_files_gced(cluster))
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
     def test_hit_cache_size_limit(self, start_cluster, URI_cache_10_MB):
         """Test eviction happens when we exceed a nonzero (10MB) cache size."""
         NUM_NODES = 3
@@ -456,7 +448,6 @@ class TestGC:
                 assert 3 < get_directory_size_bytes(local_dir) / (1024 ** 2) < 5
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 @pytest.mark.parametrize("source", [S3_PACKAGE_URI, lazy_fixture("tmp_working_dir")])
 def test_default_large_cache(start_cluster, option: str, source: str):

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import pytest
@@ -16,10 +15,6 @@ from ray._private.test_utils import wait_for_condition, check_local_files_gced
 S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
-)
 @pytest.mark.parametrize(
     "ray_start_cluster",
     [

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -58,7 +58,6 @@ S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
     ],
     indirect=True,
 )
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 def test_task_level_gc(ray_start_cluster, option):
     """Tests that task-level working_dir is GC'd when the worker exits."""

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -20,7 +20,6 @@ GS_PACKAGE_URI = "gs://public-runtime-env-test/test_module.zip"
 REMOTE_URIS = [HTTPS_PACKAGE_URI, S3_PACKAGE_URI]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("remote_uri", REMOTE_URIS)
 @pytest.mark.parametrize("option", ["failure", "working_dir", "py_modules"])
 @pytest.mark.parametrize("per_task_actor", [True, False])
@@ -77,7 +76,6 @@ def test_remote_package_uri(start_cluster, remote_uri, option, per_task_actor):
         assert ray.get(a.test_import.remote()) == 2
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
 @pytest.mark.parametrize("source", [*REMOTE_URIS, lazy_fixture("tmp_working_dir")])
 def test_multi_node(start_cluster, option: str, source: str):
@@ -108,7 +106,6 @@ def test_multi_node(start_cluster, option: str, source: str):
     assert len(set(ray.get(object_refs))) == NUM_NODES
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("working_dir", [*REMOTE_URIS, lazy_fixture("tmp_working_dir")])
 def test_runtime_context(start_cluster, working_dir):
     """Tests that the working_dir is propagated in the runtime_context."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR is just to trigger a Windows CI run with all the runtime_env tests enabled, to get an idea of what's currently not working on Windows.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
