### PR TITLE
[Scheduler] Cancel pending tasks when the scheduling class becomes infeasible

### DIFF
--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -780,9 +780,10 @@ bool LocalTaskManager::CancelTask(
 
 void LocalTaskManager::CancelInfeasiblePlacementGroupTasks(
     std::deque<std::shared_ptr<internal::Work>> &tasks) {
-  for (auto work_it = tasks.begin(); work_it != tasks.end(); work_it++) {
+  for (auto work_it = tasks.begin(); work_it != tasks.end();) {
     if ((*work_it)->GetState() != internal::WorkStatus::WAITING) {
       // Only cancel waiting tasks.
+      ++work_it;
       continue;
     }
     RAY_LOG(DEBUG) << "Canceling infeasible task "
@@ -792,7 +793,7 @@ void LocalTaskManager::CancelInfeasiblePlacementGroupTasks(
         rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_PLACEMENT_GROUP_REMOVED,
         "Task/Actor cancelled, the related placement group has been removed.");
     (*work_it)->SetStateCancelled();
-    tasks.erase(work_it);
+    work_it = tasks.erase(work_it);
   }
 }
 

--- a/src/ray/raylet/local_task_manager.h
+++ b/src/ray/raylet/local_task_manager.h
@@ -268,6 +268,12 @@ class LocalTaskManager : public ILocalTaskManager {
                    std::vector<std::unique_ptr<RayObject>> args);
   void ReleaseTaskArgs(const TaskID &task_id);
 
+  // The only reason a task becomes infeasible is because the
+  // related placement group has been removed. In this case,
+  // we should cancel all pending tasks.
+  void CancelInfeasiblePlacementGroupTasks(
+      std::deque<std::shared_ptr<internal::Work>> &tasks);
+
  private:
   const NodeID &self_node_id_;
   /// Responsible for resource tracking/view of the cluster.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The only reason a task becomes infeasible in local task manager is because of it's scheduling on a placement group, and the placement group has been removed. 

In this case, we should reply to the client that this task/work is cancelled due to pg removal.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
