### PR TITLE
[Datasets] Force local metadata resolution when unserializable `Partitioning` object provided.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -60,8 +60,8 @@ from ray.data.datasource import (
     WriteResult,
 )
 from ray.data.datasource.file_based_datasource import (
-    _wrap_s3_filesystem_workaround,
-    _unwrap_s3_filesystem_workaround,
+    _wrap_arrow_serialization_workaround,
+    _unwrap_arrow_serialization_workaround,
 )
 from ray.data.row import TableRow
 from ray.data.aggregate import AggregateFn, Sum, Max, Min, Mean, Std
@@ -1868,7 +1868,7 @@ class Dataset(Generic[T]):
                     ctx,
                     blocks,
                     metadata,
-                    _wrap_s3_filesystem_workaround(write_args),
+                    _wrap_arrow_serialization_workaround(write_args),
                 )
             )
 
@@ -2982,6 +2982,6 @@ def _do_write(
     meta: List[BlockMetadata],
     write_args: dict,
 ) -> List[ObjectRef[WriteResult]]:
-    write_args = _unwrap_s3_filesystem_workaround(write_args)
+    write_args = _unwrap_arrow_serialization_workaround(write_args)
     DatasetContext._set_current(ctx)
     return ds.do_write(blocks, meta, **write_args)

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -511,13 +511,14 @@ class _S3FileSystemWrapper:
         return _S3FileSystemWrapper._reconstruct, self._fs.__reduce__()
 
 
-def _wrap_s3_filesystem_workaround(kwargs: dict) -> dict:
+def _wrap_arrow_serialization_workaround(kwargs: dict) -> dict:
     if "filesystem" in kwargs:
         kwargs["filesystem"] = _wrap_s3_serialization_workaround(kwargs["filesystem"])
+
     return kwargs
 
 
-def _unwrap_s3_filesystem_workaround(kwargs: dict) -> dict:
+def _unwrap_arrow_serialization_workaround(kwargs: dict) -> dict:
     if isinstance(kwargs.get("filesystem"), _S3FileSystemWrapper):
         kwargs["filesystem"] = kwargs["filesystem"].unwrap()
     return kwargs

--- a/python/ray/data/impl/util.py
+++ b/python/ray/data/impl/util.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
+from types import ModuleType
 
 from ray.remote_function import DEFAULT_REMOTE_FUNCTION_CPUS
 import ray.ray_constants as ray_constants
@@ -9,6 +10,22 @@ logger = logging.getLogger(__name__)
 
 MIN_PYARROW_VERSION = (4, 0, 1)
 _VERSION_VALIDATED = False
+
+
+LazyModule = Union[None, bool, ModuleType]
+_pyarrow: LazyModule = None
+
+
+def _lazy_import_pyarrow() -> LazyModule:
+    global _pyarrow
+    if _pyarrow is None:
+        try:
+            import pyarrow as _pyarrow
+        except ModuleNotFoundError:
+            # If module is not found, set _pyarrow to False so we won't
+            # keep trying to import it on every _lazy_import_pyarrow() call.
+            _pyarrow = False
+    return _pyarrow
 
 
 def _check_pyarrow_version():

--- a/python/ray/data/impl/util.py
+++ b/python/ray/data/impl/util.py
@@ -13,19 +13,19 @@ _VERSION_VALIDATED = False
 
 
 LazyModule = Union[None, bool, ModuleType]
-_pyarrow: LazyModule = None
+_pyarrow_dataset: LazyModule = None
 
 
-def _lazy_import_pyarrow() -> LazyModule:
-    global _pyarrow
-    if _pyarrow is None:
+def _lazy_import_pyarrow_dataset() -> LazyModule:
+    global _pyarrow_dataset
+    if _pyarrow_dataset is None:
         try:
-            import pyarrow as _pyarrow
+            from pyarrow import dataset as _pyarrow_dataset
         except ModuleNotFoundError:
             # If module is not found, set _pyarrow to False so we won't
             # keep trying to import it on every _lazy_import_pyarrow() call.
