### PR TITLE
[runtime env][feature] introduce pip_check_enable and pip_version

### DIFF
--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -189,7 +189,7 @@ ray.get(f.remote())
             relative_filepath = "requirements.txt"
             pip_file = Path(relative_filepath)
             pip_file.write_text("\n".join(pip_list))
-            runtime_env = {"pip": relative_filepath}
+            runtime_env = {"pip": {"packages": relative_filepath, "pip_check": False}}
             yield {
                 "runtime_env": runtime_env,
                 "entrypoint": f"python -c '{driver_script}'",

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -320,14 +320,19 @@ The ``runtime_env`` is a Python dictionary or a python class :class:`ray.runtime
 
   - Example: ``["my_file.txt", "path/to/dir", "*.log"]``
 
-- ``pip`` (List[str] | str): Either a list of pip `requirements specifiers <https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers>`_, or a string containing the path to a pip
-  `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file.
+- ``pip`` (dict | List[str] | str): Either (1) a list of pip `requirements specifiers <https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers>`_, (2) a string containing the path to a pip
+  `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file, or (3) a python dictionary that has three fields: (a) ``packages`` (require, List[str]): a list of pip packages,
+  (b) ``pip_check`` (optional, bool): whether enable pip check at the end of pip install, default True.
+  (c) ``pip_version`` (optional, str): the version of pip, ray will spell the package name "pip" in front of the ``pip_version`` to form the final requirement string,
+  the syntax of a requirement specifier is defined in full in `PEP 508 <https://www.python.org/dev/peps/pep-0508/>`_.
   This will be installed in the Ray workers at runtime.  Packages in the preinstalled cluster environment will still be available.
   To use a library like Ray Serve or Ray Tune, you will need to include ``"ray[serve]"`` or ``"ray[tune]"`` here.
 
   - Example: ``["requests==1.0.0", "aiohttp", "ray[serve]"]``
 
   - Example: ``"./requirements.txt"``
+
+  - Example: ``{"packages":["tensorflow", "requests"], "pip_check": False, "pip_version": "==22.0.2;python_version=='3.8.11'"}``
 
   When specifying a ``requirements.txt`` file, referencing local files `within` that file is not supported (e.g. ``-r ./my-laptop/more-requirements.txt``, ``./my-pkg.whl``).
 
@@ -628,10 +633,10 @@ Example log output:
     (pid=runtime_env)   seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/private/tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/virtualenv_app_data)
     (pid=runtime_env)     added seed packages: pip==22.0.3, setuptools==60.6.0, wheel==0.37.1
     (pid=runtime_env)   activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
-    (pid=runtime_env) 
+    (pid=runtime_env)
     (pid=runtime_env) 2022-02-28 14:12:34,268       INFO utils.py:76 -- Run cmd[2] ['/tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/virtualenv/bin/python', '-c', 'import ray; print(ray.__version__, ray.__path__[0])']
     (pid=runtime_env) 2022-02-28 14:12:35,118       INFO utils.py:97 -- Output of cmd[2]: 2.0.0.dev0 /Users/user/ray/python/ray
-    (pid=runtime_env) 
+    (pid=runtime_env)
     (pid=runtime_env) 2022-02-28 14:12:35,120       INFO pip.py:236 -- Installing python requirements to /tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/virtualenv
     (pid=runtime_env) 2022-02-28 14:12:35,122       INFO utils.py:76 -- Run cmd[3] ['/tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/virtualenv/bin/python', '-m', 'pip', 'install', '--disable-pip-version-check', '--no-cache-dir', '-r', '/tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/requirements.txt']
     (pid=runtime_env) 2022-02-28 14:12:38,000       INFO utils.py:97 -- Output of cmd[3]: Requirement already satisfied: requests in /Users/user/anaconda3/envs/ray-py38/lib/python3.8/site-packages (from -r /tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/requirements.txt (line 1)) (2.26.0)
@@ -639,7 +644,7 @@ Example log output:
     (pid=runtime_env) Requirement already satisfied: certifi>=2017.4.17 in /Users/user/anaconda3/envs/ray-py38/lib/python3.8/site-packages (from requests->-r /tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/requirements.txt (line 1)) (2021.10.8)
     (pid=runtime_env) Requirement already satisfied: urllib3<1.27,>=1.21.1 in /Users/user/anaconda3/envs/ray-py38/lib/python3.8/site-packages (from requests->-r /tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/requirements.txt (line 1)) (1.26.7)
     (pid=runtime_env) Requirement already satisfied: charset-normalizer~=2.0.0 in /Users/user/anaconda3/envs/ray-py38/lib/python3.8/site-packages (from requests->-r /tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/requirements.txt (line 1)) (2.0.6)
-    (pid=runtime_env) 
+    (pid=runtime_env)
     (pid=runtime_env) 2022-02-28 14:12:38,001       INFO utils.py:76 -- Run cmd[4] ['/tmp/ray/session_2022-02-28_14-12-29_909064_87908/runtime_resources/pip/0cc818a054853c3841171109300436cad4dcf594/virtualenv/bin/python', '-c', 'import ray; print(ray.__version__, ray.__path__[0])']
     (pid=runtime_env) 2022-02-28 14:12:38,804       INFO utils.py:97 -- Output of cmd[4]: 2.0.0.dev0 /Users/user/ray/python/ray
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -321,7 +321,7 @@ The ``runtime_env`` is a Python dictionary or a python class :class:`ray.runtime
   - Example: ``["my_file.txt", "path/to/dir", "*.log"]``
 
 - ``pip`` (dict | List[str] | str): Either (1) a list of pip `requirements specifiers <https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers>`_, (2) a string containing the path to a pip
-  `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file, or (3) a python dictionary that has three fields: (a) ``packages`` (require, List[str]): a list of pip packages,
+  `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file, or (3) a python dictionary that has three fields: (a) ``packages`` (required, List[str]): a list of pip packages,
   (b) ``pip_check`` (optional, bool): whether to enable `pip check <https://pip.pypa.io/en/stable/cli/pip_check/>`_ at the end of pip install, defaults to ``True``.
   (c) ``pip_version`` (optional, str): the version of pip; Ray will spell the package name "pip" in front of the ``pip_version`` to form the final requirement string.
   The syntax of a requirement specifier is defined in full in `PEP 508 <https://www.python.org/dev/peps/pep-0508/>`_.

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -322,9 +322,9 @@ The ``runtime_env`` is a Python dictionary or a python class :class:`ray.runtime
 
 - ``pip`` (dict | List[str] | str): Either (1) a list of pip `requirements specifiers <https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers>`_, (2) a string containing the path to a pip
   `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file, or (3) a python dictionary that has three fields: (a) ``packages`` (require, List[str]): a list of pip packages,
