### PR TITLE
[runtime env] use pytest tmp_path, os.path.sep, and unskip most tests for windows

### DIFF
--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -4,7 +4,6 @@ import random
 from shutil import copytree, rmtree, make_archive
 import string
 import sys
-import tempfile
 from filecmp import dircmp
 import uuid
 
@@ -33,63 +32,52 @@ def random_string(size: int = 10):
 
 
 @pytest.fixture
-def empty_dir():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        yield tmp_dir
-
-
-@pytest.fixture
-def random_dir():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        path = Path(tmp_dir)
-        subdir = path / "subdir"
-        subdir.mkdir(parents=True)
-        for _ in range(10):
-            p1 = path / random_string(10)
-            with p1.open("w") as f1:
-                f1.write(random_string(100))
-            p2 = path / random_string(10)
-            with p2.open("w") as f2:
-                f2.write(random_string(200))
-        yield tmp_dir
+def random_dir(tmp_path):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    for _ in range(10):
+        p1 = tmp_path / random_string(10)
+        with p1.open("w") as f1:
+            f1.write(random_string(100))
+        p2 = tmp_path / random_string(10)
+        with p2.open("w") as f2:
+            f2.write(random_string(200))
+    yield tmp_path
 
 
 @pytest.fixture
 def random_zip_file_without_top_level_dir(random_dir):
-    path = Path(random_dir)
-    make_archive(path / ARCHIVE_NAME[: ARCHIVE_NAME.rfind(".")], "zip", path)
-    yield str(path / ARCHIVE_NAME)
+    make_archive(random_dir / ARCHIVE_NAME[: ARCHIVE_NAME.rfind(".")], "zip", random_dir)
+    yield str(random_dir / ARCHIVE_NAME)
 
 
 @pytest.fixture
-def random_zip_file_with_top_level_dir():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        path = Path(tmp_dir)
-        top_level_dir = path / TOP_LEVEL_DIR_NAME
-        top_level_dir.mkdir(parents=True)
-        next_level_dir = top_level_dir
-        for _ in range(10):
-            p1 = next_level_dir / random_string(10)
-            with p1.open("w") as f1:
-                f1.write(random_string(100))
-            p2 = next_level_dir / random_string(10)
-            with p2.open("w") as f2:
-                f2.write(random_string(200))
-            dir1 = next_level_dir / random_string(15)
-            dir1.mkdir(parents=True)
-            dir2 = next_level_dir / random_string(15)
-            dir2.mkdir(parents=True)
-            next_level_dir = dir2
-        make_archive(
-            path / ARCHIVE_NAME[: ARCHIVE_NAME.rfind(".")],
-            "zip",
-            path,
-            TOP_LEVEL_DIR_NAME,
-        )
-        yield str(path / ARCHIVE_NAME)
+def random_zip_file_with_top_level_dir(tmp_path):
+    path = tmp_path
+    top_level_dir = path / TOP_LEVEL_DIR_NAME
+    top_level_dir.mkdir(parents=True)
+    next_level_dir = top_level_dir
+    for _ in range(10):
+        p1 = next_level_dir / random_string(10)
+        with p1.open("w") as f1:
+            f1.write(random_string(100))
+        p2 = next_level_dir / random_string(10)
+        with p2.open("w") as f2:
+            f2.write(random_string(200))
+        dir1 = next_level_dir / random_string(15)
+        dir1.mkdir(parents=True)
+        dir2 = next_level_dir / random_string(15)
+        dir2.mkdir(parents=True)
+        next_level_dir = dir2
+    make_archive(
+        path / ARCHIVE_NAME[: ARCHIVE_NAME.rfind(".")],
+        "zip",
+        path,
+        TOP_LEVEL_DIR_NAME,
+    )
+    yield str(path / ARCHIVE_NAME)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestGetURIForDirectory:
     def test_invalid_directory(self):
         with pytest.raises(ValueError):
@@ -104,7 +92,7 @@ class TestGetURIForDirectory:
         assert len(uris) == 1
 
         # Add one file, should be different now.
-        with open(Path(random_dir) / f"test_{random_string}", "w") as f:
+        with open(random_dir / f"test_{random_string()}", "w") as f:
             f.write(random_string())
 
         assert {get_uri_for_directory(random_dir)} != uris
