### PR TITLE
[Tune] Reset error trials on resume for all cases

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -652,10 +652,10 @@ class TrialRunner:
 
         trials = load_trials_from_experiment_checkpoint(runner_state)
         for trial in sorted(trials, key=lambda t: t.last_update_time, reverse=True):
-            if run_errored_only and trial.status == Trial.ERROR:
+            if trial.status == Trial.ERROR:
                 new_trial = trial.reset()
                 self.add_trial(new_trial)
-            else:
+            elif not run_errored_only:
                 self.add_trial(trial)
 
     def update_pending_trial_resources(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Previously, we would reset errored trials only if resume was set to `ERRORED_ONLY`.

This means that if you set resume to "AUTO" or True and want to resume all trials, then errored trials won't be resumed. This PR resets errored trials for all cases. See https://github.com/ray-project/ray/issues/22343

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
