### PR TITLE
[Java] Add transient for cached hashcode of IDs to reduce serialized size.

### DIFF
--- a/java/api/src/main/java/io/ray/api/id/BaseId.java
+++ b/java/api/src/main/java/io/ray/api/id/BaseId.java
@@ -8,8 +8,8 @@ import javax.xml.bind.DatatypeConverter;
 public abstract class BaseId implements Serializable {
   private static final long serialVersionUID = 8588849129675565761L;
   private final byte[] id;
-  private volatile int hashCodeCache = 0;
-  private volatile Boolean isNilCache = null;
+  private transient int hashCodeCache = 0;
+  private transient Boolean isNilCache = null;
 
   /** Create a BaseId instance according to the input byte array. */
   protected BaseId(byte[] id) {

--- a/java/api/src/main/java/io/ray/api/id/BaseId.java
+++ b/java/api/src/main/java/io/ray/api/id/BaseId.java
@@ -8,8 +8,8 @@ import javax.xml.bind.DatatypeConverter;
 public abstract class BaseId implements Serializable {
   private static final long serialVersionUID = 8588849129675565761L;
   private final byte[] id;
-  private int hashCodeCache = 0;
-  private Boolean isNilCache = null;
+  private volatile int hashCodeCache = 0;
+  private volatile Boolean isNilCache = null;
 
   /** Create a BaseId instance according to the input byte array. */
   protected BaseId(byte[] id) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Use `transient` keyword for reducing the serialized size of  ids for transporting.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
