### PR TITLE
[Tiny][Core]save memory copy for getting data in gcs storage

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -50,9 +50,7 @@ Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
     std::unordered_map<Key, Data> values;
     for (auto &item : result) {
       if (!item.second.empty()) {
-        Data data;
-        data.ParseFromString(item.second);
-        values[Key::FromBinary(item.first)] = std::move(data);
+        values[Key::FromBinary(item.first)].ParseFromString(item.second);
       }
     }
     callback(std::move(values));
@@ -92,9 +90,7 @@ Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
     std::unordered_map<Key, Data> values;
     for (auto &item : result) {
       if (!item.second.empty()) {
-        Data data;
-        data.ParseFromString(item.second);
-        values[Key::FromBinary(item.first)] = std::move(data);
+        values[Key::FromBinary(item.first)].ParseFromString(item.second);
       }
     }
     callback(std::move(values));

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -52,7 +52,7 @@ Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
       if (!item.second.empty()) {
         Data data;
         data.ParseFromString(item.second);
-        values[Key::FromBinary(item.first)] = data;
+        values[Key::FromBinary(item.first)] = std::move(data);
       }
     }
     callback(std::move(values));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When get a bunch of data from redis, we first initialize local variables and then put them in vector, which bring so much copies from stack to heap or from local variables to vector.
This tiny little change would save the copies.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
