### PR TITLE
Fix push down dataset_kwargs.filters passed to ray.data.read_parquet

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -67,6 +67,9 @@ class ParquetDatasource(FileBasedDatasource):
             paths = paths[0]
 
         dataset_kwargs = reader_args.pop("dataset_kwargs", {})
+        filters = dataset_kwargs.get("filters", [])
+        filter_expression = pq._filters_to_expression(filters)
+
         pq_ds = pq.ParquetDataset(
             paths, **dataset_kwargs, filesystem=filesystem, use_legacy_dataset=False
         )
@@ -106,6 +109,7 @@ class ParquetDatasource(FileBasedDatasource):
                     columns=columns,
                     schema=schema,
                     batch_size=PARQUET_READER_ROW_BATCH_SIZE,
+                    filter=filter_expression,
                     **reader_args,
                 )
                 for batch in batches:


### PR DESCRIPTION
## Why are these changes needed?

Currently, push-down filter arguments to `ray.data.read_parquet("my_dataset_path", dataset_kwargs=dict(filters=[['foo', '=', 'bar']]))` do not work. The arguments are properly passed to a `ParquetDataset` object, but then not applied when reading through serialized pieces.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
