### PR TITLE
Revert "Disable scheduler_report_pinned_bytes_only"

### DIFF
--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -28,7 +28,7 @@ def test_scaledown_shared_objects(shutdown_only):
     )
 
     try:
-        cluster.start(_system_config={"scheduler_report_pinned_bytes_only": True})
+        cluster.start()
         ray.init("auto")
 
         # Triggers the addition of a GPU node.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -140,7 +140,7 @@ RAY_CONFIG(float, scheduler_spread_threshold, 0.5);
 /// Whether to only report the usage of pinned copies of objects in the
 /// object_store_memory resource. This means nodes holding secondary copies only
 /// will become eligible for removal in the autoscaler.
-RAY_CONFIG(bool, scheduler_report_pinned_bytes_only, false)
+RAY_CONFIG(bool, scheduler_report_pinned_bytes_only, true)
 
 // The max allowed size in bytes of a return object from direct actor calls.
 // Objects larger than this size will be spilled/promoted to plasma.


### PR DESCRIPTION
Reverts ray-project/ray#22132

I set `scheduler_report_pinned_bytes_only` to `True` and `pipelined_ingestion_1500_gb` passed: https://console.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_Q7xM5HSiEbM5erFXu9WE5byw?command-history-section=command_history. I wonder if the underlying issue has been fixed.

Closes #21870