### PR TITLE
Fix mac osx worker process not being killed by ray stop

### DIFF
--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -90,7 +90,12 @@ RAY_PROCESSES = [
     ["redis-server", False],
     ["default_worker.py", False],  # Python worker.
     ["setup_worker.py", False],  # Python environment setup worker.
-    ["ray::", True],  # Python worker. TODO(mehrdadn): Fix for Windows
+    # For mac osx, setproctitle doesn't change the process name returned
+    # by psutil but only cmdline.
+    [
+        "ray::",
+        sys.platform != "darwin",
+    ],  # Python worker. TODO(mehrdadn): Fix for Windows
     ["io.ray.runtime.runner.worker.DefaultWorker", False],  # Java worker.
     ["log_monitor.py", False],
     ["reporter.py", False],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For mac osx, setproctitle doesn't change the process name returned by psutil (I think it's this issue https://github.com/dvarrazzo/py-setproctitle/issues/10) but only cmdline so we need to filter by cmdline instead.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #20159
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
