### PR TITLE
[jobs] Add unit test for `parse_cluster_info`

### DIFF
--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -24,6 +24,9 @@ def test_parse_cluster_info(
     metadata: Optional[Dict[str, str]],
     headers: Optional[Dict[str, str]],
 ):
+    """
+    Test ray.dashboard.modules.job.sdk.parse_cluster_info for different format of addresses.
+    """
     mock_get_job_submission_client_cluster_info = Mock(return_value="Ray ClusterInfo")
     mock_other_module = Mock()
     mock_other_module.get_job_submission_client_cluster_info = Mock(

--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -1,0 +1,76 @@
+import pytest
+from typing import Dict, Optional, Tuple
+from unittest.mock import Mock, patch
+
+from ray.dashboard.modules.job.sdk import parse_cluster_info
+
+
+@pytest.mark.parametrize(
+    "address_param",
+    [
+        ("ray://1.2.3.4:10001", "ray", "1.2.3.4:10001"),
+        ("other_module://", "other_module", ""),
+        ("other_module://address", "other_module", "address"),
+    ],
+)
+@pytest.mark.parametrize("create_cluster_if_needed", [True, False])
+@pytest.mark.parametrize("cookies", [None, {"test_cookie_key": "test_cookie_val"}])
+@pytest.mark.parametrize("metadata", [None, {"test_metadata_key": "test_metadata_val"}])
+@pytest.mark.parametrize("headers", [None, {"test_headers_key": "test_headers_val"}])
+def test_parse_cluster_info(
+    address_param: Tuple[str, str, str],
+    create_cluster_if_needed: bool,
+    cookies: Optional[Dict[str, str]],
+    metadata: Optional[Dict[str, str]],
+    headers: Optional[Dict[str, str]],
+):
+    mock_get_job_submission_client_cluster_info = Mock(return_value="Ray ClusterInfo")
+    mock_other_module = Mock()
+    mock_other_module.get_job_submission_client_cluster_info = Mock(
+        return_value="Other module ClusterInfo"
+    )
+    mock_import_module = Mock(return_value=mock_other_module)
+
+    address, module_string, inner_address = address_param
+
+    with patch.multiple(
+        "ray.dashboard.modules.job.sdk",
+        get_job_submission_client_cluster_info=mock_get_job_submission_client_cluster_info,
+    ), patch.multiple("importlib", import_module=mock_import_module):
+        if module_string == "ray":
+            assert (
+                parse_cluster_info(
+                    address,
+                    create_cluster_if_needed=create_cluster_if_needed,
+                    cookies=cookies,
+                    metadata=metadata,
+                    headers=headers,
+                )
+                == "Ray ClusterInfo"
+            )
+            mock_get_job_submission_client_cluster_info.assert_called_once_with(
+                inner_address,
+                create_cluster_if_needed=create_cluster_if_needed,
+                cookies=cookies,
+                metadata=metadata,
+                headers=headers,
+            )
+        elif module_string == "other_module":
+            assert (
+                parse_cluster_info(
+                    address,
+                    create_cluster_if_needed=create_cluster_if_needed,
+                    cookies=cookies,
+                    metadata=metadata,
+                    headers=headers,
+                )
+                == "Other module ClusterInfo"
+            )
+            mock_import_module.assert_called_once_with(module_string)
+            mock_other_module.get_job_submission_client_cluster_info.assert_called_once_with(
+                inner_address,
+                create_cluster_if_needed=create_cluster_if_needed,
+                cookies=cookies,
+                metadata=metadata,
+                headers=headers,
+            )

--- a/dashboard/modules/job/tests/test_sdk.py
+++ b/dashboard/modules/job/tests/test_sdk.py
@@ -25,20 +25,21 @@ def test_parse_cluster_info(
     headers: Optional[Dict[str, str]],
 ):
     """
-    Test ray.dashboard.modules.job.sdk.parse_cluster_info for different format of addresses.
+    Test ray.dashboard.modules.job.sdk.parse_cluster_info for different
+    format of addresses.
     """
-    mock_get_job_submission_client_cluster_info = Mock(return_value="Ray ClusterInfo")
-    mock_other_module = Mock()
-    mock_other_module.get_job_submission_client_cluster_info = Mock(
+    mock_get_job_submission_client_cluster = Mock(return_value="Ray ClusterInfo")
+    mock_module = Mock()
+    mock_module.get_job_submission_client_cluster_info = Mock(
         return_value="Other module ClusterInfo"
     )
-    mock_import_module = Mock(return_value=mock_other_module)
+    mock_import_module = Mock(return_value=mock_module)
 
     address, module_string, inner_address = address_param
 
     with patch.multiple(
         "ray.dashboard.modules.job.sdk",
-        get_job_submission_client_cluster_info=mock_get_job_submission_client_cluster_info,
+        get_job_submission_client_cluster_info=mock_get_job_submission_client_cluster,
     ), patch.multiple("importlib", import_module=mock_import_module):
         if module_string == "ray":
             assert (
@@ -51,7 +52,7 @@ def test_parse_cluster_info(
                 )
                 == "Ray ClusterInfo"
             )
-            mock_get_job_submission_client_cluster_info.assert_called_once_with(
+            mock_get_job_submission_client_cluster.assert_called_once_with(
                 inner_address,
                 create_cluster_if_needed=create_cluster_if_needed,
                 cookies=cookies,
@@ -70,7 +71,7 @@ def test_parse_cluster_info(
                 == "Other module ClusterInfo"
             )
             mock_import_module.assert_called_once_with(module_string)
-            mock_other_module.get_job_submission_client_cluster_info.assert_called_once_with(
+            mock_module.get_job_submission_client_cluster_info.assert_called_once_with(
                 inner_address,
                 create_cluster_if_needed=create_cluster_if_needed,
                 cookies=cookies,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add unit test to check addresses of various formats are correctly passed to `get_job_submission_client_cluster_info`.

## Related issue number

<!-- For example: "Closes #1234" -->
Follow up from https://github.com/ray-project/ray/pull/22116

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
