### PR TITLE
[1/X][Pipeline] Add deployment nodes

### DIFF
--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -76,6 +76,7 @@ class ClassNode(DAGNode):
     def __str__(self) -> str:
         return get_dag_node_str(self, str(self._body))
 
+
 class _UnboundClassMethodNode(object):
     def __init__(self, actor: ClassNode, method_name: str):
         self._actor = actor

--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -1,6 +1,7 @@
 import ray
 from ray.experimental.dag.dag_node import DAGNode
 from ray.experimental.dag.input_node import InputNode
+from ray.experimental.dag.format_utils import get_dag_node_str
 
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -56,12 +57,24 @@ class ClassNode(DAGNode):
             .remote(*self._bound_args, **self._bound_kwargs)
         )
 
+    def _contain_input_node(self) -> bool:
+        """Check if InputNode is used in children DAGNodes with current node
+        as the root.
+        """
+        children_dag_nodes = self._get_all_child_nodes()
+        for child in children_dag_nodes:
+            if isinstance(child, InputNode):
+                return True
+        return False
+
     def __getattr__(self, method_name: str):
         # Raise an error if the method is invalid.
         getattr(self._body, method_name)
         call_node = _UnboundClassMethodNode(self, method_name)
         return call_node
 
+    def __str__(self) -> str:
+        return get_dag_node_str(self, str(self._body))
 
 class _UnboundClassMethodNode(object):
     def __init__(self, actor: ClassNode, method_name: str):
@@ -124,21 +137,6 @@ class ClassMethodNode(DAGNode):
             method_options,
             other_args_to_resolve=other_args_to_resolve,
         )
-        # TODO: (jiaodong) revisit constraints on dag INPUT before moving out
-        # of experimental folder
-        has_input_node = self._contain_input_node()
-        if has_input_node:
-            if (
-                len(self.get_args()) != 1
-                or not isinstance(self.get_args()[0], InputNode)
-                or self.get_kwargs() != {}
-            ):
-                raise ValueError(
-                    "InputNode marks the entrypoint of user request to the "
-                    "DAG, please ensure InputNode is the only input to a "
-                    "ClassMethodNode, and NOT used in conjunction with, or "
-                    "nested within other args or kwargs."
-                )
 
     def _copy_impl(
         self,
@@ -163,3 +161,6 @@ class ClassMethodNode(DAGNode):
             *self._bound_args,
             **self._bound_kwargs,
         )
+
+    def __str__(self) -> str:
+        return get_dag_node_str(self, f"{self._method_name}()")

--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -26,7 +26,7 @@ class ClassNode(DAGNode):
             other_args_to_resolve=other_args_to_resolve,
         )
 
-        if self._contain_input_node():
+        if self._contains_input_node():
             raise ValueError(
                 "InputNode handles user dynamic input the the DAG, and "
                 "cannot be used as args, kwargs, or other_args_to_resolve "
@@ -57,7 +57,7 @@ class ClassNode(DAGNode):
             .remote(*self._bound_args, **self._bound_kwargs)
         )
 
-    def _contain_input_node(self) -> bool:
+    def _contains_input_node(self) -> bool:
         """Check if InputNode is used in children DAGNodes with current node
         as the root.
         """

--- a/python/ray/experimental/dag/format_utils.py
+++ b/python/ray/experimental/dag/format_utils.py
@@ -1,4 +1,4 @@
-import ray.experimental.dag as ray_dag
+from ray.experimental.dag import DAGNode
 
 
 def get_indentation(num_spaces=4):
@@ -12,7 +12,7 @@ def get_args_lines(bound_args):
     indent = get_indentation()
     lines = []
     for arg in bound_args:
-        if isinstance(arg, ray_dag.DAGNode):
+        if isinstance(arg, DAGNode):
             node_repr_lines = str(arg).split("\n")
             for node_repr_line in node_repr_lines:
                 lines.append(f"{indent}" + node_repr_line)
@@ -50,7 +50,7 @@ def get_kwargs_lines(bound_kwargs):
     indent = get_indentation()
     kwargs_lines = []
     for key, val in bound_kwargs.items():
-        if isinstance(val, ray_dag.DAGNode):
+        if isinstance(val, DAGNode):
             node_repr_lines = str(val).split("\n")
             for index, node_repr_line in enumerate(node_repr_lines):
                 if index == 0:
