### PR TITLE
[5/X][Pipeline][Ray DAG] Make Ray InputNode more powerful with attr accessor

### DIFF
--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -57,9 +57,10 @@ class ClassNode(DAGNode):
     def _execute_impl(self, *args, **kwargs):
         """Executor of ClassNode by ray.remote()
 
-        args and kwargs are to match base class signature, but not in the
+        Args and kwargs are to match base class signature, but not in the
         implementation. All args and kwargs should be resolved and replaced
-        with value via bottom-up recursion when current node is executed.
+        with value in bound_args and bound_kwargs via bottom-up recursion when
+        current node is executed.
         """
         return (
             ray.remote(self._body)
@@ -188,9 +189,10 @@ class ClassMethodNode(DAGNode):
     def _execute_impl(self, *args, **kwargs):
         """Executor of ClassMethodNode by ray.remote()
 
-        args and kwargs are to match base class signature, but not in the
+        Args and kwargs are to match base class signature, but not in the
         implementation. All args and kwargs should be resolved and replaced
-        with value via bottom-up recursion when current node is executed.
+        with value in bound_args and bound_kwargs via bottom-up recursion when
+        current node is executed.
         """
         method_body = getattr(self._parent_class_node, self._method_name)
         # Execute with bound args.

--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -100,13 +100,15 @@ class ClassNode(DAGNode):
     def from_json(cls, input_json, module, object_hook=None):
         assert input_json[DAGNODE_TYPE_KEY] == ClassNode.__name__
         args_dict = super().from_json_base(input_json, object_hook=object_hook)
-        return cls(
+        node = cls(
             module.__ray_metadata__.modified_class,
             args_dict["args"],
             args_dict["kwargs"],
             args_dict["options"],
             other_args_to_resolve=args_dict["other_args_to_resolve"],
         )
+        node._stable_uuid = args_dict["uuid"]
+        return node
 
 
 class _UnboundClassMethodNode(object):
@@ -221,10 +223,12 @@ class ClassMethodNode(DAGNode):
     def from_json(cls, input_json, object_hook=None):
         assert input_json[DAGNODE_TYPE_KEY] == ClassMethodNode.__name__
         args_dict = super().from_json_base(input_json, object_hook=object_hook)
-        return cls(
+        node = cls(
             input_json["method_name"],
             args_dict["args"],
             args_dict["kwargs"],
             args_dict["options"],
             other_args_to_resolve=args_dict["other_args_to_resolve"],
         )
+        node._stable_uuid = args_dict["uuid"]
+        return node

--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -54,8 +54,13 @@ class ClassNode(DAGNode):
             other_args_to_resolve=new_other_args_to_resolve,
         )
 
-    def _execute_impl(self, *args):
-        """Executor of ClassNode by ray.remote()"""
+    def _execute_impl(self, *args, **kwargs):
+        """Executor of ClassNode by ray.remote()
+
+        args and kwargs are to match base class signature, but not in the
+        implementation. All args and kwargs should be resolved and replaced
+        with value via bottom-up recursion when current node is executed.
+        """
         return (
             ray.remote(self._body)
             .options(**self._bound_options)
@@ -180,8 +185,13 @@ class ClassMethodNode(DAGNode):
             other_args_to_resolve=new_other_args_to_resolve,
         )
 
-    def _execute_impl(self, *args):
-        """Executor of ClassMethodNode by ray.remote()"""
+    def _execute_impl(self, *args, **kwargs):
+        """Executor of ClassMethodNode by ray.remote()
+
+        args and kwargs are to match base class signature, but not in the
+        implementation. All args and kwargs should be resolved and replaced
+        with value via bottom-up recursion when current node is executed.
+        """
         method_body = getattr(self._parent_class_node, self._method_name)
         # Execute with bound args.
         return method_body.options(**self._bound_options).remote(

--- a/python/ray/experimental/dag/dag_node.py
+++ b/python/ray/experimental/dag/dag_node.py
@@ -72,8 +72,15 @@ class DAGNode:
         return self._bound_options.copy()
 
     def get_other_args_to_resolve(self) -> Dict[str, Any]:
-
+        """Return the dict of other args to resolve arguments for this node."""
         return self._bound_other_args_to_resolve.copy()
+
+    def get_stable_uuid(self) -> str:
+        """Return stable uuid for this node.
+        1) Generated only once at first instance creation
+        2) Stable across pickling, replacement and JSON serialization.
+        """
+        return self._stable_uuid
 
     def execute(self, *args, **kwargs) -> Union[ray.ObjectRef, ray.actor.ActorHandle]:
         """Execute this DAG using the Ray default executor."""
@@ -177,10 +184,18 @@ class DAGNode:
             def __init__(self, fn):
                 self.cache = {}
                 self.fn = fn
+                self.input_node_uuid = None
 
             def __call__(self, node):
                 if node._stable_uuid not in self.cache:
                     self.cache[node._stable_uuid] = self.fn(node)
+                if type(node).__name__ == "InputNode":
+                    if not self.input_node_uuid:
+                        self.input_node_uuid = node._stable_uuid
+                    elif self.input_node_uuid != node._stable_uuid:
+                        raise AssertionError(
+                            "Each DAG should only have one unique InputNode."
+                        )
                 return self.cache[node._stable_uuid]
 
         if not type(fn).__name__ == "_CachingFn":
@@ -283,8 +298,6 @@ class DAGNode:
         Returns:
             json_dict (Dict[str, Any]): JSON serialized DAGNode.
         """
-        # stable_uuid will be re-generated upon new constructor execution
-        # except for ClassNode used as parent of ClassMethodNode
         return {
             DAGNODE_TYPE_KEY: dag_node_type,
             # Will be overriden by build()
@@ -296,6 +309,7 @@ class DAGNode:
             "other_args_to_resolve": json.dumps(
                 self.get_other_args_to_resolve(), cls=encoder_cls
             ),
+            "uuid": self.get_stable_uuid(),
         }
 
     @staticmethod
@@ -308,10 +322,12 @@ class DAGNode:
         other_args_to_resolve = json.loads(
             input_json["other_args_to_resolve"], object_hook=object_hook
         )
+        uuid = input_json["uuid"]
 
         return {
             "args": args,
             "kwargs": kwargs,
             "options": options,
             "other_args_to_resolve": other_args_to_resolve,
+            "uuid": uuid,
         }

--- a/python/ray/experimental/dag/dag_node.py
+++ b/python/ray/experimental/dag/dag_node.py
@@ -75,9 +75,9 @@ class DAGNode:
 
         return self._bound_other_args_to_resolve.copy()
 
-    def execute(self, *args) -> Union[ray.ObjectRef, ray.actor.ActorHandle]:
+    def execute(self, *args, **kwargs) -> Union[ray.ObjectRef, ray.actor.ActorHandle]:
         """Execute this DAG using the Ray default executor."""
-        return self._apply_recursive(lambda node: node._execute_impl(*args))
+        return self._apply_recursive(lambda node: node._execute_impl(*args, **kwargs))
 
     def _get_toplevel_child_nodes(self) -> Set["DAGNode"]:
         """Return the set of nodes specified as top-level args.

--- a/python/ray/experimental/dag/function_node.py
+++ b/python/ray/experimental/dag/function_node.py
@@ -70,10 +70,12 @@ class FunctionNode(DAGNode):
     def from_json(cls, input_json, module, object_hook=None):
         assert input_json[DAGNODE_TYPE_KEY] == FunctionNode.__name__
         args_dict = super().from_json_base(input_json, object_hook=object_hook)
-        return cls(
+        node = cls(
             module._function,
             args_dict["args"],
             args_dict["kwargs"],
             args_dict["options"],
             other_args_to_resolve=args_dict["other_args_to_resolve"],
         )
+        node._stable_uuid = args_dict["uuid"]
+        return node

--- a/python/ray/experimental/dag/function_node.py
+++ b/python/ray/experimental/dag/function_node.py
@@ -41,8 +41,13 @@ class FunctionNode(DAGNode):
             other_args_to_resolve=new_other_args_to_resolve,
         )
 
-    def _execute_impl(self, *args):
-        """Executor of FunctionNode by ray.remote()"""
+    def _execute_impl(self, *args, **kwargs):
+        """Executor of FunctionNode by ray.remote().
+
+        args and kwargs are to match base class signature, but not in the
+        implementation. All args and kwargs should be resolved and replaced
+        with value via bottom-up recursion when current node is executed.
+        """
         return (
             ray.remote(self._body)
             .options(**self._bound_options)

--- a/python/ray/experimental/dag/function_node.py
+++ b/python/ray/experimental/dag/function_node.py
@@ -44,9 +44,10 @@ class FunctionNode(DAGNode):
     def _execute_impl(self, *args, **kwargs):
         """Executor of FunctionNode by ray.remote().
 
-        args and kwargs are to match base class signature, but not in the
+        Args and kwargs are to match base class signature, but not in the
         implementation. All args and kwargs should be resolved and replaced
-        with value via bottom-up recursion when current node is executed.
+        with value in bound_args and bound_kwargs via bottom-up recursion when
+        current node is executed.
         """
         return (
             ray.remote(self._body)

--- a/python/ray/experimental/dag/input_node.py
+++ b/python/ray/experimental/dag/input_node.py
@@ -22,10 +22,10 @@ class InputNode(DAGNode):
     In this pipeline, each user input is broadcasted to both A.forward and
     B.forward as first stop of the DAG, and authored like
 
-    input = ray.dag.InputNode()
-    a = A.forward.bind(input)
-    b = B.forward.bind(input)
-    dag = ensemble.bind(a, b)
+    with InputNode() as dag_input:
+        a = A.forward.bind(dag_input)
+        b = B.forward.bind(dag_input)
+        dag = ensemble.bind(a, b)
 
     dag.execute(user_input) --> broadcast to a and b
     """
@@ -98,9 +98,9 @@ class InputAtrributeNode(DAGNode):
     """Represents partial acces of user input based on an attribute key.
 
     Examples:
-        >>> input = InputNode()
-        >>> a = input[0]
-        >>> b = input.x
+        >>> with InputNode() as dag_input:
+        >>>     a = input[0]
+        >>>     b = input.x
 
         >>> # This makes a = 1 and b = 2
         >>> ray_dag.execute(1, x=2)
@@ -158,12 +158,12 @@ class DAGInputData:
         >>> def combine(a, b):
         ...     return a + b
 
-        >>> input = InputNode()
-        >>> m1 = Model.bind(1)
-        >>> m2 = Model.bind(2)
-        >>> m1_output = m1.forward.bind(input[0])
-        >>> m2_output = m2.forward.bind(input[1])
-        >>> ray_dag = combine.bind(m1_output, m2_output)
+        >>> with InputNode() as dag_input:
+        >>>     m1 = Model.bind(1)
+        >>>     m2 = Model.bind(2)
+        >>>     m1_output = m1.forward.bind(dag_input[0])
+        >>>     m2_output = m2.forward.bind(dag_input[1])
+        >>>     ray_dag = combine.bind(m1_output, m2_output)
 
         >>> # Pass mix of args and kwargs as input.
         >>> print(ray_dag.execute(1, 2)) # 1 sent to m1, 2 sent to m2

--- a/python/ray/experimental/dag/input_node.py
+++ b/python/ray/experimental/dag/input_node.py
@@ -90,7 +90,6 @@ class InputNode(DAGNode):
         # TODO: (jiaodong) Maybe a contenxt manager ?
         self._validate_input(input_data)
         converted_data = self._adapter_fn(input_data)
-        print(f"Returned converted_data: {converted_data}")
         return converted_data
 
     def __str__(self) -> str:

--- a/python/ray/experimental/dag/input_node.py
+++ b/python/ray/experimental/dag/input_node.py
@@ -56,7 +56,7 @@ class InputNode(DAGNode):
         return InputNode()
 
     def _execute_impl(self, *args, **kwargs):
-        """Executor of InputNode by ray.remote()"""
+        """Executor of InputNode."""
         # If user only passed in one value, for simplicity we just return it.
         if len(args) == 1 and len(kwargs) == 0:
             return args[0]
@@ -115,12 +115,19 @@ class InputAtrributeNode(DAGNode):
         )
 
     def _execute_impl(self, *args, **kwargs):
-        """Executor of InputNode by ray.remote()"""
+        """Executor of InputAtrributeNode.
 
+        Args and kwargs are to match base class signature, but not in the
+        implementation. All args and kwargs should be resolved and replaced
+        with value in bound_args and bound_kwargs via bottom-up recursion when
+        current node is executed.
+        """
         if isinstance(self._dag_input_node, DAGInputData):
             return self._dag_input_node[self._key]
         else:
-            #
+            # dag.execute() is called with only one arg, thus when an
+            # InputAtrributeNode is executed, its dependent InputNode is
+            # resolved with original user input value.
             return self._dag_input_node
 
     def __str__(self) -> str:
@@ -161,7 +168,8 @@ class DAGInputData:
 
     def __getitem__(self, key: Union[int, str]) -> Any:
         if isinstance(key, int):
-            # Accessing list args,
+            # Access list args by index.
             return self._args[key]
         else:
+            # Access kwarg by key.
             return self._kwargs[key]

--- a/python/ray/experimental/dag/input_node.py
+++ b/python/ray/experimental/dag/input_node.py
@@ -13,11 +13,11 @@ class InputNode(DAGNode):
     among all DAGNodes.
 
     Ex:
-                A.forward
-             /            \
-        input               ensemble -> output
-             \            /
-                B.forward
+                   A.forward
+                /            \
+        dag_input              ensemble -> dag_output
+                \            /
+                   B.forward
 
     In this pipeline, each user input is broadcasted to both A.forward and
     B.forward as first stop of the DAG, and authored like
@@ -28,13 +28,6 @@ class InputNode(DAGNode):
         dag = ensemble.bind(a, b)
 
     dag.execute(user_input) --> broadcast to a and b
-    """
-
-    """
-    DONE - Binding value to InputNode ? No, just schema
-    - Take input data python object
-    - Globally unique InputNode
-    - Split attributes
     """
 
     def __init__(self, *args, **kwargs):
@@ -82,15 +75,12 @@ class InputNode(DAGNode):
         pass
 
     def to_json(self, encoder_cls) -> Dict[str, Any]:
-        # TODO: (jiaodong) Support arbitrary InputNode args and pydantic
-        # input schema.
         json_dict = super().to_json_base(encoder_cls, InputNode.__name__)
         return json_dict
 
     @classmethod
     def from_json(cls, input_json):
         assert input_json[DAGNODE_TYPE_KEY] == InputNode.__name__
-        # TODO: (jiaodong) Support user passing inputs to InputNode in JSON
         return cls()
 
 

--- a/python/ray/experimental/dag/input_node.py
+++ b/python/ray/experimental/dag/input_node.py
@@ -72,6 +72,15 @@ class InputNode(DAGNode):
     def __getitem__(self, key: Union[int, str]) -> Any:
         return InputAtrributeNode(self, key)
 
+    def __enter__(self):
+        # TODO (jiaodong): Supporting input node as context manager is easy.
+        # real question is we need to decide if we want to enforce that's the
+        # only way of creating input node.
+        return self
+
+    def __exit__(self, *args):
+        pass
+
     def to_json(self, encoder_cls) -> Dict[str, Any]:
         # TODO: (jiaodong) Support arbitrary InputNode args and pydantic
         # input schema.

--- a/python/ray/experimental/dag/py_obj_scanner.py
+++ b/python/ray/experimental/dag/py_obj_scanner.py
@@ -45,7 +45,7 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler):
         # Register pickler override for DAGNode types.
         from ray.experimental.dag.function_node import FunctionNode
         from ray.experimental.dag.class_node import ClassNode, ClassMethodNode
-        from ray.experimental.dag.input_node import InputNode
+        from ray.experimental.dag.input_node import InputNode, InputAtrributeNode
         from ray.serve.pipeline.deployment_node import DeploymentNode
         from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
 
@@ -53,6 +53,7 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler):
         self.dispatch_table[ClassNode] = self._reduce_dag_node
         self.dispatch_table[ClassMethodNode] = self._reduce_dag_node
         self.dispatch_table[InputNode] = self._reduce_dag_node
+        self.dispatch_table[InputAtrributeNode] = self._reduce_dag_node
         self.dispatch_table[DeploymentNode] = self._reduce_dag_node
         self.dispatch_table[DeploymentMethodNode] = self._reduce_dag_node
         super().__init__(self._buf)

--- a/python/ray/experimental/dag/tests/test_input_node.py
+++ b/python/ray/experimental/dag/tests/test_input_node.py
@@ -4,7 +4,7 @@ request, for all DAGNode types.
 """
 
 import pytest
-from ray.experimental.dag.input_node import InputNode, InputSchema, OutputSchema
+from ray.experimental.dag.input_node import InputNode, InputSchema
 from typing import TypeVar
 
 import ray
@@ -218,9 +218,10 @@ RayHandleLike = TypeVar("RayHandleLike")
 
 def test_simple_full_input_adapt_and_validate(shared_ray_instance):
     """str to int."""
-    input_schema = InputSchema()
-    output_schema = OutputSchema()
+    def validator(input):
+        assert isinstance(input, str)
 
+    input_schema = InputSchema(validator=validator)
     def adapter_fn(input):
         if isinstance(input, str):
             return int(input)
@@ -229,10 +230,9 @@ def test_simple_full_input_adapt_and_validate(shared_ray_instance):
 
     input = InputNode(
         input_schema=input_schema,
-        output_schema=output_schema,
         adapter_fn=adapter_fn,
     )
-    assert ray.get(input.execute("1")) == 1
+    assert input.execute("1") == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/dag/tests/test_input_node.py
+++ b/python/ray/experimental/dag/tests/test_input_node.py
@@ -20,12 +20,14 @@ def test_no_args_to_input_node(shared_ray_instance):
     with pytest.raises(
         ValueError, match="InputNode should not take any args or kwargs"
     ):
-        f._bind(InputNode(0))
+        with InputNode(0) as dag_input:
+            f._bind(dag_input)
     with pytest.raises(
         ValueError,
         match="InputNode should not take any args or kwargs",
     ):
-        f._bind(InputNode(key=1))
+        with InputNode(key=1) as dag_input:
+            f._bind(dag_input)
 
 
 def test_simple_func(shared_ray_instance):
@@ -39,8 +41,9 @@ def test_simple_func(shared_ray_instance):
         return f"{a} -> b"
 
     # input -> a - > b -> ouput
-    a_node = a._bind(InputNode())
-    dag = b._bind(a_node)
+    with InputNode() as dag_input:
+        a_node = a._bind(dag_input)
+        dag = b._bind(a_node)
 
     assert ray.get(dag.execute("input")) == "input -> a -> b"
     assert ray.get(dag.execute("test")) == "test -> a -> b"
@@ -63,14 +66,14 @@ def test_func_dag(shared_ray_instance):
     def d(x, y):
         return x + y
 
-    a_ref = a._bind(InputNode())
-    b_ref = b._bind(a_ref)
-    c_ref = c._bind(a_ref)
-    d_ref = d._bind(b_ref, c_ref)
-    d1_ref = d._bind(d_ref, d_ref)
-    d2_ref = d._bind(d1_ref, d_ref)
-    dag = d._bind(d2_ref, d_ref)
-    print(dag)
+    with InputNode() as dag_input:
+        a_ref = a._bind(dag_input)
+        b_ref = b._bind(a_ref)
+        c_ref = c._bind(a_ref)
+        d_ref = d._bind(b_ref, c_ref)
+        d1_ref = d._bind(d_ref, d_ref)
+        d2_ref = d._bind(d1_ref, d_ref)
+        dag = d._bind(d2_ref, d_ref)
 
     # [(2*2 + 2+1) + (2*2 + 2+1)] + [(2*2 + 2+1) + (2*2 + 2+1)]
     assert ray.get(dag.execute(2)) == 28
@@ -91,10 +94,10 @@ def test_multi_input_func_dag(shared_ray_instance):
     def c(x, y):
         return x + y
 
-    a_ref = a._bind(InputNode())
-    b_ref = b._bind(InputNode())
-    dag = c._bind(a_ref, b_ref)
-    print(dag)
+    with InputNode() as dag_input:
+        a_ref = a._bind(dag_input)
+        b_ref = b._bind(dag_input)
+        dag = c._bind(a_ref, b_ref)
 
     # (2*2) + (2*1)
     assert ray.get(dag.execute(2)) == 7
@@ -120,7 +123,8 @@ def test_invalid_input_node_as_class_constructor(shared_ray_instance):
             "class construction or binding time."
         ),
     ):
-        Actor._bind(InputNode())
+        with InputNode() as dag_input:
+            Actor._bind(dag_input)
 
 
 def test_class_method_input(shared_ray_instance):
@@ -140,12 +144,12 @@ def test_class_method_input(shared_ray_instance):
         def process(self, input: int):
             return input * self.scale
 
-    preprocess = FeatureProcessor._bind(0.5)
-    feature = preprocess.process._bind(InputNode())
-    model = Model._bind(4)
-    dag = model.forward._bind(feature)
+    with InputNode() as dag_input:
+        preprocess = FeatureProcessor._bind(0.5)
+        feature = preprocess.process._bind(dag_input)
+        model = Model._bind(4)
+        dag = model.forward._bind(feature)
 
-    print(dag)
     # 2 * 0.5 * 4
     assert ray.get(dag.execute(2)) == 4
     # 6 * 0.5 * 4
@@ -169,14 +173,15 @@ def test_multi_class_method_input(shared_ray_instance):
     def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
         return m1 + m2
 
-    m1 = Model._bind(2)
-    m2 = Model._bind(3)
+    with InputNode() as dag_input:
+        m1 = Model._bind(2)
+        m2 = Model._bind(3)
 
-    m1_output = m1.forward._bind(InputNode())
-    m2_output = m2.forward._bind(InputNode())
+        m1_output = m1.forward._bind(dag_input)
+        m2_output = m2.forward._bind(dag_input)
 
-    dag = combine._bind(m1_output, m2_output)
-    print(dag)
+        dag = combine._bind(m1_output, m2_output)
+
     # 1*2 + 1*3
     assert ray.get(dag.execute(1)) == 5
     # 2*2 + 2*3
@@ -205,12 +210,12 @@ def test_func_class_mixed_input(shared_ray_instance):
     def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
         return m1 + m2
 
-    m1 = Model._bind(3)
-    m1_output = m1.forward._bind(InputNode())
-    m2_output = model_func._bind(InputNode())
+    with InputNode() as dag_input:
+        m1 = Model._bind(3)
+        m1_output = m1.forward._bind(dag_input)
+        m2_output = model_func._bind(dag_input)
 
     dag = combine._bind(m1_output, m2_output)
-    print(dag)
     # 2*3 + 2*2
     assert ray.get(dag.execute(2)) == 10
     # 3*3 + 3*2
@@ -230,23 +235,23 @@ def test_input_attr_partial_access(shared_ray_instance):
     def combine(a, b, c):
         return a + b + c
 
-    dag_input = InputNode()
-    m1 = Model._bind(1)
-    m2 = Model._bind(2)
-    m1_output = m1.forward._bind(dag_input[0])
-    m2_output = m2.forward._bind(dag_input[1])
-    dag = combine._bind(m1_output, m2_output, dag_input[2])
-    # 1*1 + 2*2 + 3 = 8
+    with InputNode() as dag_input:
+        m1 = Model._bind(1)
+        m2 = Model._bind(2)
+        m1_output = m1.forward._bind(dag_input[0])
+        m2_output = m2.forward._bind(dag_input[1])
+        dag = combine._bind(m1_output, m2_output, dag_input[2])
+        # 1*1 + 2*2 + 3 = 8
     assert ray.get(dag.execute(1, 2, 3)) == 8
 
     # Same DAG, but with attribute accessor and keyword input
-    dag_input = InputNode()
-    m1 = Model._bind(1)
-    m2 = Model._bind(2)
-    m1_output = m1.forward._bind(dag_input.m1)
-    m2_output = m2.forward._bind(dag_input.m2)
-    dag = combine._bind(m1_output, m2_output, dag_input.m3)
-    # 1*1 + 2*2 + 3 = 8
+    with InputNode() as dag_input:
+        m1 = Model._bind(1)
+        m2 = Model._bind(2)
+        m1_output = m1.forward._bind(dag_input.m1)
+        m2_output = m2.forward._bind(dag_input.m2)
+        dag = combine._bind(m1_output, m2_output, dag_input.m3)
+        # 1*1 + 2*2 + 3 = 8
     assert ray.get(dag.execute(m1=1, m2=2, m3=3)) == 8
 
 

--- a/python/ray/experimental/dag/tests/test_input_node.py
+++ b/python/ray/experimental/dag/tests/test_input_node.py
@@ -152,30 +152,6 @@ def test_class_method_input(shared_ray_instance):
     assert ray.get(dag.execute(6)) == 12
 
 
-def test_access_partial_attributes(shared_ray_instance):
-    @ray.remote
-    class Model:
-        def __init__(self, val):
-            self.val = val
-
-        def forward(self, input):
-            return self.val * input
-
-    @ray.remote
-    def combine(a, b):
-        return a + b
-
-    input = InputNode()
-    m1 = Model._bind(1)
-    m2 = Model._bind(2)
-    m1_output = m1.forward._bind(input[0])
-    m2_output = m2.forward._bind(input[1])
-    ray_dag = combine._bind(m1_output, m2_output)
-
-    # Pass mix of args and kwargs as input.
-    print(ray_dag.execute(1, 2))
-
-
 def test_multi_class_method_input(shared_ray_instance):
     """
     Test a multiple class methods can all be used as inputs in a dag.

--- a/python/ray/experimental/dag/tests/test_input_node.py
+++ b/python/ray/experimental/dag/tests/test_input_node.py
@@ -4,7 +4,7 @@ request, for all DAGNode types.
 """
 
 import pytest
-from ray.experimental.dag.input_node import InputNode
+from ray.experimental.dag.input_node import InputNode, InputSchema, OutputSchema
 from typing import TypeVar
 
 import ray
@@ -12,208 +12,227 @@ import ray
 RayHandleLike = TypeVar("RayHandleLike")
 
 
-def test_no_args_to_input_node(shared_ray_instance):
-    @ray.remote
-    def f(input):
-        return input
+# def test_no_args_to_input_node(shared_ray_instance):
+#     @ray.remote
+#     def f(input):
+#         return input
 
-    with pytest.raises(
-        ValueError, match="InputNode should not take any args or kwargs"
-    ):
-        f._bind(InputNode(0))
-    with pytest.raises(
-        ValueError, match="InputNode should not take any args or kwargs"
-    ):
-        f._bind(InputNode(key=1))
-
-
-def test_simple_func(shared_ray_instance):
-    @ray.remote
-    def a(input: str):
-        return f"{input} -> a"
-
-    @ray.remote
-    def b(a: "RayHandleLike"):
-        # At runtime, a is replaced with execution result of a.
-        return f"{a} -> b"
-
-    # input -> a - > b -> ouput
-    a_node = a._bind(InputNode())
-    dag = b._bind(a_node)
-
-    assert ray.get(dag.execute("input")) == "input -> a -> b"
-    assert ray.get(dag.execute("test")) == "test -> a -> b"
+#     with pytest.raises(
+#         ValueError, match="InputNode should not take any args or kwargs"
+#     ):
+#         f._bind(InputNode(0))
+#     with pytest.raises(
+#         ValueError, match="InputNode should not take any args or kwargs"
+#     ):
+#         f._bind(InputNode(key=1))
 
 
-def test_func_dag(shared_ray_instance):
-    @ray.remote
-    def a(user_input):
-        return user_input
+# def test_simple_func(shared_ray_instance):
+#     @ray.remote
+#     def a(input: str):
+#         return f"{input} -> a"
 
-    @ray.remote
-    def b(x):
-        return x * 2
+#     @ray.remote
+#     def b(a: "RayHandleLike"):
+#         # At runtime, a is replaced with execution result of a.
+#         return f"{a} -> b"
 
-    @ray.remote
-    def c(x):
-        return x + 1
+#     # input -> a - > b -> ouput
+#     a_node = a._bind(InputNode())
+#     dag = b._bind(a_node)
 
-    @ray.remote
-    def d(x, y):
-        return x + y
-
-    a_ref = a._bind(InputNode())
-    b_ref = b._bind(a_ref)
-    c_ref = c._bind(a_ref)
-    d_ref = d._bind(b_ref, c_ref)
-    d1_ref = d._bind(d_ref, d_ref)
-    d2_ref = d._bind(d1_ref, d_ref)
-    dag = d._bind(d2_ref, d_ref)
-    print(dag)
-
-    # [(2*2 + 2+1) + (2*2 + 2+1)] + [(2*2 + 2+1) + (2*2 + 2+1)]
-    assert ray.get(dag.execute(2)) == 28
-    # [(3*2 + 3+1) + (3*2 + 3+1)] + [(3*2 + 3+1) + (3*2 + 3+1)]
-    assert ray.get(dag.execute(3)) == 40
+#     assert ray.get(dag.execute("input")) == "input -> a -> b"
+#     assert ray.get(dag.execute("test")) == "test -> a -> b"
 
 
-def test_multi_input_func_dag(shared_ray_instance):
-    @ray.remote
-    def a(user_input):
-        return user_input * 2
+# def test_func_dag(shared_ray_instance):
+#     @ray.remote
+#     def a(user_input):
+#         return user_input
 
-    @ray.remote
-    def b(user_input):
-        return user_input + 1
+#     @ray.remote
+#     def b(x):
+#         return x * 2
 
-    @ray.remote
-    def c(x, y):
-        return x + y
+#     @ray.remote
+#     def c(x):
+#         return x + 1
 
-    a_ref = a._bind(InputNode())
-    b_ref = b._bind(InputNode())
-    dag = c._bind(a_ref, b_ref)
-    print(dag)
+#     @ray.remote
+#     def d(x, y):
+#         return x + y
 
-    # (2*2) + (2*1)
-    assert ray.get(dag.execute(2)) == 7
-    # (3*2) + (3*1)
-    assert ray.get(dag.execute(3)) == 10
+#     a_ref = a._bind(InputNode())
+#     b_ref = b._bind(a_ref)
+#     c_ref = c._bind(a_ref)
+#     d_ref = d._bind(b_ref, c_ref)
+#     d1_ref = d._bind(d_ref, d_ref)
+#     d2_ref = d._bind(d1_ref, d_ref)
+#     dag = d._bind(d2_ref, d_ref)
+#     print(dag)
 
-
-def test_invalid_input_node_as_class_constructor(shared_ray_instance):
-    @ray.remote
-    class Actor:
-        def __init__(self, val):
-            self.val = val
-
-        def get(self):
-            return self.val
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "InputNode handles user dynamic input the the DAG, and "
-            "cannot be used as args, kwargs, or other_args_to_resolve "
-            "in ClassNode constructor because it is not available at "
-            "class construction or binding time."
-        ),
-    ):
-        Actor._bind(InputNode())
+#     # [(2*2 + 2+1) + (2*2 + 2+1)] + [(2*2 + 2+1) + (2*2 + 2+1)]
+#     assert ray.get(dag.execute(2)) == 28
+#     # [(3*2 + 3+1) + (3*2 + 3+1)] + [(3*2 + 3+1) + (3*2 + 3+1)]
+#     assert ray.get(dag.execute(3)) == 40
 
 
-def test_class_method_input(shared_ray_instance):
-    @ray.remote
-    class Model:
-        def __init__(self, weight: int):
-            self.weight = weight
+# def test_multi_input_func_dag(shared_ray_instance):
+#     @ray.remote
+#     def a(user_input):
+#         return user_input * 2
 
