### PR TITLE
[rllib] Upper bound `gym` version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -31,7 +31,7 @@ virtualenv
 ## setup.py extras
 dm_tree
 flask
-gym>=0.21.0; python_version >= '3.7'
+gym>=0.21.0,<0.22.0; python_version >= '3.7'
 gym==0.19.0; python_version < '3.7'
 lz4
 scikit-image

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -4,7 +4,7 @@
 # ---------------------
 # Atari
 autorom[accept-rom-license]
-gym[atari]>=0.21.0; python_version >= '3.7'
+gym[atari]>=0.21.0,<0.22.0; python_version >= '3.7'
 gym[atari]==0.19.0; python_version < '3.7'
 # Kaggle envs.
 kaggle_environments==1.7.11

--- a/python/setup.py
+++ b/python/setup.py
@@ -245,7 +245,7 @@ if setup_spec.type == SetupType.RAY:
 
     setup_spec.extras["rllib"] = setup_spec.extras["tune"] + [
         "dm_tree",
-        "gym",
+        "gym<0.22",
         "lz4",
         # matplotlib (dependency of scikit-image) 3.4.3 breaks docker build
         # Todo: Remove this when safe?


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
`gym` had 0.22 release today which is breaking a lot of the rllib tests and examples. Temporarily pins gym version for now.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
