### PR TITLE
Fix [Datasets] iter_epochs not iterating using native format

### DIFF
--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -133,7 +133,7 @@ class DatasetPipeline(Generic[T]):
         *,
         prefetch_blocks: int = 0,
         batch_size: int = None,
-        batch_format: str = "pandas",
+        batch_format: str = "native",
         drop_last: bool = False,
     ) -> Iterator[BatchType]:
         """Return a local batched iterator over the data in the pipeline.
@@ -149,8 +149,10 @@ class DatasetPipeline(Generic[T]):
                 current block during the scan.
             batch_size: Record batch size, or None to let the system pick.
             batch_format: The format in which to return each batch.
-                Specify "pandas" to select ``pandas.DataFrame`` or "pyarrow" to
-                select ``pyarrow.Table``. Default is "pandas".
+                Specify "native" to use the current block format (promoting
+                Arrow to pandas automatically), "pandas" to
+                select ``pandas.DataFrame`` or "pyarrow" to select
+                ``pyarrow.Table``. Default is "native".
             drop_last: Whether to drop the last batch if it's incomplete.
 
         Returns:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

DatasetPipeline had an incorrect default. Fix it to the same one from Dataset.

Closes https://github.com/ray-project/ray/issues/20510