### PR TITLE
[scheduling-ids] enforce thread-private

### DIFF
--- a/src/ray/raylet/scheduling/scheduling_ids.h
+++ b/src/ray/raylet/scheduling/scheduling_ids.h
@@ -19,6 +19,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "ray/util/logging.h"
+#include "ray/util/util.h"
 
 /// Limit the ID range to test for collisions.
 #define MAX_ID_TEST 8
@@ -85,13 +86,13 @@ enum class SchedulingIDTag { Node, Resource };
 template <SchedulingIDTag T>
 class BaseSchedulingID {
  public:
-  explicit BaseSchedulingID(const std::string &name) : id_{GetMap().Insert(name)} {}
+  explicit BaseSchedulingID(const std::string &name) : id_{GetMap()->Insert(name)} {}
 
   explicit BaseSchedulingID(int64_t id) : id_{id} {}
 
   int64_t ToInt() const { return id_; }
 
-  std::string Binary() const { return GetMap().Get(id_); }
+  std::string Binary() const { return GetMap()->Get(id_); }
 
   bool operator==(const BaseSchedulingID &rhs) const { return id_ == rhs.id_; }
 
@@ -105,8 +106,8 @@ class BaseSchedulingID {
 
  private:
   /// Meyer's singleton to store the StringIdMap.
-  static StringIdMap &GetMap() {
-    static StringIdMap map;
+  static ThreadPrivate<StringIdMap> &GetMap() {
+    static ThreadPrivate<StringIdMap> map;
     return map;
   }
   int64_t id_ = -1;
@@ -128,14 +129,14 @@ inline std::ostream &operator<<(
 /// Specialization for SchedulingIDTag. Specifically, we populate
 /// the singleton map with PredefinedResources.
 template <>
-inline StringIdMap &BaseSchedulingID<SchedulingIDTag::Resource>::GetMap() {
-  static StringIdMap map = []() {
+inline ThreadPrivate<StringIdMap> &BaseSchedulingID<SchedulingIDTag::Resource>::GetMap() {
+  static ThreadPrivate<StringIdMap> map{[]() {
     StringIdMap map;
     return map.InsertOrDie(kCPU_ResourceLabel, CPU)
         .InsertOrDie(kGPU_ResourceLabel, GPU)
         .InsertOrDie(kObjectStoreMemory_ResourceLabel, OBJECT_STORE_MEM)
         .InsertOrDie(kMemory_ResourceLabel, MEM);
-  }();
+  }()};
   return map;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Those scheduling ids are supposed to be accessed in a single thread. Add ThreadPrivate to enforce it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