-        def forward(self, input: "RayHandleLike"):
-            return self.weight * input
+#     @ray.remote
+#     def b(user_input):
+#         return user_input + 1
 
-    @ray.remote
-    class FeatureProcessor:
-        def __init__(self, scale):
-            self.scale = scale
+#     @ray.remote
+#     def c(x, y):
+#         return x + y
 
-        def process(self, input: int):
-            return input * self.scale
+#     a_ref = a._bind(InputNode())
+#     b_ref = b._bind(InputNode())
+#     dag = c._bind(a_ref, b_ref)
+#     print(dag)
 
-    preprocess = FeatureProcessor._bind(0.5)
-    feature = preprocess.process._bind(InputNode())
-    model = Model._bind(4)
-    dag = model.forward._bind(feature)
-
-    print(dag)
-    # 2 * 0.5 * 4
-    assert ray.get(dag.execute(2)) == 4
-    # 6 * 0.5 * 4
-    assert ray.get(dag.execute(6)) == 12
+#     # (2*2) + (2*1)
+#     assert ray.get(dag.execute(2)) == 7
+#     # (3*2) + (3*1)
+#     assert ray.get(dag.execute(3)) == 10
 
 
-def test_multi_class_method_input(shared_ray_instance):
-    """
-    Test a multiple class methods can all be used as inputs in a dag.
-    """
+# def test_invalid_input_node_as_class_constructor(shared_ray_instance):
+#     @ray.remote
+#     class Actor:
+#         def __init__(self, val):
+#             self.val = val
 
