### PR TITLE
[Autoscaler] No infeasible warning for placement groups

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -75,7 +75,7 @@ from ray.worker import global_worker  # type: ignore
 from ray.util.debug import log_once
 
 from ray.autoscaler._private import subprocess_output_util as cmd_output_util
-from ray.autoscaler._private.load_metrics import LoadMetricsSummary
+from ray.autoscaler._private.util import LoadMetricsSummary
 from ray.autoscaler._private.autoscaler import AutoscalerSummary
 from ray.autoscaler._private.util import format_info_string
 

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -1,10 +1,8 @@
 from collections import Counter
-from dataclasses import dataclass
 from functools import reduce
 import logging
-from numbers import Number
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List
 
 import numpy as np
 import ray.ray_constants
@@ -14,29 +12,10 @@ from ray.autoscaler._private.constants import (
 )
 from ray._private.gcs_utils import PlacementGroupTableData
 from ray.autoscaler._private.resource_demand_scheduler import NodeIP, ResourceDict
+from ray.autoscaler._private.util import DictCount, LoadMetricsSummary
 from ray.core.generated.common_pb2 import PlacementStrategy
 
 logger = logging.getLogger(__name__)
-
-# A Dict and the count of how many times it occurred.
-# Refer to freq_of_dicts() below.
-DictCount = Tuple[Dict, Number]
-
-
-@dataclass
-class LoadMetricsSummary:
-    # Map of resource name (e.g. "memory") to pair of (Used, Available) numbers
-    usage: Dict[str, Tuple[Number, Number]]
-    # Counts of demand bundles from task/actor demand.
-    # e.g. [({"CPU": 1}, 5), ({"GPU":1}, 2)]
-    resource_demand: List[DictCount]
-    # Counts of pending placement groups
-    pg_demand: List[DictCount]
-    # Counts of demand bundles requested by autoscaler.sdk.request_resources
-    request_demand: List[DictCount]
-    node_types: List[DictCount]
-    # Optionally included for backwards compatibility: IP of the head node.
-    head_ip: Optional[NodeIP] = None
 
 
 def add_resources(dict1: Dict[str, float], dict2: Dict[str, float]) -> Dict[str, float]:

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -821,11 +821,8 @@ def get_nodes_for(
             ):
                 logger.warning(
                     f"The autoscaler could not find a node type to satisfy the "
-                    f"request: {resources}. If this request is related to "
-                    f"placement groups the resource request will resolve itself, "
-                    f"otherwise please specify a node type with the necessary "
-                    f"resource "
-                    f"https://docs.ray.io/en/master/cluster/autoscaling.html#multiple-node-type-autoscaling."  # noqa: E501
+                    f"request: {resources}. Please specify a node type with the "
+                    f"necessary resources."
                 )
             break
 

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -11,7 +11,6 @@ import copy
 import numpy as np
 import logging
 import collections
-from numbers import Real
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -21,6 +20,14 @@ from ray.autoscaler.node_provider import NodeProvider
 from ray._private.gcs_utils import PlacementGroupTableData
 from ray.core.generated.common_pb2 import PlacementStrategy
 from ray.autoscaler._private.constants import AUTOSCALER_CONSERVE_GPU_NODES
