### PR TITLE
[Client] avoid locking in async send

### DIFF
--- a/python/ray/tests/test_dataclient_disconnect.py
+++ b/python/ray/tests/test_dataclient_disconnect.py
@@ -50,7 +50,7 @@ def test_dataclient_disconnect_before_request():
         # Force grpc to error by queueing garbage request. This simulates
         # the data channel shutting down for connection issues between
         # different remote calls.
-        ray.worker.data_client.request_queue.put(Mock())
+        ray.worker.data_client.request_queue.put((Mock(), None))
 
         # The following two assertions are relatively brittle. Consider a more
         # robust mechanism if they fail with code changes or become flaky.

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -853,10 +853,10 @@ class OrderedResponseCache:
                 # Request is for an id that has already been cleared from
                 # cache/acknowledged.
                 raise RuntimeError(
-                    "Attempting to accesss a cache entry that has already "
+                    "Attempting to access a cache entry that has already "
                     "cleaned up. The client has already acknowledged "
-                    f"receiving this response. ({req_id}, "
-                    f"{self.last_received})"
+                    f"receiving this response. (this_req_id={req_id}, "
+                    f"acknowledged={self.last_received})"
                 )
             if req_id in self.cache:
                 cached_resp = self.cache[req_id]

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -97,6 +97,9 @@ class ClientObjectRef(raylet.ObjectRef):
         else:
             raise TypeError("Unexpected type for id {}".format(id))
 
+    # NOTE: synchronization primitives like threading.Lock should not be used
+    # transitively by a destructor. Otherwise deadlocks can happen. See
+    # https://stackoverflow.com/questions/18774401/self-deadlock-due-to-garbage-collector-in-single-threaded-code
     def __del__(self):
         if self._worker is not None and self._worker.is_connected():
             try:
@@ -106,8 +109,7 @@ class ClientObjectRef(raylet.ObjectRef):
                 logger.info(
                     "Exception in ObjectRef is ignored in destructor. "
                     "To receive this exception in application code, call "
-                    "a method on the actor reference before its destructor "
-                    "is run."
+                    "a method on the reference before its destructor runs."
                 )
 
     def binary(self):
@@ -202,6 +204,9 @@ class ClientActorRef(raylet.ActorID):
         else:
             raise TypeError("Unexpected type for id {}".format(id))
 
+    # NOTE: synchronization primitives like threading.Lock should not be used
+    # transitively by a destructor. Otherwise deadlocks can happen. See
+    # https://stackoverflow.com/questions/18774401/self-deadlock-due-to-garbage-collector-in-single-threaded-code
     def __del__(self):
         if self._worker is not None and self._worker.is_connected():
             try:
@@ -211,8 +216,7 @@ class ClientActorRef(raylet.ActorID):
                 logger.info(
                     "Exception from actor creation is ignored in destructor. "
                     "To receive this exception in application code, call "
-                    "a method on the actor reference before its destructor "
-                    "is run."
+                    "a method on the reference before its destructor runs."
                 )
 
     def binary(self):

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -216,7 +216,7 @@ class DataClient:
             except queue.Empty:
                 break
             except Exception:
-                logger.warning(f"Bad input data.", exc_info=True)
+                logger.exception("Bad input data")
                 continue
             if callback:
                 callback(err)

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -276,13 +276,21 @@ class Worker:
             # Unrecoverable error -- These errors are specifically raised
             # by the server's application logic
             return False
-        if e.code() == grpc.StatusCode.INTERNAL:
-            details = e.details()
-            if details == "Exception serializing request!":
-                # The client failed tried to send a bad request (for example,
-                # passing "None" instead of a valid grpc message). Don't
-                # try to reconnect/retry.
-                return False
+        if (
+            e.code() == grpc.StatusCode.INTERNAL
+            and e.details() == "Exception serializing request!"
+        ):
+            # The client failed tried to send a bad request. Don't
+            # try to reconnect/retry.
+            return False
+        if (
+            e.code() == grpc.StatusCode.UNKNOWN
+            and e.details() == "Exception iterating requests!"
+        ):
+            # The client failed tried to send a bad request (for example,
+            # passing "None" instead of a valid grpc message). Don't try to
+            # reconnect/retry.
+            return False
         # All other errors can be treated as recoverable
         return True
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As @iycheng discovered in https://github.com/ray-project/ray/issues/22082#issuecomment-1031821631, when `ClientObjectRef` is being GC'ed, `DataClient.lock` is acquired which may cause deadlock. This change avoids acquiring lock in `DataClient._async_send()`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
