### PR TITLE
[Java] Add javac.activative dependency for java worker.

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -48,6 +48,7 @@ define_java_module(
         "@maven//:com_lmax_disruptor",
         "@maven//:com_sun_xml_bind_jaxb_core",
         "@maven//:com_sun_xml_bind_jaxb_impl",
+        "@maven//:javax_activation_activation",
         "@maven//:javax_xml_bind_jaxb_api",
         "@maven//:org_apache_logging_log4j_log4j_api",
         "@maven//:org_apache_logging_log4j_log4j_core",

--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -15,6 +15,7 @@ def gen_java_deps():
             "commons-io:commons-io:2.7",
             "de.ruedigermoeller:fst:2.57",
             "javax.xml.bind:jaxb-api:2.3.0",
+            "javax.activation:activation:1.1.1",
             "org.apache.commons:commons-lang3:3.4",
             "org.msgpack:msgpack-core:0.8.20",
             "org.ow2.asm:asm:6.0",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds `javac.activative` as Java worker dependency to address the issue that some users need `JAXB`  on >= JDK9.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Close #21646
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
