### PR TITLE
[refactor cluster-task-manage 1/n] separate resource reporting logic into helper class

### DIFF
--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -23,6 +23,7 @@
 #include "ray/raylet/scheduling/cluster_resource_scheduler.h"
 #include "ray/raylet/scheduling/cluster_task_manager_interface.h"
 #include "ray/raylet/scheduling/internal.h"
+#include "ray/raylet/scheduling/scheduler_resource_reporter.h"
 #include "ray/raylet/worker.h"
 #include "ray/raylet/worker_pool.h"
 #include "ray/rpc/grpc_client.h"
@@ -276,8 +277,6 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
   /// Function to announce infeasible task to GCS.
   std::function<void(const RayTask &)> announce_infeasible_task_;
 
-  const int max_resource_shapes_per_load_report_;
-
   /// TODO(swang): Add index from TaskID -> Work to avoid having to iterate
   /// through queues to cancel tasks, etc.
   /// Queue of lease requests that are waiting for resources to become available.
@@ -346,6 +345,8 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
   /// Track the backlog of all workers belonging to this raylet.
   absl::flat_hash_map<SchedulingClass, absl::flat_hash_map<WorkerID, int64_t>>
       backlog_tracker_;
+
+  const SchedulerResourceReporter scheduler_resource_reporter_;
 
   /// TODO(Shanly): Remove `worker_pool_` and `leased_workers_` and make them as
   /// parameters of methods if necessary once we remove the legacy scheduler.

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -437,9 +437,6 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
 
   void Spillback(const NodeID &spillback_to, const std::shared_ptr<internal::Work> &work);
 
-  /// Sum up the backlog size across all workers for a given scheduling class.
-  int64_t TotalBacklogSize(SchedulingClass scheduling_class);
-
   // Helper function to pin a task's args immediately before dispatch. This
   // returns false if there are missing args (due to eviction) or if there is
   // not enough memory available to dispatch the task, due to other executing

--- a/src/ray/raylet/scheduling/internal.h
+++ b/src/ray/raylet/scheduling/internal.h
@@ -17,6 +17,7 @@
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task.h"
 #include "ray/common/task/task_common.h"
