### PR TITLE
[RLlib] `Filter.clear_buffer()` deprecated (use `Filter.reset_buffer()` instead)

### DIFF
--- a/rllib/agents/ars/ars.py
+++ b/rllib/agents/ars/ars.py
@@ -137,7 +137,7 @@ class Worker:
         for k, f in self.filters.items():
             return_filters[k] = f.as_serializable()
             if flush_after:
-                f.clear_buffer()
+                f.reset_buffer()
         return return_filters
 
     def rollout(self, timestep_limit, add_noise=False):

--- a/rllib/agents/es/es.py
+++ b/rllib/agents/es/es.py
@@ -143,7 +143,7 @@ class Worker:
         for k, f in self.filters.items():
             return_filters[k] = f.as_serializable()
             if flush_after:
-                f.clear_buffer()
+                f.reset_buffer()
         return return_filters
 
     def rollout(self, timestep_limit, add_noise=True):

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1411,7 +1411,7 @@ class RolloutWorker(ParallelIteratorWorker):
         for k, f in self.filters.items():
             return_filters[k] = f.as_serializable()
             if flush_after:
-                f.clear_buffer()
+                f.reset_buffer()
         return return_filters
 
     @DeveloperAPI

--- a/rllib/examples/custom_observation_filters.py
+++ b/rllib/examples/custom_observation_filters.py
@@ -80,7 +80,7 @@ class CustomFilter(Filter):
         self.buffer = SimpleRollingStat()
         self.shape = shape
 
-    def clear_buffer(self):
+    def reset_buffer(self) -> None:
         self.buffer = SimpleRollingStat(self.shape)
 
     def apply_changes(self, other, with_buffer=False):

--- a/rllib/tests/mock_worker.py
+++ b/rllib/tests/mock_worker.py
@@ -36,7 +36,7 @@ class _MockWorker:
         obs_filter = self.obs_filter.copy()
         rew_filter = self.rew_filter.copy()
         if flush_after:
-            self.obs_filter.clear_buffer(), self.rew_filter.clear_buffer()
+            self.obs_filter.reset_buffer(), self.rew_filter.reset_buffer()
 
         return {"obs_filter": obs_filter, "rew_filter": rew_filter}
 

--- a/rllib/tests/test_filters.py
+++ b/rllib/tests/test_filters.py
@@ -55,7 +55,7 @@ class MeanStdFilterTest(unittest.TestCase):
             self.assertEqual(filt2.rs.n, 5)
             self.assertEqual(filt2.buffer.n, 5)
 
-            filt.clear_buffer()
+            filt.reset_buffer()
             self.assertEqual(filt.buffer.n, 0)
             self.assertEqual(filt2.buffer.n, 5)
 
@@ -83,7 +83,7 @@ class FilterManagerTest(unittest.TestCase):
         for i in range(10):
             filt1(i)
         self.assertEqual(filt1.rs.n, 10)
-        filt1.clear_buffer()
+        filt1.reset_buffer()
         self.assertEqual(filt1.buffer.n, 0)
 
         RemoteWorker = ray.remote(_MockWorker)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

`Filter.clear_buffer()` deprecated (use `Filter.reset_buffer()` instead).
Remove all still existing warnings.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
