### PR TITLE
[RLlib] Example for custom multi-agent vetor env. Bug fixes related to this use-case.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2289,6 +2289,24 @@ py_test(
 )
 
 py_test(
+    name = "examples/custom_vector_multi_agent_env_tf2",
+    main = "examples/custom_vector_multi_agent_env.py",
+    tags = ["team:ml", "examples", "examples_C", "examples_C_UtoZ"],
+    size = "medium",
+    srcs = ["examples/custom_vector_multi_agent_env.py"],
+    args = ["--as-test", "--framework=tf2", "--eager-tracing", --stop-reward=40.0"]
+)
+
+py_test(
+    name = "examples/custom_vector_multi_agent_env_torch",
+    main = "examples/custom_vector_multi_agent_env.py",
+    tags = ["team:ml", "examples", "examples_C", "examples_C_UtoZ"],
+    size = "medium",
+    srcs = ["examples/custom_vector_multi_agent_env.py"],
+    args = ["--as-test", "--framework=torch", "--stop-reward=40.0"]
+)
+
+py_test(
     name = "examples/deterministic_training_tf",
     main = "examples/deterministic_training.py",
     tags = ["team:ml", "multi_gpu"],

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -834,6 +834,10 @@ def _process_observations(
             episode._add_agent_rewards(rewards[env_id])
 
         # Check episode termination conditions.
+        try:  # TODO
+            dones[env_id]["__all__"]
+        except Exception as e:
+            raise e
         if dones[env_id]["__all__"] or episode.length >= horizon:
             hit_horizon = episode.length >= horizon and not dones[env_id]["__all__"]
             all_agents_done = True
@@ -903,7 +907,10 @@ def _process_observations(
             preprocessor = _get_or_raise(worker.preprocessors, policy_id)
             prep_obs: EnvObsType = raw_obs
             if preprocessor is not None:
-                prep_obs = preprocessor.transform(raw_obs)
+                try:  # TODO
+                    prep_obs = preprocessor.transform(raw_obs)
+                except Exception as e:
+                    raise e
                 if log_once("prep_obs"):
                     logger.info("Preprocessed obs: {}".format(summarize(prep_obs)))
             filtered_obs: EnvObsType = _get_or_raise(worker.filters, policy_id)(

--- a/rllib/examples/custom_vector_multi_agent_env.py
+++ b/rllib/examples/custom_vector_multi_agent_env.py
@@ -1,0 +1,68 @@
+import argparse
+import os
+
+import ray
+from ray import tune
+from ray.rllib.examples.env.mock_env import MockMultiAgentVectorEnv
+from ray.rllib.utils.framework import try_import_tf, try_import_torch
+from ray.rllib.utils.test_utils import check_learning_achieved
+
+tf1, tf, tfv = try_import_tf()
+torch, nn = try_import_torch()
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--run", type=str, default="PPO", help="The RLlib-registered algorithm to use."
+)
+parser.add_argument(
+    "--framework",
+    choices=["tf", "tf2", "tfe", "torch"],
+    default="tf",
+    help="The DL framework specifier.",
+)
+parser.add_argument("--eager-tracing", action="store_true")
+parser.add_argument(
+    "--as-test",
+    action="store_true",
+    help="Whether this script should be run as a test: --stop-reward must "
+    "be achieved within --stop-timesteps AND --stop-iters.",
+)
+parser.add_argument(
+    "--stop-iters", type=int, default=50, help="Number of iterations to train."
+)
+parser.add_argument(
+    "--stop-timesteps", type=int, default=100000, help="Number of timesteps to train."
+)
+parser.add_argument(
+    "--stop-reward", type=float, default=400.0, help="Reward at which we stop training."
+)
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    ray.init()
+
+    # episode-len=100
+    # num-envs=4 (note that these are fake-envs as the MockVectorEnv only
+    # carries a single CartPole sub-env in it).
+    tune.register_env("custom_vec_env", lambda env_ctx: MockMultiAgentVectorEnv(100, 4))
+
+    config = {
+        "env": "custom_vec_env",
+        # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.
+        "num_gpus": int(os.environ.get("RLLIB_NUM_GPUS", "0")),
+        "num_workers": 2,
+        "framework": args.framework,
+        "eager_tracing": args.eager_tracing,
+    }
+
+    stop = {
+        "training_iteration": args.stop_iters,
+        "timesteps_total": args.stop_timesteps,
+        "episode_reward_mean": args.stop_reward,
+    }
+
+    results = tune.run(args.run, config=config, stop=stop, verbose=2)
+
+    if args.as_test:
+        check_learning_achieved(results, args.stop_reward)
+    ray.shutdown()

--- a/rllib/examples/env/multi_agent.py
+++ b/rllib/examples/env/multi_agent.py
@@ -3,7 +3,6 @@ import numpy as np
 import random
 
 from ray.rllib.env.multi_agent_env import MultiAgentEnv, make_multi_agent
-from ray.rllib.examples.env.mock_env import MockEnv, MockEnv2
 from ray.rllib.examples.env.stateless_cartpole import StatelessCartPole
 from ray.rllib.utils.deprecation import Deprecated
 
@@ -25,6 +24,8 @@ class BasicMultiAgent(MultiAgentEnv):
     }
 
     def __init__(self, num):
+        from ray.rllib.examples.env.mock_env import MockEnv
+
         super().__init__()
         self.agents = [MockEnv(25) for _ in range(num)]
         self._agent_ids = set(range(num))
@@ -58,6 +59,8 @@ class EarlyDoneMultiAgent(MultiAgentEnv):
     """Env for testing when the env terminates (after agent 0 does)."""
 
     def __init__(self):
+        from ray.rllib.examples.env.mock_env import MockEnv
+
         super().__init__()
         self.agents = [MockEnv(3), MockEnv(5)]
         self._agent_ids = set(range(len(self.agents)))
@@ -121,6 +124,8 @@ class FlexAgentsMultiAgent(MultiAgentEnv):
         self.resetted = False
 
     def spawn(self):
+        from ray.rllib.examples.env.mock_env import MockEnv
+
         # Spawn a new agent into the current episode.
         agentID = self.agentID
         self.agents[agentID] = MockEnv(25)
@@ -172,6 +177,8 @@ class RoundRobinMultiAgent(MultiAgentEnv):
     On each step() of the env, only one agent takes an action."""
 
     def __init__(self, num, increment_obs=False):
+        from ray.rllib.examples.env.mock_env import MockEnv, MockEnv2
+
         super().__init__()
         if increment_obs:
             # Observations are 0, 1, 2, 3... etc. as time advances


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Example for custom multi-agent vetor env. Bug fixes related to this use-case.

* RLlib currently does not support defining a custom VectorEnv, which has n underlying MultiAgentEnvs (this PR fixes the bugs related to this scenario).
* Adds a new example script to illustrate how to write a custom VectorEnv with one or more underlying MultiAgentEnvs.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
