### PR TITLE
[Datasets] Add non-streaming reading option for Snappy-compressed files.

### DIFF
--- a/python/ray/data/datasource/binary_datasource.py
+++ b/python/ray/data/datasource/binary_datasource.py
@@ -18,6 +18,22 @@ class BinaryDatasource(FileBasedDatasource):
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args):
         include_paths = reader_args.pop("include_paths", False)
         data = f.readall()
+        compression = reader_args.pop("compression", None)
+        if compression is not None:
+            import pyarrow as pa
+
+            decompressed_size = reader_args.pop("decompressed_size", None)
+            if decompressed_size is None:
+                raise ValueError(
+                    "Must specify decompressed size if reading Snappy-compressed "
+                    "files."
+                )
+            data = pa.decompress(
+                data,
+                codec=compression,
+                decompressed_size=decompressed_size,
+                asbytes=True,
+            )
         if include_paths:
             return [(path, data)]
         else:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -470,6 +470,7 @@ def read_text(
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     parallelism: int = 200,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
+    **read_args,
 ) -> Dataset[str]:
     """Create a dataset from lines stored in text files.
 
@@ -488,6 +489,7 @@ def read_text(
             limited by the number of files of the dataset.
         arrow_open_stream_args: kwargs passed to
             pyarrow.fs.FileSystem.open_input_stream
+        read_args: kwargs passed to BinaryDatasource._read_file().
 
     Returns:
         Dataset holding lines of text read from the specified paths.
@@ -498,6 +500,7 @@ def read_text(
         filesystem=filesystem,
         parallelism=parallelism,
         arrow_open_stream_args=arrow_open_stream_args,
+        **read_args,
     ).flat_map(lambda x: x.decode(encoding).split("\n"))
 
 
@@ -554,6 +557,7 @@ def read_binary_files(
     parallelism: int = 200,
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
+    **read_args,
 ) -> Dataset[Union[Tuple[str, bytes], bytes]]:
     """Create a dataset from binary files of arbitrary contents.
 
@@ -575,6 +579,7 @@ def read_binary_files(
             limited by the number of files of the dataset.
         arrow_open_stream_args: kwargs passed to
             pyarrow.fs.FileSystem.open_input_stream
+        read_args: kwargs passed to BinaryDatasource._read_file().
 
     Returns:
         Dataset holding Arrow records read from the specified paths.
@@ -588,6 +593,7 @@ def read_binary_files(
         ray_remote_args=ray_remote_args,
         open_stream_args=arrow_open_stream_args,
         schema=bytes,
+        **read_args,
     )
 
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1007,6 +1007,21 @@ def test_read_text(ray_start_regular_shared, tmp_path):
     assert sorted(ds.take()) == ["goodbye", "hello", "world"]
 
 
+def test_read_binary_snappy(ray_start_regular_shared, tmp_path):
+    path = os.path.join(tmp_path, "test_binary")
+    os.mkdir(path)
+    with open(os.path.join(path, "file"), "wb") as f:
+        byte_str = "hello, world".encode()
+        compressed = pa.compress(byte_str, codec="snappy", asbytes=True)
+        f.write(compressed)
+    ds = ray.data.read_binary_files(
+        path,
+        arrow_open_stream_args=dict(compression="snappy"),
+        decompressed_size=len(byte_str),
+    )
+    assert sorted(ds.take()) == [byte_str]
+
+
 @pytest.mark.parametrize("pipelined", [False, True])
 def test_write_datasource(ray_start_regular_shared, pipelined):
     output = DummyOutputDatasource()

--- a/python/ray/data/tests/util.py
+++ b/python/ray/data/tests/util.py
@@ -11,7 +11,7 @@ def gen_bin_files(n):
         for i in range(n):
             path = os.path.join(temp_dir, f"{i}.bin")
             paths.append(path)
-            fp = open(path, "wb")
-            to_write = str(i) * 500
-            fp.write(to_write.encode())
+            with open(path, "wb") as fp:
+                to_write = str(i) * 500
+                fp.write(to_write.encode())
         yield (temp_dir, paths)


### PR DESCRIPTION
Adds a non-streaming reading option for Snappy-compressed files. Arrow doesn't support streaming Snappy decompression since the canonical C++ Snappy library doesn't natively support streaming decompression (although they do define a [frame format](https://github.com/google/snappy/blob/main/framing_format.txt) for streaming compression and decompression, which other Snappy implementations implement). This PR works around this by doing non-streaming reads of Snappy-compressed files, followed by manual one-shot decompression of the in-memory buffer containing the full file.

Unfortunately, when using the manual `pa.decompress()` API, the `decompressed_size` argument is [required](https://github.com/apache/arrow/blob/e9e16c9da7a76718640f2b3f23200a3755790011/python/pyarrow/io.pxi#L1962-L1965), which puts two large constraints on the user wanting to read Snappy-compressed files:
1. The decompressed, in-memory size of the binary data must be known before reading, and provided to Datasets: `ray.data.read_binary_files(..., arrow_open_stream_args=dict(compression="snappy"), decompressed_size=1024)`
2. All Snappy-compressed files read into a single `Dataset` must have the same size.

We have three options:
1. Merge this PR providing this heavily constrained Snappy file support.
2. Contribute streaming Snappy (de)compression to upstream Arrow, via one of the C++ implementations that implement the framing format.
3. Supply a custom datasource that uses Arrow + [`python-snappy`](https://github.com/andrix/python-snappy) to read and decompress Snappy-compressed files.

## Related issue number

Closes #22023 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
