### PR TITLE
[runtime env] Add test that both APIs for getting the current runtime env agree

### DIFF
--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -23,6 +23,7 @@ from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.runtime_env.validation import ParsedRuntimeEnv
 
+
 def test_get_wheel_filename():
     ray_version = "2.0.0.dev0"
     for sys_platform in ["darwin", "linux", "win32"]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We have two ways of getting the runtime env, `ray.get_runtime_context().runtime_env` and `ray.runtime_env.get_current_runtime_env()`.  We plan to unify these soon, likely by removing the second API.  Until then, we should have a test that these have the same functionality.

The test added in this PR passes locally.  Once we remove the duplicate API, we'll modify the test again.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Related: https://github.com/ray-project/ray/pull/22244 where the second API was introduced.  I overlooked the fact that we already had an API for this.

https://github.com/ray-project/ray/pull/22594

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
