### PR TITLE
[RLlib] Disable A3C CI tests on torch for now

### DIFF
--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -27,6 +27,10 @@ a3c-pongdeterministic-v4:
         timesteps_total: 5000000
     stop:
         time_total_s: 3600
+    # TODO(sven, jungong): there seems to be a race condition between A3C
+    #    and torch, causing matrix shape mismatch error.
+    #    Fix and re-enable torch.
+    frameworks: ["tf"]
     config:
         num_gpus: 0
         num_workers: 16

--- a/release/rllib_tests/performance_tests/performance_tests.yaml
+++ b/release/rllib_tests/performance_tests/performance_tests.yaml
@@ -138,7 +138,8 @@ sac-halfcheetahbulletenv-v0:
 a3c-pongdeterministic-v4:
     env: PongDeterministic-v4
     run: A3C
-    frameworks: [ "tf", "tf2", "torch" ]
+    # TODO(sven, jungong): fix A3C on torch and re-enable.
+    frameworks: [ "tf", "tf2" ]
     stop:
         time_total_s: 3600
     config:

--- a/release/rllib_tests/rllib_tests.yaml
+++ b/release/rllib_tests/rllib_tests.yaml
@@ -99,5 +99,5 @@
     compute_template: 12gpus_192cpus.yaml
 
   run:
-    timeout: 7200
+    timeout: 10800
     script: python performance_tests/run.py


### PR DESCRIPTION
## Why are these changes needed?

Disable A3C test on torch for now due to a race condition during worker initialization.
Also extend performance_test deadline to 3hrs.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
