### PR TITLE
[Test] Try retry S3 read when it fails.

### DIFF
--- a/release/nightly_tests/dask_on_ray/dask_on_ray_sort.py
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_sort.py
@@ -53,7 +53,19 @@ def load_dataset(client, data_dir, s3_bucket, nbytes, npartitions):
         f"s3://{s3_bucket}/df-{num_bytes_per_partition}-{i}.parquet.gzip"
         for i in range(npartitions)
     ]
-    df = dd.read_parquet(filenames)
+
+    df = None
+    max_retry = 3
+    retry = 0
+    while not df and retry < max_retry:
+        try:
+            df = dd.read_parquet(filenames)
+        except FileNotFoundError as e:
+            print(f"Failed to load a file. {e}")
+            # Wait a little bit before retrying.
+            time.sleep(30)
+            retry += 1
+
     return df
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It seems like the S3 read sometimes fails; https://github.com/ray-project/ray/issues/22214. I found out the file actually does exist in S3, so it is highly likely a transient error. This PR adds a retry mechanism to avoid the issue. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/22214

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
