### PR TITLE
[gcs] Fix in_memory_store not handling nullptr callback issue

### DIFF
--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -24,7 +24,10 @@ Status InMemoryStoreClient::AsyncPut(const std::string &table_name,
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   table->records_[key] = data;
-  main_io_service_.post([callback]() { callback(Status::OK()); }, "GcsInMemoryStore.Put");
+  if (callback != nullptr) {
+    main_io_service_.post([callback]() { callback(Status::OK()); },
+                          "GcsInMemoryStore.Put");
+  }
   return Status::OK();
 }
 
@@ -37,8 +40,10 @@ Status InMemoryStoreClient::AsyncPutWithIndex(const std::string &table_name,
   absl::MutexLock lock(&(table->mutex_));
   table->records_[key] = data;
   table->index_keys_[index_key].emplace_back(key);
-  main_io_service_.post([callback]() { callback(Status::OK()); },
-                        "GcsInMemoryStore.PutWithIndex");
+  if (callback != nullptr) {
+    main_io_service_.post([callback]() { callback(Status::OK()); },
+                          "GcsInMemoryStore.PutWithIndex");
+  }
   return Status::OK();
 }
 
@@ -48,13 +53,14 @@ Status InMemoryStoreClient::AsyncGet(const std::string &table_name,
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   auto iter = table->records_.find(key);
+  boost::optional<std::string> data;
   if (iter != table->records_.end()) {
-    auto data = iter->second;
-    main_io_service_.post([callback, data]() { callback(Status::OK(), data); },
-                          "GcsInMemoryStore.Get");
-  } else {
-    main_io_service_.post([callback]() { callback(Status::OK(), boost::none); },
-                          "GcsInMemoryStore.GetNone");
+    data = iter->second;
+  }
+  if (callback) {
+    main_io_service_.post(
+        [callback, data = std::move(data)]() { callback(Status::OK(), data); },
+        "GcsInMemoryStore.Get");
   }
   return Status::OK();
 }
@@ -64,10 +70,13 @@ Status InMemoryStoreClient::AsyncGetAll(
     const MapCallback<std::string, std::string> &callback) {
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
-  auto result = std::make_shared<std::unordered_map<std::string, std::string>>();
-  result->insert(table->records_.begin(), table->records_.end());
-  main_io_service_.post([result, callback]() { callback(std::move(*result)); },
-                        "GcsInMemoryStore.GetAll");
+  auto result = std::unordered_map<std::string, std::string>();
+  result.insert(table->records_.begin(), table->records_.end());
+  if (callback != nullptr) {
+    main_io_service_.post(
+        [result = std::move(result), callback]() mutable { callback(std::move(result)); },
+        "GcsInMemoryStore.GetAll");
+  }
   return Status::OK();
 }
 
@@ -77,8 +86,10 @@ Status InMemoryStoreClient::AsyncDelete(const std::string &table_name,
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   table->records_.erase(key);
-  main_io_service_.post([callback]() { callback(Status::OK()); },
-                        "GcsInMemoryStore.Delete");
+  if (callback != nullptr) {
+    main_io_service_.post([callback]() { callback(Status::OK()); },
+                          "GcsInMemoryStore.Delete");
+  }
   return Status::OK();
 }
 
@@ -102,15 +113,10 @@ Status InMemoryStoreClient::AsyncDeleteWithIndex(const std::string &table_name,
       }
     }
   }
-
-  main_io_service_.post(
-      [callback]() {
-        if (callback) {
-          callback(Status::OK());
-        }
-      },
-      "GcsInMemoryStore.DeleteWithIndex");
-
+  if (callback != nullptr) {
+    main_io_service_.post([callback]() { callback(Status::OK()); },
+                          "GcsInMemoryStore.DeleteWithIndex");
+  }
   return Status::OK();
 }
 
@@ -122,8 +128,10 @@ Status InMemoryStoreClient::AsyncBatchDelete(const std::string &table_name,
   for (auto &key : keys) {
     table->records_.erase(key);
   }
-  main_io_service_.post([callback]() { callback(Status::OK()); },
-                        "GcsInMemoryStore.BatchDelete");
+  if (callback != nullptr) {
+    main_io_service_.post([callback]() { callback(Status::OK()); },
+                          "GcsInMemoryStore.BatchDelete");
+  }
   return Status::OK();
 }
 
