### PR TITLE
[Nightly Test] Addressed client failure properly

### DIFF
--- a/release/e2e.py
+++ b/release/e2e.py
@@ -1665,6 +1665,8 @@ def run_test_config(
     # When running the test script in client mode, the finish command is a
     # completed local process.
     def _process_finished_client_command(returncode: int, logs: str):
+        if returncode != 0:
+            raise RuntimeError(f"Client returned non-success status: {returncode}")
         if upload_artifacts:
             saved_artifacts = pull_artifacts_and_store_in_cloud(
                 temp_dir=temp_dir,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the client returns the code that's not 0, we should raise RuntimeError to properly propagate errors

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
