### PR TITLE
[gcs] Fix in_memory_store not handling nullptr callback issue (#22321)

### DIFF
--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -70,6 +70,9 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncPut(table_name_, elem.first.Binary(),
                                            elem.second.SerializeAsString(),
                                            put_calllback));
+      // Make sure no-op callback is handled well
+      RAY_CHECK_OK(store_client_->AsyncPut(table_name_, elem.first.Binary(),
+                                           elem.second.SerializeAsString(), nullptr));
     }
     WaitPendingDone();
   }
@@ -83,6 +86,8 @@ class StoreClientTestBase : public ::testing::Test {
       ++pending_count_;
       RAY_CHECK_OK(
           store_client_->AsyncDelete(table_name_, elem.first.Binary(), delete_calllback));
+      // Make sure no-op callback is handled well
+      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, elem.first.Binary(), nullptr));
     }
     WaitPendingDone();
   }
@@ -130,6 +135,10 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncPutWithIndex(
           table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(),
           elem.second.SerializeAsString(), put_calllback));
+      // Make sure no-op callback is handled well
+      RAY_CHECK_OK(store_client_->AsyncPutWithIndex(
+          table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(),
+          elem.second.SerializeAsString(), nullptr));
     }
     WaitPendingDone();
   }
@@ -161,6 +170,9 @@ class StoreClientTestBase : public ::testing::Test {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncDeleteByIndex(table_name_, elem.first.Hex(),
                                                      delete_calllback));
+      // Make sure no-op callback is handled well
+      RAY_CHECK_OK(
+          store_client_->AsyncDeleteByIndex(table_name_, elem.first.Hex(), nullptr));
     }
     WaitPendingDone();
   }
@@ -198,6 +210,8 @@ class StoreClientTestBase : public ::testing::Test {
       keys.push_back(elem.first.Binary());
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, delete_calllback));
+    // Make sure no-op callback is handled well
+    RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, nullptr));
     WaitPendingDone();
   }
 
@@ -211,6 +225,9 @@ class StoreClientTestBase : public ::testing::Test {
       RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(table_name_, elem.first.Binary(),
                                                        key_to_index_[elem.first].Hex(),
                                                        delete_calllback));
+      // Make sure no-op callback is handled well
+      RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(
+          table_name_, elem.first.Binary(), key_to_index_[elem.first].Hex(), nullptr));
     }
     WaitPendingDone();
   }
@@ -229,6 +246,9 @@ class StoreClientTestBase : public ::testing::Test {
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDeleteWithIndex(table_name_, keys, index_keys,
                                                           delete_calllback));
+    // Make sure no-op callback is handled well
+    RAY_CHECK_OK(
+        store_client_->AsyncBatchDeleteWithIndex(table_name_, keys, index_keys, nullptr));
     WaitPendingDone();
   }
 


### PR DESCRIPTION
in memory store is not handling the nullptr callback well which leads to gcs crash in node failure tests. This PR fixed it.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
