### PR TITLE
[KubeRay] Remove configmap reference in example

### DIFF
--- a/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
+++ b/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
@@ -131,18 +131,10 @@ spec:
               cpu: 250m
               memory: 512Mi
           volumeMounts:
-            - mountPath: /autoscaler/
-              name: autoscaler-config
             - mountPath: /tmp/ray
               name: ray-logs
         volumes:
         # You set volumes at the Pod level, then mount them into containers inside that Pod
-        - name: autoscaler-config
-          configMap:
-            name: autoscaler-config
-            items:
-            - key: ray_bootstrap_config.yaml
-              path: ray_bootstrap_config.yaml
         - name: ray-logs
           emptyDir: {}
   workerGroupSpecs:


### PR DESCRIPTION
## Why are these changes needed?

A follow up change of https://github.com/ray-project/ray/pull/22348

example is not up to date and we can not bring up the cluster due to missing configmap. Autoscaler is able to convert CR to autoscaler config so we don't need configmap anymore. 


## Related issue number

Address https://github.com/ray-project/ray/issues/22687

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] I manually test this change
