### PR TITLE
[clean up ClusterResourceScheduler 2/n] Introduce random policy in the scheduling policy

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_data.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_data.cc
@@ -224,6 +224,11 @@ bool NodeResources::IsAvailable(const ResourceRequest &resource_request,
     RAY_LOG(DEBUG) << "At pull manager capacity";
     return false;
   }
+
+  if (resource_request.IsEmpty()) {
+    return true;
+  }
+
   // First, check predefined resources.
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     if (i >= this->predefined_resources.size()) {
@@ -256,6 +261,9 @@ bool NodeResources::IsAvailable(const ResourceRequest &resource_request,
 }
 
 bool NodeResources::IsFeasible(const ResourceRequest &resource_request) const {
+  if (resource_request.IsEmpty()) {
+    return true;
+  }
   // First, check predefined resources.
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     if (i >= this->predefined_resources.size()) {

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -173,8 +173,6 @@ class ClusterResourceScheduler {
   StringIdMap string_to_int_map_;
   /// Identifier of local node.
   int64_t local_node_id_;
-  /// Internally maintained random number generator.
-  std::mt19937_64 gen_;
   /// Gcs client. It's not owned by this class.
   gcs::GcsClient *gcs_client_;
   /// Resources of local node.

--- a/src/ray/raylet/scheduling/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy_test.cc
@@ -66,6 +66,43 @@ TEST_F(SchedulingPolicyTest, SpreadPolicyTest) {
   ASSERT_EQ(to_schedule, remote_node_3);
 }
 
+TEST_F(SchedulingPolicyTest, RandomPolicyTest) {
+  StringIdMap map;
+  ResourceRequest req = ResourceMapToResourceRequest(map, {{"CPU", 1}}, false);
+  int64_t local_node = 0;
+  int64_t remote_node_1 = 1;
+  int64_t remote_node_2 = 2;
+  int64_t remote_node_3 = 3;
+
+  absl::flat_hash_map<int64_t, Node> nodes;
+
+  nodes.emplace(local_node, CreateNodeResources(20, 20, 0, 0, 0, 0));
+  nodes.emplace(remote_node_1, CreateNodeResources(20, 20, 0, 0, 0, 0));
+  // Unavailable node
+  nodes.emplace(remote_node_2, CreateNodeResources(0, 20, 0, 0, 0, 0));
+  // Infeasible node
+  nodes.emplace(remote_node_3, CreateNodeResources(0, 0, 0, 0, 0, 0));
+
+  raylet_scheduling_policy::SchedulingPolicy scheduling_policy(local_node, nodes);
+
+  std::map<int64_t, size_t> decisions;
+  size_t num_node_0_picks = 0;
+  size_t num_node_1_picks = 0;
+  for (int i = 0; i < 1000; i++) {
+    int64_t to_schedule = scheduling_policy.RandomPolicy(req, [](auto) { return true; });
+    ASSERT_TRUE(to_schedule >= 0);
+    ASSERT_TRUE(to_schedule <= 1);
+    if (to_schedule == 0) {
+      num_node_0_picks++;
+    } else {
+      num_node_1_picks++;
+    }
+  }
+  // It's extremely unlikely the only node 0 or node 1 is picked for 1000 runs.
+  ASSERT_TRUE(num_node_0_picks > 0);
+  ASSERT_TRUE(num_node_1_picks > 0);
+}
+
 TEST_F(SchedulingPolicyTest, FeasibleDefinitionTest) {
   StringIdMap map;
   auto task_req1 =


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are some logics in ClusterResourceScheduler that belongs to scheduling policy. We move them into ClusterResourceScheduler.RandomPolicy(...).

Note this is not truly random if there are lots of node doesn't meet the request requirement. However this doesn't affect today's usage so we will not address it in this PR.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
