### PR TITLE
[rllib] Fix impala long running test

### DIFF
--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -10,6 +10,7 @@ python:
     - gym[atari]
     - pytest
     - tensorflow
+    - torch
   conda_packages: []
 
 post_build_cmds:

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -8,6 +8,7 @@ debian_packages:
 python:
   pip_packages:
     - gym[atari]
+    - pygame
     - pytest
     - tensorflow
     - torch

--- a/release/long_running_tests/workloads/impala.py
+++ b/release/long_running_tests/workloads/impala.py
@@ -46,7 +46,7 @@ run_experiments(
     {
         "impala": {
             "run": "IMPALA",
-            "env": "CartPole-v0",
+            "env": "CartPole-v1",
             "config": {
                 "num_workers": 8,
                 "num_gpus": 0,

--- a/release/long_running_tests/workloads/impala.py
+++ b/release/long_running_tests/workloads/impala.py
@@ -41,6 +41,7 @@ if "RAY_ADDRESS" in os.environ:
 ray.init(num_cpus=10)
 # Run the workload.
 
+# Whitespace diff to test things.
 run_experiments(
     {
         "impala": {


### PR DESCRIPTION
## Why are these changes needed?

fix impala long running test.
Bandits is the first agent that requires torch import at registration time.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
