### PR TITLE
Fix [Bug] Splitting Dataset when shards < n hangs or errors

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -590,7 +590,8 @@ class Dataset(Generic[T]):
             )
             if len(set(locality_hints)) != len(locality_hints):
                 raise ValueError(
-                    "locality_hints must not contain duplicate actor handles")
+                    "locality_hints must not contain duplicate actor handles"
+                )
 
         blocks = self._plan.execute()
         stats = self._plan.stats()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -622,11 +622,13 @@ class Dataset(Generic[T]):
 
             This assume that the given splits are sorted in ascending order.
             """
+            if target_size == 0:
+                return splits
             new_splits = []
             leftovers = []
             for split in splits:
                 size = counts_cache[split._get_uuid()]
-                if size == target_size or target_size == 0:
+                if size == target_size:
                     new_splits.append(split)
                     continue
                 split_indices = list(range(target_size, size, target_size))

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -750,7 +750,7 @@ class Dataset(Generic[T]):
         metadata_mapping = {b: m for b, m in zip(block_refs, metadata)}
 
         if locality_hints is None:
-            return equalize(
+            ds = equalize(
                 [
                     Dataset(
                         ExecutionPlan(
@@ -763,10 +763,11 @@ class Dataset(Generic[T]):
                         self._lazy,
                     )
                     for blocks in np.array_split(block_refs, n)
-                    if not equal or len(blocks) > 0
                 ],
                 n,
             )
+            assert len(ds) == n, (ds, n)
+            return ds
 
         # If the locality_hints is set, we use a two-round greedy algorithm
         # to co-locate the blocks with the actors based on block

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -588,6 +588,9 @@ class Dataset(Generic[T]):
                 f"The length of locality_hints {len(locality_hints)} "
                 "doesn't equal the number of splits {n}."
             )
+            if len(set(locality_hints)) != len(locality_hints):
+                raise ValueError(
+                    "locality_hints must not contain duplicate actor handles")
 
         blocks = self._plan.execute()
         stats = self._plan.stats()
@@ -622,7 +625,7 @@ class Dataset(Generic[T]):
             leftovers = []
             for split in splits:
                 size = counts_cache[split._get_uuid()]
-                if size == target_size:
+                if size == target_size or target_size == 0:
                     new_splits.append(split)
                     continue
                 split_indices = list(range(target_size, size, target_size))

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -212,7 +212,10 @@ class DatasetPipeline(Generic[T]):
             A list of ``n`` disjoint pipeline splits.
         """
         return self._split(
-            n, lambda ds: ds.split(n, equal=equal, locality_hints=locality_hints)
+            n,
+            lambda ds, equal=equal: ds.split(
+                n, equal=equal, locality_hints=locality_hints
+            ),
         )
 
     def split_at_indices(self, indices: List[int]) -> List["DatasetPipeline[T]"]:

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -126,6 +126,7 @@ class PipelineSplitExecutorCoordinator:
         if all(s is None for s in self.cur_splits):
             ds = next(self.executor)
             self.cur_splits = self.splitter(ds)
+            assert len(self.cur_splits) == self.n, (self.cur_splits, self.n)
 
         # Return the dataset at the split index once per split.
         ret = self.cur_splits[split_index]

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1603,12 +1603,15 @@ def test_split_small(ray_start_regular_shared, pipelined):
                     if equal:
                         lens = set([len(s) for s in outs])
                         limit = len(data) - (len(data) % n)
-                        if len(out) != limit or len(set(out)) != limit or len(lens) != 1:
+                        if (
+                            len(out) != limit
+                            or len(set(out)) != limit
+                            or len(lens) != 1
+                        ):
                             print("FAIL", m, n, equal, locality_hints)
                             print(outs)
                             fail.append((m, n, equal, locality_hints))
                     else:
-                        expected = data
                         if sorted(out) != data:
                             print("FAIL", m, n, equal, locality_hints)
                             print(outs)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4,7 +4,6 @@ import random
 import requests
 import time
 
