### PR TITLE
[autoscaler] Add AWS CloudFormation support.

### DIFF
--- a/python/ray/autoscaler/aws/cloudformation/cloudformation-template-example.yaml
+++ b/python/ray/autoscaler/aws/cloudformation/cloudformation-template-example.yaml
@@ -1,0 +1,31 @@
+Resources:
+  RayExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: RayAutoscalerV1
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess # Ray Default
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess # Ray Default
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+  RayInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      InstanceProfileName: RayAutoscalerV1
+      Path: '/'
+      Roles:
+        - !Ref RayExecutionRole
+  RayClusterLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: RayAutoscalerLaunchTemplate
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt RayInstanceProfile.Arn

--- a/python/ray/autoscaler/aws/example-cloudformation.yaml
+++ b/python/ray/autoscaler/aws/example-cloudformation.yaml
@@ -1,0 +1,52 @@
+# An unique identifier for the head node and workers of this cluster.
+cluster_name: cloudformation
+
+# The maximum number of workers nodes to launch in addition to the head node.
+max_workers: 2
+
+# Cloud-provider specific configuration.
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a
+    cloud_formation:
+      # AWS CloudFormation stacks to deploy before applying Ray cluster config. Stacks are deployed in the order given.
+      # CloudFormation stack name
+      - stack_name: RayClusterExample
+        # Path to your local CloudFormation template file
+        template_file: "cloudformation/cloudformation-template-example.yaml"
+        # Additional create stack arguments. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.create_stack.
+        create_stack_args:
+          Capabilities:
+            - CAPABILITY_NAMED_IAM
+          OnFailure: DELETE
+        # Additional update stack arguments. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.update_stack.
+        update_stack_args:
+          Capabilities:
+            - CAPABILITY_NAMED_IAM
+
+
+# How Ray will authenticate with newly launched nodes.
+auth:
+    ssh_user: ubuntu
+
+available_node_types:
+  ray.head.default:
+      node_config:
+        InstanceType: c5a.large
+        LaunchTemplate:
+          LaunchTemplateName: RayAutoscalerLaunchTemplate
+          Version: "$Latest"
+        ImageId: latest_dlami
+      resources: {}
+  ray.worker.default:
+      node_config:
+        InstanceType: c5a.large
+        ImageId: latest_dlami
+        LaunchTemplate:
+          LaunchTemplateName: RayAutoscalerLaunchTemplate
+          Version: "$Latest"
+      resources: {}
+      min_workers: 0
+      max_workers: 2
+head_node_type: ray.head.default

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -181,6 +181,33 @@
                         }
                     }
                 },
+                "cloud_formation": {
+                    "type": "array",
+                    "description": "AWS cloud formation stacks to deploy before applying Ray cluster config. Stacks are deployed in the order given.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["stack_name"],
+                        "properties": {
+                            "stack_name": {
+                                "type": "string",
+                                "description": "AWS cloud formation stack name"
+                            },
+                            "template_file": {
+                                "type": "string",
+                                "description": "AWS cloud formation template file path"
+                            },
+                            "create_stack_args": {
+                                "type": "object",
+                                "description": "Additional create stack arguments. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.create_stack."
+                            },
+                            "update_stack_args": {
+                                "type": "object",
+                                "description": "Additional update stack arguments. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.update_stack."
+                            }
+                        }
+                    }
+                },
                 "cloudwatch": {
                     "agent": {
                         "CLOUDWATCH_AGENT_INSTALLED_AMI_TAG": {


### PR DESCRIPTION
## Why are these changes needed?

These changes add the ability to deploy user-specified CloudFormation stacks prior to bootstrapping a Ray AWS autoscaler cluster. CloudFormation is used extensively when provisioning new AWS accounts for running Ray and allows users to manage a collection of AWS resources as a single unit.

## Related issue number

Resolves milestone [6] of https://github.com/ray-project/ray/issues/8420.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
