### PR TITLE
[KubeRay] Provide a new Dockerfile for fast build

### DIFF
--- a/doc/source/cluster/kuberay.md
+++ b/doc/source/cluster/kuberay.md
@@ -88,9 +88,16 @@ Then in the `ray/docker/kuberay-autoscaler` directory run:
 
 ```shell
 cp ../../python/dist/ray-2.0.0.dev0-cp37-cp37m-linux_x86_64.whl ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
-docker build --build-arg WHEEL_PATH="ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl" -t rayproject/kuberay-autoscaler --no-cache .
+docker build --build-arg WHEEL_PATH="ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl" -t rayproject/kuberay-autoscaler -f Dockerfile.dev --no-cache .
 docker push rayproject/kuberay-autoscaler
 ```
 
 where you replace `rayproject/kuberay-autoscaler` with the desired image path in your own docker account (normally
 `<username>/kuberay-autoscaler`). Please also make sure to update the image in `ray-cluster.complete.yaml`.
+
+If you don't make any changes to Ray autoscaler but only touch files under `docker/kuberay-autoscaler` or just want to catch up latest ray, you can skip building the wheel and build autoscaler directly.
+
+```
+docker build -t rayproject/kuberay-autoscaler --no-cache .
+docker push rayproject/kuberay-autoscaler
+```

--- a/docker/kuberay-autoscaler/Dockerfile.dev
+++ b/docker/kuberay-autoscaler/Dockerfile.dev
@@ -1,6 +1,9 @@
 FROM rayproject/ray:nightly
+ARG WHEEL_PATH
+RUN $HOME/anaconda3/bin/pip uninstall -y ray
+COPY $WHEEL_PATH .
+RUN $HOME/anaconda3/bin/pip --no-cache-dir install "$WHEEL_PATH"[all]
 
 COPY autoscaling_config.py /home/ray/autoscaling_config.py
 COPY run_autoscaler.py /home/ray/run_autoscaler.py
 COPY run_autoscaler_with_retries.py /home/ray/run_autoscaler_with_retries.py
-RUN mkdir -p /tmp/ray/session_latest/logs


### PR DESCRIPTION
## Why are these changes needed?

I notice we don't need to build ray wheel everytime. I add a new Dockerfile for fast build and development. 

## Related issue number

N/A

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Run some manual testing