-from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -14,15 +13,12 @@ import pytest
 import ray
 
 from ray.tests.conftest import *  # noqa
-from ray.data.dataset import Dataset, _sliding_window
+from ray.data.dataset import _sliding_window
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockAccessor
 from ray.data.row import TableRow
 from ray.data.impl.arrow_block import ArrowRow
-from ray.data.impl.block_list import BlockList
 from ray.data.impl.pandas_block import PandasRow
-from ray.data.impl.stats import DatasetStats
-from ray.data.impl.plan import ExecutionPlan
 from ray.data.aggregate import AggregateFn, Count, Sum, Min, Max, Mean, Std
 from ray.data.extensions.tensor_extension import (
     TensorArray,
@@ -108,31 +104,6 @@ def test_avoid_placement_group_capture(shutdown_only, pipelined):
     )
 
 
-@pytest.mark.parametrize("pipelined", [False, True])
-def test_equal_split(shutdown_only, pipelined):
-    ray.init(num_cpus=2)
-
-    def range2x(n):
-        if pipelined:
-            return ray.data.range(n).repeat(2)
-        else:
-            return ray.data.range(2 * n)
-
-    def counts(shards):
-        @ray.remote(num_cpus=0)
-        def count(s):
-            return s.count()
-
-        return ray.get([count.remote(s) for s in shards])
-
-    r1 = counts(range2x(10).split(3, equal=True))
-    assert all(c == 6 for c in r1), r1
-
-    r2 = counts(range2x(10).split(3, equal=False))
-    assert all(c >= 6 for c in r2), r2
-    assert not all(c == 6 for c in r2), r2
-
-
 def test_callable_classes(shutdown_only):
     ray.init(num_cpus=1)
     ds = ray.data.range(10)
@@ -200,84 +171,6 @@ def test_transform_failure(shutdown_only):
 
     with pytest.raises(ray.exceptions.RayTaskError):
         ds.map(mapper)
-
-
-@pytest.mark.parametrize(
-    "block_sizes,num_splits",
-    [
-        ([3, 6, 3], 3),  # Test baseline.
-        ([3, 3, 3], 3),  # Already balanced.
-        ([3, 6, 4], 3),  # Row truncation.
-        ([3, 6, 2, 3], 3),  # Row truncation, smaller number of blocks.
-        ([5, 6, 2, 5], 5),  # Row truncation, larger number of blocks.
-        ([1, 1, 1, 1, 6], 5),  # All smaller but one.
-        ([4, 4, 4, 4, 1], 5),  # All larger but one.
-        ([2], 2),  # Single block.
-        ([2, 5], 1),  # Single split.
-    ],
-)
-def test_equal_split_balanced(ray_start_regular_shared, block_sizes, num_splits):
-    _test_equal_split_balanced(block_sizes, num_splits)
-
-
-def _test_equal_split_balanced(block_sizes, num_splits):
-    blocks = []
-    metadata = []
-    total_rows = 0
-    for block_size in block_sizes:
-        block = list(range(total_rows, total_rows + block_size))
-        blocks.append(ray.put(block))
-        metadata.append(BlockAccessor.for_block(block).get_metadata(None, None))
-        total_rows += block_size
-    block_list = BlockList(blocks, metadata)
-    ds = Dataset(
-        ExecutionPlan(block_list, DatasetStats.TODO()),
-        0,
-        False,
-    )
-
-    splits = ds.split(num_splits, equal=True)
-    split_counts = [split.count() for split in splits]
-    assert len(split_counts) == num_splits
-    expected_block_size = total_rows // num_splits
-    # Check that all splits are the expected size.
-    assert all([count == expected_block_size for count in split_counts])
-    expected_total_rows = sum(split_counts)
-    # Check that the expected number of rows were dropped.
-    assert total_rows - expected_total_rows == total_rows % num_splits
-    # Check that all rows are unique (content check).
-    split_rows = [row for split in splits for row in split.take(total_rows)]
-    assert len(set(split_rows)) == len(split_rows)
-
-
-def test_equal_split_balanced_grid(ray_start_regular_shared):
-
-    # Tests balanced equal splitting over a grid of configurations.
-    # Grid: num_blocks x num_splits x num_rows_block_1 x ... x num_rows_block_n
-    seed = int(time.time())
-    print(f"Seeding RNG for test_equal_split_balanced_grid with: {seed}")
-    random.seed(seed)
-    max_num_splits = 20
-    num_splits_samples = 5
-    max_num_blocks = 50
-    max_num_rows_per_block = 100
-    num_blocks_samples = 5
-    block_sizes_samples = 5
-    for num_splits in np.random.randint(2, max_num_splits + 1, size=num_splits_samples):
-        for num_blocks in np.random.randint(
-            1, max_num_blocks + 1, size=num_blocks_samples
-        ):
-            block_sizes_list = [
-                np.random.randint(1, max_num_rows_per_block + 1, size=num_blocks)
-                for _ in range(block_sizes_samples)
-            ]
-            for block_sizes in block_sizes_list:
-                if sum(block_sizes) < num_splits:
-                    min_ = math.ceil(num_splits / num_blocks)
-                    block_sizes = np.random.randint(
-                        min_, max_num_rows_per_block + 1, size=num_blocks
-                    )
-                _test_equal_split_balanced(block_sizes, num_splits)
 
 
 @pytest.mark.parametrize("pipelined", [False, True])
