### PR TITLE
[Datasets] Expose `TableRow` as public API; minimize copies/type conversions on row-based ops.

### DIFF
--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -73,6 +73,12 @@ Custom Datasource API
 .. autoclass:: ray.data.ReadTask
     :members:
 
+Table Row API
+---------------------
+
+.. autoclass:: ray.data.row.TableRow
+    :members:
+
 Utility
 -------
 .. autofunction:: ray.data.set_progress_bars

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1857,6 +1857,9 @@ class Dataset(Generic[T]):
         Returns:
             A local iterator over the entire dataset.
         """
+        # During row-based ops, we also choose a batch format that lines up with the
+        # current dataset format in order to eliminate unnecessary copies and type
+        # conversions.
         dataset_format = self._dataset_format()
         batch_format = (
             "pyarrow"

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1860,14 +1860,19 @@ class Dataset(Generic[T]):
         # During row-based ops, we also choose a batch format that lines up with the
         # current dataset format in order to eliminate unnecessary copies and type
         # conversions.
-        dataset_format = self._dataset_format()
-        batch_format = (
-            "pyarrow"
-            if dataset_format == "arrow"
-            else "pandas"
-            if dataset_format == "pandas"
-            else "native"
-        )
+        try:
+            dataset_format = self._dataset_format()
+        except ValueError:
+            # Dataset is empty or cleared, so fall back to "native".
+            batch_format = "native"
+        else:
+            batch_format = (
+                "pyarrow"
+                if dataset_format == "arrow"
+                else "pandas"
+                if dataset_format == "pandas"
+                else "native"
+            )
         for batch in self.iter_batches(
             prefetch_blocks=prefetch_blocks, batch_format=batch_format
         ):

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -63,6 +63,7 @@ from ray.data.datasource.file_based_datasource import (
     _wrap_s3_filesystem_workaround,
     _unwrap_s3_filesystem_workaround,
 )
+from ray.data.row import TableRow
 from ray.data.aggregate import AggregateFn, Sum, Max, Min, Mean, Std
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.batcher import Batcher
@@ -74,7 +75,6 @@ from ray.data.impl.shuffle import simple_shuffle, _shuffle_reduce
 from ray.data.impl.sort import sort_impl
 from ray.data.impl.block_list import BlockList
 from ray.data.impl.lazy_block_list import LazyBlockList
-from ray.data.impl.table_block import TableRow
 from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
 
 # An output type of iter_batches() determined by the batch_format parameter.
@@ -1837,8 +1837,12 @@ class Dataset(Generic[T]):
         finally:
             progress.close()
 
-    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[T]:
+    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
         """Return a local row iterator over the dataset.
+
+        If the dataset is a tabular dataset (Arrow/Pandas blocks), dict-like mappings
+        :py:class:`~ray.data.row.TableRow` are yielded for each row by the iterator.
+        If the dataset is not tabular, the raw row is yielded.
 
         Examples:
             >>> for i in ray.data.range(1000000).iter_rows():
@@ -1853,8 +1857,16 @@ class Dataset(Generic[T]):
         Returns:
             A local iterator over the entire dataset.
         """
+        dataset_format = self._dataset_format()
+        batch_format = (
+            "pyarrow"
+            if dataset_format == "arrow"
+            else "pandas"
+            if dataset_format == "pandas"
+            else "native"
+        )
         for batch in self.iter_batches(
-            prefetch_blocks=prefetch_blocks, batch_format="native"
+            prefetch_blocks=prefetch_blocks, batch_format=batch_format
         ):
             batch = BlockAccessor.for_block(batch)
             for row in batch.iter_rows():

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -19,6 +19,7 @@ from ray.data.impl.pipeline_executor import (
     PipelineExecutor,
     PipelineSplitExecutorCoordinator,
 )
+from ray.data.row import TableRow
 from ray.data.impl import progress_bar
 from ray.data.impl.stats import DatasetPipelineStats
 from ray.util.annotations import PublicAPI, DeveloperAPI
@@ -41,7 +42,7 @@ PER_DATASET_OUTPUT_OPS = [
 ]
 
 # Operations that operate over the stream of output batches from the pipeline.
-OUTPUT_ITER_OPS = ["take", "take_all", "show", "iter_rows", "to_tf", "to_torch"]
+OUTPUT_ITER_OPS = ["take", "take_all", "show", "to_tf", "to_torch"]
 
 
 @PublicAPI(stability="beta")
@@ -87,6 +88,42 @@ class DatasetPipeline(Generic[T]):
         self._executed = _executed or [False]
         self._stats = DatasetPipelineStats()
 
+    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterator[Union[T, TableRow]]:
+        """Return a local row iterator over the data in the pipeline.
+
+        If the dataset is a tabular dataset (Arrow/Pandas blocks), dict-like mappings
+        :py:class:`~ray.data.row.TableRow` are yielded for each row by the iterator.
+        If the dataset is not tabular, the raw row is yielded.
+
+        Examples:
+            >>> for i in ray.data.range(1000000).repeat(5).iter_rows():
+            ...     print(i)
+
+        Time complexity: O(1)
+
+        Args:
+            prefetch_blocks: The number of blocks to prefetch ahead of the
+                current block during the scan.
+
+        Returns:
+            A local iterator over the records in the pipeline.
+        """
+
+        def gen_rows() -> Iterator[Union[T, TableRow]]:
+            time_start = time.perf_counter()
+
+            for ds in self.iter_datasets():
+                wait_start = time.perf_counter()
+                for row in ds.iter_rows(prefetch_blocks=prefetch_blocks):
+                    self._stats.iter_wait_s.add(time.perf_counter() - wait_start)
+                    with self._stats.iter_user_s.timer():
+                        yield row
+                    wait_start = time.perf_counter()
+
+            self._stats.iter_total_s.add(time.perf_counter() - time_start)
+
+        return gen_rows()
+
     def iter_batches(
         self,
         *,
@@ -98,7 +135,7 @@ class DatasetPipeline(Generic[T]):
         """Return a local batched iterator over the data in the pipeline.
 
         Examples:
