### PR TITLE
[Jobs] Hide `dashboard` from Job Submission import path

### DIFF
--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -9,8 +9,7 @@ import yaml
 import click
 
 from ray.autoscaler._private.cli_logger import add_click_logging_options, cli_logger, cf
-from ray.dashboard.modules.job.common import JobStatus
-from ray.dashboard.modules.job.sdk import JobSubmissionClient
+from ray.job_submission import JobStatus, JobSubmissionClient
 
 
 def _get_sdk_client(

--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -14,9 +14,8 @@ import ray
 from ray.exceptions import RuntimeEnvSetupError
 import ray.ray_constants as ray_constants
 from ray.actor import ActorHandle
+from ray.job_submission import JobStatus, JobStatusInfo
 from ray.dashboard.modules.job.common import (
-    JobStatus,
-    JobStatusInfo,
     JobStatusStorageClient,
     JOB_ID_METADATA_KEY,
     JOB_NAME_METADATA_KEY,

--- a/dashboard/modules/job/sdk.py
+++ b/dashboard/modules/job/sdk.py
@@ -17,11 +17,11 @@ from ray._private.runtime_env.packaging import (
     get_uri_for_directory,
     parse_uri,
 )
-from ray.job_submission import JobStatusInfo
 from ray.dashboard.modules.job.common import (
     JobSubmitRequest,
     JobSubmitResponse,
     JobStopResponse,
+    JobStatusInfo,
     JobStatusResponse,
     JobLogsResponse,
     uri_to_http_components,

--- a/dashboard/modules/job/sdk.py
+++ b/dashboard/modules/job/sdk.py
@@ -17,11 +17,11 @@ from ray._private.runtime_env.packaging import (
     get_uri_for_directory,
     parse_uri,
 )
+from ray.job_submission import JobStatusInfo
 from ray.dashboard.modules.job.common import (
     JobSubmitRequest,
     JobSubmitResponse,
     JobStopResponse,
-    JobStatusInfo,
     JobStatusResponse,
     JobLogsResponse,
     uri_to_http_components,

--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -8,10 +8,10 @@ import pytest
 from unittest.mock import patch
 
 import ray
-from ray.dashboard.modules.job.common import CURRENT_VERSION, JobStatus
+from ray.job_submission import JobSubmissionClient, JobStatus
+from ray.dashboard.modules.job.common import CURRENT_VERSION
 from ray.dashboard.modules.job.sdk import (
     ClusterInfo,
-    JobSubmissionClient,
     parse_cluster_info,
 )
 from ray.dashboard.tests.conftest import *  # noqa

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -9,8 +9,8 @@ import signal
 import pytest
 
 import ray
+from ray.job_submission import JobStatus
 from ray.dashboard.modules.job.common import (
-    JobStatus,
     JOB_ID_METADATA_KEY,
     JOB_NAME_METADATA_KEY,
 )

--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -16,8 +16,8 @@ from ray.experimental.internal_kv import (
 import ray.dashboard.utils as dashboard_utils
 import ray.dashboard.optional_utils as dashboard_optional_utils
 from ray._private.runtime_env.validation import ParsedRuntimeEnv
+from ray.job_submission import JobStatusInfo
 from ray.dashboard.modules.job.common import (
-    JobStatusInfo,
     JobStatusStorageClient,
     JOB_ID_METADATA_KEY,
 )

--- a/dashboard/modules/snapshot/tests/test_job_submission.py
+++ b/dashboard/modules/snapshot/tests/test_job_submission.py
@@ -15,7 +15,7 @@ from ray._private.test_utils import (
 )
 from ray.dashboard import dashboard
 from ray.dashboard.tests.conftest import *  # noqa
-from ray.dashboard.modules.job.sdk import JobSubmissionClient
+from ray.job_submission import JobSubmissionClient
 
 logger = logging.getLogger(__name__)
 

--- a/doc/source/cluster/job-submission.rst
+++ b/doc/source/cluster/job-submission.rst
@@ -143,7 +143,7 @@ We can import and initialize the Job submission client by providing a valid Ray 
 
 .. code-block:: python
 
-    from ray.dashboard.modules.job.sdk import JobSubmissionClient
+    from ray.job_submission import JobSubmissionClient
 
     client = JobSubmissionClient("http://127.0.0.1:8265")
 
@@ -169,7 +169,7 @@ Now we can have a simple polling loop that checks the job status until it reache
 
 .. code-block:: python
 
-    from ray.dashboard.modules.job.common import JobStatus, JobStatusInfo
+    from ray.job_submission import JobStatus
 
     def wait_until_finish(job_id):
         start = time.time()

--- a/python/ray/job_submission/__init__.py
+++ b/python/ray/job_submission/__init__.py
@@ -1,0 +1,8 @@
+from ray.dashboard.modules.job.sdk import JobSubmissionClient
+from ray.dashboard.modules.job.common import JobStatus, JobStatusInfo
+
+__all__ = [
+    "JobSubmissionClient",
+    "JobStatus",
+    "JobStatusInfo"
+]

--- a/python/ray/job_submission/__init__.py
+++ b/python/ray/job_submission/__init__.py
@@ -1,8 +1,4 @@
 from ray.dashboard.modules.job.sdk import JobSubmissionClient
 from ray.dashboard.modules.job.common import JobStatus, JobStatusInfo
 
-__all__ = [
-    "JobSubmissionClient",
-    "JobStatus",
-    "JobStatusInfo"
-]
+__all__ = ["JobSubmissionClient", "JobStatus", "JobStatusInfo"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For public SDK APIs, change the import path from 

```python
from ray.dashboard.modules.job.common import JobStatus, JobStatusInfo
from ray.dashboard.modules.job.sdk import JobSubmissionClient
```

to 
```python
from ray.job_submission import JobStatus, JobSubmissionClient
```

`JobStatus`, `JobStatusInfo` and `JobSubmissionClient` were the only names referenced in the SDK doc so far, but we can add more later as they appear.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #22005 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
