### PR TITLE
[RLlib] Fix a memeory leak in SimpleReplyBuffer

### DIFF
--- a/rllib/execution/replay_ops.py
+++ b/rllib/execution/replay_ops.py
@@ -131,8 +131,6 @@ class SimpleReplayBuffer:
         self.replay_batches = []
         self.replay_index = 0
 
-        self.last_added_batches = []
-
     def add_batch(self, sample_batch: SampleBatchType) -> None:
         warn_replay_capacity(item=sample_batch, num_items=self.num_slots)
         if self.num_slots > 0:
@@ -142,8 +140,6 @@ class SimpleReplayBuffer:
                 self.replay_batches[self.replay_index] = sample_batch
                 self.replay_index += 1
                 self.replay_index %= self.num_slots
-
-            self.last_added_batches.append(sample_batch)
 
     def replay(self) -> SampleBatchType:
         return random.choice(self.replay_batches)


### PR DESCRIPTION
## Why are these changes needed?

This bug seems to completely kill sampling throughput

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
