### PR TITLE
[Serve] make client poll more frequently

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -54,6 +54,9 @@ _UUID_RE = re.compile(
     "[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}"
 )
 
+# The polling interval for serve client to wait to deployment state
+_CLIENT_POLLING_INTERVAL_S: float = 1
+
 
 def _get_controller_namespace(detached):
     controller_namespace = ray.get_runtime_context().namespace
@@ -209,7 +212,7 @@ class Client:
                 logger.debug(
                     f"Waiting for shutdown, {len(statuses)} deployments still alive."
                 )
-            time.sleep(1)
+            time.sleep(_CLIENT_POLLING_INTERVAL_S)
         else:
             live_names = list(statuses.keys())
             raise TimeoutError(
@@ -247,7 +250,7 @@ class Client:
             logger.debug(
                 f"Waiting for {name} to be healthy, current status: {status.status}."
             )
-            time.sleep(1)
+            time.sleep(_CLIENT_POLLING_INTERVAL_S)
         else:
             raise TimeoutError(
                 f"Deployment {name} did not become HEALTHY after {timeout_s}s."
@@ -268,7 +271,7 @@ class Client:
                 logger.debug(
                     f"Waiting for {name} to be deleted, current status: {curr_status}."
                 )
-            time.sleep(1)
+            time.sleep(_CLIENT_POLLING_INTERVAL_S)
         else:
             raise TimeoutError(f"Deployment {name} wasn't deleted after {timeout_s}s.")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This improve our test speed, and polling every 0.1s shouldn't bring high overhead for users.

test_api full run
Before  164.47s
After 133.74s

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
