### PR TITLE
[tune] Note `TPESampler` performance issues in docs

### DIFF
--- a/python/ray/tune/suggest/optuna.py
+++ b/python/ray/tune/suggest/optuna.py
@@ -121,6 +121,16 @@ class OptunaSearch(Searcher):
             draw hyperparameter configurations. Defaults to ``MOTPESampler``
             for multi-objective optimization with Optuna<2.9.0, and
             ``TPESampler`` in every other case.
+
+            ..warning::
+                Please note that with Optuna 2.10.0 and earlier
+                default ``MOTPESampler``/``TPESampler`` suffer
+                from performance issues when dealing with a large number of
+                completed trials (approx. >100). This will manifest as
+                a delay when suggesting new configurations.
+                This is an Optuna issue and may be fixed in a future
+                Optuna release.
+
         seed (int): Seed to initialize sampler with. This parameter is only
             used when ``sampler=None``. In all other cases, the sampler
             you pass should be initialized with the seed already.

--- a/python/ray/tune/suggest/optuna.py
+++ b/python/ray/tune/suggest/optuna.py
@@ -122,7 +122,7 @@ class OptunaSearch(Searcher):
             for multi-objective optimization with Optuna<2.9.0, and
             ``TPESampler`` in every other case.
 
-            ..warning::
+            .. warning::
                 Please note that with Optuna 2.10.0 and earlier
                 default ``MOTPESampler``/``TPESampler`` suffer
                 from performance issues when dealing with a large number of
@@ -141,7 +141,7 @@ class OptunaSearch(Searcher):
             needing to re-compute the trial. Must be the same length as
             points_to_evaluate.
 
-            ..warning::
+            .. warning::
                 When using ``evaluated_rewards``, the search space ``space``
                 must be provided as a :class:`dict` with parameter names as
                 keys and ``optuna.distributions`` instances as values. The


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The default `TPESampler` for Optuna suffers from performance issues with a large number of completed trials. This is an Optuna issue. This PR adds a warning to the docstring of `OptunaSampler` regarding this.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
