### PR TITLE
[CI] Delete `.style.yapf`

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,4 +1,0 @@
-[style]
-based_on_style=pep8
-allow_split_before_dict_value=False
-join_multiple_lines=False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

With #21986, we no longer use YAPF. So, we can safely remove `.style.yapf`.

## Related issue number

<!-- For example: "Closes #1234" -->

#21311 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