-    @ray.remote
-    class Model:
-        def __init__(self, weight: int):
-            self.weight = weight
+#         def get(self):
+#             return self.val
 
-        def forward(self, input: int):
-            return self.weight * input
-
-    @ray.remote
-    def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
-        return m1 + m2
-
-    m1 = Model._bind(2)
-    m2 = Model._bind(3)
-
-    m1_output = m1.forward._bind(InputNode())
-    m2_output = m2.forward._bind(InputNode())
-
-    dag = combine._bind(m1_output, m2_output)
-    print(dag)
-    # 1*2 + 1*3
-    assert ray.get(dag.execute(1)) == 5
-    # 2*2 + 2*3
-    assert ray.get(dag.execute(2)) == 10
+#     with pytest.raises(
+#         ValueError,
+#         match=(
+#             "InputNode handles user dynamic input the the DAG, and "
+#             "cannot be used as args, kwargs, or other_args_to_resolve "
+#             "in ClassNode constructor because it is not available at "
+#             "class construction or binding time."
+#         ),
+#     ):
+#         Actor._bind(InputNode())
 
 
-def test_func_class_mixed_input(shared_ray_instance):
-    """
-    Test both class method and function are used as input in the
-    same dag.
-    """
+# def test_class_method_input(shared_ray_instance):
+#     @ray.remote
+#     class Model:
+#         def __init__(self, weight: int):
+#             self.weight = weight
 
