### PR TITLE
Fix [Bug] DatasetPipeline .iter_epochs() can lead to infinite loops

### DIFF
--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -604,7 +604,8 @@ class DatasetPipeline(Generic[T]):
                         warned = True
                         logger.warn(
                             "Data from epoch {} was not fully read, "
-                            "skipping to next epoch.".format(self._cur_epoch - 1))
+                            "skipping to next epoch.".format(self._cur_epoch - 1)
+                        )
                     next(self._iter)
                 epoch_pipe = DatasetPipeline.from_iterable(
                     SingleEpochIterator(self._iter, epoch=self._cur_epoch)

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -1,5 +1,5 @@
 import inspect
-
+import logging
 import time
 from typing import (
     Any,
@@ -29,6 +29,8 @@ from ray.util.annotations import PublicAPI, DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
+
+logger = logging.getLogger(__name__)
 
 # Operations that can be naively applied per dataset row in the pipeline.
 PER_DATASET_OPS = ["map", "map_batches", "add_column", "flat_map", "filter"]
@@ -573,18 +575,14 @@ class DatasetPipeline(Generic[T]):
                 return item
 
         class SingleEpochIterator:
-            def __init__(self, peekable_iter: Iterator[Dataset[T]]):
+            def __init__(self, peekable_iter: Iterator[Dataset[T]], epoch: int):
                 self._iter = peekable_iter
-                self._epoch = None
+                self._epoch = epoch
 
             def __next__(self) -> Dataset[T]:
-                if (
-                    self._epoch is not None
-                    and self._iter.peek()._get_epoch() != self._epoch
-                ):
+                if self._iter.peek()._get_epoch() > self._epoch:
                     raise StopIteration
                 ds = next(self._iter)
-                self._epoch = ds._get_epoch()
                 return lambda: ds
 
             def __iter__(self):
@@ -593,11 +591,23 @@ class DatasetPipeline(Generic[T]):
         class EpochDelimitedIterator:
             def __init__(self, pipe):
                 self._iter = Peekable(pipe.iter_datasets())
+                self._cur_epoch = None
 
             def __next__(self) -> "DatasetPipeline[T]":
-                self._iter.peek()  # Raises StopIteration on end of data.
+                if self._cur_epoch is None:
+                    self._cur_epoch = self._iter.peek()._get_epoch()
+                else:
+                    self._cur_epoch += 1
+                warned = False
+                while self._iter.peek()._get_epoch() < self._cur_epoch:
+                    if not warned:
+                        warned = True
+                        logger.warn(
+                            "Data from epoch {} was not fully read, "
+                            "skipping to next epoch.".format(self._cur_epoch - 1))
+                    next(self._iter)
                 epoch_pipe = DatasetPipeline.from_iterable(
-                    SingleEpochIterator(self._iter)
+                    SingleEpochIterator(self._iter, epoch=self._cur_epoch)
                 )
                 return epoch_pipe
 

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -66,6 +66,16 @@ def test_epoch(ray_start_regular_shared):
     assert results == [[0, 1, 2, 3], [4, 0, 1, 2, 3, 4]]
 
 
+# https://github.com/ray-project/ray/issues/20394
+def test_unused_epoch(ray_start_regular_shared):
+    pipe = ray.data.from_items([0, 1, 2, 3, 4]) \
+        .repeat(3)  \
+        .random_shuffle_each_window()
+
+    for i, epoch in enumerate(pipe.iter_epochs()):
+        print("Epoch", i)
+
+
 def test_cannot_read_twice(ray_start_regular_shared):
     ds = ray.data.range(10)
     pipe = ds.window(blocks_per_window=1)

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -68,9 +68,7 @@ def test_epoch(ray_start_regular_shared):
 
 # https://github.com/ray-project/ray/issues/20394
 def test_unused_epoch(ray_start_regular_shared):
-    pipe = ray.data.from_items([0, 1, 2, 3, 4]) \
-        .repeat(3)  \
-        .random_shuffle_each_window()
+    pipe = ray.data.from_items([0, 1, 2, 3, 4]).repeat(3).random_shuffle_each_window()
 
     for i, epoch in enumerate(pipe.iter_epochs()):
         print("Epoch", i)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes an incorrect assumption that the user will fully consume iterator contents when using iter_epochs().

## Related issue number

Closes https://github.com/ray-project/ray/issues/20394