### PR TITLE
[Release] Disable failing `serve_micro_benchmark_k8s` test

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -119,7 +119,8 @@ SERVE_NIGHTLY_TESTS = {
         "autoscaling_single_deployment",
         "autoscaling_multi_deployment",
         "serve_micro_benchmark",
-        "serve_micro_benchmark_k8s",
+        # TODO(architkulkarni) Reenable after K8s migration.  Currently failing
+        # "serve_micro_benchmark_k8s",
         "serve_cluster_fault_tolerance",
     ],
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test is failing, possibly due to ongoing K8s work.  We already have a version of this test running without K8s.  We should reenable this test once the K8s migration is complete.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
