### PR TITLE
[CoreWorker] add thread for background work

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -77,7 +77,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       worker_context_(options_.worker_type, worker_id, GetProcessJobID(options_)),
       io_work_(io_service_),
       client_call_manager_(new rpc::ClientCallManager(io_service_)),
-      periodical_runner_(io_service_),
+      background_work_(background_service_),
+      periodical_runner_(background_service_),
       task_queue_length_(0),
       num_executed_tasks_(0),
       resource_ids_(new ResourceMappingType()),
@@ -424,6 +425,8 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
   // Start the IO thread after all other members have been initialized, in case
   // the thread calls back into any of our members.
   io_thread_ = std::thread([this]() { RunIOService(); });
+  // Start background thread to start periodic runners and other background work.
+  background_thread_ = std::thread([this]() { RunBackgroundService(); });
   // Tell the raylet the port that we are listening on.
   // NOTE: This also marks the worker as available in Raylet. We do this at the
   // very end in case there is a problem during construction.
@@ -500,10 +503,17 @@ void CoreWorker::Shutdown() {
     gcs_client_->Disconnect();
   }
   io_service_.stop();
-  RAY_LOG(INFO) << "Waiting for joining a core worker io thread. If it hangs here, there "
+  background_service_.stop();
+  RAY_LOG(INFO) << "Waiting for joining core worker io thread. If it hangs here, there "
                    "might be deadlock or a high load in the core worker io service.";
   if (io_thread_.joinable()) {
     io_thread_.join();
+  }
+  RAY_LOG(INFO) << "Waiting for joining core worker background thread. If it hangs here, "
+                   "there might be deadlock or a high load in the core worker background "
+                   "service.";
+  if (background_thread_.joinable()) {
+    background_thread_.join();
   }
   // Now that gcs_client is not used within io service, we can reset the pointer and clean
   // it up.
@@ -610,6 +620,7 @@ void CoreWorker::Exit(
 
   task_manager_->DrainAndShutdown(drain_references_callback);
 }
+
 void CoreWorker::RunIOService() {
 #ifndef _WIN32
   // Block SIGINT and SIGTERM so they will be handled by the main thread.
@@ -622,6 +633,20 @@ void CoreWorker::RunIOService() {
   SetThreadName("worker.io");
   io_service_.run();
   RAY_LOG(INFO) << "Core worker main io service stopped.";
+}
+
+void CoreWorker::RunBackgroundService() {
+#ifndef _WIN32
+  // Block SIGINT and SIGTERM so they will be handled by the main thread.
+  sigset_t mask;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, NULL);
+#endif
+  SetThreadName("worker.background");
+  background_service_.run();
+  RAY_LOG(INFO) << "Core worker background service stopped.";
 }
 
 void CoreWorker::OnNodeRemoved(const NodeID &node_id) {
@@ -2913,7 +2938,8 @@ void CoreWorker::HandleLocalGC(const rpc::LocalGCRequest &request,
                                rpc::LocalGCReply *reply,
                                rpc::SendReplyCallback send_reply_callback) {
   if (options_.gc_collect != nullptr) {
-    options_.gc_collect();
+    background_service_.post([gc_collect = options_.gc_collect]() { gc_collect(); },
+                             "CoreWorker.Background.LocalGC");
     send_reply_callback(Status::OK(), nullptr, nullptr);
   } else {
     send_reply_callback(Status::NotImplemented("GC callback not defined"), nullptr,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In #22161, the following deadlock is observed:
1. Some logic holds Python GIL, while trying to post work to `io_service_` or waiting for work in `io_service_` to finish.
2. The `LocalGC` handler, running on `io_service_` event loop, tries to run a callback that waits for GIL.

I tried to identify the logic in (1) to see if it is possible to release GIL while waiting for work in `io_service_` to finish, but haven't been able to. So I'm implementing the alternative, which is to break the deadlock by making `LocalGC` handler run the callback that requires GIL on a separate event loop (`background_service_`), and not wait for the callback to finish. Also, move periodic runner to `background_service_` as well.

Btw, it seems core worker `io_service_` deadlock has happened before. If this becomes more common, maybe we can consider cleaning up cython core worker interface to make sure no GIL is held when waiting for async result from core worker.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
