### PR TITLE
[client] Remove circular reference for ray client object ref

### DIFF
--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -102,7 +102,6 @@ class ClientObjectRef(raylet.ObjectRef):
     # transitively by a destructor. Otherwise deadlocks can happen. See
     # https://stackoverflow.com/questions/18774401/self-deadlock-due-to-garbage-collector-in-single-threaded-code
     def __del__(self):
-        print("???")
         worker = self._worker()
         if worker is not None and worker.is_connected():
             try:

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -89,6 +89,8 @@ CLIENT_SERVER_MAX_THREADS = float(os.getenv("RAY_CLIENT_SERVER_MAX_THREADS", 100
 class ClientObjectRef(raylet.ObjectRef):
     def __init__(self, id: Union[bytes, Future]):
         self._mutex = threading.Lock()
+        # Use weakref here to avoid circular reference so that __del__
+        # won't happen in GC but when reference count is 0
         self._worker = weakref.ref(ray.get_context().client_worker)
         self._id_future = None
         if isinstance(id, bytes):

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -180,6 +180,7 @@ class ClientObjectRef(raylet.ObjectRef):
                     data = loads_from_server(resp.get.data)
 
             py_callback(data)
+
         self._worker().register_callback(self, deserialize_obj)
 
     def _set_id(self, id):

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -52,7 +52,7 @@ class DataClient:
         # Waiting for response or shutdown.
         self.cv = threading.Condition(lock=self.lock)
 
-        self.request_queue = queue.SimpleQueue()
+        self.request_queue = queue.Queue()
         # Maps request ID (Python object address) to response.
         self.ready_data: Dict[int, Any] = {}
         # NOTE: Dictionary insertion is guaranteed to complete before lookup

--- a/python/ray/util/client/dataclient.py
+++ b/python/ray/util/client/dataclient.py
@@ -52,7 +52,7 @@ class DataClient:
         # Waiting for response or shutdown.
         self.cv = threading.Condition(lock=self.lock)
 
-        self.request_queue = queue.Queue()
+        self.request_queue = queue.SimpleQueue()
         # Maps request ID (Python object address) to response.
         self.ready_data: Dict[int, Any] = {}
         # NOTE: Dictionary insertion is guaranteed to complete before lookup


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With circular reference in ClientObjectRef, when deletion happens, it's going to happen in GC and this will cause deadlock since we are using `queue`. For more detail, please refer https://codewithoutrules.com/2017/08/16/concurrency-python/

One way to fix this is to use SimpleQueue, but it's not available in py36. Another way is to break the circular reference and make sure it'll be deleted when reference count = 0.

This PR uses the second one.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