-  (b) ``pip_check`` (optional, bool): whether enable pip check at the end of pip install, default True.
-  (c) ``pip_version`` (optional, str): the version of pip, ray will spell the package name "pip" in front of the ``pip_version`` to form the final requirement string,
-  the syntax of a requirement specifier is defined in full in `PEP 508 <https://www.python.org/dev/peps/pep-0508/>`_.
+  (b) ``pip_check`` (optional, bool): whether to enable `pip check <https://pip.pypa.io/en/stable/cli/pip_check/>`_ at the end of pip install, defaults to ``True``.
+  (c) ``pip_version`` (optional, str): the version of pip; Ray will spell the package name "pip" in front of the ``pip_version`` to form the final requirement string.
+  The syntax of a requirement specifier is defined in full in `PEP 508 <https://www.python.org/dev/peps/pep-0508/>`_.
   This will be installed in the Ray workers at runtime.  Packages in the preinstalled cluster environment will still be available.
   To use a library like Ray Serve or Ray Tune, you will need to include ``"ray[serve]"`` or ``"ray[tune]"`` here.
 

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -137,17 +137,14 @@ class PipProcessor:
             return
         python = _PathHelper.get_virtualenv_python(path)
 
-        output = await check_output_cmd(
+        await check_output_cmd(
             [python, "-m", "pip", "check", "--disable-pip-version-check"],
             logger=logger,
             cwd=cwd,
             env=pip_env,
         )
-        output = output.strip()
-        if output and "no broken" not in output.lower():
-            raise RuntimeError(f"Pip check on {path} failed:\n{output}")
-        else:
-            logger.info("Pip check on %s successfully.", path)
+
+        logger.info("Pip check on %s successfully.", path)
 
     @staticmethod
     @asynccontextmanager

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -107,6 +107,7 @@ class PipProcessor:
         pip_env: Dict,
         logger: logging.Logger,
     ):
+        """Run the pip command to reinstall pip to the specified version."""
         if not pip_version:
             return
 
@@ -132,6 +133,9 @@ class PipProcessor:
         pip_env: Dict,
         logger: logging.Logger,
     ):
+        """Run the pip check command to check python dependency conflicts.
+        If exists conflicts, the exit code of pip check command will be non-zero.
+        """
         if not pip_check:
             logger.info("Skip pip check.")
             return

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -120,19 +120,19 @@ class PipProcessor:
             "--disable-pip-version-check",
             f"pip{pip_version}",
         ]
-        logger.info("Installing pip version to %s", pip_version)
+        logger.info("Installing pip with version %s", pip_version)
 
         await check_output_cmd(pip_reinstall_cmd, logger=logger, cwd=cwd, env=pip_env)
 
     async def _pip_check(
         self,
         path: str,
-        pip_check_enable: bool,
+        pip_check: bool,
         cwd: str,
         pip_env: Dict,
         logger: logging.Logger,
     ):
-        if not pip_check_enable:
+        if not pip_check:
             logger.info("Skip pip check.")
             return
         python = _PathHelper.get_virtualenv_python(path)
@@ -145,9 +145,9 @@ class PipProcessor:
         )
         output = output.strip()
         if output and "no broken" not in output.lower():
-            raise RuntimeError(f"pip check on {path} failed:\n{output}")
+            raise RuntimeError(f"Pip check on {path} failed:\n{output}")
         else:
-            logger.info("Pip check on %s success.", path)
+            logger.info("Pip check on %s successfully.", path)
 
     @staticmethod
     @asynccontextmanager
