### PR TITLE
[serve] Make route prefix the deployment name by default

### DIFF
--- a/dashboard/modules/serve/schema.py
+++ b/dashboard/modules/serve/schema.py
@@ -3,6 +3,7 @@ from typing import Union, Tuple, List, Dict
 from ray._private.runtime_env.packaging import parse_uri
 from ray.serve.api import Deployment, deployment
 from ray.serve.common import DeploymentStatus, DeploymentStatusInfo
+from ray.serve.utils import DEFAULT
 
 
 class RayActorOptionsSchema(BaseModel, extra=Extra.forbid):
@@ -112,12 +113,13 @@ class DeploymentSchema(BaseModel, extra=Extra.forbid):
         ),
         gt=0,
     )
-    route_prefix: str = Field(
-        default=None,
+    route_prefix: Union[str, DEFAULT] = Field(
+        default=DEFAULT.VALUE,
         description=(
             "Requests to paths under this HTTP path "
             "prefix will be routed to this deployment. When null, no HTTP "
-            "endpoint will be created. Routing is done based on "
+            "endpoint will be created. When omitted, defaults to "
+            "the deployment's name. Routing is done based on "
             "longest-prefix match, so if you have deployment A with "
             'a prefix of "/a" and deployment B with a prefix of "/a/b", '
             'requests to "/a", "/a/", and "/a/c" go to A and requests '
@@ -270,7 +272,7 @@ class DeploymentSchema(BaseModel, extra=Extra.forbid):
 
         # route_prefix of None means the deployment is not exposed
         # over HTTP.
-        if v is None:
+        if v is None or v == DEFAULT.VALUE:
             return v
 
         if len(v) < 1 or v[0] != "/":

--- a/dashboard/modules/serve/schema.py
+++ b/dashboard/modules/serve/schema.py
@@ -113,7 +113,7 @@ class DeploymentSchema(BaseModel, extra=Extra.forbid):
         ),
         gt=0,
     )
-    route_prefix: Union[str, DEFAULT] = Field(
+    route_prefix: Union[str, None, DEFAULT] = Field(
         default=DEFAULT.VALUE,
         description=(
             "Requests to paths under this HTTP path "

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -341,6 +341,8 @@ class ServeController:
         if route_prefix is not None:
             endpoint_info = EndpointInfo(route=route_prefix)
             self.endpoint_state.update_endpoint(name, endpoint_info)
+        else:
+            self.endpoint_state.delete_endpoint(name)
 
         return updating
 

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -114,6 +114,9 @@ def test_deploy(ray_start_stop):
     two_deployments = os.path.join(
         os.path.dirname(__file__), "test_config_files", "two_deployments.yaml"
     )
+    deny_deployment = os.path.join(
+        os.path.dirname(__file__), "test_config_files", "deny_access.yaml"
+    )
 
     # Dictionary mapping test config file names to expected deployment names
     # and configurations. These should match the values specified in the YAML
@@ -147,35 +150,46 @@ def test_deploy(ray_start_stop):
 
     request_url = "http://localhost:8000/"
     success_message_fragment = b"Sent deploy request successfully!"
-    for config_file_name, expected_deployments in configs.items():
-        deploy_response = subprocess.check_output(["serve", "deploy", config_file_name])
+
+    # Check idempotence:
+    for _ in range(2):
+        for config_file_name, expected_deployments in configs.items():
+            deploy_response = subprocess.check_output(
+                ["serve", "deploy", config_file_name]
+            )
+            assert success_message_fragment in deploy_response
+
+            for name, deployment_config in expected_deployments.items():
+                wait_for_condition(
+                    lambda: (
+                        requests.get(f"{request_url}{name}").text
+                        == deployment_config["response"]
+                    ),
+                    timeout=15,
+                )
+
+            running_deployments = serve.list_deployments()
+
+            # Check that running deployment names match expected deployment names
+            assert set(running_deployments.keys()) == expected_deployments.keys()
+
+            for name, deployment in running_deployments.items():
+                assert (
+                    deployment.num_replicas
+                    == expected_deployments[name]["num_replicas"]
+                )
+
+        # Deploy a deployment without HTTP access
+        deploy_response = subprocess.check_output(["serve", "deploy", deny_deployment])
         assert success_message_fragment in deploy_response
 
-        running_deployments = serve.list_deployments()
-
-        # Check that running deployment names match expected deployment names
-        assert set(running_deployments.keys()) == expected_deployments.keys()
-
-        for name, deployment in running_deployments.items():
-            assert deployment.num_replicas == expected_deployments[name]["num_replicas"]
-
-        for name, deployment_config in expected_deployments.items():
-            assert (
-                requests.get(f"{request_url}{name}").text
-                == deployment_config["response"]
-            )
-
-    # Deploy a deployment without HTTP access
-    deny_deployment = os.path.join(
-        os.path.dirname(__file__), "test_config_files", "deny_access.yaml"
-    )
-    deploy_response = subprocess.check_output(["serve", "deploy", deny_deployment])
-    assert success_message_fragment in deploy_response
-    assert requests.get(f"{request_url}shallow").status_code == 404
-    assert (
-        ray.get(serve.get_deployment("shallow").get_handle().remote())
-        == "Hello shallow world!"
-    )
+        wait_for_condition(
+            lambda: requests.get(f"{request_url}shallow").status_code == 404, timeout=15
+        )
+        assert (
+            ray.get(serve.get_deployment("shallow").get_handle().remote())
+            == "Hello shallow world!"
+        )
 
     ray.shutdown()
 

--- a/python/ray/serve/tests/test_config_files/deny_access.yaml
+++ b/python/ray/serve/tests/test_config_files/deny_access.yaml
@@ -1,0 +1,19 @@
+deployments:
+
+  - name: shallow
+    import_path: "test_env.shallow_import.ShallowClass"
+    route_prefix: null
+    init_args: null
+    init_kwargs: null
+    num_replicas: null
+    max_concurrent_queries: null
+    user_config: null
+    autoscaling_config: null
+    graceful_shutdown_wait_loop_s: null
+    graceful_shutdown_timeout_s: null
+    health_check_period_s: null
+    health_check_timeout_s: null
+    ray_actor_options: 
+      runtime_env:
+        py_modules:
+          - "https://github.com/shrekris-anyscale/test_deploy_group/archive/HEAD.zip"

--- a/python/ray/serve/tests/test_config_files/three_deployments.yaml
+++ b/python/ray/serve/tests/test_config_files/three_deployments.yaml
@@ -43,7 +43,6 @@ deployments:
     init_kwargs: null
     import_path: "test_module.test.one"
     num_replicas: 2
-    route_prefix: "/one"
     max_concurrent_queries: null
     user_config: null
     autoscaling_config: null

--- a/python/ray/serve/tests/test_config_files/two_deployments.yaml
+++ b/python/ray/serve/tests/test_config_files/two_deployments.yaml
@@ -5,7 +5,6 @@ deployments:
     init_kwargs: null
     import_path: "test_env.shallow_import.ShallowClass"
     num_replicas: 3
-    route_prefix: "/shallow"
     max_concurrent_queries: null
     user_config: null
     autoscaling_config: null


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The REST API's schema default denies HTTP access to deployments when `route_prefix` is omitted. This doesn't match `@serve.deployment`'s behavior, which make `route_prefix` the deployment's name when omitted.

This change matches the schema's behavior to the decorator. When `route_prefix` is omitted from the config, the deployment's `route_prefix` defaults to its name. When the `route_prefix` is specified as `null`, the deployment won't have HTTP access.

This change also fixes a bug in Serve where when a deployment is updated from a non-`None` `route_prefix` to a `None` `route_prefix`, its `route_prefix` does not change. This bug meant that a deployment available over HTTP would continue to be available at the same route even when deployed again with `route_prefix=None`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change modifies some unit tests' config files to include cases where the `route_prefix` is omitted.
     - It also adds a unit test to `test_deploy.py` that checks route prefix behavior when updated with `None` and not `None` values.
