### PR TITLE
[Dataset][nighlty-test] use 2 instead of 15 windows for 1.5TB data ingestion

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -93,7 +93,7 @@ CORE_NIGHTLY_TESTS = {
         "inference",
         "shuffle_data_loader",
         "pipelined_training_50_gb",
-        "pipelined_ingestion_1500_gb_15_windows",
+        "pipelined_ingestion_1500_gb",
         "datasets_preprocess_ingest",
         "datasets_ingest_400G",
         SmokeTest("datasets_ingest_train_infer"),

--- a/release/nightly_tests/dataset/dataset_test.yaml
+++ b/release/nightly_tests/dataset/dataset_test.yaml
@@ -30,16 +30,16 @@
     prepare: python wait_cluster.py 15 1200
     script: python pipelined_training.py --epochs 1
 
-- name: pipelined_ingestion_1500_gb_15_windows
+- name: pipelined_ingestion_1500_gb
   team: core
   cluster:
     app_config: pipelined_ingestion_app.yaml
     compute_template: pipelined_ingestion_compute.yaml
 
   run:
-    timeout: 4800
+    timeout: 9600
     prepare: python wait_cluster.py 21 2400
-    script: python pipelined_training.py --epochs 2 --num-windows 15  --num-files 915 --debug
+    script: python pipelined_training.py --epochs 2 --num-windows 2 --num-files 915 --debug
 
 - name: datasets_ingest_train_infer
   team: core


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With improvement in last 3-4 months we can finish shuffle with a much smaller workingset : plasma store ratio. Change the nightly test to reflect it and to detect regression.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests: on going https://console.anyscale.com/o/anyscale-internal/projects/prj_SVFGM5yBqK6DHCfLtRMryXHM/clusters/ses_VARej6bF3j3pq4TfeQsBSvTe
   - [ ] This PR is not tested :(
