### PR TITLE
Ray legacy operator does not retry monitor on failure.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /src/ray/protobuf/gcs.proto @wuisawesome @ericl @ameerhajali @robertnishihara @pcmoritz @raulchen
 /src/ray/protobuf/gcs_service.proto @wuisawesome @ericl @ameerhajali @robertnishihara @pcmoritz @raulchen
 /dashboard/modules/snapshot @wuisawesome @ijrsvt @edoakes @alanwguo @architkulkarni
+/python/ray/autoscaler/_private/monitor.py @wuisawesome @DmitriGekhtman
 
 # Metrics
 /src/ray/stats/metric_defs.h @ericl @scv119 @rkooo567

--- a/python/ray/ray_operator/operator.py
+++ b/python/ray/ray_operator/operator.py
@@ -115,6 +115,7 @@ class RayCluster:
             redis_password=ray_constants.REDIS_DEFAULT_PASSWORD,
             prefix_cluster_info=True,
             stop_event=self.monitor_stop_event,
+            retry_on_failure=False,
         )
         mtr.run()
 

--- a/python/ray/tests/kubernetes_e2e/test_k8s_operator_basic.py
+++ b/python/ray/tests/kubernetes_e2e/test_k8s_operator_basic.py
@@ -249,11 +249,19 @@ class KubernetesOperatorTest(unittest.TestCase):
                 pod_spec["containers"][0]["image"] = IMAGE
                 pod_spec["containers"][0]["imagePullPolicy"] = PULL_POLICY
 
-            # Use a custom Redis port for one of the clusters.
-            example_cluster_config["spec"]["headStartRayCommands"][1] += " --port 6400"
+            # Use a custom port for one of the clusters.
+            new_head_start_cmd = example_cluster_config["spec"]["headStartRayCommands"][
+                1
+            ].replace("6379", "6380")
+            new_worker_start_cmd = example_cluster_config["spec"][
+                "workerStartRayCommands"
+            ][1].replace("6379", "6380")
+            example_cluster_config["spec"]["headStartRayCommands"][
+                1
+            ] = new_head_start_cmd
             example_cluster_config["spec"]["workerStartRayCommands"][
                 1
-            ] = " ulimit -n 65536; ray start --address=$RAY_HEAD_IP:6400"
+            ] = new_worker_start_cmd
 
             # Dump to temporary files
             yaml.dump(example_cluster_config, example_cluster_file)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/21533 changed the main monitor loop to always restart on failure.
This is great, but unfortunately it breaks the legacy Ray operator's head recovery logic, which implicitly uses the monitor
as a health check on the Ray head node. 

This PR introduces a flag allowing monitor.py to exit on failure and uses that flag in the Ray operator.

**This is a Ray 1.11.0 release-blocker.**

This PR also 
- touches up a K8s release test
- adds autoscaler maintainers to code owners for monitor.py 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
