### PR TITLE
Enable buffering and spilling to multiple remote storages

### DIFF
--- a/doc/source/ray-core/memory-management.rst
+++ b/doc/source/ray-core/memory-management.rst
@@ -277,7 +277,7 @@ usage across multiple physical devices if needed (e.g., SSD devices):
   
   To optimize the performance, it is recommended to use SSD instead of HDD when using object spilling for memory intensive workloads.
 
-If you are using an HDD, it is recommended that you specify a large buffer size (> 1MB) to lower IO requests during spilling.
+If you are using an HDD, it is recommended that you specify a large buffer size (> 1MB) to reduce IO requests during spilling.
 
 .. code-block:: python
 
@@ -307,7 +307,7 @@ To enable object spilling to remote storage (any URI supported by `smart_open <h
                 {
                   "type": "smart_open", 
                   "params": {
-                    "uri": "s3:///bucket/path"
+                    "uri": "s3://bucket/path"
                   },
                   "buffer_size": 100 * 1024 * 1024 # Use a 100MB buffer for writes
                 },
@@ -315,7 +315,7 @@ To enable object spilling to remote storage (any URI supported by `smart_open <h
         },
     )
 
-It is recommended that you specify a large buffer size (> 1MB) to lower IO requests during spilling.
+It is recommended that you specify a large buffer size (> 1MB) to reduce IO requests during spilling.
 
 Spilling to multiple remote storages is also supported.
 
@@ -329,7 +329,7 @@ Spilling to multiple remote storages is also supported.
                 {
                   "type": "smart_open", 
                   "params": {
-                    "uri": ["s3:///bucket/path1", "s3:///bucket/path2, "s3:///bucket/path3"]
+                    "uri": ["s3://bucket/path1", "s3://bucket/path2, "s3://bucket/path3"]
                   },
                   "buffer_size": 100 * 1024 * 1024 # Use a 100MB buffer for writes
                 },

--- a/doc/source/ray-core/memory-management.rst
+++ b/doc/source/ray-core/memory-management.rst
@@ -288,7 +288,7 @@ If you are using an HDD, it is recommended that you specify a large buffer size 
                   "type": "filesystem", 
                   "params": {
                     "directory_path": "/tmp/spill",
-                    "buffer_size": 1000000
+                    "buffer_size": 1_000_000
                   }
                 },
             )
