### PR TITLE
[workflow] Fix event loop can't find in thread

### DIFF
--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -22,6 +22,7 @@ from ray.workflow.common import (
     WorkflowNotFoundError,
     WorkflowStepRuntimeOptions,
     StepType,
+    asyncio_run,
 )
 from ray.workflow import serialization
 from ray.workflow.event_listener import EventListener, EventListenerType, TimerListener
@@ -354,16 +355,14 @@ def wait_for_event(
     @step
     def get_message(event_listener_type: EventListenerType, *args, **kwargs) -> Event:
         event_listener = event_listener_type()
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(event_listener.poll_for_event(*args, **kwargs))
+        return asyncio_run(event_listener.poll_for_event(*args, **kwargs))
 
     @step
     def message_committed(
         event_listener_type: EventListenerType, event: Event
     ) -> Event:
         event_listener = event_listener_type()
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(event_listener.event_checkpointed(event))
+        asyncio_run(event_listener.event_checkpointed(event))
         return event
 
     return message_committed.step(

--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import types

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -26,9 +26,6 @@ STORAGE_ACTOR_NAME = "StorageManagementActor"
 
 
 def asyncio_run(coro):
-    # The event loop will only be set in main thread by default
-    # to make sure it's working when workflow is running in
-    # other thread, need to setup the event loop if it's not there.
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -23,6 +23,18 @@ MANAGEMENT_ACTOR_NAME = "WorkflowManagementActor"
 STORAGE_ACTOR_NAME = "StorageManagementActor"
 
 
+def asyncio_run(coro):
+    # The event loop will only be set in main thread by default
+    # to make sure it's working when workflow is running in
+    # other thread, need to setup the event loop if it's not there.
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
 def get_module(f):
     return f.__module__ if hasattr(f, "__module__") else "__anonymous_module__"
 

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -1,4 +1,6 @@
 import base64
+import asyncio
+
 from ray import cloudpickle
 from collections import deque
 from enum import Enum, unique

--- a/python/ray/workflow/serialization.py
+++ b/python/ray/workflow/serialization.py
@@ -129,7 +129,7 @@ def _put_helper(
         )
     paths = obj_id_to_paths(workflow_id, identifier)
     promise = dump_to_storage(paths, obj, workflow_id, storage, update_existing=False)
-    return asyncio.get_event_loop().run_until_complete(promise)
+    return common.asyncio_run(promise)
 
 
 def _reduce_objectref(
@@ -207,7 +207,7 @@ async def dump_to_storage(
 @ray.remote
 def _load_ref_helper(key: str, storage: storage.Storage):
     # TODO(Alex): We should stream the data directly into `cloudpickle.load`.
-    serialized = asyncio.get_event_loop().run_until_complete(storage.get(key))
+    serialized = common.asyncio_run(storage.get(key))
     return cloudpickle.loads(serialized)
 
 

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -26,6 +26,7 @@ from ray.workflow.common import (
     StepID,
     WorkflowData,
     WorkflowStaticRef,
+    asyncio_run,
 )
 
 if TYPE_CHECKING:
@@ -247,7 +248,7 @@ def commit_step(
             # its input (again).
             if w.ref is None:
                 tasks.append(_write_step_inputs(store, w.step_id, w.data))
-        asyncio.get_event_loop().run_until_complete(asyncio.gather(*tasks))
+        asyncio_run(asyncio.gather(*tasks))
 
     context = workflow_context.get_workflow_step_context()
     store.save_step_output(

--- a/python/ray/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/workflow/tests/test_basic_workflows_2.py
@@ -339,6 +339,7 @@ def test_run_off_main_thread(workflow_start_regular):
         return [i for i in range(num)]
 
     succ = False
+
     # Start new thread here ⚠️
     def run():
         global succ

--- a/python/ray/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/workflow/tests/test_basic_workflows_2.py
@@ -336,7 +336,7 @@ def test_dedupe_indirect(workflow_start_regular, tmp_path):
 def test_run_off_main_thread(workflow_start_regular):
     @workflow.step
     def fake_data(num: int):
-        return [i for i in range(num)]
+        return list(range(num))
 
     succ = False
 

--- a/python/ray/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/workflow/tests/test_basic_workflows_2.py
@@ -337,6 +337,7 @@ def test_run_off_main_thread(workflow_start_regular):
     @workflow.step
     def fake_data(num: int):
         return [i for i in range(num)]
+
     succ = False
     # Start new thread here ⚠️
     def run():
@@ -344,7 +345,9 @@ def test_run_off_main_thread(workflow_start_regular):
         # Setup the workflow.
         data = fake_data.step(10)
         assert data.run(workflow_id="run") == list(range(10))
+
     import threading
+
     t = threading.Thread(target=run)
     t.start()
     t.join()

--- a/python/ray/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/workflow/tests/test_basic_workflows_2.py
@@ -333,6 +333,24 @@ def test_dedupe_indirect(workflow_start_regular, tmp_path):
     assert "4" == join.step(a, a, a, a).run()
 
 
+def test_run_off_main_thread(workflow_start_regular):
+    @workflow.step
+    def fake_data(num: int):
+        return [i for i in range(num)]
+    succ = False
+    # Start new thread here ⚠️
+    def run():
+        global succ
+        # Setup the workflow.
+        data = fake_data.step(10)
+        assert data.run(workflow_id="run") == list(range(10))
+    import threading
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+    assert workflow.get_status("run") == workflow.SUCCESSFUL
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -20,6 +20,7 @@ from ray.workflow.common import (
     WorkflowRef,
     WorkflowNotFoundError,
     WorkflowStepRuntimeOptions,
+    asyncio_run,
 )
 from ray.workflow import workflow_context
 from ray.workflow import serialization
@@ -53,12 +54,6 @@ WORKFLOW_PROGRESS = "progress.json"
 # steps with a given name. This can be very expensive if there are too
 # many duplicates.
 DUPLICATE_NAME_COUNTER = "duplicate_name_counter"
-
-
-# TODO: Get rid of this and use asyncio.run instead once we don't support py36
-def asyncio_run(coro):
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(coro)
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Event loop will only be set in main thread by default and this will make workflow unable to work if it's called in thread other than main thread which can happen when it's called from a library (for example ray serve).
This PR fixed it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/22200
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