@@ -332,7 +332,7 @@ class PipProcessor:
                 # Check python environment for conflicts.
                 await self._pip_check(
                     path,
-                    self._pip_config.get("pip_check_enable", True),
+                    self._pip_config.get("pip_check", True),
                     exec_cwd,
                     self._pip_env,
                     logger,

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -19,8 +19,8 @@ from ray._private.utils import (
 default_logger = logging.getLogger(__name__)
 
 
-def _get_pip_hash(pip_list: List[str]) -> str:
-    serialized_pip_spec = json.dumps(pip_list, sort_keys=True)
+def _get_pip_hash(pip_dict: Dict) -> str:
+    serialized_pip_spec = json.dumps(pip_dict, sort_keys=True)
     hash = hashlib.sha1(serialized_pip_spec.encode("utf-8")).hexdigest()
     return hash
 
@@ -29,12 +29,14 @@ def get_uri(runtime_env: Dict) -> Optional[str]:
     """Return `"pip://<hashed_dependencies>"`, or None if no GC required."""
     pip = runtime_env.get("pip")
     if pip is not None:
-        if isinstance(pip, list):
-            uri = "pip://" + _get_pip_hash(pip_list=pip)
+        if isinstance(pip, dict):
+            uri = "pip://" + _get_pip_hash(pip_dict=pip)
+        elif isinstance(pip, list):
+            uri = "pip://" + _get_pip_hash(pip_dict=dict(packages=pip))
         else:
             raise TypeError(
                 "pip field received by RuntimeEnvAgent must be "
-                f"list, not {type(pip).__name__}."
+                f"list or dict, not {type(pip).__name__}."
             )
     else:
         uri = None
@@ -82,6 +84,10 @@ class PipProcessor:
         self._runtime_env = runtime_env
         self._logger = logger
 
+        self._pip_config = self._runtime_env.pip_config()
+        self._pip_env = os.environ.copy()
+        self._pip_env.update(self._runtime_env.env_vars())
+
     @staticmethod
     def _is_in_virtualenv() -> bool:
         # virtualenv <= 16.7.9 sets the real_prefix,
@@ -91,6 +97,57 @@ class PipProcessor:
         return hasattr(sys, "real_prefix") or (
             hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
         )
+
+    @classmethod
+    async def _ensure_pip_version(
+        cls,
+        path: str,
+        pip_version: Optional[str],
+        cwd: str,
+        pip_env: Dict,
+        logger: logging.Logger,
+    ):
+        if not pip_version:
+            return
+
+        python = _PathHelper.get_virtualenv_python(path)
+        # Ensure pip version.
+        pip_reinstall_cmd = [
+            python,
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            f"pip{pip_version}",
+        ]
+        logger.info("Installing pip version to %s", pip_version)
+
+        await check_output_cmd(pip_reinstall_cmd, logger=logger, cwd=cwd, env=pip_env)
+
+    async def _pip_check(
+        self,
+        path: str,
+        pip_check_enable: bool,
+        cwd: str,
+        pip_env: Dict,
+        logger: logging.Logger,
+    ):
+        if not pip_check_enable:
+            logger.info("Skip pip check.")
+            return
+        python = _PathHelper.get_virtualenv_python(path)
+
+        output = await check_output_cmd(
+            [python, "-m", "pip", "check", "--disable-pip-version-check"],
+            logger=logger,
+            cwd=cwd,
+            env=pip_env,
+        )
+        output = output.strip()
+        if output and "no broken" not in output.lower():
+            raise RuntimeError(f"pip check on {path} failed:\n{output}")
+        else:
+            logger.info("Pip check on %s success.", path)
 
     @staticmethod
     @asynccontextmanager
@@ -135,7 +192,6 @@ class PipProcessor:
         cls, path: str, cwd: str, logger: logging.Logger
     ):
         """Create or get a virtualenv from path."""
-
         python = sys.executable
         virtualenv_path = os.path.join(path, "virtualenv")
         virtualenv_app_data_path = os.path.join(path, "virtualenv_app_data")
@@ -204,7 +260,7 @@ class PipProcessor:
         path: str,
         pip_packages: List[str],
         cwd: str,
-        env_vars: Dict,
+        pip_env: Dict,
         logger: logging.Logger,
     ):
         virtualenv_path = _PathHelper.get_virtualenv_path(path)
@@ -241,14 +297,13 @@ class PipProcessor:
             pip_requirements_file,
         ]
         logger.info("Installing python requirements to %s", virtualenv_path)
-        pip_env = os.environ.copy()
-        pip_env.update(env_vars)
+
         await check_output_cmd(pip_install_cmd, logger=logger, cwd=cwd, env=pip_env)
 
     async def _run(self):
         path = self._target_dir
         logger = self._logger
-        pip_packages = self._runtime_env.pip_packages()
+        pip_packages = self._pip_config["packages"]
         # We create an empty directory for exec cmd so that the cmd will
         # run more stable. e.g. if cwd has ray, then checking ray will
         # look up ray in cwd instead of site packages.
@@ -258,10 +313,30 @@ class PipProcessor:
             await self._create_or_get_virtualenv(path, exec_cwd, logger)
             python = _PathHelper.get_virtualenv_python(path)
             async with self._check_ray(python, exec_cwd, logger):
-                await self._install_pip_packages(
-                    path, pip_packages, exec_cwd, self._runtime_env.env_vars(), logger
+                # Ensure pip version.
+                await self._ensure_pip_version(
+                    path,
+                    self._pip_config.get("pip_version", None),
+                    exec_cwd,
+                    self._pip_env,
+                    logger,
                 )
-            # TODO(fyrestone): pip check.
+                # Install pip packages.
+                await self._install_pip_packages(
+                    path,
+                    pip_packages,
+                    exec_cwd,
+                    self._pip_env,
+                    logger,
+                )
+                # Check python environment for conflicts.
+                await self._pip_check(
+                    path,
+                    self._pip_config.get("pip_check_enable", True),
+                    exec_cwd,
+                    self._pip_env,
+                    logger,
+                )
         except Exception:
             logger.info("Delete incomplete virtualenv: %s", path)
             shutil.rmtree(path, ignore_errors=True)

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -129,14 +129,14 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
         if not pip_file.is_file():
             raise ValueError(f"{pip_file} is not a valid file")
         pip_list = pip_file.read_text().strip().split("\n")
-        result = dict(packages=pip_list)
+        result = dict(packages=pip_list, pip_check=True)
     elif isinstance(pip, list) and all(isinstance(dep, str) for dep in pip):
-        result = dict(packages=pip)
+        result = dict(packages=pip, pip_check=True)
     elif isinstance(pip, dict):
-        if set(pip.keys()) - set(["packages", "pip_check_enable", "pip_version"]):
+        if set(pip.keys()) - set(["packages", "pip_check", "pip_version"]):
             raise ValueError(
                 "runtime_env['pip'] can only have these fields: "
-                "packages, pip_check_enable and pip_check_enable, but got: "
+                "packages, pip_check and pip_check, but got: "
                 f"{list(pip.keys())}"
             )
 
@@ -144,10 +144,10 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
             raise ValueError(
                 f"runtime_env['pip'] must include field 'packages', but got {pip}"
             )
-        if "pip_check_enable" in pip and not isinstance(pip["pip_check_enable"], bool):
+        if "pip_check" in pip and not isinstance(pip["pip_check"], bool):
             raise TypeError(
-                "runtime_env['pip']['pip_check_enable'] must be of type bool, "
-                f"got {type(pip['pip_check_enable'])}"
+                "runtime_env['pip']['pip_check'] must be of type bool, "
+                f"got {type(pip['pip_check'])}"
             )
         if "pip_version" in pip:
             if not isinstance(pip["pip_version"], str):
@@ -155,12 +155,10 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
                     "runtime_env['pip']['pip_version'] must be of type bool, "
                     f"got {type(pip['pip_version'])}"
                 )