-            >>> for pandas_df in ray.data.range(1000000).iter_batches():
+            >>> for pandas_df in ray.data.range(1000000).repeat(5).iter_batches():
             ...     print(pandas_df)
 
         Time complexity: O(1)

--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -201,6 +201,7 @@ class ActorPool(ComputeStrategy):
             for block in results:
                 new_blocks.append(block)
                 new_metadata.append(metadata_mapping[block])
+            new_metadata = ray.get(new_metadata)
         return BlockList(new_blocks, new_metadata)
 
 

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -1,10 +1,11 @@
-from typing import Dict, List, Tuple, Any, TypeVar, Optional, TYPE_CHECKING
+from typing import Dict, List, Tuple, Iterator, Any, TypeVar, Optional, TYPE_CHECKING
 
 import collections
 import numpy as np
 
 from ray.data.block import BlockAccessor, BlockMetadata, KeyFn
-from ray.data.impl.table_block import TableBlockAccessor, TableRow, TableBlockBuilder
+from ray.data.row import TableRow
+from ray.data.impl.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data.impl.arrow_block import ArrowBlockAccessor
 from ray.data.aggregate import AggregateFn
 
@@ -28,8 +29,9 @@ def lazy_import_pandas():
 
 
 class PandasRow(TableRow):
-    def as_pydict(self) -> dict:
-        return {k: v[0] for k, v in self._row.to_dict("list").items()}
+    """
+    Row of a tabular Dataset backed by a Pandas DataFrame block.
+    """
 
     def __getitem__(self, key: str) -> Any:
         col = self._row[key]
@@ -43,6 +45,10 @@ class PandasRow(TableRow):
         except AttributeError:
             # Fallback to the original form.
             return item
+
+    def __iter__(self) -> Iterator:
+        for k in self._row.columns:
+            yield k
 
     def __len__(self):
         return self._row.shape[1]

--- a/python/ray/data/impl/table_block.py
+++ b/python/ray/data/impl/table_block.py
@@ -1,8 +1,9 @@
 import collections
 
-from typing import Dict, Iterator, List, Union, Tuple, Any, TypeVar, TYPE_CHECKING
+from typing import Dict, Iterator, List, Union, Any, TypeVar, TYPE_CHECKING
 
 from ray.data.block import Block, BlockAccessor
+from ray.data.row import TableRow
 from ray.data.impl.block_builder import BlockBuilder
 from ray.data.impl.size_estimator import SizeEstimator
 
@@ -14,38 +15,6 @@ T = TypeVar("T")
 # The max size of Python tuples to buffer before compacting them into a
 # table in the BlockBuilder.
 MAX_UNCOMPACTED_SIZE_BYTES = 50 * 1024 * 1024
-
-
-class TableRow:
-    def __init__(self, row: Any):
-        self._row = row
-
-    def as_pydict(self) -> dict:
-        raise NotImplementedError
-
-    def keys(self) -> Iterator[str]:
-        return self.as_pydict().keys()
-
-    def values(self) -> Iterator[Any]:
-        return self.as_pydict().values()
-
-    def items(self) -> Iterator[Tuple[str, Any]]:
-        return self.as_pydict().items()
-
-    def __getitem__(self, key: str) -> Any:
-        raise NotImplementedError
-
-    def __eq__(self, other: Any) -> bool:
-        return self.as_pydict() == other
-
-    def __str__(self):
-        return str(self.as_pydict())
-
-    def __repr__(self):
-        return str(self)
-
-    def __len__(self):
-        raise NotImplementedError
 
 
 class TableBlockBuilder(BlockBuilder[T]):

