### PR TITLE
[Kuberay] Updated kuberay-autoscaler.yaml to create service account

### DIFF
--- a/python/ray/autoscaler/kuberay/kuberay-autoscaler.yaml
+++ b/python/ray/autoscaler/kuberay/kuberay-autoscaler.yaml
@@ -37,6 +37,11 @@ data:
     head_node: {}
     worker_nodes: {}
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: autoscaler-sa
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Added lines to autoscaler configuration yaml to create a service account that is used to give the autoscaler permissions to list and read pods and patch the cluster CRD for up/downscaling.

## Related issue number

none

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
