### PR TITLE
scripts: Update dashboard output to print URL

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -113,7 +113,7 @@ def dashboard(cluster_config_file, cluster_name, port, remote_port, no_config_ca
         ]
         click.echo(
             "Attempting to establish dashboard locally at"
-            " localhost:{} connected to"
+            " http://localhost:{}/ connected to"
             " remote port {}".format(port, remote_port)
         )
         # We want to probe with a no-op that returns quickly to avoid


### PR DESCRIPTION
## Why are these changes needed?

Useful for Ctrl+Click for certain terminal emulators
When running `ray dashboard` I don't see a formatted URL.

It does seem to be formatted for here, but I guess that may be for head node, not for launching host? (e.g. for ray cluster)
https://github.com/ray-project/ray/blob/e84e9679326696ca46c8b81664996c0b5c4bc31b/python/ray/_private/services.py#L1490-L1497

## Related issue number

N/A

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/. (N/A)
- x ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( - simple output?
