### PR TITLE
[Train] Tell user to specify cluster address if placement group times out

### DIFF
--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -234,9 +234,9 @@ class BackendExecutor:
                     "Placement group creation timed out. Make sure your "
                     "cluster either has enough resources or use an "
                     "autoscaling cluster. If you are running on a cluster, "
-                    "make sure you are specifying an address in ray.init(). "
-                    "Current resources available: {}, resources requested by "
-                    "the placement group: {}".format(
+                    "make sure you specify an address in ray.init(). Current "
+                    "resources available: {}, resources requested by the "
+                    "placement group: {}".format(
                         ray.available_resources(), placement_group.bundle_specs
                     )
                 )

--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -235,8 +235,10 @@ class BackendExecutor:
                     "cluster either has enough resources or use an "
                     "autoscaling cluster. If you are running on a cluster, "
                     "make sure you specify an address in `ray.init()`, for example, "
-                    '`ray.init("auto")`. Current resources available: {}, resources '
-                    "requested by the placement group: {}".format(
+                    '`ray.init("auto")`. You can also increase the timeout by setting '
+                    "the TRAIN_PLACEMENT_GROUP_TIMEOUT_S environment variable. "
+                    "Current resources available: {}, resources requested by the "
+                    "placement group: {}".format(
                         ray.available_resources(), placement_group.bundle_specs
                     )
                 )

--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -231,11 +231,12 @@ class BackendExecutor:
                 logger.debug("Placement group has started.")
             else:
                 raise TimeoutError(
-                    "Placement group creation timed out. Make sure "
-                    "your cluster either has enough resources or use "
-                    "an autoscaling cluster. Current resources "
-                    "available: {}, resources requested by the "
-                    "placement group: {}".format(
+                    "Placement group creation timed out. Make sure your "
+                    "cluster either has enough resources or use an "
+                    "autoscaling cluster. If you are running on a cluster, "
+                    "make sure you are specifying an address in ray.init(). "
+                    "Current resources available: {}, resources requested by "
+                    "the placement group: {}".format(
                         ray.available_resources(), placement_group.bundle_specs
                     )
                 )

--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -234,7 +234,7 @@ class BackendExecutor:
                     "Placement group creation timed out. Make sure your "
                     "cluster either has enough resources or use an "
                     "autoscaling cluster. If you are running on a cluster, "
-                    "make sure you specify an address in ray.init(). Current "
+                    "make sure you specify an address in `ray.init()`, for example `ray.init("auto")`. Current "
                     "resources available: {}, resources requested by the "
                     "placement group: {}".format(
                         ray.available_resources(), placement_group.bundle_specs

--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -234,9 +234,9 @@ class BackendExecutor:
                     "Placement group creation timed out. Make sure your "
                     "cluster either has enough resources or use an "
                     "autoscaling cluster. If you are running on a cluster, "
-                    "make sure you specify an address in `ray.init()`, for example `ray.init("auto")`. Current "
-                    "resources available: {}, resources requested by the "
-                    "placement group: {}".format(
+                    "make sure you specify an address in `ray.init()`, for example, "
+                    '`ray.init("auto")`. Current resources available: {}, resources '
+                    "requested by the placement group: {}".format(
                         ray.available_resources(), placement_group.bundle_specs
                     )
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you don't add `ray.init("auto")` to your training script, then your training script might complain that there aren't enough resources, even if `ray status` shows that there are.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
