### PR TITLE
[runtime env] Support clone `virtualenv` from an existing `virtualenv`

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -118,6 +118,7 @@ BLACK_EXCLUDES=(
     '--extend-exclude' 'python/ray/core/src/ray/gcs/*'
     '--extend-exclude' 'python/ray/thirdparty_files/*'
     '--extend-exclude' 'python/ray/_private/thirdparty/*'
+    '--extend-exclude' 'python/ray/_private/runtime_env/_clonevirtualenv.py'
 )
 
 GIT_LS_EXCLUDES=(

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -118,11 +118,11 @@ BLACK_EXCLUDES=(
     '--extend-exclude' 'python/ray/core/src/ray/gcs/*'
     '--extend-exclude' 'python/ray/thirdparty_files/*'
     '--extend-exclude' 'python/ray/_private/thirdparty/*'
-    '--extend-exclude' 'python/ray/_private/runtime_env/_clonevirtualenv.py'
 )
 
 GIT_LS_EXCLUDES=(
   ':(exclude)python/ray/cloudpickle/'
+  ':(exclude)python/ray/_private/runtime_env/_clonevirtualenv.py'
 )
 
 JAVA_EXCLUDES=(

--- a/python/ray/_private/runtime_env/_clonevirtualenv.py
+++ b/python/ray/_private/runtime_env/_clonevirtualenv.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python
+"""
+Copyright (c) 2011, Edward George, based on code contained within the
+virtualenv project.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from __future__ import with_statement
+
+import logging
+import optparse
+import os
+import os.path
+import re
+import shutil
+import subprocess
+import sys
+import itertools
+
+__version__ = '0.5.7'
+
+
+logger = logging.getLogger()
+
+
+env_bin_dir = 'bin'
+if sys.platform == 'win32':
+    env_bin_dir = 'Scripts'
+
+
+class UserError(Exception):
+    pass
+
+
+def _dirmatch(path, matchwith):
+    """Check if path is within matchwith's tree.
+    >>> _dirmatch('/home/foo/bar', '/home/foo/bar')
+    True
+    >>> _dirmatch('/home/foo/bar/', '/home/foo/bar')
+    True
+    >>> _dirmatch('/home/foo/bar/etc', '/home/foo/bar')
+    True
+    >>> _dirmatch('/home/foo/bar2', '/home/foo/bar')
+    False
+    >>> _dirmatch('/home/foo/bar2/etc', '/home/foo/bar')
+    False
+    """
+    matchlen = len(matchwith)
+    if (path.startswith(matchwith)
+        and path[matchlen:matchlen + 1] in [os.sep, '']):
+        return True
+    return False
+
+
+def _virtualenv_sys(venv_path):
+    "obtain version and path info from a virtualenv."
+    executable = os.path.join(venv_path, env_bin_dir, 'python')
+    # Must use "executable" as the first argument rather than as the
+    # keyword argument "executable" to get correct value from sys.path
+    p = subprocess.Popen([executable,
+        '-c', 'import sys;'
+              'print ("%d.%d" % (sys.version_info.major, sys.version_info.minor));'
+              'print ("\\n".join(sys.path));'],
+        env={},
+        stdout=subprocess.PIPE)
+    stdout, err = p.communicate()
+    assert not p.returncode and stdout
+    lines = stdout.decode('utf-8').splitlines()
+    return lines[0], list(filter(bool, lines[1:]))
+
+
+def clone_virtualenv(src_dir, dst_dir):
+    if not os.path.exists(src_dir):
+        raise UserError('src dir %r does not exist' % src_dir)
+    if os.path.exists(dst_dir):
+        raise UserError('dest dir %r exists' % dst_dir)
+    #sys_path = _virtualenv_syspath(src_dir)
+    logger.info('cloning virtualenv \'%s\' => \'%s\'...' %
+            (src_dir, dst_dir))
+    shutil.copytree(src_dir, dst_dir, symlinks=True,
+            ignore=shutil.ignore_patterns('*.pyc'))
+    version, sys_path = _virtualenv_sys(dst_dir)
+    logger.info('fixing scripts in bin...')
+    fixup_scripts(src_dir, dst_dir, version)
+
+    has_old = lambda s: any(i for i in s if _dirmatch(i, src_dir))
+
+    if has_old(sys_path):
+        # only need to fix stuff in sys.path if we have old
+        # paths in the sys.path of new python env. right?
+        logger.info('fixing paths in sys.path...')
+        fixup_syspath_items(sys_path, src_dir, dst_dir)
+    v_sys = _virtualenv_sys(dst_dir)
+    remaining = has_old(v_sys[1])
+    assert not remaining, v_sys
+    fix_symlink_if_necessary(src_dir, dst_dir)
+
+def fix_symlink_if_necessary(src_dir, dst_dir):
+    #sometimes the source virtual environment has symlinks that point to itself
+    #one example is $OLD_VIRTUAL_ENV/local/lib points to $OLD_VIRTUAL_ENV/lib
+    #this function makes sure
+    #$NEW_VIRTUAL_ENV/local/lib will point to $NEW_VIRTUAL_ENV/lib
+    #usually this goes unnoticed unless one tries to upgrade a package though pip, so this bug is hard to find.
+    logger.info("scanning for internal symlinks that point to the original virtual env")
+    for dirpath, dirnames, filenames in os.walk(dst_dir):
+        for a_file in itertools.chain(filenames, dirnames):
+            full_file_path = os.path.join(dirpath, a_file)
+            if os.path.islink(full_file_path):
+                target = os.path.realpath(full_file_path)
+                if target.startswith(src_dir):
+                    new_target = target.replace(src_dir, dst_dir)
+                    logger.debug('fixing symlink in %s' % (full_file_path,))
+                    os.remove(full_file_path)
+                    os.symlink(new_target, full_file_path)
+
+
+def fixup_scripts(old_dir, new_dir, version, rewrite_env_python=False):
+    bin_dir = os.path.join(new_dir, env_bin_dir)
+    root, dirs, files = next(os.walk(bin_dir))
+    pybinre = re.compile(r'pythonw?([0-9]+(\.[0-9]+(\.[0-9]+)?)?)?$')
+    for file_ in files:
+        filename = os.path.join(root, file_)
+        if file_ in ['python', 'python%s' % version, 'activate_this.py']:
+            continue
+        elif file_.startswith('python') and pybinre.match(file_):
+            # ignore other possible python binaries
+            continue
+        elif file_.endswith('.pyc'):
+            # ignore compiled files
+            continue
+        elif file_ == 'activate' or file_.startswith('activate.'):
+            fixup_activate(os.path.join(root, file_), old_dir, new_dir)
+        elif os.path.islink(filename):
+            fixup_link(filename, old_dir, new_dir)
+        elif os.path.isfile(filename):
+            fixup_script_(root, file_, old_dir, new_dir, version,
+                rewrite_env_python=rewrite_env_python)
+
+
+def fixup_script_(root, file_, old_dir, new_dir, version,
+                  rewrite_env_python=False):
+    old_shebang = '#!%s/bin/python' % os.path.normcase(os.path.abspath(old_dir))
+    new_shebang = '#!%s/bin/python' % os.path.normcase(os.path.abspath(new_dir))
+    env_shebang = '#!/usr/bin/env python'
+
+    filename = os.path.join(root, file_)
+    with open(filename, 'rb') as f:
+        if f.read(2) != b'#!':
+            # no shebang
+            return
+        f.seek(0)
+        lines = f.readlines()
+
+    if not lines:
+        # warn: empty script
+        return
+
+    def rewrite_shebang(version=None):
+        logger.debug('fixing %s' % filename)
+        shebang = new_shebang
+        if version:
+            shebang = shebang + version
+        shebang = (shebang + '\n').encode('utf-8')
+        with open(filename, 'wb') as f:
+            f.write(shebang)
+            f.writelines(lines[1:])
+
+    try:
+        bang = lines[0].decode('utf-8').strip()
+    except UnicodeDecodeError:
+        # binary file
+        return
+
+    # This takes care of the scheme in which shebang is of type
+    # '#!/venv/bin/python3' while the version of system python
+    # is of type 3.x e.g. 3.5.
+    short_version = bang[len(old_shebang):]
+
+    if not bang.startswith('#!'):
+        return
+    elif bang == old_shebang:
+        rewrite_shebang()
+    elif (bang.startswith(old_shebang)
+          and bang[len(old_shebang):] == version):
+        rewrite_shebang(version)
+    elif (bang.startswith(old_shebang)
+          and short_version
+          and bang[len(old_shebang):] == short_version):
+        rewrite_shebang(short_version)
+    elif rewrite_env_python and bang.startswith(env_shebang):
+        if bang == env_shebang:
+            rewrite_shebang()
+        elif bang[len(env_shebang):] == version:
+            rewrite_shebang(version)
+    else:
+        # can't do anything
+        return
+
+
+def fixup_activate(filename, old_dir, new_dir):
+    logger.debug('fixing %s' % filename)
+    with open(filename, 'rb') as f:
+        data = f.read().decode('utf-8')
+
+    data = data.replace(old_dir, new_dir)
+    with open(filename, 'wb') as f:
+        f.write(data.encode('utf-8'))
+
+
+def fixup_link(filename, old_dir, new_dir, target=None):
+    logger.debug('fixing %s' % filename)
+    if target is None:
+        target = os.readlink(filename)
+
+    origdir = os.path.dirname(os.path.abspath(filename)).replace(
+        new_dir, old_dir)
+    if not os.path.isabs(target):
+        target = os.path.abspath(os.path.join(origdir, target))
+        rellink = True
+    else:
+        rellink = False
+
+    if _dirmatch(target, old_dir):
+        if rellink:
+            # keep relative links, but don't keep original in case it
+            # traversed up out of, then back into the venv.
+            # so, recreate a relative link from absolute.
+            target = target[len(origdir):].lstrip(os.sep)
+        else:
+            target = target.replace(old_dir, new_dir, 1)
+
+    # else: links outside the venv, replaced with absolute path to target.
+    _replace_symlink(filename, target)
+
+
+def _replace_symlink(filename, newtarget):
+    tmpfn = "%s.new" % filename
+    os.symlink(newtarget, tmpfn)
+    os.rename(tmpfn, filename)
+
+
+def fixup_syspath_items(syspath, old_dir, new_dir):
+    for path in syspath:
+        if not os.path.isdir(path):
+            continue
+        path = os.path.normcase(os.path.abspath(path))
+        if _dirmatch(path, old_dir):
+            path = path.replace(old_dir, new_dir, 1)
+            if not os.path.exists(path):
+                continue
+        elif not _dirmatch(path, new_dir):
+            continue
+        root, dirs, files = next(os.walk(path))
+        for file_ in files:
+            filename = os.path.join(root, file_)
+            if filename.endswith('.pth'):
+                fixup_pth_file(filename, old_dir, new_dir)
+            elif filename.endswith('.egg-link'):
+                fixup_egglink_file(filename, old_dir, new_dir)
+
+
+def fixup_pth_file(filename, old_dir, new_dir):
+    logger.debug('fixup_pth_file %s' % filename)
+
+    with open(filename, 'r') as f:
+        lines = f.readlines()
+
+    has_change = False
+
+    for num, line in enumerate(lines):
+        line = (line.decode('utf-8') if hasattr(line, 'decode') else line).strip()
+
+        if not line or line.startswith('#') or line.startswith('import '):
+            continue
+        elif _dirmatch(line, old_dir):
+            lines[num] = line.replace(old_dir, new_dir, 1)
+            has_change = True
+
+    if has_change:
+        with open(filename, 'w') as f:
+            payload = os.linesep.join([l.strip() for l in lines]) + os.linesep
+            f.write(payload)
+
+
+def fixup_egglink_file(filename, old_dir, new_dir):
+    logger.debug('fixing %s' % filename)
+    with open(filename, 'rb') as f:
+        link = f.read().decode('utf-8').strip()
+    if _dirmatch(link, old_dir):
+        link = link.replace(old_dir, new_dir, 1)
+        with open(filename, 'wb') as f:
+            link = (link + '\n').encode('utf-8')
+            f.write(link)
+
+
+def main():
+    parser = optparse.OptionParser("usage: %prog [options]"
+        " /path/to/existing/venv /path/to/cloned/venv")
+    parser.add_option('-v',
+            action="count",
+            dest='verbose',
+            default=False,
+            help='verbosity')
+    options, args = parser.parse_args()
+    try:
+        old_dir, new_dir = args
+    except ValueError:
+        print("virtualenv-clone %s" % (__version__,))
+        parser.error("not enough arguments given.")
+    old_dir = os.path.realpath(old_dir)
+    new_dir = os.path.realpath(new_dir)
+    loglevel = (logging.WARNING, logging.INFO, logging.DEBUG)[min(2,
+            options.verbose)]
+    logging.basicConfig(level=loglevel, format='%(message)s')
+    try:
+        clone_virtualenv(old_dir, new_dir)
+    except UserError:
+        e = sys.exc_info()[1]
+        parser.error(str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -144,7 +144,7 @@ class PipProcessor:
             # or
             # python -m clonevirtualenv /path/to/existing/venv /path/to/cloned/ven
             clonevirtualenv = os.path.join(
-                os.path.dirname(__file__), "clonevirtualenv.py"
+                os.path.dirname(__file__), "_clonevirtualenv.py"
             )
             create_venv_cmd = [
                 python,

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -143,10 +143,12 @@ class PipProcessor:
             # virtualenv-clone /path/to/existing/venv /path/to/cloned/ven
             # or
             # python -m clonevirtualenv /path/to/existing/venv /path/to/cloned/ven
+            clonevirtualenv = os.path.join(
+                os.path.dirname(__file__), "clonevirtualenv.py"
+            )
             create_venv_cmd = [
                 python,
-                "-m",
-                "clonevirtualenv",
+                clonevirtualenv,
                 current_python_dir,
                 virtualenv_path,
             ]

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -128,52 +128,63 @@ class PipProcessor:
     @classmethod
     def _create_or_get_virtualenv(cls, path: str, cwd: str, logger: logging.Logger):
         """Create or get a virtualenv from path."""
-        if cls._is_in_virtualenv():
-            # TODO(fyrestone): Handle create virtualenv from virtualenv.
-            #
-            # Currently, create a virtualenv from virtualenv will get an
-            # unexpected result. The new created virtualenv only inherits
-            # the site packages from the real Python, not current
-            # virtualenv.
-            #
-            # It's possible to copy the virtualenv to create a new
-            # virtualenv, but copying the entire Python is very slow.
-            #
-            # So, we decide to raise an exception until creating virtualenv
-            # from virtualenv is fully supported.
-            raise RuntimeError("Can't create virtualenv from virtualenv.")
+
         python = sys.executable
         virtualenv_path = os.path.join(path, "virtualenv")
         virtualenv_app_data_path = os.path.join(path, "virtualenv_app_data")
-        # virtualenv options:
-        # https://virtualenv.pypa.io/en/latest/cli_interface.html
-        #
-        # --app-data
-        # --reset-app-data
-        #   Set an empty seperated app data folder for current virtualenv.
-        #
-        # --no-periodic-update
-        #   Disable the periodic (once every 14 days) update of the embedded
-        #   wheels.
-        #
-        # --system-site-packages
-        #   Inherit site packages.
-        #
-        # --no-download
-        #   Never download the latest pip/setuptools/wheel from PyPI.
-        create_venv_cmd = [
-            python,
-            "-m",
-            "virtualenv",
-            "--app-data",
-            virtualenv_app_data_path,
-            "--reset-app-data",
-            "--no-periodic-update",
-            "--system-site-packages",
-            "--no-download",
-            virtualenv_path,
-        ]
-        logger.info("Creating virtualenv at %s", virtualenv_path)
+        current_python_dir = os.path.abspath(
+            os.path.join(os.path.dirname(python), "..")
+        )
+
+        if cls._is_in_virtualenv():
+            # virtualenv-clone homepage:
+            # https://github.com/edwardgeorge/virtualenv-clone
+            # virtualenv-clone Usage:
+            # virtualenv-clone /path/to/existing/venv /path/to/cloned/ven
+            create_venv_cmd = [
+                python,
+                "-m",
+                "clonevirtualenv",
+                current_python_dir,
+                virtualenv_path,
+            ]
+            logger.info(
+                "Colning virtualenv %s to %s", current_python_dir, virtualenv_path
+            )
+        else:
+            # virtualenv options:
+            # https://virtualenv.pypa.io/en/latest/cli_interface.html
+            #
+            # --app-data
+            # --reset-app-data
+            #   Set an empty seperated app data folder for current virtualenv.
+            #
+            # --no-periodic-update
+            #   Disable the periodic (once every 14 days) update of the embedded
+            #   wheels.
+            #
+            # --system-site-packages
+            #   Inherit site packages.
+            #
+            # --no-download
+            #   Never download the latest pip/setuptools/wheel from PyPI.
+            create_venv_cmd = [
+                python,
+                "-m",
+                "virtualenv",
+                "--app-data",
+                virtualenv_app_data_path,
+                "--reset-app-data",
+                "--no-periodic-update",
+                "--system-site-packages",
+                "--no-download",
+                virtualenv_path,
+            ]
+            logger.info(
+                "Creating virtualenv at %s," " current python dir %s",
+                virtualenv_path,
+                current_python_dir,
+            )
         exit_code, output = exec_cmd_stream_to_logger(
             create_venv_cmd, logger, cwd=cwd, env={}
         )

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -141,6 +141,8 @@ class PipProcessor:
             # https://github.com/edwardgeorge/virtualenv-clone
             # virtualenv-clone Usage:
             # virtualenv-clone /path/to/existing/venv /path/to/cloned/ven
+            # or
+            # python -m clonevirtualenv /path/to/existing/venv /path/to/cloned/ven
             create_venv_cmd = [
                 python,
                 "-m",
@@ -149,7 +151,7 @@ class PipProcessor:
                 virtualenv_path,
             ]
             logger.info(
-                "Colning virtualenv %s to %s", current_python_dir, virtualenv_path
+                "Cloning virtualenv %s to %s", current_python_dir, virtualenv_path
             )
         else:
             # virtualenv options:
@@ -181,7 +183,7 @@ class PipProcessor:
                 virtualenv_path,
             ]
             logger.info(
-                "Creating virtualenv at %s," " current python dir %s",
+                "Creating virtualenv at %s, current python dir %s",
                 virtualenv_path,
                 current_python_dir,
             )

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -11,7 +11,6 @@ import json
 import time
 from pathlib import Path
 from unittest import mock
-from pytest_virtualenv import VirtualEnv
 
 import ray
 import ray.ray_constants as ray_constants
@@ -588,6 +587,9 @@ def runtime_env_disable_URI_cache():
 # Note: Can't use in virtualenv, this must be noted when testing locally.
 @pytest.fixture(scope="function")
 def cloned_virtualenv():
+    # Lazy import pytest_virtualenv,
+    # aviod import `pytest_virtualenv` in test case `Minimal install`
+    from pytest_virtualenv import VirtualEnv
 
     if PipProcessor._is_in_virtualenv():
         raise RuntimeError("Forbid the use of this fixture in virtualenv")

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -599,7 +599,6 @@ def cloned_virtualenv():
             "--no-periodic-update",
             "--no-download",
         ],
-        workspace="/home/admin/anything/test_virtualenv/",
     )
     yield venv
     venv.teardown()

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -102,12 +102,14 @@ def test_run_in_virtualenv(cloned_virtualenv):
     # make sure cloned_virtualenv.run will run in virtualenv.
     cloned_virtualenv.run(
         f"{python_exe_path} -c 'from ray._private.runtime_env.pip import PipProcessor;"
-        "assert PipProcessor._is_in_virtualenv()'"
+        "assert PipProcessor._is_in_virtualenv()'",
+        capture=True,
     )
 
     # Run current test case in virtualenv again.
-    # If the command exit code is not zero, this case will be failed.
-    cloned_virtualenv.run(f"IN_VIRTUALENV=1 python -m pytest {__file__}")
+    # If the command exit code is not zero, this will raise an `Exception`
+    # which construct by this pytest-cmd's stderr
+    cloned_virtualenv.run(f"IN_VIRTUALENV=1 python -m pytest {__file__}", capture=True)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -92,7 +92,7 @@ class TestGC:
 
 
 @pytest.mark.skipif(
-    "IN_VIRTUALENV" in os.environ or (os.environ.get("CI") and sys.platform != "linux"),
+    "IN_VIRTUALENV" in os.environ or sys.platform != "linux",
     reason="Requires PR wheels built in CI, so only run on linux CI machines.",
 )
 def test_run_in_virtualenv(cloned_virtualenv):

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -17,7 +17,9 @@ if not os.environ.get("CI"):
     reason="Requires PR wheels built in CI, so only run on linux CI machines.",
 )
 def test_in_virtualenv(start_cluster):
-    assert PipProcessor._is_in_virtualenv() is False
+    assert (
+        PipProcessor._is_in_virtualenv() is False and "IN_VIRTUALENV" not in os.environ
+    ) or (PipProcessor._is_in_virtualenv() is True and "IN_VIRTUALENV" in os.environ)
     cluster, address = start_cluster
     runtime_env = {"pip": ["pip-install-test==0.5"]}
 
@@ -87,6 +89,25 @@ class TestGC:
             assert ray.get(f.remote())
 
         ray.shutdown()
+
+
+@pytest.mark.skipif(
+    "IN_VIRTUALENV" in os.environ or (os.environ.get("CI") and sys.platform != "linux"),
+    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+)
+def test_run_in_virtualenv(cloned_virtualenv):
+    python_exe_path = cloned_virtualenv.python
+    print(python_exe_path)
+
+    # make sure cloned_virtualenv.run will run in virtualenv.
+    cloned_virtualenv.run(
+        f"{python_exe_path} -c 'from ray._private.runtime_env.pip import PipProcessor;"
+        "assert PipProcessor._is_in_virtualenv()'"
+    )
+
+    # Run current test case in virtualenv again.
+    # If the command exit code is not zero, this case will be failed.
+    cloned_virtualenv.run(f"IN_VIRTUALENV=1 python -m pytest {__file__}")
 
 
 if __name__ == "__main__":

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -84,6 +84,7 @@ pytest-rerunfailures
 pytest-sugar
 pytest-lazy-fixture
 pytest-timeout
+pytest-virtualenv
 scikit-learn==0.22.2
 tensorflow==2.5.1
 testfixtures

--- a/python/setup.py
+++ b/python/setup.py
@@ -280,7 +280,6 @@ if setup_spec.type == SetupType.RAY:
         "aiosignal",
         "frozenlist",
         "virtualenv",  # For pip runtime env.
-        "virtualenv-clone",  # For clone virtualenv from an existing virtualenv.
     ]
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -280,6 +280,7 @@ if setup_spec.type == SetupType.RAY:
         "aiosignal",
         "frozenlist",
         "virtualenv",  # For pip runtime env.
+        "virtualenv-clone",  # For clone virtualenv from an existing virtualenv.
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before this PR, we can't run ray in virtualenv, cause `runtime_env` does not support create a new virtualenv  from an existing virtualenv.

More details:https://github.com/ray-project/ray/pull/21801#discussion_r796848499

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
