### PR TITLE
[Datasets] [WIP] Prototype wrapping operation-based lazy compute model.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     import tensorflow as tf
     from ray.data.dataset_pipeline import DatasetPipeline
     from ray.data.grouped_dataset import GroupedDataset
+    from ray.data.lazy_dataset import LazyDataset
 
 import collections
 import itertools
@@ -2492,6 +2493,19 @@ Dict[str, List[str]]]): The names of the columns
 
         it = Iterable(self._blocks, self._epoch)
         return DatasetPipeline(it, length=len(it._splits))
+
+    def lazy(self) -> "LazyDataset":
+        """
+        Convert this Dataset into a LazyDataset, where all subsequent
+        operations won't be applied until .compute() or a consuming
+        function (such as .iter_batches(), .to_torch(), etc.) is called.
+
+        Returns:
+            A LazyDataset.
+        """
+        from ray.data.lazy_dataset import LazyDataset
+
+        return LazyDataset(lambda: self)
 
     @DeveloperAPI
     def get_internal_block_refs(self) -> List[ObjectRef[Block]]:

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -25,6 +25,7 @@ from ray.util.annotations import PublicAPI, DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
+    from ray.data.lazy_dataset import LazyDatasetPipeline
 
 # Operations that can be naively applied per dataset row in the pipeline.
 PER_DATASET_OPS = ["map", "map_batches", "flat_map", "filter"]
@@ -562,6 +563,19 @@ class DatasetPipeline(Generic[T]):
                 return self
 
         return EpochDelimitedIterator(self)
+
+    def lazy(self) -> "LazyDatasetPipeline":
+        """
+        Convert this DatasetPipeline into a LazyDatasetPipeline, where all subsequent
+        operations won't be applied until .compute() or a consuming
+        function (such as .iter_batches(), .to_torch(), etc.) is called.
+
+        Returns:
+            A LazyDatasetPipeline.
+        """
+        from ray.data.lazy_dataset import LazyDatasetPipeline
+
+        return LazyDatasetPipeline(lambda: self)
 
     @DeveloperAPI
     def iter_datasets(self) -> Iterator[Dataset[T]]:

