### PR TITLE
[RLlib] Bug fix: eval-workers in offline RL setup have no env, even though eval_config includes `env` key.

### DIFF
--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -1,6 +1,8 @@
 import copy
 import gym
 import numpy as np
+import os
+from pathlib import Path
 from random import choice
 import time
 import unittest
@@ -8,6 +10,7 @@ import unittest
 import ray
 import ray.rllib.agents.a3c as a3c
 import ray.rllib.agents.dqn as dqn
+from ray.rllib.agents.marwil import BCTrainer
 import ray.rllib.agents.pg as pg
 from ray.rllib.agents.trainer import COMMON_CONFIG
 from ray.rllib.examples.env.multi_agent import MultiAgentCartPole
@@ -273,6 +276,36 @@ class TestTrainer(unittest.TestCase):
         print(f"Spaces given manually in config: {wo_lookup}sec")
         self.assertLess(wo_lookup, w_lookup)
         trainer.stop()
+
+    def test_no_env_but_eval_workers_do_have_env(self):
+        """Tests whether no env on workers, but env on eval workers works ok."""
+        script_path = Path(__file__)
+        input_file = os.path.join(
+            script_path.parent.parent.parent, "tests/data/cartpole/small.json"
+        )
+
+        env = gym.make("CartPole-v0")
+
+        offline_rl_config = {
+            # Offline RL -> No env on regular workers.
+            "input": input_file,
+            # No env -> Must specify spaces here.
+            "observation_space": env.observation_space,
+            "action_space": env.action_space,
+            # Configure env to be created on evaluation workers.
+            "evaluation_interval": 1,
+            "evaluation_num_workers": 1,
+            "evaluation_config": {
+                "env": "CartPole-v0",
+                "input": "sampler",
+                "observation_space": None,  # Test, whether this is inferred.
+                "action_space": None,  # Test, whether this is inferred.
+            },
+        }
+
+        bc_trainer = BCTrainer(config=offline_rl_config)
+        bc_trainer.train()
+        bc_trainer.stop()
 
 
 if __name__ == "__main__":

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1002,12 +1002,15 @@ class Trainer(Trainable):
 
             self.config["evaluation_config"] = eval_config
 
+            env_id = self._register_if_needed(eval_config.get("env"), eval_config)
+            env_creator = self._get_env_creator_from_env_id(env_id)
+
             # Create a separate evaluation worker set for evaluation.
             # If evaluation_num_workers=0, use the evaluation set's local
             # worker for evaluation, otherwise, use its remote workers
             # (parallelized evaluation).
             self.evaluation_workers: WorkerSet = WorkerSet(
-                env_creator=self.env_creator,
+                env_creator=env_creator,
                 validate_env=None,
                 policy_class=self.get_default_policy_class(self.config),
                 trainer_config=eval_config,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Bug fix: eval-workers in offline RL setup have no env, even though eval_config includes `env` key.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
