### PR TITLE
[RLlib] Fix tree.flatten dict ordering bug: `flatten_space([obs_space])` should produce same struct as `tree.flatten([obs])`.

### DIFF
--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -1,6 +1,7 @@
 import gym
 import logging
 import importlib.util
+import os
 from types import FunctionType
 from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
@@ -457,7 +458,8 @@ class WorkerSet:
             return tf1.Session(config=tf1.ConfigProto(**config["tf_session_args"]))
 
         def valid_module(class_path):
-            if isinstance(class_path, str) and "." in class_path:
+            if isinstance(class_path, str) and not os.path.isfile(class_path) and \
+                    "." in class_path:
                 module_path, class_name = class_path.rsplit(".", 1)
                 try:
                     spec = importlib.util.find_spec(module_path)
@@ -470,31 +472,40 @@ class WorkerSet:
                     )
             return False
 
+        # A callable returning an InputReader object to use.
         if isinstance(config["input"], FunctionType):
             input_creator = config["input"]
+        # Use RLlib's Sampler classes (SyncSampler or AsynchSampler, depending
+        # on `config.sample_async` setting).
         elif config["input"] == "sampler":
             input_creator = lambda ioctx: ioctx.default_sampler_input()
+        # Ray Dataset input -> Use `config.input_config` to construct DatasetReader.
         elif config["input"] == "dataset":
             # Input dataset shards should have already been prepared.
             # We just need to take the proper shard here.
             input_creator = lambda ioctx: DatasetReader(
                 ioctx, self._ds_shards[worker_index]
             )
+        # Dict: Mix of different input methods with different ratios.
         elif isinstance(config["input"], dict):
             input_creator = lambda ioctx: ShuffledInput(
                 MixedInput(config["input"], ioctx), config["shuffle_buffer_size"]
             )
+        # A pre-registered input descriptor (str).
         elif isinstance(config["input"], str) and registry_contains_input(
             config["input"]
         ):
             input_creator = registry_get_input(config["input"])
+        # D4RL input.
         elif "d4rl" in config["input"]:
             env_name = config["input"].split(".")[-1]
             input_creator = lambda ioctx: D4RLReader(env_name, ioctx)
+        # Valid python module (class path) -> Create using `from_config`.
         elif valid_module(config["input"]):
             input_creator = lambda ioctx: ShuffledInput(
                 from_config(config["input"], ioctx=ioctx)
             )
+        # JSON file or list of JSON files -> Use JsonReader (shuffled).
         else:
             input_creator = lambda ioctx: ShuffledInput(
                 JsonReader(config["input"], ioctx), config["shuffle_buffer_size"]

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -458,8 +458,11 @@ class WorkerSet:
             return tf1.Session(config=tf1.ConfigProto(**config["tf_session_args"]))
 
         def valid_module(class_path):
-            if isinstance(class_path, str) and not os.path.isfile(class_path) and \
-                    "." in class_path:
+            if (
+                isinstance(class_path, str)
+                and not os.path.isfile(class_path)
+                and "." in class_path
+            ):
                 module_path, class_name = class_path.rsplit(".", 1)
                 try:
                     spec = importlib.util.find_spec(module_path)

--- a/rllib/offline/dataset_reader.py
+++ b/rllib/offline/dataset_reader.py
@@ -38,7 +38,7 @@ def get_dataset_and_shards(
             " when using Ray dataset input."
         )
 
-    parallelism = input_config.get("parallelism", num_workers)
+    parallelism = input_config.get("parallelism", num_workers or 1)
     cpus_per_task = input_config.get(
         "num_cpus_per_read_task", DEFAULT_NUM_CPUS_PER_TASK
     )

--- a/rllib/utils/spaces/space_utils.py
+++ b/rllib/utils/spaces/space_utils.py
@@ -27,7 +27,7 @@ def flatten_space(space: gym.Space) -> List[gym.Space]:
             for s in space_:
                 _helper_flatten(s, return_list)
         elif isinstance(space_, (Dict, FlexDict)):
-            for k in space_.spaces:
+            for k in sorted(space_.spaces):
                 _helper_flatten(space_[k], return_list)
         else:
             return_list.append(space_)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix tree.flatten dict ordering bug: `flatten_space([obs_space])` should produce same struct as `tree.flatten([obs])`.

Simple reproduction of the issue:
```
from gym.spaces import Dict, Discrete
from ray.rllib.utils.space_utils import flatten_space
import tree  # dm_tree

space = Dict({"b": Discrete(200), "a": Discrete(1)})
flattened_spaces = flatten_space(space)
# flattened_spaces.spaces = [Discrete(200), Discrete(1)]  <- sorts dict keys by order of insertion!

flat_sample = tree.flatten(space.sample())
# flat_sample = [50, 0]  <- sorts dict keys by alphabet(!)

```

The above discrepancy could lead to mismatches (even unnoticed) when complex spaces are used, e.g. in our default `ComplexInputNets` (for tf and torch).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
