### PR TITLE
PB2 example in docs correction

### DIFF
--- a/python/ray/tune/schedulers/pb2.py
+++ b/python/ray/tune/schedulers/pb2.py
@@ -263,9 +263,9 @@ class PB2(PopulationBasedTraining):
         >>>     metric="episode_reward_mean",
         >>>     mode="max",
         >>>     perturbation_interval=10000,
-        >>>     hyperparam_mutations={
-        >>>         # These must be continuous, currently a limitation.
-        >>>         "factor_1": lambda: random.uniform(0.0, 20.0),
+        >>>     hyperparam_bounds={
+        >>>         "factor_1": [0.0, 20.0],
+        >>>         "factor_2": [0.0, 1.0]
         >>>     })
         >>> tune.run({...}, num_samples=8, scheduler=pb2)
     """


### PR DESCRIPTION
Change the the PB2 example to use the correct `hyperparam_bounds` parameter name instead of `hyperparam_mutations`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The example in the class definition refers to parameter name `hyperparam_mutations` -- but that parameter is not in the class constructor. The correct parameter name is `hyperparam_bounds` and uses a slightly different format ([min, max]) to define the parameter spaces.

This PR updates the example with the correct parameter name and the correct way to specify the bounds.

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
