### PR TITLE
[Core] Fix null pointer crash when GcsResourceManager::SetAvailableResources

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -325,6 +325,10 @@ void GcsResourceManager::SetAvailableResources(const NodeID &node_id,
   auto iter = cluster_scheduling_resources_.find(node_id);
   if (iter != cluster_scheduling_resources_.end()) {
     iter->second->SetAvailableResources(ResourceSet(resources));
+  } else {
+    RAY_LOG(WARNING)
+        << "Skip the setting of available resources of node " << node_id
+        << " as it does not exist, maybe it is not registered yet or is already dead.";
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -322,7 +322,10 @@ const absl::flat_hash_map<NodeID, std::shared_ptr<SchedulingResources>>
 
 void GcsResourceManager::SetAvailableResources(const NodeID &node_id,
                                                const ResourceSet &resources) {
-  cluster_scheduling_resources_[node_id]->SetAvailableResources(ResourceSet(resources));
+  auto iter = cluster_scheduling_resources_.find(node_id);
+  if (iter != cluster_scheduling_resources_.end()) {
+    iter->second->SetAvailableResources(ResourceSet(resources));
+  }
 }
 
 void GcsResourceManager::UpdateResourceCapacity(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
> Before, when node_id does not exist in cluster_scheduling_resources_, a SchedulingResources will be created. Now, only an empty std::shared_ptr<SchedulingResources> is created, so this can crash
https://github.com/ray-project/ray/pull/22376#discussion_r808606948

The GcsResourceManager::SetAvailableResources is only invoked when resource usage updated, so I think we could skip the setting of available resources when node_id is not in cluster_scheduling_resources_, maybe the node is not registered yet or is already dead.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
