### PR TITLE
Update README.rst to fix the broken RLlib logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ If TensorBoard is installed, automatically visualize all trial results:
 RLlib Quick Start
 -----------------
 
-.. image:: https://github.com/ray-project/ray/raw/master/doc/source/images/rllib/rllib-logo.png
+.. image:: https://github.com/ray-project/ray/raw/master/doc/source/rllib/images/rllib-logo.png
 
 `RLlib`_ is an industry-grade library for reinforcement learning (RL), built on top of Ray.
 It offers high scalability and unified APIs for a


### PR DESCRIPTION
## Why are these changes needed?

Images got moved during doc restructuring.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
