### PR TITLE
[placement group] fix pg benchmark regression

### DIFF
--- a/python/ray/_private/ray_microbenchmark_helpers.py
+++ b/python/ray/_private/ray_microbenchmark_helpers.py
@@ -11,11 +11,14 @@ from contextlib import contextmanager
 filter_pattern = os.environ.get("TESTS_TO_RUN", "")
 
 
-def timeit(name, fn, multiplier=1) -> List[Optional[Tuple[str, float, float]]]:
+def timeit(
+    name, fn, multiplier=1, warmup_time_sec=10
+) -> List[Optional[Tuple[str, float, float]]]:
     if filter_pattern not in name:
         return [None]
-    # sleep for 10 seconds to avoid noisy neighbors.
-    time.sleep(10)
+    # sleep for a while to avoid noisy neigbhors.
+    # related issue: https://github.com/ray-project/ray/issues/22045
+    time.sleep(warmup_time_sec)
     # warmup
     start = time.perf_counter()
     count = 0

--- a/release/nightly_tests/placement_group_tests/placement_group_performance_test.py
+++ b/release/nightly_tests/placement_group_tests/placement_group_performance_test.py
@@ -37,6 +37,7 @@ def test_placement_group_perf(num_pgs, num_bundles, num_pending_pgs):
         "placement group create per second",
         lambda: placement_group_create(num_pgs),
         num_pgs,
+        warmup_time_sec=0,
     )
 
     # Get fine-grained scheduling stats.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We added a warmup time in timeit which affects the pg benchmark time accounting. add an option to cancel warmup.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
