### PR TITLE
[remove/hide StringIdMap 2/n] Make StringIdMap thread-safe singleton and rename it to ResourceIdMap

### DIFF
--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -30,12 +30,6 @@ namespace ray {
 /// divide to convert from internal to actual.
 constexpr double kResourceConversionFactor = 10000;
 
-const std::string kCPU_ResourceLabel = "CPU";
-const std::string kGPU_ResourceLabel = "GPU";
-const std::string kObjectStoreMemory_ResourceLabel = "object_store_memory";
-const std::string kMemory_ResourceLabel = "memory";
-const std::string kBundle_ResourceLabel = "bundle";
-
 /// \class ResourceSet
 /// \brief Encapsulates and operates on a set of resources, including CPUs,
 /// GPUs, and custom labels.

--- a/src/ray/raylet/placement_group_resource_manager.cc
+++ b/src/ray/raylet/placement_group_resource_manager.cc
@@ -128,7 +128,6 @@ void NewPlacementGroupResourceManager::CommitBundle(
   const auto &bundle_state = it->second;
   bundle_state->state_ = CommitState::COMMITTED;
 
-  const auto &string_id_map = cluster_resource_scheduler_->GetStringIdMap();
   const auto &task_resource_instances = *bundle_state->resources_;
 
   const auto &resources = bundle_spec.GetFormattedResources();
@@ -136,8 +135,7 @@ void NewPlacementGroupResourceManager::CommitBundle(
     const auto &resource_name = resource.first;
     const auto &original_resource_name = GetOriginalResourceName(resource_name);
     if (original_resource_name != kBundle_ResourceLabel) {
-      const auto &instances =
-          task_resource_instances.Get(original_resource_name, string_id_map);
+      const auto &instances = task_resource_instances.Get(original_resource_name);
       cluster_resource_scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
           resource_name, instances);
     } else {

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -27,9 +27,6 @@
 
 namespace ray {
 
-/// List of predefined resources.
-enum PredefinedResources { CPU, MEM, GPU, OBJECT_STORE_MEM, PredefinedResources_MAX };
-
 const std::string ResourceEnumToString(PredefinedResources resource);
 
 const PredefinedResources ResourceStringToEnum(const std::string &resource);
@@ -84,8 +81,7 @@ class TaskResourceInstances {
   absl::flat_hash_map<int64_t, std::vector<FixedPoint>> custom_resources;
   bool operator==(const TaskResourceInstances &other);
   /// Get instances based on the string.
-  const std::vector<FixedPoint> &Get(const std::string &resource_name,
-                                     const StringIdMap &string_id_map) const;
+  const std::vector<FixedPoint> &Get(const std::string &resource_name) const;
   /// For each resource of this request aggregate its instances.
   ResourceRequest ToResourceRequest() const;
   /// Get CPU instances only.
@@ -138,7 +134,7 @@ class TaskResourceInstances {
   /// Check whether there are no resource instances.
   bool IsEmpty() const;
   /// Returns human-readable string for these resources.
-  [[nodiscard]] std::string DebugString(const StringIdMap &string_id_map) const;
+  [[nodiscard]] std::string DebugString() const;
 };
 
 /// Total and available capacities of each resource of a node.
@@ -170,9 +166,9 @@ class NodeResources {
   bool operator==(const NodeResources &other);
   bool operator!=(const NodeResources &other);
   /// Returns human-readable string for these resources.
-  std::string DebugString(StringIdMap string_to_int_map) const;
+  std::string DebugString() const;
   /// Returns compact dict-like string.
-  std::string DictString(StringIdMap string_to_int_map) const;
+  std::string DictString() const;
 };
 
 /// Total and available capacities of each resource instance.
@@ -189,7 +185,7 @@ class NodeResourceInstances {
   /// Returns if this equals another node resources.
   bool operator==(const NodeResourceInstances &other);
   /// Returns human-readable string for these resources.
-  [[nodiscard]] std::string DebugString(StringIdMap string_to_int_map) const;
+  [[nodiscard]] std::string DebugString() const;
 };
 
 struct Node {
@@ -211,13 +207,11 @@ struct Node {
 
 /// \request Conversion result to a ResourceRequest data structure.
 NodeResources ResourceMapToNodeResources(
-    StringIdMap &string_to_int_map,
     const absl::flat_hash_map<std::string, double> &resource_map_total,
     const absl::flat_hash_map<std::string, double> &resource_map_available);
 
 /// Convert a map of resources to a ResourceRequest data structure.
 ResourceRequest ResourceMapToResourceRequest(
-    StringIdMap &string_to_int_map,
     const absl::flat_hash_map<std::string, double> &resource_map,
     bool requires_object_store_memory);
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -37,13 +37,10 @@ class ClusterTaskManagerTest;
 /// This class is not thread safe.
 class ClusterResourceManager {
  public:
-  explicit ClusterResourceManager(StringIdMap &string_to_int_map);
+  explicit ClusterResourceManager();
 
   /// Get the resource view of the cluster.
   const absl::flat_hash_map<std::string, Node> &GetResourceView() const;
-
-  // Mapping from predefined resource indexes to resource strings
-  std::string GetResourceNameFromIndex(int64_t res_idx);
 
   /// Update node resources. This hanppens when a node resource usage udpated.
   ///
@@ -106,9 +103,6 @@ class ClusterResourceManager {
   /// List of nodes in the clusters and their resources organized as a map.
   /// The key of the map is the node ID.
   absl::flat_hash_map<std::string, Node> nodes_;
-  /// Keep the mapping between node and resource IDs in string representation
-  /// to integer representation. Used for improving map performance.
-  StringIdMap &string_to_int_map_;
 
   friend class ClusterResourceSchedulerTest;
   friend class raylet::ClusterTaskManagerTest;

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -92,7 +92,7 @@ class ClusterResourceManager {
   ///
   /// \param node_id: Node ID.
   /// \param node_resources: Up to date total and available resources of the node.
-  void AddOrUpdateNode(const std::string& node_id, const NodeResources &node_resources);
+  void AddOrUpdateNode(const std::string &node_id, const NodeResources &node_resources);
 
   void AddOrUpdateNode(
       const std::string &node_id,

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -40,50 +40,49 @@ class ClusterResourceManager {
   explicit ClusterResourceManager(StringIdMap &string_to_int_map);
 
   /// Get the resource view of the cluster.
-  const absl::flat_hash_map<int64_t, Node> &GetResourceView() const;
+  const absl::flat_hash_map<std::string, Node> &GetResourceView() const;
 
   // Mapping from predefined resource indexes to resource strings
   std::string GetResourceNameFromIndex(int64_t res_idx);
 
   /// Update node resources. This hanppens when a node resource usage udpated.
   ///
-  /// \param node_id_string ID of the node which resoruces need to be udpated.
+  /// \param node_id ID of the node which resoruces need to be udpated.
   /// \param resource_data The node resource data.
-  bool UpdateNode(const std::string &node_id_string,
-                  const rpc::ResourcesData &resource_data);
+  bool UpdateNode(const std::string &node_id, const rpc::ResourcesData &resource_data);
 
   /// Remove node from the cluster data structure. This happens
   /// when a node fails or it is removed from the cluster.
   ///
-  /// \param node_id_string ID of the node to be removed.
-  bool RemoveNode(const std::string &node_id_string);
+  /// \param node_id ID of the node to be removed.
+  bool RemoveNode(const std::string &node_id);
 
   /// Get number of nodes in the cluster.
   int64_t NumNodes() const;
 
   /// Update total capacity of a given resource of a given node.
   ///
-  /// \param node_name: Node whose resource we want to update.
+  /// \param node_id: Node whose resource we want to update.
   /// \param resource_name: Resource which we want to update.
   /// \param resource_total: New capacity of the resource.
-  void UpdateResourceCapacity(const std::string &node_name,
+  void UpdateResourceCapacity(const std::string &node_id,
                               const std::string &resource_name, double resource_total);
 
   /// Delete a given resource from a given node.
   ///
-  /// \param node_name: Node whose resource we want to delete.
+  /// \param node_id: Node whose resource we want to delete.
   /// \param resource_name: Resource we want to delete
-  void DeleteResource(const std::string &node_name, const std::string &resource_name);
+  void DeleteResource(const std::string &node_id, const std::string &resource_name);
 
   /// Return local resources in human-readable string form.
-  std::string GetNodeResourceViewString(const std::string &node_name) const;
+  std::string GetNodeResourceViewString(const std::string &node_id) const;
 
   /// Get local resource.
-  const NodeResources &GetNodeResources(const std::string &node_name) const;
+  const NodeResources &GetNodeResources(const std::string &node_id) const;
 
   /// Subtract available resource from a given node.
   //// Return false if such node doesn't exist.
-  bool SubtractNodeAvailableResources(int64_t node_id,
+  bool SubtractNodeAvailableResources(const std::string &node_id,
                                       const ResourceRequest &resource_request);
 
  private:
@@ -93,26 +92,20 @@ class ClusterResourceManager {
   ///
   /// \param node_id: Node ID.
   /// \param node_resources: Up to date total and available resources of the node.
-  void AddOrUpdateNode(int64_t node_id, const NodeResources &node_resources);
+  void AddOrUpdateNode(const std::string& node_id, const NodeResources &node_resources);
 
   void AddOrUpdateNode(
       const std::string &node_id,
       const absl::flat_hash_map<std::string, double> &resource_map_total,
       const absl::flat_hash_map<std::string, double> &resource_map_available);
 
-  /// Remove node from the cluster data structure. This happens
-  /// when a node fails or it is removed from the cluster.
-  ///
-  /// \param node_id ID of the node to be removed.
-  bool RemoveNode(int64_t node_id);
-
   /// Return resources associated to the given node_id in ret_resources.
   /// If node_id not found, return false; otherwise return true.
-  bool GetNodeResources(int64_t node_id, NodeResources *ret_resources) const;
+  bool GetNodeResources(const std::string &node_id, NodeResources *ret_resources) const;
 
   /// List of nodes in the clusters and their resources organized as a map.
   /// The key of the map is the node ID.
-  absl::flat_hash_map<int64_t, Node> nodes_;
+  absl::flat_hash_map<std::string, Node> nodes_;
   /// Keep the mapping between node and resource IDs in string representation
   /// to integer representation. Used for improving map performance.
   StringIdMap &string_to_int_map_;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -244,10 +244,10 @@ const StringIdMap &ClusterResourceScheduler::GetStringIdMap() const {
 
 std::string ClusterResourceScheduler::DebugString(void) const {
   std::stringstream buffer;
-  buffer << "\nLocal id: " << local_node_id_;
+  buffer << "\nLocal id: " << absl::Base64Escape(local_node_id_);
   buffer << " Local resources: " << local_resource_manager_->DebugString();
   for (auto &node : cluster_resource_manager_->GetResourceView()) {
-    buffer << "node id: " << node.first;
+    buffer << "node id: " << absl::Base64Escape(node.first);
     buffer << node.second.GetLocalView().DebugString(string_to_int_map_);
   }
   return buffer.str();

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -49,7 +49,7 @@ ClusterResourceScheduler::ClusterResourceScheduler() {
 }
 
 ClusterResourceScheduler::ClusterResourceScheduler(
-    int64_t local_node_id, const NodeResources &local_node_resources,
+    const std::string &local_node_id, , const NodeResources &local_node_resources,
     gcs::GcsClient &gcs_client)
     : string_to_int_map_(),
       local_node_id_(local_node_id),
@@ -75,11 +75,10 @@ ClusterResourceScheduler::ClusterResourceScheduler(
     gcs::GcsClient &gcs_client, std::function<int64_t(void)> get_used_object_store_memory,
     std::function<bool(void)> get_pull_manager_at_capacity)
     : string_to_int_map_(),
-      local_node_id_(),
+      local_node_id_(local_node_id),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
       gcs_client_(&gcs_client) {
   PopulatePredefinedResources(string_to_int_map_);
-  local_node_id_ = string_to_int_map_.Insert(local_node_id);
   NodeResources node_resources = ResourceMapToNodeResources(
       string_to_int_map_, local_node_resources, local_node_resources);
   cluster_resource_manager_ =

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -195,9 +195,8 @@ std::string ClusterResourceScheduler::GetBestSchedulableNode(
   RAY_LOG(DEBUG) << "Scheduling decision. "
                  << "forcing spillback: " << force_spillback
                  << ". Best node: " << best_node_id << " "
-                 << (best_node_id == "-1"
-                         ? NodeID::Nil()
-                         : NodeID::FromBinary(best_node_id))
+                 << (best_node_id == "-1" ? NodeID::Nil()
+                                          : NodeID::FromBinary(best_node_id))
                  << ", is infeasible: " << *is_infeasible;
   return best_node_id;
 }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -50,7 +50,7 @@ class ClusterResourceScheduler {
   /// \param local_node_id: ID of local node,
   /// \param local_node_resources: The total and the available resources associated
   /// with the local node.
-  ClusterResourceScheduler(int64_t local_node_id,
+  ClusterResourceScheduler(const std::string &local_node_id,
                            const NodeResources &local_node_resources,
                            gcs::GcsClient &gcs_client);
   ClusterResourceScheduler(
@@ -172,7 +172,7 @@ class ClusterResourceScheduler {
   /// to integer representation. Used for improving map performance.
   StringIdMap string_to_int_map_;
   /// Identifier of local node.
-  int64_t local_node_id_;
+  const std::string local_node_id_;
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
   /// Gcs client. It's not owned by this class.
@@ -185,7 +185,6 @@ class ClusterResourceScheduler {
   std::unique_ptr<raylet_scheduling_policy::SchedulingPolicy> scheduling_policy_;
 
   friend class ClusterResourceSchedulerTest;
-  FRIEND_TEST(ClusterResourceSchedulerTest, PopulatePredefinedResources);
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingDeleteClusterNodeTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingModifyClusterNodeTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -168,7 +168,7 @@ class ClusterResourceScheduler {
       bool requires_object_store_memory, bool actor_creation, bool force_spillback,
       int64_t *violations, bool *is_infeasible);
 
-  /// Keep the mapping between node and resource IDs in string representation
+  /// Keep the mapping between resource IDs in string representation
   /// to integer representation. Used for improving map performance.
   StringIdMap string_to_int_map_;
   /// Identifier of local node.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -60,8 +60,6 @@ class ClusterResourceScheduler {
       std::function<int64_t(void)> get_used_object_store_memory = nullptr,
       std::function<bool(void)> get_pull_manager_at_capacity = nullptr);
 
-  const StringIdMap &GetStringIdMap() const;
-
   ///  Find a node in the cluster on which we can schedule a given resource request.
   ///  In hybrid mode, see `scheduling_policy.h` for a description of the policy.
   ///
@@ -168,9 +166,6 @@ class ClusterResourceScheduler {
       bool requires_object_store_memory, bool actor_creation, bool force_spillback,
       int64_t *violations, bool *is_infeasible);
 
-  /// Keep the mapping between resource IDs in string representation
-  /// to integer representation. Used for improving map performance.
-  StringIdMap string_to_int_map_;
   /// Identifier of local node.
   const std::string local_node_id_;
   /// Internally maintained random number generator.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -109,7 +109,7 @@ class ClusterResourceScheduler {
   }
 
  private:
-  bool NodeAlive(int64_t node_id) const;
+  bool NodeAlive(const std::string &node_id) const;
 
   /// Decrease the available resources of a node when a resource request is
   /// scheduled on the given node.
@@ -119,7 +119,7 @@ class ClusterResourceScheduler {
   ///
   /// \return true, if resource_request can be indeed scheduled on the node,
   /// and false otherwise.
-  bool SubtractRemoteNodeAvailableResources(int64_t node_id,
+  bool SubtractRemoteNodeAvailableResources(const std::string &node_id,
                                             const ResourceRequest &resource_request);
 
   /// Check whether a resource request can be scheduled given a node.
@@ -133,7 +133,7 @@ class ClusterResourceScheduler {
   ///     a map find call which could be expensive.)
   ///
   ///  \return: Whether the request can be scheduled.
-  bool IsSchedulable(const ResourceRequest &resource_request, int64_t node_id,
+  bool IsSchedulable(const ResourceRequest &resource_request, const std::string &node_id,
                      const NodeResources &resources) const;
 
   ///  Find a node in the cluster on which we can schedule a given resource request.
@@ -151,10 +151,10 @@ class ClusterResourceScheduler {
   ///
   ///  \return -1, if no node can schedule the current request; otherwise,
   ///          return the ID of a node that can schedule the resource request.
-  int64_t GetBestSchedulableNode(const ResourceRequest &resource_request,
-                                 const rpc::SchedulingStrategy &scheduling_strategy,
-                                 bool actor_creation, bool force_spillback,
-                                 int64_t *violations, bool *is_infeasible);
+  std::string GetBestSchedulableNode(const ResourceRequest &resource_request,
+                                     const rpc::SchedulingStrategy &scheduling_strategy,
+                                     bool actor_creation, bool force_spillback,
+                                     int64_t *violations, bool *is_infeasible);
 
   /// Similar to
   ///    int64_t GetBestSchedulableNode(...)

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -185,7 +185,8 @@ class ClusterResourceSchedulerTest : public ::testing::Test {
 
       initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
 
-      resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(i, node_resources);
+      resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(std::to_string(i),
+                                                                     node_resources);
 
       node_resources.custom_resources.clear();
     }
@@ -322,7 +323,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingInitClusterTest) {
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingDeleteClusterNodeTest) {
   int num_nodes = 4;
-  int64_t remove_id = 2;
+  std::string remove_id = "2";
 
   ClusterResourceScheduler resource_scheduler;
 
@@ -334,7 +335,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingDeleteClusterNodeTest) {
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingModifyClusterNodeTest) {
   int num_nodes = 4;
-  int64_t update_id = 2;
+  std::string update_id = "2";
   ClusterResourceScheduler resource_scheduler;
 
   initCluster(resource_scheduler, num_nodes);
@@ -402,7 +403,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
   vector<int64_t> cust_ids{1, 2};
   vector<FixedPoint> cust_capacities{5, 5};
   initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
-  ClusterResourceScheduler resource_scheduler(1, node_resources, *gcs_client_);
+  ClusterResourceScheduler resource_scheduler("1", node_resources, *gcs_client_);
   AssertPredefinedNodeResources(resource_scheduler);
 
   {
@@ -416,9 +417,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
     bool is_infeasible;
     rpc::SchedulingStrategy scheduling_strategy;
     scheduling_strategy.mutable_default_scheduling_strategy();
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
+    auto node_id = resource_scheduler.GetBestSchedulableNode(
         resource_request, scheduling_strategy, false, false, &violations, &is_infeasible);
-    ASSERT_EQ(node_id, 1);
+    ASSERT_EQ(node_id, std::string("1"));
     ASSERT_TRUE(violations == 0);
 
     NodeResources nr1, nr2;
@@ -478,7 +479,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest) {
 TEST_F(ClusterResourceSchedulerTest, SchedulingAddOrUpdateNodeTest) {
   ClusterResourceScheduler resource_scheduler;
   NodeResources nr, nr_out;
-  int64_t node_id = 1;
+  std::string node_id = "1";
 
   // Add node.
   {
@@ -526,7 +527,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
   initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
   ClusterResourceScheduler resource_scheduler(0, node_resources, *gcs_client_);
   auto node_id = NodeID::FromRandom();
-  auto node_internal_id = resource_scheduler.string_to_int_map_.Insert(node_id.Binary());
+  auto node_internal_id = node_id.Binary();
   rpc::SchedulingStrategy scheduling_strategy;
   scheduling_strategy.mutable_default_scheduling_strategy();
   {
@@ -546,9 +547,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
                         EmptyFixedPointVector);
     int64_t violations;
     bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
+    std::string node_id = resource_scheduler.GetBestSchedulableNode(
         resource_request, scheduling_strategy, false, false, &violations, &is_infeasible);
-    ASSERT_EQ(node_id, -1);
+    ASSERT_EQ(node_id, "-1");
   }
 
   // Predefined resources, no constraint violation.
@@ -559,9 +560,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
                         EmptyFixedPointVector);
     int64_t violations;
     bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
+    std::string node_id = resource_scheduler.GetBestSchedulableNode(
         resource_request, scheduling_strategy, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id != -1);
+    ASSERT_TRUE(node_id != "-1");
     ASSERT_TRUE(violations == 0);
   }
   // Custom resources, hard constraint violation.
@@ -573,9 +574,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
     initResourceRequest(resource_request, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
+    std::string node_id = resource_scheduler.GetBestSchedulableNode(
         resource_request, scheduling_strategy, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id == -1);
+    ASSERT_TRUE(node_id == "-1");
   }
   // Custom resources, no constraint violation.
   {
@@ -586,9 +587,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
     initResourceRequest(resource_request, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
+    std::string node_id = resource_scheduler.GetBestSchedulableNode(
         resource_request, scheduling_strategy, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id != -1);
+    ASSERT_TRUE(node_id != "-1");
     ASSERT_TRUE(violations == 0);
   }
   // Custom resource missing, hard constraint violation.
@@ -600,9 +601,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
     initResourceRequest(resource_request, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
+    std::string node_id = resource_scheduler.GetBestSchedulableNode(
         resource_request, scheduling_strategy, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id == -1);
+    ASSERT_TRUE(node_id == "-1");
   }
   // Placement hints, no constraint violation.
   {
@@ -613,9 +614,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
     initResourceRequest(resource_request, pred_demands, cust_ids, cust_demands);
     int64_t violations;
     bool is_infeasible;
-    int64_t node_id = resource_scheduler.GetBestSchedulableNode(
+    std::string node_id = resource_scheduler.GetBestSchedulableNode(
         resource_request, scheduling_strategy, false, false, &violations, &is_infeasible);
-    ASSERT_TRUE(node_id != -1);
+    ASSERT_TRUE(node_id != "-1");
     ASSERT_TRUE(violations == 0);
   }
 }
@@ -913,7 +914,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest2) {
 }
 
 TEST_F(ClusterResourceSchedulerTest, DeadNodeTest) {
-  ClusterResourceScheduler resource_scheduler("local", {}, *gcs_client_);
+  ClusterResourceScheduler resource_scheduler("local", NodeResources{}, *gcs_client_);
   absl::flat_hash_map<std::string, double> resource;
   resource["CPU"] = 10000.0;
   auto node_id = NodeID::FromRandom();
@@ -1104,7 +1105,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstanceWithoutCpuUnitTest) {
 
 TEST_F(ClusterResourceSchedulerTest, TestAlwaysSpillInfeasibleTask) {
   absl::flat_hash_map<std::string, double> resource_spec({{"CPU", 1}});
-  ClusterResourceScheduler resource_scheduler("local", {}, *gcs_client_);
+  ClusterResourceScheduler resource_scheduler("local", NodeResources{}, *gcs_client_);
   for (int i = 0; i < 100; i++) {
     resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
         NodeID::FromRandom().Binary(), {}, {});
@@ -1152,7 +1153,7 @@ TEST_F(ClusterResourceSchedulerTest, ResourceUsageReportTest) {
   vector<FixedPoint> other_cust_capacities{5., 4., 3., 2., 1.};
   initNodeResources(other_node_resources, other_pred_capacities, cust_ids,
                     other_cust_capacities);
-  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(12345,
+  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode("12345",
                                                                  other_node_resources);
 
   {  // Cluster is idle.
@@ -1236,7 +1237,7 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
   vector<FixedPoint> other_cust_capacities{10.};
   initNodeResources(other_node_resources, other_pred_capacities, cust_ids,
                     other_cust_capacities);
-  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(12345,
+  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode("12345",
                                                                  other_node_resources);
 
   {

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -22,7 +22,7 @@
 namespace ray {
 
 LocalResourceManager::LocalResourceManager(
-    int64_t local_node_id, StringIdMap &resource_name_to_id,
+    std::string local_node_id, StringIdMap &resource_name_to_id,
     const NodeResources &node_resources,
     std::function<int64_t(void)> get_used_object_store_memory,
     std::function<bool(void)> get_pull_manager_at_capacity,

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -40,13 +40,13 @@ namespace ray {
 class LocalResourceManager {
  public:
   LocalResourceManager(
-      int64_t local_node_id, StringIdMap &resource_name_to_id,
+      std::string local_node_id, StringIdMap &resource_name_to_id,
       const NodeResources &node_resources,
       std::function<int64_t(void)> get_used_object_store_memory,
       std::function<bool(void)> get_pull_manager_at_capacity,
       std::function<void(const NodeResources &)> resource_change_subscriber);
 
-  int64_t GetNodeId() const { return local_node_id_; }
+  std::string GetNodeId() const { return local_node_id_; }
 
   /// Add a local resource that is available.
   ///
@@ -270,7 +270,7 @@ class LocalResourceManager {
   void UpdateAvailableObjectStoreMemResource();
 
   /// Identifier of local node.
-  int64_t local_node_id_;
+  const std::string local_node_id_;
   /// Keep the mapping between node and resource IDs in string representation
   /// to integer representation. Used for improving map performance.
   StringIdMap &resource_name_to_id_;

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -40,8 +40,7 @@ namespace ray {
 class LocalResourceManager {
  public:
   LocalResourceManager(
-      std::string local_node_id, StringIdMap &resource_name_to_id,
-      const NodeResources &node_resources,
+      std::string local_node_id, const NodeResources &node_resources,
       std::function<int64_t(void)> get_used_object_store_memory,
       std::function<bool(void)> get_pull_manager_at_capacity,
       std::function<void(const NodeResources &)> resource_change_subscriber);
@@ -271,9 +270,6 @@ class LocalResourceManager {
 
   /// Identifier of local node.
   const std::string local_node_id_;
-  /// Keep the mapping between node and resource IDs in string representation
-  /// to integer representation. Used for improving map performance.
-  StringIdMap &resource_name_to_id_;
   /// Resources of local node.
   NodeResourceInstances local_resources_;
   /// Cached resources, used to compare with newest one in light heartbeat mode.

--- a/src/ray/raylet/scheduling/local_task_manager.cc
+++ b/src/ray/raylet/scheduling/local_task_manager.cc
@@ -842,8 +842,7 @@ void LocalTaskManager::Dispatch(
       if (predefined_resources[res_idx][inst_idx] > 0.) {
         if (first) {
           resource = reply->add_resource_mapping();
-          resource->set_name(cluster_resource_scheduler_->GetClusterResourceManager()
-                                 .GetResourceNameFromIndex(res_idx));
+          resource->set_name(ResourceIdMap::GetResourceIdMap().Get(res_idx));
           first = false;
         }
         auto rid = resource->add_resource_ids();
@@ -860,8 +859,7 @@ void LocalTaskManager::Dispatch(
       if (it->second[inst_idx] > 0.) {
         if (first) {
           resource = reply->add_resource_mapping();
-          resource->set_name(cluster_resource_scheduler_->GetClusterResourceManager()
-                                 .GetResourceNameFromIndex(it->first));
+          resource->set_name(ResourceIdMap::GetResourceIdMap().Get(it->first));
           first = false;
         }
         auto rid = resource->add_resource_ids();
@@ -984,7 +982,6 @@ bool LocalTaskManager::ReturnCpuResourcesToBlockedWorker(
 
 ResourceSet LocalTaskManager::CalcNormalTaskResources() const {
   absl::flat_hash_map<std::string, FixedPoint> total_normal_task_resources;
-  const auto &string_id_map = cluster_resource_scheduler_->GetStringIdMap();
   for (auto &entry : leased_workers_) {
     std::shared_ptr<WorkerInterface> worker = entry.second;
     auto &task_spec = worker->GetAssignedTask().GetTaskSpecification();
@@ -1009,7 +1006,8 @@ ResourceSet LocalTaskManager::CalcNormalTaskResources() const {
       }
       for (auto &entry : resource_request.custom_resources) {
         if (entry.second > 0) {
-          total_normal_task_resources[string_id_map.Get(entry.first)] += entry.second;
+          total_normal_task_resources[ResourceIdMap::GetResourceIdMap().Get(
+              entry.first)] += entry.second;
         }
       }
     }

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -148,7 +148,7 @@ std::string SchedulingPolicy::HybridPolicyWithFilter(
                    << resource_request.DebugString()
                    << " with critical resource utilization "
                    << critical_resource_utilization << " based on local view "
-                   << node.GetLocalView().DebugString(StringIdMap());
+                   << node.GetLocalView().DebugString();
     if (critical_resource_utilization < spread_threshold) {
       critical_resource_utilization = 0;
     }

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -116,7 +116,7 @@ std::string SchedulingPolicy::HybridPolicyWithFilter(
   // place.
   std::sort(round.begin() + start_index, round.end());
 
-  std::string best_node_id = "-1";
+  std::string best_node_id{kNullNodeID};
   float best_utilization_score = INFINITY;
   bool best_is_available = false;
 
@@ -193,7 +193,7 @@ std::string SchedulingPolicy::HybridPolicy(
   auto best_node_id = HybridPolicyWithFilter(
       resource_request, spread_threshold, force_spillback,
       /*require_available*/ true, is_node_available, NodeFilter::kNonGpu);
-  if (best_node_id != "-1") {
+  if (best_node_id != kNullNodeID) {
     return best_node_id;
   }
 

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -23,6 +23,8 @@
 namespace ray {
 namespace raylet_scheduling_policy {
 
+constexpr std::string_view kNullNodeID = "";
+
 class SchedulingPolicy {
  public:
   SchedulingPolicy(std::string local_node_id,

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -25,7 +25,8 @@ namespace raylet_scheduling_policy {
 
 class SchedulingPolicy {
  public:
-  SchedulingPolicy(int64_t local_node_id, const absl::flat_hash_map<int64_t, Node> &nodes)
+  SchedulingPolicy(std::string local_node_id,
+                   const absl::flat_hash_map<std::string, Node> &nodes)
       : local_node_id_(local_node_id), nodes_(nodes) {}
 
   /// This scheduling policy was designed with the following assumptions in mind:
@@ -60,24 +61,24 @@ class SchedulingPolicy {
   ///
   /// \return -1 if the task is unfeasible, otherwise the node id (key in `nodes`) to
   /// schedule on.
-  int64_t HybridPolicy(
+  std::string HybridPolicy(
       const ResourceRequest &resource_request, float spread_threshold,
       bool force_spillback, bool require_available,
-      std::function<bool(int64_t)> is_node_available,
+      std::function<bool(const std::string &)> is_node_available,
       bool scheduler_avoid_gpu_nodes = RayConfig::instance().scheduler_avoid_gpu_nodes());
 
   /// Round robin among available nodes.
   /// If there are no available nodes, fallback to hybrid policy.
-  int64_t SpreadPolicy(const ResourceRequest &resource_request, bool force_spillback,
-                       bool require_available,
-                       std::function<bool(int64_t)> is_node_available);
+  std::string SpreadPolicy(const ResourceRequest &resource_request, bool force_spillback,
+                           bool require_available,
+                           std::function<bool(const std::string &)> is_node_available);
 
  private:
   /// Identifier of local node.
-  const int64_t local_node_id_;
+  const std::string local_node_id_;
   /// List of nodes in the clusters and their resources organized as a map.
   /// The key of the map is the node ID.
-  const absl::flat_hash_map<int64_t, Node> &nodes_;
+  const absl::flat_hash_map<std::string, Node> &nodes_;
   // The node to start round robin if it's spread scheduling.
   // The index may be inaccurate when nodes are added or removed dynamically,
   // but it should still be better than always scanning from 0 for spread scheduling.
@@ -101,11 +102,11 @@ class SchedulingPolicy {
   ///
   /// \return -1 if the task is unfeasible, otherwise the node id (key in `nodes`) to
   /// schedule on.
-  int64_t HybridPolicyWithFilter(const ResourceRequest &resource_request,
-                                 float spread_threshold, bool force_spillback,
-                                 bool require_available,
-                                 std::function<bool(int64_t)> is_node_available,
-                                 NodeFilter node_filter = NodeFilter::kAny);
+  std::string HybridPolicyWithFilter(
+      const ResourceRequest &resource_request, float spread_threshold,
+      bool force_spillback, bool require_available,
+      std::function<bool(const std::string &)> is_node_available,
+      NodeFilter node_filter = NodeFilter::kAny);
 };
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy_test.cc
@@ -38,12 +38,12 @@ class SchedulingPolicyTest : public ::testing::Test {};
 TEST_F(SchedulingPolicyTest, SpreadPolicyTest) {
   StringIdMap map;
   ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node_1 = 1;
-  int64_t remote_node_2 = 2;
-  int64_t remote_node_3 = 3;
+  std::string local_node = "0";
+  std::string remote_node_1 = "1";
+  std::string remote_node_2 = "2";
+  std::string remote_node_3 = "3";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(20, 20, 0, 0, 0, 0));
   // Unavailable node
   nodes.emplace(remote_node_1, CreateNodeResources(0, 20, 0, 0, 0, 0));
@@ -53,7 +53,7 @@ TEST_F(SchedulingPolicyTest, SpreadPolicyTest) {
 
   raylet_scheduling_policy::SchedulingPolicy scheduling_policy(local_node, nodes);
 
-  int64_t to_schedule =
+  std::string to_schedule =
       scheduling_policy.SpreadPolicy(req, false, false, [](auto) { return true; });
   ASSERT_EQ(to_schedule, local_node);
 
@@ -157,15 +157,16 @@ TEST_F(SchedulingPolicyTest, AvailableTruncationTest) {
   // should still pick the local node (due to traversal order).
   StringIdMap map;
   ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(1, 2, 0, 0, 0, 0));
   nodes.emplace(remote_node, CreateNodeResources(0.75, 2, 0, 0, 0, 0));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.51, false, false, [](auto) { return true; });
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.51, false, false, [](auto) { return true; });
   ASSERT_EQ(to_schedule, local_node);
 }
 
@@ -174,15 +175,16 @@ TEST_F(SchedulingPolicyTest, AvailableTieBreakTest) {
   // has a lower critical resource utilization so we schedule on it.
   StringIdMap map;
   ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(1, 2, 0, 0, 0, 0));
   nodes.emplace(remote_node, CreateNodeResources(1.5, 2, 0, 0, 0, 0));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -193,15 +195,16 @@ TEST_F(SchedulingPolicyTest, AvailableOverFeasibleTest) {
   StringIdMap map;
   ResourceRequest req =
       ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(10, 10, 0, 0, 0, 1));
   nodes.emplace(remote_node, CreateNodeResources(1, 10, 0, 0, 1, 1));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -210,16 +213,17 @@ TEST_F(SchedulingPolicyTest, InfeasibleTest) {
   StringIdMap map;
   ResourceRequest req =
       ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(10, 10, 0, 0, 0, 0));
   nodes.emplace(remote_node, CreateNodeResources(1, 10, 0, 0, 0, 0));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
-  ASSERT_EQ(to_schedule, -1);
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+  ASSERT_EQ(to_schedule, "-1");
 }
 
 TEST_F(SchedulingPolicyTest, BarelyFeasibleTest) {
@@ -228,13 +232,14 @@ TEST_F(SchedulingPolicyTest, BarelyFeasibleTest) {
   StringIdMap map;
   ResourceRequest req =
       ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-  int64_t local_node = 0;
+  std::string local_node = "0";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(0, 1, 0, 0, 0, 1));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
   ASSERT_EQ(to_schedule, local_node);
 }
 
@@ -244,15 +249,16 @@ TEST_F(SchedulingPolicyTest, TruncationAcrossFeasibleNodesTest) {
   StringIdMap map;
   ResourceRequest req =
       ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(1, 2, 0, 0, 0, 1));
   nodes.emplace(remote_node, CreateNodeResources(0.75, 2, 0, 0, 0, 1));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.51, false, false, [](auto) { return true; });
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.51, false, false, [](auto) { return true; });
   ASSERT_EQ(to_schedule, local_node);
 }
 
@@ -262,24 +268,25 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackIfAvailableTest) {
   StringIdMap map;
   ResourceRequest req =
       ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(2, 2, 0, 0, 1, 1));
   nodes.emplace(remote_node, CreateNodeResources(1, 10, 0, 0, 1, 10));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.51, true, true, [](auto) { return true; });
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.51, true, true, [](auto) { return true; });
   ASSERT_EQ(to_schedule, remote_node);
 }
 
 TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
   StringIdMap map;
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(10, 10, 0, 0, 1, 1));
   nodes.emplace(remote_node, CreateNodeResources(1, 2, 0, 0, 0, 0));
 
@@ -288,7 +295,7 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
     // non GPU, and the remote node does not have GPUs, thus
     // we should schedule on remote node.
     const ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
-    const int to_schedule =
+    const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
                 ResourceMapToResourceRequest(map, {{"CPU", 1}}, false), 0.51, false, true,
@@ -298,7 +305,7 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
   {
     // A GPU request should be scheduled on a GPU node.
     const ResourceRequest req = ResourceMapToResourceRequest(map, {{"GPU", 1}}, false);
-    const int to_schedule =
+    const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
                 req, 0.51, false, true, [](auto) { return true; }, true);
@@ -307,7 +314,7 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
   {
     // A CPU request can be be scheduled on a CPU node.
     const ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
-    const int to_schedule =
+    const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
                 req, 0.51, false, true, [](auto) { return true; }, true);
@@ -317,7 +324,7 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
     // A mixed CPU/GPU request should be scheduled on a GPU node.
     const ResourceRequest req =
         ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-    const int to_schedule =
+    const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
                 req, 0.51, false, true, [](auto) { return true; }, true);
@@ -330,14 +337,14 @@ TEST_F(SchedulingPolicyTest, SchedulenCPURequestsOnGPUNodeAsALastResort) {
   // we can not schedule on CPU nodes.
   StringIdMap map;
   ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(0, 10, 0, 0, 0, 0));
   nodes.emplace(remote_node, CreateNodeResources(1, 1, 0, 0, 1, 1));
 
-  const int to_schedule =
+  const std::string to_schedule =
       raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
           .HybridPolicy(
               req, 0.51, false, true, [](auto) { return true; }, true);
@@ -349,15 +356,16 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackTest) {
   StringIdMap map;
   ResourceRequest req =
       ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(2, 2, 0, 0, 1, 1));
   nodes.emplace(remote_node, CreateNodeResources(0, 2, 0, 0, 0, 1));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.51, true, false, [](auto) { return true; });
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.51, true, false, [](auto) { return true; });
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -367,38 +375,39 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackOnlyFeasibleLocallyTest) {
   StringIdMap map;
   ResourceRequest req =
       ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
-  int64_t local_node = 0;
-  int64_t remote_node = 1;
+  std::string local_node = "0";
+  std::string remote_node = "1";
 
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(2, 2, 0, 0, 1, 1));
   nodes.emplace(remote_node, CreateNodeResources(0, 2, 0, 0, 0, 0));
 
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(req, 0.51, true, false, [](auto) { return true; });
-  ASSERT_EQ(to_schedule, -1);
+  std::string to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+          .HybridPolicy(req, 0.51, true, false, [](auto) { return true; });
+  ASSERT_EQ(to_schedule, "-1");
 }
 
 TEST_F(SchedulingPolicyTest, NonGpuNodePreferredSchedulingTest) {
   // Prefer to schedule on CPU nodes first.
   // GPU nodes should be preferred as a last resort.
   StringIdMap map;
-  int64_t local_node = 0;
-  int64_t remote_node_1 = 1;
-  int64_t remote_node_2 = 2;
+  std::string local_node = "0";
+  std::string remote_node_1 = "1";
+  std::string remote_node_2 = "2";
 
   // local {CPU:2, GPU:1}
   // Remote {CPU: 2}
-  absl::flat_hash_map<int64_t, Node> nodes;
+  absl::flat_hash_map<std::string, Node> nodes;
   nodes.emplace(local_node, CreateNodeResources(2, 2, 0, 0, 1, 1));
   nodes.emplace(remote_node_1, CreateNodeResources(2, 2, 0, 0, 0, 0));
   nodes.emplace(remote_node_2, CreateNodeResources(3, 3, 0, 0, 0, 0));
 
   ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
-  int to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                        .HybridPolicy(
-                            req, 0.51, false, true, [](auto) { return true; },
-                            /*gpu_avoid_scheduling*/ true);
+  std::string to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
+                                .HybridPolicy(
+                                    req, 0.51, false, true, [](auto) { return true; },
+                                    /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, remote_node_1);
 
   req = ResourceMapToResourceRequest(map, {{"CPU", 3}}, false);

--- a/src/ray/raylet/scheduling/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy_test.cc
@@ -36,8 +36,7 @@ NodeResources CreateNodeResources(double available_cpu, double total_cpu,
 class SchedulingPolicyTest : public ::testing::Test {};
 
 TEST_F(SchedulingPolicyTest, SpreadPolicyTest) {
-  StringIdMap map;
-  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node_1 = "1";
   std::string remote_node_2 = "2";
@@ -67,10 +66,9 @@ TEST_F(SchedulingPolicyTest, SpreadPolicyTest) {
 }
 
 TEST_F(SchedulingPolicyTest, FeasibleDefinitionTest) {
-  StringIdMap map;
   auto task_req1 =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"object_store_memory", 1}}, false);
-  auto task_req2 = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+      ResourceMapToResourceRequest({{"CPU", 1}, {"object_store_memory", 1}}, false);
+  auto task_req2 = ResourceMapToResourceRequest({{"CPU", 1}}, false);
   {
     // Don't break with a non-resized predefined resources array.
     NodeResources resources;
@@ -90,10 +88,9 @@ TEST_F(SchedulingPolicyTest, FeasibleDefinitionTest) {
 }
 
 TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
-  StringIdMap map;
   auto task_req1 =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"object_store_memory", 1}}, false);
-  auto task_req2 = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+      ResourceMapToResourceRequest({{"CPU", 1}, {"object_store_memory", 1}}, false);
+  auto task_req2 = ResourceMapToResourceRequest({{"CPU", 1}}, false);
   {
     // Don't break with a non-resized predefined resources array.
     NodeResources resources;
@@ -155,8 +152,8 @@ TEST_F(SchedulingPolicyTest, AvailableTruncationTest) {
   // In this test, the local node and a remote node are both  available. The remote node
   // has a lower critical resource utilization, but they're both truncated to 0, so we
   // should still pick the local node (due to traversal order).
-  StringIdMap map;
-  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -173,8 +170,8 @@ TEST_F(SchedulingPolicyTest, AvailableTruncationTest) {
 TEST_F(SchedulingPolicyTest, AvailableTieBreakTest) {
   // In this test, the local node and a remote node are both available. The remote node
   // has a lower critical resource utilization so we schedule on it.
-  StringIdMap map;
-  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -192,9 +189,8 @@ TEST_F(SchedulingPolicyTest, AvailableOverFeasibleTest) {
   // In this test, the local node is feasible and has a lower critical resource
   // utilization, but the remote node can run the task immediately, so we pick the remote
   // node.
-  StringIdMap map;
-  ResourceRequest req =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -210,9 +206,8 @@ TEST_F(SchedulingPolicyTest, AvailableOverFeasibleTest) {
 
 TEST_F(SchedulingPolicyTest, InfeasibleTest) {
   // All the nodes are infeasible, so we return -1.
-  StringIdMap map;
-  ResourceRequest req =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -229,9 +224,8 @@ TEST_F(SchedulingPolicyTest, InfeasibleTest) {
 TEST_F(SchedulingPolicyTest, BarelyFeasibleTest) {
   // Test the edge case where a task requires all of a node's resources, and the node is
   // fully utilized.
-  StringIdMap map;
-  ResourceRequest req =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   std::string local_node = "0";
 
   absl::flat_hash_map<std::string, Node> nodes;
@@ -246,9 +240,8 @@ TEST_F(SchedulingPolicyTest, BarelyFeasibleTest) {
 TEST_F(SchedulingPolicyTest, TruncationAcrossFeasibleNodesTest) {
   // Same as AvailableTruncationTest except now none of the nodes are available, but the
   // tie break logic should apply to feasible nodes too.
-  StringIdMap map;
-  ResourceRequest req =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -265,9 +258,8 @@ TEST_F(SchedulingPolicyTest, TruncationAcrossFeasibleNodesTest) {
 TEST_F(SchedulingPolicyTest, ForceSpillbackIfAvailableTest) {
   // The local node is better, but we force spillback, so we'll schedule on a non-local
   // node anyways.
-  StringIdMap map;
-  ResourceRequest req =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -282,7 +274,6 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackIfAvailableTest) {
 }
 
 TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
-  StringIdMap map;
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -294,17 +285,17 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
     // The local node is better, but it has GPUs, the request is
     // non GPU, and the remote node does not have GPUs, thus
     // we should schedule on remote node.
-    const ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+    const ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
     const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
-                ResourceMapToResourceRequest(map, {{"CPU", 1}}, false), 0.51, false, true,
+                ResourceMapToResourceRequest({{"CPU", 1}}, false), 0.51, false, true,
                 [](auto) { return true; }, true);
     ASSERT_EQ(to_schedule, remote_node);
   }
   {
     // A GPU request should be scheduled on a GPU node.
-    const ResourceRequest req = ResourceMapToResourceRequest(map, {{"GPU", 1}}, false);
+    const ResourceRequest req = ResourceMapToResourceRequest({{"GPU", 1}}, false);
     const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
@@ -313,7 +304,7 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
   }
   {
     // A CPU request can be be scheduled on a CPU node.
-    const ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+    const ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
     const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
@@ -323,7 +314,7 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
   {
     // A mixed CPU/GPU request should be scheduled on a GPU node.
     const ResourceRequest req =
-        ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+        ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
     const std::string to_schedule =
         raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
             .HybridPolicy(
@@ -335,8 +326,8 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
 TEST_F(SchedulingPolicyTest, SchedulenCPURequestsOnGPUNodeAsALastResort) {
   // Schedule on remote node, even though the request is CPU only, because
   // we can not schedule on CPU nodes.
-  StringIdMap map;
-  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -353,9 +344,8 @@ TEST_F(SchedulingPolicyTest, SchedulenCPURequestsOnGPUNodeAsALastResort) {
 
 TEST_F(SchedulingPolicyTest, ForceSpillbackTest) {
   // The local node is available but disqualified.
-  StringIdMap map;
-  ResourceRequest req =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -372,9 +362,8 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackTest) {
 TEST_F(SchedulingPolicyTest, ForceSpillbackOnlyFeasibleLocallyTest) {
   // The local node is better, but we force spillback, so we'll schedule on a non-local
   // node anyways.
-  StringIdMap map;
-  ResourceRequest req =
-      ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   std::string local_node = "0";
   std::string remote_node = "1";
 
@@ -391,7 +380,7 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackOnlyFeasibleLocallyTest) {
 TEST_F(SchedulingPolicyTest, NonGpuNodePreferredSchedulingTest) {
   // Prefer to schedule on CPU nodes first.
   // GPU nodes should be preferred as a last resort.
-  StringIdMap map;
+
   std::string local_node = "0";
   std::string remote_node_1 = "1";
   std::string remote_node_2 = "2";
@@ -403,28 +392,28 @@ TEST_F(SchedulingPolicyTest, NonGpuNodePreferredSchedulingTest) {
   nodes.emplace(remote_node_1, CreateNodeResources(2, 2, 0, 0, 0, 0));
   nodes.emplace(remote_node_2, CreateNodeResources(3, 3, 0, 0, 0, 0));
 
-  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
   std::string to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
                                 .HybridPolicy(
                                     req, 0.51, false, true, [](auto) { return true; },
                                     /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, remote_node_1);
 
-  req = ResourceMapToResourceRequest(map, {{"CPU", 3}}, false);
+  req = ResourceMapToResourceRequest({{"CPU", 3}}, false);
   to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
                     .HybridPolicy(
                         req, 0.51, false, true, [](auto) { return true; },
                         /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, remote_node_2);
 
-  req = ResourceMapToResourceRequest(map, {{"CPU", 1}, {"GPU", 1}}, false);
+  req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
   to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
                     .HybridPolicy(
                         req, 0.51, false, true, [](auto) { return true; },
                         /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, local_node);
 
-  req = ResourceMapToResourceRequest(map, {{"CPU", 2}}, false);
+  req = ResourceMapToResourceRequest({{"CPU", 2}}, false);
   to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
                     .HybridPolicy(
                         req, 0.51, false, true, [](auto) { return true; },

--- a/src/ray/raylet/scheduling/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy_test.cc
@@ -223,7 +223,7 @@ TEST_F(SchedulingPolicyTest, InfeasibleTest) {
   std::string to_schedule =
       raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
           .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
-  ASSERT_EQ(to_schedule, "-1");
+  ASSERT_EQ(to_schedule, "");
 }
 
 TEST_F(SchedulingPolicyTest, BarelyFeasibleTest) {
@@ -385,7 +385,7 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackOnlyFeasibleLocallyTest) {
   std::string to_schedule =
       raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
           .HybridPolicy(req, 0.51, true, false, [](auto) { return true; });
-  ASSERT_EQ(to_schedule, "-1");
+  ASSERT_EQ(to_schedule, "");
 }
 
 TEST_F(SchedulingPolicyTest, NonGpuNodePreferredSchedulingTest) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR rename StringIdMap to ResourceIdMap, and make it singleton so that we don't need to pass it around.
This PR depends on #22662

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
