### PR TITLE
[Doc] Add actor max restarts default value to fault tolerance doc

### DIFF
--- a/doc/source/ray-core/fault-tolerance.rst
+++ b/doc/source/ray-core/fault-tolerance.rst
@@ -50,6 +50,7 @@ Ray will automatically restart actors that crash unexpectedly.
 This behavior is controlled using ``max_restarts``,
 which sets the maximum number of times that an actor will be restarted.
 If 0, the actor won't be restarted. If -1, it will be restarted infinitely.
+The default value of ``max_restarts`` is 0.
 When an actor is restarted, its state will be recreated by rerunning its
 constructor.
 After the specified number of restarts, subsequent actor methods will


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the fault tolerance page, in the section defining `max_restarts`, the default value isn't described (it only appears in the API reference for `.remote()`, which is on a different page).  This PR includes the default value on the fault tolerance page itself.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
