### PR TITLE
[serve] Fix HTTP proxy controller namespace bug (#22287)

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -71,6 +71,7 @@ class ReplicaContext:
     deployment: str
     replica_tag: ReplicaTag
     _internal_controller_name: str
+    _internal_controller_namespace: str
     servable_object: Callable
 
 
@@ -78,11 +79,13 @@ def _set_internal_replica_context(
         deployment: str,
         replica_tag: ReplicaTag,
         controller_name: str,
+        controller_namespace: str,
         servable_object: Callable,
 ):
     global _INTERNAL_REPLICA_CONTEXT
     _INTERNAL_REPLICA_CONTEXT = ReplicaContext(
-        deployment, replica_tag, controller_name, servable_object)
+        deployment, replica_tag, controller_name, controller_namespace,
+        servable_object)
 
 
 def _ensure_connected(f: Callable) -> Callable:
@@ -542,7 +545,7 @@ def _connect() -> Client:
         controller_namespace = _get_controller_namespace(detached=True)
     else:
         controller_name = _INTERNAL_REPLICA_CONTEXT._internal_controller_name
-        controller_namespace = _get_controller_namespace(detached=False)
+        controller_namespace = _INTERNAL_REPLICA_CONTEXT._internal_controller_namespace
 
     # Try to get serve controller if it exists
     try:

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -197,7 +197,8 @@ class ActorReplicaWrapper:
                 deployment_info.replica_config.init_args,
                 deployment_info.replica_config.init_kwargs,
                 deployment_info.deployment_config.to_proto_bytes(), version,
-                self._controller_name, self._detached)
+                self._controller_name, self._controller_namespace,
+                self._detached)
 
         self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
         self._ready_obj_ref = self._actor_handle.reconfigure.remote(

--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -201,8 +201,8 @@ class HTTPProxy:
     def __init__(self, controller_name: str, controller_namespace: str):
         # Set the controller name so that serve will connect to the
         # controller instance this proxy is running in.
-        ray.serve.api._set_internal_replica_context(None, None,
-                                                    controller_name, None)
+        ray.serve.api._set_internal_replica_context(
+            None, None, controller_name, controller_namespace, None)
 
         # Used only for displaying the route table.
         self.route_info: Dict[str, EndpointTag] = dict()

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -102,6 +102,7 @@ class HTTPState:
                 proxy = HTTPProxyActor.options(
                     num_cpus=self._config.num_cpus,
                     name=name,
+                    namespace=self._controller_namespace,
                     lifetime="detached" if self._detached else None,
                     max_concurrency=ASYNC_CONCURRENCY,
                     max_restarts=-1,

--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -44,7 +44,7 @@ def create_replica_wrapper(name: str, serialized_deployment_def: bytes):
         async def __init__(self, deployment_name, replica_tag, init_args,
                            init_kwargs, deployment_config_proto_bytes: bytes,
                            version: DeploymentVersion, controller_name: str,
-                           detached: bool):
+                           controller_namespace: str, detached: bool):
             deployment_def = cloudpickle.loads(serialized_deployment_def)
             deployment_config = DeploymentConfig.from_proto_bytes(
                 deployment_config_proto_bytes)
@@ -64,12 +64,11 @@ def create_replica_wrapper(name: str, serialized_deployment_def: bytes):
                 deployment_name,
                 replica_tag,
                 controller_name,
+                controller_namespace,
                 servable_object=None)
 
             assert controller_name, "Must provide a valid controller_name"
 
-            controller_namespace = ray.serve.api._get_controller_namespace(
-                detached)
             controller_handle = ray.get_actor(
                 controller_name, namespace=controller_namespace)
 
@@ -95,6 +94,7 @@ def create_replica_wrapper(name: str, serialized_deployment_def: bytes):
                     deployment_name,
                     replica_tag,
                     controller_name,
+                    controller_namespace,
                     servable_object=_callable)
 
                 self.replica = RayServeReplica(

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -109,12 +109,13 @@ def test_detached_deployment(ray_cluster):
     first_job_id = ray.get_runtime_context().job_id
     serve.start(detached=True)
 
-    @serve.deployment
+    @serve.deployment(route_prefix="/say_hi_f")
     def f(*args):
-        return "hello"
+        return "from_f"
 
     f.deploy()
-    assert ray.get(f.get_handle().remote()) == "hello"
+    assert ray.get(f.get_handle().remote()) == "from_f"
+    assert requests.get("http://localhost:8000/say_hi_f").text == "from_f"
 
     serve.api._global_client = None
     ray.shutdown()
@@ -123,12 +124,14 @@ def test_detached_deployment(ray_cluster):
     ray.init(head_node.address, namespace="serve")
     assert ray.get_runtime_context().job_id != first_job_id
 
-    @serve.deployment
+    @serve.deployment(route_prefix="/say_hi_g")
     def g(*args):
-        return "world"
+        return "from_g"
 
     g.deploy()
-    assert ray.get(g.get_handle().remote()) == "world"
+    assert ray.get(g.get_handle().remote()) == "from_g"
+    assert requests.get("http://localhost:8000/say_hi_g").text == "from_g"
+    assert requests.get("http://localhost:8000/say_hi_f").text == "from_f"
 
 
 @pytest.mark.parametrize("detached", [True, False])


### PR DESCRIPTION
Closes https://github.com/ray-project/ray/issues/22265

This was caused by implicitly inferring the namespace from within the HTTP proxy when calling `get_handle`. This makes me think we really need to simplify the namespace handling logic.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