@@ -108,7 +108,7 @@ def get_other_args_to_resolve_lines(other_args_to_resolve):
     indent = get_indentation()
     other_args_to_resolve_lines = []
     for key, val in other_args_to_resolve.items():
-        if isinstance(val, ray_dag.DAGNode):
+        if isinstance(val, DAGNode):
             node_repr_lines = str(val).split("\n")
             for index, node_repr_line in enumerate(node_repr_lines):
                 if index == 0:
@@ -131,3 +131,22 @@ def get_other_args_to_resolve_lines(other_args_to_resolve):
         other_args_to_resolve_line += f"\n{indent}{line}"
     other_args_to_resolve_line += f"\n{indent}}}"
     return other_args_to_resolve_line
+
+
+def get_dag_node_str(
+    dag_node: DAGNode,
+    body_line,
+):
+    indent = get_indentation()
+    other_args_to_resolve_lines = get_other_args_to_resolve_lines(
+        dag_node._bound_other_args_to_resolve
+    )
+    return (
+        f"({dag_node.__class__.__name__})(\n"
+        f"{indent}body={body_line}\n"
+        f"{indent}args={get_args_lines(dag_node._bound_args)}\n"
+        f"{indent}kwargs={get_kwargs_lines(dag_node._bound_kwargs)}\n"
+        f"{indent}options={get_options_lines(dag_node._bound_options)}\n"
+        f"{indent}other_args_to_resolve={other_args_to_resolve_lines}\n"
+        f")"
+    )

--- a/python/ray/experimental/dag/function_node.py
+++ b/python/ray/experimental/dag/function_node.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 import ray
 from ray.experimental.dag.dag_node import DAGNode
 from ray.experimental.dag.input_node import InputNode
+from ray.experimental.dag.format_utils import get_dag_node_str
 
 
 class FunctionNode(DAGNode):
@@ -24,27 +25,6 @@ class FunctionNode(DAGNode):
             func_options,
             other_args_to_resolve=other_args_to_resolve,
         )
-        # TODO: (jiaodong) Disallow binding other args if InputNode is used.
-        # revisit this constraint before moving out of experimental folder
-        has_input_node = self._contain_input_node()
-        if has_input_node:
-            # Invalid usecases:
-            # f.bind(InputNode(), 1, 2)
-            # f.bind(1, 2, key=InputNode())
-            # f.bind({"nested": InputNode()})
-            # f.bind(InputNode(), key=123)
-            if (
-                len(self.get_args()) != 1
-                or not isinstance(self.get_args()[0], InputNode)
-                or self.get_kwargs() != {}
-                or self.get_other_args_to_resolve() != {}
-            ):
-                raise ValueError(
-                    "InputNode marks the entrypoint of user request to the "
-                    "DAG, please ensure InputNode is the only input to a "
-                    "FunctionNode, and NOT used in conjunction with, or "
-                    "nested within other args or kwargs."
-                )
 
     def _copy_impl(
         self,
@@ -68,3 +48,6 @@ class FunctionNode(DAGNode):
             .options(**self._bound_options)
             .remote(*self._bound_args, **self._bound_kwargs)
         )
+
+    def __str__(self) -> str:
+        return get_dag_node_str(self, str(self._body))

--- a/python/ray/experimental/dag/function_node.py
+++ b/python/ray/experimental/dag/function_node.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List
 
 import ray
 from ray.experimental.dag.dag_node import DAGNode
-from ray.experimental.dag.input_node import InputNode
 from ray.experimental.dag.format_utils import get_dag_node_str
 
 

--- a/python/ray/experimental/dag/input_node.py
+++ b/python/ray/experimental/dag/input_node.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 from ray.experimental.dag import DAGNode
+from ray.experimental.dag.format_utils import get_dag_node_str
 
 
 class InputNode(DAGNode):
@@ -45,3 +46,6 @@ class InputNode(DAGNode):
         """Executor of InputNode by ray.remote()"""
         # TODO: (jiaodong) Extend this to take more complicated user inputs
         return args[0]
+
+    def __str__(self) -> str:
+        return get_dag_node_str(self, "__InputNode__")

--- a/python/ray/experimental/dag/py_obj_scanner.py
+++ b/python/ray/experimental/dag/py_obj_scanner.py
@@ -36,11 +36,15 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler):
         from ray.experimental.dag.function_node import FunctionNode
         from ray.experimental.dag.class_node import ClassNode, ClassMethodNode
         from ray.experimental.dag.input_node import InputNode
