### PR TITLE
[Dataset] avoid pyarrow 7.0.0 for dataset

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -47,7 +47,7 @@ starlette
 aiorwlock
 
 # Requirements for running tests
-pyarrow >= 4.0.1, <7.0.0
+pyarrow >= 4.0.1, < 7.0.0
 blist; platform_system != "Windows"
 azure-cli-core==2.29.1
 azure-identity==1.7.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -47,7 +47,7 @@ starlette
 aiorwlock
 
 # Requirements for running tests
-pyarrow==4.0.1
+pyarrow >= 4.0.1, <7.0.0
 blist; platform_system != "Windows"
 azure-cli-core==2.29.1
 azure-identity==1.7.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -202,7 +202,7 @@ if setup_spec.type == SetupType.RAY:
     setup_spec.extras = {
         "data": [
             "pandas",
-            "pyarrow>=4.0.1",
+            "pyarrow>=4.0.1,<7.0.0",
             "fsspec",
         ],
         "default": [

--- a/python/setup.py
+++ b/python/setup.py
@@ -202,7 +202,7 @@ if setup_spec.type == SetupType.RAY:
     setup_spec.extras = {
         "data": [
             "pandas",
-            "pyarrow>=4.0.1,<7.0.0",
+            "pyarrow >= 4.0.1, < 7.0.0",
             "fsspec",
         ],
         "default": [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Turns out there is an (incompatibility) bug in pyarrow 7.0.0 that causes huge single object size in dataset.

I've verified revert pyarrow back to 6.0.0 fixed the issue in master on my linux dev server; need to trigger a release test run.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
