### PR TITLE
WIP, Windows: skip test_actor_recursive which is flakey

### DIFF
--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -24,6 +24,8 @@ if client_test_enabled():
 else:
     import ray
 
+_WIN32 = os.name == "nt"
+
 logger = logging.getLogger(__name__)
 
 
@@ -504,6 +506,7 @@ def test_actor_pass_by_ref(ray_start_regular_shared):
         ray.get(a.f.remote(error.remote()))
 
 
+@pytest.mark.skipif(_WIN32, reason="Flakey")
 def test_actor_recursive(ray_start_regular_shared):
     @ray.remote
     class Actor:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test `test_actor_recursive` is hanging on many windows CI runs. It passes flawlessly locally. In order to clean up CI, let's skip it for now.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Related to issue #20376, #21625, #21730. I am trying to recreate the exact CI environment but in the mean time I think it is prudent to skip this test.

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