-    @ray.remote
-    class Model:
-        def __init__(self, weight: int):
-            self.weight = weight
+#         def forward(self, input: "RayHandleLike"):
+#             return self.weight * input
 
-        def forward(self, input: int):
-            return self.weight * input
+#     @ray.remote
+#     class FeatureProcessor:
+#         def __init__(self, scale):
+#             self.scale = scale
 
-    @ray.remote
-    def model_func(input: int):
-        return input * 2
+#         def process(self, input: int):
+#             return input * self.scale
 
-    @ray.remote
-    def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
-        return m1 + m2
+#     preprocess = FeatureProcessor._bind(0.5)
+#     feature = preprocess.process._bind(InputNode())
+#     model = Model._bind(4)
+#     dag = model.forward._bind(feature)
 
-    m1 = Model._bind(3)
-    m1_output = m1.forward._bind(InputNode())
-    m2_output = model_func._bind(InputNode())
+#     print(dag)
+#     # 2 * 0.5 * 4
+#     assert ray.get(dag.execute(2)) == 4
+#     # 6 * 0.5 * 4
+#     assert ray.get(dag.execute(6)) == 12
 
-    dag = combine._bind(m1_output, m2_output)
-    print(dag)
-    # 2*3 + 2*2
-    assert ray.get(dag.execute(2)) == 10
-    # 3*3 + 3*2
-    assert ray.get(dag.execute(3)) == 15
+
+# def test_multi_class_method_input(shared_ray_instance):
+#     """
+#     Test a multiple class methods can all be used as inputs in a dag.
+#     """
+
+#     @ray.remote
+#     class Model:
+#         def __init__(self, weight: int):
+#             self.weight = weight
+
+#         def forward(self, input: int):
+#             return self.weight * input
+
+#     @ray.remote
+#     def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
+#         return m1 + m2
+
+#     m1 = Model._bind(2)
+#     m2 = Model._bind(3)
+
+#     m1_output = m1.forward._bind(InputNode())
+#     m2_output = m2.forward._bind(InputNode())
+
+#     dag = combine._bind(m1_output, m2_output)
+#     print(dag)
+#     # 1*2 + 1*3
+#     assert ray.get(dag.execute(1)) == 5
+#     # 2*2 + 2*3
+#     assert ray.get(dag.execute(2)) == 10
+
+
+# def test_func_class_mixed_input(shared_ray_instance):
+#     """
+#     Test both class method and function are used as input in the
+#     same dag.
+#     """
+
+#     @ray.remote
+#     class Model:
+#         def __init__(self, weight: int):
+#             self.weight = weight
+
+#         def forward(self, input: int):
+#             return self.weight * input
+
+#     @ray.remote
+#     def model_func(input: int):
+#         return input * 2
+
+#     @ray.remote
+#     def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
+#         return m1 + m2
+
+#     m1 = Model._bind(3)
+#     m1_output = m1.forward._bind(InputNode())
+#     m2_output = model_func._bind(InputNode())
+
+#     dag = combine._bind(m1_output, m2_output)
+#     print(dag)
+#     # 2*3 + 2*2
+#     assert ray.get(dag.execute(2)) == 10
+#     # 3*3 + 3*2
+#     assert ray.get(dag.execute(3)) == 15
+
+
+def test_simple_full_input_adapt_and_validate(shared_ray_instance):
+    """str to int."""
+    input_schema = InputSchema()
+    output_schema = OutputSchema()
+
+    def adapter_fn(input):
+        if isinstance(input, str):
+            return int(input)
+        else:
+            return input
+
+    input = InputNode(
+        input_schema=input_schema,
+        output_schema=output_schema,
+        adapter_fn=adapter_fn,
+    )
+    assert ray.get(input.execute("1")) == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/dag/tests/test_input_node.py
+++ b/python/ray/experimental/dag/tests/test_input_node.py
@@ -12,216 +12,219 @@ import ray
 RayHandleLike = TypeVar("RayHandleLike")
 
 
