### PR TITLE
Revert "[Client] avoid locking in async send"

### DIFF
--- a/python/ray/tests/test_dataclient_disconnect.py
+++ b/python/ray/tests/test_dataclient_disconnect.py
@@ -50,7 +50,7 @@ def test_dataclient_disconnect_before_request():
         # Force grpc to error by queueing garbage request. This simulates
         # the data channel shutting down for connection issues between
         # different remote calls.
-        ray.worker.data_client.request_queue.put((Mock(), None))
+        ray.worker.data_client.request_queue.put(Mock())
 
         # The following two assertions are relatively brittle. Consider a more
         # robust mechanism if they fail with code changes or become flaky.

--- a/python/ray/util/client/common.py
+++ b/python/ray/util/client/common.py
@@ -97,9 +97,6 @@ class ClientObjectRef(raylet.ObjectRef):
         else:
             raise TypeError("Unexpected type for id {}".format(id))
 
-    # NOTE: synchronization primitives like threading.Lock should not be used
-    # transitively by a destructor. Otherwise deadlocks can happen. See
-    # https://stackoverflow.com/questions/18774401/self-deadlock-due-to-garbage-collector-in-single-threaded-code
     def __del__(self):
         if self._worker is not None and self._worker.is_connected():
             try:
@@ -109,7 +106,8 @@ class ClientObjectRef(raylet.ObjectRef):
                 logger.info(
                     "Exception in ObjectRef is ignored in destructor. "
                     "To receive this exception in application code, call "
-                    "a method on the reference before its destructor runs."
+                    "a method on the actor reference before its destructor "
+                    "is run."
                 )
 
     def binary(self):
@@ -204,9 +202,6 @@ class ClientActorRef(raylet.ActorID):
         else:
             raise TypeError("Unexpected type for id {}".format(id))
 
-    # NOTE: synchronization primitives like threading.Lock should not be used
-    # transitively by a destructor. Otherwise deadlocks can happen. See
-    # https://stackoverflow.com/questions/18774401/self-deadlock-due-to-garbage-collector-in-single-threaded-code
     def __del__(self):
         if self._worker is not None and self._worker.is_connected():
             try:
@@ -216,7 +211,8 @@ class ClientActorRef(raylet.ActorID):
                 logger.info(
                     "Exception from actor creation is ignored in destructor. "
                     "To receive this exception in application code, call "
-                    "a method on the reference before its destructor runs."
+                    "a method on the actor reference before its destructor "
+                    "is run."
                 )
 
     def binary(self):
@@ -857,10 +853,10 @@ class OrderedResponseCache:
                 # Request is for an id that has already been cleared from
                 # cache/acknowledged.
                 raise RuntimeError(
-                    "Attempting to access a cache entry that has already "
+                    "Attempting to accesss a cache entry that has already "
                     "cleaned up. The client has already acknowledged "
-                    f"receiving this response. (this_req_id={req_id}, "
-                    f"acknowledged={self.last_received})"
+                    f"receiving this response. ({req_id}, "
+                    f"{self.last_received})"
                 )
             if req_id in self.cache:
                 cached_resp = self.cache[req_id]

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -276,21 +276,13 @@ class Worker:
             # Unrecoverable error -- These errors are specifically raised
             # by the server's application logic
             return False
-        if (
-            e.code() == grpc.StatusCode.INTERNAL
-            and e.details() == "Exception serializing request!"
-        ):
-            # The client failed tried to send a bad request. Don't
-            # try to reconnect/retry.
-            return False
-        if (
-            e.code() == grpc.StatusCode.UNKNOWN
-            and e.details() == "Exception iterating requests!"
-        ):
-            # The client failed tried to send a bad request (for example,
-            # passing "None" instead of a valid grpc message). Don't try to
-            # reconnect/retry.
-            return False
+        if e.code() == grpc.StatusCode.INTERNAL:
+            details = e.details()
+            if details == "Exception serializing request!":
+                # The client failed tried to send a bad request (for example,
+                # passing "None" instead of a valid grpc message). Don't
+                # try to reconnect/retry.
+                return False
         # All other errors can be treated as recoverable
         return True
 


### PR DESCRIPTION
Reverts ray-project/ray#22193, which makes `windows://python/ray/serve:test_ray_client` very flaky (timeouts).