### PR TITLE
Basic log observability for spilling

### DIFF
--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -40,7 +40,7 @@ ID_SIZE = 28
 
 # The default maximum number of bytes to allocate to the object store unless
 # overridden by the user.
-DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10**9
+DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10 ** 9
 # The default proportion of available memory allocated to the object store
 DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 # The smallest cap on the memory used by the object store that we allow.
@@ -48,18 +48,18 @@ DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 OBJECT_STORE_MINIMUM_MEMORY_BYTES = 75 * 1024 * 1024
 # The default maximum number of bytes that the non-primary Redis shards are
 # allowed to use unless overridden by the user.
-DEFAULT_REDIS_MAX_MEMORY_BYTES = 10**10
+DEFAULT_REDIS_MAX_MEMORY_BYTES = 10 ** 10
 # The smallest cap on the memory used by Redis that we allow.
-REDIS_MINIMUM_MEMORY_BYTES = 10**7
+REDIS_MINIMUM_MEMORY_BYTES = 10 ** 7
 # Above this number of bytes, raise an error by default unless the user sets
 # RAY_ALLOW_SLOW_STORAGE=1. This avoids swapping with large object stores.
-REQUIRE_SHM_SIZE_THRESHOLD = 10**10
+REQUIRE_SHM_SIZE_THRESHOLD = 10 ** 10
 # Mac with 16GB memory has degraded performance when the object store size is
 # greater than 2GB.
 # (see https://github.com/ray-project/ray/issues/20388 for details)
 # The workaround here is to limit capacity to 2GB for Mac by default,
 # and raise error if the capacity is overwritten by user.
-MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2**30
+MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2 ** 30
 # If a user does not specify a port for the primary Ray service,
 # we attempt to start the service running at this port.
 DEFAULT_PORT = 6379
@@ -88,8 +88,8 @@ DEFAULT_CLIENT_RECONNECT_GRACE_PERIOD = 30
 
 # If a remote function or actor (or some other export) has serialized size
 # greater than this quantity, print an warning.
-FUNCTION_SIZE_WARN_THRESHOLD = 10**7
-FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10**8))
+FUNCTION_SIZE_WARN_THRESHOLD = 10 ** 7
+FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10 ** 8))
 
 # If remote functions with the same source are imported this many times, then
 # print a warning.

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -40,7 +40,7 @@ ID_SIZE = 28
 
 # The default maximum number of bytes to allocate to the object store unless
 # overridden by the user.
-DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10 ** 9
+DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10**9
 # The default proportion of available memory allocated to the object store
 DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 # The smallest cap on the memory used by the object store that we allow.
@@ -48,18 +48,18 @@ DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 OBJECT_STORE_MINIMUM_MEMORY_BYTES = 75 * 1024 * 1024
 # The default maximum number of bytes that the non-primary Redis shards are
 # allowed to use unless overridden by the user.
-DEFAULT_REDIS_MAX_MEMORY_BYTES = 10 ** 10
+DEFAULT_REDIS_MAX_MEMORY_BYTES = 10**10
 # The smallest cap on the memory used by Redis that we allow.
-REDIS_MINIMUM_MEMORY_BYTES = 10 ** 7
+REDIS_MINIMUM_MEMORY_BYTES = 10**7
 # Above this number of bytes, raise an error by default unless the user sets
 # RAY_ALLOW_SLOW_STORAGE=1. This avoids swapping with large object stores.
-REQUIRE_SHM_SIZE_THRESHOLD = 10 ** 10
+REQUIRE_SHM_SIZE_THRESHOLD = 10**10
 # Mac with 16GB memory has degraded performance when the object store size is
 # greater than 2GB.
 # (see https://github.com/ray-project/ray/issues/20388 for details)
 # The workaround here is to limit capacity to 2GB for Mac by default,
 # and raise error if the capacity is overwritten by user.
-MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2 ** 30
+MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2**30
 # If a user does not specify a port for the primary Ray service,
 # we attempt to start the service running at this port.
 DEFAULT_PORT = 6379