--- a/python/ray/data/lazy_dataset.py
+++ b/python/ray/data/lazy_dataset.py
@@ -1,0 +1,493 @@
+import abc
+import functools
+import inspect
+import re
+import textwrap
+from typing import List, Callable, Optional, Tuple, Dict, Any
+
+import ray
+from ray.data.dataset import Dataset
+from ray.data.dataset_pipeline import (
+    DatasetPipeline,
+    PER_DATASET_OPS,
+    HOLISTIC_PER_DATASET_OPS,
+    PER_DATASET_OUTPUT_OPS,
+    OUTPUT_ITER_OPS,
+)
+from ray.data.grouped_dataset import GroupedDataset
+
+
+DATASET_PROXY_OPS = [
+    "map",
+    "map_batches",
+    "flat_map",
+    "filter",
+    "repartition",
+    "random_shuffle",
+    "union",
+    "sort",
+    "zip",
+    "limit",
+    "force_reads",
+]
+TO_PIPELINE_OPS = ["repeat", "window"]
+GROUPED_DATASET_PROXY_OPS = ["aggregate", "sum", "min", "max", "mean", "std"]
+CONSUME_OPS = [
+    "take",
+    "take_all",
+    "show",
+    "iter_rows",
+    "iter_batches",
+    "count",
+    "schema",
+    "num_blocks",
+    "size_bytes",
+    "input_files",
+    "get_internal_block_refs",
+    "stats",
+    "sum",
+    "min",
+    "max",
+    "mean",
+    "std",
+    "aggregate",
+    "write_parquet",
+    "write_json",
+    "write_csv",
+    "write_numpy",
+    "write_datasource",
+    "to_torch",
+    "to_tf",
+    "to_dask",
+    "to_mars",
+    "to_modin",
+    "to_spark",
+    "to_pandas",
+    "to_pandas_refs",
+    "to_numpy_refs",
+    "to_arrow_refs",
+]
+
+PIPELINE_PROXY_OPS = PER_DATASET_OPS + [
+    f"{op}_each_window" for op in HOLISTIC_PER_DATASET_OPS
+]
+PIPELINE_CONSUME_OPS = PER_DATASET_OUTPUT_OPS + OUTPUT_ITER_OPS
+
+
+class LazyComputable(abc.ABC):
+    """
+    A set of lazy operations that can be computed via calling .compute().
+    """
+
+    def __init__(
+        self,
+        func: Callable,
+        args: Optional[Tuple] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Builds a LazyComputable by holding a function application specification
+        (func, args, kwargs) whose application would produce a new concrete result
+        (Dataset/DatasetPipeline/etc.)
+
+        Args:
+            func: The function whose application will produce a new result.
+            args: Positional arguments for the function.
+            kwargs: Keyword arguments for the function.
+        """
+        self.func = func
+        if args is None:
+            args = tuple()
+        self.args = args
+        if kwargs is None:
+            kwargs = {}
+        self.kwargs = kwargs
+
+    def cache(self) -> "LazyComputable":
+        """
+        Cache the computable, such that multiple references to the same computable won't
+        result in redundant computation.
+
+        Returns:
+            A new LazyComputable whose computation is coordinated by a centralized
+            actor.
+        """
+        coordinator = ComputeCoordinator.remote(self)
+        return type(self)(func=lambda: ray.get(coordinator.get_or_compute.remote()))
+
+    def compute(self):
+        """
+        Compute the Dataset, executing the underlying Dataset operations and
+        returning the resulting Dataset.
+
+        Returns:
+            A Dataset.
+        """
+        args = [
+            arg.compute() if isinstance(arg, LazyComputable) else arg
+            for arg in self.args
+        ]
+        kwargs = {
+            k: v.compute() if isinstance(v, LazyComputable) else v
+            for k, v in self.kwargs
+        }
+        return self.func(*args, **kwargs)
+
+
+class LazyDataset(LazyComputable):
+    """
+    A lazy version of Dataset, exposing the same API but executing the
+    operations lazily.
+
+    A LazyDataset consists of a function application specification for producing
+    a new dataset.
+
+    To materialize the result of all Dataset operations, call .compute().
+    All functions that produce a non-Dataset/DatasetPipeline/GroupedDataset
+    output will trigger computation, as will all consuming functions
+    (e.g. .iter_batches(), .to_torch(), etc.)
+    """
+
+    def split(self, num_splits, *args, **kwargs) -> List["LazyDataset"]:
+        parent = LazyDataset(
+            func=Dataset.split, args=(self, num_splits) + args, kwargs=kwargs
+        )
+        coordinator = ComputeCoordinator.remote(parent)
+        return [
+            LazyDataset(
+                func=lambda: ray.get(coordinator.get_or_compute.remote(split_idx))
+            )
+            for split_idx in range(num_splits)
+        ]
+
+    def split_at_indices(self, indices, *args, **kwargs) -> List["LazyDataset"]:
+        parent = LazyDataset(
+            func=Dataset.split_at_indices,
+            args=(self, indices) + args,
+            kwargs=kwargs,
+        )
+        coordinator = ComputeCoordinator.remote(parent)
+        return [
+            LazyDataset(
+                func=lambda: ray.get(coordinator.get_or_compute.remote(split_idx))
+            )
+            for split_idx in range(len(indices) + 1)
+        ]
+
+    def groupby(self, *args, **kwargs) -> "LazyGroupedDataset":
+        return LazyGroupedDataset(
+            func=Dataset.groupby, args=(self,) + args, kwargs=kwargs
+        )
+
+
+LazyDataset.split.__doc__ = (
+    """
+Lazy version of ``Dataset.split``, returning a List[LazyDataset].
+"""
+    + Dataset.split.__doc__
+)
+
+LazyDataset.split_at_indices.__doc__ = (
+    """
+Lazy version of ``Dataset.split_at_indices``, returning a List[LazyDataset].
+"""
+    + Dataset.split_at_indices.__doc__
+)
+
+LazyDataset.groupby.__doc__ = (
+    """
+Lazy version of ``Dataset.groupby``, returning a LazyGroupedDataset.
+"""
+    + Dataset.groupby.__doc__
+)
+
+
+for method in DATASET_PROXY_OPS:
+
+    def make_impl(method):
+        delegate = getattr(Dataset, method)
+
+        def impl(self, *args, **kwargs) -> "LazyDataset":
+            return LazyDataset(func=delegate, args=(self,) + args, kwargs=kwargs)
+
+        impl.__name__ = delegate.__name__
+        lazy_preamble = """
+        Lazy version of ``Dataset.{method}``, returning a LazyDataset.
+        """.format(
+            method=method
+        )
+        impl.__doc__ = lazy_preamble + delegate.__doc__
+        setattr(
+            impl,
+            "__signature__",
+            inspect.signature(delegate).replace(return_annotation="LazyDataset"),
+        )
+        return impl
+
+    setattr(LazyDataset, method, make_impl(method))
+
+for method in TO_PIPELINE_OPS:
+
+    def make_impl(method):
+        delegate = getattr(Dataset, method)
+
+        def impl(self, *args, **kwargs) -> "LazyDatasetPipeline":
+            return LazyDatasetPipeline(
+                func=delegate, args=(self,) + args, kwargs=kwargs
+            )
+
+        impl.__name__ = delegate.__name__
+        lazy_preamble = """
+        Lazy version of ``Dataset.{method}``, returning a LazyDatasetPipeline.
+        """.format(
+            method=method
+        )
+        impl.__doc__ = lazy_preamble + delegate.__doc__
+        setattr(
+            impl,
+            "__signature__",
+            inspect.signature(delegate).replace(
+                return_annotation="LazyDatasetPipeline"
+            ),
+        )
+        return impl
+
+    setattr(LazyDataset, method, make_impl(method))
+
+for method in CONSUME_OPS:
+
+    def make_impl(method):
+        delegate = getattr(Dataset, method)
+
+        def impl(self, *args, **kwargs):
+            return getattr(self.compute(), method)(*args, **kwargs)
+
+        impl.__name__ = delegate.__name__
+        lazy_preamble = """
+        NOTE: This will trigger computation and materialize the lazy Dataset!
+        """
+        impl.__doc__ = lazy_preamble + delegate.__doc__
+        setattr(
+            impl,
+            "__signature__",
+            inspect.signature(delegate),
+        )
+        return impl
+
+    setattr(LazyDataset, method, make_impl(method))
+
+
+@ray.remote(num_cpus=0, placement_group=None)
+class ComputeCoordinator:
+    """
+    Actor that coordinates the computation of a dataset. This is used when a dataset
+    is needed by multiple downstream operations/consumers, such as branching
+    computations or splits.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+        self.computed = None
+
+    def get_or_compute(self, split_idx=None):
+        if self.computed is None:
+            self.computed = self.parent.compute()
+        if split_idx is not None:
+            assert isinstance(self.computed, list)
+            return self.computed[split_idx]
+        return self.computed
+
+
+class LazyGroupedDataset(LazyComputable):
+    """
+    A lazy proxy for a GroupedDataset.
+    """
+
+    pass
+
+
+for method in GROUPED_DATASET_PROXY_OPS:
+
+    def make_impl(method):
+        delegate = getattr(GroupedDataset, method)
+
+        def impl(self, *args, **kwargs) -> "LazyDataset":
+            return LazyDataset(func=delegate, args=(self,) + args, kwargs=kwargs)
+
+        impl.__name__ = delegate.__name__
+        lazy_preamble = """
+        Lazy version of ``GroupedDataset.{method}``, returning a LazyDataset.
+        """.format(
+            method=method
+        )
+        impl.__doc__ = lazy_preamble + delegate.__doc__
+        setattr(
+            impl,
+            "__signature__",
+            inspect.signature(delegate).replace(return_annotation="LazyDataset"),
+        )
+        return impl
+
+    setattr(LazyGroupedDataset, method, make_impl(method))
+
+
+class LazyDatasetPipeline(LazyComputable):
+    """
+    A lazy version of DatasetPipeline, exposing the same API but executing the
+    operations lazily.
+
+    A LazyDatasetPipeline consists of a reference to a function application
+    specification for producing a new DatasetPipeline.
+
+    To materialize the result of all DatasetPipeline operations, call .compute().
+    All functions that produce a non-Dataset/DatasetPipeline/GroupedDataset
+    output will trigger computation, as will all consuming functions
+    (e.g. .iter_batches(), .to_torch(), etc.)
+    """
+
+    def split(self, num_splits, *args, **kwargs) -> List["LazyDatasetPipeline"]:
+        parent = LazyDatasetPipeline(
+            func=DatasetPipeline.split,
+            args=(self, num_splits) + args,
+            kwargs=kwargs,
+        )
+        coordinator = ComputeCoordinator.remote(parent)
+        return [
+            LazyDatasetPipeline(
+                func=lambda: ray.get(coordinator.get_or_compute.remote(split_idx))
+            )
+            for split_idx in range(num_splits)
+        ]
+
+    def split_at_indices(self, indices, *args, **kwargs) -> List["LazyDatasetPipeline"]:
+        parent = LazyDatasetPipeline(
+            func=DatasetPipeline.split_at_indices,
+            args=(self, indices) + args,
+            kwargs=kwargs,
+        )
+        coordinator = ComputeCoordinator.remote(parent)
+        return [
+            LazyDatasetPipeline(
+                func=lambda: ray.get(coordinator.get_or_compute.remote(split_idx))
+            )
+            for split_idx in range(len(indices) + 1)
+        ]
+
+
+LazyDatasetPipeline.split.__doc__ = (
+    """
+Lazy version of ``DatasetPipeline.split``, returning a List[LazyDatasetPipeline].
+"""
+    + DatasetPipeline.split.__doc__
+)
+
+LazyDatasetPipeline.split_at_indices.__doc__ = (
+    """
+Lazy version of ``DatasetPipeline.split_at_indices``, returning a
+List[LazyDatasetPipeline].
+"""
+    + DatasetPipeline.split_at_indices.__doc__
+)
+
+
+for method in PIPELINE_PROXY_OPS:
+
+    def make_impl(method):
+        delegate = getattr(DatasetPipeline, method)
+
+        def impl(self, *args, **kwargs) -> "LazyDatasetPipeline":
+            return LazyDatasetPipeline(
+                func=delegate, args=(self,) + args, kwargs=kwargs
+            )
+
+        impl.__name__ = delegate.__name__
+        lazy_preamble = """
+        Lazy version of ``DatasetPipeline.{method}``, returning a LazyDatasetPipeline.
+        """.format(
+            method=method
+        )
+        impl.__doc__ = lazy_preamble + delegate.__doc__
+        setattr(
+            impl,
+            "__signature__",
+            inspect.signature(delegate).replace(
+                return_annotation="LazyDatasetPipeline"
+            ),
+        )
+        return impl
+
+    setattr(LazyDatasetPipeline, method, make_impl(method))
+
+for method in PIPELINE_CONSUME_OPS:
+
+    def make_impl(method):
+        delegate = getattr(DatasetPipeline, method)
+
+        def impl(self, *args, **kwargs):
+            return getattr(self.compute(), method)(*args, **kwargs)
+
+        impl.__name__ = delegate.__name__
+        lazy_preamble = """
+        NOTE: This will trigger computation and materialize the lazy DatasetPipeline!
+        """
+        impl.__doc__ = lazy_preamble + delegate.__doc__
+        setattr(
+            impl,
+            "__signature__",
+            inspect.signature(delegate),
+        )
+        return impl
+
+    setattr(LazyDatasetPipeline, method, make_impl(method))
+
+
+def add_lazy_option(fn):
+    """
+    Add a lazy kwarg to a Dataset-generating function, instead returning a
+    LazyDataset.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if kwargs.pop("lazy", False):
+            return LazyDataset(func=fn, args=args, kwargs=kwargs)
+        return fn(*args, **kwargs)
+
+    doc = fn.__doc__
+    wrapper.__doc__ = _add_arg_to_docstring(doc)
+
+    return wrapper
+
+
+def _add_arg_to_docstring(doc):
+    lines = doc.split("\n")
+    i = 0
+    while i < len(lines):
+        if lines[i].strip().startswith("Args:"):
+            # Found the start of the args section.
+            break
+        i += 1
+    else:
+        # No args section found.
+        return doc
+    i += 1
+    # Get indentation.
+    indent = re.match(r"\s*", lines[i]).group(0)
+    while i < len(lines):
+        if len(lines[i]) == 0:
+            # Found the end of the args section (double-newline).
+            break
+        i += 1
+    else:
+        # No args section found.
+        return doc
+    lazy_arg_doc = (
+        "lazy: Whether to create the dataset lazily. If True, a LazyDataset will be "
+        "returned and the dataset won't be created and processed until .compute() is "
+        "called or it is consumed. See the LazyDataset docs for more information."
+    )
+    wrapper = textwrap.TextWrapper(
+        width=80, initial_indent=indent, subsequent_indent=indent + "    "
+    )
+    lines.insert(i, wrapper.fill(lazy_arg_doc))
+    return "\n".join(lines)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -37,6 +37,7 @@ from ray.data.block import (
 )
 from ray.data.context import DatasetContext
 from ray.data.dataset import Dataset
+from ray.data.lazy_dataset import add_lazy_option
 from ray.data.datasource import (
     Datasource,
     RangeDatasource,
@@ -65,6 +66,7 @@ logger = logging.getLogger(__name__)
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def from_items(items: List[Any], *, parallelism: int = 200) -> Dataset[Any]:
     """Create a dataset from a list of local Python objects.
 
@@ -106,6 +108,7 @@ def from_items(items: List[Any], *, parallelism: int = 200) -> Dataset[Any]:
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def range(n: int, *, parallelism: int = 200) -> Dataset[int]:
     """Create a dataset from a range of integers [0..n).
 
@@ -126,6 +129,7 @@ def range(n: int, *, parallelism: int = 200) -> Dataset[int]:
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def range_arrow(n: int, *, parallelism: int = 200) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from a range of integers [0..n).
 
@@ -150,6 +154,7 @@ def range_arrow(n: int, *, parallelism: int = 200) -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def range_tensor(
     n: int, *, shape: Tuple = (1,), parallelism: int = 200
 ) -> Dataset[ArrowRow]:
@@ -181,6 +186,7 @@ def range_tensor(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def read_datasource(
     datasource: Datasource[T],
     *,
@@ -291,6 +297,7 @@ def read_datasource(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def read_parquet(
     paths: Union[str, List[str]],
     *,
@@ -369,6 +376,7 @@ def read_parquet(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def read_json(
     paths: Union[str, List[str]],
     *,
@@ -416,6 +424,7 @@ def read_json(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def read_csv(
     paths: Union[str, List[str]],
     *,
@@ -463,6 +472,7 @@ def read_csv(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def read_text(
     paths: Union[str, List[str]],
     *,
@@ -502,6 +512,7 @@ def read_text(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def read_numpy(
     paths: Union[str, List[str]],
     *,
@@ -546,6 +557,7 @@ def read_numpy(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def read_binary_files(
     paths: Union[str, List[str]],
     *,
@@ -592,6 +604,7 @@ def read_binary_files(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a Dask DataFrame.
 
@@ -625,6 +638,7 @@ def from_dask(df: "dask.DataFrame") -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def from_mars(df: "mars.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a MARS dataframe.
 
@@ -638,6 +652,7 @@ def from_mars(df: "mars.DataFrame") -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
     """Create a dataset from a Modin dataframe.
 
@@ -654,6 +669,7 @@ def from_modin(df: "modin.DataFrame") -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def from_pandas(
     dfs: Union["pandas.DataFrame", List["pandas.DataFrame"]]
 ) -> Dataset[ArrowRow]:
@@ -673,6 +689,7 @@ def from_pandas(
 
 
 @DeveloperAPI
+@add_lazy_option
 def from_pandas_refs(
     dfs: Union[ObjectRef["pandas.DataFrame"], List[ObjectRef["pandas.DataFrame"]]]
 ) -> Dataset[ArrowRow]:
@@ -717,6 +734,7 @@ def from_pandas_refs(
     )
 
 
+@add_lazy_option
 def from_numpy(ndarrays: List[ObjectRef[np.ndarray]]) -> Dataset[ArrowRow]:
     """Create a dataset from a set of NumPy ndarrays.
 
@@ -738,6 +756,7 @@ def from_numpy(ndarrays: List[ObjectRef[np.ndarray]]) -> Dataset[ArrowRow]:
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def from_arrow(
     tables: Union["pyarrow.Table", bytes, List[Union["pyarrow.Table", bytes]]]
 ) -> Dataset[ArrowRow]:
@@ -758,6 +777,7 @@ def from_arrow(
 
 
 @DeveloperAPI
+@add_lazy_option
 def from_arrow_refs(
     tables: Union[
         ObjectRef[Union["pyarrow.Table", bytes]],
@@ -786,6 +806,7 @@ def from_arrow_refs(
 
 
 @PublicAPI(stability="beta")
+@add_lazy_option
 def from_spark(
     df: "pyspark.sql.DataFrame", *, parallelism: Optional[int] = None
 ) -> Dataset[ArrowRow]:


### PR DESCRIPTION
This PR contains a rough prototype of a lazy compute model for Datasets, implemented via wrapping the existing eagerly-computed Datasets abstractions with lazy proxies. After switching to lazy mode (via a `ds.lazy()` call or a `lazy=True` arg to any dataset-creating APIs), all future operations are lazy, building up an operation graph that won't be executed until `.compute()` or a consuming method (e.g. `.show()`, `.iter_batches()`, `.to_torch()`, etc.) is called.

```python
import ray

ds = ray.data.range(100)
ds = ds.lazy()  # Comment me out.
# ds is now a LazyDataset

print("# Map")
# It exposes the same API as Dataset.
ds = ds.map(lambda x: x + 1)
print("# Shuffle")
ds = ds.random_shuffle()
print("# Show")
# A consuming function like .show() triggers execution.
ds.show()
```

**I'm pushing this PR up for reference; we will almost surely be going with the operation-based lazy compute model in #22233 since it provides a clearer path to implementing (1) move semantics for blocks within operations, and (2) optimizations such as task fusion.**

The big pros of this PR are:
1. The lazy compute model is implemented as a wrapper of `Dataset`, `DatasetPipeline`, and `GroupedDataset`; the only changes to those abstractions as the addition of the `.lazy()` API. The fact that this prototype doesn't touch the core Datasets abstractions makes it very easy to add and later remove.
2. `.split()` and `.split_at_indices()` are still lazy, and support automatic caching of the materialized pre-split dataset (pipeline) and triggering of execution by any of the consumers. This is done by parking the pre-split dataset (pipeline) in an actor, where all downstream operations of the split reference a split fetch to the actor, the first of which will trigger execution of the dataset on the actor, after which the dataset will be cached. The lifetime of this actor is tied to the lifetime of the underlying dataset, so the cached dataset should be released once it's no longer needed by any of the splits.
3. The materialized caching is also exposed to the user via a `ds.cache()` method, which can be used before a branching computation, even if the branches are then passed to Ray tasks.
4. Easy, low-code addition of fully lazy dataset creation to all read/creation APIs.

Hopefully we can pull a subset of these pros that makes sense into the other prototype.