@@ -152,13 +160,10 @@ Status InMemoryStoreClient::AsyncBatchDeleteWithIndex(
     }
   }
 
-  main_io_service_.post(
-      [callback]() {
-        if (callback) {
-          callback(Status::OK());
-        }
-      },
-      "GcsInMemoryStore.BatchDeleteWithIndex");
+  if (callback != nullptr) {
+    main_io_service_.post([callback]() { callback(Status::OK()); },
+                          "GcsInMemoryStore.BatchDeleteWithIndex");
+  }
 
   return Status::OK();
 }
@@ -169,17 +174,20 @@ Status InMemoryStoreClient::AsyncGetByIndex(
   auto table = GetOrCreateTable(table_name);
   absl::MutexLock lock(&(table->mutex_));
   auto iter = table->index_keys_.find(index_key);
-  auto result = std::make_shared<std::unordered_map<std::string, std::string>>();
+  auto result = std::unordered_map<std::string, std::string>();
   if (iter != table->index_keys_.end()) {
     for (auto &key : iter->second) {
       auto kv_iter = table->records_.find(key);
       if (kv_iter != table->records_.end()) {
-        (*result)[kv_iter->first] = kv_iter->second;
+        result[kv_iter->first] = kv_iter->second;
       }
     }
   }
-  main_io_service_.post([result, callback]() { callback(std::move(*result)); },
-                        "GcsInMemoryStore.GetByIndex");
+  if (callback != nullptr) {
+    main_io_service_.post(
+        [result = std::move(result), callback]() mutable { callback(std::move(result)); },
+        "GcsInMemoryStore.GetByIndex");
+  }
 
   return Status::OK();
 }
@@ -196,13 +204,10 @@ Status InMemoryStoreClient::AsyncDeleteByIndex(const std::string &table_name,
     }
     table->index_keys_.erase(iter);
   }
-  main_io_service_.post(
-      [callback]() {
-        if (callback) {
-          callback(Status::OK());
-        }
-      },
-      "GcsInMemoryStore.DeleteByIndex");
+  if (callback != nullptr) {
+    main_io_service_.post([callback]() { callback(Status::OK()); },
+                          "GcsInMemoryStore.DeleteByIndex");
+  }
   return Status::OK();
 }
 

--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -74,11 +74,9 @@ Status InMemoryStoreClient::AsyncGetAll(
   absl::MutexLock lock(&(table->mutex_));
   auto result = std::unordered_map<std::string, std::string>();
   result.insert(table->records_.begin(), table->records_.end());
-  if (callback != nullptr) {
-    main_io_service_.post(
-        [result = std::move(result), callback]() mutable { callback(std::move(result)); },
-        "GcsInMemoryStore.GetAll");
-  }
+  main_io_service_.post(
+      [result = std::move(result), callback]() mutable { callback(std::move(result)); },
+      "GcsInMemoryStore.GetAll");
   return Status::OK();
 }
 
@@ -186,11 +184,9 @@ Status InMemoryStoreClient::AsyncGetByIndex(
       }
     }
   }
-  if (callback != nullptr) {
-    main_io_service_.post(
-        [result = std::move(result), callback]() mutable { callback(std::move(result)); },
-        "GcsInMemoryStore.GetByIndex");
-  }
+  main_io_service_.post(
+      [result = std::move(result), callback]() mutable { callback(std::move(result)); },
+      "GcsInMemoryStore.GetByIndex");
 
   return Status::OK();
 }

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -70,6 +70,7 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncPut(table_name_, elem.first.Binary(),
                                            elem.second.SerializeAsString(),
                                            put_calllback));
+      // Make sure no-op callback is handled well
       RAY_CHECK_OK(store_client_->AsyncPut(table_name_, elem.first.Binary(),
                                            elem.second.SerializeAsString(), nullptr));
     }
@@ -85,6 +86,7 @@ class StoreClientTestBase : public ::testing::Test {
       ++pending_count_;
       RAY_CHECK_OK(
           store_client_->AsyncDelete(table_name_, elem.first.Binary(), delete_calllback));
+      // Make sure no-op callback is handled well
       RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, elem.first.Binary(), nullptr));
     }
     WaitPendingDone();
