### PR TITLE
[RFC] Disable actor queueing warning for concurrent actors

### DIFF
--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -193,14 +193,24 @@ TEST_P(DirectActorSubmitterTest, TestQueueingWarning) {
     ASSERT_TRUE(CheckSubmitTask(task));
     /* no ack */
   }
-  ASSERT_EQ(last_queue_warning_, 5000);
+  // TODO(ekl) support warning when true.
+  // https://github.com/ray-project/ray/issues/22278
+  if (execute_out_of_order) {
+    ASSERT_EQ(last_queue_warning_, 0);
+  } else {
+    ASSERT_EQ(last_queue_warning_, 5000);
+  }
 
   for (int i = 15000; i < 35000; i++) {
     auto task = CreateActorTaskHelper(actor_id, worker_id, i);
     ASSERT_TRUE(CheckSubmitTask(task));
     /* no ack */
   }
-  ASSERT_EQ(last_queue_warning_, 20000);
+  if (execute_out_of_order) {
+    ASSERT_EQ(last_queue_warning_, 0);
+  } else {
+    ASSERT_EQ(last_queue_warning_, 20000);
+  }
 }
 
 TEST_P(DirectActorSubmitterTest, TestDependencies) {

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.cc
@@ -393,7 +393,7 @@ void CoreWorkerDirectActorTaskSubmitter::PushActorTask(ClientQueue &queue,
   RAY_LOG(DEBUG) << "Pushing task " << task_id << " to actor " << actor_id
                  << " actor counter " << actor_counter << " seq no "
                  << request->sequence_number() << " num queued " << num_queued;
-  if (num_queued >= next_queueing_warn_threshold_) {
+  if (num_queued >= next_queueing_warn_threshold_ && !skip_queue) {
     // TODO(ekl) add more debug info about the actor name, etc.
     warn_excess_queueing_(actor_id, num_queued);
     next_queueing_warn_threshold_ *= 2;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The warning was not implemented properly for out of order actors. Disable it for now.

## Related issue number

Closes https://github.com/ray-project/ray/issues/22278

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
