### PR TITLE
[serve] Support `init_args` and `init_kwargs` in `serve run`

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -277,7 +277,7 @@ def run(
             )
             cli_logger.newline()
 
-        if not is_config:
+        else:
             cli_logger.print(
                 "Deploying function or class imported from " f"{config_or_import_path}."
             )

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -251,6 +251,7 @@ def run(
         args, kwargs = process_args_and_kwargs(args_and_kwargs)
 
         if is_config:
+            # Delay serve.start() to catch invalid inputs without waiting
             if len(args) + len(kwargs) > 0:
                 raise ValueError(
                     "ARGS_AND_KWARGS cannot be defined for a "

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -320,7 +320,7 @@ def run(
         if isinstance(e, KeyboardInterrupt):
             cli_logger.print("Got SIGINT (KeyboardInterrupt). Removing deployments.")
         else:
-            cli_logger.error(f"Got {type(e)}. Removing deployments.")
+            cli_logger.error(f"Got {type(e).__name__}. Removing deployments.")
         for deployment in deployments:
             deployment.delete()
         if len(serve.list_deployments()) == 0:

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -98,37 +98,6 @@ def process_args_and_kwargs(
     del args_and_kwargs["args"]
     return args, args_and_kwargs
 
-    # args, kwargs = [], {}
-
-    # token_idx = 0
-    # while args_and_kwargs is not None and token_idx < len(args_and_kwargs):
-    #     token = args_and_kwargs[token_idx]
-    #     if token[:2] == "--":
-    #         if "=" in token:
-    #             eq_idx = token.find("=")
-    #             kwargs[token[2:eq_idx]] = token[eq_idx + 1 :]
-    #             token_idx += 1
-    #         elif token_idx + 1 < len(args_and_kwargs):
-    #             kwargs[token[2:]] = args_and_kwargs[token_idx + 1]
-    #             token_idx += 2
-    #         else:
-    #             raise ValueError(
-    #                 f"Got no value for keyword {token[:2]}. All "
-    #                 "keyword arguments specified must have a value."
-    #             )
-    #     else:
-    #         if len(kwargs) > 0:
-    #             raise ValueError(
-    #                 f"Got argument {token} after some keyword "
-    #                 "arguments were already specified. All args "
-    #                 "must come before kwargs."
-    #             )
-    #         else:
-    #             args.append(token)
-    #             token_idx += 1
-
-    # return args, kwargs
-
 
 @click.group(help="[EXPERIMENTAL] CLI for managing Serve instances on a Ray cluster.")
 @click.option(

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -251,13 +251,13 @@ def run(
 
     try:
         # Check if path provided is for config or import
+        serve.start(detached=True)
+        deployments = []
         is_config = pathlib.Path(config_or_import_path).is_file()
         args, kwargs = process_args_and_kwargs(args_and_kwargs)
 
-        deployments = []
         if is_config:
             config_path = config_or_import_path
-            # Delay serve.start() to catch invalid inputs without waiting
             if len(args) + len(kwargs) > 0:
                 raise ValueError(
                     "ARGS_AND_KWARGS cannot be defined for a "
@@ -274,7 +274,6 @@ def run(
             schematized_config = ServeApplicationSchema.parse_obj(config)
             deployments = schema_to_serve_application(schematized_config)
 
-            serve.start(detached=True)
             deploy_group(deployments)
 
             cli_logger.newline()
@@ -299,8 +298,6 @@ def run(
             deployment = serve.deployment(name=deployment_name)(import_path)
             deployments = [deployment]
 
-            serve.start(detached=True)
-
             deployment.options(
                 init_args=args,
                 init_kwargs=kwargs,
@@ -319,13 +316,18 @@ def run(
             cli_logger.newline()
             time.sleep(10)
 
-    except KeyboardInterrupt:
-        cli_logger.print("Got SIGINT (KeyboardInterrupt). Removing deployments.")
+    except (Exception, KeyboardInterrupt) as e:
+        if isinstance(e, KeyboardInterrupt):
+            cli_logger.print("Got SIGINT (KeyboardInterrupt). Removing deployments.")
+        else:
+            cli_logger.error(f"Got {type(e)}. Removing deployments.")
         for deployment in deployments:
             deployment.delete()
         if len(serve.list_deployments()) == 0:
             cli_logger.print("No deployments left. Shutting down Serve.")
             serve.shutdown()
+        if isinstance(e, Exception):
+            raise e
         sys.exit()
 
 

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -43,8 +43,8 @@ def process_args_and_kwargs(
 ) -> Tuple[List[str], Dict[str, str]]:
     """
     Takes in a Tuple of strings. Any string prepended with "--" is considered a
-    keyword and the string following it is considered its value. All other
-    strings are considered args. All args must come before kwargs.
+    keyword. Keywords must be formatted as --keyword=value or --keyword value.
+    All other strings are considered args. All args must come before kwargs.
 
     For example:
 
@@ -62,7 +62,11 @@ def process_args_and_kwargs(
     while args_and_kwargs is not None and token_idx < len(args_and_kwargs):
         token = args_and_kwargs[token_idx]
         if token[:2] == "--":
-            if token_idx + 1 < len(args_and_kwargs):
+            if "=" in token:
+                eq_idx = token.find("=")
+                kwargs[token[2:eq_idx]] = token[eq_idx + 1 :]
+                token_idx += 1
+            elif token_idx + 1 < len(args_and_kwargs):
                 kwargs[token[2:]] = args_and_kwargs[token_idx + 1]
                 token_idx += 2
             else:
@@ -309,6 +313,7 @@ def run(
 
     except KeyboardInterrupt:
         cli_logger.print("Got SIGINT (KeyboardInterrupt). Shutting down Serve.")
+        serve.shutdown()
         sys.exit()
 
 

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -71,9 +71,9 @@ def process_args_and_kwargs(
                 # Give clear message when args come between or after kwargs
                 arg = message[message.find(":") + 2 :]
                 raise ValueError(
-                    f'Got argument "{arg}" after some keyword arguments '
-                    "were already specified. All args must come before "
-                    f"kwargs. \nMessage from parser: {message}"
+                    f'Argument "{arg}" was separated from other args by '
+                    "keyword arguments. Args cannot be separated by "
+                    f"kwargs.\nMessage from parser: {message}"
                 )
             elif message.endswith("expected one argument"):
                 # Give clear message when kwargs are undefined

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -390,12 +390,16 @@ def test_run_basic(ray_start_stop):
 
 
 class Macaw:
-    def __init__(self, color, name="Mulligan"):
+    def __init__(self, color, name="Mulligan", surname=None):
         self.color = color
         self.name = name
+        self.surname = surname
 
     def __call__(self):
-        return f"{self.name} is {self.color}!"
+        if self.surname is not None:
+            return f"{self.name} {self.surname} is {self.color}!"
+        else:
+            return f"{self.name} is {self.color}!"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
@@ -415,6 +419,26 @@ def test_run_init_args_kwargs(ray_start_stop):
         ]
     )
     wait_for_condition(lambda: ping_endpoint("run") == "Molly is green!", timeout=10)
+    p.send_signal(signal.SIGINT)
+    p.wait()
+    ping_endpoint("run") == "connection error"
+
+    # Mix and match keyword notation
+    p = subprocess.Popen(
+        [
+            "serve",
+            "run",
+            "ray.serve.tests.test_cli.Macaw",
+            "--",
+            "green",
+            "--name",
+            "Molly",
+            "--surname==./u=6y",
+        ]
+    )
+    wait_for_condition(
+        lambda: ping_endpoint("run") == "Molly =./u=6y is green!", timeout=10
+    )
     p.send_signal(signal.SIGINT)
     p.wait()
     ping_endpoint("run") == "connection error"

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -514,6 +514,10 @@ def test_run_simultaneous(ray_start_stop):
     # Test that two serve run processes can run simultaneously
 
     p1 = subprocess.Popen(["serve", "run", "ray.serve.tests.test_cli.parrot"])
+    wait_for_condition(
+        lambda: ping_endpoint("parrot", params="?sound=squawk") == "squawk", timeout=10
+    )
+
     p2 = subprocess.Popen(
         [
             "serve",
@@ -525,7 +529,6 @@ def test_run_simultaneous(ray_start_stop):
             "--surname=Malarkey",
         ]
     )
-
     wait_for_condition(
         lambda: ping_endpoint("parrot", params="?sound=squawk") == "squawk", timeout=10
     )

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -14,6 +14,13 @@ from ray._private.test_utils import wait_for_condition
 from ray.dashboard.optional_utils import RAY_INTERNAL_DASHBOARD_NAMESPACE
 
 
+def ping_endpoint(endpoint: str, params: str = ""):
+    try:
+        return requests.get(f"http://localhost:8000/{endpoint}{params}").text
+    except requests.exceptions.ConnectionError:
+        return "connection error"
+
+
 @pytest.fixture
 def ray_start_stop():
     subprocess.check_output(["ray", "start", "--head"])

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -494,20 +494,6 @@ def test_run_init_args_kwargs(ray_start_stop):
             ["serve", "run", config_file_name, "--", "green", "--name", "Molly"]
         )
 
-    # Incorrect args/kwargs ordering
-    with pytest.raises(subprocess.CalledProcessError):
-        subprocess.check_output(
-            [
-                "serve",
-                "run",
-                "ray.serve.tests.test_cli.Macaw",
-                "--",
-                "--name",
-                "Molly",
-                "green",
-            ]
-        )
-
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
 def test_run_simultaneous(ray_start_stop):

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -484,6 +484,16 @@ def test_run_init_args_kwargs(ray_start_stop):
     p.wait()
     assert ping_endpoint("Macaw") == "connection error"
 
+    # Args/kwargs with config file
+    config_file_name = os.path.join(
+        os.path.dirname(__file__), "test_config_files", "macaw.yaml"
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_output(
+            ["serve", "run", config_file_name, "--", "green", "--name", "Molly"]
+        )
+
     # Incorrect args/kwargs ordering
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_output(
@@ -496,16 +506,6 @@ def test_run_init_args_kwargs(ray_start_stop):
                 "Molly",
                 "green",
             ]
-        )
-
-    # Args/kwargs with config file
-    config_file_name = os.path.join(
-        os.path.dirname(__file__), "test_config_files", "macaw.yaml"
-    )
-
-    with pytest.raises(subprocess.CalledProcessError):
-        subprocess.check_output(
-            ["serve", "run", config_file_name, "--", "green", "--name", "Molly"]
         )
 
 

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -274,6 +274,10 @@ def test_delete(ray_start_stop):
         wait_for_condition(lambda: get_num_deployments() == 0, timeout=35)
 
 
+def parrot(request):
+    return request.query_params["sound"]
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
 def test_run_basic(ray_start_stop):
     # Deploys valid config file and import path via serve run

--- a/python/ray/serve/tests/test_config_files/macaw.yaml
+++ b/python/ray/serve/tests/test_config_files/macaw.yaml
@@ -1,0 +1,16 @@
+deployments:
+
+  - name: Macaw
+    init_args: null
+    init_kwargs: null
+    import_path: "ray.serve.tests.test_cli.Macaw"
+    num_replicas: 1
+    route_prefix: "/Macaw"
+    max_concurrent_queries: null
+    user_config: null
+    autoscaling_config: null
+    graceful_shutdown_wait_loop_s: null
+    graceful_shutdown_timeout_s: null
+    health_check_period_s: null
+    health_check_timeout_s: null
+    ray_actor_options: null


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#22714 added `serve run` to the Serve CLI. This change allows the user to specify `init_args` and `init_kwargs` in `serve run` if they are deploying via import path.

## Related issue number

<!-- For example: "Closes #1234" -->

This change is related to #21881.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This changes adds unit tests to `test_cli.py`.
