### PR TITLE
[RLlib] Fix typo in vector_env docstring

### DIFF
--- a/rllib/env/vector_env.py
+++ b/rllib/env/vector_env.py
@@ -60,7 +60,7 @@ class VectorEnv:
             action_space: The action space. If None, use existing_envs[0]'s
                 action space.
             observation_space: The observation space. If None, use
-                existing_envs[0]'s action space.
+                existing_envs[0]'s observation space.
 
         Returns:
             The resulting _VectorizedGymEnv object (subclass of VectorEnv).
@@ -207,7 +207,7 @@ class _VectorizedGymEnv(VectorEnv):
             action_space: The action space. If None, use existing_envs[0]'s
                 action space.
             observation_space: The observation space. If None, use
-                existing_envs[0]'s action space.
+                existing_envs[0]'s observation space.
         """
         self.envs = existing_envs
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previous docstring about vector_env's `observation_space` is wrong.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

(Not applicable)
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] (Not )I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
