### PR TITLE
Remove exporting symbols

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -596,6 +596,7 @@ cc_library(
     srcs = [
         "src/ray/stats/metric.cc",
         "src/ray/stats/metric_defs.cc",
+        "src/ray/stats/tag_defs.cc",
     ],
     hdrs = [
         "src/ray/stats/metric.h",

--- a/src/ray/internal/internal.cc
+++ b/src/ray/internal/internal.cc
@@ -52,5 +52,8 @@ std::vector<rpc::ObjectReference> SendInternal(const ActorID &peer_actor_id,
   }
   return result.value();
 }
+const ray::stats::TagKeyType TagRegister(const std::string tag_name) {
+  return ray::stats::TagKeyType::Register(tag_name);
+}
 }  // namespace internal
 }  // namespace ray

--- a/src/ray/internal/internal.h
+++ b/src/ray/internal/internal.h
@@ -16,6 +16,7 @@
 #include "ray/common/buffer.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/common.h"
+#include "ray/stats/metric.h"
 
 // This header is used to warp some internal code so we can reduce suspicious
 // symbols export.
@@ -33,5 +34,6 @@ std::vector<rpc::ObjectReference> SendInternal(const ActorID &peer_actor_id,
                                                std::shared_ptr<LocalMemoryBuffer> buffer,
                                                RayFunction &function, int return_num);
 
+const stats::TagKeyType TagRegister(const std::string tag_name);
 }  // namespace internal
 }  // namespace ray

--- a/src/ray/ray_exported_symbols.lds
+++ b/src/ray/ray_exported_symbols.lds
@@ -29,6 +29,7 @@
 *ray*gcs*
 *ray*CoreWorker*
 *ray*PeriodicalRunner*
+*ray*internal*
 *PyInit__raylet*
 *Java_io_ray*
 _JNI_On*

--- a/src/ray/ray_exported_symbols.lds
+++ b/src/ray/ray_exported_symbols.lds
@@ -24,13 +24,11 @@
 *ray*ObjectReference*
 # Others
 *ray*metrics*
-*opencensus*;
 *ray*stats*
 *ray*rpc*
 *ray*gcs*
 *ray*CoreWorker*
-*ray*PeriodicalRunner*;
+*ray*PeriodicalRunner*
 *PyInit__raylet*
 *Java_io_ray*
 _JNI_On*
-*ray*internal*

--- a/src/ray/ray_version_script.lds
+++ b/src/ray/ray_version_script.lds
@@ -26,7 +26,6 @@ VERSION_1.0 {
         *ray*ObjectReference*;
         # Others
         *ray*metrics*;
-        *opencensus*;
         *ray*rpc*;
         *ray*gcs*;
         *ray*stats*;

--- a/src/ray/ray_version_script.lds
+++ b/src/ray/ray_version_script.lds
@@ -35,7 +35,6 @@ VERSION_1.0 {
         *init_raylet*;
         *Java*;
         *JNI_*;
-        *ray*internal*;
         *aligned_free*;
         *aligned_malloc*;
     local: *;

--- a/src/ray/ray_version_script.lds
+++ b/src/ray/ray_version_script.lds
@@ -31,6 +31,7 @@ VERSION_1.0 {
         *ray*stats*;
         *ray*CoreWorker*;
         *ray*PeriodicalRunner*;
+        *ray*internal*;
         *PyInit*;
         *init_raylet*;
         *Java*;

--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -129,6 +129,8 @@ void Metric::Record(double value,
   Record(value, tags_pair_vec);
 }
 
+Metric::~Metric() { opencensus::stats::StatsExporter::RemoveView(name_); }
+
 void Gauge::RegisterView() {
   opencensus::stats::ViewDescriptor view_descriptor =
       opencensus::stats::ViewDescriptor()

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -109,7 +109,7 @@ class Metric {
         tag_keys_(tag_keys),
         measure_(nullptr) {}
 
-  virtual ~Metric() { opencensus::stats::StatsExporter::RemoveView(name_); }
+  virtual ~Metric();
 
   Metric &operator()() { return *this; }
 

--- a/src/ray/stats/tag_defs.cc
+++ b/src/ray/stats/tag_defs.cc
@@ -1,0 +1,39 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/stats/metric.h"
+
+namespace ray {
+namespace stats {
+const TagKeyType ComponentKey = TagKeyType::Register("Component");
+
+const TagKeyType JobNameKey = TagKeyType::Register("JobName");
+
+const TagKeyType CustomKey = TagKeyType::Register("CustomKey");
+
+const TagKeyType NodeAddressKey = TagKeyType::Register("NodeAddress");
+
+const TagKeyType VersionKey = TagKeyType::Register("Version");
+
+const TagKeyType LanguageKey = TagKeyType::Register("Language");
+
+const TagKeyType WorkerPidKey = TagKeyType::Register("WorkerPid");
+
+const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
+
+const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
+
+const TagKeyType ActorIdKey = TagKeyType::Register("ActorId");
+}  // namespace stats
+}  // namespace ray

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -20,22 +20,22 @@
 using TagKeyType = opencensus::tags::TagKey;
 using TagsType = std::vector<std::pair<opencensus::tags::TagKey, std::string>>;
 
-static const TagKeyType ComponentKey = TagKeyType::Register("Component");
+extern const TagKeyType ComponentKey;
 
-static const TagKeyType JobNameKey = TagKeyType::Register("JobName");
+extern const TagKeyType JobNameKey;
 
-static const TagKeyType CustomKey = TagKeyType::Register("CustomKey");
+extern const TagKeyType CustomKey;
 
-static const TagKeyType NodeAddressKey = TagKeyType::Register("NodeAddress");
+extern const TagKeyType NodeAddressKey;
 
-static const TagKeyType VersionKey = TagKeyType::Register("Version");
+extern const TagKeyType VersionKey;
 
-static const TagKeyType LanguageKey = TagKeyType::Register("Language");
+extern const TagKeyType LanguageKey;
 
-static const TagKeyType WorkerPidKey = TagKeyType::Register("WorkerPid");
+extern const TagKeyType WorkerPidKey;
 
-static const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
+extern const TagKeyType DriverPidKey;
 
-static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
+extern const TagKeyType ResourceNameKey;
 
-static const TagKeyType ActorIdKey = TagKeyType::Register("ActorId");
+extern const TagKeyType ActorIdKey;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
To hidden symbols of thirdparty library, this pull request reuses internal namespace that can be imported by any external native projects without side effects.

Besides, we suggest all of contributors to make sure it'd better use thirdparty library in ray scopes/namspaces and only ray::internal should be exported.

More details in https://github.com/ray-project/ray/pull/22526

Mobius has applied this change in https://github.com/ray-project/mobius/pull/28.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
