### PR TITLE
[refactor cluster-task-manage 3/n] Separate stats reporting into its own file

### DIFF
--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -53,7 +53,8 @@ ClusterTaskManager::ClusterTaskManager(
       get_time_ms_(get_time_ms),
       sched_cls_cap_enabled_(RayConfig::instance().worker_cap_enabled()),
       sched_cls_cap_interval_ms_(sched_cls_cap_interval_ms),
-      sched_cls_cap_max_ms_(RayConfig::instance().worker_cap_max_backoff_delay_ms()) {}
+      sched_cls_cap_max_ms_(RayConfig::instance().worker_cap_max_backoff_delay_ms()),
+      internal_stats_(*this) {}
 
 bool ClusterTaskManager::SchedulePendingTasks() {
   // Always try to schedule infeasible tasks in case they are now feasible.
@@ -814,212 +815,10 @@ bool ClusterTaskManager::AnyPendingTasksForResourceAcquisition(
   return *any_pending;
 }
 
-void ClusterTaskManager::RecomputeDebugStats() const {
-  auto accumulator =
-      [](size_t state,
-         const std::pair<int, std::deque<std::shared_ptr<internal::Work>>> &pair) {
-        return state + pair.second.size();
-      };
-  size_t num_waiting_for_resource = 0;
-  size_t num_waiting_for_plasma_memory = 0;
-  size_t num_waiting_for_remote_node_resources = 0;
-  size_t num_worker_not_started_by_job_config_not_exist = 0;
-  size_t num_worker_not_started_by_registration_timeout = 0;
-  size_t num_worker_not_started_by_process_rate_limit = 0;
-  size_t num_tasks_waiting_for_workers = 0;
-  size_t num_cancelled_tasks = 0;
-
-  size_t num_infeasible_tasks = std::accumulate(
-      infeasible_tasks_.begin(), infeasible_tasks_.end(), (size_t)0, accumulator);
-
-  // TODO(sang): Normally, the # of queued tasks are not large, so this is less likley to
-  // be an issue that we iterate all of them. But if it uses lots of CPU, consider
-  // optimizing by updating live instead of iterating through here.
-  auto per_work_accumulator = [&num_waiting_for_resource, &num_waiting_for_plasma_memory,
-                               &num_waiting_for_remote_node_resources,
-                               &num_worker_not_started_by_job_config_not_exist,
-                               &num_worker_not_started_by_registration_timeout,
-                               &num_worker_not_started_by_process_rate_limit,
-                               &num_tasks_waiting_for_workers, &num_cancelled_tasks](
-                                  size_t state,
-                                  const std::pair<
-                                      int, std::deque<std::shared_ptr<internal::Work>>>
-                                      &pair) {
-    const auto &work_queue = pair.second;
-    for (auto work_it = work_queue.begin(); work_it != work_queue.end();) {
-      const auto &work = *work_it++;
-      if (work->GetState() == internal::WorkStatus::WAITING_FOR_WORKER) {
-        num_tasks_waiting_for_workers += 1;
-      } else if (work->GetState() == internal::WorkStatus::CANCELLED) {
-        num_cancelled_tasks += 1;
-      } else if (work->GetUnscheduledCause() ==
-                 internal::UnscheduledWorkCause::WAITING_FOR_RESOURCE_ACQUISITION) {
-        num_waiting_for_resource += 1;
-      } else if (work->GetUnscheduledCause() ==
-                 internal::UnscheduledWorkCause::WAITING_FOR_AVAILABLE_PLASMA_MEMORY) {
-        num_waiting_for_plasma_memory += 1;
-      } else if (work->GetUnscheduledCause() ==
-                 internal::UnscheduledWorkCause::WAITING_FOR_RESOURCES_AVAILABLE) {
-        num_waiting_for_remote_node_resources += 1;
-      } else if (work->GetUnscheduledCause() ==
-                 internal::UnscheduledWorkCause::WORKER_NOT_FOUND_JOB_CONFIG_NOT_EXIST) {
-        num_worker_not_started_by_job_config_not_exist += 1;
-      } else if (work->GetUnscheduledCause() ==
-                 internal::UnscheduledWorkCause::WORKER_NOT_FOUND_REGISTRATION_TIMEOUT) {
-        num_worker_not_started_by_registration_timeout += 1;
-      } else if (work->GetUnscheduledCause() ==
-                 internal::UnscheduledWorkCause::WORKER_NOT_FOUND_RATE_LIMITED) {
-        num_worker_not_started_by_process_rate_limit += 1;
-      }
-    }
-    return state + pair.second.size();
-  };
-  size_t num_tasks_to_schedule =
-      std::accumulate(tasks_to_schedule_.begin(), tasks_to_schedule_.end(), (size_t)0,
-                      per_work_accumulator);
-  size_t num_tasks_to_dispatch =
-      std::accumulate(tasks_to_dispatch_.begin(), tasks_to_dispatch_.end(), (size_t)0,
-                      per_work_accumulator);
-
-  /// Update the internal states.
-  internal_stats_.num_waiting_for_resource = num_waiting_for_resource;
-  internal_stats_.num_waiting_for_plasma_memory = num_waiting_for_plasma_memory;
-  internal_stats_.num_waiting_for_remote_node_resources =
-      num_waiting_for_remote_node_resources;
-  internal_stats_.num_worker_not_started_by_job_config_not_exist =
-      num_worker_not_started_by_job_config_not_exist;
-  internal_stats_.num_worker_not_started_by_registration_timeout =
-      num_worker_not_started_by_registration_timeout;
-  internal_stats_.num_worker_not_started_by_process_rate_limit =
-      num_worker_not_started_by_process_rate_limit;
-  internal_stats_.num_tasks_waiting_for_workers = num_tasks_waiting_for_workers;
-  internal_stats_.num_cancelled_tasks = num_cancelled_tasks;
-  internal_stats_.num_infeasible_tasks = num_infeasible_tasks;
-  internal_stats_.num_tasks_to_schedule = num_tasks_to_schedule;
-  internal_stats_.num_tasks_to_dispatch = num_tasks_to_dispatch;
-}
-
-void ClusterTaskManager::RecordMetrics() const {
-  /// This method intentionally doesn't call RecomputeDebugStats() because
-  /// that function is expensive. RecomputeDebugStats is called by DebugStr method
-  /// and they are always periodically called by node manager.
-  stats::NumSpilledTasks.Record(internal_stats_.metric_tasks_spilled);
-  stats::NumInfeasibleSchedulingClasses.Record(infeasible_tasks_.size());
-
-  /// Worker startup failure
-  ray::stats::STATS_scheduler_failed_worker_startup_total.Record(
-      internal_stats_.num_worker_not_started_by_job_config_not_exist, "JobConfigMissing");
-  ray::stats::STATS_scheduler_failed_worker_startup_total.Record(
-      internal_stats_.num_worker_not_started_by_registration_timeout,
-      "RegistrationTimedOut");
-  ray::stats::STATS_scheduler_failed_worker_startup_total.Record(
-      internal_stats_.num_worker_not_started_by_process_rate_limit, "RateLimited");
-
-  /// Queued tasks.
-  ray::stats::STATS_scheduler_tasks.Record(internal_stats_.num_cancelled_tasks,
-                                           "Cancelled");
-  ray::stats::STATS_scheduler_tasks.Record(executing_task_args_.size(), "Executing");
-  ray::stats::STATS_scheduler_tasks.Record(waiting_tasks_index_.size(), "Waiting");
-  ray::stats::STATS_scheduler_tasks.Record(internal_stats_.num_tasks_to_dispatch,
-                                           "Dispatched");
-  ray::stats::STATS_scheduler_tasks.Record(internal_stats_.num_tasks_to_schedule,
-                                           "Received");
-
-  /// Pending task count.
-  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(
-      internal_stats_.num_infeasible_tasks, "Infeasible");
-  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(
-      internal_stats_.num_waiting_for_resource, "WaitingForResources");
-  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(
-      internal_stats_.num_waiting_for_plasma_memory, "WaitingForPlasmaMemory");
-  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(
-      internal_stats_.num_waiting_for_remote_node_resources, "WaitingForRemoteResources");
-  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(
-      internal_stats_.num_tasks_waiting_for_workers, "WaitingForWorkers");
-}
+void ClusterTaskManager::RecordMetrics() const { internal_stats_.RecordMetrics(); }
 
 std::string ClusterTaskManager::DebugStr() const {
-  RecomputeDebugStats();
-  if (internal_stats_.num_tasks_to_schedule + internal_stats_.num_tasks_to_dispatch +
-          internal_stats_.num_infeasible_tasks >
-      1000) {
-    RAY_LOG(WARNING)
-        << "More than 1000 tasks are queued in this node. This can cause slow down.";
-  }
-
-  std::stringstream buffer;
-  buffer << "========== Node: " << self_node_id_ << " =================\n";
-  buffer << "Infeasible queue length: " << internal_stats_.num_infeasible_tasks << "\n";
-  buffer << "Schedule queue length: " << internal_stats_.num_tasks_to_schedule << "\n";
-  buffer << "Dispatch queue length: " << internal_stats_.num_tasks_to_dispatch << "\n";
-  buffer << "num_waiting_for_resource: " << internal_stats_.num_waiting_for_resource
-         << "\n";
-  buffer << "num_waiting_for_plasma_memory: "
-         << internal_stats_.num_waiting_for_plasma_memory << "\n";
-  buffer << "num_waiting_for_remote_node_resources: "
-         << internal_stats_.num_waiting_for_remote_node_resources << "\n";
-  buffer << "num_worker_not_started_by_job_config_not_exist: "
-         << internal_stats_.num_worker_not_started_by_job_config_not_exist << "\n";
-  buffer << "num_worker_not_started_by_registration_timeout: "
-         << internal_stats_.num_worker_not_started_by_registration_timeout << "\n";
-  buffer << "num_worker_not_started_by_process_rate_limit: "
-         << internal_stats_.num_worker_not_started_by_process_rate_limit << "\n";
-  buffer << "num_tasks_waiting_for_workers: "
-         << internal_stats_.num_tasks_waiting_for_workers << "\n";
-  buffer << "num_cancelled_tasks: " << internal_stats_.num_cancelled_tasks << "\n";
-  buffer << "Waiting tasks size: " << waiting_tasks_index_.size() << "\n";
-  buffer << "Number of executing tasks: " << executing_task_args_.size() << "\n";
-  buffer << "Number of pinned task arguments: " << pinned_task_arguments_.size() << "\n";
-  buffer << "cluster_resource_scheduler state: "
-         << cluster_resource_scheduler_->DebugString() << "\n";
-  buffer << "Resource usage {\n";
-
-  // Calculates how much resources are occupied by tasks or actors.
-  // Only iterate upto this number to avoid excessive CPU usage.
-  auto max_iteration = RayConfig::instance().worker_max_resource_analysis_iteration();
-  uint32_t iteration = 0;
-  for (const auto &worker :
-       worker_pool_.GetAllRegisteredWorkers(/*filter_dead_workers*/ true)) {
-    if (max_iteration < iteration++) {
-      break;
-    }
-    if (worker->IsDead()        // worker is dead
-        || worker->IsBlocked()  // worker is blocked by blocking Ray API
-        || (worker->GetAssignedTaskId().IsNil() &&
-            worker->GetActorId().IsNil())) {  // Tasks or actors not assigned
-      // Then this shouldn't have allocated resources.
-      continue;
-    }
-
-    const auto &task_or_actor_name = worker->GetAssignedTask()
-                                         .GetTaskSpecification()
-                                         .FunctionDescriptor()
-                                         ->CallString();
-    buffer << "    - ("
-           << "language="
-           << rpc::Language_descriptor()->FindValueByNumber(worker->GetLanguage())->name()
-           << " "
-           << "actor_or_task=" << task_or_actor_name << " "
-           << "pid=" << worker->GetProcess().GetId() << "): "
-           << worker->GetAssignedTask()
-                  .GetTaskSpecification()
-                  .GetRequiredResources()
-                  .ToString()
-           << "\n";
-  }
-  buffer << "}\n";
-  buffer << "Running tasks by scheduling class:\n";
-
-  for (const auto &pair : info_by_sched_cls_) {
-    const auto &sched_cls = pair.first;
-    const auto &info = pair.second;
-    const auto &descriptor = TaskSpecification::GetSchedulingClassDescriptor(sched_cls);
-    buffer << "    - " << descriptor.DebugString() << ": " << info.running_tasks.size()
-           << "/" << info.capacity << "\n";
-  }
-
-  buffer << "==================================================\n";
-  return buffer.str();
+  return internal_stats_.ComputeAndReportDebugStr();
 }
 
 void ClusterTaskManager::TryLocalInfeasibleTaskScheduling() {
@@ -1144,7 +943,7 @@ void ClusterTaskManager::Spillback(const NodeID &spillback_to,
     return;
   }
 
-  internal_stats_.metric_tasks_spilled++;
+  internal_stats_.TaskSpilled();
   const auto &task = work->task;
   const auto &task_spec = task.GetTaskSpecification();
   RAY_LOG(DEBUG) << "Spilling task " << task_spec.TaskId() << " to node " << spillback_to;

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -24,6 +24,7 @@
 #include "ray/raylet/scheduling/cluster_task_manager_interface.h"
 #include "ray/raylet/scheduling/internal.h"
 #include "ray/raylet/scheduling/scheduler_resource_reporter.h"
+#include "ray/raylet/scheduling/scheduler_stats.h"
 #include "ray/raylet/worker.h"
 #include "ray/raylet/worker_pool.h"
 #include "ray/rpc/grpc_client.h"
@@ -389,39 +390,7 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
 
   const int64_t sched_cls_cap_max_ms_;
 
-  struct InternalStats {
-    /// Number of tasks that are spilled to other
-    /// nodes because it cannot be scheduled locally.
-    int64_t metric_tasks_spilled = 0;
-    /// Number of tasks that are waiting for
-    /// resources to be available locally.
-    int64_t num_waiting_for_resource = 0;
-    /// Number of tasks that are waiting for available memory
-    /// from the plasma store.
-    int64_t num_waiting_for_plasma_memory = 0;
-    /// Number of tasks that are waiting for nodes with available resources.
-    int64_t num_waiting_for_remote_node_resources = 0;
-    /// Number of workers that couldn't be started because the job config wasn't local.
-    int64_t num_worker_not_started_by_job_config_not_exist = 0;
-    /// Number of workers that couldn't be started because the worker registration timed
-    /// out.
-    int64_t num_worker_not_started_by_registration_timeout = 0;
-    /// Number of workers that couldn't be started becasue it hits the worker startup rate
-    /// limit.
-    int64_t num_worker_not_started_by_process_rate_limit = 0;
-    /// Number of tasks that are waiting for worker processes to start.
-    int64_t num_tasks_waiting_for_workers = 0;
-    /// Number of cancelled tasks.
-    int64_t num_cancelled_tasks = 0;
-    /// Number of infeasible tasks.
-    int64_t num_infeasible_tasks = 0;
-    /// Number of tasks to schedule.
-    int64_t num_tasks_to_schedule = 0;
-    /// Number of tasks to dispatch.
-    int64_t num_tasks_to_dispatch = 0;
-  };
-
-  mutable InternalStats internal_stats_;
+  mutable SchedulerStats internal_stats_;
 
   /// Determine whether a task should be immediately dispatched,
   /// or placed on a wait queue.
@@ -449,6 +418,7 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
                    std::vector<std::unique_ptr<RayObject>> args);
   void ReleaseTaskArgs(const TaskID &task_id);
 
+  friend class SchedulerStats;
   friend class ClusterTaskManagerTest;
   FRIEND_TEST(ClusterTaskManagerTest, FeasibleToNonFeasible);
 };

--- a/src/ray/raylet/scheduling/scheduler_stats.cc
+++ b/src/ray/raylet/scheduling/scheduler_stats.cc
@@ -1,0 +1,170 @@
+// Copyright 2020-2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/scheduler_stats.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/ray_config.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/raylet/scheduling/internal.h"
+
+namespace ray {
+namespace raylet {
+
+void SchedulerStats::ComputeStats() {
+  auto accumulator =
+      [](size_t state,
+         const std::pair<int, std::deque<std::shared_ptr<internal::Work>>> &pair) {
+        return state + pair.second.size();
+      };
+  size_t num_waiting_for_resource = 0;
+  size_t num_waiting_for_plasma_memory = 0;
+  size_t num_waiting_for_remote_node_resources = 0;
+  size_t num_worker_not_started_by_job_config_not_exist = 0;
+  size_t num_worker_not_started_by_registration_timeout = 0;
+  size_t num_worker_not_started_by_process_rate_limit = 0;
+  size_t num_tasks_waiting_for_workers = 0;
+  size_t num_cancelled_tasks = 0;
+
+  size_t num_infeasible_tasks = std::accumulate(
+      infeasible_tasks_.begin(), infeasible_tasks_.end(), (size_t)0, accumulator);
+
+  // TODO(sang): Normally, the # of queued tasks are not large, so this is less likley to
+  // be an issue that we iterate all of them. But if it uses lots of CPU, consider
+  // optimizing by updating live instead of iterating through here.
+  auto per_work_accumulator = [&num_waiting_for_resource, &num_waiting_for_plasma_memory,
+                               &num_waiting_for_remote_node_resources,
+                               &num_worker_not_started_by_job_config_not_exist,
+                               &num_worker_not_started_by_registration_timeout,
+                               &num_worker_not_started_by_process_rate_limit,
+                               &num_tasks_waiting_for_workers, &num_cancelled_tasks](
+                                  size_t state,
+                                  const std::pair<
+                                      int, std::deque<std::shared_ptr<internal::Work>>>
+                                      &pair) {
+    const auto &work_queue = pair.second;
+    for (auto work_it = work_queue.begin(); work_it != work_queue.end();) {
+      const auto &work = *work_it++;
+      if (work->GetState() == internal::WorkStatus::WAITING_FOR_WORKER) {
+        num_tasks_waiting_for_workers += 1;
+      } else if (work->GetState() == internal::WorkStatus::CANCELLED) {
+        num_cancelled_tasks += 1;
+      } else if (work->GetUnscheduledCause() ==
+                 internal::UnscheduledWorkCause::WAITING_FOR_RESOURCE_ACQUISITION) {
+        num_waiting_for_resource += 1;
+      } else if (work->GetUnscheduledCause() ==
+                 internal::UnscheduledWorkCause::WAITING_FOR_AVAILABLE_PLASMA_MEMORY) {
+        num_waiting_for_plasma_memory += 1;
+      } else if (work->GetUnscheduledCause() ==
+                 internal::UnscheduledWorkCause::WAITING_FOR_RESOURCES_AVAILABLE) {
+        num_waiting_for_remote_node_resources += 1;
+      } else if (work->GetUnscheduledCause() ==
+                 internal::UnscheduledWorkCause::WORKER_NOT_FOUND_JOB_CONFIG_NOT_EXIST) {
+        num_worker_not_started_by_job_config_not_exist += 1;
+      } else if (work->GetUnscheduledCause() ==
+                 internal::UnscheduledWorkCause::WORKER_NOT_FOUND_REGISTRATION_TIMEOUT) {
+        num_worker_not_started_by_registration_timeout += 1;
+      } else if (work->GetUnscheduledCause() ==
+                 internal::UnscheduledWorkCause::WORKER_NOT_FOUND_RATE_LIMITED) {
+        num_worker_not_started_by_process_rate_limit += 1;
+      }
+    }
+    return state + pair.second.size();
+  };
+  size_t num_tasks_to_schedule =
+      std::accumulate(tasks_to_schedule_.begin(), tasks_to_schedule_.end(), (size_t)0,
+                      per_work_accumulator);
+  size_t num_tasks_to_dispatch =
+      std::accumulate(tasks_to_dispatch_.begin(), tasks_to_dispatch_.end(), (size_t)0,
+                      per_work_accumulator);
+
+  /// Update the internal states.
+  num_waiting_for_resource = num_waiting_for_resource;
+  num_waiting_for_plasma_memory = num_waiting_for_plasma_memory;
+  num_waiting_for_remote_node_resources = num_waiting_for_remote_node_resources;
+  num_worker_not_started_by_job_config_not_exist =
+      num_worker_not_started_by_job_config_not_exist;
+  num_worker_not_started_by_registration_timeout =
+      num_worker_not_started_by_registration_timeout;
+  num_worker_not_started_by_process_rate_limit =
+      num_worker_not_started_by_process_rate_limit;
+  num_tasks_waiting_for_workers = num_tasks_waiting_for_workers;
+  num_cancelled_tasks = num_cancelled_tasks;
+  num_infeasible_tasks = num_infeasible_tasks;
+  num_tasks_to_schedule = num_tasks_to_schedule;
+  num_tasks_to_dispatch = num_tasks_to_dispatch;
+}
+
+void SchedulerStats::RecordMetrics() const {
+  /// This method intentionally doesn't call ComputeStats() because
+  /// that function is expensive. ComputeStats is called by DebugStr method
+  /// and they are always periodically called by node manager.
+  stats::NumSpilledTasks.Record(metric_tasks_spilled);
+  stats::NumInfeasibleSchedulingClasses.Record(infeasible_tasks_.size());
+
+  /// Worker startup failure
+  ray::stats::STATS_scheduler_failed_worker_startup_total.Record(
+      num_worker_not_started_by_job_config_not_exist, "JobConfigMissing");
+  ray::stats::STATS_scheduler_failed_worker_startup_total.Record(
+      num_worker_not_started_by_registration_timeout, "RegistrationTimedOut");
+  ray::stats::STATS_scheduler_failed_worker_startup_total.Record(
+      num_worker_not_started_by_process_rate_limit, "RateLimited");
+
+  /// Queued tasks.
+  ray::stats::STATS_scheduler_tasks.Record(num_cancelled_tasks, "Cancelled");
+  ray::stats::STATS_scheduler_tasks.Record(executing_task_args_.size(), "Executing");
+  ray::stats::STATS_scheduler_tasks.Record(waiting_tasks_index_.size(), "Waiting");
+  ray::stats::STATS_scheduler_tasks.Record(num_tasks_to_dispatch, "Dispatched");
+  ray::stats::STATS_scheduler_tasks.Record(num_tasks_to_schedule, "Received");
+
+  /// Pending task count.
+  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(num_infeasible_tasks,
+                                                          "Infeasible");
+  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(num_waiting_for_resource,
+                                                          "WaitingForResources");
+  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(num_waiting_for_plasma_memory,
+                                                          "WaitingForPlasmaMemory");
+  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(
+      num_waiting_for_remote_node_resources, "WaitingForRemoteResources");
+  ray::stats::STATS_scheduler_unscheduleable_tasks.Record(num_tasks_waiting_for_workers,
+                                                          "WaitingForWorkers");
+}
+
+std::string SchedulerStats::DebugStr() const {
+  ComputeStats();
+  if (num_tasks_to_schedule + num_tasks_to_dispatch + num_infeasible_tasks > 1000) {
+    RAY_LOG(WARNING)
+        << "More than 1000 tasks are queued in this node. This can cause slow down.";
+  }
+
+  std::stringstream buffer;
+  buffer << "Infeasible queue length: " << num_infeasible_tasks << "\n";
+  buffer << "Schedule queue length: " << num_tasks_to_schedule << "\n";
+  buffer << "Dispatch queue length: " << num_tasks_to_dispatch << "\n";
+  buffer << "num_waiting_for_resource: " << num_waiting_for_resource << "\n";
+  buffer << "num_waiting_for_plasma_memory: " << num_waiting_for_plasma_memory << "\n";
+  buffer << "num_waiting_for_remote_node_resources: "
+         << num_waiting_for_remote_node_resources << "\n";
+  buffer << "num_worker_not_started_by_job_config_not_exist: "
+         << num_worker_not_started_by_job_config_not_exist << "\n";
+  buffer << "num_worker_not_started_by_registration_timeout: "
+         << num_worker_not_started_by_registration_timeout << "\n";
+  buffer << "num_worker_not_started_by_process_rate_limit: "
+         << num_worker_not_started_by_process_rate_limit << "\n";
+  buffer << "num_tasks_waiting_for_workers: " << num_tasks_waiting_for_workers << "\n";
+  buffer << "num_cancelled_tasks: " << num_cancelled_tasks << "\n";
+}
+
+}  // namespace raylet
+}  // namespace ray

--- a/src/ray/raylet/scheduling/scheduler_stats.h
+++ b/src/ray/raylet/scheduling/scheduler_stats.h
@@ -18,59 +18,62 @@
 #include "ray/common/ray_config.h"
 #include "ray/common/task/task_spec.h"
 #include "ray/raylet/scheduling/internal.h"
+#include "ray/raylet/worker_pool.h"
 
 namespace ray {
 namespace raylet {
+class ClusterTaskManager;
 
+// Helper class that collects and reports scheduler's metrics into counters or human
+// readable string.
 class SchedulerStats {
  public:
-  SchedulerStats();
-  void ComputeStats();
+  explicit SchedulerStats(const ClusterTaskManager &cluster_task_manager);
+
+  // Report metrics doesn't recompute the stats.
   void RecordMetrics() const;
-  std::string SchedulerStats::DebugStr() const;
+
+  // Recompute the stats and report the result as string.
+  std::string ComputeAndReportDebugStr();
+
+  // increase the task spilled counter.
+  void TaskSpilled();
 
  private:
-  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
-      &tasks_to_schedule_;
+  // recompute the metrics.
+  void ComputeStats();
 
-  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
-      &tasks_to_dispatch_;
-
-  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
-      &infeasible_tasks_;
-
-  const absl::flat_hash_map<SchedulingClass, SchedulingClassInfo> &info_by_sched_cls_;
-  const WorkerPoolInterface &worker_pool_;
+  const ClusterTaskManager &cluster_task_manager_;
 
   /// Number of tasks that are spilled to other
   /// nodes because it cannot be scheduled locally.
-  int64_t metric_tasks_spilled = 0;
+  int64_t metric_tasks_spilled_ = 0;
   /// Number of tasks that are waiting for
   /// resources to be available locally.
-  int64_t num_waiting_for_resource = 0;
+  int64_t num_waiting_for_resource_ = 0;
   /// Number of tasks that are waiting for available memory
   /// from the plasma store.
-  int64_t num_waiting_for_plasma_memory = 0;
+  int64_t num_waiting_for_plasma_memory_ = 0;
   /// Number of tasks that are waiting for nodes with available resources.
-  int64_t num_waiting_for_remote_node_resources = 0;
+  int64_t num_waiting_for_remote_node_resources_ = 0;
   /// Number of workers that couldn't be started because the job config wasn't local.
-  int64_t num_worker_not_started_by_job_config_not_exist = 0;
+  int64_t num_worker_not_started_by_job_config_not_exist_ = 0;
   /// Number of workers that couldn't be started because the worker registration timed
   /// out.
-  int64_t num_worker_not_started_by_registration_timeout = 0;
+  int64_t num_worker_not_started_by_registration_timeout_ = 0;
   /// Number of workers that couldn't be started becasue it hits the worker startup rate
   /// limit.
-  int64_t num_worker_not_started_by_process_rate_limit = 0;
+  int64_t num_worker_not_started_by_process_rate_limit_ = 0;
   /// Number of tasks that are waiting for worker processes to start.
-  int64_t num_tasks_waiting_for_workers = 0;
+  int64_t num_tasks_waiting_for_workers_ = 0;
   /// Number of cancelled tasks.
-  int64_t num_cancelled_tasks = 0;
+  int64_t num_cancelled_tasks_ = 0;
   /// Number of infeasible tasks.
-  int64_t num_infeasible_tasks = 0;
+  int64_t num_infeasible_tasks_ = 0;
   /// Number of tasks to schedule.
-  int64_t num_tasks_to_schedule = 0;
+  int64_t num_tasks_to_schedule_ = 0;
   /// Number of tasks to dispatch.
-  int64_t num_tasks_to_dispatch = 0;
+  int64_t num_tasks_to_dispatch_ = 0;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/scheduling/scheduler_stats.h
+++ b/src/ray/raylet/scheduling/scheduler_stats.h
@@ -1,0 +1,77 @@
+// Copyright 2020-2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/ray_config.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/raylet/scheduling/internal.h"
+
+namespace ray {
+namespace raylet {
+
+class SchedulerStats {
+ public:
+  SchedulerStats();
+  void ComputeStats();
+  void RecordMetrics() const;
+  std::string SchedulerStats::DebugStr() const;
+
+ private:
+  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
+      &tasks_to_schedule_;
+
+  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
+      &tasks_to_dispatch_;
+
+  const absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
+      &infeasible_tasks_;
+
+  const absl::flat_hash_map<SchedulingClass, SchedulingClassInfo> &info_by_sched_cls_;
+  const WorkerPoolInterface &worker_pool_;
+
+  /// Number of tasks that are spilled to other
+  /// nodes because it cannot be scheduled locally.
+  int64_t metric_tasks_spilled = 0;
+  /// Number of tasks that are waiting for
+  /// resources to be available locally.
+  int64_t num_waiting_for_resource = 0;
+  /// Number of tasks that are waiting for available memory
+  /// from the plasma store.
+  int64_t num_waiting_for_plasma_memory = 0;
+  /// Number of tasks that are waiting for nodes with available resources.
+  int64_t num_waiting_for_remote_node_resources = 0;
+  /// Number of workers that couldn't be started because the job config wasn't local.
+  int64_t num_worker_not_started_by_job_config_not_exist = 0;
+  /// Number of workers that couldn't be started because the worker registration timed
+  /// out.
+  int64_t num_worker_not_started_by_registration_timeout = 0;
+  /// Number of workers that couldn't be started becasue it hits the worker startup rate
+  /// limit.
+  int64_t num_worker_not_started_by_process_rate_limit = 0;
+  /// Number of tasks that are waiting for worker processes to start.
+  int64_t num_tasks_waiting_for_workers = 0;
+  /// Number of cancelled tasks.
+  int64_t num_cancelled_tasks = 0;
+  /// Number of infeasible tasks.
+  int64_t num_infeasible_tasks = 0;
+  /// Number of tasks to schedule.
+  int64_t num_tasks_to_schedule = 0;
+  /// Number of tasks to dispatch.
+  int64_t num_tasks_to_dispatch = 0;
+};
+
+}  // namespace raylet
+}  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Separate the stats reporting logic into a separate file to make the local scheduler/distribute scheduler reporting easier.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
