### PR TITLE
[GCS-Ray] update doc and error message for GCS-Ray

### DIFF
--- a/doc/source/cluster/cloud.rst
+++ b/doc/source/cluster/cloud.rst
@@ -264,16 +264,18 @@ random port.
   ...
   Next steps
     To connect to this Ray runtime from another node, run
-      ray start --address='<ip address>:6379' --redis-password='<password>'
+      ray start --address='<ip address>:6379'
 
   If connection fails, check your firewall settings and network configuration.
 
-The command will print out the address of the Redis server that was started
+The command will print out the address of the Ray GCS server that was started
 (the local node IP address plus the port number you specified).
 
 .. note::
 
-    If you already has remote redis instances, you can specify `--address=ip1:port1,ip2:port2...` to use them. The first one is primary and rest are shards. Ray will create a redis instance if the default is unreachable.
+    If you already has remote Redis instances, you can specify environment variable
+    `RAY_REDIS_ADDRESS=ip1:port1,ip2:port2...` to use them. The first one is
+    primary and rest are shards.
 
 **Then on each of the other nodes**, run the following. Make sure to replace
 ``<address>`` with the value printed by the command on the head node (it
@@ -288,7 +290,7 @@ place of an IP address and rely on the DNS.
 
 .. code-block:: bash
 
-  $ ray start --address=<address> --redis-password='<password>'
+  $ ray start --address=<address>
   --------------------
   Ray runtime started.
   --------------------
@@ -299,19 +301,15 @@ place of an IP address and rely on the DNS.
 If you wish to specify that a machine has 10 CPUs and 1 GPU, you can do this
 with the flags ``--num-cpus=10`` and ``--num-gpus=1``. See the :ref:`Configuration <configuring-ray>` page for more information.
 
-If you see ``Unable to connect to Redis. If the Redis instance is on a
-different machine, check that your firewall is configured properly.``,
-this means the ``--port`` is inaccessible at the given IP address (because, for
-example, the head node is not actually running Ray, or you have the wrong IP
-address).
+If you see ``Unable to connect to GCS at ...``,
+this means the head node is inaccessible at the given ``--address`` (because, for
+example, the head node is not actually running, a different version of Ray is
+running at the specified address, the specified address is wrong, or there are
+firewall settings preventing access).
 
 If you see ``Ray runtime started.``, then the node successfully connected to
-the IP address at the ``--port``. You should now be able to connect to the
+the head node at the ``--address``. You should now be able to connect to the
 cluster with ``ray.init(address='auto')``.
-
-If ``ray.init(address='auto')`` keeps repeating
-``redis_context.cc:303: Failed to connect to Redis, retrying.``, then the node
-is failing to connect to some other port(s) besides the main port.
 
 .. code-block:: bash
 
@@ -327,7 +325,7 @@ you can use a tool such as ``nmap`` or ``nc``.
   Host is up, received echo-reply ttl 60 (0.00087s latency).
   rDNS record for 123.456.78.910: compute04.berkeley.edu
   PORT     STATE SERVICE REASON         VERSION
-  6379/tcp open  redis   syn-ack ttl 60 Redis key-value store
+  6379/tcp open  redis?  syn-ack
   Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
   $ nc -vv -z $HEAD_ADDRESS $PORT
   Connection to compute04.berkeley.edu 6379 port [tcp/*] succeeded!

--- a/doc/source/cluster/guide.rst
+++ b/doc/source/cluster/guide.rst
@@ -229,7 +229,7 @@ architecture means that the head node will have extra stress due to GCS.
   at least as good as an r5dn.16xlarge on AWS EC2.
 * Set ``resources: {"CPU": 0}`` on the head node. (For Ray clusters deployed using Helm,
   set ``rayResources: {"CPU": 0}``.) Due to the heavy networking
-  load (and the GCS and redis processes), we recommend setting the number of
+  load (and the GCS and dashboard processes), we recommend setting the number of
   CPUs to 0 on the head node to avoid scheduling additional tasks on it.
 
 Configuring the autoscaler

--- a/doc/source/cluster/lsf.rst
+++ b/doc/source/cluster/lsf.rst
@@ -8,7 +8,7 @@ Deploying on LSF
 This document describes a couple high-level steps to run ray cluster on LSF.
 
 1) Obtain desired nodes from LSF scheduler using bsub directives.
-2) Obtain free ports on the desired nodes to start ray services like dashboard, redis etc.
+2) Obtain free ports on the desired nodes to start ray services like dashboard, GCS etc.
 3) Start ray head node on one of the available nodes.
 4) Connect all the worker nodes to the head node.
 5) Perform port forwarding to access ray dashboard.

--- a/doc/source/ray-contribute/debugging.rst
+++ b/doc/source/ray-contribute/debugging.rst
@@ -35,49 +35,6 @@ useful when filing `issues`_. The process to obtain a core dump is OS-specific,
 but usually involves running ``ulimit -c unlimited`` before starting Ray to
 allow core dump files to be written.
 
-Inspecting Redis shards
------------------------
-To inspect Redis, you can use the global state API. The easiest way to do this
-is to start or connect to a Ray cluster with ``ray.init()``, then query the API
-like so:
-
-.. code-block:: python
-
- ray.init()
- ray.nodes()
- # Returns current information about the nodes in the cluster, such as:
- # [{'ClientID': '2a9d2b34ad24a37ed54e4fcd32bf19f915742f5b',
- #   'IsInsertion': True,
- #   'NodeManagerAddress': '1.2.3.4',
- #   'NodeManagerPort': 43280,
- #   'ObjectManagerPort': 38062,
- #   'ObjectStoreSocketName': '/tmp/ray/session_2019-01-21_16-28-05_4216/sockets/plasma_store',
- #   'RayletSocketName': '/tmp/ray/session_2019-01-21_16-28-05_4216/sockets/raylet',
- #   'Resources': {'CPU': 8.0, 'GPU': 1.0}}]
-
-To inspect the primary Redis shard manually, you can also query with commands
-like the following.
-
-.. code-block:: python
-
- r_primary = ray.worker.global_worker.redis_client
- r_primary.keys("*")
-
-To inspect other Redis shards, you will need to create a new Redis client.
-For example (assuming the relevant IP address is ``127.0.0.1`` and the
-relevant port is ``1234``), you can do this as follows.
-
-.. code-block:: python
-
- import redis
- r = redis.StrictRedis(host='127.0.0.1', port=1234)
-
-You can find a list of the relevant IP addresses and ports by running
-
-.. code-block:: python
-
- r_primary.lrange('RedisShards', 0, -1)
-
 .. _backend-logging:
 
 Backend logging

--- a/doc/source/ray-core/configure.rst
+++ b/doc/source/ray-core/configure.rst
@@ -114,10 +114,9 @@ Head Node
 ~~~~~~~~~
 In addition to ports specified above, the head node needs to open several more ports.
 
-- ``--port``: Port of Redis. If `--address` is not specified, the head node will start a redis instance listening on this port. Default: 6379.
+- ``--port``: Port of Ray (GCS server). The head node will start a GCS server listening on this port. Default: 6379.
 - ``--ray-client-server-port``: Listening port for Ray Client Server. Default: 10001.
 - ``--redis-shard-ports``: Comma-separated list of ports for non-primary Redis shards. Default: Random values.
-- ``--gcs-server-port``: GCS Server port. GCS server is a stateless service that is in charge of communicating with the GCS. Default: Random value.
 
 - If ``--include-dashboard`` is true (the default), then the head node must open ``--dashboard-port``. Default: 8265.
 
@@ -158,53 +157,6 @@ and ``ray start``, it may become reachable again due to the dashboard
 restarting.
 
 If you don't want the dashboard, set ``--include-dashboard=false``.
-
-Redis Port Authentication
--------------------------
-
-Ray instances should run on a secure network without public facing ports.
-The most common threat for Ray instances is unauthorized access to Redis,
-which can be exploited to gain shell access and run arbitrary code.
-The best fix is to run Ray instances on a secure, trusted network.
-
-Running Ray on a secured network is not always feasible.
-To prevent exploits via unauthorized Redis access, Ray provides the option to
-password-protect Redis ports. While this is not a replacement for running Ray
-behind a firewall, this feature is useful for instances exposed to the internet
-where configuring a firewall is not possible. Because Redis is
-very fast at serving queries, the chosen password should be long.
-
-
-.. note:: The Redis passwords provided below may not contain spaces.
-
-Redis authentication is only supported on the raylet code path.
-
-To add authentication via the Python API, start Ray using:
-
-.. code-block:: python
-
-  ray.init(_redis_password="password")
-
-To add authentication via the CLI or to connect to an existing Ray instance with
-password-protected Redis ports:
-
-.. code-block:: bash
-
-  ray start [--head] --redis-password="password"
-
-While Redis port authentication may protect against external attackers,
-Ray does not encrypt traffic between nodes so man-in-the-middle attacks are
-possible for clusters on untrusted networks.
-
-One of most common attack with Redis is port-scanning attack. Attacker scans
-open port with unprotected redis instance and execute arbitrary code. Ray
-enables a default password for redis. Even though this does not prevent brute
-force password cracking, the default password should alleviate most of the
-port-scanning attack. Furthermore, redis and other ray services are bind
-to localhost when the ray is started using ``ray.init``.
-
-See the `Redis security documentation <https://redis.io/topics/security>`__
-for more information.
 
 TLS Authentication
 ------------------

--- a/doc/source/ray-core/memory-management.rst
+++ b/doc/source/ray-core/memory-management.rst
@@ -13,7 +13,7 @@ There are several ways that Ray applications use memory:
 .. image:: images/memory.svg
 
 Ray system memory: this is memory used internally by Ray
-  - **Redis**: memory used for storing the list of nodes and actors present in the cluster. The amount of memory used for these purposes is typically quite small.
+  - **GCS**: memory used for storing the list of nodes and actors present in the cluster. The amount of memory used for these purposes is typically quite small.
   - **Raylet**: memory used by the C++ raylet process running on each node. This cannot be controlled, but is typically quite small.
 
 Application memory: this is memory used by your application

--- a/doc/source/ray-observability/ray-logging.rst
+++ b/doc/source/ray-observability/ray-logging.rst
@@ -115,7 +115,7 @@ Here's a Ray log directory structure. Note that ``.out`` is logs from stdout/std
 
 - ``dashboard.log``: A log file of a Ray dashboard.
 - ``dashboard_agent.log``: Every Ray node has one dashboard agent. This is a log file of the agent.
-- ``gcs_server.[out|err]``: The GCS server is a stateless server that manages business logic that needs to be performed on GCS (Redis). It exists only in the head node.
+- ``gcs_server.[out|err]``: The GCS server is a stateless server that manages Ray cluster metadata. It exists only in the head node.
 - ``log_monitor.log``: The log monitor is in charge of streaming logs to the driver.
 - ``monitor.log``: Ray's cluster launcher is operated with a monitor process. It also manages the autoscaler.
 - ``monitor.[out|err]``: Stdout and stderr of a cluster launcher.
@@ -123,14 +123,14 @@ Here's a Ray log directory structure. Note that ``.out`` is logs from stdout/std
 - ``python-core-driver-[worker_id]_[pid].log``: Ray drivers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
 - ``python-core-worker-[worker_id]_[pid].log``: Ray workers consist of CPP core and Python/Java frontend. This is a log file generated from CPP code.
 - ``raylet.[out|err]``: A log file of raylets.
-- ``redis-shard_[shard_index].[out|err]``: A log file of GCS (Redis by default) shards.
-- ``redis.[out|err]``: A log file of GCS (Redis by default).
+- ``redis-shard_[shard_index].[out|err]``: Redis shard log files.
+- ``redis.[out|err]``: Redis log files.
 - ``worker-[worker_id]-[job_id]-[pid].[out|err]``: Python/Java part of Ray drivers and workers. All of stdout and stderr from tasks/actors are streamed here. Note that job_id is an id of the driver.
 - ``io-worker-[worker_id]-[pid].[out|err]``: Ray creates IO workers to spill/restore objects to external storage by default from Ray 1.3+. This is a log file of IO workers.
 
 Log rotation
 ------------
-Ray supports log rotation of log files. Note that not all components are currently supporting log rotation. (Raylet, Python/Java worker, and Redis logs are not rotating).
+Ray supports log rotation of log files. Note that not all components are currently supporting log rotation. (Raylet and Python/Java worker logs are not rotating).
 
 By default, logs are rotating when it reaches to 512MB (maxBytes), and there could be up to 5 backup files (backupCount). Indexes are appended to all backup files (e.g., `raylet.out.1`)
 If you'd like to change the log rotation configuration, you can do it by specifying environment variables. For example,

--- a/doc/source/raysgd/raysgd_pytorch.rst
+++ b/doc/source/raysgd/raysgd_pytorch.rst
@@ -472,7 +472,7 @@ Then, in your program, you'll need to connect to this cluster via ``ray.init``:
 
 .. code-block:: python
 
-    ray.init(address="auto")  # or a specific redis address of the form "ip-address:port"
+    ray.init(address="auto")  # or a specific Ray address of the form "ip-address:port"
 
 After connecting, you can scale up the number of workers seamlessly across multiple nodes:
 

--- a/doc/source/tune/tutorials/tune-distributed.rst
+++ b/doc/source/tune/tutorials/tune-distributed.rst
@@ -95,7 +95,7 @@ Running a distributed (multi-node) experiment requires Ray to be started already
 
 Across your machines, Tune will automatically detect the number of GPUs and CPUs without you needing to manage ``CUDA_VISIBLE_DEVICES``.
 
-To execute a distributed experiment, call ``ray.init(address=XXX)`` before ``tune.run``, where ``XXX`` is the Ray redis address, which defaults to ``localhost:6379``. The Tune python script should be executed only on the head node of the Ray cluster.
+To execute a distributed experiment, call ``ray.init(address=XXX)`` before ``tune.run``, where ``XXX`` is the Ray address, which defaults to ``localhost:6379``. The Tune python script should be executed only on the head node of the Ray cluster.
 
 One common approach to modifying an existing Tune experiment to go distributed is to set an ``argparse`` variable so that toggling between distributed and single-node is seamless.
 
@@ -124,7 +124,7 @@ If you used a cluster configuration (starting a cluster with ``ray up`` or ``ray
 
 .. tip::
 
-    1. In the examples, the Ray redis address commonly used is ``localhost:6379``.
+    1. In the examples, the Ray address commonly used is ``localhost:6379``.
     2. If the Ray cluster is already started, you should not need to run anything on the worker nodes.
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Update documentation to reflect that Ray no longer starts Redis by default.

Improvement error messages during Ray bootstrapping for head and worker nodes, when GCS is unavailable at the given address. Currently the error messages are:
```
2022-02-21 04:57:29,895	ERROR utils.py:1208 -- Internal KV Get failed
Traceback (most recent call last):
  File "/home/ubuntu/ray/python/ray/_private/utils.py", line 1206, in internal_kv_get_with_retry
    result = gcs_client.internal_kv_get(key, namespace)
  File "/home/ubuntu/ray/python/ray/_private/gcs_utils.py", line 146, in wrapper
    return f(self, *args, **kwargs)
  File "/home/ubuntu/ray/python/ray/_private/gcs_utils.py", line 230, in internal_kv_get
    reply = self._kv_stub.InternalKVGet(req)
  File "/home/ubuntu/anaconda3/envs/ray/lib/python3.8/site-packages/grpc/_channel.py", line 923, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/home/ubuntu/anaconda3/envs/ray/lib/python3.8/site-packages/grpc/_channel.py", line 826, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "failed to connect to all addresses"
	debug_error_string = "{"created":"@1645419449.895707218","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":4142,"referenced_errors":[{"created":"@1645419449.895701231","description":"failed to connect to all addresses","file":"src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc","file_line":397,"grpc_status":14}]}"
>
```
and:
```
2022-02-21 05:36:25,442	ERROR utils.py:1234 -- Internal KV Put failed
Traceback (most recent call last):
  File "/home/ubuntu/ray/python/ray/_private/utils.py", line 1230, in internal_kv_put_with_retry
    return gcs_client.internal_kv_put(
  File "/home/ubuntu/ray/python/ray/_private/gcs_utils.py", line 146, in wrapper
    return f(self, *args, **kwargs)
  File "/home/ubuntu/ray/python/ray/_private/gcs_utils.py", line 249, in internal_kv_put
    reply = self._kv_stub.InternalKVPut(req)
  File "/home/ubuntu/anaconda3/envs/ray/lib/python3.8/site-packages/grpc/_channel.py", line 923, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/home/ubuntu/anaconda3/envs/ray/lib/python3.8/site-packages/grpc/_channel.py", line 826, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "failed to connect to all addresses"
	debug_error_string = "{"created":"@1645421785.442421870","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":4142,"referenced_errors":[{"created":"@1645421785.442418121","description":"failed to connect to all addresses","file":"src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc","file_line":397,"grpc_status":14}]}"
>
```
which are not very helpful to the users for troubleshooting. The updated message is:
```
2022-02-20 21:53:52,369	WARNING utils.py:1213 -- Unable to connect to GCS at 127.0.0.1:8080. Check that (1) Ray GCS with matching version started successfully at the specified address, and (2) there is no firewall setting preventing access.
```

This change should have been sent out when enabling GCS-Ray. I'm asking for this to be cherry picked into the `releases/1.11.0` branch.



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
