### PR TITLE
add optional empty lines filter in read_text

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -338,10 +338,8 @@ fi
 # There's a import ray above it.
 
 PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
-echo "$PYTHON_EXECUTABLE"
 
-#$PYTHON_EXECUTABLE
-python3 ci/travis/check_import_order.py . -s ci -s python/ray/thirdparty_files -s python/build -s lib
+$PYTHON_EXECUTABLE ci/travis/check_import_order.py . -s ci -s python/ray/thirdparty_files -s python/build -s lib
 
 if ! git diff --quiet &>/dev/null; then
     echo 'Reformatted changed files. Please review and stage the changes.'

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -338,8 +338,10 @@ fi
 # There's a import ray above it.
 
 PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
+echo "$PYTHON_EXECUTABLE"
 
-$PYTHON_EXECUTABLE ci/travis/check_import_order.py . -s ci -s python/ray/thirdparty_files -s python/build -s lib
+#$PYTHON_EXECUTABLE
+python3 ci/travis/check_import_order.py . -s ci -s python/ray/thirdparty_files -s python/build -s lib
 
 if ! git diff --quiet &>/dev/null; then
     echo 'Reformatted changed files. Please review and stage the changes.'

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -468,6 +468,7 @@ def read_text(
     *,
     encoding: str = "utf-8",
     errors: str = "ignore",
+    filter_empty_lines: bool = True,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     parallelism: int = 200,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
@@ -495,13 +496,18 @@ def read_text(
     Returns:
         Dataset holding lines of text read from the specified paths.
     """
+    def to_text(s):
+        lines = s.decode(encoding).split("\n")
+        if filter_empty_lines:
+            lines = [line for line in lines if line.strip() != ""]
+        return lines
 
     return read_binary_files(
         paths,
         filesystem=filesystem,
         parallelism=parallelism,
         arrow_open_stream_args=arrow_open_stream_args,
-    ).flat_map(lambda x: x.decode(encoding, errors=errors).split("\n"))
+    ).flat_map(to_text)
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -498,7 +498,7 @@ def read_text(
     """
     def to_text(s):
         lines = s.decode(encoding).split("\n")
-        if filter_empty_lines:
+        if drop_empty_lines:
             lines = [line for line in lines if line.strip() != ""]
         return lines
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -468,7 +468,7 @@ def read_text(
     *,
     encoding: str = "utf-8",
     errors: str = "ignore",
-    filter_empty_lines: bool = True,
+    drop_empty_lines: bool = True,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     parallelism: int = 200,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -496,6 +496,7 @@ def read_text(
     Returns:
         Dataset holding lines of text read from the specified paths.
     """
+
     def to_text(s):
         lines = s.decode(encoding).split("\n")
         if drop_empty_lines:

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1007,7 +1007,7 @@ def test_read_text(ray_start_regular_shared, tmp_path):
         f.write("ray\n")
     ds = ray.data.read_text(path)
     assert sorted(ds.take()) == ["goodbye", "hello", "ray", "world"]
-    ds = ray.data.read_text(path, filter_empty_lines=False)
+    ds = ray.data.read_text(path, drop_empty_lines=False)
     assert ds.count()== 5
 
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1008,8 +1008,7 @@ def test_read_text(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_text(path)
     assert sorted(ds.take()) == ["goodbye", "hello", "ray", "world"]
     ds = ray.data.read_text(path, drop_empty_lines=False)
-    assert ds.count()== 5
-
+    assert ds.count() == 5
 
 
 @pytest.mark.parametrize("pipelined", [False, True])

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1003,8 +1003,13 @@ def test_read_text(ray_start_regular_shared, tmp_path):
         f.write("world")
     with open(os.path.join(path, "file2.txt"), "w") as f:
         f.write("goodbye")
+    with open(os.path.join(path, "file3.txt"), "w") as f:
+        f.write("ray\n")
     ds = ray.data.read_text(path)
-    assert sorted(ds.take()) == ["goodbye", "hello", "world"]
+    assert sorted(ds.take()) == ["goodbye", "hello", "ray", "world"]
+    ds = ray.data.read_text(path, filter_empty_lines=False)
+    assert ds.count()== 5
+
 
 
 @pytest.mark.parametrize("pipelined", [False, True])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
ray.data.read_text() currently doesn't take care of empty lines; this pr adds a flag to enable the empty line filter; 
with this change, read_text will only return non-empty line by default, unless otherwise setting drop_empty_line to False.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
