### PR TITLE
[workflow] Fix different step directories are used for "workflow.wait" during recovery

### DIFF
--- a/python/ray/workflow/recovery.py
+++ b/python/ray/workflow/recovery.py
@@ -61,6 +61,7 @@ def _recover_workflow_step(
 
 def _reconstruct_wait_step(
     reader: workflow_storage.WorkflowStorage,
+    step_id: StepID,
     result: workflow_storage.StepInspectResult,
     input_map: Dict[StepID, Any],
 ):
@@ -89,7 +90,10 @@ def _reconstruct_wait_step(
 
     from ray import workflow
 
-    return workflow.wait(input_workflows, **wait_options)
+    wait_step = workflow.wait(input_workflows, **wait_options)
+    # override step id
+    wait_step._step_id = step_id
+    return wait_step
 
 
 def _construct_resume_workflow_from_step(
@@ -126,7 +130,7 @@ def _construct_resume_workflow_from_step(
     step_options = result.step_options
     # Process the wait step as a special case.
     if step_options.step_type == StepType.WAIT:
-        return _reconstruct_wait_step(reader, result, input_map)
+        return _reconstruct_wait_step(reader, step_id, result, input_map)
 
     with serialization.objectref_cache():
         input_workflows = []

--- a/python/ray/workflow/tests/test_wait.py
+++ b/python/ray/workflow/tests/test_wait.py
@@ -266,7 +266,8 @@ def test_wait_recovery_step_id(workflow_start_regular_shared):
     from ray.workflow import storage, workflow_storage
     global_storage = storage.get_global_storage()
     wf_storage = workflow_storage.WorkflowStorage("test_wait_recovery_step_id", global_storage)
-    result = wf_storage.inspect_step("workflow.wait")
+    index = wf_storage.gen_step_id("workflow.wait")
+    assert index <= 1
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_wait.py
+++ b/python/ray/workflow/tests/test_wait.py
@@ -247,7 +247,8 @@ def test_wait_failure_recovery_2(workflow_start_regular_shared):
     indirect=True,
 )
 def test_wait_recovery_step_id(workflow_start_regular_shared):
-    # Test failing "workflow.wait" and its input steps.
+    # This test ensures workflow reuse the original directory and
+    # step id for "workflow.wait" during recovery.
 
     @workflow.step
     def identity(x: int):
@@ -270,6 +271,7 @@ def test_wait_recovery_step_id(workflow_start_regular_shared):
         "test_wait_recovery_step_id", global_storage
     )
     index = wf_storage.gen_step_id("workflow.wait")
+    # no new step id
     assert index <= 1
 
 

--- a/python/ray/workflow/tests/test_wait.py
+++ b/python/ray/workflow/tests/test_wait.py
@@ -264,8 +264,11 @@ def test_wait_recovery_step_id(workflow_start_regular_shared):
     assert ready == [42]
 
     from ray.workflow import storage, workflow_storage
+
     global_storage = storage.get_global_storage()
-    wf_storage = workflow_storage.WorkflowStorage("test_wait_recovery_step_id", global_storage)
+    wf_storage = workflow_storage.WorkflowStorage(
+        "test_wait_recovery_step_id", global_storage
+    )
     index = wf_storage.gen_step_id("workflow.wait")
     assert index <= 1
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Due to a bug, during the recovery of a workflow with "workflow.wait", different names are created. This would split different checkpoints into different locations (checkpoints/metadata before recovery in the original directory, after recovery in the new directory).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
