### PR TITLE
[Release 1.11.0] Cherrypick [Dataset][nighlyt-test] pin pyarrow==4.0.1 for dataset related tests

### DIFF
--- a/release/nightly_tests/dataset/app_config.yaml
+++ b/release/nightly_tests/dataset/app_config.yaml
@@ -3,7 +3,7 @@ base_image: "anyscale/ray-ml:nightly-py37-gpu"
 python:
   pip_packages:
     - boto3
-    - pyarrow
+    - pyarrow<7.0.0
     - tqdm
   conda_packages: []
 

--- a/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
@@ -2,7 +2,7 @@ base_image: "anyscale/ray-ml:nightly-py37-gpu"
 env_vars: {"RAY_lineage_pinning_enabled": "1", "RAY_record_ref_creation_sites": "1"}
 python:
   pip_packages:
-    - pyarrow
+    - pyarrow<7.0.0
     - cmake
   conda_packages: []
 

--- a/release/nightly_tests/dataset/pipelined_training_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_app.yaml
@@ -2,7 +2,7 @@ base_image: "anyscale/ray-ml:nightly-py37-gpu"
 
 python:
   pip_packages:
-    - pyarrow
+    - pyarrow<7.0.0
     - cmake
   conda_packages: []
 

--- a/release/nightly_tests/dataset/ray_sgd_training_app.yaml
+++ b/release/nightly_tests/dataset/ray_sgd_training_app.yaml
@@ -1,7 +1,8 @@
 base_image: "anyscale/ray:nightly-py37-cu102"
 
 python:
-  pip_packages: []
+  pip_packages:
+    - pyarrow<7.0.0
   conda_packages: []
 
 post_build_cmds:

--- a/release/nightly_tests/dataset/shuffle_app_config.yaml
+++ b/release/nightly_tests/dataset/shuffle_app_config.yaml
@@ -1,7 +1,9 @@
 base_image: "anyscale/ray-ml:nightly-py37-gpu"
 
 python:
-  pip_packages: ["boto3", "pyarrow"]
+  pip_packages:
+    - boto3
+    - pyarrow<7.0.0
   conda_packages: []
 
 post_build_cmds:


### PR DESCRIPTION
Original PR: #22277

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is likely needed to fix the `pipelined_ingestion_1500_gb_15_windows` failure on the `releases/1.11.0` branch. I ran the test with this patched and verified it fixes the failure on the release branch.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #22437

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