-# def test_no_args_to_input_node(shared_ray_instance):
-#     @ray.remote
-#     def f(input):
-#         return input
+def test_no_args_to_input_node(shared_ray_instance):
+    @ray.remote
+    def f(input):
+        return input
 
-#     with pytest.raises(
-#         ValueError, match="InputNode should not take any args or kwargs"
-#     ):
-#         f._bind(InputNode(0))
-#     with pytest.raises(
-#         ValueError, match="InputNode should not take any args or kwargs"
-#     ):
-#         f._bind(InputNode(key=1))
-
-
-# def test_simple_func(shared_ray_instance):
-#     @ray.remote
-#     def a(input: str):
-#         return f"{input} -> a"
-
-#     @ray.remote
-#     def b(a: "RayHandleLike"):
-#         # At runtime, a is replaced with execution result of a.
-#         return f"{a} -> b"
-
-#     # input -> a - > b -> ouput
-#     a_node = a._bind(InputNode())
-#     dag = b._bind(a_node)
-
-#     assert ray.get(dag.execute("input")) == "input -> a -> b"
-#     assert ray.get(dag.execute("test")) == "test -> a -> b"
+    # TODO (jiaodong): handle random args without using kw
+    # with pytest.raises(
+    #     ValueError, match="InputNode should not take any args or kwargs other than"
+    # ):
+    #     f._bind(InputNode(0))
+    with pytest.raises(
+        ValueError, match="InputNode should not take any args or kwargs other than"
+    ):
+        f._bind(InputNode(key=1))
 
 
-# def test_func_dag(shared_ray_instance):
-#     @ray.remote
-#     def a(user_input):
-#         return user_input
+def test_simple_func(shared_ray_instance):
+    @ray.remote
+    def a(input: str):
+        return f"{input} -> a"
 
