### PR TITLE
[WIP] Add typing-extensions requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -100,3 +100,5 @@ cryptography>=3.0.0
 myst-parser==0.15.2
 myst-nb==0.13.1
 jupytext==1.13.6
+# Needed for ParamSpec typing extensions w/fastapi
+typing-extensions>=4.1.1


### PR DESCRIPTION
## Why are these changes needed?

With Python 3.8 and Ray built from HEAD and a fresh install the raylet fails to start with:

```
ImportError: cannot import name 'ParamSpec' from 'typing_extensions' (/home/ray/anaconda3/lib/python3.8/site-packages/typing_extensions.py)
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/services.py", line 1485, in start_dashboard
    raise Exception(err_msg + last_log_str)
Exception: Failed to start the dashboard, return code 1
 The last 10 lines of /tmp/ray/session_2022-02-26_20-30-19_521353_439/logs/dashboard.log:
  File "/home/ray/anaconda3/lib/python3.8/site-packages/fastapi/routing.py", line 22, in <module>
    from fastapi.datastructures import Default, DefaultPlaceholder
  File "/home/ray/anaconda3/lib/python3.8/site-packages/fastapi/datastructures.py", line 3, in <module>
    from starlette.datastructures import URL as URL  # noqa: F401
  File "/home/ray/anaconda3/lib/python3.8/site-packages/starlette/datastructures.py", line 8, in <module>
    from starlette.concurrency import run_in_threadpool
  File "/home/ray/anaconda3/lib/python3.8/site-packages/starlette/concurrency.py", line 10, in <module>
    from typing_extensions import ParamSpec
ImportError: cannot import name 'ParamSpec' from 'typing_extensions' (/home/ray/anaconda3/lib/python3.8/site-packages/typing_extensions.py)
2022-02-26 20:30:19,514 INFO scripts.py:695 -- Local node IP: 10.42.4.16
```

## Related issue number

N/A

## Checks

- [ X ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ X ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
Manual test with `pip install typing-extensions>=4.1.1` in the container and verifying that `from typing_extensions import ParamSpec` no longer causes import error.