### PR TITLE
[e2e] Update e2e test to use redisless ray by default.

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -1521,15 +1521,20 @@ def run_test_config(
 
     app_config_rel_path = test_config["cluster"].get("app_config", None)
     app_config = _load_config(local_dir, app_config_rel_path)
+    if app_config["env_vars"] is None:
+        app_config["env_vars"] = {}
     # A lot of staging tests share the same app config yaml, except the flags.
     # `app_env_vars` in test config will help this one.
     # Here we extend the env_vars to use the one specified in the test config.
     if test_config.get("app_env_vars") is not None:
-        if app_config["env_vars"] is None:
-            app_config["env_vars"] = test_config["app_env_vars"]
-        else:
-            app_config["env_vars"].update(test_config["app_env_vars"])
+        app_config["env_vars"].update(test_config["app_env_vars"])
         logger.info(f"Using app config:\n{app_config}")
+
+    # Flags for redisless ray.
+    # TODO: remove them once done.
+    app_config["env_vars"]["MATCH_AUTOSCALER_AND_RAY_IMAGES"] = "1"
+    app_config["env_vars"]["RAY_bootstrap_with_gcs"] = "1"
+    app_config["env_vars"]["RAY_gcs_storage"] = "memory"
 
     compute_tpl_rel_path = test_config["cluster"].get("compute_template", None)
     compute_tpl = _load_config(local_dir, compute_tpl_rel_path)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As title, after infra got updated, we need to merge the PR so that test can run ray without redis.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
