### PR TITLE
[Core] Bug fix about FixedPoint

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -238,6 +238,30 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingFixedPointTest) {
 
     ASSERT_TRUE(fp1.Double() == 1.);
   }
+
+  {
+    FixedPoint fp1(1.);
+    auto fp2 = fp1 - 1.0;
+    ASSERT_TRUE(fp2 == 0);
+
+    auto fp3 = fp1 + 1.0;
+    ASSERT_TRUE(fp3 == 2);
+
+    auto fp4 = -fp1;
+    ASSERT_TRUE(fp4 == -1.0);
+
+    fp1 = 2.0;
+    ASSERT_TRUE(fp1 == 2.0);
+
+    FixedPoint fp5(-1.0);
+    ASSERT_TRUE(fp5 == -1);
+
+    FixedPoint f6(-1);
+    FixedPoint f7(int64_t(-1));
+    ASSERT_TRUE(f6 == f7);
+
+    ASSERT_TRUE(f6 == -1.0);
+  }
 }
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingIdTest) {

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -27,15 +27,13 @@ class FixedPoint {
 
  public:
   FixedPoint() : FixedPoint(0.0) {}
-  FixedPoint(double d) { i_ = (uint64_t)(d * RESOURCE_UNIT_SCALING); }  // NOLINT
+  FixedPoint(double d) { i_ = (int64_t)(d * RESOURCE_UNIT_SCALING); }  // NOLINT
 
   FixedPoint(int i) { i_ = (i * RESOURCE_UNIT_SCALING); }  // NOLINT
 
   FixedPoint(uint32_t i) { i_ = (i * RESOURCE_UNIT_SCALING); }  // NOLINT
 
   FixedPoint(int64_t i) : FixedPoint((double)i) {}  // NOLINT
-
-  FixedPoint(uint64_t i) : FixedPoint((double)i) {}  // NOLINT
 
   static FixedPoint Sum(const std::vector<FixedPoint> &list) {
     FixedPoint sum;

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -81,7 +81,7 @@ class FixedPoint {
 
   FixedPoint operator-(double const d) const {
     FixedPoint res;
-    res.i_ = i_ + static_cast<int64_t>(d * RESOURCE_UNIT_SCALING);
+    res.i_ = i_ - static_cast<int64_t>(d * RESOURCE_UNIT_SCALING);
     return res;
   }
 

--- a/src/ray/raylet/scheduling/fixed_point.h
+++ b/src/ray/raylet/scheduling/fixed_point.h
@@ -31,8 +31,6 @@ class FixedPoint {
 
   FixedPoint(int i) { i_ = (i * RESOURCE_UNIT_SCALING); }  // NOLINT
 
-  FixedPoint(uint32_t i) { i_ = (i * RESOURCE_UNIT_SCALING); }  // NOLINT
-
   FixedPoint(int64_t i) : FixedPoint((double)i) {}  // NOLINT
 
   static FixedPoint Sum(const std::vector<FixedPoint> &list) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
I think it's a typo.

**BTW:**
The following test will be failed too due to the incorrect constructor
FixedPoint::FixedPoint(double d) { i_ = (**`uint64_t`**)(d * RESOURCE_UNIT_SCALING); }
```
{
    FixedPoint fp1(1.0);
    auto fp2 = -fp1;
    ASSERT_TRUE(fp2 == -1.0);
}

{
  FixedPoint fp5(-1.0);
  ASSERT_TRUE(fp5 == -1);
}
```

But if I change

FixedPoint::FixedPoint(double d) { i_ = (**`uint64_t`**)(d * RESOURCE_UNIT_SCALING); } 

to

FixedPoint::FixedPoint(double d) { i_ = (**`int64_t`**)(d * RESOURCE_UNIT_SCALING); } 

then, the following test will be failed

```
{
    FixedPoint f1(uint64_t(-1));
    FixedPoint f2(int64_t(-1));
    ASSERT_TRUE(f1 == f2);
}

{
    FixedPoint f1(uint64_t(-1));
    ASSERT_TRUE(f1 == -1.0);
}
```

Since the `_i` is a signed type `int64_t` inside `FixedPoint`, I decide to remove the constructor `FixedPoint::FixedPoint(uint64_t d)` and change 

FixedPoint::FixedPoint(double d) { i_ = (**`uint64_t`**)(d * RESOURCE_UNIT_SCALING); } 

to

FixedPoint::FixedPoint(double d) { i_ = (**`int64_t`**)(d * RESOURCE_UNIT_SCALING); } 

cc @iycheng @rkooo567 @scv119 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