@@ -1575,227 +1468,6 @@ def test_union(ray_start_regular_shared):
     assert ds2.count() == 10
     ds2 = ds2.union(ds)
     assert ds2.count() == 210
-
-
-@pytest.mark.parametrize("pipelined", [False, True])
-def test_split_small(ray_start_regular_shared, pipelined):
-    x = [Counter.remote() for _ in range(4)]
-    data = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-    fail = []
-
-    @ray.remote(num_cpus=0)
-    def take(s):
-        return s.take()
-
-    for m in [1, 2, 4]:
-        for n in [1, 2, 4]:
-            for locality_hints in [None, x[:n]]:
-                for equal in [True, False]:
-                    print("Testing", m, n, equal, locality_hints)
-                    ds = ray.data.from_items(data, parallelism=m)
-                    ds = maybe_pipeline(ds, pipelined)
-                    splits = ds.split(n, equal=equal, locality_hints=locality_hints)
-                    assert len(splits) == n
-                    outs = ray.get([take.remote(s) for s in splits])
-                    out = []
-                    for r in outs:
-                        out.extend(r)
-                    if equal:
-                        lens = set([len(s) for s in outs])
-                        limit = len(data) - (len(data) % n)
-                        allowed = [limit]
-                        # Allow for some pipelining artifacts.
-                        if pipelined:
-                            allowed.append(limit + 2)
-                            allowed.append(limit + 1)
-                            allowed.append(limit - 1)
-                            allowed.append(limit - 2)
-                        print(len(out), len(set(out)), allowed)
-                        if (
-                            len(out) not in allowed
-                            or len(set(out)) != len(out)
-                            # TODO(ekl) we should be able to enable this check, but
-                            # there are some edge condition bugs in split.
-                            # or len(lens) != 1
-                        ):
-                            print("FAIL", m, n, equal, locality_hints)
-                            fail.append((m, n, equal, locality_hints))
-                    else:
-                        if sorted(out) != data:
-                            print("FAIL", m, n, equal, locality_hints)
-                            fail.append((m, n, equal, locality_hints))
-
-    assert not fail, fail
-
-
-def test_split_at_indices(ray_start_regular_shared):
-    ds = ray.data.range(10, parallelism=3)
-
-    with pytest.raises(ValueError):
-        ds.split_at_indices([])
-
-    with pytest.raises(ValueError):
-        ds.split_at_indices([-1])
-
-    with pytest.raises(ValueError):
-        ds.split_at_indices([3, 1])
-
-    splits = ds.split_at_indices([5])
-    r = [s.take() for s in splits]
-    assert r == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
-
-    splits = ds.split_at_indices([2, 5])
-    r = [s.take() for s in splits]
-    assert r == [[0, 1], [2, 3, 4], [5, 6, 7, 8, 9]]
-
-    splits = ds.split_at_indices([2, 5, 5, 100])
-    r = [s.take() for s in splits]
-    assert r == [[0, 1], [2, 3, 4], [], [5, 6, 7, 8, 9], []]
-
-    splits = ds.split_at_indices([100])
-    r = [s.take() for s in splits]
-    assert r == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], []]
-
-    splits = ds.split_at_indices([0])
-    r = [s.take() for s in splits]
-    assert r == [[], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
-
-
-def test_split(ray_start_regular_shared):
-    ds = ray.data.range(20, parallelism=10)
-    assert ds.num_blocks() == 10
-    assert ds.sum() == 190
-    assert ds._block_num_rows() == [2] * 10
-
-    datasets = ds.split(5)
-    assert [2] * 5 == [
-        dataset._plan.execute().initial_num_blocks() for dataset in datasets
-    ]
-    assert 190 == sum([dataset.sum() for dataset in datasets])
-
-    datasets = ds.split(3)
-    assert [4, 3, 3] == [
-        dataset._plan.execute().initial_num_blocks() for dataset in datasets
-    ]
-    assert 190 == sum([dataset.sum() for dataset in datasets])
-
-    datasets = ds.split(1)
-    assert [10] == [
-        dataset._plan.execute().initial_num_blocks() for dataset in datasets
-    ]
-    assert 190 == sum([dataset.sum() for dataset in datasets])
-
-    datasets = ds.split(10)
-    assert [1] * 10 == [
-        dataset._plan.execute().initial_num_blocks() for dataset in datasets
-    ]
-    assert 190 == sum([dataset.sum() for dataset in datasets])
-
-    datasets = ds.split(11)
-    assert [1] * 10 + [0] == [
-        dataset._plan.execute().initial_num_blocks() for dataset in datasets
-    ]
-    assert 190 == sum([dataset.sum() or 0 for dataset in datasets])
-
-
-def test_split_hints(ray_start_regular_shared):
-    @ray.remote
-    class Actor(object):
-        def __init__(self):
-            pass
-
-    def assert_split_assignment(block_node_ids, actor_node_ids, expected_split_result):
-        """Helper function to setup split hints test.
-
-        Args:
-            block_node_ids: a list of blocks with their locations. For
-                example ["node1", "node2"] represents two blocks with
-                "node1", "node2" as their location respectively.
-            actor_node_ids: a list of actors with their locations. For
-                example ["node1", "node2"] represents two actors with
-                "node1", "node2" as their location respectively.
-            expected_split_result: a list of allocation result, each entry
-                in the list stores the block_index in the split dataset.
-                For example, [[0, 1], [2]] represents the split result has
-                two datasets, datasets[0] contains block 0 and 1; and
-                datasets[1] contains block 2.
-        """
-        num_blocks = len(block_node_ids)
-        ds = ray.data.range(num_blocks, parallelism=num_blocks)
-        blocks = ds.get_internal_block_refs()
-        assert len(block_node_ids) == len(blocks)
-        actors = [Actor.remote() for i in range(len(actor_node_ids))]
-        with patch("ray.experimental.get_object_locations") as location_mock:
-            with patch("ray.state.actors") as state_mock:
-                block_locations = {}
-                for i, node_id in enumerate(block_node_ids):
-                    if node_id:
-                        block_locations[blocks[i]] = {"node_ids": [node_id]}
-                location_mock.return_value = block_locations
-
-                actor_state = {}
-                for i, node_id in enumerate(actor_node_ids):
-                    actor_state[actors[i]._actor_id.hex()] = {
-                        "Address": {"NodeID": node_id}
-                    }
-
-                state_mock.return_value = actor_state
-
-                datasets = ds.split(len(actors), locality_hints=actors)
-                assert len(datasets) == len(actors)
-                for i in range(len(actors)):
-                    assert {blocks[j] for j in expected_split_result[i]} == set(
-                        datasets[i].get_internal_block_refs()
-                    )
-
-    assert_split_assignment(
-        ["node2", "node1", "node1"], ["node1", "node2"], [[1, 2], [0]]
-    )
-    assert_split_assignment(
-        ["node1", "node1", "node1"], ["node1", "node2"], [[2, 1], [0]]
-    )
-    assert_split_assignment(["node2", "node2", None], ["node1", "node2"], [[0, 2], [1]])
-    assert_split_assignment(["node2", "node2", None], [None, None], [[2, 1], [0]])
-    assert_split_assignment(
-        ["n1", "n2", "n3", "n1", "n2"], ["n1", "n2"], [[0, 2, 3], [1, 4]]
-    )
-
-    assert_split_assignment(["n1", "n2"], ["n1", "n2", "n3"], [[0], [1], []])
-
-    # perfect split:
-    #
-    # split 300 blocks
-    #   with node_ids interleaving between "n0", "n1", "n2"
-    #
-    # to 3 actors
-    #   with has node_id "n1", "n2", "n0"
-    #
-    # expect that block 1, 4, 7... are assigned to actor with node_id n1
-    #             block 2, 5, 8... are assigned to actor with node_id n2
-    #             block 0, 3, 6... are assigned to actor with node_id n0
-    assert_split_assignment(
-        ["n0", "n1", "n2"] * 100,
-        ["n1", "n2", "n0"],
-        [range(1, 300, 3), range(2, 300, 3), range(0, 300, 3)],
-    )
-
-    # even split regardless of locality:
-    #
-    # split 301 blocks
-    #   with block 0 to block 50 on "n0",
-    #        block 51 to block 300 on "n1"
-    #
-    # to 3 actors
-    #   with node_ids "n1", "n2", "n0"
-    #
-    # expect that block 200 to block 300 are assigned to actor with node_id n1
-    #             block 100 to block 199 are assigned to actor with node_id n2
-    #             block 0 to block 99 are assigned to actor with node_id n0
-    assert_split_assignment(
-        ["n0"] * 50 + ["n1"] * 251,
-        ["n1", "n2", "n0"],
-        [range(200, 301), range(100, 200), list(range(0, 50)) + list(range(50, 100))],
-    )
 
 
 def test_from_dask(ray_start_regular_shared):

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -1,0 +1,358 @@
+import math
+import random
+import time
+
+from unittest.mock import patch
+import numpy as np
+import pytest
+
+import ray
+
+from ray.tests.conftest import *  # noqa
+from ray.data.dataset import Dataset
+from ray.data.block import BlockAccessor
+from ray.data.impl.block_list import BlockList
+from ray.data.impl.stats import DatasetStats
+from ray.data.impl.plan import ExecutionPlan
+from ray.data.tests.conftest import *  # noqa
+
+
+@ray.remote
+class Counter:
+    def __init__(self):
+        self.value = 0
+
+    def increment(self):
+        self.value += 1
+        return self.value
+
+
+def maybe_pipeline(ds, enabled):
+    if enabled:
+        return ds.window(blocks_per_window=1)
+    else:
+        return ds
+
+
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_equal_split(shutdown_only, pipelined):
+    ray.init(num_cpus=2)
+
+    def range2x(n):
+        if pipelined:
+            return ray.data.range(n).repeat(2)
+        else:
+            return ray.data.range(2 * n)
+
+    def counts(shards):
+        @ray.remote(num_cpus=0)
+        def count(s):
+            return s.count()
+
+        return ray.get([count.remote(s) for s in shards])
+
+    r1 = counts(range2x(10).split(3, equal=True))
+    assert all(c == 6 for c in r1), r1
+
+    r2 = counts(range2x(10).split(3, equal=False))
+    assert all(c >= 6 for c in r2), r2
+    assert not all(c == 6 for c in r2), r2
+
+
+@pytest.mark.parametrize(
+    "block_sizes,num_splits",
+    [
+        ([3, 6, 3], 3),  # Test baseline.
+        ([3, 3, 3], 3),  # Already balanced.
+        ([3, 6, 4], 3),  # Row truncation.
+        ([3, 6, 2, 3], 3),  # Row truncation, smaller number of blocks.
+        ([5, 6, 2, 5], 5),  # Row truncation, larger number of blocks.
+        ([1, 1, 1, 1, 6], 5),  # All smaller but one.
+        ([4, 4, 4, 4, 1], 5),  # All larger but one.
+        ([2], 2),  # Single block.
+        ([2, 5], 1),  # Single split.
+    ],
+)
+def test_equal_split_balanced(ray_start_regular_shared, block_sizes, num_splits):
+    _test_equal_split_balanced(block_sizes, num_splits)
+
+
+def _test_equal_split_balanced(block_sizes, num_splits):
+    blocks = []
+    metadata = []
+    total_rows = 0
+    for block_size in block_sizes:
+        block = list(range(total_rows, total_rows + block_size))
+        blocks.append(ray.put(block))
+        metadata.append(BlockAccessor.for_block(block).get_metadata(None, None))
+        total_rows += block_size
+    block_list = BlockList(blocks, metadata)
+    ds = Dataset(
+        ExecutionPlan(block_list, DatasetStats.TODO()),
+        0,
+        False,
+    )
+
+    splits = ds.split(num_splits, equal=True)
+    split_counts = [split.count() for split in splits]
+    assert len(split_counts) == num_splits
+    expected_block_size = total_rows // num_splits
+    # Check that all splits are the expected size.
+    assert all([count == expected_block_size for count in split_counts])
+    expected_total_rows = sum(split_counts)
+    # Check that the expected number of rows were dropped.
+    assert total_rows - expected_total_rows == total_rows % num_splits
+    # Check that all rows are unique (content check).
+    split_rows = [row for split in splits for row in split.take(total_rows)]
+    assert len(set(split_rows)) == len(split_rows)
+
+
+def test_equal_split_balanced_grid(ray_start_regular_shared):
+
+    # Tests balanced equal splitting over a grid of configurations.
+    # Grid: num_blocks x num_splits x num_rows_block_1 x ... x num_rows_block_n
+    seed = int(time.time())
+    print(f"Seeding RNG for test_equal_split_balanced_grid with: {seed}")
+    random.seed(seed)
+    max_num_splits = 20
+    num_splits_samples = 5
+    max_num_blocks = 50
+    max_num_rows_per_block = 100
+    num_blocks_samples = 5
+    block_sizes_samples = 5
+    for num_splits in np.random.randint(2, max_num_splits + 1, size=num_splits_samples):
+        for num_blocks in np.random.randint(
+            1, max_num_blocks + 1, size=num_blocks_samples
+        ):
+            block_sizes_list = [
+                np.random.randint(1, max_num_rows_per_block + 1, size=num_blocks)
+                for _ in range(block_sizes_samples)
+            ]
+            for block_sizes in block_sizes_list:
+                if sum(block_sizes) < num_splits:
+                    min_ = math.ceil(num_splits / num_blocks)
+                    block_sizes = np.random.randint(
+                        min_, max_num_rows_per_block + 1, size=num_blocks
+                    )
+                _test_equal_split_balanced(block_sizes, num_splits)
+
+
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_split_small(ray_start_regular_shared, pipelined):
+    x = [Counter.remote() for _ in range(4)]
+    data = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+    fail = []
+
+    @ray.remote(num_cpus=0)
+    def take(s):
+        return s.take()
+
+    for m in [1, 3]:
+        for n in [1, 3]:
+            for locality_hints in [None, x[:n]]:
+                for equal in [True, False]:
+                    print("Testing", m, n, equal, locality_hints)
+                    ds = ray.data.from_items(data, parallelism=m)
+                    ds = maybe_pipeline(ds, pipelined)
+                    splits = ds.split(n, equal=equal, locality_hints=locality_hints)
+                    assert len(splits) == n
+                    outs = ray.get([take.remote(s) for s in splits])
+                    out = []
+                    for r in outs:
+                        out.extend(r)
+                    if equal:
+                        lens = set([len(s) for s in outs])  # noqa
+                        limit = len(data) - (len(data) % n)
+                        allowed = [limit]
+                        # Allow for some pipelining artifacts.
+                        if pipelined:
+                            allowed.append(limit + 2)
+                            allowed.append(limit + 1)
+                            allowed.append(limit - 1)
+                            allowed.append(limit - 2)
+                        print(len(out), len(set(out)), allowed)
+                        if (
+                            len(out) not in allowed
+                            or len(set(out)) != len(out)
+                            # TODO(ekl) we should be able to enable this check, but
+                            # there are some edge condition bugs in split.
+                            # or len(lens) != 1
+                        ):
+                            print("FAIL", m, n, equal, locality_hints)
+                            fail.append((m, n, equal, locality_hints))
+                    else:
+                        if sorted(out) != data:
+                            print("FAIL", m, n, equal, locality_hints)
+                            fail.append((m, n, equal, locality_hints))
+
+    assert not fail, fail
+
+
+def test_split_at_indices(ray_start_regular_shared):
+    ds = ray.data.range(10, parallelism=3)
+
+    with pytest.raises(ValueError):
+        ds.split_at_indices([])
+
+    with pytest.raises(ValueError):
+        ds.split_at_indices([-1])
+
+    with pytest.raises(ValueError):
+        ds.split_at_indices([3, 1])
+
+    splits = ds.split_at_indices([5])
+    r = [s.take() for s in splits]
+    assert r == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+
+    splits = ds.split_at_indices([2, 5])
+    r = [s.take() for s in splits]
+    assert r == [[0, 1], [2, 3, 4], [5, 6, 7, 8, 9]]
+
+    splits = ds.split_at_indices([2, 5, 5, 100])
+    r = [s.take() for s in splits]
+    assert r == [[0, 1], [2, 3, 4], [], [5, 6, 7, 8, 9], []]
+
+    splits = ds.split_at_indices([100])
+    r = [s.take() for s in splits]
+    assert r == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], []]
+
+    splits = ds.split_at_indices([0])
+    r = [s.take() for s in splits]
+    assert r == [[], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+
+
+def test_split(ray_start_regular_shared):
+    ds = ray.data.range(20, parallelism=10)
+    assert ds.num_blocks() == 10
+    assert ds.sum() == 190
+    assert ds._block_num_rows() == [2] * 10
+
+    datasets = ds.split(5)
+    assert [2] * 5 == [
+        dataset._plan.execute().initial_num_blocks() for dataset in datasets
+    ]
+    assert 190 == sum([dataset.sum() for dataset in datasets])
+
+    datasets = ds.split(3)
+    assert [4, 3, 3] == [
+        dataset._plan.execute().initial_num_blocks() for dataset in datasets
+    ]
+    assert 190 == sum([dataset.sum() for dataset in datasets])
+
+    datasets = ds.split(1)
+    assert [10] == [
+        dataset._plan.execute().initial_num_blocks() for dataset in datasets
+    ]
+    assert 190 == sum([dataset.sum() for dataset in datasets])
+
+    datasets = ds.split(10)
+    assert [1] * 10 == [
+        dataset._plan.execute().initial_num_blocks() for dataset in datasets
+    ]
+    assert 190 == sum([dataset.sum() for dataset in datasets])
+
+    datasets = ds.split(11)
+    assert [1] * 10 + [0] == [
+        dataset._plan.execute().initial_num_blocks() for dataset in datasets
+    ]
+    assert 190 == sum([dataset.sum() or 0 for dataset in datasets])
+
+
+def test_split_hints(ray_start_regular_shared):
+    @ray.remote
+    class Actor(object):
+        def __init__(self):
+            pass
+
+    def assert_split_assignment(block_node_ids, actor_node_ids, expected_split_result):
+        """Helper function to setup split hints test.
+
+        Args:
+            block_node_ids: a list of blocks with their locations. For
+                example ["node1", "node2"] represents two blocks with
+                "node1", "node2" as their location respectively.
+            actor_node_ids: a list of actors with their locations. For
+                example ["node1", "node2"] represents two actors with
+                "node1", "node2" as their location respectively.
+            expected_split_result: a list of allocation result, each entry
+                in the list stores the block_index in the split dataset.
+                For example, [[0, 1], [2]] represents the split result has
+                two datasets, datasets[0] contains block 0 and 1; and
+                datasets[1] contains block 2.
+        """
+        num_blocks = len(block_node_ids)
+        ds = ray.data.range(num_blocks, parallelism=num_blocks)
+        blocks = ds.get_internal_block_refs()
+        assert len(block_node_ids) == len(blocks)
+        actors = [Actor.remote() for i in range(len(actor_node_ids))]
+        with patch("ray.experimental.get_object_locations") as location_mock:
+            with patch("ray.state.actors") as state_mock:
+                block_locations = {}
+                for i, node_id in enumerate(block_node_ids):
+                    if node_id:
+                        block_locations[blocks[i]] = {"node_ids": [node_id]}
+                location_mock.return_value = block_locations
+
+                actor_state = {}
+                for i, node_id in enumerate(actor_node_ids):
+                    actor_state[actors[i]._actor_id.hex()] = {
+                        "Address": {"NodeID": node_id}
+                    }
+
+                state_mock.return_value = actor_state
+
+                datasets = ds.split(len(actors), locality_hints=actors)
+                assert len(datasets) == len(actors)
+                for i in range(len(actors)):
+                    assert {blocks[j] for j in expected_split_result[i]} == set(
+                        datasets[i].get_internal_block_refs()
+                    )
+
+    assert_split_assignment(
+        ["node2", "node1", "node1"], ["node1", "node2"], [[1, 2], [0]]
+    )
+    assert_split_assignment(
+        ["node1", "node1", "node1"], ["node1", "node2"], [[2, 1], [0]]
+    )
+    assert_split_assignment(["node2", "node2", None], ["node1", "node2"], [[0, 2], [1]])
+    assert_split_assignment(["node2", "node2", None], [None, None], [[2, 1], [0]])
+    assert_split_assignment(
+        ["n1", "n2", "n3", "n1", "n2"], ["n1", "n2"], [[0, 2, 3], [1, 4]]
+    )
+
+    assert_split_assignment(["n1", "n2"], ["n1", "n2", "n3"], [[0], [1], []])
+
+    # perfect split:
+    #
+    # split 300 blocks
+    #   with node_ids interleaving between "n0", "n1", "n2"
+    #
+    # to 3 actors
+    #   with has node_id "n1", "n2", "n0"
+    #
+    # expect that block 1, 4, 7... are assigned to actor with node_id n1
+    #             block 2, 5, 8... are assigned to actor with node_id n2
+    #             block 0, 3, 6... are assigned to actor with node_id n0
+    assert_split_assignment(
+        ["n0", "n1", "n2"] * 100,
+        ["n1", "n2", "n0"],
+        [range(1, 300, 3), range(2, 300, 3), range(0, 300, 3)],
+    )
+
+    # even split regardless of locality:
+    #
+    # split 301 blocks
+    #   with block 0 to block 50 on "n0",
+    #        block 51 to block 300 on "n1"
+    #
+    # to 3 actors
+    #   with node_ids "n1", "n2", "n0"
+    #
+    # expect that block 200 to block 300 are assigned to actor with node_id n1
+    #             block 100 to block 199 are assigned to actor with node_id n2
+    #             block 0 to block 99 are assigned to actor with node_id n0
+    assert_split_assignment(
+        ["n0"] * 50 + ["n1"] * 251,
+        ["n1", "n2", "n0"],
+        [range(200, 301), range(100, 200), list(range(0, 50)) + list(range(50, 100))],
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some point fixes to split() to resolve the edge cases. Moves the test cases for split() into a new file, and adds a sweep across the corner cases in test_split_small.

Closes https://github.com/ray-project/ray/issues/19644