### PR TITLE
re-remove unused opencv-python-headless

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -35,7 +35,6 @@ gym>=0.21.0,<0.22.0; python_version >= '3.7'
 gym==0.19.0; python_version < '3.7'
 lz4
 scikit-image
-opencv-python-headless==4.3.0.36
 pandas>=1.0.5; python_version < '3.7'
 pandas>=1.2.0; python_version >= '3.7'
 scipy==1.4.1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
PR #16929 removed opencv-python-headless.
PR #17158 added it back but did not use it. This was noted by [a reviewer](https://github.com/ray-project/ray/pull/17158#issuecomment-982976429) since it breaks python3.9 (no wheel is available for installation).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