+        from ray.serve.pipeline.deployment_node import DeploymentNode
+        from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
 
         self.dispatch_table[FunctionNode] = self._reduce_dag_node
         self.dispatch_table[ClassNode] = self._reduce_dag_node
         self.dispatch_table[ClassMethodNode] = self._reduce_dag_node
         self.dispatch_table[InputNode] = self._reduce_dag_node
+        self.dispatch_table[DeploymentNode] = self._reduce_dag_node
+        self.dispatch_table[DeploymentMethodNode] = self._reduce_dag_node
         super().__init__(self._buf)
 
     def find_nodes(self, obj: Any) -> List["DAGNode"]:

--- a/python/ray/experimental/dag/tests/test_input_node.py
+++ b/python/ray/experimental/dag/tests/test_input_node.py
@@ -101,29 +101,6 @@ def test_multi_input_func_dag(shared_ray_instance):
     assert ray.get(dag.execute(3)) == 10
 
 
-def test_invalid_input_node_in_function_node(shared_ray_instance):
-    @ray.remote
-    def f(input):
-        return input
-
-    with pytest.raises(
-        ValueError, match="ensure InputNode is the only input to a FunctionNode"
-    ):
-        f._bind([[{"nested": InputNode()}]])
-    with pytest.raises(
-        ValueError, match="ensure InputNode is the only input to a FunctionNode"
-    ):
-        f._bind(InputNode(), 1, 2)
-    with pytest.raises(
-        ValueError, match="ensure InputNode is the only input to a FunctionNode"
-    ):
-        f._bind(1, 2, key=InputNode())
-    with pytest.raises(
-        ValueError, match="ensure InputNode is the only input to a FunctionNode"
-    ):
-        f._bind(InputNode(), key=123)
-
-
 def test_invalid_input_node_as_class_constructor(shared_ray_instance):
     @ray.remote
     class Actor:
@@ -143,39 +120,6 @@ def test_invalid_input_node_as_class_constructor(shared_ray_instance):
         ),
     ):
         Actor._bind(InputNode())
-
-
-def test_invalid_input_node_in_class_method_node(shared_ray_instance):
-    @ray.remote
-    class Actor:
-        def __init__(self, val):
-            self.val = val
-
-        def get(self, input1, input2):
-            return self.val + input1 + input2
-
-    actor = Actor._bind(1)
-
-    with pytest.raises(
-        ValueError,
-        match="ensure InputNode is the only input to a ClassMethodNode",
-    ):
-        actor.get._bind([[{"nested": InputNode()}]])
-    with pytest.raises(
-        ValueError,
-        match="ensure InputNode is the only input to a ClassMethodNode",
-    ):
-        actor.get._bind(InputNode(), 1, 2)
-    with pytest.raises(
-        ValueError,
-        match="ensure InputNode is the only input to a ClassMethodNode",
-    ):
-        actor.get._bind(1, 2, key=InputNode())
-    with pytest.raises(
-        ValueError,
-        match="ensure InputNode is the only input to a ClassMethodNode",
-    ):
-        actor.get._bind(InputNode(), key=123)
 
 
 def test_class_method_input(shared_ray_instance):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1155,6 +1155,13 @@ class Deployment:
             _internal=True,
         )
 
