### PR TITLE
[State] Add pid to the actor table data.

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -136,6 +136,7 @@ class GlobalState:
             "StartTime": actor_table_data.start_time,
             "EndTime": actor_table_data.end_time,
             "DeathCause": actor_table_data.death_cause,
+            "Pid": actor_table_data.pid,
         }
         return actor_info
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It is requested by users that they'd like to get the pid of actors using ray.state.actors. This PR addresses that.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
