### PR TITLE
[runtime env] Make env_vars take effect when pip install packages

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -24,7 +24,11 @@ from ray._private.test_utils import (
     wait_for_condition,
     chdir,
 )
-from ray._private.utils import get_conda_env_dir, get_conda_bin_executable
+from ray._private.utils import (
+    get_conda_env_dir,
+    get_conda_bin_executable,
+    try_to_create_directory,
+)
 
 if not os.environ.get("CI"):
     # This flags turns on the local development that link against current ray
@@ -932,6 +936,76 @@ def test_runtime_env_override(call_ray_start):
         assert ray.get(child.read.remote("hello")) == "world"
 
         ray.shutdown()
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform != "linux",
+    reason="This test is only run on linux CI machines.",
+)
+def test_pip_with_env_vars(start_cluster):
+
+    with tempfile.TemporaryDirectory() as tmpdir, chdir(tmpdir):
+        TEST_ENV_NAME = "TEST_ENV_VARS"
+        TEST_ENV_VALUE = "TEST"
+        package_name = "test_package"
+        package_dir = os.path.join(tmpdir, package_name)
+        try_to_create_directory(package_dir)
+
+        setup_filename = os.path.join(package_dir, "setup.py")
+        setup_code = """import os
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+class InstallTestPackage(install):
+    # this function will be called when pip install this package
+    def run(self):
+        assert os.environ.get('{TEST_ENV_NAME}') == '{TEST_ENV_VALUE}'
+
+setup(
+    name='test_package',
+    version='0.0.1',
+    packages=find_packages(),
+    cmdclass=dict(install=InstallTestPackage),
+    license="MIT",
+    zip_safe=False,
+)
+""".format(
+            TEST_ENV_NAME=TEST_ENV_NAME, TEST_ENV_VALUE=TEST_ENV_VALUE
+        )
+        with open(setup_filename, "wt") as f:
+            f.writelines(setup_code)
+
+        python_filename = os.path.join(package_dir, "test.py")
+        python_code = "import os; print(os.environ)"
+        with open(python_filename, "wt") as f:
+            f.writelines(python_code)
+
+        gz_filename = os.path.join(tmpdir, package_name + ".tar.gz")
+        subprocess.check_call(["tar", "-zcvf", gz_filename, package_name])
+
+        with pytest.raises(ray.exceptions.RuntimeEnvSetupError):
+
+            @ray.remote(
+                runtime_env={
+                    "env_vars": {TEST_ENV_NAME: "failed"},
+                    "pip": [gz_filename],
+                }
+            )
+            def f1():
+                return True
+
+            ray.get(f1.remote())
+
+        @ray.remote(
+            runtime_env={
+                "env_vars": {TEST_ENV_NAME: TEST_ENV_VALUE},
+                "pip": [gz_filename],
+            }
+        )
+        def f2():
+            return True
+
+        assert ray.get(f2.remote())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, for the stability of pip installation, we set env to empty, but when pip installs some gzip package, maybe need env_vars.  like this issue: https://github.com/ray-project/ray/issues/22610

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
