### PR TITLE
[RLlib] Add a callback for when trainer finishes initialization.

### DIFF
--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -70,6 +70,23 @@ class DefaultCallbacks:
         """
         pass
 
+    def on_trainer_init(
+        self,
+        *,
+        trainer: "Trainer",
+        **kwargs,
+    ) -> None:
+        """Callback run when a new trainer instance has finished setup.
+
+        This method gets callled at the end of Trainer.setup() after all
+        the initialization is done, and before actually training starts.
+
+        Args:
+            trainer: Reference to the trainer instance.
+            kwargs: Forward compatibility placeholder.
+        """
+        pass
+
     def on_episode_start(
         self,
         *,

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1017,6 +1017,9 @@ class Trainer(Trainable):
                 logdir=self.logdir,
             )
 
+        # Run any callbacks after trainer initialization is done.
+        self.callbacks.on_trainer_init(trainer=self)
+
     # TODO: Deprecated: In your sub-classes of Trainer, override `setup()`
     #  directly and call super().setup() from within it if you would like the
     #  default setup behavior plus some own setup logic.
@@ -1873,7 +1876,7 @@ class Trainer(Trainable):
             config=config,
             policy_state=policy_state,
             policy_mapping_fn=policy_mapping_fn,
-            policies_to_train=list(policies_to_train),
+            policies_to_train=list(policies_to_train) if policies_to_train else None,
         )
 
         def fn(worker: RolloutWorker):


### PR DESCRIPTION
## Why are these changes needed?

Add a callback so users can add customization to Trainer instance without having to extend Trainer class.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