@@ -304,7 +304,35 @@ To enable object spilling to remote storage (any URI supported by `smart_open <h
             "max_io_workers": 4,  # More IO workers for remote storage.
             "min_spilling_size": 100 * 1024 * 1024,  # Spill at least 100MB at a time.
             "object_spilling_config": json.dumps(
-                {"type": "smart_open", "params": {"uri": "s3:///bucket/path"}},
+                {
+                  "type": "smart_open", 
+                  "params": {
+                    "uri": "s3:///bucket/path"
+                  },
+                  "buffer_size": 100 * 1024 * 1024 # Use a 100MB buffer for writes
+                },
+            )
+        },
+    )
+
+It is recommended that you specify a large buffer size (> 1MB) to lower IO requests during spilling.
+
+Spilling to multiple remote storages is also supported.
+
+.. code-block:: python
+
+    ray.init(
+        _system_config={
+            "max_io_workers": 4,  # More IO workers for remote storage.
+            "min_spilling_size": 100 * 1024 * 1024,  # Spill at least 100MB at a time.
+            "object_spilling_config": json.dumps(
+                {
+                  "type": "smart_open", 
+                  "params": {
+                    "uri": ["s3:///bucket/path1", "s3:///bucket/path2, "s3:///bucket/path3"]
+                  },
+                  "buffer_size": 100 * 1024 * 1024 # Use a 100MB buffer for writes
+                },
             )
         },
     )

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -386,9 +386,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         uri: str or list,
         prefix: str = DEFAULT_OBJECT_PREFIX,
         override_transport_params: dict = None,
-        buffer_size=50
-        * 1024
-        * 1024,  # For remote spilling, at least 1MB is recommended.
+        buffer_size=1024 * 1024,  # For remote spilling, at least 1MB is recommended.
     ):
         try:
             from smart_open import open  # noqa
@@ -405,7 +403,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             uri = [uri]
         assert isinstance(uri, list), "uri must be a single string or list of strings."
         assert isinstance(buffer_size, int), "buffer_size must be an integer."
-        
+
         uri_is_s3 = [u.startswith("s3://") for u in uri]
         self.is_for_s3 = all(uri_is_s3)
         if not self.is_for_s3:

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -386,7 +386,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         uri: str or list,
         prefix: str = DEFAULT_OBJECT_PREFIX,
         override_transport_params: dict = None,
-        buffer_size=1024*1024 # For remote spilling, at least 1MB is recommended.
+        buffer_size=1024 * 1024,  # For remote spilling, at least 1MB is recommended.
     ):
         try:
             from smart_open import open  # noqa
@@ -398,21 +398,19 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             )
 
         # Validation
-        assert (
-            uri is not None
-        ), "uri should be provided to use object spilling."
+        assert uri is not None, "uri should be provided to use object spilling."
         if isinstance(uri, str):
             uri = [uri]
         assert isinstance(uri, list), "uri must be a single string or list of strings."
         assert isinstance(buffer_size, int), "buffer_size must be an integer."
         self._buffer_size = buffer_size
-        
+
         self._uris = [u.strip("/") for u in uri]
         assert len(self._uris) == len(uri)
-        
+
         s3 = [u.startswith("s3") for u in self._uris]
-        if (any(s3)):
-            assert ( all(s3) ), "all uri's must be s3 or none can be s3."
+        if any(s3):
+            assert all(s3), "all uri's must be s3 or none can be s3."
         self.is_for_s3 = all(s3)
         self._current_uri_index = random.randrange(0, len(self._uris))
 
@@ -430,7 +428,11 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             # smart_open always seek to 0 if we don't set this argument.
             # This will lead us to call a Object.get when it is not necessary,
             # so defer seek and call seek before reading objects instead.
-            self.transport_params = {"defer_seek": True, "resource": self.s3, "buffer_size": self._buffer_size}
+            self.transport_params = {
+                "defer_seek": True,
+                "resource": self.s3,
+                "buffer_size": self._buffer_size,
+            }
         else:
             self.transport_params = {}
 
@@ -449,8 +451,13 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         first_ref = object_refs[0]
         key = f"{self.prefix}-{first_ref.hex()}-multi-{len(object_refs)}"
         url = f"{uri}/{key}"
-        
-        with open(url, mode="wb", buffering=self._buffer_size, transport_params=self.transport_params) as file_like:
+
+        with open(
+            url,
+            mode="wb",
+            buffering=self._buffer_size,
+            transport_params=self.transport_params,
+        ) as file_like:
             return self._write_multiple_objects(
                 file_like, object_refs, owner_addresses, url
             )
@@ -492,6 +499,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
 
     def destroy_external_storage(self):
         pass
+
 
 _external_storage = NullStorage()
 
@@ -595,4 +603,3 @@ def delete_spilled_objects(urls: List[str]):
         urls: URLs that store spilled object files.
     """
     _external_storage.delete_spilled_objects(urls)
-

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -383,7 +383,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
 
     def __init__(
         self,
-        uri: str,
+        uri: str or list,
         prefix: str = DEFAULT_OBJECT_PREFIX,
         override_transport_params: dict = None,
     ):
@@ -396,10 +396,24 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
                 f"is not downloaded. Original error: {e}"
             )
 
-        self.uri = uri.strip("/")
+        assert (
+            uri is not None
+        ), "uri should be provided to use object spilling."
+        if isinstance(uri, str):
+            uri = [uri]
+        assert isinstance(uri, list), "uri must be a single string or list of strings."
+        
+        self._uris = [u.strip("/") for u in uri]
+        assert len(self._uris) == len(uri)
+        
+        s3 = [uri.startswith("s3") for u in self._uris]
+        if (any(s3)):
+            assert ( all(s3) ), "all uri's must be s3 or none can be s3."
+        self.is_for_s3 = all(s3)
+        self._current_uri_index = random.randrange(0, len(self._uris))
+
         self.prefix = prefix
         self.override_transport_params = override_transport_params or {}
-        self.is_for_s3 = uri.startswith("s3")
 
         if self.is_for_s3:
             import boto3  # noqa
@@ -423,10 +437,14 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             return []
         from smart_open import open
 
+        # Choose the current uri by round robin order.
+        self._current_uri_index = (self._current_uri_index + 1) % len(self._uris)
+        uri = self._uris[self._current_uri_index]
+
         # Always use the first object ref as a key when fusioning objects.
         first_ref = object_refs[0]
         key = f"{self.prefix}-{first_ref.hex()}-multi-{len(object_refs)}"
-        url = f"{self.uri}/{key}"
+        url = f"{uri}/{key}"
         with open(url, "wb", transport_params=self.transport_params) as file_like:
             return self._write_multiple_objects(
                 file_like, object_refs, owner_addresses, url
@@ -469,7 +487,6 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
 
     def destroy_external_storage(self):
         pass
-
 
 _external_storage = NullStorage()
 

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -386,7 +386,9 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         uri: str or list,
         prefix: str = DEFAULT_OBJECT_PREFIX,
         override_transport_params: dict = None,
-        buffer_size=50*1024*1024 # For remote spilling, at least 1MB is recommended.
+        buffer_size=50
+        * 1024
+        * 1024,  # For remote spilling, at least 1MB is recommended.
     ):
         try:
             from smart_open import open  # noqa
@@ -398,17 +400,15 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             )
 
         # Validation
-        assert (
-            uri is not None
-        ), "uri should be provided to use object spilling."
+        assert uri is not None, "uri should be provided to use object spilling."
         if isinstance(uri, str):
             uri = [uri]
         assert isinstance(uri, list), "uri must be a single string or list of strings."
         assert isinstance(buffer_size, int), "buffer_size must be an integer."
-        
+
         s3 = [u.startswith("s3") for u in uri]
-        if (any(s3)):
-            assert ( all(s3) ), "all uri's must be s3 or none can be s3."
+        if any(s3):
+            assert all(s3), "all uri's must be s3 or none can be s3."
         self.is_for_s3 = all(s3)
         if self.is_for_s3:
             self._uris = [u.strip("/") for u in uri]
@@ -432,7 +432,11 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             # smart_open always seek to 0 if we don't set this argument.
             # This will lead us to call a Object.get when it is not necessary,
             # so defer seek and call seek before reading objects instead.
-            self.transport_params = {"defer_seek": True, "resource": self.s3, "buffer_size": self._buffer_size}
+            self.transport_params = {
+                "defer_seek": True,
+                "resource": self.s3,
+                "buffer_size": self._buffer_size,
+            }
             # self.transport_params = {"defer_seek": True, "resource": self.s3}
         else:
             self.transport_params = {}
@@ -452,8 +456,13 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         first_ref = object_refs[0]
         key = f"{self.prefix}-{first_ref.hex()}-multi-{len(object_refs)}"
         url = f"{uri}/{key}"
-        #with open(url, mode="wb", transport_params=self.transport_params) as file_like:
-        with open(url, mode="wb", buffering=self._buffer_size, transport_params=self.transport_params) as file_like:
+        # with open(url, mode="wb", transport_params=self.transport_params) as file_like:
+        with open(
+            url,
+            mode="wb",
+            buffering=self._buffer_size,
+            transport_params=self.transport_params,
+        ) as file_like:
             return self._write_multiple_objects(
                 file_like, object_refs, owner_addresses, url
             )
@@ -495,6 +504,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
 
     def destroy_external_storage(self):
         pass
+
 
 _external_storage = NullStorage()
 
@@ -598,4 +608,3 @@ def delete_spilled_objects(urls: List[str]):
         urls: URLs that store spilled object files.
     """
     _external_storage.delete_spilled_objects(urls)
-

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -406,7 +406,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         self._uris = [u.strip("/") for u in uri]
         assert len(self._uris) == len(uri)
         
-        s3 = [uri.startswith("s3") for u in self._uris]
+        s3 = [u.startswith("s3") for u in self._uris]
         if (any(s3)):
             assert ( all(s3) ), "all uri's must be s3 or none can be s3."
         self.is_for_s3 = all(s3)

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -386,7 +386,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         uri: str or list,
         prefix: str = DEFAULT_OBJECT_PREFIX,
         override_transport_params: dict = None,
-        buffer_size=1024 * 1024,  # For remote spilling, at least 1MB is recommended.
+        buffer_size=50*1024*1024 # For remote spilling, at least 1MB is recommended.
     ):
         try:
             from smart_open import open  # noqa
@@ -398,23 +398,27 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             )
 
         # Validation
-        assert uri is not None, "uri should be provided to use object spilling."
+        assert (
+            uri is not None
+        ), "uri should be provided to use object spilling."
         if isinstance(uri, str):
             uri = [uri]
         assert isinstance(uri, list), "uri must be a single string or list of strings."
         assert isinstance(buffer_size, int), "buffer_size must be an integer."
-        self._buffer_size = buffer_size
-
-        self._uris = [u.strip("/") for u in uri]
-        assert len(self._uris) == len(uri)
-
-        s3 = [u.startswith("s3") for u in self._uris]
-        if any(s3):
-            assert all(s3), "all uri's must be s3 or none can be s3."
+        
+        s3 = [u.startswith("s3") for u in uri]
+        if (any(s3)):
+            assert ( all(s3) ), "all uri's must be s3 or none can be s3."
         self.is_for_s3 = all(s3)
+        if self.is_for_s3:
+            self._uris = [u.strip("/") for u in uri]
+        else:
+            self._uris = uri
+        assert len(self._uris) == len(uri)
         self._current_uri_index = random.randrange(0, len(self._uris))
 
         self.prefix = prefix
+        self._buffer_size = buffer_size
         self.override_transport_params = override_transport_params or {}
 
         if self.is_for_s3:
@@ -428,11 +432,8 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
             # smart_open always seek to 0 if we don't set this argument.
             # This will lead us to call a Object.get when it is not necessary,
             # so defer seek and call seek before reading objects instead.
-            self.transport_params = {
-                "defer_seek": True,
-                "resource": self.s3,
-                "buffer_size": self._buffer_size,
-            }
+            self.transport_params = {"defer_seek": True, "resource": self.s3, "buffer_size": self._buffer_size}
+            # self.transport_params = {"defer_seek": True, "resource": self.s3}
         else:
             self.transport_params = {}
 
@@ -451,13 +452,8 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         first_ref = object_refs[0]
         key = f"{self.prefix}-{first_ref.hex()}-multi-{len(object_refs)}"
         url = f"{uri}/{key}"
-
-        with open(
-            url,
-            mode="wb",
-            buffering=self._buffer_size,
-            transport_params=self.transport_params,
-        ) as file_like:
+        #with open(url, mode="wb", transport_params=self.transport_params) as file_like:
+        with open(url, mode="wb", buffering=self._buffer_size, transport_params=self.transport_params) as file_like:
             return self._write_multiple_objects(
                 file_like, object_refs, owner_addresses, url
             )
@@ -499,7 +495,6 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
 
     def destroy_external_storage(self):
         pass
-
 
 _external_storage = NullStorage()
 
@@ -603,3 +598,4 @@ def delete_spilled_objects(urls: List[str]):
         urls: URLs that store spilled object files.
     """
     _external_storage.delete_spilled_objects(urls)
+

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -461,6 +461,10 @@ smart_open_object_spilling_config = {
     "type": "smart_open",
     "params": {"uri": f"s3://{bucket_name}/"},
 }
+multi_smart_open_object_spilling_config = {
+    "type": "smart_open",
+    "params": {"uri": [f"s3://{bucket_name}/{i}" for i in range(3)]},
+}
 
 unstable_object_spilling_config = {
     "type": "unstable_fs",

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -461,6 +461,10 @@ smart_open_object_spilling_config = {
     "type": "smart_open",
     "params": {"uri": f"s3://{bucket_name}/"},
 }
+buffer_open_object_spilling_config = {
+    "type": "smart_open",
+    "params": {"uri": f"s3://{bucket_name}/", "buffer_size": 1000},
+}
 multi_smart_open_object_spilling_config = {
     "type": "smart_open",
     "params": {"uri": [f"s3://{bucket_name}/{i}" for i in range(3)]},


### PR DESCRIPTION
## Why are these changes needed?
Buffering writes to AWS S3 is highly recommended to maximize throughput. Reducing the number of remote I/O requests can make spilling to remote storages as effective as spilling locally.

In a test where 512GB of objects were created and spilled, varying just the buffer size while spilling to a S3 bucket resulted in the following runtimes.

Buffer Size | Runtime (s)
-- | --
Default | 3221.865916
256KB | 1758.885839
1MB | 748.226089
10MB | 526.406466
100MB | 494.830513

Based on these results, a default buffer size of 1MB has been added. This is the minimum buffer size used by AWS Kinesis Firehose, a streaming service for S3. On systems with larger availability, it is good to configure a larger buffer size.

For processes that reach the throughput limits provided by S3, we can remove that bottleneck by supporting more prefixes/buckets. These impacts are less noticeable as the performance gains from using a large buffer prevent us from reaching a bottleneck. The following runtimes were achieved by spilling 512GB with a 1MB buffer and varying prefixes.

Prefixes | Runtime (s)
-- | --
1 | 748.226089
3 | 527.658646
10 | 516.010742


Together these changes enable faster large-scale object spilling.

## Related issue number
https://github.com/ray-project/ray/issues/22833
This PR enables more scalability and will improve performance in data shuffling.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests (S3 tests are currently a TODO until a mock dependency is made available.)
   - [ ] Release tests
   - [ ] This PR is not tested :(