+from ray.autoscaler._private.util import (
+    is_placement_group_resource,
+    NodeType,
+    NodeTypeConfigDict,
+    ResourceDict,
+    NodeID,
+    NodeIP,
+)
 from ray.autoscaler.tags import (
     TAG_RAY_USER_NODE_TYPE,
     NODE_KIND_UNMANAGED,
@@ -36,21 +43,6 @@ logger = logging.getLogger(__name__)
 
 # The minimum number of nodes to launch concurrently.
 UPSCALING_INITIAL_NUM_NODES = 5
-
-# e.g., cpu_4_ondemand.
-NodeType = str
-
-# e.g., {"resources": ..., "max_workers": ...}.
-NodeTypeConfigDict = str
-
-# e.g., {"GPU": 1}.
-ResourceDict = Dict[str, Real]
-
-# e.g., "node-1".
-NodeID = str
-
-# e.g., "127.0.0.1".
-NodeIP = str
 
 
 class ResourceDemandScheduler:
@@ -822,18 +814,19 @@ def get_nodes_for(
 
         # Give up, no feasible node.
         if not utilization_scores:
-            # TODO (Alex): We will hit this case every time a placement group
-            # starts up because placement groups are scheduled via custom
-            # resources. This will behave properly with the current utilization
-            # score heuristic, but it's a little dangerous and misleading.
-            logger.warning(
-                f"The autoscaler could not find a node type to satisfy the "
-                f"request: {resources}. If this request is related to "
-                f"placement groups the resource request will resolve itself, "
-                f"otherwise please specify a node type with the necessary "
-                f"resource "
-                f"https://docs.ray.io/en/master/cluster/autoscaling.html#multiple-node-type-autoscaling."  # noqa: E501
-            )
+            if not any(
+                is_placement_group_resource(resource)
+                for resources_dict in resources
+                for resource in resources_dict
+            ):
+                logger.warning(
+                    f"The autoscaler could not find a node type to satisfy the "
+                    f"request: {resources}. If this request is related to "
+                    f"placement groups the resource request will resolve itself, "
+                    f"otherwise please specify a node type with the necessary "
+                    f"resource "
+                    f"https://docs.ray.io/en/master/cluster/autoscaling.html#multiple-node-type-autoscaling."  # noqa: E501
+                )
             break
 
         utilization_scores = sorted(utilization_scores, reverse=True)
@@ -886,7 +879,7 @@ def _utilization_score(
         if k in resource_types:
             num_matching_resource_types += 1
         util = (v - remaining[k]) / v
-        util_by_resources.append(v * (util ** 3))
+        util_by_resources.append(v * (util**3))
 
     # Could happen if node_resources has only zero values.
     if not util_by_resources:

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -879,7 +879,7 @@ def _utilization_score(
         if k in resource_types:
             num_matching_resource_types += 1
         util = (v - remaining[k]) / v
-        util_by_resources.append(v * (util**3))
+        util_by_resources.append(v * (util ** 3))
 
     # Could happen if node_resources has only zero values.
     if not util_by_resources:

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -395,7 +395,7 @@ def hash_runtime_conf(
     def add_content_hashes(path, allow_non_existing_paths: bool = False):
         def add_hash_of_file(fpath):
             with open(fpath, "rb") as f:
-                for chunk in iter(lambda: f.read(2**20), b""):
+                for chunk in iter(lambda: f.read(2 ** 20), b""):
                     contents_hasher.update(chunk)
 
         path = os.path.expanduser(path)
@@ -538,7 +538,7 @@ def get_usage_report(lm_summary: LoadMetricsSummary) -> str:
             used = used - pg_total + pg_used
 
         if resource in ["memory", "object_store_memory"]:
-            to_GiB = 1 / 2**30
+            to_GiB = 1 / 2 ** 30
             line = f" {(used * to_GiB):.2f}/" f"{(total * to_GiB):.3f} GiB {resource}"
             if used_in_pg:
                 line = line + (

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -1466,8 +1466,8 @@ class LoadMetricsTest(unittest.TestCase):
 
         assert summary.usage["CPU"] == (190, 194)
         assert summary.usage["GPU"] == (15, 16)
-        assert summary.usage["memory"] == (500 * 2**20, 1000 * 2**20)
-        assert summary.usage["object_store_memory"] == (1000 * 2**20, 2000 * 2**20)
+        assert summary.usage["memory"] == (500 * 2 ** 20, 1000 * 2 ** 20)
+        assert summary.usage["object_store_memory"] == (1000 * 2 ** 20, 2000 * 2 ** 20)
         assert (
             summary.usage["accelerator_type:V100"][1] == 2
         ), "Not comparing the usage value due to floating point error."
@@ -1496,10 +1496,10 @@ class LoadMetricsTest(unittest.TestCase):
         summary_dict = asdict(summary)
         assert summary_dict["usage"]["CPU"] == (190, 194)
         assert summary_dict["usage"]["GPU"] == (15, 16)
-        assert summary_dict["usage"]["memory"] == (500 * 2**20, 1000 * 2**20)
+        assert summary_dict["usage"]["memory"] == (500 * 2 ** 20, 1000 * 2 ** 20)
         assert summary_dict["usage"]["object_store_memory"] == (
-            1000 * 2**20,
-            2000 * 2**20,
+            1000 * 2 ** 20,
+            2000 * 2 ** 20,
         )
         assert (
             summary_dict["usage"]["accelerator_type:V100"][1] == 2
@@ -2792,8 +2792,8 @@ def test_info_string():
             "CPU": (530.0, 544.0),
             "GPU": (2, 2),
             "AcceleratorType:V100": (0, 2),
-            "memory": (2 * 2**30, 2**33),
-            "object_store_memory": (3.14 * 2**30, 2**34),
+            "memory": (2 * 2 ** 30, 2 ** 33),
+            "object_store_memory": (3.14 * 2 ** 30, 2 ** 34),
         },
         resource_demand=[({"CPU": 1}, 150)],
         pg_demand=[({"bundles": [({"CPU": 4}, 5)], "strategy": "PACK"}, 420)],
@@ -2853,8 +2853,8 @@ def test_info_string_failed_node_cap():
             "CPU": (530.0, 544.0),
             "GPU": (2, 2),
             "AcceleratorType:V100": (0, 2),
-            "memory": (2 * 2**30, 2**33),
-            "object_store_memory": (3.14 * 2**30, 2**34),
+            "memory": (2 * 2 ** 30, 2 ** 33),
+            "object_store_memory": (3.14 * 2 ** 30, 2 ** 34),
             "CPU_group_4a82a217aadd8326a3a49f02700ac5c2": (2.0, 2.0),
         },
         resource_demand=[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ensures that we don't log a warning message about an infeasible resource demand when that custom resource is a placement group (since the placement group resource likely just needs to be created by the raylet).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #21847

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
