### PR TITLE
[clean up ClusterResourceScheduler 1/n] move IsSchedulable logic into ClusterResourceManager

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1053,6 +1053,20 @@ cc_test(
 )
 
 cc_test(
+    name = "cluster_resource_manager_test",
+    size = "small",
+    srcs = [
+        "src/ray/raylet/scheduling/cluster_resource_manager_test.cc",
+    ],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        ":raylet_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "local_object_manager_test",
     size = "small",
     srcs = [

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -86,6 +86,17 @@ class ClusterResourceManager {
   bool SubtractNodeAvailableResources(int64_t node_id,
                                       const ResourceRequest &resource_request);
 
+  /// Check if we have sufficient resource to fullfill resource request for an given node.
+  ///
+  /// \param node_id: the id of the node.
+  /// \param resource_request: the request we want to check.
+  /// \param ignore_object_store_memory_requirement: if true, we will ignore the
+  ///  require_object_store_memory in the resource_request.
+  bool HasSufficientResource(int64_t node_id, const ResourceRequest &resource_request,
+                             bool ignore_object_store_memory_requirement) const;
+
+  void DebugString(std::stringstream &buffer) const;
+
  private:
   friend class ClusterResourceScheduler;
 
@@ -118,6 +129,7 @@ class ClusterResourceManager {
   StringIdMap &string_to_int_map_;
 
   friend class ClusterResourceSchedulerTest;
+  friend struct ClusterResourceManagerTest;
   friend class raylet::ClusterTaskManagerTest;
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingDeleteClusterNodeTest);
   FRIEND_TEST(ClusterResourceSchedulerTest, SchedulingModifyClusterNodeTest);

--- a/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/cluster_resource_manager.h"
+
+#include "gtest/gtest.h"
+
+namespace ray {
+
+NodeResources CreateNodeResources(StringIdMap &map, double available_cpu,
+                                  double total_cpu, double available_custom_resource = 0,
+                                  double total_custom_resource = 0,
+                                  bool object_pulls_queued = false) {
+  NodeResources resources;
+  resources.predefined_resources = {{available_cpu, total_cpu}, {0, 0}, {0, 0}, {0, 0}};
+  resources.custom_resources[map.Insert("CUSTOM")] = {available_custom_resource,
+                                                      total_custom_resource};
+  resources.object_pulls_queued = object_pulls_queued;
+  return resources;
+}
+
+struct ClusterResourceManagerTest : public ::testing::Test {
+  void SetUp() {
+    ::testing::Test::SetUp();
+    manager = std::make_unique<ClusterResourceManager>(map);
+    manager->AddOrUpdateNode(
+        node0, CreateNodeResources(map, /*available_cpu*/ 1, /*total_cpu*/ 1));
+    manager->AddOrUpdateNode(
+        node1, CreateNodeResources(map, /*available_cpu*/ 0, /*total_cpu*/ 0,
+                                   /*available_custom*/ 1, /*total_custom*/ 1));
+    manager->AddOrUpdateNode(
+        node2, CreateNodeResources(map, /*available_cpu*/ 1, /*total_cpu*/ 1,
+                                   /*available_custom*/ 1, /*total_custom*/ 1,
+                                   /*object_pulls_queued*/ true));
+  }
+  StringIdMap map;
+  int64_t node0 = 0;
+  int64_t node1 = 1;
+  int64_t node2 = 2;
+  int64_t node3 = 3;
+  std::unique_ptr<ClusterResourceManager> manager;
+};
+
+TEST_F(ClusterResourceManagerTest, HasSufficientResourceTest) {
+  ASSERT_FALSE(manager->HasSufficientResource(
+      node3, {}, /*ignore_object_store_memory_requirement*/ false));
+  ASSERT_TRUE(manager->HasSufficientResource(
+      node0,
+      ResourceMapToResourceRequest(map, {{"CPU", 1}},
+                                   /*requires_object_store_memory=*/true),
+      /*ignore_object_store_memory_requirement*/ false));
+  ASSERT_FALSE(manager->HasSufficientResource(
+      node0,
+      ResourceMapToResourceRequest(map, {{"CUSTOM", 1}},
+                                   /*requires_object_store_memory=*/true),
+      /*ignore_object_store_memory_requirement*/ false));
+  ASSERT_TRUE(manager->HasSufficientResource(
+      node1,
+      ResourceMapToResourceRequest(map, {{"CUSTOM", 1}},
+                                   /*requires_object_store_memory=*/true),
+      /*ignore_object_store_memory_requirement*/ false));
+  ASSERT_TRUE(manager->HasSufficientResource(
+      node2,
+      ResourceMapToResourceRequest(map, {{"CPU", 1}},
+                                   /*requires_object_store_memory=*/false),
+      /*ignore_object_store_memory_requirement*/ false));
+  ASSERT_FALSE(manager->HasSufficientResource(
+      node2,
+      ResourceMapToResourceRequest(map, {{"CPU", 1}},
+                                   /*requires_object_store_memory=*/true),
+      /*ignore_object_store_memory_requirement*/ false));
+  ASSERT_TRUE(manager->HasSufficientResource(
+      node2,
+      ResourceMapToResourceRequest(map, {{"CPU", 1}},
+                                   /*requires_object_store_memory=*/true),
+      /*ignore_object_store_memory_requirement*/ true));
+}
+}  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -106,43 +106,13 @@ bool ClusterResourceScheduler::NodeAlive(int64_t node_id) const {
 }
 
 bool ClusterResourceScheduler::IsSchedulable(const ResourceRequest &resource_request,
-                                             int64_t node_id,
-                                             const NodeResources &resources) const {
-  if (resource_request.requires_object_store_memory && resources.object_pulls_queued &&
-      node_id != local_node_id_) {
-    // It's okay if the local node's pull manager is at capacity because we
-    // will eventually spill the task back from the waiting queue if its args
-    // cannot be pulled.
-    return false;
-  }
-
-  // First, check predefined resources.
-  for (size_t i = 0; i < PredefinedResources_MAX; i++) {
-    if (resource_request.predefined_resources[i] >
-        resources.predefined_resources[i].available) {
-      // A hard constraint has been violated, so we cannot schedule
-      // this resource request.
-      return false;
-    }
-  }
-
-  // Now check custom resources.
-  for (const auto &task_req_custom_resource : resource_request.custom_resources) {
-    auto it = resources.custom_resources.find(task_req_custom_resource.first);
-
-    if (it == resources.custom_resources.end()) {
-      // Requested resource doesn't exist at this node.
-      // This is a hard constraint so cannot schedule this resource request.
-      return false;
-    } else {
-      if (task_req_custom_resource.second > it->second.available) {
-        // Resource constraint is violated.
-        return false;
-      }
-    }
-  }
-
-  return true;
+                                             int64_t node_id) const {
+  // It's okay if the local node's pull manager is at capacity because we
+  // will eventually spill the task back from the waiting queue if its args
+  // cannot be pulled.
+  return cluster_resource_manager_->HasSufficientResource(
+      node_id, resource_request,
+      /*ignore_object_store_memory_requirement*/ node_id == local_node_id_);
 }
 
 int64_t ClusterResourceScheduler::GetBestSchedulableNode(
@@ -232,17 +202,11 @@ std::string ClusterResourceScheduler::GetBestSchedulableNode(
 bool ClusterResourceScheduler::SubtractRemoteNodeAvailableResources(
     int64_t node_id, const ResourceRequest &resource_request) {
   RAY_CHECK(node_id != local_node_id_);
-  const auto &resource_view = cluster_resource_manager_->GetResourceView();
-  auto it = resource_view.find(node_id);
-  if (it == resource_view.end()) {
-    return false;
-  }
 
   // Just double check this node can still schedule the resource request.
-  if (!IsSchedulable(resource_request, node_id, it->second.GetLocalView())) {
+  if (!IsSchedulable(resource_request, node_id)) {
     return false;
   }
-
   return cluster_resource_manager_->SubtractNodeAvailableResources(node_id,
                                                                    resource_request);
 }
@@ -255,10 +219,7 @@ std::string ClusterResourceScheduler::DebugString(void) const {
   std::stringstream buffer;
   buffer << "\nLocal id: " << local_node_id_;
   buffer << " Local resources: " << local_resource_manager_->DebugString();
-  for (auto &node : cluster_resource_manager_->GetResourceView()) {
-    buffer << "node id: " << node.first;
-    buffer << node.second.GetLocalView().DebugString(string_to_int_map_);
-  }
+  cluster_resource_manager_->DebugString(buffer);
   return buffer.str();
 }
 
@@ -277,8 +238,7 @@ bool ClusterResourceScheduler::IsSchedulableOnNode(
   int64_t node_id = string_to_int_map_.Get(node_name);
   auto resource_request = ResourceMapToResourceRequest(
       string_to_int_map_, shape, /*requires_object_store_memory=*/false);
-  return IsSchedulable(resource_request, node_id,
-                       cluster_resource_manager_->GetNodeResources(node_name));
+  return IsSchedulable(resource_request, node_id);
 }
 
 std::string ClusterResourceScheduler::GetBestSchedulableNode(

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -126,15 +126,9 @@ class ClusterResourceScheduler {
   ///
   ///  \param resource_request: Resource request to be scheduled.
   ///  \param node_id: ID of the node.
-  ///  \param resources: Node's resources. (Note: Technically, this is
-  ///     redundant, as we can get the node's resources from nodes_
-  ///     using node_id. However, typically both node_id and resources
-  ///     are available when we call this function, and this way we avoid
-  ///     a map find call which could be expensive.)
   ///
   ///  \return: Whether the request can be scheduled.
-  bool IsSchedulable(const ResourceRequest &resource_request, int64_t node_id,
-                     const NodeResources &resources) const;
+  bool IsSchedulable(const ResourceRequest &resource_request, int64_t node_id) const;
 
   ///  Find a node in the cluster on which we can schedule a given resource request.
   ///  In hybrid mode, see `scheduling_policy.h` for a description of the policy.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

IsSchedulable checks if a node has sufficient resource to fulfill resource request. This logic should belong to ClusterResourceManager, instead of ClusterResourceScheduler.

We also move DebugString logic into ClusterResourceManager.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
