### PR TITLE
[RLlib] Issue 22539: agent_key not deleted from 2 dicts in simple list collector.

### DIFF
--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -867,6 +867,10 @@ class SimpleListCollector(SampleCollector):
             # setting (used by our PolicyClients).
             last_info = episode.last_info_for(agent_id)
             if last_info and not last_info.get("training_enabled", True):
+                if is_done:
+                    agent_key = (episode_id, agent_id)
+                    del self.agent_key_to_policy_id[agent_key]
+                    del self.agent_collectors[agent_key]
                 continue
 
             if len(pre_batches) > 1:
@@ -946,6 +950,7 @@ class SimpleListCollector(SampleCollector):
             del self.episode_steps[episode_id]
             del self.agent_steps[episode_id]
             del self.episodes[episode_id]
+
             # Make PolicyCollectorGroup available for more agent batches in
             # other episodes. Do not reset count to 0.
             if policy_collector_group:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 22539: agent_key not deleted from 2 dicts in simple list collector.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Issue #22539 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #22539 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
