### PR TITLE
[Datasets] Batch across windows in DatasetPipelines.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -66,7 +66,7 @@ from ray.data.datasource.file_based_datasource import (
 from ray.data.row import TableRow
 from ray.data.aggregate import AggregateFn, Sum, Max, Min, Mean, Std
 from ray.data.impl.remote_fn import cached_remote_fn
-from ray.data.impl.batcher import Batcher
+from ray.data.impl.block_batching import batch_blocks, BatchType
 from ray.data.impl.plan import ExecutionPlan, OneToOneStage, AllToAllStage
 from ray.data.impl.stats import DatasetStats
 from ray.data.impl.compute import cache_wrapper, CallableClass, ComputeStrategy
@@ -78,9 +78,6 @@ from ray.data.impl.sort import sort_impl
 from ray.data.impl.block_list import BlockList
 from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
-
-# An output type of iter_batches() determined by the batch_format parameter.
-BatchType = Union["pandas.DataFrame", "pyarrow.Table", np.ndarray, list]
 
 logger = logging.getLogger(__name__)
 
@@ -1971,65 +1968,21 @@ class Dataset(Generic[T]):
             drop_last: Whether to drop the last batch if it's incomplete.
 
         Returns:
-            A list of iterators over record batches.
+            An iterator over record batches.
         """
-
-        import pyarrow as pa
-
         blocks = self._plan.execute()
         stats = self._plan.stats()
 
         time_start = time.perf_counter()
 
-        def format_batch(batch: Block, format: str) -> BatchType:
-            if batch_format == "native":
-                # Always promote Arrow blocks to pandas for consistency, since
-                # we lazily convert pandas->Arrow internally for efficiency.
-                if isinstance(batch, pa.Table) or isinstance(batch, bytes):
-                    batch = BlockAccessor.for_block(batch)
-                    batch = batch.to_pandas()
-                return batch
-            elif batch_format == "pandas":
-                batch = BlockAccessor.for_block(batch)
-                return batch.to_pandas()
-            elif batch_format == "pyarrow":
-                batch = BlockAccessor.for_block(batch)
-                return batch.to_arrow()
-            else:
-                raise ValueError(
-                    f"The given batch format: {batch_format} "
-                    f"is invalid. Supported batch type: {BatchType}"
-                )
-
-        batcher = Batcher(batch_size=batch_size)
-
-        def batch_block(block: ObjectRef[Block]):
-            with stats.iter_get_s.timer():
-                block = ray.get(block)
-            batcher.add(block)
-            while batcher.has_batch():
-                with stats.iter_format_batch_s.timer():
-                    result = format_batch(batcher.next_batch(), batch_format)
-                with stats.iter_user_s.timer():
-                    yield result
-
-        block_window = []  # Handle empty sliding window gracefully.
-        for block_window in _sliding_window(blocks.iter_blocks(), prefetch_blocks + 1):
-            block_window = list(block_window)
-            with stats.iter_wait_s.timer():
-                ray.wait(block_window, num_returns=1, fetch_local=True)
-            yield from batch_block(block_window[0])
-
-        # Consume remainder of final block window.
-        for block in block_window[1:]:
-            yield from batch_block(block)
-
-        # Yield any remainder batches.
-        if batcher.has_any() and not drop_last:
-            with stats.iter_format_batch_s.timer():
-                result = format_batch(batcher.next_batch(), batch_format)
-            with stats.iter_user_s.timer():
-                yield result
+        yield from batch_blocks(
+            blocks.iter_blocks(),
+            stats,
+            prefetch_blocks=prefetch_blocks,
+            batch_size=batch_size,
+            batch_format=batch_format,
+            drop_last=drop_last,
+        )
 
         stats.iter_total_s.add(time.perf_counter() - time_start)
 

--- a/python/ray/data/impl/block_batching.py
+++ b/python/ray/data/impl/block_batching.py
@@ -1,0 +1,130 @@
+import collections
+import itertools
+from typing import Iterator, Iterable, Union, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow
+    import pandas
+
+import numpy as np
+
+import ray
+from ray.types import ObjectRef
+from ray.data.block import Block, BlockAccessor
+from ray.data.impl.batcher import Batcher
+from ray.data.impl.stats import DatasetStats, DatasetPipelineStats
+
+# An output type of iter_batches() determined by the batch_format parameter.
+BatchType = Union["pandas.DataFrame", "pyarrow.Table", np.ndarray, list]
+
+
+def batch_blocks(
+    blocks: Iterator[Block],
+    stats: Union[DatasetStats, DatasetPipelineStats],
+    *,
+    prefetch_blocks: int = 0,
+    batch_size: Optional[int] = None,
+    batch_format: str = "native",
+    drop_last: bool = False,
+) -> Iterator[BatchType]:
+    """Create batches of data from 1 or more blocks.
+
+    This takes a block iterator and creates batch_size batches, slicing and unioning
+    blocks as needed.
+
+    This is used by both Dataset.iter_batches() and DatasetPipeline.iter_batches().
+
+    Args:
+        prefetch_blocks: The number of blocks to prefetch ahead of the
+            current block during the scan.
+        batch_size: Record batch size, or None to let the system pick.
+        batch_format: The format in which to return each batch.
+            Specify "native" to use the current block format (promoting
+            Arrow to pandas automatically), "pandas" to
+            select ``pandas.DataFrame`` or "pyarrow" to select
+            ``pyarrow.Table``. Default is "native".
+        drop_last: Whether to drop the last batch if it's incomplete.
+
+    Returns:
+        An iterator over record batches.
+    """
+    batcher = Batcher(batch_size=batch_size)
+
+    def batch_block(block: ObjectRef[Block]):
+        with stats.iter_get_s.timer():
+            block = ray.get(block)
+        batcher.add(block)
+        while batcher.has_batch():
+            with stats.iter_format_batch_s.timer():
+                result = _format_batch(batcher.next_batch(), batch_format)
+            with stats.iter_user_s.timer():
+                yield result
+
+    block_window = []  # Handle empty sliding window gracefully.
+    for block_window in _sliding_window(blocks, prefetch_blocks + 1):
+        block_window = list(block_window)
+        with stats.iter_wait_s.timer():
+            ray.wait(block_window, num_returns=1, fetch_local=True)
+        yield from batch_block(block_window[0])
+
+    # Consume remainder of final block window.
+    for block in block_window[1:]:
+        yield from batch_block(block)
+
+    # Yield any remainder batches.
+    if batcher.has_any() and not drop_last:
+        with stats.iter_format_batch_s.timer():
+            result = _format_batch(batcher.next_batch(), batch_format)
+        with stats.iter_user_s.timer():
+            yield result
+
+
+def _format_batch(batch: Block, batch_format: str) -> BatchType:
+    import pyarrow as pa
+
+    if batch_format == "native":
+        # Always promote Arrow blocks to pandas for consistency, since
+        # we lazily convert pandas->Arrow internally for efficiency.
+        if isinstance(batch, pa.Table) or isinstance(batch, bytes):
+            batch = BlockAccessor.for_block(batch)
+            batch = batch.to_pandas()
+        return batch
+    elif batch_format == "pandas":
+        batch = BlockAccessor.for_block(batch)
+        return batch.to_pandas()
+    elif batch_format == "pyarrow":
+        batch = BlockAccessor.for_block(batch)
+        return batch.to_arrow()
+    else:
+        raise ValueError(
+            f"The given batch format: {batch_format} "
+            f"is invalid. Supported batch type: {BatchType}"
+        )
+
+
+def _sliding_window(iterable: Iterable, n: int):
+    """Creates an iterator consisting of n-width sliding windows over
+    iterable. The sliding windows are constructed lazily such that an
+    element on the base iterator (iterable) isn't consumed until the
+    first sliding window containing that element is reached.
+
+    If n > len(iterable), then a single len(iterable) window is
+    returned.
+
+    Args:
+        iterable: The iterable on which the sliding window will be
+            created.
+        n: The width of the sliding window.
+
+    Returns:
+        An iterator of n-width windows over iterable.
+        If n > len(iterable), then a single len(iterable) window is
+        returned.
+    """
+    it = iter(iterable)
+    window = collections.deque(itertools.islice(it, n), maxlen=n)
+    if len(window) > 0:
+        yield tuple(window)
+    for elem in it:
+        window.append(elem)
+        yield tuple(window)

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -225,11 +225,21 @@ def test_repartition(ray_start_regular_shared):
     assert pipe.repartition_each_window(100).sum() == 450
 
 
-def test_iter_batches(ray_start_regular_shared):
+def test_iter_batches_basic(ray_start_regular_shared):
     pipe = ray.data.range(10).window(blocks_per_window=2)
     batches = list(pipe.iter_batches())
     assert len(batches) == 10
     assert all(len(e) == 1 for e in batches)
+
+
+def test_iter_batches_batch_across_windows(ray_start_regular_shared):
+    # 3 windows, each containing 3 blocks, each containing 3 rows.
+    pipe = ray.data.range(27, parallelism=9).window(blocks_per_window=3)
+    # 4-row batches, with batches spanning both blocks and windows.
+    batches = list(pipe.iter_batches(batch_size=4))
+    assert len(batches) == 7, batches
+    assert all(len(e) == 4 for e in batches[:-1])
+    assert len(batches[-1]) == 3
 
 
 def test_iter_datasets(ray_start_regular_shared):

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -171,13 +171,6 @@ Stage N map: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Dataset iterator time breakdown:
-* In ray.wait(): T
-* In ray.get(): T
-* In format_batch(): T
-* In user code: T
-* Total time: T
-
 == Pipeline Window N ==
 Stage N read->map_batches: [execution cached]
 Stage N map: N/N blocks executed in T
@@ -187,13 +180,6 @@ Stage N map: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Dataset iterator time breakdown:
-* In ray.wait(): T
-* In ray.get(): T
-* In format_batch(): T
-* In user code: T
-* Total time: T
-
 == Pipeline Window N ==
 Stage N read->map_batches: [execution cached]
 Stage N map: N/N blocks executed in T
@@ -202,18 +188,16 @@ Stage N map: N/N blocks executed in T
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-
-Dataset iterator time breakdown:
-* In ray.wait(): T
-* In ray.get(): T
-* In format_batch(): T
-* In user code: T
-* Total time: T
 
 ##### Overall Pipeline Time Breakdown #####
 * Time stalled waiting for next dataset: T min, T max, T mean, T total
-* Time in dataset iterator: T
-* Time in user code: T
+
+DatasetPipeline iterator time breakdown:
+* Waiting for next dataset: T
+* In ray.wait(): T
+* In ray.get(): T
+* In format_batch(): T
+* In user code: T
 * Total time: T
 """
     )
