### PR TITLE
[RLlib] Add A3C to rllib perf regression tests.

### DIFF
--- a/release/rllib_tests/performance_tests/performance_tests.yaml
+++ b/release/rllib_tests/performance_tests/performance_tests.yaml
@@ -134,3 +134,35 @@ sac-halfcheetahbulletenv-v0:
         num_workers: 0
         num_gpus: 1
         metrics_smoothing_episodes: 5
+
+a3c-pongdeterministic-v4:
+    env: PongDeterministic-v4
+    run: A3C
+    frameworks: [ "tf", "tf2", "torch" ]
+    stop:
+        time_total_s: 3600
+    config:
+        num_gpus: 0
+        num_workers: 16
+        rollout_fragment_length: 20
+        vf_loss_coeff: 0.5
+        entropy_coeff: 0.01
+        gamma: 0.99
+        grad_clip: 40.0
+        lambda: 1.0
+        lr: 0.0001
+        observation_filter: NoFilter
+        preprocessor_pref: rllib
+        model:
+            use_lstm: true
+            conv_activation: elu
+            dim: 42
+            grayscale: true
+            zero_mean: false
+            # Reduced channel depth and kernel size from default.
+            conv_filters: [
+                [32, [3, 3], 2],
+                [32, [3, 3], 2],
+                [32, [3, 3], 2],
+                [32, [3, 3], 2],
+            ]

--- a/release/rllib_tests/performance_tests/performance_tests.yaml
+++ b/release/rllib_tests/performance_tests/performance_tests.yaml
@@ -166,3 +166,5 @@ a3c-pongdeterministic-v4:
                 [32, [3, 3], 2],
                 [32, [3, 3], 2],
             ]
+        # TODO(jungong) : flip to True after we have collected some data.
+        _disable_execution_plan_api: false


### PR DESCRIPTION
## Why are these changes needed?

Auto perf-regression A3C

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