+    def _bind(self, *args, **kwargs):
+        raise AttributeError(
+            "DAG building API should only be used for @ray.remote decorated "
+            "class or function, not in serve deployment or library "
+            "specific API."
+        )
+
     def __eq__(self, other):
         return all(
             [

--- a/python/ray/serve/pipeline/conftest.py
+++ b/python/ray/serve/pipeline/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
 import ray
-from ray import serve
 from ray.serve.pipeline.test_utils import LOCAL_EXECUTION_ONLY
+from ray.serve.tests.conftest import _shared_serve_instance, serve_instance  # noqa
 
 
 @pytest.fixture(scope="session")
@@ -13,39 +13,3 @@ def shared_ray_instance():
     else:
         # Overriding task_retry_delay_ms to relaunch actors more quickly.
         yield ray.init(num_cpus=36, _system_config={"task_retry_delay_ms": 50})
-
-
-@pytest.fixture
-def ray_shutdown():
-    yield
-    serve.shutdown()
-    ray.shutdown()
-
-
-@pytest.fixture(scope="session")
-def _shared_serve_instance():
-    # Note(simon):
-    # This line should be not turned on on master because it leads to very
-    # spammy and not useful log in case of a failure in CI.
-    # To run locally, please use this instead.
-    # SERVE_LOG_DEBUG=1 pytest -v -s test_api.py
-    # os.environ["SERVE_LOG_DEBUG"] = "1" <- Do not uncomment this.
-
-    # Overriding task_retry_delay_ms to relaunch actors more quickly
-    ray.init(
-        num_cpus=36,
-        namespace="default_test_namespace",
-        _metrics_export_port=9999,
-        _system_config={"metrics_report_interval_ms": 1000, "task_retry_delay_ms": 50},
-    )
-    yield serve.start(detached=True)
-
-
-@pytest.fixture
-def serve_instance(_shared_serve_instance):
-    yield _shared_serve_instance
-    # Clear all state between tests to avoid naming collisions.
-    for deployment in serve.list_deployments().values():
-        deployment.delete()
-    # Clear the ServeHandle cache between tests to avoid them piling up.
-    _shared_serve_instance.handle_cache.clear()

--- a/python/ray/serve/pipeline/conftest.py
+++ b/python/ray/serve/pipeline/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 import ray
+from ray import serve
 from ray.serve.pipeline.test_utils import LOCAL_EXECUTION_ONLY
 
 
@@ -12,3 +13,39 @@ def shared_ray_instance():
     else:
         # Overriding task_retry_delay_ms to relaunch actors more quickly.
         yield ray.init(num_cpus=36, _system_config={"task_retry_delay_ms": 50})
+
+
+@pytest.fixture
+def ray_shutdown():
+    yield
+    serve.shutdown()
+    ray.shutdown()
+
+
+@pytest.fixture(scope="session")
+def _shared_serve_instance():
+    # Note(simon):
+    # This line should be not turned on on master because it leads to very
+    # spammy and not useful log in case of a failure in CI.
+    # To run locally, please use this instead.
+    # SERVE_LOG_DEBUG=1 pytest -v -s test_api.py
+    # os.environ["SERVE_LOG_DEBUG"] = "1" <- Do not uncomment this.
+
+    # Overriding task_retry_delay_ms to relaunch actors more quickly
+    ray.init(
+        num_cpus=36,
+        namespace="default_test_namespace",
+        _metrics_export_port=9999,
+        _system_config={"metrics_report_interval_ms": 1000, "task_retry_delay_ms": 50},
+    )
+    yield serve.start(detached=True)
+
+
+@pytest.fixture
+def serve_instance(_shared_serve_instance):
+    yield _shared_serve_instance
+    # Clear all state between tests to avoid naming collisions.
+    for deployment in serve.list_deployments().values():
+        deployment.delete()
+    # Clear the ServeHandle cache between tests to avoid them piling up.
+    _shared_serve_instance.handle_cache.clear()

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -1,0 +1,67 @@
+from typing import Any, Dict, Tuple, List
+
+from ray.experimental.dag import DAGNode
+from ray.experimental.dag.format_utils import get_dag_node_str
+from ray.serve.api import Deployment
+from ray.serve.handle import RayServeHandle
+
+class DeploymentMethodNode(DAGNode):
+    """Represents a deployment method invocation in a Ray function DAG."""
+
+    def __init__(
+        self,
+        deployment_body: Deployment,
+        deployment_name: str,
+        method_name: str,
+        method_args: Tuple[Any],
+        method_kwargs: Dict[str, Any],
+        method_options: Dict[str, Any],
+    ):
+        self._body = deployment_body
+        self._deployment_name: str = deployment_name
+        self._method_name: str = method_name
+        self._deployment_handle: RayServeHandle = deployment_body.get_handle()
+
+        self._bound_args = method_args or []
+        self._bound_kwargs = method_kwargs or {}
+        self._bound_options = method_options or {}
+
+        super().__init__(
+            method_args,
+            method_kwargs,
+            method_options,
+            other_args_to_resolve={},
+        )
+
+    def _copy_impl(
+        self,
+        new_args: List[Any],
+        new_kwargs: Dict[str, Any],
+        new_options: Dict[str, Any],
+        new_other_args_to_resolve: Dict[str, Any],
+    ):
+        return DeploymentMethodNode(
+            self._body,
+            self._deployment_name,
+            self._method_name,
+            new_args,
+            new_kwargs,
+            new_options,
+        )
+
+    def _execute_impl(self, *args):
+        """Executor of DeploymentMethodNode by ray.remote()"""
+        # Execute with bound args.
+        method_body = getattr(self._deployment_handle, self._method_name)
+
+        return method_body.options(**self._bound_options).remote(
+            *self._bound_args,
+            **self._bound_kwargs,
+        )
+
+
+    def __str__(self) -> str:
+        return get_dag_node_str(
+            self,
+            str(self._method_name) + "() @ " + str(self._body)
+        )

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -7,7 +7,7 @@ from ray.serve.handle import RayServeSyncHandle, RayServeHandle
 
 
 class DeploymentMethodNode(DAGNode):
-    """Represents a deployment method invocation in a Ray function DAG."""
+    """Represents a deployment method invocation of a DeploymentNode in DAG."""
 
     def __init__(
         self,
@@ -20,10 +20,12 @@ class DeploymentMethodNode(DAGNode):
     ):
         self._body = deployment_body
         self._method_name: str = method_name
-        self._bound_args = method_args or ()
-        self._bound_kwargs = method_kwargs or {}
-        self._bound_options = method_options or {}
-        self._bound_other_args_to_resolve = other_args_to_resolve or {}
+        super().__init__(
+            method_args,
+            method_kwargs,
+            method_options,
+            other_args_to_resolve=other_args_to_resolve,
+        )
         # Serve handle is sync by default.
         if (
             "sync_handle" in self._bound_other_args_to_resolve
@@ -36,13 +38,6 @@ class DeploymentMethodNode(DAGNode):
             self._deployment_handle: RayServeHandle = deployment_body.get_handle(
                 sync=False
             )
-
-        super().__init__(
-            method_args,
-            method_kwargs,
-            method_options,
-            other_args_to_resolve=other_args_to_resolve,
-        )
 
     def _copy_impl(
         self,

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -20,10 +20,14 @@ class DeploymentMethodNode(DAGNode):
     ):
         self._body = deployment_body
         self._method_name: str = method_name
+        self._bound_args = method_args or ()
+        self._bound_kwargs = method_kwargs or {}
+        self._bound_options = method_options or {}
+        self._bound_other_args_to_resolve = other_args_to_resolve or {}
         # Serve handle is sync by default.
         if (
-            "sync_handle" in other_args_to_resolve
-            and other_args_to_resolve.get("sync_handle") is True
+            "sync_handle" in self._bound_other_args_to_resolve
+            and self._bound_other_args_to_resolve.get("sync_handle") is True
         ):
             self._deployment_handle: RayServeSyncHandle = deployment_body.get_handle(
                 sync=True
@@ -32,11 +36,6 @@ class DeploymentMethodNode(DAGNode):
             self._deployment_handle: RayServeHandle = deployment_body.get_handle(
                 sync=False
             )
-
-        self._bound_args = method_args or ()
-        self._bound_kwargs = method_kwargs or {}
-        self._bound_options = method_options or {}
-        self._bound_other_args_to_resolve = other_args_to_resolve or {}
 
         super().__init__(
             method_args,

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -19,10 +19,14 @@ class DeploymentNode(DAGNode):
         other_args_to_resolve: Optional[Dict[str, Any]] = None,
     ):
         self._body: Deployment = deployment_body
+        self._bound_args = cls_args or ()
+        self._bound_kwargs = cls_kwargs or {}
+        self._bound_options = cls_options or {}
+        self._bound_other_args_to_resolve = other_args_to_resolve or {}
         # Serve handle is sync by default.
         if (
-            "sync_handle" in other_args_to_resolve
-            and other_args_to_resolve.get("sync_handle") is True
+            "sync_handle" in self._bound_other_args_to_resolve
+            and self._bound_other_args_to_resolve.get("sync_handle") is True
         ):
             self._deployment_handle: RayServeSyncHandle = deployment_body.get_handle(
                 sync=True
@@ -31,11 +35,6 @@ class DeploymentNode(DAGNode):
             self._deployment_handle: RayServeHandle = deployment_body.get_handle(
                 sync=False
             )
-
-        self._bound_args = cls_args or ()
-        self._bound_kwargs = cls_kwargs or {}
-        self._bound_options = cls_options or {}
-        self._bound_other_args_to_resolve = other_args_to_resolve or {}
 
         super().__init__(
             cls_args,

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -44,7 +44,7 @@ class DeploymentNode(DAGNode):
             other_args_to_resolve=other_args_to_resolve,
         )
 
-        if self._contain_input_node():
+        if self._contains_input_node():
             raise ValueError(
                 "InputNode handles user dynamic input the the DAG, and "
                 "cannot be used as args, kwargs, or other_args_to_resolve "
@@ -73,7 +73,7 @@ class DeploymentNode(DAGNode):
             *self._bound_args, **self._bound_kwargs
         )
 
-    def _contain_input_node(self) -> bool:
+    def _contains_input_node(self) -> bool:
         """Check if InputNode is used in children DAGNodes with current node
         as the root.
         """

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -19,10 +19,12 @@ class DeploymentNode(DAGNode):
         other_args_to_resolve: Optional[Dict[str, Any]] = None,
     ):
         self._body: Deployment = deployment_body
-        self._bound_args = cls_args or ()
-        self._bound_kwargs = cls_kwargs or {}
-        self._bound_options = cls_options or {}
-        self._bound_other_args_to_resolve = other_args_to_resolve or {}
+        super().__init__(
+            cls_args,
+            cls_kwargs,
+            cls_options,
+            other_args_to_resolve=other_args_to_resolve,
+        )
         # Serve handle is sync by default.
         if (
             "sync_handle" in self._bound_other_args_to_resolve
@@ -36,19 +38,12 @@ class DeploymentNode(DAGNode):
                 sync=False
             )
 
-        super().__init__(
-            cls_args,
-            cls_kwargs,
-            cls_options,
-            other_args_to_resolve=other_args_to_resolve,
-        )
-
         if self._contains_input_node():
             raise ValueError(
                 "InputNode handles user dynamic input the the DAG, and "
                 "cannot be used as args, kwargs, or other_args_to_resolve "
-                "in DeploymentNode constructor because it is not available at "
-                "class construction or binding time."
+                "in the DeploymentNode constructor because it is not available "
+                "at class construction or binding time."
             )
 
     def _copy_impl(

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -1,0 +1,74 @@
+
+from typing import Any, Dict, List
+
+from ray.experimental.dag import DAGNode, InputNode
+from ray.serve.api import Deployment
+from ray.serve.handle import RayServeHandle
+from ray.experimental.dag.format_utils import get_dag_node_str
+
+
+class DeploymentNode(DAGNode):
+    """Represents a deployment node in a DAG authored Ray DAG API."""
+
+    def __init__(
+        self,
+        deployment_body,
+        deployment_name,
+        cls_args,
+        cls_kwargs,
+        cls_options,
+        other_args_to_resolve=None,
+    ):
+        self._body: Deployment = deployment_body
+        self._deployment_name: str = deployment_name
+        # TODO: (jiaodong) Support async handle
+        self._deployment_handle: RayServeHandle = deployment_body.get_handle()
+
+        super().__init__(
+            cls_args,
+            cls_kwargs,
+            cls_options,
+            other_args_to_resolve=other_args_to_resolve,
+        )
+
+        if self._contain_input_node():
+            raise ValueError(
+                "InputNode handles user dynamic input the the DAG, and "
+                "cannot be used as args, kwargs, or other_args_to_resolve "
+                "in DeploymentNode constructor because it is not available at "
+                "class construction or binding time."
+            )
+
+    def _copy_impl(
+        self,
+        new_args: List[Any],
+        new_kwargs: Dict[str, Any],
+        new_options: Dict[str, Any],
+        new_other_args_to_resolve: Dict[str, Any],
+    ):
+        return DeploymentNode(
+            self._body,
+            new_args,
+            new_kwargs,
+            new_options,
+            other_args_to_resolve=new_other_args_to_resolve,
+        )
+
+    def _execute_impl(self, *args):
+        """Executor of DeploymentNode by ray.remote()"""
+        return self._deployment_handle.options(**self._bound_options).remote(
+            *self._bound_args, **self._bound_kwargs
+        )
+
+    def _contain_input_node(self) -> bool:
+        """Check if InputNode is used in children DAGNodes with current node
+        as the root.
+        """
+        children_dag_nodes = self._get_all_child_nodes()
+        for child in children_dag_nodes:
+            if isinstance(child, InputNode):
+                return True
+        return False
+
+    def __str__(self) -> str:
+        return get_dag_node_str(self, str(self._body))

--- a/python/ray/serve/pipeline/tests/test_deployment_node.py
+++ b/python/ray/serve/pipeline/tests/test_deployment_node.py
@@ -2,6 +2,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray.experimental.dag.input_node import InputNode
 from ray.serve.api import Deployment
 from ray.serve.config import DeploymentConfig
 from ray.serve.pipeline.deployment_node import DeploymentNode
@@ -9,6 +10,17 @@ from ray.serve.pipeline.deployment_node import DeploymentNode
 
 @serve.deployment
 class ServeActor:
+    def __init__(self, init_value=0):
+        self.i = init_value
+
+    def inc(self):
+        self.i += 1
+
+    def get(self):
+        return self.i
+
+
+class SyncActor:
     def __init__(self, init_value=0):
         self.i = init_value
 
@@ -35,14 +47,14 @@ def test_disallow_binding_deployments(serve_instance):
         AttributeError,
         match="DAG building API should only be used for @ray.remote decorated",
     ):
-        a1 = ServeActor._bind(10)
+        _ = ServeActor._bind(10)
 
 
 @pytest.mark.asyncio
 async def test_simple_deployment_async(serve_instance):
     """Internal testing only for simple creation and execution.
 
-    User should not directly create instances of Deployment or DeploymentNode.
+    User should NOT directly create instances of Deployment or DeploymentNode.
     """
     deployment = Deployment(
         Actor,
@@ -65,12 +77,14 @@ async def test_simple_deployment_async(serve_instance):
     assert ray.get(await node.get.execute()) == 10
     ray.get(await node.inc.execute())
     assert ray.get(await node.get.execute()) == 11
-    assert ray.get(await node.get.execute()) == ray.get(
-        await handle.get.remote()
-    )
+    assert ray.get(await node.get.execute()) == ray.get(await handle.get.remote())
 
 
 def test_simple_deployment_sync(serve_instance):
+    """Internal testing only for simple creation and execution.
+
+    User should NOT directly create instances of Deployment or DeploymentNode.
+    """
     deployment = Deployment(
         Actor,
         "test",
@@ -96,10 +110,62 @@ def test_simple_deployment_sync(serve_instance):
 
 
 def test_no_input_node_as_init_args(serve_instance):
+    """
+    User should NOT directly create instances of Deployment or DeploymentNode.
+    """
+    deployment = Deployment(
+        Actor,
+        "test",
+        DeploymentConfig(),
+        _internal=True,
+    )
+    with pytest.raises(
+        ValueError,
+        match="cannot be used as args, kwargs, or other_args_to_resolve",
+    ):
+        _ = DeploymentNode(
+            deployment,
+            [InputNode()],
+            {},
+            {},
+            other_args_to_resolve={"sync_handle": True},
+        )
+    with pytest.raises(
+        ValueError,
+        match="cannot be used as args, kwargs, or other_args_to_resolve",
+    ):
+        _ = DeploymentNode(
+            deployment,
+            [],
+            {"a": InputNode()},
+            {},
+            other_args_to_resolve={"sync_handle": True},
+        )
+    with pytest.raises(
+        ValueError,
+        match="cannot be used as args, kwargs, or other_args_to_resolve",
+    ):
+        _ = DeploymentNode(
+            deployment,
+            [],
+            {},
+            {},
+            other_args_to_resolve={"sync_handle": {"options_a": InputNode()}},
+        )
+
+
+def test_mix_sync_async_handle(serve_instance):
+    # TODO: (jiaodong) Add complex multi-deployment tests from ray DAG.
     pass
 
 
 def test_deployment_node_as_init_args(serve_instance):
+    # TODO: (jiaodong) Add complex multi-deployment tests from ray DAG.
+    pass
+
+
+def test_multi_deployment_nodes(serve_instance):
+    # TODO: (jiaodong) Add complex multi-deployment tests from ray DAG.
     pass
 
 

--- a/python/ray/serve/pipeline/tests/test_deployment_node.py
+++ b/python/ray/serve/pipeline/tests/test_deployment_node.py
@@ -1,0 +1,109 @@
+import pytest
+
+import ray
+from ray import serve
+from ray.serve.api import Deployment
+from ray.serve.config import DeploymentConfig
+from ray.serve.pipeline.deployment_node import DeploymentNode
+
+
+@serve.deployment
+class ServeActor:
+    def __init__(self, init_value=0):
+        self.i = init_value
+
+    def inc(self):
+        self.i += 1
+
+    def get(self):
+        return self.i
+
+
+class Actor:
+    def __init__(self, init_value=0):
+        self.i = init_value
+
+    async def inc(self):
+        self.i += 1
+
+    async def get(self):
+        return self.i
+
+
+def test_disallow_binding_deployments(serve_instance):
+    with pytest.raises(
+        AttributeError,
+        match="DAG building API should only be used for @ray.remote decorated",
+    ):
+        a1 = ServeActor._bind(10)
+
+
+@pytest.mark.asyncio
+async def test_simple_deployment_async(serve_instance):
+    """Internal testing only for simple creation and execution.
+
+    User should not directly create instances of Deployment or DeploymentNode.
+    """
+    deployment = Deployment(
+        Actor,
+        "test",
+        DeploymentConfig(),
+        init_args=(10,),
+        route_prefix="/test",
+        _internal=True,
+    )
+    node = DeploymentNode(
+        deployment,
+        [],
+        {},
+        {},
+        other_args_to_resolve={"sync_handle": False},
+    )
+    deployment.deploy()
+    handle = deployment.get_handle(sync=False)
+
+    assert ray.get(await node.get.execute()) == 10
+    ray.get(await node.inc.execute())
+    assert ray.get(await node.get.execute()) == 11
+    assert ray.get(await node.get.execute()) == ray.get(
+        await handle.get.remote()
+    )
+
+
+def test_simple_deployment_sync(serve_instance):
+    deployment = Deployment(
+        Actor,
+        "test",
+        DeploymentConfig(),
+        init_args=(10,),
+        route_prefix="/test",
+        _internal=True,
+    )
+    node = DeploymentNode(
+        deployment,
+        [],
+        {},
+        {},
+        other_args_to_resolve={"sync_handle": True},
+    )
+    deployment.deploy()
+    handle = deployment.get_handle(sync=True)
+
+    assert ray.get(node.get.execute()) == 10
+    ray.get(node.inc.execute())
+    assert ray.get(node.get.execute()) == 11
+    assert ray.get(node.get.execute()) == ray.get(handle.get.remote())
+
+
+def test_no_input_node_as_init_args(serve_instance):
+    pass
+
+
+def test_deployment_node_as_init_args(serve_instance):
+    pass
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray.serve.tests.conftest import serve_instance  # noqa
 
 if os.environ.get("RAY_SERVE_INTENTIONALLY_CRASH", False) == 1:
     serve.controller._CRASH_AFTER_CHECKPOINT_PROBABILITY = 0.5
@@ -14,32 +15,3 @@ def ray_shutdown():
     yield
     serve.shutdown()
     ray.shutdown()
-
-
-@pytest.fixture(scope="session")
-def _shared_serve_instance():
-    # Note(simon):
-    # This line should be not turned on on master because it leads to very
-    # spammy and not useful log in case of a failure in CI.
-    # To run locally, please use this instead.
-    # SERVE_LOG_DEBUG=1 pytest -v -s test_api.py
-    # os.environ["SERVE_LOG_DEBUG"] = "1" <- Do not uncomment this.
-
-    # Overriding task_retry_delay_ms to relaunch actors more quickly
-    ray.init(
-        num_cpus=36,
-        namespace="default_test_namespace",
-        _metrics_export_port=9999,
-        _system_config={"metrics_report_interval_ms": 1000, "task_retry_delay_ms": 50},
-    )
-    yield serve.start(detached=True)
-
-
-@pytest.fixture
-def serve_instance(_shared_serve_instance):
-    yield _shared_serve_instance
-    # Clear all state between tests to avoid naming collisions.
-    for deployment in serve.list_deployments().values():
-        deployment.delete()
-    # Clear the ServeHandle cache between tests to avoid them piling up.
-    _shared_serve_instance.handle_cache.clear()


### PR DESCRIPTION
WIP, but content is there up for review, I will add more tests on this PR.

## Diff Summary

Ray DAG Changes
- Restructured and resolves circular imports in current dag_node.py. 
- Moved `__str__` to each DAGNode subclass level with centralized utils imports
- Removed restrictions on binding `InputNode` to `FunctionNode` and `ClassMethodNode`
- Moved `_contain_input_node` to only `ClassNode` and `DeploymentNode`

Serve DAG Changes
- Added DeploymentNode
  - Cannot be directly constructed
  - Holds deployment func or class body as well as handle that trivially maps to `__call__` method (match current behavior)
  - Upon accessing an attribute, it will spawn DeploymentMethodNode node with `other_args_to_resolve` passed in to differentiate sync handle type and others
- Added DeploymentMethodNode
  - Holds arg and deployment handle
  - Executing on it translate to deployment handle call on the method. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Test Plan

Ray dag unit tests 
New serve deployment node tests

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
