### PR TITLE
[runtime env][bugfix] Fix runtime env retry

### DIFF
--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -252,6 +252,7 @@ class RuntimeEnvAgent(
                     runtime_env_context = await _setup_runtime_env(
                         serialized_env, request.serialized_allocated_resource_instances
                     )
+                    error_message = None
                     break
                 except Exception as e:
                     err_msg = f"Failed to create runtime env {serialized_env}."

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -604,3 +604,13 @@ def cloned_virtualenv():
     )
     yield venv
     venv.teardown()
+
+
+@pytest.fixture
+def set_runtime_env_retry_times(request):
+    runtime_env_retry_times = getattr(request, "param", "0")
+    try:
+        os.environ["RUNTIME_ENV_RETRY_TIMES"] = runtime_env_retry_times
+        yield runtime_env_retry_times
+    finally:
+        del os.environ["RUNTIME_ENV_RETRY_TIMES"]

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -458,6 +458,8 @@ success_retry_number = 3
 runtime_env_retry_times = 0
 
 
+# This plugin can make runtime env creation failed before the retry times
+# increased to `success_retry_number`.
 class MyPlugin(RuntimeEnvPlugin):
     @staticmethod
     def validate(runtime_env_dict: dict) -> str:
@@ -489,6 +491,7 @@ def test_runtime_env_retry(set_runtime_env_retry_times, ray_start_regular):
 
     runtime_env_retry_times = int(set_runtime_env_retry_times)
     if runtime_env_retry_times >= success_retry_number:
+        # Enough retry times
         output = ray.get(
             f.options(
                 runtime_env={"plugins": {MY_PLUGIN_CLASS_PATH: {"key": "value"}}}
@@ -496,6 +499,7 @@ def test_runtime_env_retry(set_runtime_env_retry_times, ray_start_regular):
         )
         assert output == "ok"
     else:
+        # No enough retry times
         with pytest.raises(
             RuntimeEnvSetupError, match=f"Fault injection {runtime_env_retry_times}"
         ):

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -19,6 +19,8 @@ from ray._private.utils import (
 )
 
 from ray._private.runtime_env.uri_cache import URICache
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 
 
 def test_get_wheel_filename():
@@ -449,6 +451,59 @@ def test_runtime_env_log_msg(
         assert "runtime_env" in sources
     else:
         assert "runtime_env" not in sources
+
+
+MY_PLUGIN_CLASS_PATH = "ray.tests.test_runtime_env.MyPlugin"
+success_retry_number = 3
+runtime_env_retry_times = 0
+
+
+class MyPlugin(RuntimeEnvPlugin):
+    @staticmethod
+    def validate(runtime_env_dict: dict) -> str:
+        return runtime_env_dict["plugins"][MY_PLUGIN_CLASS_PATH]
+
+    @staticmethod
+    def modify_context(
+        uri: str, plugin_config_dict: dict, ctx: RuntimeEnvContext
+    ) -> None:
+        global runtime_env_retry_times
+        runtime_env_retry_times += 1
+        if runtime_env_retry_times != success_retry_number:
+            raise ValueError(f"Fault injection {runtime_env_retry_times}")
+        pass
+
+
+@pytest.mark.parametrize(
+    "set_runtime_env_retry_times",
+    [
+        str(success_retry_number - 1),
+        str(success_retry_number),
+    ],
+    indirect=True,
+)
+def test_runtime_env_retry(set_runtime_env_retry_times, ray_start_regular):
+    @ray.remote
+    def f():
+        return "ok"
+
+    runtime_env_retry_times = int(set_runtime_env_retry_times)
+    if runtime_env_retry_times >= success_retry_number:
+        output = ray.get(
+            f.options(
+                runtime_env={"plugins": {MY_PLUGIN_CLASS_PATH: {"key": "value"}}}
+            ).remote()
+        )
+        assert output == "ok"
+    else:
+        with pytest.raises(
+            RuntimeEnvSetupError, match=f"Fault injection {runtime_env_retry_times}"
+        ):
+            ray.get(
+                f.options(
+                    runtime_env={"plugins": {MY_PLUGIN_CLASS_PATH: {"key": "value"}}}
+                ).remote()
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Why are these changes needed?
- Bug: `error_message` is not cleared when the retry succeeds. This bug lead to runtime env creation failing.
- Add test case for this. 


## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
