### PR TITLE
[Dataset] disable pandas as default block type

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -15,8 +15,9 @@ DEFAULT_TARGET_MAX_BLOCK_SIZE = 2048 * 1024 * 1024
 DEFAULT_BLOCK_SPLITTING_ENABLED = False
 
 # Whether pandas block format is enabled.
+# Turned off due to issue https://github.com/ray-project/ray/issues/22177
 # TODO (kfstorm): Remove this once stable.
-DEFAULT_ENABLE_PANDAS_BLOCK = True
+DEFAULT_ENABLE_PANDAS_BLOCK = False
 
 
 @DeveloperAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The hypothesis is that pandas' deepcopy doesn't work as expected. specifically it still returns the full base copy even if the dataframe only has a a sliced view. this caused the shuffle-reduce to fail in our nightly test.

TODO: verify this fixed the object size too large issue.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