--- a/python/ray/data/row.py
+++ b/python/ray/data/row.py
@@ -1,0 +1,39 @@
+from collections.abc import Mapping
+from typing import Any
+
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="beta")
+class TableRow(Mapping):
+    """
+    A dict-like row of a tabular ``Dataset``.
+
+    This implements the dictionary mapping interface, but provides more
+    efficient access with less data copying than converting Arrow Tables
+    or Pandas DataFrames into per-row dicts. This class must be subclassed,
+    with subclasses implementing ``__getitem__``, ``__iter__``, and ``__len__``.
+
+    Concrete subclasses include ``ray.data.impl.arrow_block.ArrowRow`` and
+    ``ray.data.impl.pandas_block.PandasRow``.
+    """
+
+    def __init__(self, row: Any):
+        """
+        Construct a ``TableRow`` (internal API).
+
+        Args:
+            row: The tabular row that backs this row mapping.
+        """
+        self._row = row
+
+    def as_pydict(self) -> dict:
+        """
+        Convert to a normal Python dict. This will create a new copy of the row."""
+        return dict(self.items())
+
+    def __str__(self):
+        return str(self.as_pydict())
+
+    def __repr__(self):
+        return str(self)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -21,7 +21,10 @@ from ray.data.dataset import Dataset, _sliding_window
 from ray.data.datasource import DummyOutputDatasource
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockAccessor
+from ray.data.row import TableRow
+from ray.data.impl.arrow_block import ArrowRow
 from ray.data.impl.block_list import BlockList
+from ray.data.impl.pandas_block import PandasRow
 from ray.data.impl.stats import DatasetStats
 from ray.data.aggregate import AggregateFn, Count, Sum, Min, Max, Mean, Std
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
@@ -1919,6 +1922,52 @@ def test_sliding_window():
     windows = list(_sliding_window(arr, 15))
     assert len(windows) == 1
     assert list(windows[0]) == arr
+
+
+def test_iter_rows(ray_start_regular_shared):
+    # Test simple rows.
+    n = 10
+    ds = ray.data.range(n)
+    for row, k in zip(ds.iter_rows(), range(n)):
+        assert row == k
+
+    # Test tabular rows.
+    t1 = pa.Table.from_pydict({"one": [1, 2, 3], "two": [2, 3, 4]})
+    t2 = pa.Table.from_pydict({"one": [4, 5, 6], "two": [5, 6, 7]})
+    t3 = pa.Table.from_pydict({"one": [7, 8, 9], "two": [8, 9, 10]})
+    t4 = pa.Table.from_pydict({"one": [10, 11, 12], "two": [11, 12, 13]})
+    ts = [t1, t2, t3, t4]
+    t = pa.concat_tables(ts)
+    ds = ray.data.from_arrow(ts)
+
+    def to_pylist(table):
+        pydict = table.to_pydict()
+        names = table.schema.names
+        pylist = [
+            {column: pydict[column][row] for column in names}
+            for row in range(table.num_rows)
+        ]
+        return pylist
+
+    # Default ArrowRows.
+    for row, t_row in zip(ds.iter_rows(), to_pylist(t)):
+        assert isinstance(row, TableRow)
+        assert isinstance(row, ArrowRow)
+        assert row == t_row
+
+    # PandasRows after conversion.
+    pandas_ds = ds.map_batches(lambda x: x, batch_format="pandas")
+    df = t.to_pandas()
+    for row, (index, df_row) in zip(pandas_ds.iter_rows(), df.iterrows()):
+        assert isinstance(row, TableRow)
+        assert isinstance(row, PandasRow)
+        assert row == df_row.to_dict()
+
+    # Prefetch.
+    for row, t_row in zip(ds.iter_rows(prefetch_blocks=1), to_pylist(t)):
+        assert isinstance(row, TableRow)
+        assert isinstance(row, ArrowRow)
+        assert row == t_row
 
 
 def test_iter_batches_basic(ray_start_regular_shared):


### PR DESCRIPTION
This PR properly exposes `TableRow` as a public API (API docs + the "Public" tag), since it's already exposed to the user in our row-based ops. In addition, the following changes are made:
1. During row-based ops, we also choose a batch format that lines up with the current dataset format in order to eliminate unnecessary copies and type conversions.
2. `TableRow` now derives from `collections.abc.Mapping`, which lets `TableRow` better interop with code expecting a mapping, and includes a few helpful mixins so we only have to implement `__getitem__`, `__iter__`, and `__len__`.

## TODOs

- [x] More tests? Should mostly be covered by existing tests, but might want to add a test to cover our batch format + dataset format alignment logic.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
