### PR TITLE
[client] Deflaky `test_basic_5_client_mode` in redisless ray.

### DIFF
--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -291,7 +291,7 @@ class DataClient:
         #     1. _async_send is executing
         #     2. gc is triggered
         # In this case 1) is holding the lock, and 2) is trying to hold the
-        # lock which actually are deadlock.
+        # lock which actually make a deadlock.
         # To avoid this, when in case 2) we put request into gc_queue, and
         # and when it returns to 1) it'll finish sending the request.
         # But there is a race condition where 1) is just about to release


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
lock is not supposed to be used in gc since it'll bring a deadlock between gc and the code and this will lead client to hang.
This PR fixed this by queuing the gc request into another queue. There is a rare race condition, but we think overall it's ok.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #22082 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
