### PR TITLE
[HOTFIX]fix some compilation failures in core worker test

### DIFF
--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -991,11 +991,11 @@ TEST(TestOverrideRuntimeEnv, TestOverrideEnvVars) {
 TEST(TestOverrideRuntimeEnv, TestPyModulesInherit) {
   rpc::RuntimeEnv child;
   auto parent = std::make_shared<rpc::RuntimeEnv>();
-  parent->mutable_python_runtime_env()->mutable_dependent_modules()->Add("s3://456");
+  parent->mutable_python_runtime_env()->mutable_py_modules()->Add("s3://456");
   parent->mutable_uris()->mutable_py_modules_uris()->Add("s3://456");
   auto result = CoreWorker::OverrideRuntimeEnv(child, parent);
-  ASSERT_EQ(result.python_runtime_env().dependent_modules().size(), 1);
-  ASSERT_EQ(result.python_runtime_env().dependent_modules()[0], "s3://456");
+  ASSERT_EQ(result.python_runtime_env().py_modules().size(), 1);
+  ASSERT_EQ(result.python_runtime_env().py_modules()[0], "s3://456");
   ASSERT_EQ(result.uris().py_modules_uris().size(), 1);
   ASSERT_EQ(result.uris().py_modules_uris()[0], "s3://456");
 }
@@ -1003,15 +1003,15 @@ TEST(TestOverrideRuntimeEnv, TestPyModulesInherit) {
 TEST(TestOverrideRuntimeEnv, TestOverridePyModules) {
   rpc::RuntimeEnv child;
   auto parent = std::make_shared<rpc::RuntimeEnv>();
-  child.mutable_python_runtime_env()->mutable_dependent_modules()->Add("s3://123");
+  child.mutable_python_runtime_env()->mutable_py_modules()->Add("s3://123");
   child.mutable_uris()->mutable_py_modules_uris()->Add("s3://123");
-  parent->mutable_python_runtime_env()->mutable_dependent_modules()->Add("s3://456");
-  parent->mutable_python_runtime_env()->mutable_dependent_modules()->Add("s3://789");
+  parent->mutable_python_runtime_env()->mutable_py_modules()->Add("s3://456");
+  parent->mutable_python_runtime_env()->mutable_py_modules()->Add("s3://789");
   parent->mutable_uris()->mutable_py_modules_uris()->Add("s3://456");
   parent->mutable_uris()->mutable_py_modules_uris()->Add("s3://789");
   auto result = CoreWorker::OverrideRuntimeEnv(child, parent);
-  ASSERT_EQ(result.python_runtime_env().dependent_modules().size(), 1);
-  ASSERT_EQ(result.python_runtime_env().dependent_modules()[0], "s3://123");
+  ASSERT_EQ(result.python_runtime_env().py_modules().size(), 1);
+  ASSERT_EQ(result.python_runtime_env().py_modules()[0], "s3://123");
   ASSERT_EQ(result.uris().py_modules_uris().size(), 1);
   ASSERT_EQ(result.uris().py_modules_uris()[0], "s3://123");
 }

--- a/src/ray/core_worker/test/mock_worker.cc
+++ b/src/ray/core_worker/test/mock_worker.cc
@@ -106,7 +106,7 @@ class MockWorker {
     // Merge all the content from input args.
     std::vector<uint8_t> buffer;
     for (const auto &arg : args) {
-      auto &data = arg->GetData();
+      auto data = arg->GetData();
       buffer.insert(buffer.end(), data->Data(), data->Data() + data->Size());
     }
     if (buffer.size() >= 8) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There're some compilation failures in core worker test when we build project using `bazel build //:all`. It seems broken and not integrated in CI.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
