### PR TITLE
Increase `test_failed_job_status` timeout in `test_job_submission`

### DIFF
--- a/dashboard/modules/snapshot/tests/test_job_submission.py
+++ b/dashboard/modules/snapshot/tests/test_job_submission.py
@@ -149,7 +149,7 @@ def test_failed_job_status(
                     assert entry["endTime"] >= entry["startTime"] + job_sleep_time_s
         return legacy_job_failed and job_failed
 
-    wait_for_condition(wait_for_job_to_fail, timeout=10)
+    wait_for_condition(wait_for_job_to_fail, timeout=25)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_job_submission` has become [flakey](https://flakey-tests.ray.io/) due to timeout. This change increases the timeout in `test_failed_job_status` from 10 to 25 seconds.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
