### PR TITLE
[Scheduler] Fix string id map bug

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -22,18 +22,18 @@
 namespace ray {
 
 namespace {
-// Preserve predefined resource in string_to_int_map to
+// Add predefined resource in string_to_int_map to
 // avoid conflict.
-void PreservePredefinedResources(StringIdMap &string_to_int_map) {
-  string_to_int_map.Preserve(ray::kCPU_ResourceLabel, CPU)
-      .Preserve(ray::kGPU_ResourceLabel, GPU)
-      .Preserve(ray::kObjectStoreMemory_ResourceLabel, OBJECT_STORE_MEM)
-      .Preserve(ray::kMemory_ResourceLabel, MEM);
+void PopulatePredefinedResources(StringIdMap &string_to_int_map) {
+  string_to_int_map.InsertOrDie(ray::kCPU_ResourceLabel, CPU)
+      .InsertOrDie(ray::kGPU_ResourceLabel, GPU)
+      .InsertOrDie(ray::kObjectStoreMemory_ResourceLabel, OBJECT_STORE_MEM)
+      .InsertOrDie(ray::kMemory_ResourceLabel, MEM);
 }
 }  // namespace
 
 ClusterResourceScheduler::ClusterResourceScheduler() {
-  PreservePredefinedResources(string_to_int_map_);
+  PopulatePredefinedResources(string_to_int_map_);
   cluster_resource_manager_ =
       std::make_unique<ClusterResourceManager>(string_to_int_map_);
   NodeResources node_resources;
@@ -55,7 +55,7 @@ ClusterResourceScheduler::ClusterResourceScheduler(
       local_node_id_(local_node_id),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
       gcs_client_(&gcs_client) {
-  PreservePredefinedResources(string_to_int_map_);
+  PopulatePredefinedResources(string_to_int_map_);
   cluster_resource_manager_ =
       std::make_unique<ClusterResourceManager>(string_to_int_map_);
   local_resource_manager_ = std::make_unique<LocalResourceManager>(
@@ -78,7 +78,7 @@ ClusterResourceScheduler::ClusterResourceScheduler(
       local_node_id_(),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
       gcs_client_(&gcs_client) {
-  PreservePredefinedResources(string_to_int_map_);
+  PopulatePredefinedResources(string_to_int_map_);
   local_node_id_ = string_to_int_map_.Insert(local_node_id);
   NodeResources node_resources = ResourceMapToNodeResources(
       string_to_int_map_, local_node_resources, local_node_resources);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -21,7 +21,19 @@
 
 namespace ray {
 
+namespace {
+// Preserve predefined resource in string_to_int_map to
+// avoid conflict.
+void PreservePredefinedResources(StringIdMap &string_to_int_map) {
+  string_to_int_map.Preserve(ray::kCPU_ResourceLabel, CPU)
+      .Preserve(ray::kGPU_ResourceLabel, GPU)
+      .Preserve(ray::kObjectStoreMemory_ResourceLabel, OBJECT_STORE_MEM)
+      .Preserve(ray::kMemory_ResourceLabel, MEM);
+}
+}  // namespace
+
 ClusterResourceScheduler::ClusterResourceScheduler() {
+  PreservePredefinedResources(string_to_int_map_);
   cluster_resource_manager_ =
       std::make_unique<ClusterResourceManager>(string_to_int_map_);
   NodeResources node_resources;
@@ -43,6 +55,7 @@ ClusterResourceScheduler::ClusterResourceScheduler(
       local_node_id_(local_node_id),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
       gcs_client_(&gcs_client) {
+  PreservePredefinedResources(string_to_int_map_);
   cluster_resource_manager_ =
       std::make_unique<ClusterResourceManager>(string_to_int_map_);
   local_resource_manager_ = std::make_unique<LocalResourceManager>(
@@ -65,6 +78,7 @@ ClusterResourceScheduler::ClusterResourceScheduler(
       local_node_id_(),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
       gcs_client_(&gcs_client) {
+  PreservePredefinedResources(string_to_int_map_);
   local_node_id_ = string_to_int_map_.Insert(local_node_id);
   NodeResources node_resources = ResourceMapToNodeResources(
       string_to_int_map_, local_node_resources, local_node_resources);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -167,6 +167,7 @@ class ClusterResourceScheduler {
   std::unique_ptr<raylet_scheduling_policy::SchedulingPolicy> scheduling_policy_;
 
   friend class ClusterResourceSchedulerTest;
+  FRIEND_TEST(ClusterResourceSchedulerTest, PopulatePredefinedResources);
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingDeleteClusterNodeTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingModifyClusterNodeTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest);

--- a/src/ray/raylet/scheduling/scheduling_ids.cc
+++ b/src/ray/raylet/scheduling/scheduling_ids.cc
@@ -60,7 +60,7 @@ int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
   }
 };
 
-void StringIdMap::Preserve(const std::string &string_id, int64_t value) {
+StringIdMap &StringIdMap::InsertOrDie(const std::string &string_id, int64_t value) {
   RAY_CHECK(Get(string_id) == -1) << string_id << " or " << value << " already exist!";
   string_to_int_.emplace(string_id, value);
   int_to_string_.emplace(value, string_id);

--- a/src/ray/raylet/scheduling/scheduling_ids.cc
+++ b/src/ray/raylet/scheduling/scheduling_ids.cc
@@ -60,4 +60,11 @@ int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
   }
 };
 
+void StringIdMap::Preserve(const std::string &string_id, int64_t value) {
+  RAY_CHECK(Get(string_id) == -1) << string_id << " or " << value << " already exist!";
+  string_to_int_.emplace(string_id, value);
+  int_to_string_.emplace(value, string_id);
+  return *this;
+}
+
 int64_t StringIdMap::Count() { return string_to_int_.size(); }

--- a/src/ray/raylet/scheduling/scheduling_ids.h
+++ b/src/ray/raylet/scheduling/scheduling_ids.h
@@ -52,9 +52,9 @@ class StringIdMap {
   /// \return The integer ID associated with string ID string_id.
   int64_t Insert(const std::string &string_id, uint8_t num_ids = 0);
 
-  /// Preserve a string ID and its integer ID in the map.
+  /// Insert string ID and its integer ID in the map.
   /// It will crash the process if either string_id or id exists.
-  StringIdMap &Preserve(const std::string &string_id, int64_t id);
+  StringIdMap &InsertOrDie(const std::string &string_id, int64_t id);
 
   /// Removing an ID is unsupported, because it is prone to erroneously
   /// deleting an ID still in use.

--- a/src/ray/raylet/scheduling/scheduling_ids.h
+++ b/src/ray/raylet/scheduling/scheduling_ids.h
@@ -52,6 +52,10 @@ class StringIdMap {
   /// \return The integer ID associated with string ID string_id.
   int64_t Insert(const std::string &string_id, uint8_t num_ids = 0);
 
+  /// Preserve a string ID and its integer ID in the map.
+  /// It will crash the process if either string_id or id exists.
+  StringIdMap &Preserve(const std::string &string_id, int64_t id);
+
   /// Removing an ID is unsupported, because it is prone to erroneously
   /// deleting an ID still in use.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We risk the potential conflict if a custom resource or a node id's hash value conflict with those predefined resources in cluster_resource_scheduler.

Resolve it by preallocate predefined resources.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
