### PR TITLE
WINDOWS: enable and fix failures in test_runtime_env_complicated

### DIFF
--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -29,6 +29,8 @@ steps:
   parallelism: 6
   commands:
     - *prelude_commands
+    # conda init should be moved to the docker image setup
+    - conda init
     - . ./ci/travis/ci.sh init
     - . ./ci/travis/ci.sh build
     - if [ "${BUILDKITE_PARALLEL_JOB}" = "0" ]; then . ./ci/travis/ci.sh test_core; fi

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -178,6 +178,8 @@ test_python() {
     bazel test --config=ci \
       --build_tests_only $(./scripts/bazel_export_options) \
       --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
+      --test_env=USERPROFILE="${USERPROFILE}" \
+      --test_output=streamed \
       -- \
       ${test_shard_selection};
   fi

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -179,6 +179,7 @@ test_python() {
       --build_tests_only $(./scripts/bazel_export_options) \
       --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
       --test_env=USERPROFILE="${USERPROFILE}" \
+      --test_env=CI \
       --test_output=streamed \
       -- \
       ${test_shard_selection};

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -179,7 +179,8 @@ test_python() {
       --build_tests_only $(./scripts/bazel_export_options) \
       --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
       --test_env=USERPROFILE="${USERPROFILE}" \
-      --test_env=CI \
+      --test_env=CI=1 \
+      --test_env=RAY_CI_POST_WHEEL_TESTS=1 \
       --test_output=streamed \
       -- \
       ${test_shard_selection};

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -156,7 +156,6 @@ test_python() {
       -python/ray/tests:test_multi_node_3
       -python/ray/tests:test_object_manager # OOM on test_object_directory_basic
       -python/ray/tests:test_resource_demand_scheduler
-      -python/ray/tests:test_runtime_env_complicated # requires conda
       -python/ray/tests:test_stress  # timeout
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_operator_unit_tests

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -275,7 +275,10 @@ class ReporterAgent(
             return {
                 "/": psutil._common.sdiskusage(total=1, used=0, free=1, percent=0.0)
             }
-        root = os.environ["USERPROFILE"] if sys.platform == "win32" else os.sep
+        if sys.platform == "win32":
+            root = psutil.disk_partitions()[0].mountpoint
+        else:
+            root = os.sep
         tmp = ray._private.utils.get_user_temp_dir()
         return {
             "/": psutil.disk_usage(root),

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -52,7 +52,7 @@ Runtime environments
 
 .. note::
 
-    This feature requires a full installation of Ray using ``pip install "ray[default]"``. This feature is available starting with Ray 1.4.0 and is currently only supported on macOS and Linux.
+    This feature requires a full installation of Ray using ``pip install "ray[default]"``. This feature is available starting with Ray 1.4.0 and is currently supported on macOS and Linux. It is experimentally supported on Widows.
 
 The second way to set up dependencies is to install them dynamically while Ray is running.
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -52,7 +52,7 @@ Runtime environments
 
 .. note::
 
-    This feature requires a full installation of Ray using ``pip install "ray[default]"``. This feature is available starting with Ray 1.4.0 and is currently supported on macOS and Linux. It is experimentally supported on Widows.
+    This feature requires a full installation of Ray using ``pip install "ray[default]"``. This feature is available starting with Ray 1.4.0 and is currently supported on macOS and Linux. It is experimentally supported on Windows.
 
 The second way to set up dependencies is to install them dynamically while Ray is running.
 

--- a/python/ray/_private/runtime_env/_clonevirtualenv.py
+++ b/python/ray/_private/runtime_env/_clonevirtualenv.py
@@ -21,6 +21,9 @@ logger = logging.getLogger()
 env_bin_dir = "bin"
 if sys.platform == "win32":
     env_bin_dir = "Scripts"
+    _WIN32 = True
+else:
+    _WIN32 = False
 
 
 class UserError(Exception):
@@ -49,6 +52,10 @@ def _dirmatch(path, matchwith):
 def _virtualenv_sys(venv_path):
     """obtain version and path info from a virtualenv."""
     executable = os.path.join(venv_path, env_bin_dir, "python")
+    if _WIN32:
+        env = os.environ.copy()
+    else:
+        env = {}    
     # Must use "executable" as the first argument rather than as the
     # keyword argument "executable" to get correct value from sys.path
     p = subprocess.Popen(
@@ -59,7 +66,7 @@ def _virtualenv_sys(venv_path):
             'print ("%d.%d" % (sys.version_info.major, sys.version_info.minor));'
             'print ("\\n".join(sys.path));',
         ],
-        env={},
+        env=env,
         stdout=subprocess.PIPE,
     )
     stdout, err = p.communicate()

--- a/python/ray/_private/runtime_env/_clonevirtualenv.py
+++ b/python/ray/_private/runtime_env/_clonevirtualenv.py
@@ -55,7 +55,7 @@ def _virtualenv_sys(venv_path):
     if _WIN32:
         env = os.environ.copy()
     else:
-        env = {}    
+        env = {}
     # Must use "executable" as the first argument rather than as the
     # keyword argument "executable" to get correct value from sys.path
     p = subprocess.Popen(

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -33,6 +33,8 @@ from ray._private.runtime_env.packaging import Protocol, parse_uri
 
 default_logger = logging.getLogger(__name__)
 
+_WIN32 = os.name == 'nt'
+
 
 def _resolve_current_ray_path() -> str:
     # When ray is built from source with pip install -e,
@@ -63,7 +65,10 @@ def _inject_ray_to_conda_site(
     conda_path, logger: Optional[logging.Logger] = default_logger
 ):
     """Write the current Ray site package directory to a new site"""
-    python_binary = os.path.join(conda_path, "bin/python")
+    if _WIN32:
+        python_binary = os.path.join(conda_path, "python")
+    else:
+        python_binary = os.path.join(conda_path, "bin/python")
     site_packages_path = (
         subprocess.check_output(
             [python_binary, "-c", "import site; print(site.getsitepackages()[0])"]

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -33,7 +33,7 @@ from ray._private.runtime_env.packaging import Protocol, parse_uri
 
 default_logger = logging.getLogger(__name__)
 
-_WIN32 = os.name == 'nt'
+_WIN32 = os.name == "nt"
 
 
 def _resolve_current_ray_path() -> str:

--- a/python/ray/_private/runtime_env/conda_utils.py
+++ b/python/ray/_private/runtime_env/conda_utils.py
@@ -59,6 +59,8 @@ def get_conda_bin_executable(executable_name: str) -> str:
                 return candidate
         else:
             return os.path.join(conda_home, "bin/%s" % executable_name)
+    else:
+        conda_home = '.'
     # Use CONDA_EXE as per https://github.com/conda/conda/issues/7126
     if "CONDA_EXE" in os.environ:
         conda_bin_dir = os.path.dirname(os.environ["CONDA_EXE"])
@@ -71,6 +73,8 @@ def get_conda_bin_executable(executable_name: str) -> str:
                 return candidate
         else:
             return os.path.join(conda_bin_dir, executable_name)
+    if _WIN32:
+        return executable_name + '.bat'
     return executable_name
 
 
@@ -99,7 +103,7 @@ def create_conda_env_if_needed(
         exec_cmd([conda_path, "--help"], throw_on_error=False)
     except EnvironmentError:
         raise ValueError(
-            f"Could not find Conda executable at {conda_path}. "
+            f"Could not find Conda executable at '{conda_path}'. "
             "Ensure Conda is installed as per the instructions at "
             "https://conda.io/projects/conda/en/latest/"
             "user-guide/install/index.html. "

--- a/python/ray/_private/runtime_env/conda_utils.py
+++ b/python/ray/_private/runtime_env/conda_utils.py
@@ -60,7 +60,7 @@ def get_conda_bin_executable(executable_name: str) -> str:
         else:
             return os.path.join(conda_home, "bin/%s" % executable_name)
     else:
-        conda_home = '.'
+        conda_home = "."
     # Use CONDA_EXE as per https://github.com/conda/conda/issues/7126
     if "CONDA_EXE" in os.environ:
         conda_bin_dir = os.path.dirname(os.environ["CONDA_EXE"])
@@ -74,7 +74,7 @@ def get_conda_bin_executable(executable_name: str) -> str:
         else:
             return os.path.join(conda_bin_dir, executable_name)
     if _WIN32:
-        return executable_name + '.bat'
+        return executable_name + ".bat"
     return executable_name
 
 

--- a/python/ray/_private/runtime_env/conda_utils.py
+++ b/python/ray/_private/runtime_env/conda_utils.py
@@ -12,7 +12,7 @@ from typing import Optional, List, Union, Tuple
 # will default to running "conda" if unset.
 RAY_CONDA_HOME = "RAY_CONDA_HOME"
 
-_WIN32 = os.name == 'nt'
+_WIN32 = os.name == "nt"
 
 
 def get_conda_activate_commands(conda_env_name: str) -> List[str]:
@@ -200,7 +200,7 @@ def exec_cmd_stream_to_logger(
     The last n_lines lines of output are also returned (stdout and stderr).
     """
     if "env" in kwargs and _WIN32 and "PATH" not in [x.upper() for x in kwargs.keys]:
-        raise ValueError("On windows, Popen requires 'PATH' in 'env'") 
+        raise ValueError("On windows, Popen requires 'PATH' in 'env'")
     child = subprocess.Popen(
         cmd,
         universal_newlines=True,

--- a/python/ray/_private/runtime_env/conda_utils.py
+++ b/python/ray/_private/runtime_env/conda_utils.py
@@ -101,7 +101,7 @@ def create_conda_env_if_needed(
     conda_path = get_conda_bin_executable("conda")
     try:
         exec_cmd([conda_path, "--help"], throw_on_error=False)
-    except EnvironmentError:
+    except (EnvironmentError, FileNotFoundError):
         raise ValueError(
             f"Could not find Conda executable at '{conda_path}'. "
             "Ensure Conda is installed as per the instructions at "

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -18,7 +18,7 @@ from ray._private.utils import (
 
 default_logger = logging.getLogger(__name__)
 
-_WIN32 = os.name == 'nt'
+_WIN32 = os.name == "nt"
 
 
 def _get_pip_hash(pip_dict: Dict) -> str:
@@ -267,9 +267,9 @@ class PipProcessor:
                 "Creating virtualenv at %s, current python dir %s",
                 virtualenv_path,
                 virtualenv_path,
-                
             )
         await check_output_cmd(create_venv_cmd, logger=logger, cwd=cwd, env=env)
+
     @classmethod
     async def _install_pip_packages(
         cls,
@@ -312,10 +312,6 @@ class PipProcessor:
             "-r",
             pip_requirements_file,
         ]
-        if _WIN32:
-            env = os.environ.copy()
-        else:
-            env = {}
         logger.info("Installing python requirements to %s", virtualenv_path)
 
         await check_output_cmd(pip_install_cmd, logger=logger, cwd=cwd, env=pip_env)

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -18,6 +18,8 @@ from ray._private.utils import (
 
 default_logger = logging.getLogger(__name__)
 
+_WIN32 = os.name == 'nt'
+
 
 def _get_pip_hash(pip_dict: Dict) -> str:
     serialized_pip_spec = json.dumps(pip_dict, sort_keys=True)
@@ -51,7 +53,10 @@ class _PathHelper:
     @classmethod
     def get_virtualenv_python(cls, target_dir: str) -> str:
         virtualenv_path = cls.get_virtualenv_path(target_dir)
-        return os.path.join(virtualenv_path, "bin/python")
+        if _WIN32:
+            return os.path.join(virtualenv_path, "Scripts", "python.exe")
+        else:
+            return os.path.join(virtualenv_path, "bin", "python")
 
     @classmethod
     def get_virtualenv_activate_command(cls, target_dir: str) -> str:
@@ -196,7 +201,11 @@ class PipProcessor:
         python = sys.executable
         virtualenv_path = os.path.join(path, "virtualenv")
         virtualenv_app_data_path = os.path.join(path, "virtualenv_app_data")
-        current_python_dir = os.path.abspath(
+
+        if _WIN32:
+            current_python_dir = sys.prefix
+        else:
+            current_python_dir = os.path.abspath(
             os.path.join(os.path.dirname(python), "..")
         )
 
@@ -251,10 +260,10 @@ class PipProcessor:
             logger.info(
                 "Creating virtualenv at %s, current python dir %s",
                 virtualenv_path,
-                current_python_dir,
+                virtualenv_path,
+                
             )
         await check_output_cmd(create_venv_cmd, logger=logger, cwd=cwd, env={})
-
     @classmethod
     async def _install_pip_packages(
         cls,

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -172,8 +172,12 @@ class PipProcessor:
                 "-c",
                 "import ray; print(ray.__version__, ray.__path__[0])",
             ]
+            if _WIN32:
+                env = os.environ.copy()
+            else:
+                env = {}
             output = await check_output_cmd(
-                check_ray_cmd, logger=logger, cwd=cwd, env={}
+                check_ray_cmd, logger=logger, cwd=cwd, env=env
             )
             # print after import ray may have [0m endings, so we strip them by *_
             ray_version, ray_path, *_ = [s.strip() for s in output.split()]
@@ -204,10 +208,12 @@ class PipProcessor:
 
         if _WIN32:
             current_python_dir = sys.prefix
+            env = os.environ.copy()
         else:
             current_python_dir = os.path.abspath(
-            os.path.join(os.path.dirname(python), "..")
-        )
+                os.path.join(os.path.dirname(python), "..")
+            )
+            env = {}
 
         if cls._is_in_virtualenv():
             # virtualenv-clone homepage:
@@ -263,7 +269,7 @@ class PipProcessor:
                 virtualenv_path,
                 
             )
-        await check_output_cmd(create_venv_cmd, logger=logger, cwd=cwd, env={})
+        await check_output_cmd(create_venv_cmd, logger=logger, cwd=cwd, env=env)
     @classmethod
     async def _install_pip_packages(
         cls,
@@ -306,6 +312,10 @@ class PipProcessor:
             "-r",
             pip_requirements_file,
         ]
+        if _WIN32:
+            env = os.environ.copy()
+        else:
+            env = {}
         logger.info("Installing python requirements to %s", virtualenv_path)
 
         await check_output_cmd(pip_install_cmd, logger=logger, cwd=cwd, env=pip_env)

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -73,14 +73,15 @@ def parse_and_validate_conda(conda: Union[str, dict]) -> Union[str, dict]:
     """
     assert conda is not None
 
-    result = None
     if sys.platform == "win32":
-        raise NotImplementedError(
-            "The 'conda' field in runtime_env "
-            "is not currently supported on "
-            "Windows."
+        logger.warning(
+            "runtime environment support is experimental on Windows. "
+            "If you run into issues please file a report at "
+            "https://github.com/ray-project/ray/issues."
         )
-    elif isinstance(conda, str):
+
+    result = None
+    if isinstance(conda, str):
         yaml_file = Path(conda)
         if yaml_file.suffix in (".yaml", ".yml"):
             if not yaml_file.is_file():
@@ -132,12 +133,12 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
 
     result = None
     if sys.platform == "win32":
-        raise NotImplementedError(
-            "The 'pip' field in runtime_env "
-            "is not currently supported on "
-            "Windows."
+        logger.warning(
+            "runtime environment support is experimental on Windows. "
+            "If you run into issues please file a report at "
+            "https://github.com/ray-project/ray/issues."
         )
-    elif isinstance(pip, str):
+    if isinstance(pip, str):
         # We have been given a path to a requirements.txt file.
         pip_list = _handle_local_pip_requirement_file(pip)
         result = dict(packages=pip_list, pip_check=False)

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import sys
 from typing import Dict, List, Optional, Union
 
 from collections import OrderedDict

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-import sys
 from typing import Dict, List, Optional, Union
 
 from collections import OrderedDict

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -65,6 +65,7 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_client.py",
+    "test_client_reconnect.py",
   ],
   size = "large",
   extra_srcs = SRCS,
@@ -82,7 +83,6 @@ py_test_module_list(
     "test_client_references.py",
     "test_client_warnings.py",
     "test_client_library_integration.py",
-    "test_client_reconnect.py",
   ],
   size = "medium",
   extra_srcs = SRCS,

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -225,7 +225,6 @@ def ray_start_cluster_init(request):
 @pytest.fixture
 def ray_start_cluster_head(request):
     param = getattr(request, "param", {})
-    param["skip_cluster"] = False
     with _ray_start_cluster(do_init=True, num_nodes=1, **param) as res:
         yield res
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -225,6 +225,7 @@ def ray_start_cluster_init(request):
 @pytest.fixture
 def ray_start_cluster_head(request):
     param = getattr(request, "param", {})
+    param["skip_cluster"] = False
     with _ray_start_cluster(do_init=True, num_nodes=1, **param) as res:
         yield res
 
@@ -324,10 +325,10 @@ def call_ray_stop_only():
 # Used to test both Ray Client and non-Ray Client codepaths.
 # Usage: In your test, call `ray.init(address)`.
 @pytest.fixture(scope="function", params=["ray_client", "no_ray_client"])
-def start_cluster(ray_start_cluster, request):
+def start_cluster(ray_start_cluster_enabled, request):
     assert request.param in {"ray_client", "no_ray_client"}
     use_ray_client: bool = request.param == "ray_client"
-    cluster = ray_start_cluster
+    cluster = ray_start_cluster_enabled
     cluster.add_node(num_cpus=4)
     if use_ray_client:
         cluster.head_node._ray_params.ray_client_server_port = "10004"

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -230,6 +230,7 @@ def test_runtime_env_no_spurious_resource_deadlock_msg(
     assert len(errors) == 0
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows.")
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
 def test_failed_job_env_no_hang(shutdown_only, runtime_env_class):
     """Test that after a failed job-level env, tasks can still be run."""

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -145,9 +145,6 @@ def test_container_option_serialize(runtime_env_class):
     assert job_config_serialized.count(b"--name=test") == 1
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="runtime_env unsupported on Windows."
-)
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
 def test_no_spurious_worker_startup(shutdown_only, runtime_env_class):
     """Test that no extra workers start up during a long env installation."""
@@ -233,7 +230,6 @@ def test_runtime_env_no_spurious_resource_deadlock_msg(
     assert len(errors) == 0
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="pip not supported on Windows.")
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
 def test_failed_job_env_no_hang(shutdown_only, runtime_env_class):
     """Test that after a failed job-level env, tasks can still be run."""

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import time
 from typing import List
-from unittest import mock, skipIf
+from unittest import mock
 import yaml
 
 import ray

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -534,14 +534,16 @@ def test_pip_job_config(shutdown_only, pip_as_str, tmp_path):
     assert ray.get(f.remote())
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform == "win32",
+    reason="dirname(__file__) returns an invalid path",
+)
 def test_experimental_package(shutdown_only):
     ray.init(num_cpus=2)
     pkg = ray.experimental.load_package(
-        os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "../experimental/packaging/example_pkg/ray_pkg.yaml",
-            )
+        os.path.join(
+            os.path.dirname(__file__),
+            "../experimental/packaging/example_pkg/ray_pkg.yaml",
         )
     )
     a = pkg.MyActor.remote()
@@ -549,13 +551,15 @@ def test_experimental_package(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform == "win32",
+    reason="dirname(__file__) returns an invalid path",
+)
 def test_experimental_package_lazy(shutdown_only):
     pkg = ray.experimental.load_package(
-        os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "../experimental/packaging/example_pkg/ray_pkg.yaml",
-            )
+        os.path.join(
+            os.path.dirname(__file__),
+            "../experimental/packaging/example_pkg/ray_pkg.yaml",
         )
     )
     ray.init(num_cpus=2)

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -74,7 +74,7 @@ def conda_envs():
                 stderr=subprocess.PIPE,
             )
             if proc.returncode != 0:
-                print("pip install failed")
+                print("conda/pip install failed")
                 print(proc.stdout.decode())
                 print(proc.stderr.decode())
                 assert False
@@ -279,8 +279,13 @@ def test_get_conda_env_dir(tmp_path):
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.",
 )
+@pytest.mark.skipif(
+    os.environ.get("CONDA_EXE") is None,
+    reason="Requires properly set-up conda shell",
+)
 def test_conda_create_task(shutdown_only):
-    """Tests dynamic creation of a conda env in a task's runtime env."""
+    """Tests dynamic creation of a conda env in a task's runtime env. Assumes
+    `conda init` has been successfully called."""
     ray.init()
     runtime_env = {
         "conda": {"dependencies": ["pip", {"pip": ["pip-install-test==0.5"]}]}
@@ -304,6 +309,10 @@ def test_conda_create_task(shutdown_only):
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.",
+)
+@pytest.mark.skipif(
+    os.environ.get("CONDA_EXE") is None,
+    reason="Requires properly set-up conda shell",
 )
 def test_conda_create_job_config(shutdown_only):
     """Tests dynamic conda env creation in a runtime env in the JobConfig."""
@@ -499,7 +508,6 @@ def test_pip_job_config(shutdown_only, pip_as_str, tmp_path):
     assert ray.get(f.remote())
 
 
-@skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package(shutdown_only):
     ray.init(num_cpus=2)
     pkg = ray.experimental.load_package(
@@ -513,7 +521,6 @@ def test_experimental_package(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
-@skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package_lazy(shutdown_only):
     pkg = ray.experimental.load_package(
         os.path.join(
@@ -527,7 +534,6 @@ def test_experimental_package_lazy(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
-@skipIf(sys.platform == "win32", "Fail to create temp dir.")
 def test_experimental_package_github(shutdown_only):
     ray.init(num_cpus=2)
     pkg = ray.experimental.load_package(

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -571,6 +571,7 @@ def test_experimental_package_github(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
+@pytest.mark.skipif(_WIN32, reason="Fails on windows")
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.",
@@ -619,6 +620,7 @@ def test_client_working_dir_filepath(call_ray_start, tmp_path):
             assert ray.get(f.remote())
 
 
+@pytest.mark.skipif(_WIN32, reason="Hangs on windows")
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.",
@@ -773,6 +775,7 @@ def test_simultaneous_install(shutdown_only):
 CLIENT_SERVER_PORT = 24001
 
 
+@pytest.mark.skipif(_WIN32, reason="Fails on windows")
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.",
@@ -915,6 +918,7 @@ def test_e2e_complex(call_ray_start, tmp_path):
         assert ray.get(a.test.remote()) == "Hello"
 
 
+@pytest.mark.skipif(_WIN32, reason="Fails on windows")
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.",
@@ -972,6 +976,7 @@ def test_runtime_env_override(call_ray_start):
         ray.shutdown()
 
 
+@pytest.mark.skipif(_WIN32, reason="RecursionError on windows")
 @pytest.mark.skipif(
     os.environ.get("CI") and sys.platform != "linux",
     reason="This test is only run on linux CI machines.",

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -568,6 +568,7 @@ def test_experimental_package_lazy(shutdown_only):
     assert ray.get(pkg.my_func.remote()) == "hello world"
 
 
+@pytest.mark.skipif(_WIN32, reason="requires tar cli command")
 def test_experimental_package_github(shutdown_only):
     ray.init(num_cpus=2)
     pkg = ray.experimental.load_package(

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -537,9 +537,11 @@ def test_pip_job_config(shutdown_only, pip_as_str, tmp_path):
 def test_experimental_package(shutdown_only):
     ray.init(num_cpus=2)
     pkg = ray.experimental.load_package(
-        os.path.join(
-            os.path.dirname(__file__),
-            "../experimental/packaging/example_pkg/ray_pkg.yaml",
+        os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../experimental/packaging/example_pkg/ray_pkg.yaml",
+            )
         )
     )
     a = pkg.MyActor.remote()
@@ -549,9 +551,11 @@ def test_experimental_package(shutdown_only):
 
 def test_experimental_package_lazy(shutdown_only):
     pkg = ray.experimental.load_package(
-        os.path.join(
-            os.path.dirname(__file__),
-            "../experimental/packaging/example_pkg/ray_pkg.yaml",
+        os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../experimental/packaging/example_pkg/ray_pkg.yaml",
+            )
         )
     )
     ray.init(num_cpus=2)

--- a/python/ray/tests/test_runtime_env_conda_and_pip_2.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_2.py
@@ -12,7 +12,6 @@ if not os.environ.get("CI"):
     os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
 
 
-
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on windows")
 @pytest.mark.parametrize("field", ["conda", "pip"])
 @pytest.mark.parametrize("specify_env_in_init", [True, False])

--- a/python/ray/tests/test_runtime_env_conda_and_pip_2.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_2.py
@@ -12,6 +12,8 @@ if not os.environ.get("CI"):
     os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
 
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on windows")
 @pytest.mark.parametrize("field", ["conda", "pip"])
 @pytest.mark.parametrize("specify_env_in_init", [True, False])
 @pytest.mark.parametrize("spec_format", ["file", "python_object"])

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -352,10 +352,10 @@ RAY_CONFIG(uint64_t, max_pending_lease_requests_per_scheduling_category, 10)
 
 /// Wait timeout for dashboard agent register.
 #ifdef _WIN32
-  // agent startup time can involve creating conda environments
-  RAY_CONFIG(uint32_t, agent_register_timeout_ms, 100 * 1000)
+// agent startup time can involve creating conda environments
+RAY_CONFIG(uint32_t, agent_register_timeout_ms, 100 * 1000)
 #else
-  RAY_CONFIG(uint32_t, agent_register_timeout_ms, 30 * 1000)
+RAY_CONFIG(uint32_t, agent_register_timeout_ms, 30 * 1000)
 #endif
 
 /// If the agent manager fails to communicate with the dashboard agent, we will retry

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -351,7 +351,12 @@ RAY_CONFIG(int64_t, task_rpc_inlined_bytes_limit, 10 * 1024 * 1024)
 RAY_CONFIG(uint64_t, max_pending_lease_requests_per_scheduling_category, 10)
 
 /// Wait timeout for dashboard agent register.
-RAY_CONFIG(uint32_t, agent_register_timeout_ms, 30 * 1000)
+#ifdef _WIN32
+  // agent startup time can involve creating conda environments
+  RAY_CONFIG(uint32_t, agent_register_timeout_ms, 100 * 1000)
+#else
+  RAY_CONFIG(uint32_t, agent_register_timeout_ms, 30 * 1000)
+#endif
 
 /// If the agent manager fails to communicate with the dashboard agent, we will retry
 /// after this interval.


### PR DESCRIPTION
Continuation of #22342 to enable runtime_env tests on windows. Part of #22186 

Enable runtime_env tests in test_runtime_env_complicated. The fixes involved getting paths correct in conda, virtualenvs, and base python, since there are differences between the layouts on linux and windows.