@@ -133,6 +135,7 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncPutWithIndex(
           table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(),
           elem.second.SerializeAsString(), put_calllback));
+      // Make sure no-op callback is handled well
       RAY_CHECK_OK(store_client_->AsyncPutWithIndex(
           table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(),
           elem.second.SerializeAsString(), nullptr));
@@ -167,6 +170,7 @@ class StoreClientTestBase : public ::testing::Test {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncDeleteByIndex(table_name_, elem.first.Hex(),
                                                      delete_calllback));
+      // Make sure no-op callback is handled well
       RAY_CHECK_OK(
           store_client_->AsyncDeleteByIndex(table_name_, elem.first.Hex(), nullptr));
     }
@@ -206,6 +210,7 @@ class StoreClientTestBase : public ::testing::Test {
       keys.push_back(elem.first.Binary());
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, delete_calllback));
+    // Make sure no-op callback is handled well
     RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, nullptr));
     WaitPendingDone();
   }
@@ -220,6 +225,7 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(table_name_, elem.first.Binary(),
                                                        key_to_index_[elem.first].Hex(),
                                                        delete_calllback));
+      // Make sure no-op callback is handled well
       RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(
           table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(), nullptr));
     }
@@ -240,6 +246,7 @@ class StoreClientTestBase : public ::testing::Test {
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDeleteWithIndex(table_name_, keys, index_keys,
                                                           delete_calllback));
+    // Make sure no-op callback is handled well
     RAY_CHECK_OK(
         store_client_->AsyncBatchDeleteWithIndex(table_name_, keys, index_keys, nullptr));
     WaitPendingDone();

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -70,6 +70,8 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncPut(table_name_, elem.first.Binary(),
                                            elem.second.SerializeAsString(),
                                            put_calllback));
+      RAY_CHECK_OK(store_client_->AsyncPut(table_name_, elem.first.Binary(),
+                                           elem.second.SerializeAsString(), nullptr));
     }
     WaitPendingDone();
   }
@@ -83,6 +85,7 @@ class StoreClientTestBase : public ::testing::Test {
       ++pending_count_;
       RAY_CHECK_OK(
           store_client_->AsyncDelete(table_name_, elem.first.Binary(), delete_calllback));
+      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, elem.first.Binary(), nullptr));
     }
     WaitPendingDone();
   }
@@ -130,6 +133,9 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncPutWithIndex(
           table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(),
           elem.second.SerializeAsString(), put_calllback));
+      RAY_CHECK_OK(store_client_->AsyncPutWithIndex(
+          table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(),
+          elem.second.SerializeAsString(), nullptr));
     }
     WaitPendingDone();
   }
@@ -161,6 +167,8 @@ class StoreClientTestBase : public ::testing::Test {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncDeleteByIndex(table_name_, elem.first.Hex(),
                                                      delete_calllback));
+      RAY_CHECK_OK(
+          store_client_->AsyncDeleteByIndex(table_name_, elem.first.Hex(), nullptr));
     }
     WaitPendingDone();
   }
@@ -198,6 +206,7 @@ class StoreClientTestBase : public ::testing::Test {
       keys.push_back(elem.first.Binary());
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, delete_calllback));
+    RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, nullptr));
     WaitPendingDone();
   }
 
@@ -211,6 +220,8 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(table_name_, elem.first.Binary(),
                                                        key_to_index_[elem.first].Hex(),
                                                        delete_calllback));
+      RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(
+          table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(), nullptr));
     }
     WaitPendingDone();
   }
@@ -229,6 +240,8 @@ class StoreClientTestBase : public ::testing::Test {
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDeleteWithIndex(table_name_, keys, index_keys,
                                                           delete_calllback));
+    RAY_CHECK_OK(
+        store_client_->AsyncBatchDeleteWithIndex(table_name_, keys, index_keys, nullptr));
     WaitPendingDone();
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
in memory store is not handling the nullptr callback well which leads to gcs crash in node failure tests. This PR fixed it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #22319 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
