### PR TITLE
Use shared_ptr to instead of object in cluster_scheduling_resources_ to reduce rehash cost.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
@@ -127,7 +127,7 @@ NodeID GcsBasedActorScheduler::GetHighestScoreNodeResource(
   double highest_score = std::numeric_limits<double>::lowest();
   auto highest_score_node = NodeID::Nil();
   for (const auto &pair : cluster_map) {
-    double least_resource_val = scorer.Score(required_resources, pair.second);
+    double least_resource_val = scorer.Score(required_resources, *pair.second);
     if (least_resource_val > highest_score) {
       highest_score = least_resource_val;
       highest_score_node = pair.first;
@@ -143,7 +143,7 @@ void GcsBasedActorScheduler::WarnResourceAllocationFailure(
   const SchedulingResources *scheduling_resource = nullptr;
   auto iter = gcs_resource_manager_->GetClusterResources().find(scheduling_node_id);
   if (iter != gcs_resource_manager_->GetClusterResources().end()) {
-    scheduling_resource = &iter->second;
+    scheduling_resource = iter->second.get();
   }
   std::string scheduling_resource_str =
       scheduling_resource ? scheduling_resource->DebugString() : "None";

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -82,7 +82,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   /// Get the resources of all nodes in the cluster.
   ///
   /// \return The resources of all nodes in the cluster.
-  const absl::flat_hash_map<NodeID, SchedulingResources> &GetClusterResources() const;
+  const absl::flat_hash_map<NodeID, std::shared_ptr<SchedulingResources>>
+      &GetClusterResources() const;
 
   /// Handle a node registration.
   ///
@@ -204,7 +205,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   /// Whether or not to broadcast resource usage via redis.
   const bool redis_broadcast_enabled_;
   /// Map from node id to the scheduling resources of the node.
-  absl::flat_hash_map<NodeID, SchedulingResources> cluster_scheduling_resources_;
+  absl::flat_hash_map<NodeID, std::shared_ptr<SchedulingResources>>
+      cluster_scheduling_resources_;
   /// Placement group load information that is used for autoscaler.
   absl::optional<std::shared_ptr<rpc::PlacementGroupLoad>> placement_group_load_;
   /// Normal task resources could be uploaded by 1) Raylets' periodical reporters; 2)

--- a/src/ray/gcs/gcs_server/gcs_resource_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_scheduler.cc
@@ -107,7 +107,8 @@ SchedulingResult GcsResourceScheduler::Schedule(
 }
 
 absl::flat_hash_set<NodeID> GcsResourceScheduler::FilterCandidateNodes(
-    const absl::flat_hash_map<NodeID, SchedulingResources> &cluster_resources,
+    const absl::flat_hash_map<NodeID, std::shared_ptr<SchedulingResources>>
+        &cluster_resources,
     const std::function<bool(const NodeID &)> &node_filter_func) {
   absl::flat_hash_set<NodeID> result;
   result.reserve(cluster_resources.size());
@@ -214,7 +215,7 @@ SchedulingResult GcsResourceScheduler::StrictPackSchedule(
   const auto &right_node_it = std::find_if(
       cluster_resource.begin(), cluster_resource.end(),
       [required_resources](const auto &node_resource) {
-        return required_resources.IsSubset(node_resource.second.GetTotalResources());
+        return required_resources.IsSubset(node_resource.second->GetTotalResources());
       });
 
   if (right_node_it == cluster_resource.end()) {
@@ -302,7 +303,7 @@ std::optional<NodeID> GcsResourceScheduler::GetBestNode(
   for (const auto &node_id : candidate_nodes) {
     const auto &iter = cluster_resources.find(node_id);
     RAY_CHECK(iter != cluster_resources.end());
-    double node_score = node_scorer_->Score(required_resources, iter->second);
+    double node_score = node_scorer_->Score(required_resources, *iter->second);
     if (best_node_id == nullptr || best_node_score < node_score) {
       best_node_id = &node_id;
       best_node_score = node_score;

--- a/src/ray/gcs/gcs_server/gcs_resource_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_scheduler.h
@@ -115,7 +115,8 @@ class GcsResourceScheduler {
   /// can be used for scheduling.
   /// \return The candidate nodes which can be used for scheduling.
   absl::flat_hash_set<NodeID> FilterCandidateNodes(
-      const absl::flat_hash_map<NodeID, SchedulingResources> &cluster_resources,
+      const absl::flat_hash_map<NodeID, std::shared_ptr<SchedulingResources>>
+          &cluster_resources,
       const std::function<bool(const NodeID &)> &node_filter_func);
 
   /// Sort required resources according to the scarcity and capacity of resources.

--- a/src/ray/gcs/gcs_server/test/gcs_based_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_based_actor_scheduler_test.cc
@@ -157,7 +157,12 @@ TEST_F(GcsBasedActorSchedulerTest, TestScheduleAndDestroyOneActor) {
   auto node = AddNewNode(node_resources);
   auto node_id = NodeID::FromBinary(node->node_id());
   ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
-  auto cluster_resources_before_scheduling = gcs_resource_manager_->GetClusterResources();
+  absl::flat_hash_map<NodeID, std::shared_ptr<SchedulingResources>>
+      cluster_resources_before_scheduling;
+  for (auto &entry : gcs_resource_manager_->GetClusterResources()) {
+    cluster_resources_before_scheduling.emplace(
+        entry.first, std::make_shared<SchedulingResources>(*entry.second));
+  }
   ASSERT_TRUE(cluster_resources_before_scheduling.contains(node_id));
 
   // Schedule a actor (requiring 32 memory units and 4 CPU).
@@ -191,16 +196,16 @@ TEST_F(GcsBasedActorSchedulerTest, TestScheduleAndDestroyOneActor) {
   auto cluster_resources_after_scheduling = gcs_resource_manager_->GetClusterResources();
   ASSERT_TRUE(cluster_resources_after_scheduling.contains(node_id));
   ASSERT_FALSE(
-      cluster_resources_before_scheduling[node_id].GetAvailableResources().IsEqual(
-          cluster_resources_after_scheduling[node_id].GetAvailableResources()));
+      cluster_resources_before_scheduling[node_id]->GetAvailableResources().IsEqual(
+          cluster_resources_after_scheduling[node_id]->GetAvailableResources()));
 
   // When destroying an actor, its acquired resources have to be returned.
   gcs_actor_scheduler_->OnActorDestruction(actor);
   auto cluster_resources_after_destruction = gcs_resource_manager_->GetClusterResources();
   ASSERT_TRUE(cluster_resources_after_destruction.contains(node_id));
   ASSERT_TRUE(
-      cluster_resources_before_scheduling[node_id].GetAvailableResources().IsEqual(
-          cluster_resources_after_destruction[node_id].GetAvailableResources()));
+      cluster_resources_before_scheduling[node_id]->GetAvailableResources().IsEqual(
+          cluster_resources_after_destruction[node_id]->GetAvailableResources()));
 }
 
 TEST_F(GcsBasedActorSchedulerTest, TestBalancedSchedule) {

--- a/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
@@ -51,7 +51,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     const auto &cluster_resource = gcs_resource_manager_->GetClusterResources();
     auto iter = cluster_resource.find(node_id);
     ASSERT_TRUE(iter != cluster_resource.end());
-    ASSERT_EQ(iter->second.GetAvailableResources().GetResource(resource_name).Double(),
+    ASSERT_EQ(iter->second->GetAvailableResources().GetResource(resource_name).Double(),
               resource_value);
   }
 


### PR DESCRIPTION
…to reduce rehash cost

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
1. In scheduling optimization, we should encapsulate `SchedulingResources`, `GcsNodeInfo` and other node related information into a `NodeContext` for use, which requires that `SchedulingResources` is shareable. This PR does not involve the transformation logic of `NodeContext`, but only transforms `SchedulingResources` into shareable.
2. `cluster_scheduling_resources_` holds raw object of `SchedulingResources`, which will bring some overhead when rehash (even though the std::move used when rehash).
 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
