### PR TITLE
[data] Pin pipeline executor actors to the driver node

### DIFF
--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -272,7 +272,8 @@ class DatasetPipeline(Generic[T]):
         # will fate-share with the coordinator anyway.
         local_node_resource = "node:{}".format(ray.util.get_node_ip_address())
         coordinator = PipelineSplitExecutorCoordinator.options(
-            resources={local_node_resource: 0.0001}
+            resources={local_node_resource: 0.0001},
+            placement_group=None,
         ).remote(self, n, splitter, DatasetContext.get_current())
         if self._executed[0]:
             raise RuntimeError("Pipeline cannot be read multiple times.")

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -267,9 +267,13 @@ class DatasetPipeline(Generic[T]):
 
     def _split(self, n: int, splitter: Callable[[Dataset], "DatasetPipeline[T]"]):
 
-        coordinator = PipelineSplitExecutorCoordinator.remote(
-            self, n, splitter, DatasetContext.get_current()
-        )
+        # Pin the coordinator (and any child actors) to the local node to avoid
+        # errors during node failures. If the local node dies, then the driver
+        # will fate-share with the coordinator anyway.
+        local_node_resource = "node:{}".format(ray.util.get_node_ip_address())
+        coordinator = PipelineSplitExecutorCoordinator.options(
+            resources={local_node_resource: 0.0001}
+        ).remote(self, n, splitter, DatasetContext.get_current())
         if self._executed[0]:
             raise RuntimeError("Pipeline cannot be read multiple times.")
         self._executed[0] = True

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -37,7 +37,9 @@ class PipelineExecutor:
         # the PipelineExecutor during a node failure.
         local_node_resource = "node:{}".format(ray.util.get_node_ip_address())
         self._stage_runners = [
-            _StageRunner.options(resources={local_node_resource: 0.0001}).remote()
+            _StageRunner.options(
+                resources={local_node_resource: 0.0001}, placement_group=None
+            ).remote()
             for _ in self._stages
         ]
         self._iter = iter(self._pipeline._base_iterable)

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -33,7 +33,13 @@ class PipelineExecutor:
         self._stages: List[ObjectRef[Dataset[Any]]] = [None] * (
             len(self._pipeline._optimized_stages) + 1
         )
-        self._stage_runners = [_StageRunner.remote() for _ in self._stages]
+        # Pin the child actors to the local node so that they fate-share with
+        # the PipelineExecutor during a node failure.
+        local_node_resource = "node:{}".format(ray.util.get_node_ip_address())
+        self._stage_runners = [
+            _StageRunner.options(resources={local_node_resource: 0.0001}).remote()
+            for _ in self._stages
+        ]
         self._iter = iter(self._pipeline._base_iterable)
         self._stages[0] = self._stage_runners[0].run.remote(
             next(self._iter), DatasetContext.get_current()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

DatasetPipeline execution is coordinated by a pool of actors and optionally the driver process. To recover from failures with lineage reconstruction, we need to keep these actors alive as long as the driver is alive. Currently, they are spread randomly throughout the cluster, so they can be killed during a node failure.

This PR pins the actors to the same node as the driver so that they will survive any other node failures. It's also okay if the driver node dies, since the driver itself will also die.

## Related issue number

Closes #21098.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
