### PR TITLE
[minor] Fix dataset shuffle bug on empty blocks.

### DIFF
--- a/python/ray/data/impl/delegating_block_builder.py
+++ b/python/ray/data/impl/delegating_block_builder.py
@@ -32,10 +32,11 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
         self._builder.add(item)
 
     def add_block(self, block: Block) -> None:
-        if isinstance(block, list) and not block:
+        accessor = BlockAccessor.for_block(block)
+        if accessor.num_rows() == 0:
             return  # Don't infer types of empty lists.
         if self._builder is None:
-            self._builder = BlockAccessor.for_block(block).builder()
+            self._builder = accessor.builder()
         self._builder.add_block(block)
 
     def build(self) -> Block:

--- a/python/ray/data/impl/delegating_block_builder.py
+++ b/python/ray/data/impl/delegating_block_builder.py
@@ -10,6 +10,7 @@ from ray.data.impl.pandas_block import PandasRow, PandasBlockBuilder
 class DelegatingBlockBuilder(BlockBuilder[T]):
     def __init__(self):
         self._builder = None
+        self._empty_block = None
 
     def add(self, item: Any) -> None:
 
@@ -34,14 +35,20 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
     def add_block(self, block: Block) -> None:
         accessor = BlockAccessor.for_block(block)
         if accessor.num_rows() == 0:
-            return  # Don't infer types of empty lists.
+            # Don't infer types of empty lists. Store the block and use it if no
+            # other data is added. https://github.com/ray-project/ray/issues/20290
+            self._empty_block = block
+            return
         if self._builder is None:
             self._builder = accessor.builder()
         self._builder.add_block(block)
 
     def build(self) -> Block:
         if self._builder is None:
-            self._builder = ArrowBlockBuilder()
+            if self._empty_block is not None:
+                self._builder = BlockAccessor.for_block(self._empty_block).builder()
+            else:
+                self._builder = ArrowBlockBuilder()
         return self._builder.build()
 
     def num_rows(self) -> int:

--- a/python/ray/data/impl/delegating_block_builder.py
+++ b/python/ray/data/impl/delegating_block_builder.py
@@ -32,6 +32,8 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
         self._builder.add(item)
 
     def add_block(self, block: Block) -> None:
+        if not block:
+            return  # Dpn't infer types of empty lists.
         if self._builder is None:
             self._builder = BlockAccessor.for_block(block).builder()
         self._builder.add_block(block)

--- a/python/ray/data/impl/delegating_block_builder.py
+++ b/python/ray/data/impl/delegating_block_builder.py
@@ -32,8 +32,8 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
         self._builder.add(item)
 
     def add_block(self, block: Block) -> None:
-        if not block:
-            return  # Dpn't infer types of empty lists.
+        if isinstance(block, list) and not block:
+            return  # Don't infer types of empty lists.
         if self._builder is None:
             self._builder = BlockAccessor.for_block(block).builder()
         self._builder.add_block(block)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -998,6 +998,14 @@ def test_tensors_in_tables_to_tf(ray_start_regular_shared, pipelined):
     np.testing.assert_array_equal(arr, combined_iterations)
 
 
+def test_empty_shuffle(ray_start_regular_shared):
+    ds = ray.data.range(100, parallelism=100)
+    ds = ds.filter(lambda x: x)
+    ds = ds.map_batches(lambda x: x)
+    ds = ds.random_shuffle()  # Would prev. crash with AssertionError: pyarrow.Table.
+    ds.show()
+
+
 def test_empty_dataset(ray_start_regular_shared):
     ds = ray.data.range(0)
     assert ds.count() == 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There's an edge case where we can crash if empty blocks end up in shuffle (type gets inferred as Arrow, then fails when we add list-type blocks).