### PR TITLE
[RLlib] Fix Unity3D built-in examples action bounds from -inf/inf to -1.0/1.0.

### DIFF
--- a/rllib/env/wrappers/unity3d_env.py
+++ b/rllib/env/wrappers/unity3d_env.py
@@ -295,9 +295,9 @@ class Unity3DEnv(MultiAgentEnv):
         }
         action_spaces = {
             # 3DBall.
-            "3DBall": Box(float("-inf"), float("inf"), (2,), dtype=np.float32),
+            "3DBall": Box(-1.0, 1.0, (2,), dtype=np.float32),
             # 3DBallHard.
-            "3DBallHard": Box(float("-inf"), float("inf"), (2,), dtype=np.float32),
+            "3DBallHard": Box(-1.0, 1.0, (2,), dtype=np.float32),
             # GridFoodCollector.
             "GridFoodCollector": MultiDiscrete([3, 3, 3, 2]),
             # Pyramids.
@@ -308,11 +308,11 @@ class Unity3DEnv(MultiAgentEnv):
             # Sorter.
             "Sorter": MultiDiscrete([3, 3, 3]),
             # Tennis.
-            "Tennis": Box(float("-inf"), float("inf"), (3,)),
+            "Tennis": Box(-1.0, 1.0, (3,)),
             # VisualHallway.
             "VisualHallway": MultiDiscrete([5]),
             # Walker.
-            "Walker": Box(float("-inf"), float("inf"), (39,)),
+            "Walker": Box(-1.0, 1.0, (39,)),
             # FoodCollector.
             "FoodCollector": MultiDiscrete([3, 3, 3, 2]),
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix Unity3D built-in examples action bounds from -inf/inf to -1.0/1.0.

If the action space is -inf/inf, unsquashing (e.g. from PPO's normalized action range of roughly -1.0/1.0) will not happen and the env may complain. Unity3D envs usually use action bounds of -1.0/1.0 as indicated by the hard-coded clipping code in Unity's ML-Agents, doing something like:

```
action = clip(action, -3.0, 3.0) / 3.0 -> always between -1.0 and 1.0.
```

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/issues/21109
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Issue #21109
<!-- For example: "Closes #1234" -->
Closes #21109
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
