### PR TITLE
[Core] Include java worker log with log monitor

### DIFF
--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -24,8 +24,8 @@ from ray._private.ray_logging import setup_component_logger
 # entry/init points.
 logger = logging.getLogger(__name__)
 
-# The groups are worker id, job id, and pid.
-JOB_LOG_PATTERN = re.compile(".*worker-([0-9a-f]+)-([0-9a-f]+)-(\d+)")
+# The groups are job id, and pid.
+JOB_LOG_PATTERN = re.compile(".*worker.*-([0-9a-f]+)-(\d+)")
 # The groups are job id.
 RUNTIME_ENV_SETUP_PATTERN = re.compile(".*runtime_env_setup-(\d+).log")
 # Log name update interval under pressure.
@@ -164,7 +164,9 @@ class LogMonitor:
     def update_log_filenames(self):
         """Update the list of log files to monitor."""
         # output of user code is written here
-        log_file_paths = glob.glob(f"{self.logs_dir}/worker*[.out|.err]")
+        log_file_paths = glob.glob(f"{self.logs_dir}/worker*[.out|.err]") + glob.glob(
+            f"{self.logs_dir}/java-worker*.log"
+        )
         # segfaults and other serious errors are logged here
         raylet_err_paths = glob.glob(f"{self.logs_dir}/raylet*.err")
         # monitor logs are needed to report autoscaler events
@@ -186,8 +188,8 @@ class LogMonitor:
             if os.path.isfile(file_path) and file_path not in self.log_filenames:
                 job_match = JOB_LOG_PATTERN.match(file_path)
                 if job_match:
-                    job_id = job_match.group(2)
-                    worker_pid = int(job_match.group(3))
+                    job_id = job_match.group(1)
+                    worker_pid = int(job_match.group(2))
                 else:
                     job_id = None
                     worker_pid = None

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -4,9 +4,12 @@ import re
 from datetime import datetime
 from collections import defaultdict, Counter
 from pathlib import Path
+import subprocess
+import tempfile
 import pytest
 
 import ray
+from ray.cross_language import java_actor_class
 from ray import ray_constants
 from ray._private.test_utils import (
     get_log_batch,
@@ -372,6 +375,40 @@ def test_segfault_stack_trace(ray_start_cluster, capsys):
     assert (
         "Fatal Python error: Segmentation fault" in stderr
     ), f"Python stack trace not found in stderr: {stderr}"
+
+
+def test_log_java_worker_logs(shutdown_only, capsys):
+    tmp_dir = tempfile.mkdtemp()
+    print("using tmp_dir", tmp_dir)
+    with open(os.path.join(tmp_dir, "MyClass.java"), "w") as f:
+        f.write(
+            """
+public class MyClass {
+    public int printToLog(String line) {
+        System.err.println(line);
+        return 0;
+    }
+}
+        """
+        )
+    subprocess.check_call(["javac", "MyClass.java"], cwd=tmp_dir)
+    subprocess.check_call(["jar", "-cf", "myJar.jar", "MyClass.class"], cwd=tmp_dir)
+
+    ray.init(
+        job_config=ray.job_config.JobConfig(code_search_path=[tmp_dir]),
+    )
+
+    handle = java_actor_class("MyClass").remote()
+    ray.get(handle.printToLog.remote("here's my random line!"))
+
+    def check():
+        out, err = capsys.readouterr()
+        out += err
+        with capsys.disabled():
+            print(out)
+        return "here's my random line!" in out
+
+    wait_for_condition(check)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Without this patch, Python driver has trouble seeing cross language Java worker's log.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