@@ -142,26 +130,24 @@ class TestGetURIForDirectory:
         assert len(hex_hash) == 16
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestUploadPackageIfNeeded:
-    def test_create_upload_once(self, empty_dir, random_dir, ray_start_regular):
+    def test_create_upload_once(self, tmp_path, random_dir, ray_start_regular):
         uri = get_uri_for_directory(random_dir)
-        uploaded = upload_package_if_needed(uri, empty_dir, random_dir)
+        uploaded = upload_package_if_needed(uri, tmp_path, random_dir)
         assert uploaded
         assert _internal_kv_exists(uri, namespace=KV_NAMESPACE_PACKAGE)
 
-        uploaded = upload_package_if_needed(uri, empty_dir, random_dir)
+        uploaded = upload_package_if_needed(uri, tmp_path, random_dir)
         assert not uploaded
         assert _internal_kv_exists(uri, namespace=KV_NAMESPACE_PACKAGE)
 
         # Delete the URI from the internal_kv. This should trigger re-upload.
         _internal_kv_del(uri, namespace=KV_NAMESPACE_PACKAGE)
         assert not _internal_kv_exists(uri, namespace=KV_NAMESPACE_PACKAGE)
-        uploaded = upload_package_if_needed(uri, empty_dir, random_dir)
+        uploaded = upload_package_if_needed(uri, tmp_path, random_dir)
         assert uploaded
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestGetTopLevelDirFromCompressedPackage:
     def test_get_top_level_valid(self, random_zip_file_with_top_level_dir):
         top_level_dir_name = get_top_level_dir_from_compressed_package(
@@ -176,7 +162,6 @@ class TestGetTopLevelDirFromCompressedPackage:
         assert top_level_dir_name is None
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 class TestRemoveDirFromFilepaths:
     def test_valid_removal(self, random_zip_file_with_top_level_dir):
         # This test copies the TOP_LEVEL_DIR_NAME directory, and then it
@@ -185,12 +170,12 @@ class TestRemoveDirFromFilepaths:
         # TOP_LEVEL_DIR_NAME directory to ensure that they match.
 
         archive_path = random_zip_file_with_top_level_dir
-        tmp_path = archive_path[: archive_path.rfind("/")]
+        tmp_path = archive_path[: archive_path.rfind(os.path.sep)]
         original_dir_path = os.path.join(tmp_path, TOP_LEVEL_DIR_NAME)
         copy_dir_path = os.path.join(tmp_path, TOP_LEVEL_DIR_NAME + "_copy")
         copytree(original_dir_path, copy_dir_path)
         remove_dir_from_filepaths(tmp_path, TOP_LEVEL_DIR_NAME + "_copy")
-        dcmp = dircmp(tmp_path, f"{tmp_path}/{TOP_LEVEL_DIR_NAME}")
+        dcmp = dircmp(tmp_path, os.path.join(tmp_path, TOP_LEVEL_DIR_NAME))
 
         # Since this test uses the tmp_path as the target directory, and since
         # the tmp_path also contains the zip file and the top level directory,
@@ -206,7 +191,6 @@ class TestRemoveDirFromFilepaths:
         assert len(dcmp.right_only) == 0
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("remove_top_level_directory", [False, True])
 @pytest.mark.parametrize("unlink_zip", [False, True])
 class TestUnzipPackage:
@@ -215,10 +199,11 @@ class TestUnzipPackage:
     ):
         dcmp = None
         if remove_top_level_directory:
-            dcmp = dircmp(f"{tmp_subdir}", f"{tmp_path}/{TOP_LEVEL_DIR_NAME}")
+            dcmp = dircmp(tmp_subdir, os.path.join(tmp_path, TOP_LEVEL_DIR_NAME))
         else:
             dcmp = dircmp(
-                f"{tmp_subdir}/{TOP_LEVEL_DIR_NAME}", f"{tmp_path}/{TOP_LEVEL_DIR_NAME}"
+                os.path.join(tmp_subdir, TOP_LEVEL_DIR_NAME),
+                os.path.join(tmp_path, TOP_LEVEL_DIR_NAME)
             )
         assert len(dcmp.left_only) == 0
         assert len(dcmp.right_only) == 0
@@ -232,8 +217,8 @@ class TestUnzipPackage:
         self, random_zip_file_with_top_level_dir, remove_top_level_directory, unlink_zip
     ):
         archive_path = random_zip_file_with_top_level_dir
