### PR TITLE
Prep K8s operator for the Ray 1.11.0 release.  (#22264)

### DIFF
--- a/deploy/charts/ray/templates/raycluster.yaml
+++ b/deploy/charts/ray/templates/raycluster.yaml
@@ -51,7 +51,7 @@ spec:
             - name: RAY_gcs_server_rpc_server_thread_num
               value: "1"
             ports:
-            - containerPort: 6379  # Redis port
+            - containerPort: 6379  # Redis port for Ray <= 1.10.0. GCS server port for Ray >= 1.11.0.
             - containerPort: 10001  # Used by Ray Client
             - containerPort: 8265  # Used by Ray Dashboard
             - containerPort: 8000 # Used by Ray Serve
@@ -92,7 +92,7 @@ spec:
   # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.
   headStartRayCommands:
     - ray stop
-    - ulimit -n 65536; ray start --head --no-monitor --dashboard-host 0.0.0.0
+    - ulimit -n 65536; ray start --head --port=6379 --no-monitor --dashboard-host 0.0.0.0
   # Commands to start Ray on worker nodes. You don't need to change this.
   workerStartRayCommands:
     - ray stop

--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -3,6 +3,8 @@
 # RayCluster settings:
 
 # image is Ray image to use for the head and workers of this Ray cluster.
+# It's recommended to build custom dependencies for your workload into this image,
+# taking one of the offical `rayproject/ray` images as base.
 image: rayproject/ray:latest
 # headPodType is the podType used for the Ray head node (as configured below).
 headPodType: rayHeadType
@@ -96,11 +98,8 @@ namespacedOperator: false
 # in which to launch the operator.
 operatorNamespace: default
 # operatorImage - The image used in the operator deployment.
+# It is recommended to use one of the official `rayproject/ray` images for the operator.
+# It is recommended to use the same Ray version in the operator as in the Ray clusters managed
+# by the operator. In other words, the images specified under the fields `operatorImage` and `image`
+# should carry matching Ray versions.
 operatorImage: rayproject/ray:latest
-# `rayproject/ray:latest` contains the latest official release version of Ray.
-# `rayproject/ray:nightly` runs the current master version of Ray.
-# For a particular official release version of Ray, use `rayproject/ray:1.x.y`.
-# For a specific master commit, use the first 6 characters of the commit SHA, e.g. `rayproject/ray:050a07`.
-# The operator and Ray cluster can use different Ray versions, provided both versions are >= 1.2.0
-
-

--- a/deploy/components/example_cluster.yaml
+++ b/deploy/components/example_cluster.yaml
@@ -54,7 +54,7 @@ spec:
           command: ["/bin/bash", "-c", "--"]
           args: ["trap : TERM INT; touch /tmp/raylogs; tail -f /tmp/raylogs; sleep infinity & wait;"]
           ports:
-          - containerPort: 6379  # Redis port
+          - containerPort: 6379  # Redis port for Ray <= 1.10.0. GCS server port for Ray >= 1.11.0.
           - containerPort: 10001  # Used by Ray Client
           - containerPort: 8265  # Used by Ray Dashboard
           - containerPort: 8000 # Used by Ray Serve
@@ -129,7 +129,7 @@ spec:
   # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.
   headStartRayCommands:
     - ray stop
-    - ulimit -n 65536; ray start --head --no-monitor --dashboard-host 0.0.0.0 &> /tmp/raylogs
+    - ulimit -n 65536; ray start --head --port=6379 --no-monitor --dashboard-host 0.0.0.0 &> /tmp/raylogs
   # Commands to start Ray on worker nodes. You don't need to change this.
   workerStartRayCommands:
     - ray stop

--- a/python/ray/autoscaler/kubernetes/defaults.yaml
+++ b/python/ray/autoscaler/kubernetes/defaults.yaml
@@ -171,7 +171,7 @@ available_node_types:
           command: ["/bin/bash", "-c", "--"]
           args: ['trap : TERM INT; sleep infinity & wait;']
           ports:
-          - containerPort: 6379  # Redis port
+          - containerPort: 6379  # Redis port for Ray <= 1.10.0. GCS server port for Ray >= 1.11.0.
           - containerPort: 10001  # Used by Ray Client
           - containerPort: 8265  # Used by Ray Dashboard
 
@@ -200,7 +200,7 @@ available_node_types:
 # Note dashboard-host is set to 0.0.0.0 so that kubernetes can port forward.
 head_start_ray_commands:
     - ray stop
-    - ulimit -n 65536; ray start --head --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host 0.0.0.0
+    - ulimit -n 65536; ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host 0.0.0.0
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:

--- a/python/ray/autoscaler/kubernetes/example-full-legacy.yaml
+++ b/python/ray/autoscaler/kubernetes/example-full-legacy.yaml
@@ -137,7 +137,7 @@ head_node:
           command: ["/bin/bash", "-c", "--"]
           args: ["trap : TERM INT; sleep infinity & wait;"]
           ports:
-          - containerPort: 6379  # Redis port
+          - containerPort: 6379  # Redis port for Ray <= 1.10.0. GCS server port for Ray >= 1.11.0.
           - containerPort: 10001  # Used by Ray Client
           - containerPort: 8265  # Used by Ray Dashboard
 
@@ -253,7 +253,7 @@ worker_setup_commands: []
 # Note dashboard-host is set to 0.0.0.0 so that kubernetes can port forward.
 head_start_ray_commands:
     - ray stop
-    - ulimit -n 65536; ray start --head --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host 0.0.0.0
+    - ulimit -n 65536; ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host 0.0.0.0
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:

--- a/python/ray/autoscaler/kubernetes/example-full.yaml
+++ b/python/ray/autoscaler/kubernetes/example-full.yaml
@@ -205,7 +205,7 @@ available_node_types:
 # Note dashboard-host is set to 0.0.0.0 so that kubernetes can port forward.
 head_start_ray_commands:
     - ray stop
-    - ulimit -n 65536; ray start --head --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host 0.0.0.0
+    - ulimit -n 65536; ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host 0.0.0.0
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:

--- a/python/ray/autoscaler/kubernetes/example-ingress.yaml
+++ b/python/ray/autoscaler/kubernetes/example-ingress.yaml
@@ -152,9 +152,7 @@ head_node:
               command: ["/bin/bash", "-c", "--"]
               args: ["trap : TERM INT; sleep infinity & wait;"]
               ports:
-                  - containerPort: 6379 # Redis port.
-                  - containerPort: 6380 # Redis port.
-                  - containerPort: 6381 # Redis port.
+                  - containerPort: 6379 # Redis port for Ray <= 1.10.0. GCS server port for Ray >= 1.11.0
                   - containerPort: 22345 # Ray internal communication.
                   - containerPort: 22346 # Ray internal communication.
 


### PR DESCRIPTION
For consistency and safety, we fix an explicit 6379 port for all default and example configs for Ray on K8s.
Documentation is updated to recommend matching Ray versions in operator and Ray cluster.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
