### PR TITLE
[Test] Increase timeout for microbenchmark

### DIFF
--- a/release/microbenchmark/microbenchmark.yaml
+++ b/release/microbenchmark/microbenchmark.yaml
@@ -5,5 +5,5 @@
     compute_template: tpl_64.yaml
 
   run:
-    timeout: 900
+    timeout: 1800
     script: OMP_NUM_THREADS=64 RAY_ADDRESS= python run_microbenchmark.py


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It seems like microbenchmark takes 14 minutes to finish, whereas the timeout is 15m. We should increase it for the safety. (it's also flaky because of that). 

If it takes 15 minutes due to regression, we should fix it separately. Regardless we should increase the timeout. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/22635

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
