### PR TITLE
[RLlib] Discussion 4986: OU Exploration (torch) crashes when restoring from checkpoint.

### DIFF
--- a/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
+++ b/rllib/utils/exploration/ornstein_uhlenbeck_noise.py
@@ -263,10 +263,10 @@ class OrnsteinUhlenbeckNoise(GaussianNoise):
     def set_state(self, state: dict, sess: Optional["tf.Session"] = None) -> None:
         if self.framework == "tf":
             self.ou_state.load(state["ou_state"], session=sess)
-        elif isinstance(self.ou_state, np.ndarray) or (
-            torch and torch.is_tensor(self.ou_state)
-        ):
+        elif isinstance(self.ou_state, np.ndarray):
             self.ou_state = state["ou_state"]
+        elif torch and torch.is_tensor(self.ou_state):
+            self.ou_state = torch.from_numpy(state["ou_state"])
         else:
             self.ou_state.assign(state["ou_state"])
         super().set_state(state, sess=sess)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Discussion 4986: Ornstein-Uhlenbeck Exploration (torch) crashes when restoring from checkpoint.

See also this discussion here:
https://discuss.ray.io/t/crash-when-calling-train-after-loading-from-checkpoint/4986

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