-            if 0 == len(_rewrite_pip_list_ray_libraries([f"pip{pip['pip_version']}"])):
-                raise ValueError(
-                    "runtime_env['pip']['pip_version'] is an invalid version: "
-                    f"{pip['pip_version']}"
-                )
         result = pip.copy()
+        result["pip_check"] = (
+            True if pip.get("pip_check") is None else pip.get("pip_check")
+        )
     else:
         raise TypeError(
             "runtime_env['pip'] must be of type str or " f"List[str], got {type(pip)}"

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -110,7 +110,7 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
         2) A string pointing to a local requirements file. In this case, the
            file contents will be read split into a list.
         3) A python dictionary that has three fields:
-            a) packages (require, List[str]): a list of pip packages, it same as 1).
+            a) packages (required, List[str]): a list of pip packages, it same as 1).
             b) pip_check (optional, bool): whether enable pip check at the end of pip
                install, default True.
             c) pip_version (optional, str): the version of pip, ray will spell

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -109,6 +109,14 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
         1) A List[str] describing the requirements. This is passed through.
         2) A string pointing to a local requirements file. In this case, the
            file contents will be read split into a list.
+        3) A python dictionary that has three fields:
+            a) packages (require, List[str]): a list of pip packages, it same as 1).
+            b) pip_check (optional, bool): whether enable pip check at the end of pip
+               install, default True.
+            c) pip_version (optional, str): the version of pip, ray will spell
+               the package name 'pip' in front of the `pip_version` to form the final
+               requirement string, the syntax of a requirement specifier is defined in
+               full in PEP 508.
 
     The returned parsed value will be a list of pip packages. If a Ray library
     (e.g. "ray[serve]") is specified, it will be deleted and replaced by its

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -133,7 +133,7 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
     elif isinstance(pip, list) and all(isinstance(dep, str) for dep in pip):
         result = dict(packages=pip, pip_check=True)
     elif isinstance(pip, dict):
-        if set(pip.keys()) - set(["packages", "pip_check", "pip_version"]):
+        if set(pip.keys()) - {"packages", "pip_check", "pip_version"}:
             raise ValueError(
                 "runtime_env['pip'] can only have these fields: "
                 "packages, pip_check and pip_check, but got: "
@@ -152,7 +152,7 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
         if "pip_version" in pip:
             if not isinstance(pip["pip_version"], str):
                 raise TypeError(
-                    "runtime_env['pip']['pip_version'] must be of type bool, "
+                    "runtime_env['pip']['pip_version'] must be of type str, "
                     f"got {type(pip['pip_version'])}"
                 )
         result = pip.copy()

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -171,7 +171,7 @@ class RuntimeEnv(dict):
             file that will be unpacked in the directory of each task/actor.
         pip (dict | List[str] | str): Either a list of pip packages, a string
             containing the path to a pip requirements.txt file, or a python
-            dictionary that has three fields: 1) ``packages`` (require, List[str]): a
+            dictionary that has three fields: 1) ``packages`` (required, List[str]): a
             list of pip packages, 2) ``pip_check`` (optional, bool): whether enable
             pip check at the end of pip install, default True.
             3) ``pip_version`` (optional, str): the version of pip, ray will spell

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -349,6 +349,8 @@ class RuntimeEnv(dict):
         res_value = value
         if key in OPTION_TO_VALIDATION_FN:
             res_value = OPTION_TO_VALIDATION_FN[key](value)
+            if res_value is None:
+                return
         return super().__setitem__(key, res_value)
 
     @classmethod

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -158,14 +158,26 @@ class RuntimeEnv(dict):
         # Example for set env_vars
         RuntimeEnv(env_vars={"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"})
 
+        # Example for set pip
+        RuntimeEnv(
+            pip={"packages":["tensorflow", "requests"], "pip_check": False,
+            "pip_version": "==22.0.2;python_version=='3.8.11'"})
+
     Args:
         py_modules (List[URI]): List of URIs (either in the GCS or external
             storage), each of which is a zip file that will be unpacked and
             inserted into the PYTHONPATH of the workers.
         working_dir (URI): URI (either in the GCS or external storage) of a zip
             file that will be unpacked in the directory of each task/actor.
-        pip (List[str] | str): Either a list of pip packages, or a string
-            containing the path to a pip requirements.txt file.
+        pip (dict | List[str] | str): Either a list of pip packages, a string
+            containing the path to a pip requirements.txt file, or a python
+            dictionary that has three fields: 1) ``packages`` (require, List[str]): a
+            list of pip packages, 2) ``pip_check`` (optional, bool): whether enable
+            pip check at the end of pip install, default True.
+            3) ``pip_version`` (optional, str): the version of pip, ray will spell
+            the package name "pip" in front of the ``pip_version`` to form the final
+            requirement string, the syntax of a requirement specifier is defined in
+            full in PEP 508.
         conda (dict | str): Either the conda YAML config, the name of a
             local conda env (e.g., "pytorch_p36"), or the path to a conda
             environment.yaml file.

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -608,13 +608,3 @@ class RuntimeEnv(dict):
                 plugin = runtime_env.python_runtime_env.plugin_runtime_env.plugins.add()
                 plugin.class_path = class_path
                 plugin.config = plugin_field