-        tmp_path = archive_path[: archive_path.rfind("/")]
-        tmp_subdir = f"{tmp_path}/{TOP_LEVEL_DIR_NAME}_tmp"
+        tmp_path = archive_path[: archive_path.rfind(os.path.sep)]
+        tmp_subdir = os.path.join(tmp_path, TOP_LEVEL_DIR_NAME + "_tmp")
 
         unzip_package(
             package_path=archive_path,
@@ -247,52 +232,50 @@ class TestUnzipPackage:
         )
 
     def test_unzip_with_matching_subdirectory_names(
-        self, remove_top_level_directory, unlink_zip
+        self, remove_top_level_directory, unlink_zip, tmp_path,
     ):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir)
-            top_level_dir = path / TOP_LEVEL_DIR_NAME
-            top_level_dir.mkdir(parents=True)
-            next_level_dir = top_level_dir
-            for _ in range(10):
-                dir1 = next_level_dir / TOP_LEVEL_DIR_NAME
-                dir1.mkdir(parents=True)
-                next_level_dir = dir1
-            make_archive(
-                path / ARCHIVE_NAME[: ARCHIVE_NAME.rfind(".")],
-                "zip",
-                path,
-                TOP_LEVEL_DIR_NAME,
-            )
-            archive_path = str(path / ARCHIVE_NAME)
+        path = tmp_path
+        top_level_dir = path / TOP_LEVEL_DIR_NAME
+        top_level_dir.mkdir(parents=True)
+        next_level_dir = top_level_dir
+        for _ in range(10):
+            dir1 = next_level_dir / TOP_LEVEL_DIR_NAME
+            dir1.mkdir(parents=True)
+            next_level_dir = dir1
+        make_archive(
+            path / ARCHIVE_NAME[: ARCHIVE_NAME.rfind(".")],
+            "zip",
+            path,
+            TOP_LEVEL_DIR_NAME,
+        )
+        archive_path = str(path / ARCHIVE_NAME)
 
-            tmp_path = archive_path[: archive_path.rfind("/")]
-            tmp_subdir = f"{tmp_path}/{TOP_LEVEL_DIR_NAME}_tmp"
+        tmp_path = archive_path[: archive_path.rfind(os.path.sep)]
+        tmp_subdir = os.path.join(tmp_path, TOP_LEVEL_DIR_NAME + "_tmp")
 
-            unzip_package(
-                package_path=archive_path,
-                target_dir=tmp_subdir,
-                remove_top_level_directory=remove_top_level_directory,
-                unlink_zip=unlink_zip,
-            )
+        unzip_package(
+            package_path=archive_path,
+            target_dir=tmp_subdir,
+            remove_top_level_directory=remove_top_level_directory,
+            unlink_zip=unlink_zip,
+        )
 
-            self.dcmp_helper(
-                remove_top_level_directory,
-                unlink_zip,
-                tmp_subdir,
-                tmp_path,
-                archive_path,
-            )
+        self.dcmp_helper(
+            remove_top_level_directory,
+            unlink_zip,
+            tmp_subdir,
+            tmp_path,
+            archive_path,
+        )
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
-def test_travel():
-    with tempfile.TemporaryDirectory() as tmp_dir:
+@pytest.mark.skipif(sys.platform == "win32", reason="Fails on windows")
+def test_travel(tmp_path):
         dir_paths = set()
         file_paths = set()
         item_num = 0
         excludes = []
-        root = Path(tmp_dir) / "test"
+        root = tmp_path / "test"
 
         def construct(path, excluded=False, depth=0):
             nonlocal item_num
@@ -319,14 +302,14 @@ def test_travel():
 
             for _ in range(file_num):
                 uid = str(uuid.uuid4()).split("-")[0]
+                v = random.randint(0, 1000)
                 with (path / uid).open("w") as f:
-                    v = random.randint(0, 1000)
                     f.write(str(v))
-                    if not excluded:
-                        if random.randint(0, 5) == 0:
-                            excludes.append(str((path / uid).relative_to(root)))
-                        else:
-                            file_paths.add((str(path / uid), str(v)))
+                if not excluded:
+                    if random.randint(0, 5) == 0:
+                        excludes.append(str((path / uid).relative_to(root)))
+                    else:
+                        file_paths.add((str(path / uid), str(v)))
                 item_num += 1
 
         construct(root)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Complements #22186 to enable runtime tests on windows. This refactors the tests to use the pytest `tmp_path` fixture, replaces '/' with `os.path.sep` and unskips almost all the tests on windows. One failing test is still skipped, I propose leaving this for a future PR.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
