### PR TITLE
[RLlib] Removed the `sampler()` function in the ParallelRollouts() as it is not needed.

### DIFF
--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -132,11 +132,9 @@ def ParallelRollouts(
     if not workers.remote_workers():
         # Handle the `num_workers=0` case, in which the local worker
         # has to do sampling as well.
-        def sampler(_):
-            while True:
-                yield workers.local_worker().sample()
-
-        return LocalIterator(sampler, SharedMetrics()).for_each(report_timesteps)
+        return LocalIterator(
+            lambda timeout: workers.local_worker().item_generator, SharedMetrics()
+        ).for_each(report_timesteps)
 
     # Create a parallel iterator over generated experiences.
     rollouts = from_actors(workers.remote_workers())


### PR DESCRIPTION
…needed. Instead the item_generator of the ParallelIteratorWorker is used.

## Why are these changes needed?

These changes define a more general setup in the `ParallelRollouts()` class by always using the `item_generator` of the worker for sampling. Furthermore, it also makes the code more readable as no second function definition for sampling is needed. 

I also timed some test runs and it appears that the modification is not slower than the original code - it was rather faster, but this should be tested more extensively to make a good judgement. 

## Related issue number

None, this is simply an enhancement. 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