-#     @ray.remote
-#     def b(x):
-#         return x * 2
+    @ray.remote
+    def b(a: "RayHandleLike"):
+        # At runtime, a is replaced with execution result of a.
+        return f"{a} -> b"
 
-#     @ray.remote
-#     def c(x):
-#         return x + 1
+    # input -> a - > b -> ouput
+    a_node = a._bind(InputNode())
+    dag = b._bind(a_node)
 
-#     @ray.remote
-#     def d(x, y):
-#         return x + y
-
-#     a_ref = a._bind(InputNode())
-#     b_ref = b._bind(a_ref)
-#     c_ref = c._bind(a_ref)
-#     d_ref = d._bind(b_ref, c_ref)
-#     d1_ref = d._bind(d_ref, d_ref)
-#     d2_ref = d._bind(d1_ref, d_ref)
-#     dag = d._bind(d2_ref, d_ref)
-#     print(dag)
-
-#     # [(2*2 + 2+1) + (2*2 + 2+1)] + [(2*2 + 2+1) + (2*2 + 2+1)]
-#     assert ray.get(dag.execute(2)) == 28
-#     # [(3*2 + 3+1) + (3*2 + 3+1)] + [(3*2 + 3+1) + (3*2 + 3+1)]
-#     assert ray.get(dag.execute(3)) == 40
+    assert ray.get(dag.execute("input")) == "input -> a -> b"
+    assert ray.get(dag.execute("test")) == "test -> a -> b"
 
 
-# def test_multi_input_func_dag(shared_ray_instance):
-#     @ray.remote
-#     def a(user_input):
-#         return user_input * 2
+def test_func_dag(shared_ray_instance):
+    @ray.remote
+    def a(user_input):
+        return user_input
 
-#     @ray.remote
-#     def b(user_input):
-#         return user_input + 1
+    @ray.remote
+    def b(x):
+        return x * 2
 
-#     @ray.remote
-#     def c(x, y):
-#         return x + y
+    @ray.remote
+    def c(x):
+        return x + 1
 
-#     a_ref = a._bind(InputNode())
-#     b_ref = b._bind(InputNode())
-#     dag = c._bind(a_ref, b_ref)
-#     print(dag)
+    @ray.remote
+    def d(x, y):
+        return x + y
 
-#     # (2*2) + (2*1)
-#     assert ray.get(dag.execute(2)) == 7
-#     # (3*2) + (3*1)
-#     assert ray.get(dag.execute(3)) == 10
+    a_ref = a._bind(InputNode())
+    b_ref = b._bind(a_ref)
+    c_ref = c._bind(a_ref)
+    d_ref = d._bind(b_ref, c_ref)
+    d1_ref = d._bind(d_ref, d_ref)
+    d2_ref = d._bind(d1_ref, d_ref)
+    dag = d._bind(d2_ref, d_ref)
+    print(dag)
 
-
-# def test_invalid_input_node_as_class_constructor(shared_ray_instance):
-#     @ray.remote
-#     class Actor:
-#         def __init__(self, val):
-#             self.val = val
-
-#         def get(self):
-#             return self.val
-
-#     with pytest.raises(
-#         ValueError,
-#         match=(
-#             "InputNode handles user dynamic input the the DAG, and "
-#             "cannot be used as args, kwargs, or other_args_to_resolve "
-#             "in ClassNode constructor because it is not available at "
-#             "class construction or binding time."
-#         ),
-#     ):
-#         Actor._bind(InputNode())
+    # [(2*2 + 2+1) + (2*2 + 2+1)] + [(2*2 + 2+1) + (2*2 + 2+1)]
+    assert ray.get(dag.execute(2)) == 28
+    # [(3*2 + 3+1) + (3*2 + 3+1)] + [(3*2 + 3+1) + (3*2 + 3+1)]
+    assert ray.get(dag.execute(3)) == 40
 
 
-# def test_class_method_input(shared_ray_instance):
-#     @ray.remote
-#     class Model:
-#         def __init__(self, weight: int):
-#             self.weight = weight
+def test_multi_input_func_dag(shared_ray_instance):
+    @ray.remote
+    def a(user_input):
+        return user_input * 2
 
-#         def forward(self, input: "RayHandleLike"):
-#             return self.weight * input
+    @ray.remote
+    def b(user_input):
+        return user_input + 1
 
-#     @ray.remote
-#     class FeatureProcessor:
-#         def __init__(self, scale):
-#             self.scale = scale
+    @ray.remote
+    def c(x, y):
+        return x + y
 
-#         def process(self, input: int):
-#             return input * self.scale
+    a_ref = a._bind(InputNode())
+    b_ref = b._bind(InputNode())
+    dag = c._bind(a_ref, b_ref)
+    print(dag)
 
-#     preprocess = FeatureProcessor._bind(0.5)
-#     feature = preprocess.process._bind(InputNode())
-#     model = Model._bind(4)
-#     dag = model.forward._bind(feature)
-
-#     print(dag)
-#     # 2 * 0.5 * 4
-#     assert ray.get(dag.execute(2)) == 4
-#     # 6 * 0.5 * 4
-#     assert ray.get(dag.execute(6)) == 12
+    # (2*2) + (2*1)
+    assert ray.get(dag.execute(2)) == 7
+    # (3*2) + (3*1)
+    assert ray.get(dag.execute(3)) == 10
 
 
-# def test_multi_class_method_input(shared_ray_instance):
-#     """
-#     Test a multiple class methods can all be used as inputs in a dag.
-#     """
+def test_invalid_input_node_as_class_constructor(shared_ray_instance):
+    @ray.remote
+    class Actor:
+        def __init__(self, val):
+            self.val = val
 
-#     @ray.remote
-#     class Model:
-#         def __init__(self, weight: int):
-#             self.weight = weight
+        def get(self):
+            return self.val
 
-#         def forward(self, input: int):
-#             return self.weight * input
-
-#     @ray.remote
-#     def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
-#         return m1 + m2
-
-#     m1 = Model._bind(2)
-#     m2 = Model._bind(3)
-
-#     m1_output = m1.forward._bind(InputNode())
-#     m2_output = m2.forward._bind(InputNode())
-
-#     dag = combine._bind(m1_output, m2_output)
-#     print(dag)
-#     # 1*2 + 1*3
-#     assert ray.get(dag.execute(1)) == 5
-#     # 2*2 + 2*3
-#     assert ray.get(dag.execute(2)) == 10
+    with pytest.raises(
+        ValueError,
+        match=(
+            "InputNode handles user dynamic input the the DAG, and "
+            "cannot be used as args, kwargs, or other_args_to_resolve "
+            "in ClassNode constructor because it is not available at "
+            "class construction or binding time."
+        ),
+    ):
+        Actor._bind(InputNode())
 
 
-# def test_func_class_mixed_input(shared_ray_instance):
-#     """
-#     Test both class method and function are used as input in the
-#     same dag.
-#     """
+def test_class_method_input(shared_ray_instance):
+    @ray.remote
+    class Model:
+        def __init__(self, weight: int):
+            self.weight = weight
 
-#     @ray.remote
-#     class Model:
-#         def __init__(self, weight: int):
-#             self.weight = weight
+        def forward(self, input: "RayHandleLike"):
+            return self.weight * input
 
-#         def forward(self, input: int):
-#             return self.weight * input
+    @ray.remote
+    class FeatureProcessor:
+        def __init__(self, scale):
+            self.scale = scale
 
