### PR TITLE
Remove DEFAULT_SCHEDULING_STRATEGY and SPREAD_SCHEDULING_STRATEGY

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -125,8 +125,6 @@ from ray.exceptions import (
 )
 from ray import external_storage
 from ray.util.scheduling_strategies import (
-    DEFAULT_SCHEDULING_STRATEGY,
-    SPREAD_SCHEDULING_STRATEGY,
     PlacementGroupSchedulingStrategy,
 )
 import ray.ray_constants as ray_constants
@@ -1459,9 +1457,9 @@ cdef class CoreWorker:
             CPlacementGroupSchedulingStrategy \
                 *c_placement_group_scheduling_strategy
         assert python_scheduling_strategy is not None
-        if python_scheduling_strategy == DEFAULT_SCHEDULING_STRATEGY:
+        if python_scheduling_strategy == "DEFAULT":
             c_scheduling_strategy[0].mutable_default_scheduling_strategy()
-        elif python_scheduling_strategy == SPREAD_SCHEDULING_STRATEGY:
+        elif python_scheduling_strategy == "SPREAD":
             c_scheduling_strategy[0].mutable_spread_scheduling_strategy()
         elif isinstance(python_scheduling_strategy,
                         PlacementGroupSchedulingStrategy):

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -10,7 +10,6 @@ import ray.worker
 from ray.util.annotations import PublicAPI
 from ray.util.placement_group import configure_placement_group_based_on_context
 from ray.util.scheduling_strategies import (
-    DEFAULT_SCHEDULING_STRATEGY,
     PlacementGroupSchedulingStrategy,
     SchedulingStrategyT,
 )
@@ -943,7 +942,7 @@ class ActorClass:
                     placement_group_capture_child_tasks,
                 )
             else:
-                scheduling_strategy = DEFAULT_SCHEDULING_STRATEGY
+                scheduling_strategy = "DEFAULT"
 
         if runtime_env:
             if isinstance(runtime_env, str):

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -5,7 +5,6 @@ import uuid
 
 from ray import cloudpickle as pickle
 from ray.util.scheduling_strategies import (
-    DEFAULT_SCHEDULING_STRATEGY,
     PlacementGroupSchedulingStrategy,
     SchedulingStrategyT,
 )
@@ -416,7 +415,7 @@ class RemoteFunction:
                     placement_group_capture_child_tasks,
                 )
             else:
-                scheduling_strategy = DEFAULT_SCHEDULING_STRATEGY
+                scheduling_strategy = "DEFAULT"
 
         if not runtime_env or runtime_env == "{}":
             runtime_env = self._runtime_env

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -8,8 +8,6 @@ import ray
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 import ray.experimental.internal_kv as internal_kv
 from ray.util.scheduling_strategies import (
-    DEFAULT_SCHEDULING_STRATEGY,
-    SPREAD_SCHEDULING_STRATEGY,
     PlacementGroupSchedulingStrategy,
 )
 
@@ -108,7 +106,7 @@ def test_default_scheduling_strategy(ray_start_cluster, connect_to_client):
 
     with connect_to_client_or_not(connect_to_client):
 
-        @ray.remote(scheduling_strategy=DEFAULT_SCHEDULING_STRATEGY)
+        @ray.remote(scheduling_strategy="DEFAULT")
         def get_node_id_1():
             return ray.worker.global_worker.current_node_id
 
@@ -127,11 +125,7 @@ def test_default_scheduling_strategy(ray_start_cluster, connect_to_client):
             return ray.worker.global_worker.current_node_id
 
         assert (
-            ray.get(
-                get_node_id_2.options(
-                    scheduling_strategy=DEFAULT_SCHEDULING_STRATEGY
-                ).remote()
-            )
+            ray.get(get_node_id_2.options(scheduling_strategy="DEFAULT").remote())
             == head_node_id
         )
 
@@ -152,9 +146,7 @@ def test_default_scheduling_strategy(ray_start_cluster, connect_to_client):
                     # Use parent's placement group
                     ray.get(get_node_id_3.remote()),
                     ray.get(
-                        get_node_id_3.options(
-                            scheduling_strategy=DEFAULT_SCHEDULING_STRATEGY
-                        ).remote()
+                        get_node_id_3.options(scheduling_strategy="DEFAULT").remote()
                     ),
                 ]
 
@@ -179,7 +171,7 @@ def test_placement_group_scheduling_strategy(ray_start_cluster, connect_to_clien
 
     with connect_to_client_or_not(connect_to_client):
 
-        @ray.remote(scheduling_strategy=DEFAULT_SCHEDULING_STRATEGY)
+        @ray.remote(scheduling_strategy="DEFAULT")
         def get_node_id_1():
             return ray.worker.global_worker.current_node_id
 
@@ -286,7 +278,7 @@ def test_spread_scheduling_strategy(ray_start_cluster, connect_to_client):
         # Wait for updating driver raylet's resource view.
         time.sleep(5)
 
-        @ray.remote(scheduling_strategy=SPREAD_SCHEDULING_STRATEGY)
+        @ray.remote(scheduling_strategy="SPREAD")
         def task1():
             internal_kv._internal_kv_put("test_task1", "task1")
             while internal_kv._internal_kv_exists("test_task1"):
@@ -304,9 +296,7 @@ def test_spread_scheduling_strategy(ray_start_cluster, connect_to_client):
             time.sleep(0.1)
         # Wait for updating driver raylet's resource view.
         time.sleep(5)
-        locations.append(
-            task2.options(scheduling_strategy=SPREAD_SCHEDULING_STRATEGY).remote()
-        )
+        locations.append(task2.options(scheduling_strategy="SPREAD").remote())
         while not internal_kv._internal_kv_exists("test_task2"):
             time.sleep(0.1)
         internal_kv._internal_kv_del("test_task1")

--- a/python/ray/util/scheduling_strategies.py
+++ b/python/ray/util/scheduling_strategies.py
@@ -2,13 +2,11 @@ from typing import Union, Optional
 from ray.util.annotations import PublicAPI
 from ray.util.placement_group import PlacementGroup
 
-# The default hybrid scheduling strategy
+# "DEFAULT": The default hybrid scheduling strategy
 # based on config scheduler_spread_threshold.
 # This disables any potential placement group capture.
-DEFAULT_SCHEDULING_STRATEGY = "DEFAULT"
 
-# Spread scheduling on a best effort basis.
-SPREAD_SCHEDULING_STRATEGY = "SPREAD"
+# "SPREAD": Spread scheduling on a best effort basis.
 
 
 @PublicAPI(stability="beta")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
"SPREAD" and "DEFAULT" literals are already public APIs, it's not worthwhile maintaining extra aliases of those.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
