### PR TITLE
[CI] run Mac C++ tests with static linking

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -65,7 +65,9 @@ steps:
     - export RAY_INSTALL_JAVA=1
     - *prelude_commands
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
-    - bazel test --config=ci --test_env=CI $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=-post_wheel_build --
+    # Use --dynamic_mode=off until MacOS CI runs on Big Sur or newer. Otherwise there are problems with running tests
+    # with dynamic linking.
+    - bazel test --config=ci --dynamic_mode=off --test_env=CI $(./scripts/bazel_export_options) --build_tests_only --test_tag_filters=-post_wheel_build --
       //:all python/ray/serve/... python/ray/dashboard/... -rllib/... -core_worker_test
     # clang-format is needed by java/test.sh
     - pip install clang-format==12.0.1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are problems with running C++ tests in MacOS 10.15 Catalina, when upgrading to the newest grpc due to dynamic linking: https://github.com/ray-project/ray/pull/22384#issuecomment-1058741405. The problem does not exist for Python tests in Catalina, or in C++ tests of other systems.

Upgrading MacOS CI from Catalina is also blocked in the short term: https://github.com/ray-project/buildkite-ci-stack/pull/24#issuecomment-1059447667

So working around the issue by using static linking for C++ tests on Mac.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