-#     @ray.remote
-#     def model_func(input: int):
-#         return input * 2
+        def process(self, input: int):
+            return input * self.scale
 
-#     @ray.remote
-#     def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
-#         return m1 + m2
+    preprocess = FeatureProcessor._bind(0.5)
+    feature = preprocess.process._bind(InputNode())
+    model = Model._bind(4)
+    dag = model.forward._bind(feature)
 
-#     m1 = Model._bind(3)
-#     m1_output = m1.forward._bind(InputNode())
-#     m2_output = model_func._bind(InputNode())
+    print(dag)
+    # 2 * 0.5 * 4
+    assert ray.get(dag.execute(2)) == 4
+    # 6 * 0.5 * 4
+    assert ray.get(dag.execute(6)) == 12
 
-#     dag = combine._bind(m1_output, m2_output)
-#     print(dag)
-#     # 2*3 + 2*2
-#     assert ray.get(dag.execute(2)) == 10
-#     # 3*3 + 3*2
-#     assert ray.get(dag.execute(3)) == 15
+
+def test_multi_class_method_input(shared_ray_instance):
+    """
+    Test a multiple class methods can all be used as inputs in a dag.
+    """
+
+    @ray.remote
+    class Model:
+        def __init__(self, weight: int):
+            self.weight = weight
+
+        def forward(self, input: int):
+            return self.weight * input
+
+    @ray.remote
+    def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
+        return m1 + m2
+
+    m1 = Model._bind(2)
+    m2 = Model._bind(3)
+
+    m1_output = m1.forward._bind(InputNode())
+    m2_output = m2.forward._bind(InputNode())
+
+    dag = combine._bind(m1_output, m2_output)
+    print(dag)
+    # 1*2 + 1*3
+    assert ray.get(dag.execute(1)) == 5
+    # 2*2 + 2*3
+    assert ray.get(dag.execute(2)) == 10
+
+
+def test_func_class_mixed_input(shared_ray_instance):
+    """
+    Test both class method and function are used as input in the
+    same dag.
+    """
+
+    @ray.remote
+    class Model:
+        def __init__(self, weight: int):
+            self.weight = weight
+
+        def forward(self, input: int):
+            return self.weight * input
+
+    @ray.remote
+    def model_func(input: int):
+        return input * 2
+
+    @ray.remote
+    def combine(m1: "RayHandleLike", m2: "RayHandleLike"):
+        return m1 + m2
+
+    m1 = Model._bind(3)
+    m1_output = m1.forward._bind(InputNode())
+    m2_output = model_func._bind(InputNode())
+
+    dag = combine._bind(m1_output, m2_output)
+    print(dag)
+    # 2*3 + 2*2
+    assert ray.get(dag.execute(2)) == 10
+    # 3*3 + 3*2
+    assert ray.get(dag.execute(3)) == 15
 
 
 def test_simple_full_input_adapt_and_validate(shared_ray_instance):
     """str to int."""
+
     def validator(input):
         assert isinstance(input, str)
 
     input_schema = InputSchema(validator=validator)
+
     def adapter_fn(input):
         if isinstance(input, str):
             return int(input)

--- a/python/ray/serve/pipeline/json_serde.py
+++ b/python/ray/serve/pipeline/json_serde.py
@@ -88,7 +88,7 @@ def dagnode_from_json(input_json: Any) -> Union[DAGNode, RayServeHandle, Any]:
             return input_json
     # Deserialize DAGNode type
     elif input_json[DAGNODE_TYPE_KEY] == InputNode.__name__:
-        return InputNode.from_json(input_json)
+        return InputNode.from_json(input_json, object_hook=dagnode_from_json)
     elif input_json[DAGNODE_TYPE_KEY] == ClassMethodNode.__name__:
         return ClassMethodNode.from_json(input_json, object_hook=dagnode_from_json)
     elif input_json[DAGNODE_TYPE_KEY] == DeploymentNode.__name__:

--- a/python/ray/serve/pipeline/tests/test_generate.py
+++ b/python/ray/serve/pipeline/tests/test_generate.py
@@ -32,8 +32,9 @@ def _validate_consistent_output(
 
 def test_simple_single_class(serve_instance):
     # Assert converting both arg and kwarg
-    model = Model._bind(2, ratio=0.3)
-    ray_dag = model.forward._bind(InputNode())
+    with InputNode() as dag_input:
+        model = Model._bind(2, ratio=0.3)
+        ray_dag = model.forward._bind(dag_input)
 
     serve_root_dag = ray_dag._apply_recursive(transform_ray_dag_to_serve_dag)
     deployments = extract_deployments_from_serve_dag(serve_root_dag)
@@ -43,8 +44,9 @@ def test_simple_single_class(serve_instance):
 
 
 def test_single_class_with_valid_ray_options(serve_instance):
-    model = Model.options(num_cpus=1, memory=1000)._bind(2, ratio=0.3)
-    ray_dag = model.forward._bind(InputNode())
+    with InputNode() as dag_input:
+        model = Model.options(num_cpus=1, memory=1000)._bind(2, ratio=0.3)
+        ray_dag = model.forward._bind(dag_input)
 
     serve_root_dag = ray_dag._apply_recursive(transform_ray_dag_to_serve_dag)
     deployments = extract_deployments_from_serve_dag(serve_root_dag)
@@ -61,8 +63,9 @@ def test_single_class_with_valid_ray_options(serve_instance):
 
 
 def test_single_class_with_invalid_deployment_options(serve_instance):
-    model = Model.options(name="my_deployment")._bind(2, ratio=0.3)
-    ray_dag = model.forward._bind(InputNode())
+    with InputNode() as dag_input:
+        model = Model.options(name="my_deployment")._bind(2, ratio=0.3)
+        ray_dag = model.forward._bind(dag_input)
 
     serve_root_dag = ray_dag._apply_recursive(transform_ray_dag_to_serve_dag)
     deployments = extract_deployments_from_serve_dag(serve_root_dag)
@@ -79,11 +82,12 @@ def test_multi_instantiation_class_deployment_in_init_args(serve_instance):
     multiple times for the same class, and we can still correctly replace
     args with deployment handle and parse correct deployment instances.
     """
-    m1 = Model._bind(2)
-    m2 = Model._bind(3)
-    combine = Combine._bind(m1, m2=m2)
-    ray_dag = combine.__call__._bind(InputNode())
-    print(f"Ray DAG: \n{ray_dag}")
+    with InputNode() as dag_input:
+        m1 = Model._bind(2)
+        m2 = Model._bind(3)
+        combine = Combine._bind(m1, m2=m2)
+        ray_dag = combine.__call__._bind(dag_input)
+        print(f"Ray DAG: \n{ray_dag}")
 
     serve_root_dag = ray_dag._apply_recursive(transform_ray_dag_to_serve_dag)
     print(f"Serve DAG: \n{serve_root_dag}")
@@ -100,10 +104,11 @@ def test_shared_deployment_handle(serve_instance):
     Test we can re-use the same deployment handle multiple times or in
     multiple places, without incorrectly parsing duplicated deployments.
     """
-    m = Model._bind(2)
-    combine = Combine._bind(m, m2=m)
-    ray_dag = combine.__call__._bind(InputNode())
-    print(f"Ray DAG: \n{ray_dag}")
+    with InputNode() as dag_input:
+        m = Model._bind(2)
+        combine = Combine._bind(m, m2=m)
+        ray_dag = combine.__call__._bind(dag_input)
+        print(f"Ray DAG: \n{ray_dag}")
 
     serve_root_dag = ray_dag._apply_recursive(transform_ray_dag_to_serve_dag)
     print(f"Serve DAG: \n{serve_root_dag}")
@@ -121,11 +126,12 @@ def test_multi_instantiation_class_nested_deployment_arg(serve_instance):
     instantiated multiple times for the same class, and we can still correctly
     replace args with deployment handle and parse correct deployment instances.
     """
-    m1 = Model._bind(2)
-    m2 = Model._bind(3)
-    combine = Combine._bind(m1, m2={NESTED_HANDLE_KEY: m2}, m2_nested=True)
-    ray_dag = combine.__call__._bind(InputNode())
-    print(f"Ray DAG: \n{ray_dag}")
+    with InputNode() as dag_input:
+        m1 = Model._bind(2)
+        m2 = Model._bind(3)
+        combine = Combine._bind(m1, m2={NESTED_HANDLE_KEY: m2}, m2_nested=True)
+        ray_dag = combine.__call__._bind(dag_input)
+        print(f"Ray DAG: \n{ray_dag}")
 
     serve_root_dag = ray_dag._apply_recursive(transform_ray_dag_to_serve_dag)
     print(f"Serve DAG: \n{serve_root_dag}")

--- a/python/ray/serve/pipeline/tests/test_json_serde.py
+++ b/python/ray/serve/pipeline/tests/test_json_serde.py
@@ -139,6 +139,7 @@ def test_simple_function_node_json_serde(serve_instance):
             "kwargs": "{}",
             "options": "{}",
             "other_args_to_resolve": "{}",
+            "uuid": original_dag_node.get_stable_uuid(),
         },
     )
 
@@ -153,6 +154,7 @@ def test_simple_function_node_json_serde(serve_instance):
             "kwargs": '{"kwargs_output": 3}',
             "options": "{}",
             "other_args_to_resolve": "{}",
+            "uuid": original_dag_node.get_stable_uuid(),
         },
     )
 
@@ -167,6 +169,7 @@ def test_simple_function_node_json_serde(serve_instance):
             "kwargs": "{}",
             "options": "{}",
             "other_args_to_resolve": "{}",
+            "uuid": original_dag_node.get_stable_uuid(),
         },
     )
 
@@ -196,6 +199,7 @@ def test_simple_class_node_json_serde(serve_instance):
             "kwargs": "{}",
             "options": "{}",
             "other_args_to_resolve": "{}",
+            "uuid": original_dag_node.get_stable_uuid(),
         },
     )
 
@@ -210,6 +214,7 @@ def test_simple_class_node_json_serde(serve_instance):
             "kwargs": "{}",
             "options": "{}",
             "other_args_to_resolve": "{}",
+            "uuid": original_dag_node.get_stable_uuid(),
         },
     )
 
@@ -224,6 +229,7 @@ def test_simple_class_node_json_serde(serve_instance):
             "kwargs": '{"ratio": 0.5}',
             "options": "{}",
             "other_args_to_resolve": "{}",
+            "uuid": original_dag_node.get_stable_uuid(),
         },
     )
 

--- a/python/ray/serve/pipeline/tests/test_json_serde.py
+++ b/python/ray/serve/pipeline/tests/test_json_serde.py
@@ -283,10 +283,11 @@ def test_simple_deployment_method_call_chain(serve_instance):
 
 
 def test_multi_instantiation_class_nested_deployment_arg(serve_instance):
-    m1 = Model._bind(2)
-    m2 = Model._bind(3)
-    combine = Combine._bind(m1, m2={NESTED_HANDLE_KEY: m2}, m2_nested=True)
-    ray_dag = combine.__call__._bind(InputNode())
+    with InputNode() as dag_input:
+        m1 = Model._bind(2)
+        m2 = Model._bind(3)
+        combine = Combine._bind(m1, m2={NESTED_HANDLE_KEY: m2}, m2_nested=True)
+        ray_dag = combine.__call__._bind(dag_input)
 
     (
         serve_root_dag,
@@ -298,13 +299,14 @@ def test_multi_instantiation_class_nested_deployment_arg(serve_instance):
 
 
 def test_nested_deployment_node_json_serde(serve_instance):
-    m1 = Model._bind(2)
-    m2 = Model._bind(3)
+    with InputNode() as dag_input:
+        m1 = Model._bind(2)
+        m2 = Model._bind(3)
 
-    m1_output = m1.forward._bind(InputNode())
-    m2_output = m2.forward._bind(InputNode())
+        m1_output = m1.forward._bind(dag_input)
+        m2_output = m2.forward._bind(dag_input)
 
-    ray_dag = combine._bind(m1_output, m2_output)
+        ray_dag = combine._bind(m1_output, m2_output)
     (
         serve_root_dag,
         deserialized_serve_root_dag_node,

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -278,7 +278,6 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   void PushActorTask(std::unique_ptr<PushTaskRequest> request, bool skip_queue,
                      const ClientCallback<PushTaskReply> &callback) override {
     if (skip_queue) {
-      RAY_LOG(ERROR) << "Skip queue true";
       // Set this value so that the actor does not skip any tasks when
       // processing this request. We could also set it to max_finished_seq_no_,
       // but we just set it to the default of -1 to avoid taking the lock.
@@ -299,7 +298,6 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   void PushNormalTask(std::unique_ptr<PushTaskRequest> request,
                       const ClientCallback<PushTaskReply> &callback) override {
-    RAY_LOG(ERROR) << "Push normal task";
     request->set_sequence_number(-1);
     request->set_client_processed_up_to(-1);
     INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, callback, grpc_client_,
@@ -333,7 +331,6 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
           if (seq_no > max_finished_seq_no_) {
             max_finished_seq_no_ = seq_no;
           }
-          RAY_LOG(ERROR) << "Process " << seq_no << " " << max_finished_seq_no_;
           rpc_bytes_in_flight_ -= task_size;
           RAY_CHECK(rpc_bytes_in_flight_ >= 0);
         }

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -278,6 +278,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   void PushActorTask(std::unique_ptr<PushTaskRequest> request, bool skip_queue,
                      const ClientCallback<PushTaskReply> &callback) override {
     if (skip_queue) {
+      RAY_LOG(ERROR) << "Skip queue true";
       // Set this value so that the actor does not skip any tasks when
       // processing this request. We could also set it to max_finished_seq_no_,
       // but we just set it to the default of -1 to avoid taking the lock.
@@ -298,6 +299,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   void PushNormalTask(std::unique_ptr<PushTaskRequest> request,
                       const ClientCallback<PushTaskReply> &callback) override {
+    RAY_LOG(ERROR) << "Push normal task";
     request->set_sequence_number(-1);
     request->set_client_processed_up_to(-1);
     INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, callback, grpc_client_,
@@ -331,6 +333,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
           if (seq_no > max_finished_seq_no_) {
             max_finished_seq_no_ = seq_no;
           }
+          RAY_LOG(ERROR) << "Process " << seq_no << " " << max_finished_seq_no_;
           rpc_bytes_in_flight_ -= task_size;
           RAY_CHECK(rpc_bytes_in_flight_ >= 0);
         }


### PR DESCRIPTION
## Why are these changes needed?

- Enhanced ray dag InputNode to take arbitrary user input via `.execute()`.
  - If only one value is provided, like `dag.execute(1)`, return raw value;
  - Otherwise wrap user input into an `DAGInputData` object that can be accessed via index or key.
  - User can also pass list / dict object and just access them via index [0] or key ["key"]
- Introduced `InputAttrNode` that helps to connect partial attribute of user input to the DAG. 
- Added context manager syntax for `InputNode`.
- Add InputNode enforcements with tests, such as DAG level singleton, exception with messages, etc. 
- Enforce only simple int or str key
- Take care of JSON serialization for InputNode that carried original context manager info, ensure it's preserved.
- DAGNode UUID is also preserved in JSON serde.

## Next steps

On ray dag level we're proceeding with
```
with InputNode() as input:      # Probably better to rename it to DAGInput()
   a = Model.bind(input[0])
   b = Model.bind(input.x)
   dag = combine.bind(a, b)
```
But also enforces
   1) InputNode is always used in context manager as opposed to directly created
   2) There should be one and only one InputNode instance for each dag.
   3) No args passed by user to InputNode at ray dag level.

Then in serve we subclass a ServeInputNode() to enhance it like the following to support HTTP input validation and conversion:
```
with ServeInputNode(schema=MySchemaCls) as input:
   a = Model.bind(input[0])
   b = Model.bind(input.x)
   dag = combine.bind(a, b)
```

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