+#include "src/ray/protobuf/node_manager.pb.h"
 
 namespace ray {
 namespace raylet {

--- a/src/ray/raylet/scheduling/scheduler_resource_reporter.cc
+++ b/src/ray/raylet/scheduling/scheduler_resource_reporter.cc
@@ -1,0 +1,184 @@
+// Copyright 2020-2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/scheduler_resource_reporter.h"
+
+namespace ray {
+namespace raylet {
+
+SchedulerResourceReporter::SchedulerResourceReporter(
+    const absl::flat_hash_map<
+        SchedulingClass, std::deque<std::shared_ptr<internal::Work>>> &tasks_to_schedule,
+    const absl::flat_hash_map<
+        SchedulingClass, std::deque<std::shared_ptr<internal::Work>>> &tasks_to_dispatch,
+    const absl::flat_hash_map<
+        SchedulingClass, std::deque<std::shared_ptr<internal::Work>>> &infeasible_tasks,
+    const absl::flat_hash_map<SchedulingClass, absl::flat_hash_map<WorkerID, int64_t>>
+        &backlog_tracker)
+    : max_resource_shapes_per_load_report_(
+          RayConfig::instance().max_resource_shapes_per_load_report()),
+      tasks_to_schedule_(tasks_to_schedule),
+      tasks_to_dispatch_(tasks_to_dispatch),
+      infeasible_tasks_(infeasible_tasks),
+      backlog_tracker_(backlog_tracker) {}
+
+int64_t SchedulerResourceReporter::TotalBacklogSize(
+    SchedulingClass scheduling_class) const {
+  auto backlog_it = backlog_tracker_.find(scheduling_class);
+  if (backlog_it == backlog_tracker_.end()) {
+    return 0;
+  }
+
+  int64_t sum = 0;
+  for (const auto &worker_id_and_backlog_size : backlog_it->second) {
+    sum += worker_id_and_backlog_size.second;
+  }
+  return sum;
+}
+
+void SchedulerResourceReporter::FillResourceUsage(
+    rpc::ResourcesData &data,
+    const std::shared_ptr<SchedulingResources> &last_reported_resources) const {
+  if (max_resource_shapes_per_load_report_ == 0) {
+    return;
+  }
+  auto resource_loads = data.mutable_resource_load();
+  auto resource_load_by_shape =
+      data.mutable_resource_load_by_shape()->mutable_resource_demands();
+
+  int num_reported = 0;
+  int64_t skipped_requests = 0;
+
+  for (const auto &pair : tasks_to_schedule_) {
+    const auto &scheduling_class = pair.first;
+    if (num_reported++ >= max_resource_shapes_per_load_report_ &&
+        max_resource_shapes_per_load_report_ >= 0) {
+      // TODO (Alex): It's possible that we skip a different scheduling key which contains
+      // the same resources.
+      skipped_requests++;
+      break;
+    }
+    const auto &resources =
+        TaskSpecification::GetSchedulingClassDescriptor(scheduling_class)
+            .resource_set.GetResourceMap();
+    const auto &queue = pair.second;
+    const auto &count = queue.size();
+
+    auto by_shape_entry = resource_load_by_shape->Add();
+
+    for (const auto &resource : resources) {
+      // Add to `resource_loads`.
+      const auto &label = resource.first;
+      const auto &quantity = resource.second;
+      (*resource_loads)[label] += quantity * count;
+
+      // Add to `resource_load_by_shape`.
+      (*by_shape_entry->mutable_shape())[label] = quantity;
+    }
+
+    // If a task is not feasible on the local node it will not be feasible on any other
+    // node in the cluster. See the scheduling policy defined by
+    // ClusterResourceScheduler::GetBestSchedulableNode for more details.
+    int num_ready = by_shape_entry->num_ready_requests_queued();
+    by_shape_entry->set_num_ready_requests_queued(num_ready + count);
+    by_shape_entry->set_backlog_size(TotalBacklogSize(scheduling_class));
+  }
+
+  for (const auto &pair : tasks_to_dispatch_) {
+    const auto &scheduling_class = pair.first;
+    if (num_reported++ >= max_resource_shapes_per_load_report_ &&
+        max_resource_shapes_per_load_report_ >= 0) {
+      // TODO (Alex): It's possible that we skip a different scheduling key which contains
+      // the same resources.
+      skipped_requests++;
+      break;
+    }
+    const auto &resources =
+        TaskSpecification::GetSchedulingClassDescriptor(scheduling_class)
+            .resource_set.GetResourceMap();
+    const auto &queue = pair.second;
+    const auto &count = queue.size();
+
+    auto by_shape_entry = resource_load_by_shape->Add();
+
+    for (const auto &resource : resources) {
+      // Add to `resource_loads`.
+      const auto &label = resource.first;
+      const auto &quantity = resource.second;
+      (*resource_loads)[label] += quantity * count;
+
+      // Add to `resource_load_by_shape`.
+      (*by_shape_entry->mutable_shape())[label] = quantity;
+    }
+    int num_ready = by_shape_entry->num_ready_requests_queued();
+    by_shape_entry->set_num_ready_requests_queued(num_ready + count);
+    by_shape_entry->set_backlog_size(TotalBacklogSize(scheduling_class));
+  }
+
+  for (const auto &pair : infeasible_tasks_) {
+    const auto &scheduling_class = pair.first;
+    if (num_reported++ >= max_resource_shapes_per_load_report_ &&
+        max_resource_shapes_per_load_report_ >= 0) {
+      // TODO (Alex): It's possible that we skip a different scheduling key which contains
+      // the same resources.
+      skipped_requests++;
+      break;
+    }
+    const auto &resources =
+        TaskSpecification::GetSchedulingClassDescriptor(scheduling_class)
+            .resource_set.GetResourceMap();
+    const auto &queue = pair.second;
+    const auto &count = queue.size();
+
+    auto by_shape_entry = resource_load_by_shape->Add();
+    for (const auto &resource : resources) {
+      // Add to `resource_loads`.
+      const auto &label = resource.first;
+      const auto &quantity = resource.second;
+      (*resource_loads)[label] += quantity * count;
+
+      // Add to `resource_load_by_shape`.
+      (*by_shape_entry->mutable_shape())[label] = quantity;
+    }
+
+    // If a task is not feasible on the local node it will not be feasible on any other
+    // node in the cluster. See the scheduling policy defined by
+    // ClusterResourceScheduler::GetBestSchedulableNode for more details.
+    int num_infeasible = by_shape_entry->num_infeasible_requests_queued();
+    by_shape_entry->set_num_infeasible_requests_queued(num_infeasible + count);
+    by_shape_entry->set_backlog_size(TotalBacklogSize(scheduling_class));
+  }
+
+  if (skipped_requests > 0) {
+    RAY_LOG(INFO) << "More than " << max_resource_shapes_per_load_report_
+                  << " scheduling classes. Some resource loads may not be reported to "
+                     "the autoscaler.";
+  }
+
+  if (RayConfig::instance().enable_light_weight_resource_report()) {
+    // Check whether resources have been changed.
+    absl::flat_hash_map<std::string, double> local_resource_map(
+        data.resource_load().begin(), data.resource_load().end());
+    ResourceSet local_resource(local_resource_map);
+    if (last_reported_resources == nullptr ||
+        !last_reported_resources->GetLoadResources().IsEqual(local_resource)) {
+      data.set_resource_load_changed(true);
+    }
+  } else {
+    data.set_resource_load_changed(true);
+  }
+}
+
+}  // namespace raylet
+}  // namespace ray

--- a/src/ray/raylet/scheduling/scheduler_resource_reporter.h
+++ b/src/ray/raylet/scheduling/scheduler_resource_reporter.h
@@ -1,0 +1,62 @@
+// Copyright 2020-2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/ray_config.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/raylet/scheduling/internal.h"
+
+namespace ray {
+namespace raylet {
+
+/// Helper class that reports resource_load and resource_load_by_shape to gcs.
+class SchedulerResourceReporter {
+ public:
+  SchedulerResourceReporter(
+      const absl::flat_hash_map<SchedulingClass,
+                                std::deque<std::shared_ptr<internal::Work>>>
+          &tasks_to_schedule,
+      const absl::flat_hash_map<SchedulingClass,
+                                std::deque<std::shared_ptr<internal::Work>>>
+          &tasks_to_dispatch,
+      const absl::flat_hash_map<
+          SchedulingClass, std::deque<std::shared_ptr<internal::Work>>> &infeasible_tasks,
+      const absl::flat_hash_map<SchedulingClass, absl::flat_hash_map<WorkerID, int64_t>>
+          &backlog_tracker);
+
+  void FillResourceUsage(
+      rpc::ResourcesData &data,
+      const std::shared_ptr<SchedulingResources> &last_reported_resources) const;
+
+ private:
+  int64_t TotalBacklogSize(SchedulingClass scheduling_class) const;
+
+  const int64_t max_resource_shapes_per_load_report_;
+  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
+      &tasks_to_schedule_;
+
+  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
+      &tasks_to_dispatch_;
+
+  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
+      &infeasible_tasks_;
+
+  const absl::flat_hash_map<SchedulingClass, absl::flat_hash_map<WorkerID, int64_t>>
+      &backlog_tracker_;
+};
+
+}  // namespace raylet
+}  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Separate Scheduler Resource Reporting logic into a separate class for better readability and maintainability.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
