### PR TITLE
[runtime env] Make plugin setup process that has not been refactor run in threads.

### DIFF
--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -210,6 +210,8 @@ class RuntimeEnvAgent(
                     )
 
             loop = asyncio.get_event_loop()
+            # Plugins setup method is sync process, running in other threads
+            # is to avoid  blocks asyncio loop
             await loop.run_in_executor(None, setup_plugins)
 
             return context

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -194,17 +194,23 @@ class RuntimeEnvAgent(
                 for uri in runtime_env.plugin_uris():
                     self._uris_to_envs[uri].add(serialized_runtime_env)
 
-            # Run setup function from all the plugins
-            for plugin_class_path, config in runtime_env.plugins():
-                per_job_logger.debug(
-                    f"Setting up runtime env plugin {plugin_class_path}"
-                )
-                plugin_class = import_attr(plugin_class_path)
-                # TODO(simon): implement uri support
-                plugin_class.create("uri not implemented", json.loads(config), context)
-                plugin_class.modify_context(
-                    "uri not implemented", json.loads(config), context
-                )
+            def setup_plugins():
+                # Run setup function from all the plugins
+                for plugin_class_path, config in runtime_env.plugins():
+                    per_job_logger.debug(
+                        f"Setting up runtime env plugin {plugin_class_path}"
+                    )
+                    plugin_class = import_attr(plugin_class_path)
+                    # TODO(simon): implement uri support
+                    plugin_class.create(
+                        "uri not implemented", json.loads(config), context
+                    )
+                    plugin_class.modify_context(
+                        "uri not implemented", json.loads(config), context
+                    )
+
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(None, setup_plugins)
 
             return context
 

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -307,6 +307,10 @@ class CondaManager:
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ) -> int:
+        # Currently create method is still a sync process, to avoid blocking
+        # the loop, need to run this function in another thread.
+        # TODO(Catch-Bull): Refactor method create into an async process, and
+        # make this method running in current loop.
         def _create():
             logger.debug(
                 "Setting up conda for runtime_env: " f"{runtime_env.serialize()}"

--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -131,6 +131,10 @@ class PyModulesManager:
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ) -> int:
+        # Currently create method is still a sync process, to avoid blocking
+        # the loop, need to run this function in another thread.
+        # TODO(Catch-Bull): Refactor method create into an async process, and
+        # make this method running in current loop.
         def _create():
             module_dir = download_and_unpack_package(
                 uri, self._resources_dir, logger=logger

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -117,6 +117,10 @@ class WorkingDirManager:
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ) -> int:
+        # Currently create method is still a sync process, to avoid blocking
+        # the loop, need to run this function in another thread.
+        # TODO(Catch-Bull): Refactor method create into an async process, and
+        # make this method running in current loop.
         def _create():
             local_dir = download_and_unpack_package(
                 uri, self._resources_dir, logger=logger

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -106,6 +106,7 @@ class MyPluginForHang(RuntimeEnvPlugin):
 
 def test_plugin_hang(ray_start_regular):
     env_key = MyPluginForHang.env_key
+
     @ray.remote(num_cpus=0.1)
     def f():
         return os.environ[env_key]

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -122,9 +122,12 @@ def test_plugin_hang(ray_start_regular):
     def condition():
         for ref in refs:
             try:
-                assert int(ray.get(ref, timeout=1)) == 2
+                res = ray.get(ref, timeout=1)
+                print("result:", res)
+                assert int(res) == 2
                 return True
-            except Exception:
+            except Exception as error:
+                print(f"Got error: {error}")
                 pass
         return False
 

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -1,9 +1,11 @@
 import os
 import tempfile
+from time import sleep
 
 import pytest
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.test_utils import wait_for_condition
 
 import ray
 
@@ -70,6 +72,63 @@ def test_simple_env_modification_plugin(ray_start_regular):
         )
 
         assert output == {"env_value": "42", "tmp_content": "hello", "nice": 19}
+
+
+MY_PLUGIN_FOR_HANG_CLASS_PATH = "ray.tests.test_runtime_env_plugin.MyPluginForHang"
+my_plugin_setup_times = 0
+
+
+# This plugin will hang when first setup, second setup will ok
+class MyPluginForHang(RuntimeEnvPlugin):
+    env_key = "MY_PLUGIN_FOR_HANG_TEST_ENVIRONMENT_KEY"
+
+    @staticmethod
+    def validate(runtime_env_dict: dict) -> str:
+        return "True"
+
+    @staticmethod
+    def create(uri: str, runtime_env: dict, ctx: RuntimeEnvContext) -> float:
+        global my_plugin_setup_times
+        my_plugin_setup_times += 1
+
+        # first setup
+        if my_plugin_setup_times == 1:
+            # sleep forever
+            sleep(3600)
+
+    @staticmethod
+    def modify_context(
+        uri: str, plugin_config_dict: dict, ctx: RuntimeEnvContext
+    ) -> None:
+        global my_plugin_setup_times
+        ctx.env_vars[MyPluginForHang.env_key] = str(my_plugin_setup_times)
+
+
+def test_plugin_hang(ray_start_regular):
+    @ray.remote(num_cpus=0.1)
+    def f():
+        return os.environ[MyPluginForHang.env_key]
+
+    refs = [
+        f.options(
+            # Avoid hitting the cache of runtime_env
+            runtime_env={"plugins": {MY_PLUGIN_FOR_HANG_CLASS_PATH: {"name": "f1"}}}
+        ).remote(),
+        f.options(
+            runtime_env={"plugins": {MY_PLUGIN_FOR_HANG_CLASS_PATH: {"name": "f2"}}}
+        ).remote(),
+    ]
+
+    def condition():
+        for ref in refs:
+            try:
+                assert int(ray.get(ref, timeout=1)) == 2
+                return True
+            except Exception:
+                pass
+        return False
+
+    wait_for_condition(condition, timeout=60)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -105,9 +105,10 @@ class MyPluginForHang(RuntimeEnvPlugin):
 
 
 def test_plugin_hang(ray_start_regular):
+    env_key = MyPluginForHang.env_key
     @ray.remote(num_cpus=0.1)
     def f():
-        return os.environ[MyPluginForHang.env_key]
+        return os.environ[env_key]
 
     refs = [
         f.options(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

I recently realized that during a runtime_env creation process, a plugin/manager that is very slow to setup may block the creation of other runtime_env, so I make plugin/manager setup run in threads.

[The refactor of `PipManager`](https://github.com/ray-project/ray/pull/22381) is about to be completed, so I ignore it in this PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