@@ -243,13 +227,6 @@ Stage N read: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Dataset iterator time breakdown:
-* In ray.wait(): T
-* In ray.get(): T
-* In format_batch(): T
-* In user code: T
-* Total time: T
-
 == Pipeline Window N ==
 Stage N read: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
@@ -258,17 +235,15 @@ Stage N read: N/N blocks executed in T
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Dataset iterator time breakdown:
+##### Overall Pipeline Time Breakdown #####
+* Time stalled waiting for next dataset: T min, T max, T mean, T total
+
+DatasetPipeline iterator time breakdown:
+* Waiting for next dataset: T
 * In ray.wait(): T
 * In ray.get(): T
 * In format_batch(): T
 * In user code: T
-* Total time: T
-
-##### Overall Pipeline Time Breakdown #####
-* Time stalled waiting for next dataset: T min, T max, T mean, T total
-* Time in dataset iterator: T
-* Time in user code: T
 * Total time: T
 """
     )


### PR DESCRIPTION
This PR allows `DatasetPipeline.iter_batches()` to batch data across windows in the pipeline. This prevents partial batches from popping up in the middle of consuming a dataset pipeline due to window boundaries, and now allows us to provide the following guarantee to the user: `pipe.iter_batches()` will yield `len(pipe) // batch_size` full batches, with a partial batch occurring only (1) as the final batch and (2) only if `len(pipe) % batch_size > 0`, and if it exists, will have size `len(pipe) % batch_size`.

The crux of this PR takes the block batching implementation from `Dataset.iter_batches()`, refactors it to operate on an iterator of blocks instead of a `Dataset` and pulls it out into a shared `batch_blocks()` utility, and have `DatasetPipeline.iter_batches()` use it to batch over windows by providing an iterator over all blocks in all windows.

## Related issue number

Closes #19063 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