-            _pyarrow = False
-    return _pyarrow
+            _pyarrow_dataset = False
+    return _pyarrow_dataset
 
 
 def _check_pyarrow_version():

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -48,8 +48,8 @@ from ray.data.datasource import (
     ReadTask,
 )
 from ray.data.datasource.file_based_datasource import (
-    _wrap_s3_filesystem_workaround,
-    _unwrap_s3_filesystem_workaround,
+    _wrap_arrow_serialization_workaround,
+    _unwrap_arrow_serialization_workaround,
 )
 from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.impl.arrow_block import ArrowRow
@@ -58,7 +58,7 @@ from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.plan import ExecutionPlan
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.stats import DatasetStats, get_or_create_stats_actor
-from ray.data.impl.util import _get_spread_resources_iter
+from ray.data.impl.util import _get_spread_resources_iter, _lazy_import_pyarrow
 
 T = TypeVar("T")
 
@@ -205,9 +205,14 @@ def read_datasource(
     Returns:
         Dataset holding the data read from the datasource.
     """
-
     # TODO(ekl) remove this feature flag.
-    if "RAY_DATASET_FORCE_LOCAL_METADATA" in os.environ:
+    force_local = "RAY_DATASET_FORCE_LOCAL_METADATA" in os.environ
+    pa = _lazy_import_pyarrow()
+    if pa:
+        partitioning = read_args.get("dataset_kwargs", {}).get("partitioning", None)
+        force_local = force_local or isinstance(partitioning, pa.dataset.Partitioning)
+
+    if force_local:
         read_tasks = datasource.prepare_read(parallelism, **read_args)
     else:
         # Prepare read in a remote task so that in Ray client mode, we aren't
@@ -218,7 +223,10 @@ def read_datasource(
         )
         read_tasks = ray.get(
             prepare_read.remote(
-                datasource, ctx, parallelism, _wrap_s3_filesystem_workaround(read_args)
+                datasource,
+                ctx,
+                parallelism,
+                _wrap_arrow_serialization_workaround(read_args),
             )
         )
 
@@ -873,6 +881,6 @@ def _get_metadata(table: Union["pyarrow.Table", "pandas.DataFrame"]) -> BlockMet
 def _prepare_read(
     ds: Datasource, ctx: DatasetContext, parallelism: int, kwargs: dict
 ) -> List[ReadTask]:
-    kwargs = _unwrap_s3_filesystem_workaround(kwargs)
+    kwargs = _unwrap_arrow_serialization_workaround(kwargs)
     DatasetContext._set_current(ctx)
     return ds.prepare_read(parallelism, **kwargs)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -210,7 +210,12 @@ def read_datasource(
     pa = _lazy_import_pyarrow()
     if pa:
         partitioning = read_args.get("dataset_kwargs", {}).get("partitioning", None)
-        force_local = force_local or isinstance(partitioning, pa.dataset.Partitioning)
+        if isinstance(partitioning, pa.dataset.Partitioning):
+            logger.info(
+                "Forcing local metadata resolution since the provided partitioning "
+                f"{partitioning} is not serializable."
+            )
+            force_local = True
 
     if force_local:
         read_tasks = datasource.prepare_read(parallelism, **read_args)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -58,7 +58,7 @@ from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.plan import ExecutionPlan
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.stats import DatasetStats, get_or_create_stats_actor
-from ray.data.impl.util import _get_spread_resources_iter, _lazy_import_pyarrow
+from ray.data.impl.util import _get_spread_resources_iter, _lazy_import_pyarrow_dataset
 
 T = TypeVar("T")
 
@@ -207,10 +207,10 @@ def read_datasource(
     """
     # TODO(ekl) remove this feature flag.
     force_local = "RAY_DATASET_FORCE_LOCAL_METADATA" in os.environ
-    pa = _lazy_import_pyarrow()
-    if pa:
+    pa_ds = _lazy_import_pyarrow_dataset()
+    if pa_ds:
         partitioning = read_args.get("dataset_kwargs", {}).get("partitioning", None)
-        if isinstance(partitioning, pa.dataset.Partitioning):
+        if isinstance(partitioning, pa_ds.Partitioning):
             logger.info(
                 "Forcing local metadata resolution since the provided partitioning "
                 f"{partitioning} is not serializable."


### PR DESCRIPTION
`pa.dataset.Partitioning` objects aren't serializable, so we need to force local metadata resolution when such objects are given as `read_parquet()` args.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #22453 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
