### PR TITLE
[core][docs] Document port/IP binding and slurm concerns

### DIFF
--- a/doc/source/cluster/slurm.rst
+++ b/doc/source/cluster/slurm.rst
@@ -168,19 +168,56 @@ assign some internal ports to a few services. The issue is that as soon as the
 first head node is created, it will bind some ports and prevent them to be
 used by another head node. To prevent any conflicts, users have to manually
 specify non overlapping ranges of ports. The following ports are to be
-adjusted::
+adjusted. For an explanation on ports, see :ref:`here <ray-ports>`::
 
+    # used for all ports
     --node-manager-port
     --object-manager-port
-    --port
-    --gcs-server-port
     --min-worker-port
     --max-worker-port
+    # used for the head node
+    --port
+    --ray-client-server-port
+    --redis-shard-ports
+
+For instance, again with 2 users, they would have to adapt the instructions
+seen above to:
+
+.. code-block:: bash
+
+  # user 1
+  # same as above
+  ...
+  srun --nodes=1 --ntasks=1 -w "$head_node" \
+      ray start --head --node-ip-address="$head_node_ip" \
+          --port=6379 \
+          --node-manager-port=6700 \
+          --object-manager-port=6701 \
+          --ray-client-server-port=10001 \
+          --redis-shard-ports=6702 \
+          --min-worker-port=10002 \
+          --max-worker-port=19999 \
+          --num-cpus "${SLURM_CPUS_PER_TASK}" --num-gpus "${SLURM_GPUS_PER_TASK}" --block &
+
+  # user 2
+  # same as above
+  ...
+  srun --nodes=1 --ntasks=1 -w "$head_node" \
+      ray start --head --node-ip-address="$head_node_ip" \
+          --port=6380 \
+          --node-manager-port=6800 \
+          --object-manager-port=6801 \
+          --ray-client-server-port=20001 \
+          --redis-shard-ports=6802 \
+          --min-worker-port=20002 \
+          --max-worker-port=29999 \
+          --num-cpus "${SLURM_CPUS_PER_TASK}" --num-gpus "${SLURM_GPUS_PER_TASK}" --block &
 
 As for the IP binding, on some cluster architecture the network interfaces
 do not allow to use external IPs between nodes. Instead, there are internal
 network interfaces (`eth0`, `eth1`, etc.). Currently, it's difficult to
-set an internal IP.
+set an internal IP
+(see the open `issue <https://github.com/ray-project/ray/issues/22732>`_).
 
 Python-interface SLURM scripts
 ------------------------------


### PR DESCRIPTION
## Why are these changes needed?

Using Ray on SLURM system is documented but missing some pitfalls about network. This PR adds some information about port binding and address binding (I will open a feature request with more and link it here later).

I did not put any real recommendation on this last point since `--address` did not work. I had cannot resolve issue after setting an internal IP although it's reachable.

## Related issue number

Closes #10154 and is a recurring theme on the forum.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
