### PR TITLE
[RLlib] Add swa option for base torch optimizer

### DIFF
--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -39,3 +39,5 @@ starlette==0.16.0
 onnx==1.9.0
 onnxruntime==1.9.0
 tf2onnx==1.8.5
+# For SWA optimizer
+torchcontrib==0.0.2

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -183,9 +183,9 @@ COMMON_CONFIG: TrainerConfigDict = {
     "swa_config": {
         # Start SWA after this many model updates
         # Note this counts each minibatch as an update
-        "start": 10,
+        "start": 0,
         # Run a SWA update after this many model updates
-        "freq": 10
+        "freq": 3,
     },
 
     # === Environment Settings ===

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -177,6 +177,16 @@ COMMON_CONFIG: TrainerConfigDict = {
     "model": MODEL_DEFAULTS,
     # Arguments to pass to the policy optimizer. These vary by optimizer.
     "optimizer": {},
+    # Stochastic weight averaging, which supposedly helps learning
+    # stability and reduces catastrophic forgetting
+    "swa": False,
+    "swa_config": {
+        # Start SWA after this many model updates
+        # Note this counts each minibatch as an update
+        "start": 10,
+        # Run a SWA update after this many model updates
+        "freq": 10
+    },
 
     # === Environment Settings ===
     # Number of steps after which the episode is forced to terminate. Defaults

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -842,6 +842,16 @@ class TorchPolicy(Policy):
             optimizers = [
                 torch.optim.Adam(self.model.parameters(), lr=self.config["lr"])
             ]
+            if self.config["swa"]:
+                import torchcontrib
+
+                optimizers = [
+                    torchcontrib.optim.swa.SWA(
+                        optimizer=optimizers[0],
+                        swa_start=self.config["swa_config"]["start"],
+                        swa_freq=self.config["swa_config"]["freq"],
+                    )
+                ]
         else:
             optimizers = [torch.optim.Adam(self.model.parameters())]
         if getattr(self, "exploration", None):

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -843,7 +843,13 @@ class TorchPolicy(Policy):
                 torch.optim.Adam(self.model.parameters(), lr=self.config["lr"])
             ]
             if self.config["swa"]:
-                import torchcontrib
+                try:
+                    import torchcontrib
+                except ImportError:
+                    print(
+                        "torchcontrib is not installed -- `pip install torchcontrib' to use swa"
+                    )
+                    raise
 
                 optimizers = [
                     torchcontrib.optim.swa.SWA(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Stochastic weight averaging (SWA) is known to significantly improve generalization capabilities in supervised learning at very little cost. [Recent works](https://www.gatsby.ucl.ac.uk/~balaji/udl-camera-ready/UDL-24.pdf) suggest it improves stability in RL as well.

This patch introduces `swa` for `torch` models. Using the tuned PPO cartpole example, changes seem significant:
```yaml
# without_swa.yaml
cartpole-ppo:
    env: CartPole-v0
    run: PPO
    stop:
        timesteps_total: 200000
    config:
        # Works for both torch and tf.
        framework: torch
        gamma: 0.99
        lr: 0.0003
        num_workers: 1
        observation_filter: MeanStdFilter
        num_sgd_iter: 6
        vf_loss_coeff: 0.01
        swa: False
        model:
            fcnet_hiddens: [32]
            fcnet_activation: linear
            vf_share_layers: true
```
```yaml
# with_swa.yaml
cartpole-ppo:
    env: CartPole-v0
    run: PPO
    stop:
        timesteps_total: 200000
    config:
        # Works for both torch and tf.
        framework: torch
        gamma: 0.99
        lr: 0.0003
        num_workers: 1
        observation_filter: MeanStdFilter
        num_sgd_iter: 6
        vf_loss_coeff: 0.01
        swa: True
        swa_config:
          start: 0
          # Every 3 batches
          freq: 18
        model:
            fcnet_hiddens: [32]
            fcnet_activation: linear
            vf_share_layers: true
```

```bash
rllib train -f without_swa.yaml
rllib train -f with_swa.yaml
```

The pink line is without SWA and the red line is with SWA. As you can see, SWA seems to greatly improve policy stability. I'm excited to see the results for more difficult tasks.
<img width="351" alt="Screen Shot 2022-02-28 at 12 52 03 PM" src="https://user-images.githubusercontent.com/1743889/155987596-e7a03e99-b5d0-44d2-b466-95d246e31324.png">

Note that this only works for algorithms which use the base optimizer. Policies that instantiate their own optimizers (utilizing `policy_template.py:build_policy` can't use this without plumbing this change through each policy individually. This can be done, but it is a lot of boilerplate so I'll wait to see how everyone feels before starting.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