@@ -88,8 +88,8 @@ DEFAULT_CLIENT_RECONNECT_GRACE_PERIOD = 30
 
 # If a remote function or actor (or some other export) has serialized size
 # greater than this quantity, print an warning.
-FUNCTION_SIZE_WARN_THRESHOLD = 10 ** 7
-FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10 ** 8))
+FUNCTION_SIZE_WARN_THRESHOLD = 10**7
+FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10**8))
 
 # If remote functions with the same source are imported this many times, then
 # print a warning.
@@ -244,6 +244,9 @@ LOG_MONITOR_MAX_OPEN_FILES = 200
 
 # Autoscaler events are denoted by the ":event_summary:" magic token.
 LOG_PREFIX_EVENT_SUMMARY = ":event_summary:"
+# Cluster-level info events are denoted by the ":info_message:" magic token. These may
+# be emitted in the stderr of Ray components.
+LOG_PREFIX_INFO_MESSAGE = ":info_message:"
 # Actor names are recorded in the logs with this magic token as a prefix.
 LOG_PREFIX_ACTOR_NAME = ":actor_name:"
 # Task names are recorded in the logs with this magic token as a prefix.

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -530,7 +530,7 @@ if __name__ == "__main__":
         # about low shm memory in Linux environment.
         # The test failures currently complain it only has 2 GB memory,
         # so let's set it much lower than that.
-        MB = 1000 ** 2
+        MB = 1000**2
         ray.init(num_cpus=1, object_store_memory=(100 * MB))
         ray.shutdown()
     else:

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -14,6 +14,7 @@ from ray._private.test_utils import (
 )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_spill_logs():
     script = """
 import ray

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -530,7 +530,7 @@ if __name__ == "__main__":
         # about low shm memory in Linux environment.
         # The test failures currently complain it only has 2 GB memory,
         # so let's set it much lower than that.
-        MB = 1000**2
+        MB = 1000 ** 2
         ray.init(num_cpus=1, object_store_memory=(100 * MB))
         ray.shutdown()
     else:

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -14,6 +14,30 @@ from ray._private.test_utils import (
 )
 
 
+def test_spill_logs():
+    script = """
+import ray
+import numpy as np
+
+ray.init(object_store_memory=200e6)
+
+x = []
+
+for _ in range(10):
+    x.append(ray.put(np.ones(100 * 1024 * 1024, dtype=np.uint8)))
+"""
+
+    proc = run_string_as_driver_nonblocking(script, env={"RAY_verbose_spill_logs": "1"})
+    out_str = proc.stdout.read().decode("ascii") + proc.stderr.read().decode("ascii")
+    print(out_str)
+    assert "Spilled " in out_str
+
+    proc = run_string_as_driver_nonblocking(script, env={"RAY_verbose_spill_logs": "0"})
+    out_str = proc.stdout.read().decode("ascii") + proc.stderr.read().decode("ascii")
+    print(out_str)
+    assert "Spilled " not in out_str
+
+
 def test_autoscaler_infeasible():
     script = """
 import ray

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2113,7 +2113,7 @@ def wait(
                 "of objects provided to ray.wait."
             )
 
-        timeout = timeout if timeout is not None else 10**6
+        timeout = timeout if timeout is not None else 10 ** 6
         timeout_milliseconds = int(timeout * 1000)
         ready_ids, remaining_ids = worker.core_worker.wait(
             object_refs,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1305,9 +1305,18 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                 res = data["task_name"] + " " + res
             return res
 
+    def message_for(data: Dict[str, str], line: str) -> str:
+        """The printed message of this log line."""
+        if ray_constants.LOG_PREFIX_INFO_MESSAGE in line:
+            return line.split(ray_constants.LOG_PREFIX_INFO_MESSAGE)[1]
+        return line
+
     def color_for(data: Dict[str, str], line: str) -> str:
         """The color for this log line."""
-        if data.get("pid") == "raylet":
+        if (
+            data.get("pid") == "raylet"
+            and ray_constants.LOG_PREFIX_INFO_MESSAGE not in line
+        ):
             return colorama.Fore.YELLOW
         elif data.get("pid") == "autoscaler":
             if "Error:" in line or "Warning:" in line:
@@ -1333,7 +1342,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     prefix_for(data),
                     pid,
                     colorama.Style.RESET_ALL,
-                    line,
+                    message_for(data, line),
                 ),
                 file=print_file,
             )
