### PR TITLE
[1][resource reporting] Remove redis based resource broadcasting.

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -288,9 +288,6 @@ RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)
 RAY_CONFIG(int, gcs_resource_report_poll_period_ms, 100)
 // The number of concurrent polls to polls to GCS.
 RAY_CONFIG(uint64_t, gcs_max_concurrent_resource_pulls, 100)
-// Feature flag to use grpc instead of redis for resource broadcast.
-// TODO(ekl) broken as of https://github.com/ray-project/ray/issues/16858
-RAY_CONFIG(bool, grpc_based_resource_broadcast, true)
 // Feature flag to enable grpc based pubsub in GCS.
 RAY_CONFIG(bool, gcs_grpc_based_pubsub, true)
 // The storage backend to use for the GCS. It can be either 'redis' or 'memory'.

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -72,9 +72,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
 
     // Tests legacy code paths. The poller and broadcaster have their own dedicated unit
     // test targets.
-    config_.grpc_based_resource_broadcast = false;
     config_.grpc_pubsub_enabled = enable_gcs_bootstrap_;
-    ;
 
     client_io_service_ = std::make_unique<instrumented_io_context>();
     client_io_service_thread_ = std::make_unique<std::thread>([this] {
@@ -577,37 +575,6 @@ TEST_P(GcsClientTest, TestNodeInfo) {
   ASSERT_TRUE(gcs_client_->Nodes().IsRemoved(node2_id));
 }
 
-TEST_P(GcsClientTest, TestNodeResources) {
-  // Subscribe to node resource changes.
-  std::atomic<int> add_count(0);
-  std::atomic<int> remove_count(0);
-  auto on_subscribe = [&add_count,
-                       &remove_count](const rpc::NodeResourceChange &notification) {
-    if (0 == notification.deleted_resources_size()) {
-      ++add_count;
-    } else {
-      ++remove_count;
-    }
-  };
-  ASSERT_TRUE(SubscribeToResources(on_subscribe));
-
-  // Register node.
-  auto node_info = Mocker::GenNodeInfo();
-  RAY_CHECK(RegisterNode(*node_info));
-
-  // Update resources of node in GCS.
-  NodeID node_id = NodeID::FromBinary(node_info->node_id());
-  std::string key = "CPU";
-  ASSERT_TRUE(UpdateResources(node_id, key));
-  WaitForExpectedCount(add_count, 1);
-  ASSERT_TRUE(GetResources(node_id).count(key));
-
-  // Delete resources of a node from GCS.
-  ASSERT_TRUE(DeleteResources(node_id, {key}));
-  WaitForExpectedCount(remove_count, 1);
-  ASSERT_TRUE(GetResources(node_id).empty());
-}
-
 TEST_P(GcsClientTest, TestNodeResourceUsage) {
   // Register node.
   auto node_info = Mocker::GenNodeInfo();
@@ -844,14 +811,6 @@ TEST_P(GcsClientTest, TestNodeTableResubscribe) {
   };
   ASSERT_TRUE(SubscribeToNodeChange(node_subscribe));
 
-  // Subscribe to node resource changes.
-  std::atomic<int> resource_change_count(0);
-  auto resource_subscribe =
-      [&resource_change_count](const rpc::NodeResourceChange &result) {
-        ++resource_change_count;
-      };
-  ASSERT_TRUE(SubscribeToResources(resource_subscribe));
-
   auto node_info = Mocker::GenNodeInfo(1);
   ASSERT_TRUE(RegisterNode(*node_info));
   NodeID node_id = NodeID::FromBinary(node_info->node_id());
@@ -873,7 +832,6 @@ TEST_P(GcsClientTest, TestNodeTableResubscribe) {
   ASSERT_TRUE(ReportResourceUsage(resources));
 
   WaitForExpectedCount(node_change_count, 2);
-  WaitForExpectedCount(resource_change_count, 2);
 }
 
 TEST_P(GcsClientTest, TestWorkerTableResubscribe) {

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -133,8 +133,10 @@ void GcsResourceManager::HandleDeleteResources(
       for (const auto &resource_name : resource_names) {
         node_resource_change.add_deleted_resources(resource_name);
       }
-      absl::MutexLock guard(&resource_buffer_mutex_);
-      resources_buffer_proto_.add_batch()->mutable_change()->Swap(&node_resource_change);
+      {
+        absl::MutexLock guard(&resource_buffer_mutex_);
+        resources_buffer_proto_.add_batch()->mutable_change()->Swap(&node_resource_change);
+      }
 
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
     };

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -22,20 +22,12 @@ namespace gcs {
 
 GcsResourceManager::GcsResourceManager(
     instrumented_io_context &main_io_service, std::shared_ptr<GcsPublisher> gcs_publisher,
-    std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage, bool redis_broadcast_enabled)
+    std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage)
     : periodical_runner_(main_io_service),
       gcs_publisher_(gcs_publisher),
       gcs_table_storage_(gcs_table_storage),
-      redis_broadcast_enabled_(redis_broadcast_enabled),
       max_broadcasting_batch_size_(
-          RayConfig::instance().resource_broadcast_batch_size()) {
-  if (redis_broadcast_enabled_) {
-    periodical_runner_.RunFnPeriodically(
-        [this] { SendBatchedResourceUsage(); },
-        RayConfig::instance().raylet_report_resources_period_milliseconds(),
-        "GcsResourceManager.deadline_timer.send_batched_resource_usage");
-  }
-}
+          RayConfig::instance().resource_broadcast_batch_size()) {}
 
 void GcsResourceManager::HandleGetResources(const rpc::GetResourcesRequest &request,
                                             rpc::GetResourcesReply *reply,
@@ -92,14 +84,9 @@ void GcsResourceManager::HandleUpdateResources(
       node_resource_change.set_node_id(node_id.Binary());
       node_resource_change.mutable_updated_resources()->insert(changed_resources->begin(),
                                                                changed_resources->end());
-      if (redis_broadcast_enabled_) {
-        RAY_CHECK_OK(
-            gcs_publisher_->PublishNodeResource(node_id, node_resource_change, nullptr));
-      } else {
-        absl::MutexLock guard(&resource_buffer_mutex_);
-        resources_buffer_proto_.add_batch()->mutable_change()->Swap(
-            &node_resource_change);
-      }
+      absl::MutexLock guard(&resource_buffer_mutex_);
+      resources_buffer_proto_.add_batch()->mutable_change()->Swap(
+          &node_resource_change);
 
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
       RAY_LOG(DEBUG) << "Finished updating resources, node id = " << node_id;
@@ -147,14 +134,10 @@ void GcsResourceManager::HandleDeleteResources(
       for (const auto &resource_name : resource_names) {
         node_resource_change.add_deleted_resources(resource_name);
       }
-      if (redis_broadcast_enabled_) {
-        RAY_CHECK_OK(
-            gcs_publisher_->PublishNodeResource(node_id, node_resource_change, nullptr));
-      } else {
-        absl::MutexLock guard(&resource_buffer_mutex_);
-        resources_buffer_proto_.add_batch()->mutable_change()->Swap(
-            &node_resource_change);
-      }
+      absl::MutexLock guard(&resource_buffer_mutex_);
+      resources_buffer_proto_.add_batch()->mutable_change()->Swap(
+          &node_resource_change);
+
 
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
     };
@@ -421,16 +404,6 @@ void GcsResourceManager::GetResourceUsageBatchForBroadcast_Locked(
     buffer.add_batch()->Swap(&ptr->second);
   }
   resources_buffer_.erase(beg, ptr);
-}
-
-void GcsResourceManager::SendBatchedResourceUsage() {
-  absl::MutexLock guard(&resource_buffer_mutex_);
-  rpc::ResourceUsageBatchData batch;
-  GetResourceUsageBatchForBroadcast_Locked(batch);
-  if (batch.ByteSizeLong() > 0) {
-    RAY_CHECK_OK(gcs_publisher_->PublishResourceBatch(batch, nullptr));
-    stats::OutboundHeartbeatSizeKB.Record(batch.ByteSizeLong() / 1024.0);
-  }
 }
 
 void GcsResourceManager::UpdatePlacementGroupLoad(

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -135,7 +135,8 @@ void GcsResourceManager::HandleDeleteResources(
       }
       {
         absl::MutexLock guard(&resource_buffer_mutex_);
-        resources_buffer_proto_.add_batch()->mutable_change()->Swap(&node_resource_change);
+        resources_buffer_proto_.add_batch()->mutable_change()->Swap(
+            &node_resource_change);
       }
 
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -85,8 +85,7 @@ void GcsResourceManager::HandleUpdateResources(
       node_resource_change.mutable_updated_resources()->insert(changed_resources->begin(),
                                                                changed_resources->end());
       absl::MutexLock guard(&resource_buffer_mutex_);
-      resources_buffer_proto_.add_batch()->mutable_change()->Swap(
-          &node_resource_change);
+      resources_buffer_proto_.add_batch()->mutable_change()->Swap(&node_resource_change);
 
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
       RAY_LOG(DEBUG) << "Finished updating resources, node id = " << node_id;
@@ -135,9 +134,7 @@ void GcsResourceManager::HandleDeleteResources(
         node_resource_change.add_deleted_resources(resource_name);
       }
       absl::MutexLock guard(&resource_buffer_mutex_);
-      resources_buffer_proto_.add_batch()->mutable_change()->Swap(
-          &node_resource_change);
-
+      resources_buffer_proto_.add_batch()->mutable_change()->Swap(&node_resource_change);
 
       GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
     };

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -394,18 +394,6 @@ void GcsResourceManager::GetResourceUsageBatchForBroadcast(
   resources_buffer_.erase(beg, ptr);
 }
 
-void GcsResourceManager::GetResourceUsageBatchForBroadcast_Locked(
-    rpc::ResourceUsageBatchData &buffer) {
-  auto beg = resources_buffer_.begin();
-  auto ptr = beg;
-  for (size_t cnt = 0;
-       cnt < max_broadcasting_batch_size_ && cnt < resources_buffer_.size();
-       ++ptr, ++cnt) {
-    buffer.add_batch()->Swap(&ptr->second);
-  }
-  resources_buffer_.erase(beg, ptr);
-}
-
 void GcsResourceManager::UpdatePlacementGroupLoad(
     const std::shared_ptr<rpc::PlacementGroupLoad> placement_group_load) {
   placement_group_load_ = absl::make_optional(placement_group_load);

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -43,8 +43,7 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   /// \param gcs_table_storage GCS table external storage accessor.
   explicit GcsResourceManager(instrumented_io_context &main_io_service,
                               std::shared_ptr<GcsPublisher> gcs_publisher,
-                              std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
-                              bool redis_broadcast_enabled);
+                              std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage);
 
   virtual ~GcsResourceManager() {}
 
@@ -175,9 +174,6 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   void DeleteResources(const NodeID &node_id,
                        const std::vector<std::string> &deleted_resources);
 
-  /// Send any buffered resource usage as a single publish.
-  void SendBatchedResourceUsage();
-
   /// Prelocked version of GetResourceUsageBatchForBroadcast. This is necessary for need
   /// the functionality as part of a larger transaction.
   void GetResourceUsageBatchForBroadcast_Locked(rpc::ResourceUsageBatchData &buffer)
@@ -202,8 +198,6 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   std::shared_ptr<GcsPublisher> gcs_publisher_;
   /// Storage for GCS tables.
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
-  /// Whether or not to broadcast resource usage via redis.
-  const bool redis_broadcast_enabled_;
   /// Map from node id to the scheduling resources of the node.
   absl::flat_hash_map<NodeID, std::shared_ptr<SchedulingResources>>
       cluster_scheduling_resources_;

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -174,7 +174,7 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   void DeleteResources(const NodeID &node_id,
                        const std::vector<std::string> &deleted_resources);
 
-    /// The runner to run function periodically.
+  /// The runner to run function periodically.
   PeriodicalRunner periodical_runner_;
   /// Newest resource usage of all nodes.
   absl::flat_hash_map<NodeID, rpc::ResourcesData> node_resource_usages_;

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -174,12 +174,7 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler {
   void DeleteResources(const NodeID &node_id,
                        const std::vector<std::string> &deleted_resources);
 
-  /// Prelocked version of GetResourceUsageBatchForBroadcast. This is necessary for need
-  /// the functionality as part of a larger transaction.
-  void GetResourceUsageBatchForBroadcast_Locked(rpc::ResourceUsageBatchData &buffer)
-      EXCLUSIVE_LOCKS_REQUIRED(resource_buffer_mutex_);
-
-  /// The runner to run function periodically.
+    /// The runner to run function periodically.
   PeriodicalRunner periodical_runner_;
   /// Newest resource usage of all nodes.
   absl::flat_hash_map<NodeID, rpc::ResourcesData> node_resource_usages_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -415,13 +415,12 @@ void GcsServer::InitResourceReportPolling(const GcsInitData &gcs_init_data) {
 
 void GcsServer::InitResourceReportBroadcasting(const GcsInitData &gcs_init_data) {
   grpc_based_resource_broadcaster_ = std::make_unique<GrpcBasedResourceBroadcaster>(
-      raylet_client_pool_,
-      [this](rpc::ResourceUsageBroadcastData &buffer) {
-    gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
+      raylet_client_pool_, [this](rpc::ResourceUsageBroadcastData &buffer) {
+        gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
       });
 
-    grpc_based_resource_broadcaster_->Initialize(gcs_init_data);
-    grpc_based_resource_broadcaster_->Start();
+  grpc_based_resource_broadcaster_->Initialize(gcs_init_data);
+  grpc_based_resource_broadcaster_->Start();
 }
 
 void GcsServer::InitStatsHandler() {

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -211,9 +211,7 @@ void GcsServer::Stop() {
 
     gcs_resource_report_poller_->Stop();
 
-    if (config_.grpc_based_resource_broadcast) {
-      grpc_based_resource_broadcaster_->Stop();
-    }
+    grpc_based_resource_broadcaster_->Stop();
 
     // Shutdown the rpc server
     rpc_server_.Shutdown();
@@ -258,8 +256,8 @@ void GcsServer::InitGcsHeartbeatManager(const GcsInitData &gcs_init_data) {
 void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
   RAY_CHECK(gcs_table_storage_ && gcs_publisher_);
   gcs_resource_manager_ = std::make_shared<GcsResourceManager>(
-      main_service_, gcs_publisher_, gcs_table_storage_,
-      !config_.grpc_based_resource_broadcast);
+      main_service_, gcs_publisher_, gcs_table_storage_);
+
   // Initialize by gcs tables data.
   gcs_resource_manager_->Initialize(gcs_init_data);
   // Register service.
@@ -416,14 +414,11 @@ void GcsServer::InitResourceReportPolling(const GcsInitData &gcs_init_data) {
 }
 
 void GcsServer::InitResourceReportBroadcasting(const GcsInitData &gcs_init_data) {
-  if (config_.grpc_based_resource_broadcast) {
-    grpc_based_resource_broadcaster_.reset(new GrpcBasedResourceBroadcaster(
-        raylet_client_pool_,
-        [this](rpc::ResourceUsageBroadcastData &buffer) {
-          gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
-        }
-
-        ));
+  grpc_based_resource_broadcaster_ = std::make_unique<GrpcBasedResourceBroadcaster>(
+      raylet_client_pool_,
+      [this](rpc::ResourceUsageBroadcastData &buffer) {
+        gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
+      };
 
     grpc_based_resource_broadcaster_->Initialize(gcs_init_data);
     grpc_based_resource_broadcaster_->Start();
@@ -515,9 +510,7 @@ void GcsServer::InstallEventListeners() {
     gcs_actor_manager_->SchedulePendingActors();
     gcs_heartbeat_manager_->AddNode(NodeID::FromBinary(node->node_id()));
     gcs_resource_report_poller_->HandleNodeAdded(*node);
-    if (config_.grpc_based_resource_broadcast) {
-      grpc_based_resource_broadcaster_->HandleNodeAdded(*node);
-    }
+    grpc_based_resource_broadcaster_->HandleNodeAdded(*node);
   });
   gcs_node_manager_->AddNodeRemovedListener(
       [this](std::shared_ptr<rpc::GcsNodeInfo> node) {
@@ -530,9 +523,7 @@ void GcsServer::InstallEventListeners() {
         gcs_actor_manager_->OnNodeDead(node_id, node_ip_address);
         raylet_client_pool_->Disconnect(NodeID::FromBinary(node->node_id()));
         gcs_resource_report_poller_->HandleNodeRemoved(*node);
-        if (config_.grpc_based_resource_broadcast) {
-          grpc_based_resource_broadcaster_->HandleNodeRemoved(*node);
-        }
+        grpc_based_resource_broadcaster_->HandleNodeRemoved(*node);
       });
 
   // Install worker event listener.
@@ -597,9 +588,7 @@ std::string GcsServer::GetDebugState() const {
          << gcs_publisher_->DebugString() << "\n\n"
          << runtime_env_manager_->DebugString() << "\n\n";
 
-  if (config_.grpc_based_resource_broadcast) {
-    stream << grpc_based_resource_broadcaster_->DebugString();
-  }
+  stream << grpc_based_resource_broadcaster_->DebugString();
   return stream.str();
 }
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -417,12 +417,12 @@ void GcsServer::InitResourceReportBroadcasting(const GcsInitData &gcs_init_data)
   grpc_based_resource_broadcaster_ = std::make_unique<GrpcBasedResourceBroadcaster>(
       raylet_client_pool_,
       [this](rpc::ResourceUsageBroadcastData &buffer) {
-        gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
+    gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
       };
 
     grpc_based_resource_broadcaster_->Initialize(gcs_init_data);
     grpc_based_resource_broadcaster_->Start();
-  }
+}
 }
 
 void GcsServer::InitStatsHandler() {

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -418,11 +418,10 @@ void GcsServer::InitResourceReportBroadcasting(const GcsInitData &gcs_init_data)
       raylet_client_pool_,
       [this](rpc::ResourceUsageBroadcastData &buffer) {
     gcs_resource_manager_->GetResourceUsageBatchForBroadcast(buffer);
-      };
+      });
 
     grpc_based_resource_broadcaster_->Initialize(gcs_init_data);
     grpc_based_resource_broadcaster_->Start();
-}
 }
 
 void GcsServer::InitStatsHandler() {

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -46,7 +46,6 @@ struct GcsServerConfig {
   bool retry_redis = true;
   bool enable_sharding_conn = true;
   std::string node_ip_address;
-  bool grpc_based_resource_broadcast = false;
   bool grpc_pubsub_enabled = false;
   std::string log_dir;
   // This includes the config list of raylet.

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -84,8 +84,6 @@ int main(int argc, char *argv[]) {
   gcs_server_config.redis_password = redis_password;
   gcs_server_config.retry_redis = retry_redis;
   gcs_server_config.node_ip_address = node_ip_address;
-  gcs_server_config.grpc_based_resource_broadcast =
-      RayConfig::instance().grpc_based_resource_broadcast();
   gcs_server_config.grpc_pubsub_enabled = RayConfig::instance().gcs_grpc_based_pubsub();
   gcs_server_config.log_dir = log_dir;
   gcs_server_config.raylet_config_list = config_list;

--- a/src/ray/gcs/gcs_server/test/gcs_based_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_based_actor_scheduler_test.cc
@@ -40,7 +40,7 @@ class GcsBasedActorSchedulerTest : public ::testing::Test {
     gcs_actor_table_ =
         std::make_shared<GcsServerMocker::MockedGcsActorTable>(store_client_);
     gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(
-        io_service_, gcs_publisher_, gcs_table_storage_, true);
+        io_service_, gcs_publisher_, gcs_table_storage_);
     auto resource_scheduler =
         std::make_shared<gcs::GcsResourceScheduler>(*gcs_resource_manager_);
     gcs_actor_scheduler_ =

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
@@ -37,7 +37,7 @@ class GcsPlacementGroupManagerMockTest : public Test {
     gcs_placement_group_scheduler_ =
         std::make_shared<MockGcsPlacementGroupSchedulerInterface>();
     resource_manager_ =
-        std::make_shared<MockGcsResourceManager>(io_context_, nullptr, nullptr, true);
+        std::make_shared<MockGcsResourceManager>(io_context_, nullptr, nullptr);
 
     gcs_placement_group_manager_ = std::make_unique<GcsPlacementGroupManager>(
         io_context_, gcs_placement_group_scheduler_, gcs_table_storage_,

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -80,7 +80,7 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
         std::make_unique<GcsServerMocker::MockGcsPubSub>(redis_client_));
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_resource_manager_ =
-        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr);
     gcs_placement_group_manager_.reset(new gcs::GcsPlacementGroupManager(
         io_service_, mock_placement_group_scheduler_, gcs_table_storage_,
         *gcs_resource_manager_,

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -42,7 +42,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     gcs_publisher_ = std::make_shared<gcs::GcsPublisher>(
         std::make_unique<GcsServerMocker::MockGcsPubSub>(redis_client_));
     gcs_resource_manager_ =
-        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr);
     gcs_resource_scheduler_ =
         std::make_shared<gcs::GcsResourceScheduler>(*gcs_resource_manager_);
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -28,7 +28,7 @@ class GcsResourceManagerTest : public ::testing::Test {
  public:
   GcsResourceManagerTest() {
     gcs_resource_manager_ =
-        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr);
   }
 
   instrumented_io_context io_service_;

--- a/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
@@ -28,7 +28,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
  public:
   void SetUp() override {
     gcs_resource_manager_ =
-        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr, true);
+        std::make_shared<gcs::GcsResourceManager>(io_service_, nullptr, nullptr);
     gcs_resource_scheduler_ =
         std::make_shared<gcs::GcsResourceScheduler>(*gcs_resource_manager_);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This flag has been turned on by default for almost 4 months. Delete the old code so that when refactoring, we don't need to take care of the legacy code path.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
