### PR TITLE
[Core] release GIL when running `parallel_memcopy()` / `memcpy()` during serializations

### DIFF
--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -362,7 +362,8 @@ cdef class Pickle5Writer:
         (<int64_t*>ptr)[1] = protobuf_size
         # Write inband data.
         ptr += sizeof(int64_t) * 2
-        memcpy(ptr, &inband[0], len(inband))
+        with nogil:
+            memcpy(ptr, &inband[0], len(inband))
         # Write protobuf data.
         ptr += len(inband)
         self.python_object.SerializeWithCachedSizesToArray(ptr)
@@ -375,14 +376,15 @@ cdef class Pickle5Writer:
         for i in range(self.python_object.buffer_size()):
             buffer_addr = self.python_object.buffer(i).address()
             buffer_len = self.python_object.buffer(i).length()
-            if (memcopy_threads > 1 and
-                    buffer_len > kMemcopyDefaultThreshold):
-                parallel_memcopy(ptr + buffer_addr,
-                                 <const uint8_t*> self.buffers[i].buf,
-                                 buffer_len,
-                                 kMemcopyDefaultBlocksize, memcopy_threads)
-            else:
-                memcpy(ptr + buffer_addr, self.buffers[i].buf, buffer_len)
+            with nogil:
+                if (memcopy_threads > 1 and
+                        buffer_len > kMemcopyDefaultThreshold):
+                    parallel_memcopy(ptr + buffer_addr,
+                                     <const uint8_t*> self.buffers[i].buf,
+                                     buffer_len,
+                                     kMemcopyDefaultBlocksize, memcopy_threads)
+                else:
+                    memcpy(ptr + buffer_addr, self.buffers[i].buf, buffer_len)
 
 
 cdef class SerializedObject(object):
@@ -487,9 +489,10 @@ cdef class MessagePackSerializedObject(SerializedObject):
         cdef uint8_t *ptr = &buffer[0]
 
         # Write msgpack data first.