-
-    def __getstate__(self):
-        # When pickle serialization, exclude some fields
-        # which can't be serialized by pickle
-        return dict(**self)
-
-    def __setstate__(self, state):
-        for k, v in state.items():
-            self[k] = v
-        self.__proto_runtime_env = None

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -565,7 +565,7 @@ class RuntimeEnv(dict):
                     pip_config["pip_check"]
                 )
                 if "pip_version" in pip_config:
-                    runtime_env.python_runtime_env.pip_runtime_env.config.pip_version = pip_config[
+                    runtime_env.python_runtime_env.pip_runtime_env.config.pip_version = pip_config[  # noqa: E501
                         "pip_version"
                     ]
             else:

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -25,8 +25,8 @@ def _parse_proto_pip_runtime_env(runtime_env: ProtoRuntimeEnv, runtime_env_dict:
     """Parse pip runtime env protobuf to runtime env dict."""
     if runtime_env.python_runtime_env.HasField("pip_runtime_env"):
         if runtime_env.python_runtime_env.pip_runtime_env.HasField("config"):
-            runtime_env_dict["pip"] = list(
-                runtime_env.python_runtime_env.pip_runtime_env.config.packages
+            runtime_env_dict["pip"] = json.loads(
+                runtime_env.python_runtime_env.pip_runtime_env.config
             )
         else:
             runtime_env_dict[
@@ -482,6 +482,13 @@ class RuntimeEnv(dict):
         if not self.has_pip() or not isinstance(self["pip"], str):
             return None
         return self["pip"]
+	
+    def pip_config(self) -> List:
+        if not self.has_pip():
+            return {}
+        return json.loads(
+            self._proto_runtime_env.python_runtime_env.pip_runtime_env.config
+        )
 
     def get_extension(self, key) -> Optional[str]:
         if key not in RuntimeEnv.extensions_fields:

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -565,9 +565,9 @@ class RuntimeEnv(dict):
                     pip_config["pip_check"]
                 )
                 if "pip_version" in pip_config:
-                    runtime_env.python_runtime_env.pip_runtime_env.config.pip_version = (
-                        pip_config["pip_version"]
-                    )
+                    runtime_env.python_runtime_env.pip_runtime_env.config.pip_version = pip_config[
+                        "pip_version"
+                    ]
             else:
                 runtime_env.python_runtime_env.pip_runtime_env.virtual_env_name = (
                     virtualenv_name

--- a/python/ray/serve/examples/doc/conda_env.py
+++ b/python/ray/serve/examples/doc/conda_env.py
@@ -11,11 +11,15 @@ def requests_version(request):
 
 requests_version.options(
     name="25",
-    ray_actor_options={"runtime_env": {"pip": ["ray[serve]", "requests==2.25.1"]}},
+    ray_actor_options={
+        "runtime_env": {"pip": ["ray[serve]", "requests==2.25.1"], "pip_check": False}
+    },
 ).deploy()
 requests_version.options(
     name="26",
-    ray_actor_options={"runtime_env": {"pip": ["ray[serve]", "requests==2.26.0"]}},
+    ray_actor_options={
+        "runtime_env": {"pip": ["ray[serve]", "requests==2.26.0"], "pip_check": False}
+    },
 ).deploy()
 
 assert requests.get("http://127.0.0.1:8000/25").text == "2.25.1"

--- a/python/ray/serve/examples/doc/conda_env.py
+++ b/python/ray/serve/examples/doc/conda_env.py
@@ -12,13 +12,17 @@ def requests_version(request):
 requests_version.options(
     name="25",
     ray_actor_options={
-        "runtime_env": {"pip": ["ray[serve]", "requests==2.25.1"], "pip_check": False}
+        "runtime_env": {
+            "pip": {"packages": ["ray[serve]", "requests==2.25.1"], "pip_check": False}
+        }
     },
 ).deploy()
 requests_version.options(
     name="26",
     ray_actor_options={
-        "runtime_env": {"pip": ["ray[serve]", "requests==2.26.0"], "pip_check": False}
+        "runtime_env": {
+            "pip": {"packages": ["ray[serve]", "requests==2.26.0"], "pip_check": False}
+        }
     },
 ).deploy()
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -262,6 +262,7 @@ py_test_module_list(
     "test_runtime_env_conda_and_pip_2.py",
     "test_runtime_env_conda_and_pip_3.py",
     "test_runtime_env_conda_and_pip_4.py",
+    "test_runtime_env_conda_and_pip_5.py",
     "test_runtime_env_complicated.py"
   ],
   size = "large",

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -817,20 +817,20 @@ def test_runtime_env_interface():
         runtime_env = RuntimeEnv(pip=pip_packages)
         runtime_env_dict = runtime_env.to_dict()
         assert runtime_env.has_pip()
-        assert set(runtime_env.pip_packages()) == set(pip_packages)
+        assert set(runtime_env.pip_config()["packages"]) == set(pip_packages)
         assert runtime_env.virtualenv_name() is None
         runtime_env["pip"].extend(addition_pip_packages)
         runtime_env_dict["pip"].extend(addition_pip_packages)
         assert runtime_env_dict == runtime_env.to_dict()
         assert runtime_env.has_pip()
-        assert set(runtime_env.pip_packages()) == set(
+        assert set(runtime_env.pip_config()["packages"]) == set(
             pip_packages + addition_pip_packages
         )
         assert runtime_env.virtualenv_name() is None
         runtime_env["pip"] = requirement_file
         runtime_env_dict["pip"] = requirement_packages
         assert runtime_env.has_pip()
-        assert set(runtime_env.pip_packages()) == set(requirement_packages)
+        assert set(runtime_env.pip_config()["packages"]) == set(requirement_packages)
         assert runtime_env.virtualenv_name() is None
         assert runtime_env_dict == runtime_env.to_dict()
         # Test that the modification of pip also works on

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -665,12 +665,18 @@ def test_runtime_env_retry(set_runtime_env_retry_times, ray_start_regular):
 )
 @pytest.mark.parametrize(
     "option",
-    ["pip_list", "conda_name", "conda_dict", "container", "plugins"],
+    ["pip_list", "pip_dict", "conda_name", "conda_dict", "container", "plugins"],
 )
 def test_serialize_deserialize(option):
     runtime_env = dict()
     if option == "pip_list":
         runtime_env["pip"] = ["pkg1", "pkg2"]
+    elif option == "pip_dict":
+        runtime_env["pip"] = {
+            "packages": ["pkg1", "pkg2"],
+            "pip_check": False,
+            "pip_version": "<22,>20",
+        }
     elif option == "conda_name":
         runtime_env["conda"] = "env_name"
     elif option == "conda_dict":
@@ -695,7 +701,7 @@ def test_serialize_deserialize(option):
     cls_runtime_env = RuntimeEnv.from_proto(proto_runtime_env)
     cls_runtime_env_dict = cls_runtime_env.to_dict()
 
-    if "pip" in runtime_env:
+    if "pip" in runtime_env and isinstance(runtime_env["pip"], list):
         pip_config_in_cls_runtime_env = cls_runtime_env_dict.pop("pip")
         pip_config_in_runtime_env = runtime_env.pop("pip")
         assert {

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -821,6 +821,8 @@ def test_runtime_env_interface():
         assert runtime_env.virtualenv_name() is None
         runtime_env["pip"]["packages"].extend(addition_pip_packages)
         runtime_env_dict["pip"]["packages"].extend(addition_pip_packages)
+        # The default value of pip_check is True
+        runtime_env_dict["pip"]["pip_check"] = True
         assert runtime_env_dict == runtime_env.to_dict()
         assert runtime_env.has_pip()
         assert set(runtime_env.pip_config()["packages"]) == set(
@@ -832,6 +834,8 @@ def test_runtime_env_interface():
         assert runtime_env.has_pip()
         assert set(runtime_env.pip_config()["packages"]) == set(requirement_packages)
         assert runtime_env.virtualenv_name() is None
+        # The default value of pip_check is True
+        runtime_env_dict["pip"] = dict(packages=runtime_env_dict["pip"], pip_check=True)
         assert runtime_env_dict == runtime_env.to_dict()
         # Test that the modification of pip also works on
         # proto serialization

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -693,7 +693,17 @@ def test_serialize_deserialize(option):
         **runtime_env, _validate=False
     ).build_proto_runtime_env()
     cls_runtime_env = RuntimeEnv.from_proto(proto_runtime_env)
-    assert cls_runtime_env.to_dict() == runtime_env
+    cls_runtime_env_dict = cls_runtime_env.to_dict()
+
+    if "pip" in runtime_env:
+        pip_config_in_cls_runtime_env = cls_runtime_env_dict.pop("pip")
+        pip_config_in_runtime_env = runtime_env.pop("pip")
+        assert {
+            "packages": pip_config_in_runtime_env,
+            "pip_check": True,
+        } == pip_config_in_cls_runtime_env
+
+    assert cls_runtime_env_dict == runtime_env
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -819,8 +819,8 @@ def test_runtime_env_interface():
         assert runtime_env.has_pip()
         assert set(runtime_env.pip_config()["packages"]) == set(pip_packages)
         assert runtime_env.virtualenv_name() is None
-        runtime_env["pip"].extend(addition_pip_packages)
-        runtime_env_dict["pip"].extend(addition_pip_packages)
+        runtime_env["pip"]["packages"].extend(addition_pip_packages)
+        runtime_env_dict["pip"]["packages"].extend(addition_pip_packages)
         assert runtime_env_dict == runtime_env.to_dict()
         assert runtime_env.has_pip()
         assert set(runtime_env.pip_config()["packages"]) == set(

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -727,15 +727,15 @@ def test_simultaneous_install(shutdown_only):
     # installed concurrently, leading to errors:
     # https://github.com/ray-project/ray/issues/17086
     # Now we use a global lock, so the envs are installed sequentially.
-    worker_1 = VersionWorker.options(runtime_env={"pip": ["requests==2.2.0"]}).remote(
+    worker_1 = VersionWorker.options(runtime_env={"pip": ["requests==2.22.0"]}).remote(
         key=1
     )
-    worker_2 = VersionWorker.options(runtime_env={"pip": ["requests==2.3.0"]}).remote(
+    worker_2 = VersionWorker.options(runtime_env={"pip": ["requests==2.23.0"]}).remote(
         key=2
     )
 
-    assert ray.get(worker_1.get.remote()) == (1, "2.2.0")
-    assert ray.get(worker_2.get.remote()) == (2, "2.3.0")
+    assert ray.get(worker_1.get.remote()) == (1, "2.22.0")
+    assert ray.get(worker_2.get.remote()) == (2, "2.23.0")
 
 
 CLIENT_SERVER_PORT = 24001

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -727,12 +727,12 @@ def test_simultaneous_install(shutdown_only):
     # installed concurrently, leading to errors:
     # https://github.com/ray-project/ray/issues/17086
     # Now we use a global lock, so the envs are installed sequentially.
-    worker_1 = VersionWorker.options(runtime_env={"pip": ["requests==2.22.0"]}).remote(
-        key=1
-    )
-    worker_2 = VersionWorker.options(runtime_env={"pip": ["requests==2.23.0"]}).remote(
-        key=2
-    )
+    worker_1 = VersionWorker.options(
+        runtime_env={"pip": {"packages": ["requests==2.22.0"], "pip_check": False}}
+    ).remote(key=1)
+    worker_2 = VersionWorker.options(
+        runtime_env={"pip": {"packages": ["requests==2.23.0"], "pip_check": False}}
+    ).remote(key=2)
 
     assert ray.get(worker_1.get.remote()) == (1, "2.22.0")
     assert ray.get(worker_2.get.remote()) == (2, "2.23.0")

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -728,14 +728,14 @@ def test_simultaneous_install(shutdown_only):
     # https://github.com/ray-project/ray/issues/17086
     # Now we use a global lock, so the envs are installed sequentially.
     worker_1 = VersionWorker.options(
-        runtime_env={"pip": {"packages": ["requests==2.22.0"], "pip_check": False}}
+        runtime_env={"pip": {"packages": ["requests==2.2.0"], "pip_check": False}}
     ).remote(key=1)
     worker_2 = VersionWorker.options(
-        runtime_env={"pip": {"packages": ["requests==2.23.0"], "pip_check": False}}
+        runtime_env={"pip": {"packages": ["requests==2.3.0"], "pip_check": False}}
     ).remote(key=2)
 
-    assert ray.get(worker_1.get.remote()) == (1, "2.22.0")
-    assert ray.get(worker_2.get.remote()) == (2, "2.23.0")
+    assert ray.get(worker_1.get.remote()) == (1, "2.2.0")
+    assert ray.get(worker_2.get.remote()) == (2, "2.3.0")
 
 
 CLIENT_SERVER_PORT = 24001

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -113,8 +113,8 @@ def test_run_in_virtualenv(cloned_virtualenv):
 
 
 @pytest.mark.skipif(
-    "IN_VIRTUALENV" in os.environ or sys.platform != "linux",
-    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+    "IN_VIRTUALENV" in os.environ or sys.platform == "win32",
+    reason="Pip option not supported on Windows.",
 )
 def test_runtime_env_with_pip_config(start_cluster):
     @ray.remote(

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -112,5 +112,23 @@ def test_run_in_virtualenv(cloned_virtualenv):
     cloned_virtualenv.run(f"IN_VIRTUALENV=1 python -m pytest {__file__}", capture=True)
 
 
+@pytest.mark.skipif(
+    "IN_VIRTUALENV" in os.environ or sys.platform != "linux",
+    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+)
+def test_runtime_env_with_pip_config(start_cluster):
+    @ray.remote(
+        runtime_env={
+            "pip": {"packages": ["pip-install-test==0.5"], "pip_version": "==20.2.3"}
+        }
+    )
+    def f():
+        import pip
+
+        return pip.__version__
+
+    assert ray.get(f.remote()) == "20.2.3"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -1,0 +1,107 @@
+import os
+import sys
+import pytest
+from pkg_resources import Requirement
+
+import ray
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform != "linux",
+    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+)
+def test_runtime_env_with_pip_config(start_cluster):
+
+    pip_versions = [
+        "==20.2.3",
+        "<20.3, >19",
+    ]
+
+    @ray.remote
+    def f():
+        import pip
+
+        return pip.__version__
+
+    for pip_version in pip_versions:
+        requirement = Requirement.parse(f"pip{pip_version}")
+        assert (
+            ray.get(
+                f.options(
+                    runtime_env={
+                        "pip": {
+                            "packages": ["pip-install-test==0.5"],
+                            "pip_version": pip_version,
+                        }
+                    }
+                ).remote()
+            )
+            in requirement
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform != "linux",
+    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+)
+def test_runtime_env_with_conflict_pip_version(start_cluster):
+    pip_version = "<19,>19"
+
+    @ray.remote(
+        runtime_env={
+            "pip": {"packages": ["pip-install-test==0.5"], "pip_version": "<19,>19"}
+        }
+    )
+    def f():
+        import pip
+
+        return pip.__version__
+
+    with pytest.raises(ray.exceptions.RuntimeEnvSetupError) as error:
+        ray.get(f.remote())
+
+    assert f"No matching distribution found for pip{pip_version}" in str(error.value)
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") and sys.platform != "linux",
+    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+)
+def test_runtime_env_cache_with_pip_check(start_cluster):
+
+    # moto require requests>=2.5
+    conflict_packages = ["moto==3.0.5", "requests==2.4.0"]
+    runtime_env = {
+        "pip": {
+            "packages": conflict_packages,
+            "pip_version": "==20.2.3",
+            "pip_check_enable": False,
+        }
+    }
+
+    @ray.remote
+    def f():
+        return True
+
+    assert ray.get(f.options(runtime_env=runtime_env).remote())
+
+    runtime_env["pip"]["pip_version"] = "==22.0.2"
+    # Just modify filed pip_version, but this time,
+    # not hit cache and raise an exception
+    with pytest.raises(ray.exceptions.RuntimeEnvSetupError) as error:
+        ray.get(f.options(runtime_env=runtime_env).remote())
+
+    assert "The conflict is caused by:" in str(error.value)
+    assert "The user requested requests==2.4.0" in str(error.value)
+    assert "moto 3.0.5 depends on requests>=2.5" in str(error.value)
+
+    runtime_env["pip"]["pip_check_enable"] = True
+    runtime_env["pip"]["pip_version"] = "==20.2.3"
+    # Just modify filed pip_check_enable, but this time,
+    # not hit cache and raise an exception
+    with pytest.raises(ray.exceptions.RuntimeEnvSetupError) as error:
+        ray.get(f.options(runtime_env=runtime_env).remote())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -75,7 +75,7 @@ def test_runtime_env_cache_with_pip_check(start_cluster):
         "pip": {
             "packages": conflict_packages,
             "pip_version": "==20.2.3",
-            "pip_check_enable": False,
+            "pip_check": False,
         }
     }
 
@@ -85,7 +85,7 @@ def test_runtime_env_cache_with_pip_check(start_cluster):
 
     assert ray.get(f.options(runtime_env=runtime_env).remote())
 
-    runtime_env["pip"]["pip_version"] = "==22.0.2"
+    runtime_env["pip"]["pip_version"] = "==21.3.1"
     # Just modify filed pip_version, but this time,
     # not hit cache and raise an exception
     with pytest.raises(ray.exceptions.RuntimeEnvSetupError) as error:
@@ -95,9 +95,9 @@ def test_runtime_env_cache_with_pip_check(start_cluster):
     assert "The user requested requests==2.4.0" in str(error.value)
     assert "moto 3.0.5 depends on requests>=2.5" in str(error.value)
 
-    runtime_env["pip"]["pip_check_enable"] = True
+    runtime_env["pip"]["pip_check"] = True
     runtime_env["pip"]["pip_version"] = "==20.2.3"
-    # Just modify filed pip_check_enable, but this time,
+    # Just modify filed pip_check, but this time,
     # not hit cache and raise an exception
     with pytest.raises(ray.exceptions.RuntimeEnvSetupError) as error:
         ray.get(f.options(runtime_env=runtime_env).remote())

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 from pkg_resources import Requirement
@@ -7,8 +6,8 @@ import ray
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+    sys.platform == "win32",
+    reason="Pip option not supported on Windows.",
 )
 def test_runtime_env_with_pip_config(start_cluster):
 
@@ -41,8 +40,8 @@ def test_runtime_env_with_pip_config(start_cluster):
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+    sys.platform == "win32",
+    reason="Pip option not supported on Windows.",
 )
 def test_runtime_env_with_conflict_pip_version(start_cluster):
     pip_version = "<19,>19"
@@ -64,8 +63,8 @@ def test_runtime_env_with_conflict_pip_version(start_cluster):
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+    sys.platform == "win32",
+    reason="Pip option not supported on Windows.",
 )
 def test_runtime_env_cache_with_pip_check(start_cluster):
 

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -207,15 +207,21 @@ class TestValidatePip:
             requirements_file = requirements_file.resolve()
 
         result = parse_and_validate_pip(str(requirements_file))
-        assert result == PIP_LIST
+        assert result["packages"] == PIP_LIST
+        assert result["pip_check"] == True
+        assert "pip_version" not in result
 
     def test_validate_pip_valid_list(self):
         result = parse_and_validate_pip(PIP_LIST)
-        assert result == PIP_LIST
+        assert result["packages"] == PIP_LIST
+        assert result["pip_check"] == True
+        assert "pip_version" not in result
 
     def test_validate_ray(self):
         result = parse_and_validate_pip(["pkg1", "ray", "pkg2"])
-        assert result == ["pkg1", "ray", "pkg2"]
+        assert result["packages"] == ["pkg1", "ray", "pkg2"]
+        assert result["pip_check"] == True
+        assert "pip_version" not in result
 
 
 class TestValidateEnvVars:

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -208,19 +208,19 @@ class TestValidatePip:
 
         result = parse_and_validate_pip(str(requirements_file))
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"] == True
+        assert result["pip_check"]
         assert "pip_version" not in result
 
     def test_validate_pip_valid_list(self):
         result = parse_and_validate_pip(PIP_LIST)
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"] == True
+        assert result["pip_check"]
         assert "pip_version" not in result
 
     def test_validate_ray(self):
         result = parse_and_validate_pip(["pkg1", "ray", "pkg2"])
         assert result["packages"] == ["pkg1", "ray", "pkg2"]
-        assert result["pip_check"] == True
+        assert result["pip_check"]
         assert "pip_version" not in result
 
 

--- a/src/ray/protobuf/runtime_env_common.proto
+++ b/src/ray/protobuf/runtime_env_common.proto
@@ -21,9 +21,17 @@ option java_package = "io.ray.runtime.generated";
 
 /// The pip type runtime env.
 message PipRuntimeEnv {
+  message Config {
+    /// A list of pip packages, such as ["redis >= 3.5.0", "numpy"].
+    repeated string packages = 1;
+    /// Whether enable pip check after runtime env finish pip install packages
+    bool pip_check = 2;
+    /// Pip version in virtualenv
+    string pip_version = 3;
+  }
   oneof pip_runtime_env {
     /// The pip packages config, serialized by json.
-    string config = 1;
+    Config config = 1;
     /// The name of a local virtual env.
     string virtual_env_name = 2;
   }

--- a/src/ray/protobuf/runtime_env_common.proto
+++ b/src/ray/protobuf/runtime_env_common.proto
@@ -21,14 +21,9 @@ option java_package = "io.ray.runtime.generated";
 
 /// The pip type runtime env.
 message PipRuntimeEnv {
-  /// The pip packages config.
-  message Config {
-    /// A list of pip packages, such as ["redis >= 3.5.0", "numpy"].
-    repeated string packages = 1;
-  }
   oneof pip_runtime_env {
-    /// The pip packages config.
-    Config config = 1;
+    /// The pip packages config, serialized by json.
+    string config = 1;
     /// The name of a local virtual env.
     string virtual_env_name = 2;
   }

--- a/src/ray/protobuf/runtime_env_common.proto
+++ b/src/ray/protobuf/runtime_env_common.proto
@@ -30,7 +30,7 @@ message PipRuntimeEnv {
     string pip_version = 3;
   }
   oneof pip_runtime_env {
-    /// The pip packages config, serialized by json.
+    /// The pip packages config.
     Config config = 1;
     /// The name of a local virtual env.
     string virtual_env_name = 2;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

add pip_check_enable and pip_version for runtime_env, detils: https://github.com/ray-project/ray/issues/21952

API like this:
```python
runtime_env = {
        "pip": {
            "packages": [PACKAGE_A, PACKAGE_B,...],
            "pip_version": "==20.2.3",
            "pip_check": False,
        }
    }
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
