### PR TITLE
[serve] Enable serve-decorated deployment via import path

### DIFF
--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -30,6 +30,7 @@ from ray.serve.constants import (
 )
 from ray.serve.version import DeploymentVersion
 from ray.serve.utils import wrap_to_ray_error, parse_import_path
+from ray.serve.api import Deployment
 
 logger = _get_logger()
 
@@ -73,12 +74,20 @@ def create_replica_wrapper(
             if import_path is not None:
                 module_name, attr_name = parse_import_path(import_path)
                 deployment_def = getattr(import_module(module_name), attr_name)
-                # For ray decorated class or function, strip to return original
-                # body
+                # For ray or serve decorated class or function, strip to return
+                # original body
                 if isinstance(deployment_def, RemoteFunction):
                     deployment_def = deployment_def._function
                 elif isinstance(deployment_def, ActorClass):
                     deployment_def = deployment_def.__ray_metadata__.modified_class
+                elif isinstance(deployment_def, Deployment):
+                    logger.warning(
+                        f'The import path "{import_path}" contains a '
+                        "decorated Serve deployment. The decorator's settings "
+                        "are ignored when deploying via import path."
+                    )
+                    deployment_def = deployment_def.func_or_class
+
             else:
                 deployment_def = cloudpickle.loads(serialized_deployment_def)
 

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -1373,6 +1373,37 @@ class TestDeployGroup:
 
         self.deploy_and_check_responses(deployments, responses)
 
+    def test_import_path_deployment_decorated(self, serve_instance):
+        func = serve.deployment(
+            name="decorated_func",
+        )("ray.serve.tests.test_deploy.decorated_func")
+
+        clss = serve.deployment(
+            name="decorated_clss",
+        )("ray.serve.tests.test_deploy.DecoratedClass")
+
+        deployments = [func, clss]
+        responses = ["got decorated func", "got decorated class"]
+
+        self.deploy_and_check_responses(deployments, responses)
+
+        # Check that non-default decorated values were overwritten
+        assert serve.get_deployment("decorated_func").max_concurrent_queries != 17
+        assert serve.get_deployment("decorated_clss").max_concurrent_queries != 17
+
+
+# Decorated function with non-default max_concurrent queries
+@serve.deployment(max_concurrent_queries=17)
+def decorated_func(req=None):
+    return "got decorated func"
+
+
+# Decorated class with non-default max_concurrent queries
+@serve.deployment(max_concurrent_queries=17)
+class DecoratedClass:
+    def __call__(self, req=None):
+        return "got decorated class"
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, classes and functions can be deployed by setting `Deployment`'s`func_or_class` to their import path. However, if these classes or functions are already decorated with `@serve.deployment`, the import path deployment will error.

This change instead ignores the settings in a class or function's `@serve.deployment` decorator when deploying via import path. It takes the code definition and deploys it without erroring. It also logs a warning about the ignored settings.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds tests to `test_deploy.py`.
