### PR TITLE
Fix AttributeError with None obs shape and tf

### DIFF
--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -439,10 +439,16 @@ def _unpack_obs(obs: TensorType, space: Space, tensorlib: Any = tf) -> TensorStr
             )
         offset = 0
         if tensorlib == tf:
-            batch_dims = [
-                v if isinstance(v, (int, type(None))) else v.value
-                for v in obs.shape[:-1]
-            ]
+
+            def get_value(v):
+                if v is None:
+                    return -1
+                elif isinstance(v, int):
+                    return v
+                else:
+                    return v.value
+
+            batch_dims = [get_value(v) for v in obs.shape[:-1]]
             batch_dims = [-1 if v is None else v for v in batch_dims]
         else:
             batch_dims = list(obs.shape[:-1])

--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -445,11 +445,12 @@ def _unpack_obs(obs: TensorType, space: Space, tensorlib: Any = tf) -> TensorStr
                     return -1
                 elif isinstance(v, int):
                     return v
+                elif v.value is None:
+                    return -1
                 else:
                     return v.value
 
             batch_dims = [get_value(v) for v in obs.shape[:-1]]
-            batch_dims = [-1 if v is None else v for v in batch_dims]
         else:
             batch_dims = list(obs.shape[:-1])
         if isinstance(space, gym.spaces.Tuple):

--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -439,7 +439,10 @@ def _unpack_obs(obs: TensorType, space: Space, tensorlib: Any = tf) -> TensorStr
             )
         offset = 0
         if tensorlib == tf:
-            batch_dims = [v if isinstance(v, int) else v.value for v in obs.shape[:-1]]
+            batch_dims = [
+                v if isinstance(v, (int, type(None))) else v.value
+                for v in obs.shape[:-1]
+            ]
             batch_dims = [-1 if v is None else v for v in batch_dims]
         else:
             batch_dims = list(obs.shape[:-1])


### PR DESCRIPTION

## Why are these changes needed?

When obs shape is None, calling v.value lead to  *AttributeError: 'NoneType' object has no attribute 'value'* in *ModelV2* with  tensorflow.  This fix adds a check for None value:
```python
batch_dims = [
                v if isinstance(v, (int, type(None))) else v.value
                for v in obs.shape[:-1]
            ]
```
## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/pull/16286

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
