### PR TITLE
Optimize MultiItemCallback and MapCallback to reduce data copy when GCS load data after restart

### DIFF
--- a/src/ray/gcs/callback.h
+++ b/src/ray/gcs/callback.h
@@ -43,8 +43,7 @@ using OptionalItemCallback =
 /// \param status Status indicates whether the read was successful.
 /// \param result The items returned by GCS.
 template <typename Data>
-using MultiItemCallback =
-    std::function<void(Status status, const std::vector<Data> &result)>;
+using MultiItemCallback = std::function<void(Status status, std::vector<Data> &&result)>;
 
 /// This callback is used to receive notifications of the subscribed items in the GCS.
 /// \param id The id of the item.
@@ -60,7 +59,7 @@ using ItemCallback = std::function<void(const Data &result)>;
 /// This callback is used to receive multiple key-value items from GCS.
 /// \param result The key-value items returned by GCS.
 template <typename Key, typename Value>
-using MapCallback = std::function<void(const std::unordered_map<Key, Value> &result)>;
+using MapCallback = std::function<void(std::unordered_map<Key, Value> &&result)>;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -122,8 +122,7 @@ Status JobInfoAccessor::AsyncGetAll(
   rpc::GetAllJobInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllJobInfo(
       request, [callback](const Status &status, const rpc::GetAllJobInfoReply &reply) {
-        auto result = VectorFromProtobuf(reply.job_info_list());
-        callback(status, result);
+        callback(status, VectorFromProtobuf(reply.job_info_list()));
         RAY_LOG(DEBUG) << "Finished getting all job info.";
       });
   return Status::OK();
@@ -172,8 +171,7 @@ Status ActorInfoAccessor::AsyncGetAll(
   rpc::GetAllActorInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllActorInfo(
       request, [callback](const Status &status, const rpc::GetAllActorInfoReply &reply) {
-        auto result = VectorFromProtobuf(reply.actor_table_data());
-        callback(status, result);
+        callback(status, VectorFromProtobuf(reply.actor_table_data()));
         RAY_LOG(DEBUG) << "Finished getting all actor info, status = " << status;
       });
   return Status::OK();
@@ -515,7 +513,7 @@ Status NodeInfoAccessor::AsyncGetAll(const MultiItemCallback<GcsNodeInfo> &callb
         for (int index = 0; index < reply.node_info_list_size(); ++index) {
           result.emplace_back(reply.node_info_list(index));
         }
-        callback(status, result);
+        callback(status, std::move(result));
         RAY_LOG(DEBUG) << "Finished getting information of all nodes, status = "
                        << status;
       });
@@ -713,9 +711,7 @@ Status NodeResourceInfoAccessor::AsyncGetAllAvailableResources(
   client_impl_->GetGcsRpcClient().GetAllAvailableResources(
       request,
       [callback](const Status &status, const rpc::GetAllAvailableResourcesReply &reply) {
-        std::vector<rpc::AvailableResources> result =
-            VectorFromProtobuf(reply.resources_list());
-        callback(status, result);
+        callback(status, VectorFromProtobuf(reply.resources_list()));
         RAY_LOG(DEBUG) << "Finished getting available resources of all nodes, status = "
                        << status;
       });
@@ -916,8 +912,7 @@ Status StatsInfoAccessor::AsyncGetAll(
   client_impl_->GetGcsRpcClient().GetAllProfileInfo(
       request,
       [callback](const Status &status, const rpc::GetAllProfileInfoReply &reply) {
-        auto result = VectorFromProtobuf(reply.profile_info_list());
-        callback(status, result);
+        callback(status, VectorFromProtobuf(reply.profile_info_list()));
         RAY_LOG(DEBUG) << "Finished getting all job info.";
       });
   return Status::OK();
@@ -1008,8 +1003,7 @@ Status WorkerInfoAccessor::AsyncGetAll(
   rpc::GetAllWorkerInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllWorkerInfo(
       request, [callback](const Status &status, const rpc::GetAllWorkerInfoReply &reply) {
-        auto result = VectorFromProtobuf(reply.worker_table_data());
-        callback(status, result);
+        callback(status, VectorFromProtobuf(reply.worker_table_data()));
         RAY_LOG(DEBUG) << "Finished getting all worker info, status = " << status;
       });
   return Status::OK();

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -304,9 +304,9 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
     {
       absl::ReaderMutexLock lock(&mutex_);
       RAY_CHECK_OK(gcs_client_->Nodes().AsyncGetAll(
-          [&promise](Status status, const std::vector<rpc::GcsNodeInfo> &nodes) {
-            promise.set_value(
-                std::pair<Status, std::vector<rpc::GcsNodeInfo>>(status, nodes));
+          [&promise](Status status, std::vector<rpc::GcsNodeInfo> &&nodes) {
+            promise.set_value(std::pair<Status, std::vector<rpc::GcsNodeInfo>>(
+                status, std::move(nodes)));
           }));
     }
     auto result = promise.get_future().get();

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -188,7 +188,7 @@ class GlobalStateAccessor {
   template <class DATA>
   MultiItemCallback<DATA> TransformForMultiItemCallback(
       std::vector<std::string> &data_vec, std::promise<bool> &promise) {
-    return [&data_vec, &promise](const Status &status, const std::vector<DATA> &result) {
+    return [&data_vec, &promise](const Status &status, std::vector<DATA> &&result) {
       RAY_CHECK_OK(status);
       std::transform(result.begin(), result.end(), std::back_inserter(data_vec),
                      [](const DATA &data) { return data.SerializeAsString(); });

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -264,7 +264,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     std::vector<rpc::ActorTableData> actors;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAll(
         [filter_non_dead_actor, &actors, &promise](
-            Status status, const std::vector<rpc::ActorTableData> &result) {
+            Status status, std::vector<rpc::ActorTableData> &&result) {
           if (!result.empty()) {
             if (filter_non_dead_actor) {
               for (auto &iter : result) {
@@ -273,7 +273,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
                 }
               }
             } else {
-              actors.assign(result.begin(), result.end());
+              actors = std::move(result);
             }
           }
           promise.set_value(true);
@@ -311,9 +311,9 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     std::promise<bool> promise;
     std::vector<rpc::GcsNodeInfo> nodes;
     RAY_CHECK_OK(gcs_client_->Nodes().AsyncGetAll(
-        [&nodes, &promise](Status status, const std::vector<rpc::GcsNodeInfo> &result) {
+        [&nodes, &promise](Status status, std::vector<rpc::GcsNodeInfo> &&result) {
           assert(!result.empty());
-          nodes.assign(result.begin(), result.end());
+          nodes = std::move(result);
           promise.set_value(status.ok());
         }));
     EXPECT_TRUE(WaitReady(promise.get_future(), timeout_ms_));

--- a/src/ray/gcs/gcs_server/gcs_init_data.cc
+++ b/src/ray/gcs/gcs_server/gcs_init_data.cc
@@ -41,8 +41,8 @@ void GcsInitData::AsyncLoad(const EmptyCallback &on_done) {
 void GcsInitData::AsyncLoadJobTableData(const EmptyCallback &on_done) {
   RAY_LOG(INFO) << "Loading job table data.";
   auto load_job_table_data_callback =
-      [this, on_done](const std::unordered_map<JobID, rpc::JobTableData> &result) {
-        job_table_data_ = result;
+      [this, on_done](std::unordered_map<JobID, rpc::JobTableData> &&result) {
+        job_table_data_ = std::move(result);
         RAY_LOG(INFO) << "Finished loading job table data, size = "
                       << job_table_data_.size();
         on_done();
@@ -53,8 +53,8 @@ void GcsInitData::AsyncLoadJobTableData(const EmptyCallback &on_done) {
 void GcsInitData::AsyncLoadNodeTableData(const EmptyCallback &on_done) {
   RAY_LOG(INFO) << "Loading node table data.";
   auto load_node_table_data_callback =
-      [this, on_done](const std::unordered_map<NodeID, rpc::GcsNodeInfo> &result) {
-        node_table_data_ = result;
+      [this, on_done](std::unordered_map<NodeID, rpc::GcsNodeInfo> &&result) {
+        node_table_data_ = std::move(result);
         RAY_LOG(INFO) << "Finished loading node table data, size = "
                       << node_table_data_.size();
         on_done();
@@ -65,8 +65,8 @@ void GcsInitData::AsyncLoadNodeTableData(const EmptyCallback &on_done) {
 void GcsInitData::AsyncLoadResourceTableData(const EmptyCallback &on_done) {
   RAY_LOG(INFO) << "Loading cluster resources table data.";
   auto load_resource_table_data_callback =
-      [this, on_done](const std::unordered_map<NodeID, rpc::ResourceMap> &result) {
-        resource_table_data_ = result;
+      [this, on_done](std::unordered_map<NodeID, rpc::ResourceMap> &&result) {
+        resource_table_data_ = std::move(result);
         RAY_LOG(INFO) << "Finished loading cluster resources table data, size = "
                       << resource_table_data_.size();
         on_done();
@@ -78,9 +78,9 @@ void GcsInitData::AsyncLoadResourceTableData(const EmptyCallback &on_done) {
 void GcsInitData::AsyncLoadPlacementGroupTableData(const EmptyCallback &on_done) {
   RAY_LOG(INFO) << "Loading placement group table data.";
   auto load_placement_group_table_data_callback =
-      [this, on_done](const std::unordered_map<PlacementGroupID,
-                                               rpc::PlacementGroupTableData> &result) {
-        placement_group_table_data_ = result;
+      [this, on_done](
+          std::unordered_map<PlacementGroupID, rpc::PlacementGroupTableData> &&result) {
+        placement_group_table_data_ = std::move(result);
         RAY_LOG(INFO) << "Finished loading placement group table data, size = "
                       << placement_group_table_data_.size();
         on_done();
@@ -92,8 +92,8 @@ void GcsInitData::AsyncLoadPlacementGroupTableData(const EmptyCallback &on_done)
 void GcsInitData::AsyncLoadActorTableData(const EmptyCallback &on_done) {
   RAY_LOG(INFO) << "Loading actor table data.";
   auto load_actor_table_data_callback =
-      [this, on_done](const std::unordered_map<ActorID, ActorTableData> &result) {
-        actor_table_data_ = result;
+      [this, on_done](std::unordered_map<ActorID, ActorTableData> &&result) {
+        actor_table_data_ = std::move(result);
         RAY_LOG(INFO) << "Finished loading actor table data, size = "
                       << actor_table_data_.size();
         on_done();

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -46,7 +46,7 @@ Status GcsTable<Key, Data>::Get(const Key &key,
 
 template <typename Key, typename Data>
 Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
-  auto on_done = [callback](const std::unordered_map<std::string, std::string> &result) {
+  auto on_done = [callback](std::unordered_map<std::string, std::string> &&result) {
     std::unordered_map<Key, Data> values;
     for (auto &item : result) {
       if (!item.second.empty()) {
@@ -55,7 +55,7 @@ Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
         values[Key::FromBinary(item.first)] = data;
       }
     }
-    callback(values);
+    callback(std::move(values));
   };
   return store_client_->AsyncGetAll(table_name_, on_done);
 }
@@ -88,7 +88,7 @@ Status GcsTableWithJobId<Key, Data>::Put(const Key &key, const Data &value,
 template <typename Key, typename Data>
 Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
                                                 const MapCallback<Key, Data> &callback) {
-  auto on_done = [callback](const std::unordered_map<std::string, std::string> &result) {
+  auto on_done = [callback](std::unordered_map<std::string, std::string> &&result) {
     std::unordered_map<Key, Data> values;
     for (auto &item : result) {
       if (!item.second.empty()) {
@@ -97,7 +97,7 @@ Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
         values[Key::FromBinary(item.first)] = std::move(data);
       }
     }
-    callback(values);
+    callback(std::move(values));
   };
   return this->store_client_->AsyncGetByIndex(this->table_name_, job_id.Binary(),
                                               on_done);

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -317,7 +317,7 @@ std::string RedisStoreClient::GetKeyFromRedisKey(const std::string &redis_key,
 }
 
 Status RedisStoreClient::MGetValues(
-    std::shared_ptr<RedisClient> redis_client, std::string table_name,
+    std::shared_ptr<RedisClient> redis_client, const std::string &table_name,
     const std::vector<std::string> &keys,
     const MapCallback<std::string, std::string> &callback) {
   // The `MGET` command for each shard.
@@ -354,7 +354,7 @@ Status RedisStoreClient::MGetValues(
 }
 
 RedisStoreClient::RedisScanner::RedisScanner(std::shared_ptr<RedisClient> redis_client,
-                                             std::string table_name)
+                                             const std::string &table_name)
     : table_name_(std::move(table_name)), redis_client_(std::move(redis_client)) {
   for (size_t index = 0; index < redis_client_->GetShardContexts().size(); ++index) {
     shard_to_cursor_[index] = 0;
@@ -362,7 +362,8 @@ RedisStoreClient::RedisScanner::RedisScanner(std::shared_ptr<RedisClient> redis_
 }
 
 Status RedisStoreClient::RedisScanner::ScanKeysAndValues(
-    std::string match_pattern, const MapCallback<std::string, std::string> &callback) {
+    const std::string &match_pattern,
+    const MapCallback<std::string, std::string> &callback) {
   auto on_done = [this, callback](const Status &status,
                                   const std::vector<std::string> &result) {
     if (result.empty()) {
@@ -375,7 +376,7 @@ Status RedisStoreClient::RedisScanner::ScanKeysAndValues(
 }
 
 Status RedisStoreClient::RedisScanner::ScanKeys(
-    std::string match_pattern, const MultiItemCallback<std::string> &callback) {
+    const std::string &match_pattern, const MultiItemCallback<std::string> &callback) {
   auto on_done = [this, callback](const Status &status) {
     std::vector<std::string> result;
     result.insert(result.begin(), keys_.begin(), keys_.end());
@@ -385,7 +386,7 @@ Status RedisStoreClient::RedisScanner::ScanKeys(
   return Status::OK();
 }
 
-void RedisStoreClient::RedisScanner::Scan(std::string match_pattern,
+void RedisStoreClient::RedisScanner::Scan(const std::string &match_pattern,
                                           const StatusCallback &callback) {
   // This lock guards the iterator over shard_to_cursor_ because the callbacks
   // can remove items from the shard_to_cursor_ map. If performance is a concern,
@@ -420,7 +421,7 @@ void RedisStoreClient::RedisScanner::Scan(std::string match_pattern,
 }
 
 void RedisStoreClient::RedisScanner::OnScanCallback(
-    std::string match_pattern, size_t shard_index,
+    const std::string &match_pattern, size_t shard_index,
     const std::shared_ptr<CallbackReply> &reply, const StatusCallback &callback) {
   RAY_CHECK(reply);
   std::vector<std::string> scan_result;

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -75,18 +75,18 @@ class RedisStoreClient : public StoreClient {
   class RedisScanner {
    public:
     explicit RedisScanner(std::shared_ptr<RedisClient> redis_client,
-                          std::string table_name);
+                          const std::string &table_name);
 
-    Status ScanKeysAndValues(std::string match_pattern,
+    Status ScanKeysAndValues(const std::string &match_pattern,
                              const MapCallback<std::string, std::string> &callback);
 
-    Status ScanKeys(std::string match_pattern,
+    Status ScanKeys(const std::string &match_pattern,
                     const MultiItemCallback<std::string> &callback);
 
    private:
-    void Scan(std::string match_pattern, const StatusCallback &callback);
+    void Scan(const std::string &match_pattern, const StatusCallback &callback);
 
-    void OnScanCallback(std::string match_pattern, size_t shard_index,
+    void OnScanCallback(const std::string &match_pattern, size_t shard_index,
                         const std::shared_ptr<CallbackReply> &reply,
                         const StatusCallback &callback);
 
@@ -143,7 +143,8 @@ class RedisStoreClient : public StoreClient {
                                         const std::string &index_key);
 
   static Status MGetValues(std::shared_ptr<RedisClient> redis_client,
-                           std::string table_name, const std::vector<std::string> &keys,
+                           const std::string &table_name,
+                           const std::vector<std::string> &keys,
                            const MapCallback<std::string, std::string> &callback);
 
   std::shared_ptr<RedisClient> redis_client_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After GCS restarts, metadata will be loaded from redis. Now redis callback returns `const &`, which requires a copy of the loaded data. After modifying to `&&` and then using `std::move`, data copy can be reduced.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
