### PR TITLE
[runtime_env] Remove get_current_runtime_env from docs

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -391,7 +391,7 @@ The runtime environment is inheritable, so it will apply to all tasks/actors wit
   # ChildActor's actual `runtime_env` (specify runtime_env overrides)
   {"env_vars": {"A": "a", "B": "b"}}
 
-3. If you'd like to still use current runtime env, you can use the API :ref:`ray.get_current_runtime_env() <runtime-env-apis>` to get the current runtime env and modify it by yourself.
+3. If you'd like to still use current runtime env, you can use the :ref:`ray.get_runtime_context() <runtime-context-apis>` API to get the current runtime env and modify it by yourself.
 
 .. code-block:: python
 

--- a/doc/source/ray-core/package-ref.rst
+++ b/doc/source/ray-core/package-ref.rst
@@ -208,13 +208,6 @@ Runtime Context APIs
 .. autoclass:: ray.runtime_context.RuntimeContext
     :members:
 
-.. _runtime-env-apis:
-
-Runtime Env APIs
---------------------
-
-.. autofunction:: ray.runtime_env.get_current_runtime_env
-
 .. _package-ref-debugging-apis:
 
 Debugging APIs

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -1,10 +1,8 @@
 import ray
 
-from ray.util.annotations import PublicAPI
 from ray._private.client_mode_hook import client_mode_hook
 
 
-@PublicAPI(stability="beta")
 @client_mode_hook(auto_init=False)
 def get_current_runtime_env():
     """Get the runtime env of the current job/worker.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We should just encourage people to use the existing `get_runtime_context` API instead of introducing a new one here. Just removing the docs for now while we discuss this.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
