### PR TITLE
[Test] Unflake pg test + add pg tests that weren't running

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -94,6 +94,7 @@ py_test_module_list(
     "test_placement_group.py",
     "test_placement_group_2.py",
     "test_placement_group_3.py",
+    "test_placement_group_4.py",
     "test_ray_init.py",
     "test_reference_counting.py",
     "test_resource_demand_scheduler.py",

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -20,7 +20,7 @@ from ray._private.test_utils import (
     is_placement_group_removed,
     convert_actor_state,
 )
-from ray.exceptions import RaySystemError, GetTimeoutError
+from ray.exceptions import RaySystemError
 from ray.util.placement_group import placement_group, remove_placement_group
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 import ray.experimental.internal_kv as internal_kv
@@ -685,27 +685,6 @@ def test_fractional_resources_handle_correct(ray_start_cluster):
     pg = placement_group(bundles, strategy="SPREAD")
 
     ray.get(pg.ready(), timeout=10)
-
-
-def test_infeasible_pg(ray_start_cluster):
-    """Test infeasible pgs are scheduled after new nodes are added."""
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=2)
-    ray.init("auto")
-
-    bundle = {"CPU": 4, "GPU": 1}
-    pg = placement_group([bundle], name="worker_1", strategy="STRICT_PACK")
-
-    # Placement group is infeasible.
-    with pytest.raises(GetTimeoutError):
-        ray.get(pg.ready(), timeout=3)
-
-    state = ray.util.placement_group_table()[pg.id.hex()]["stats"]["scheduling_state"]
-    assert state == "INFEASIBLE"
-
-    # Add a new node. PG can now be scheduled.
-    cluster.add_node(num_cpus=4, num_gpus=1)
-    assert ray.get(pg.ready(), timeout=10)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_placement_group_4.py
+++ b/python/ray/tests/test_placement_group_4.py
@@ -407,3 +407,24 @@ def test_placement_group_reschedule_when_node_dead(
         ray.get(actor_6.value.remote())
         placement_group_assert_no_leak([placement_group])
         ray.shutdown()
+
+
+def test_infeasible_pg(ray_start_cluster):
+    """Test infeasible pgs are scheduled after new nodes are added."""
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    ray.init("auto")
+
+    bundle = {"CPU": 4, "GPU": 1}
+    pg = ray.util.placement_group([bundle], name="worker_1", strategy="STRICT_PACK")
+
+    # Placement group is infeasible.
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(pg.ready(), timeout=3)
+
+    state = ray.util.placement_group_table()[pg.id.hex()]["stats"]["scheduling_state"]
+    assert state == "INFEASIBLE"
+
+    # Add a new node. PG can now be scheduled.
+    cluster.add_node(num_cpus=4, num_gpus=1)
+    assert ray.get(pg.ready(), timeout=10)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unflake pg test (pg test 3 times out occasionally)+ add pg tests that weren't running

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
