### PR TITLE
[RLlib] RecSim Interest evolution environment should use custom video sampler: `IEvVideoSampler` due to only one cluster being used.

### DIFF
--- a/rllib/examples/env/recsim_recommender_system_envs.py
+++ b/rllib/examples/env/recsim_recommender_system_envs.py
@@ -83,19 +83,18 @@ def iev_user_model_creator(env_ctx):
 
 # Extend IEvVideo to fix a bug caused by None cluster_ids.
 class SingleClusterIEvVideo(iev.IEvVideo):
-    def __init__(self,
-                 doc_id,
-                 features,
-                 video_length=None,
-                 quality=None):
+    def __init__(self, doc_id, features, video_length=None, quality=None):
         super(SingleClusterIEvVideo, self).__init__(
-            doc_id=doc_id, features=features, cluster_id=0, # single cluster.
-            video_length=video_length, quality=quality)
+            doc_id=doc_id,
+            features=features,
+            cluster_id=0,  # single cluster.
+            video_length=video_length,
+            quality=quality,
+        )
 
 
 def iev_document_sampler_creator(env_ctx):
-    return iev.IEvVideoSampler(doc_ctor=SingleClusterIEvVideo,
-                               seed=env_ctx["seed"])
+    return iev.IEvVideoSampler(doc_ctor=SingleClusterIEvVideo, seed=env_ctx["seed"])
 
 
 InterestEvolutionRecSimEnv = make_recsim_env(

--- a/rllib/examples/env/recsim_recommender_system_envs.py
+++ b/rllib/examples/env/recsim_recommender_system_envs.py
@@ -74,15 +74,28 @@ InterestExplorationRecSimEnv = make_recsim_env(
 def iev_user_model_creator(env_ctx):
     return iev.IEvUserModel(
         env_ctx["slate_size"],
-        choice_model_ctor=choice_model.MultinomialProportionalChoiceModel,
+        choice_model_ctor=choice_model.MultinomialLogitChoiceModel,
         response_model_ctor=iev.IEvResponse,
         user_state_ctor=iev.IEvUserState,
         seed=env_ctx["seed"],
     )
 
 
+# Extend IEvVideo to fix a bug caused by None cluster_ids.
+class SingleClusterIEvVideo(iev.IEvVideo):
+    def __init__(self,
+                 doc_id,
+                 features,
+                 video_length=None,
+                 quality=None):
+        super(SingleClusterIEvVideo, self).__init__(
+            doc_id=doc_id, features=features, cluster_id=0, # single cluster.
+            video_length=video_length, quality=quality)
+
+
 def iev_document_sampler_creator(env_ctx):
-    return iev.UtilityModelVideoSampler(doc_ctor=iev.IEvVideo, seed=env_ctx["seed"])
+    return iev.IEvVideoSampler(doc_ctor=SingleClusterIEvVideo,
+                               seed=env_ctx["seed"])
 
 
 InterestEvolutionRecSimEnv = make_recsim_env(


### PR DESCRIPTION
## Why are these changes needed?

Interest evolution env should probably use IEV video sampler, instead of the utility model video sampler.
Docs returned from this sampler contains actual features, instead of utility indices.
This may help your slateq runs.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