-        memcpy(ptr, self.msgpack_header_ptr, self._msgpack_header_bytes)
-        memcpy(ptr + kMessagePackOffset,
-               self.msgpack_data_ptr, self._msgpack_data_bytes)
+        with nogil:
+            memcpy(ptr, self.msgpack_header_ptr, self._msgpack_header_bytes)
+            memcpy(ptr + kMessagePackOffset,
+                   self.msgpack_data_ptr, self._msgpack_data_bytes)
 
         if self.nest_serialized_object is not None:
             self.nest_serialized_object.write_to(
@@ -516,11 +519,12 @@ cdef class RawSerializedObject(SerializedObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cdef void write_to(self, uint8_t[:] buffer) nogil:
-        if (MEMCOPY_THREADS > 1 and
-                self._total_bytes > kMemcopyDefaultThreshold):
-            parallel_memcopy(&buffer[0],
-                             self.value_ptr,
-                             self._total_bytes, kMemcopyDefaultBlocksize,
-                             MEMCOPY_THREADS)
-        else:
-            memcpy(&buffer[0], self.value_ptr, self._total_bytes)
+        with nogil:
+            if (MEMCOPY_THREADS > 1 and
+                    self._total_bytes > kMemcopyDefaultThreshold):
+                parallel_memcopy(&buffer[0],
+                                 self.value_ptr,
+                                 self._total_bytes, kMemcopyDefaultBlocksize,
+                                 MEMCOPY_THREADS)
+            else:
+                memcpy(&buffer[0], self.value_ptr, self._total_bytes)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
While investigating #22161, it is observed GIL is held for an extended amount of time (up to 1000s) with stack trace [1]. It is possible either there are many iterations within `Pickle5Writer.write_to()` calling `ray::parallel_memcopy()`, or a few `ray::parallel_memcopy()` taking a long time (less likely). Either way, `ray::parallel_memcopy()` or `std::memcpy()` should not hold GIL.

The `MessagePackSerializedObject` / `Pickle5SerializedObject` / `Pickle5Writer` `write_to()` functions have been annotated with `nogil`, which allows calling the functions without holding GIL (the annotation itself does not release GIL). It might be possible to release GIL while calling `write_to()` in `store_task_output()`, but it seems riskier for cherrypicking and requires more testing.

[1]
Python stack:
```
Process 532: ray::IDLE
Python v3.7.7 (/home/ray/anaconda3/bin/python3.7)

Thread 0x7F0A5571F740 (active+gil): "MainThread"
    main_loop (ray/worker.py:453)
    <module> (ray/workers/default_worker.py:225)
```
Python + native stack:
```
Thread 532 (idle): "MainThread"
    __pthread_timedjoin_ex (libpthread-2.27.so)
    __gthread_join (gthr-default.h:682)
    std::thread::join (thread.cc:110)
    ray::parallel_memcopy (ray/_raylet.so)
    Pickle5Writer_write_to (ray/_raylet.so)
    Pickle5SerializedObject_write_to (ray/_raylet.so)
    MessagePackSerializedObject_write_to (ray/_raylet.so)
    CoreWorker_store_task_output (ray/_raylet.so)
    CoreWorker_store_task_outputs (ray/_raylet.so)
    _raylet_task_execution_handler (ray/_raylet.so)
    std::_Function_handler<ray::Status(ray::rpc::TaskType, std::string, ray::core::RayFunction const&, std::unordered_map<std::string, double, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, double> > > const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > > const&, std::vector<ray::rpc::ObjectReference, std::allocator<ray::rpc::ObjectReference> > const&, std::vector<ray::ObjectID, std::allocator<ray::ObjectID> > const&, std::string const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > >*, std::shared_ptr<ray::LocalMemoryBuffer>&, bool*, std::vector<ray::ConcurrencyGroup, std::allocator<ray::ConcurrencyGroup> > const&, std::string), ray::Status (*)(ray::rpc::TaskType, std::string, ray::core::RayFunction const&, std::unordered_map<std::string, double, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, double> > > const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > > const&, std::vector<ray::rpc::ObjectReference, std::allocator<ray::rpc::ObjectReference> > const&, std::vector<ray::ObjectID, std::allocator<ray::ObjectID> > const&, std::string, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > >*, std::shared_ptr<ray::LocalMemoryBuffer>&, bool*, std::vector<ray::ConcurrencyGroup, std::allocator<ray::ConcurrencyGroup> > const&, std::string)>::_M_invoke (ray/_raylet.so)
    ray::core::CoreWorker::ExecuteTask (ray/_raylet.so)
    std::_Function_handler<ray::Status(ray::TaskSpecification const&, std::shared_ptr<std::unordered_map<std::string, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > >, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > > > > > >, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > >*, google::protobuf::RepeatedPtrField<ray::rpc::ObjectReferenceCount>*, bool*), std::_Bind<ray::Status (ray::core::CoreWorker(ray::core::CoreWorker*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>, std::_Placeholder<4>, std::_Placeholder<5>)::*)(ray::TaskSpecification const&, std::shared_ptr<std::unordered_map<std::string, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > >, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > > > > > > const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > >*, google::protobuf::RepeatedPtrField<ray::rpc::ObjectReferenceCount>*, bool*)> >::_M_invoke (ray/_raylet.so)
    ray::core::CoreWorkerDirectTaskReceiver::HandleTask(ray::rpc::PushTaskRequest const&, ray::rpc::PushTaskReply*, std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>)::{lambda(std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>)#1}::operator() const (ray/_raylet.so)
    std::_Function_handler<void (std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>), ray::core::CoreWorkerDirectTaskReceiver::HandleTask(ray::rpc::PushTaskRequest const&, ray::rpc::PushTaskReply*, std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>)::{lambda(std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>)#1}>::_M_invoke (ray/_raylet.so)
    ray::core::InboundRequest::Accept (ray/_raylet.so)
    ray::core::NormalSchedulingQueue::ScheduleRequests (ray/_raylet.so)
    EventTracker::RecordExecution (ray/_raylet.so)
    std::_Function_handler<void (), instrumented_io_context::post(std::function<void ()>, std::string)::{lambda()#1}>::_M_invoke (ray/_raylet.so)
    boost::asio::detail::completion_handler<std::function<void ()>, boost::asio::io_context::basic_executor_type<std::allocator<void>, (unsigned int)0> >::do_complete (ray/_raylet.so)
    boost::asio::detail::scheduler::do_run_one (ray/_raylet.so)
    boost::asio::detail::scheduler::run (ray/_raylet.so)
    boost::asio::io_context::run (ray/_raylet.so)
    ray::core::CoreWorker::RunTaskExecutionLoop (ray/_raylet.so)
    ray::core::CoreWorkerProcessImpl::RunWorkerTaskExecutionLoop (ray/_raylet.so)
    ray::core::CoreWorkerProcess::RunTaskExecutionLoop (ray/_raylet.so)
    run_task_loop (ray/_raylet.so)
    main_loop (ray/worker.py:453)
    <module> (ray/workers/default_worker.py:225)
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
