### PR TITLE
[Doc] Fix bad doc and recover doc of c++ api

### DIFF
--- a/cpp/example/example.cc
+++ b/cpp/example/example.cc
@@ -1,5 +1,6 @@
 /// This is an example of Ray C++ application. Please visit
-/// `https://docs.ray.io/en/master/index.html` for more details.
+/// `https://docs.ray.io/en/master/ray-core/walkthrough.html#installation`
+/// for more details.
 
 /// including the `<ray/api.h>` header
 #include <ray/api.h>

--- a/doc/source/ray-core/starting-ray.rst
+++ b/doc/source/ray-core/starting-ray.rst
@@ -95,9 +95,9 @@ When the process calling ``ray.init()`` terminates, the Ray runtime will also te
         ... // ray program
         ray::Shutdown()
 
-.. tabbed:: Python
+To check if Ray is initialized, use the ``is_initialized`` API.
 
-    To check if Ray is initialized, you can call ``ray.is_initialized()``:
+.. tabbed:: Python
 
     .. code-block:: python
 
@@ -109,8 +109,6 @@ When the process calling ``ray.init()`` terminates, the Ray runtime will also te
         assert ray.is_initialized() == False
 
 .. tabbed:: Java
-
-    To check if Ray is initialized, you can call ``Ray.isInitialized()``:
 
     .. code-block:: java
 
@@ -127,8 +125,6 @@ When the process calling ``ray.init()`` terminates, the Ray runtime will also te
         }
 
 .. tabbed:: C++
-
-    To check if Ray is initialized, you can call ``ray::IsInitialized()``:
 
     .. code-block:: c++
 
@@ -168,6 +164,7 @@ Use ``ray start`` from the CLI to start a 1 node ray runtime on a machine. This 
 You can connect to this Ray runtime by starting a driver process on the same node as where you ran ``ray start``:
 
 .. tabbed:: Python
+
   .. code-block:: python
 
     # This must

--- a/doc/source/ray-core/walkthrough.rst
+++ b/doc/source/ray-core/walkthrough.rst
@@ -29,7 +29,32 @@ Installation
 
 .. tabbed:: C++
 
-    To run this walkthrough, install Ray with ``pip install -U ray[cpp]``. For the latest wheels (for a snapshot of ``master``), you can use these instructions at :ref:`install-nightlies`.
+    The C++ Ray API is currently experimental with limited support. You can track its development `here <https://github.com/ray-project/ray/milestone/17>`__ and report issues on GitHub.
+    Run the following commands to get started:
+
+    Install ray with C++ API support and generate a bazel project with the ray command.
+
+    .. code-block:: shell
+
+      pip install "ray[cpp]"
+      mkdir ray-template && ray cpp --generate-bazel-project-template-to ray-template
+
+    The project template comes with a simple example application. You can try this example out in 2 ways:
+
+    1. Run the example application directly, which will start a Ray cluster locally.
+
+    .. code-block:: shell
+
+      cd ray-template && bash run.sh
+
+    2. Connect the example application to an existing Ray cluster by specifying the RAY_ADDRESS env var.
+
+    .. code-block:: shell
+
+      ray start --head
+      RAY_ADDRESS=127.0.0.1:6379 bash run.sh
+
+    Now you can build your own Ray C++ application based on this project template.
 
 Starting Ray
 ------------
@@ -280,6 +305,7 @@ this default behavior by passing in specific resources.
 
 
 .. tabbed:: C++
+
     .. code-block:: c++
 
         RayConfig config;
@@ -437,6 +463,7 @@ Object refs can be created in multiple ways.
   2. They are returned by ``put`` (:ref:`docstring <ray-put-ref>`).
 
 .. tabbed:: Python
+
   .. code-block:: python
 
     # Put an object in Ray's object store.
@@ -444,6 +471,7 @@ Object refs can be created in multiple ways.
     object_ref = ray.put(y)
 
 .. tabbed:: Java
+
   .. code-block:: java
 
     // Put an object in Ray's object store.
@@ -451,6 +479,7 @@ Object refs can be created in multiple ways.
     ObjectRef<Integer> objectRef = Ray.put(y);
 
 .. tabbed:: C++
+
   .. code-block:: c++
 
     // Put an object in Ray's object store.
@@ -550,11 +579,13 @@ finished executing. This can be done with ``wait`` (:ref:`ray-wait-ref`). The fu
 works as follows.
 
 .. tabbed:: Python
+
   .. code-block:: python
 
     ready_refs, remaining_refs = ray.wait(object_refs, num_returns=1, timeout=None)
 
 .. tabbed:: Java
+
   .. code-block:: java
 
     WaitResult<Integer> waitResult = Ray.wait(objectRefs, /*num_returns=*/0, /*timeoutMs=*/1000);
@@ -562,6 +593,7 @@ works as follows.
     System.out.println(waitResult.getUnready());  // list of unready objects.
 
 .. tabbed:: C++
+
   .. code-block:: c++
 
     ray::WaitResult<int> wait_result = ray::Wait(object_refs, /*num_objects=*/0, /*timeout_ms=*/1000);


### PR DESCRIPTION
## Why are these changes needed?
- Some bad docs:
![image](https://user-images.githubusercontent.com/26714159/152961439-6cde6654-b2e0-41ce-905a-8fc88341d869.png)

![image](https://user-images.githubusercontent.com/26714159/152961505-e78fc0e1-a52e-403f-a30d-a4ea0df8c908.png)

![image](https://user-images.githubusercontent.com/26714159/152961598-c90336ad-68a7-4173-b29d-b5a580f0cc28.png)

- Recover the doc of c++ api(don't know why this doc has been deleted or lost):
![image](https://user-images.githubusercontent.com/26714159/152961976-7173118f-267f-4e13-947f-29554ac2bbf1.png)

copied from v1.10.0 https://docs.ray.io/en/latest/#getting-started-with-ray 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
