### PR TITLE
[Serve] Add data structure to encapsulate the Serve controller's deploy() arguments

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -512,7 +512,7 @@ class Client:
             version=version,
             prev_version=prev_version,
             route_prefix=route_prefix,
-            deployer_job_id=ray.get_runtime_context().job_id
+            deployer_job_id=ray.get_runtime_context().job_id,
         )
 
     @_ensure_connected

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -61,7 +61,7 @@ class AutoscalingConfig(BaseModel):
     # How long to wait before scaling up replicas
     upscale_delay_s: NonNegativeFloat = 30.0
 
-    @validator("max_replicas")
+    @validator("max_replicas", allow_reuse=True)
     def max_replicas_greater_than_or_equal_to_min_replicas(cls, v, values):
         if "min_replicas" in values and v < values["min_replicas"]:
             raise ValueError(

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -277,6 +277,44 @@ class ReplicaConfig:
             self.resource_dict.update(custom_resources)
 
 
+class DeploymentRequest(BaseModel):
+    """
+    Options needed to issue a deploy() call from the Serve controller.
+
+    Args:
+        name (str): The deployment's name.
+        deployment_config_proto_bytes (byte): The serialized DeploymentConfig,
+            which contains the deployment's configurations.
+        replica_config (ReplicaConfig): The configurations needed to launch
+            each replica's Ray actor.
+        version (Optional[str]): The requested deployment's version.
+        prev_version (Optional[str]): The expected version for the existing
+            deployment with the requested name.
+        route_prefix (Optional[str]): The route prefix for the requested
+            deployment's endpoint.
+        deployer_job_id (str): JobID string of format "ray._raylet.JobID".
+    """
+
+    name: str
+    deployment_config_proto_bytes: bytes
+    replica_config: ReplicaConfig
+    version: Optional[str] = None
+    prev_version: Optional[str] = None
+    route_prefix: Optional[str] = None
+    deployer_job_id: str
+
+    @validator("deployer_job_id", always=True)
+    def check_job_id_format(cls, v):
+        parts = v.split(".")
+        if len(parts) < 3 and parts[0] != "ray" and parts[1] != "_raylet":
+            raise ValueError(f"DeploymentRequest got deployer_job_id "
+                             f"\"{v}\". Expected deployer_job_id of format "
+                             f"\"ray._raylet.[JobID]\".")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
 class DeploymentMode(str, Enum):
     NoServer = "NoServer"
     HeadOnly = "HeadOnly"

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -28,6 +28,7 @@ from ray.serve.generated.serve_pb2 import (
     DeploymentLanguage,
     AutoscalingConfig as AutoscalingConfigProto,
 )
+from ray._raylet import JobID
 
 
 class AutoscalingConfig(BaseModel):
@@ -292,7 +293,7 @@ class DeploymentRequest(BaseModel):
             deployment with the requested name.
         route_prefix (Optional[str]): The route prefix for the requested
             deployment's endpoint.
-        deployer_job_id (str): JobID string of format "ray._raylet.JobID".
+        deployer_job_id (ray._raylet.JobID): The runtime context's JobID
     """
 
     name: str
@@ -301,17 +302,7 @@ class DeploymentRequest(BaseModel):
     version: Optional[str] = None
     prev_version: Optional[str] = None
     route_prefix: Optional[str] = None
-    deployer_job_id: str
-
-    @validator("deployer_job_id", always=True)
-    def check_job_id_format(cls, v):
-        parts = v.split(".")
-        if len(parts) < 3 or parts[0] != "ray" or parts[1] != "_raylet":
-            raise ValueError(
-                f"DeploymentRequest got deployer_job_id "
-                f'"{v}". Expected deployer_job_id of format '
-                f'"ray._raylet.[JobID]".'
-            )
+    deployer_job_id: JobID
 
     class Config:
         arbitrary_types_allowed = True

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -306,7 +306,7 @@ class DeploymentRequest(BaseModel):
     @validator("deployer_job_id", always=True)
     def check_job_id_format(cls, v):
         parts = v.split(".")
-        if len(parts) < 3 and parts[0] != "ray" and parts[1] != "_raylet":
+        if len(parts) < 3 or parts[0] != "ray" or parts[1] != "_raylet":
             raise ValueError(f"DeploymentRequest got deployer_job_id "
                              f"\"{v}\". Expected deployer_job_id of format "
                              f"\"ray._raylet.[JobID]\".")

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -307,9 +307,11 @@ class DeploymentRequest(BaseModel):
     def check_job_id_format(cls, v):
         parts = v.split(".")
         if len(parts) < 3 or parts[0] != "ray" or parts[1] != "_raylet":
-            raise ValueError(f"DeploymentRequest got deployer_job_id "
-                             f"\"{v}\". Expected deployer_job_id of format "
-                             f"\"ray._raylet.[JobID]\".")
+            raise ValueError(
+                f"DeploymentRequest got deployer_job_id "
+                f'"{v}". Expected deployer_job_id of format '
+                f'"ray._raylet.[JobID]".'
+            )
 
     class Config:
         arbitrary_types_allowed = True

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -18,7 +18,11 @@ from ray.serve.common import (
     NodeId,
     RunningReplicaInfo,
 )
-from ray.serve.config import DeploymentConfig, DeploymentRequest, HTTPOptions, ReplicaConfig
+from ray.serve.config import (
+    DeploymentConfig,
+    DeploymentRequest,
+    HTTPOptions,
+)
 from ray.serve.constants import CONTROL_LOOP_PERIOD_S, SERVE_ROOT_URL_ENV_KEY
 from ray.serve.endpoint_state import EndpointState
 from ray.serve.http_state import HTTPState

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 import pytest
 from pydantic import ValidationError
 
@@ -166,12 +165,17 @@ def test_zero_default_proto():
 class TestDeploymentRequest:
     def test_deployment_request_required_fields(self):
         # Check that missing required fields raises ValidationError
-        required_fields = ["name", "deployment_config_proto_bytes", "replica_config", "deployer_job_id"]
+        required_fields = [
+            "name",
+            "deployment_config_proto_bytes",
+            "replica_config",
+            "deployer_job_id",
+        ]
         all_req_fields = dict(
             name="test",
             deployment_config_proto_bytes=b"bytes",
             replica_config=ReplicaConfig("test_replica"),
-            deployer_job_id="ray._raylet.validjobid"
+            deployer_job_id="ray._raylet.validjobid",
         )
 
         for field in required_fields:
@@ -179,7 +183,7 @@ class TestDeploymentRequest:
                 missing_one_req_field = all_req_fields.copy()
                 missing_one_req_field.pop(field)
                 DeploymentRequest(**missing_one_req_field)
-        
+
         # Should pass with all required fields specified:
         DeploymentRequest(**all_req_fields)
 
@@ -190,17 +194,16 @@ class TestDeploymentRequest:
                 name="test",
                 deployment_config_proto_bytes=b"bytes",
                 replica_config=ReplicaConfig("test_replica"),
-                deployer_job_id="invalid_JobID"
+                deployer_job_id="invalid_JobID",
             )
-        
+
         # Valid JobID should pass
         DeploymentRequest(
             name="test",
             deployment_config_proto_bytes=b"bytes",
             replica_config=ReplicaConfig("test_replica"),
-            deployer_job_id="ray._raylet.validjobid"
+            deployer_job_id="ray._raylet.validjobid",
         )
-
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -9,6 +9,7 @@ from ray.serve.config import (
     DeploymentRequest,
 )
 from ray.serve.config import AutoscalingConfig
+from ray._raylet import JobID
 
 
 def test_autoscaling_config_validation():
@@ -162,48 +163,29 @@ def test_zero_default_proto():
     assert new_delay_s != default_downscale_delay_s
 
 
-class TestDeploymentRequest:
-    def test_deployment_request_required_fields(self):
-        # Check that missing required fields raises ValidationError
-        required_fields = [
-            "name",
-            "deployment_config_proto_bytes",
-            "replica_config",
-            "deployer_job_id",
-        ]
-        all_req_fields = dict(
-            name="test",
-            deployment_config_proto_bytes=b"bytes",
-            replica_config=ReplicaConfig("test_replica"),
-            deployer_job_id="ray._raylet.validjobid",
-        )
+def test_deployment_request_required_fields():
+    # Check that missing required fields raises ValidationError
+    required_fields = [
+        "name",
+        "deployment_config_proto_bytes",
+        "replica_config",
+        "deployer_job_id",
+    ]
+    all_req_fields = dict(
+        name="test",
+        deployment_config_proto_bytes=b"bytes",
+        replica_config=ReplicaConfig("test_replica"),
+        deployer_job_id=JobID.nil(),
+    )
 
-        for field in required_fields:
-            with pytest.raises(ValidationError):
-                missing_one_req_field = all_req_fields.copy()
-                missing_one_req_field.pop(field)
-                DeploymentRequest(**missing_one_req_field)
+    for field in required_fields:
+        with pytest.raises(ValidationError):
+            missing_one_req_field = all_req_fields.copy()
+            missing_one_req_field.pop(field)
+            DeploymentRequest(**missing_one_req_field)
 
-        # Should pass with all required fields specified:
-        DeploymentRequest(**all_req_fields)
-
-    def test_deployment_request_job_id(self):
-        # Check that invalid JobID causes ValueError
-        with pytest.raises(ValueError):
-            DeploymentRequest(
-                name="test",
-                deployment_config_proto_bytes=b"bytes",
-                replica_config=ReplicaConfig("test_replica"),
-                deployer_job_id="invalid_JobID",
-            )
-
-        # Valid JobID should pass
-        DeploymentRequest(
-            name="test",
-            deployment_config_proto_bytes=b"bytes",
-            replica_config=ReplicaConfig("test_replica"),
-            deployer_job_id="ray._raylet.validjobid",
-        )
+    # Should pass with all required fields specified:
+    DeploymentRequest(**all_req_fields)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, the Serve controller's `deploy()` function takes in a series of parameters. Therefore, `deploy_group()` must generate a list of parameter dictionaries for a deployment list to atomically deploy those deployments. This hinders readability and code iteration.

This change adds a new Pydantic-validated object called `DeploymentRequest` that encapsulates `deploy`'s parameters, simplifying the objects that need to be passed between `deploy_group()` and `deploy()`.

## Related issue number

<!-- For example: "Closes #1234" -->

This change addresses readability concerns raised in [this comment](https://github.com/ray-project/ray/pull/22039#discussion_r799598782).

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds a unit test to `test_config.py` that assesses `DeploymentRequest`'s behavior.
