### PR TITLE
Fix ResourceWarnings

### DIFF
--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -355,7 +355,8 @@ def _get_gpu_info_string():
             gpu_dirs = os.listdir(proc_gpus_path)
             if len(gpu_dirs) > 0:
                 gpu_info_path = f"{proc_gpus_path}/{gpu_dirs[0]}/information"
-                info_str = open(gpu_info_path).read()
+                with open(gpu_info_path) as f:
+                    info_str = f.read()
                 return info_str
     return None
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1301,3 +1301,9 @@ def check_version_info(cluster_metadata):
             "    Python: " + version_info[1] + "\n"
         )
         raise RuntimeError(error_message)
+
+
+def maybe_enter_context(stack, *args):
+    for arg in args:
+        if arg is not None:
+            stack.enter_context(arg)


### PR DESCRIPTION
## Why are these changes needed?

This makes `unittest` logs easier to read which can reduce iteration time.

The GPU one should be uncontroversial.

I added a wait after forcibly killing a subprocess; this doesn't guarantee that the ResourceWarning goes away, but it fixed it for me. Might be better to change the subprocess so it responds to SIGTERM more quickly, but that would take more effort.

The remaining changes close log files after passing them to subprocesses. I noticed a comment on https://github.com/ray-project/ray/issues/10279 which claims that they were kept open deliberately. It's possible that I'm missing something, but I think the files are only used by these subprocesses, and most OSs I'm aware of will keep file descriptors open in child processes after the parent closes them. In any case `subprocess.Popen` duplicates these handles before passing them to the child on POSIX [1] and Windows [2].

[1] https://github.com/python/cpython/blob/07119dd38c9a6e5da84ca8a0a46acdf8a3e60ecf/Lib/subprocess.py#L1541
[2] https://github.com/python/cpython/blob/07119dd38c9a6e5da84ca8a0a46acdf8a3e60ecf/Lib/subprocess.py#L1208

## Related issue number

Closes https://github.com/ray-project/ray/issues/9546 and https://github.com/ray-project/ray/issues/10279.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
