### PR TITLE
[RLlib] Restore policies on `eval_workers` as well.

### DIFF
--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -75,6 +75,7 @@ class TestTrainer(unittest.TestCase):
                     # time.
                     "policy_map_capacity": 2,
                 },
+                "evaluation_num_workers": 1,
             }
         )
 
@@ -110,6 +111,13 @@ class TestTrainer(unittest.TestCase):
                 # than what's defined in the config dict).
                 test = pg.PGTrainer(config=config)
                 test.restore(checkpoint)
+
+                # Make sure evaluation worker also gets the restored policy.
+                def _has_policy(w):
+                    assert w.get_policy("p0") is not None
+                test.evaluation_workers.foreach_worker(_has_policy)
+
+                # Make sure trainer can continue training the restored policy.
                 pol0 = test.get_policy("p0")
                 test.train()
                 # Test creating an action with the added (and restored) policy.

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -120,7 +120,9 @@ class TestTrainer(unittest.TestCase):
                 def _has_policy(w):
                     return w.get_policy("p0") is not None
 
-                self.assertTrue(all(test.evaluation_workers.foreach_worker(_has_policy)))
+                self.assertTrue(
+                    all(test.evaluation_workers.foreach_worker(_has_policy))
+                )
 
                 # Make sure trainer can continue training the restored policy.
                 pol0 = test.get_policy("p0")

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -115,6 +115,7 @@ class TestTrainer(unittest.TestCase):
                 # Make sure evaluation worker also gets the restored policy.
                 def _has_policy(w):
                     assert w.get_policy("p0") is not None
+
                 test.evaluation_workers.foreach_worker(_has_policy)
 
                 # Make sure trainer can continue training the restored policy.

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -61,6 +61,7 @@ class TestTrainer(unittest.TestCase):
                     },
                 },
                 "num_workers": 2,  # Test on remote workers as well.
+                "num_cpus_per_worker": 0.1,
                 "model": {
                     "fcnet_hiddens": [5],
                     "fcnet_activation": "linear",
@@ -76,6 +77,9 @@ class TestTrainer(unittest.TestCase):
                     "policy_map_capacity": 2,
                 },
                 "evaluation_num_workers": 1,
+                "evaluation_config": {
+                    "num_cpus_per_worker": 0.1,
+                },
             }
         )
 

--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -114,9 +114,9 @@ class TestTrainer(unittest.TestCase):
 
                 # Make sure evaluation worker also gets the restored policy.
                 def _has_policy(w):
-                    assert w.get_policy("p0") is not None
+                    return w.get_policy("p0") is not None
 
-                test.evaluation_workers.foreach_worker(_has_policy)
+                self.assertTrue(all(test.evaluation_workers.foreach_worker(_has_policy)))
 
                 # Make sure trainer can continue training the restored policy.
                 pol0 = test.get_policy("p0")

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -2687,6 +2687,11 @@ class Trainer(Trainable):
             remote_state = ray.put(state["worker"])
             for r in self.workers.remote_workers():
                 r.restore.remote(remote_state)
+            if self.evaluation_workers:
+                # If evaluation workers are used, also restore the policies
+                # there in case they are used for evaluation purpose.
+                for r in self.evaluation_workers.remote_workers():
+                    r.restore.remote(remote_state)
         # If necessary, restore replay data as well.
         if self.local_replay_buffer is not None:
             # TODO: Experimental functionality: Restore contents of replay


### PR DESCRIPTION
## Why are these changes needed?

We need to restore checkpoint-ed policies on eval workers too.
Since add_policy() does it, and those policies may be used for eval purpose.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