@@ -1347,7 +1356,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
                     pid,
                     data.get("ip"),
                     colorama.Style.RESET_ALL,
-                    line,
+                    message_for(data, line),
                 ),
                 file=print_file,
             )
@@ -2104,7 +2113,7 @@ def wait(
                 "of objects provided to ray.wait."
             )
 
-        timeout = timeout if timeout is not None else 10 ** 6
+        timeout = timeout if timeout is not None else 10**6
         timeout_milliseconds = int(timeout * 1000)
         ready_ids, remaining_ids = worker.core_worker.wait(
             object_refs,

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -394,6 +394,10 @@ RAY_CONFIG(int64_t, max_placement_group_load_report_size, 1000)
 /// external storage.
 RAY_CONFIG(std::string, object_spilling_config, "")
 
+/// Log an ERROR-level message about spilling every time this amount of bytes has been
+/// spilled, with exponential increase in interval. This can be set to zero to disable.
+RAY_CONFIG(int64_t, verbose_spill_logs, 2L * 1024 * 1024 * 1024)
+
 /// Whether to enable automatic object spilling. If enabled, then
 /// Ray will choose objects to spill when the object store is out of
 /// memory.

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -211,7 +211,8 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
               << static_cast<int>(spilled_bytes_total_ / (1024 * 1024) /
                                   spill_time_total_s_)
               << " MiB/s";
-          if (next_spill_error_log_bytes > 0 && spilled_bytes_total_ >= next_spill_error_log_bytes_) {
+          if (next_spill_error_log_bytes > 0 &&
+              spilled_bytes_total_ >= next_spill_error_log_bytes_) {
             next_spill_error_log_bytes_ *= 2;
             if (last_spill_error_log_bytes_ == 0) {
               msg << ". Set RAY_verbose_spill_logs=0 to disable this message.";

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -205,7 +205,7 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
         spill_time_total_s_ += (now - std::max(start_time, last_spill_finish_ns_)) / 1e9;
         if (now - last_spill_log_ns_ > 1e9) {
           last_spill_log_ns_ = now;
-          RAY_LOG(INFO) << "Spilled "
+          RAY_LOG(ERROR) << "Spilled "
                         << static_cast<int>(spilled_bytes_total_ / (1024 * 1024))
                         << " MiB, " << spilled_objects_total_
                         << " objects, write throughput "

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -211,12 +211,14 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
               << static_cast<int>(spilled_bytes_total_ / (1024 * 1024) /
                                   spill_time_total_s_)
               << " MiB/s";
-          if (next_spill_error_log_bytes > 0 &&
+          if (next_spill_error_log_bytes_ > 0 &&
               spilled_bytes_total_ >= next_spill_error_log_bytes_) {
-            next_spill_error_log_bytes_ *= 2;
-            if (last_spill_error_log_bytes_ == 0) {
+            // Add an advisory the first time this is logged.
+            if (next_spill_error_log_bytes_ == RayConfig::instance().verbose_spill_logs()) {
               msg << ". Set RAY_verbose_spill_logs=0 to disable this message.";
             }
+            // Exponential backoff on the spill messages.
+            next_spill_error_log_bytes_ *= 2;
             RAY_LOG(ERROR) << msg.str();
           } else {
             RAY_LOG(INFO) << msg.str();

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -206,17 +206,19 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
         if (now - last_spill_log_ns_ > 1e9) {
           last_spill_log_ns_ = now;
           std::stringstream msg;
-          msg << "Spilled " << static_cast<int>(spilled_bytes_total_ / (1024 * 1024))
-              << " MiB, " << spilled_objects_total_ << " objects, write throughput "
+          // Keep :info_message: in sync with LOG_PREFIX_INFO_MESSAGE in ray_constants.py.
+          msg << ":info_message:Spilled "
+              << static_cast<int>(spilled_bytes_total_ / (1024 * 1024)) << " MiB, "
+              << spilled_objects_total_ << " objects, write throughput "
               << static_cast<int>(spilled_bytes_total_ / (1024 * 1024) /
                                   spill_time_total_s_)
-              << " MiB/s";
+              << " MiB/s.";
           if (next_spill_error_log_bytes_ > 0 &&
               spilled_bytes_total_ >= next_spill_error_log_bytes_) {
             // Add an advisory the first time this is logged.
             if (next_spill_error_log_bytes_ ==
                 RayConfig::instance().verbose_spill_logs()) {
-              msg << ". Set RAY_verbose_spill_logs=0 to disable this message.";
+              msg << " Set RAY_verbose_spill_logs=0 to disable this message.";
             }
             // Exponential backoff on the spill messages.
             next_spill_error_log_bytes_ *= 2;

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -214,7 +214,8 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
           if (next_spill_error_log_bytes_ > 0 &&
               spilled_bytes_total_ >= next_spill_error_log_bytes_) {
             // Add an advisory the first time this is logged.
-            if (next_spill_error_log_bytes_ == RayConfig::instance().verbose_spill_logs()) {
+            if (next_spill_error_log_bytes_ ==
+                RayConfig::instance().verbose_spill_logs()) {
               msg << ". Set RAY_verbose_spill_logs=0 to disable this message.";
             }
             // Exponential backoff on the spill messages.

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -60,6 +60,7 @@ class LocalObjectManager {
         is_plasma_object_spillable_(is_plasma_object_spillable),
         is_external_storage_type_fs_(is_external_storage_type_fs),
         max_fused_object_count_(max_fused_object_count),
+        next_spill_error_log_bytes_(RayConfig::instance().verbose_spill_logs()),
         core_worker_subscriber_(core_worker_subscriber) {}
 
   /// Pin objects.
@@ -277,6 +278,10 @@ class LocalObjectManager {
 
   /// Maximum number of objects that can be fused into a single file.
   int64_t max_fused_object_count_;
+
+  /// The next total bytes for an error-level spill log, or zero to disable.
+  /// This is doubled each time a message is logged.
+  int64_t next_spill_error_log_bytes_;
 
   /// The raylet client to initiate the pubsub to core workers (owners).
   /// It is used to subscribe objects to evict.

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -278,6 +278,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   void PushActorTask(std::unique_ptr<PushTaskRequest> request, bool skip_queue,
                      const ClientCallback<PushTaskReply> &callback) override {
     if (skip_queue) {
+      RAY_LOG(ERROR) << "Skip queue true";
       // Set this value so that the actor does not skip any tasks when
       // processing this request. We could also set it to max_finished_seq_no_,
       // but we just set it to the default of -1 to avoid taking the lock.
@@ -298,6 +299,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   void PushNormalTask(std::unique_ptr<PushTaskRequest> request,
                       const ClientCallback<PushTaskReply> &callback) override {
+    RAY_LOG(ERROR) << "Push normal task";
     request->set_sequence_number(-1);
     request->set_client_processed_up_to(-1);
     INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, callback, grpc_client_,
@@ -331,6 +333,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
           if (seq_no > max_finished_seq_no_) {
             max_finished_seq_no_ = seq_no;
           }
+          RAY_LOG(ERROR) << "Process " << seq_no << " " << max_finished_seq_no_;
           rpc_bytes_in_flight_ -= task_size;
           RAY_CHECK(rpc_bytes_in_flight_ >= 0);
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, it is quite difficult to know when spilling is happening if you aren't explicitly looking for it. This PR adds basic observability for spilling out of the box via an driver log. In the future, we can improve on this simple approach.

Sample output:
```
2022-02-28 17:13:22,502	INFO services.py:1490 -- View the Ray dashboard at http://127.0.0.1:8265
(raylet) Spilled 800 MiB, 1 objects, write throughput 502 MiB/s. Set RAY_verbose_spill_logs=0 to disable this message.
(raylet) Spilled 4800 MiB, 6 objects, write throughput 1795 MiB/s.
(raylet) Spilled 7200 MiB, 9 objects, write throughput 1947 MiB/s.
(raylet) Spilled 10400 MiB, 13 objects, write throughput 2204 MiB/s.
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
