### PR TITLE
[scheduling-policy 1/n] pass check-node-liveness by constructor

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -33,7 +33,8 @@ ClusterResourceScheduler::ClusterResourceScheduler()
         cluster_resource_manager_->AddOrUpdateNode(local_node_id_, local_resource_update);
       });
   scheduling_policy_ = std::make_unique<raylet_scheduling_policy::SchedulingPolicy>(
-      local_node_id_, cluster_resource_manager_->GetResourceView());
+      local_node_id_, cluster_resource_manager_->GetResourceView(),
+      [this](auto node_id) { return this->NodeAlive(node_id); });
 }
 
 ClusterResourceScheduler::ClusterResourceScheduler(
@@ -49,7 +50,8 @@ ClusterResourceScheduler::ClusterResourceScheduler(
       });
   cluster_resource_manager_->AddOrUpdateNode(local_node_id_, local_node_resources);
   scheduling_policy_ = std::make_unique<raylet_scheduling_policy::SchedulingPolicy>(
-      local_node_id_, cluster_resource_manager_->GetResourceView());
+      local_node_id_, cluster_resource_manager_->GetResourceView(),
+      [this](auto node_id) { return this->NodeAlive(node_id); });
 }
 
 ClusterResourceScheduler::ClusterResourceScheduler(
@@ -68,7 +70,8 @@ ClusterResourceScheduler::ClusterResourceScheduler(
       });
   cluster_resource_manager_->AddOrUpdateNode(local_node_id_, node_resources);
   scheduling_policy_ = std::make_unique<raylet_scheduling_policy::SchedulingPolicy>(
-      local_node_id_, cluster_resource_manager_->GetResourceView());
+      local_node_id_, cluster_resource_manager_->GetResourceView(),
+      [this](auto node_id) { return this->NodeAlive(node_id); });
 }
 
 bool ClusterResourceScheduler::NodeAlive(scheduling::NodeID node_id) const {
@@ -98,23 +101,20 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
   // The zero cpu actor is a special case that must be handled the same way by all
   // scheduling policies.
   if (actor_creation && resource_request.IsEmpty()) {
-    return scheduling_policy_->RandomPolicy(
-        resource_request, [this](auto node_id) { return this->NodeAlive(node_id); });
+    return scheduling_policy_->RandomPolicy(resource_request);
   }
 
   auto best_node_id = scheduling::NodeID::Nil();
   if (scheduling_strategy.scheduling_strategy_case() ==
       rpc::SchedulingStrategy::SchedulingStrategyCase::kSpreadSchedulingStrategy) {
-    best_node_id = scheduling_policy_->SpreadPolicy(
-        resource_request, force_spillback, force_spillback,
-        [this](auto node_id) { return this->NodeAlive(node_id); });
+    best_node_id = scheduling_policy_->SpreadPolicy(resource_request, force_spillback,
+                                                    force_spillback);
   } else {
     // TODO (Alex): Setting require_available == force_spillback is a hack in order to
     // remain bug compatible with the legacy scheduling algorithms.
     best_node_id = scheduling_policy_->HybridPolicy(
         resource_request, RayConfig::instance().scheduler_spread_threshold(),
-        force_spillback, force_spillback,
-        [this](auto node_id) { return this->NodeAlive(node_id); });
+        force_spillback, force_spillback);
   }
 
   *is_infeasible = best_node_id.IsNil();

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -26,10 +26,12 @@ namespace raylet_scheduling_policy {
 class SchedulingPolicy {
  public:
   SchedulingPolicy(scheduling::NodeID local_node_id,
-                   const absl::flat_hash_map<scheduling::NodeID, Node> &nodes)
+                   const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
+                   std::function<bool(scheduling::NodeID)> is_node_available)
       : local_node_id_(local_node_id),
         nodes_(nodes),
-        gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
+        gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
+        is_node_available_(is_node_available) {}
 
   /// This scheduling policy was designed with the following assumptions in mind:
   ///   1. Scheduling a task on a new node incurs a cold start penalty (warming the worker
@@ -66,21 +68,17 @@ class SchedulingPolicy {
   scheduling::NodeID HybridPolicy(
       const ResourceRequest &resource_request, float spread_threshold,
       bool force_spillback, bool require_available,
-      std::function<bool(scheduling::NodeID)> is_node_available,
       bool scheduler_avoid_gpu_nodes = RayConfig::instance().scheduler_avoid_gpu_nodes());
 
   /// Round robin among available nodes.
   /// If there are no available nodes, fallback to hybrid policy.
-  scheduling::NodeID SpreadPolicy(
-      const ResourceRequest &resource_request, bool force_spillback,
-      bool require_available, std::function<bool(scheduling::NodeID)> is_node_available);
+  scheduling::NodeID SpreadPolicy(const ResourceRequest &resource_request,
+                                  bool force_spillback, bool require_available);
 
   /// Policy that "randomly" picks a node that could fulfil the request.
   /// TODO(scv119): if there are a lot of nodes died or can't fulfill the resource
   /// requirement, the distribution might not be even.
-  scheduling::NodeID RandomPolicy(
-      const ResourceRequest &resource_request,
-      std::function<bool(scheduling::NodeID)> is_node_available);
+  scheduling::NodeID RandomPolicy(const ResourceRequest &resource_request);
 
  private:
   /// Identifier of local node.
@@ -94,6 +92,8 @@ class SchedulingPolicy {
   size_t spread_scheduling_next_index_ = 0;
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
+  /// Function Checks if node is alive.
+  std::function<bool(scheduling::NodeID)> is_node_available_;
 
   enum class NodeFilter {
     /// Default scheduling.
@@ -113,11 +113,10 @@ class SchedulingPolicy {
   ///
   /// \return -1 if the task is unfeasible, otherwise the node id (key in `nodes`) to
   /// schedule on.
-  scheduling::NodeID HybridPolicyWithFilter(
-      const ResourceRequest &resource_request, float spread_threshold,
-      bool force_spillback, bool require_available,
-      std::function<bool(scheduling::NodeID)> is_node_available,
-      NodeFilter node_filter = NodeFilter::kAny);
+  scheduling::NodeID HybridPolicyWithFilter(const ResourceRequest &resource_request,
+                                            float spread_threshold, bool force_spillback,
+                                            bool require_available,
+                                            NodeFilter node_filter = NodeFilter::kAny);
 };
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy_test.cc
@@ -52,18 +52,16 @@ TEST_F(SchedulingPolicyTest, SpreadPolicyTest) {
   nodes.emplace(remote_node_2, CreateNodeResources(0, 0, 0, 0, 0, 0));
   nodes.emplace(remote_node_3, CreateNodeResources(20, 20, 0, 0, 0, 0));
 
-  raylet_scheduling_policy::SchedulingPolicy scheduling_policy(local_node, nodes);
+  raylet_scheduling_policy::SchedulingPolicy scheduling_policy(local_node, nodes,
+                                                               [](auto) { return true; });
 
-  auto to_schedule =
-      scheduling_policy.SpreadPolicy(req, false, false, [](auto) { return true; });
+  auto to_schedule = scheduling_policy.SpreadPolicy(req, false, false);
   ASSERT_EQ(to_schedule, local_node);
 
-  to_schedule =
-      scheduling_policy.SpreadPolicy(req, false, false, [](auto) { return true; });
+  to_schedule = scheduling_policy.SpreadPolicy(req, false, false);
   ASSERT_EQ(to_schedule, remote_node_3);
 
-  to_schedule = scheduling_policy.SpreadPolicy(req, /*force_spillback=*/true, false,
-                                               [](auto) { return true; });
+  to_schedule = scheduling_policy.SpreadPolicy(req, /*force_spillback=*/true, false);
   ASSERT_EQ(to_schedule, remote_node_3);
 }
 
@@ -77,13 +75,14 @@ TEST_F(SchedulingPolicyTest, RandomPolicyTest) {
   // Infeasible node
   nodes.emplace(remote_node_3, CreateNodeResources(0, 0, 0, 0, 0, 0));
 
-  raylet_scheduling_policy::SchedulingPolicy scheduling_policy(local_node, nodes);
+  raylet_scheduling_policy::SchedulingPolicy scheduling_policy(local_node, nodes,
+                                                               [](auto) { return true; });
 
   std::map<scheduling::NodeID, size_t> decisions;
   size_t num_node_0_picks = 0;
   size_t num_node_1_picks = 0;
   for (int i = 0; i < 1000; i++) {
-    auto to_schedule = scheduling_policy.RandomPolicy(req, [](auto) { return true; });
+    auto to_schedule = scheduling_policy.RandomPolicy(req);
     ASSERT_TRUE(to_schedule.ToInt() >= 0);
     ASSERT_TRUE(to_schedule.ToInt() <= 1);
     if (to_schedule.ToInt() == 0) {
@@ -190,8 +189,9 @@ TEST_F(SchedulingPolicyTest, AvailableTruncationTest) {
   nodes.emplace(remote_node, CreateNodeResources(0.75, 2, 0, 0, 0, 0));
 
   auto to_schedule =
-      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-          .HybridPolicy(req, 0.51, false, false, [](auto) { return true; });
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.51, false, false);
   ASSERT_EQ(to_schedule, local_node);
 }
 
@@ -204,8 +204,9 @@ TEST_F(SchedulingPolicyTest, AvailableTieBreakTest) {
   nodes.emplace(remote_node, CreateNodeResources(1.5, 2, 0, 0, 0, 0));
 
   auto to_schedule =
-      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.50, false, false);
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -218,8 +219,9 @@ TEST_F(SchedulingPolicyTest, AvailableOverFeasibleTest) {
   nodes.emplace(remote_node, CreateNodeResources(1, 10, 0, 0, 1, 1));
 
   auto to_schedule =
-      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.50, false, false);
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -230,8 +232,9 @@ TEST_F(SchedulingPolicyTest, InfeasibleTest) {
   nodes.emplace(remote_node, CreateNodeResources(1, 10, 0, 0, 0, 0));
 
   auto to_schedule =
-      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.50, false, false);
   ASSERT_TRUE(to_schedule.IsNil());
 }
 
@@ -243,8 +246,9 @@ TEST_F(SchedulingPolicyTest, BarelyFeasibleTest) {
   nodes.emplace(local_node, CreateNodeResources(0, 1, 0, 0, 0, 1));
 
   auto to_schedule =
-      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-          .HybridPolicy(req, 0.50, false, false, [](auto) { return true; });
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.50, false, false);
   ASSERT_EQ(to_schedule, local_node);
 }
 
@@ -256,8 +260,9 @@ TEST_F(SchedulingPolicyTest, TruncationAcrossFeasibleNodesTest) {
   nodes.emplace(remote_node, CreateNodeResources(0.75, 2, 0, 0, 0, 1));
 
   auto to_schedule =
-      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-          .HybridPolicy(req, 0.51, false, false, [](auto) { return true; });
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.51, false, false);
   ASSERT_EQ(to_schedule, local_node);
 }
 
@@ -268,8 +273,10 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackIfAvailableTest) {
   nodes.emplace(local_node, CreateNodeResources(2, 2, 0, 0, 1, 1));
   nodes.emplace(remote_node, CreateNodeResources(1, 10, 0, 0, 1, 10));
 
-  auto to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                         .HybridPolicy(req, 0.51, true, true, [](auto) { return true; });
+  auto to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.51, true, true);
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -282,28 +289,29 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
     // non GPU, and the remote node does not have GPUs, thus
     // we should schedule on remote node.
     const ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
-    const auto to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                                 .HybridPolicy(
-                                     ResourceMapToResourceRequest({{"CPU", 1}}, false),
-                                     0.51, false, true, [](auto) { return true; }, true);
+    const auto to_schedule =
+        raylet_scheduling_policy::SchedulingPolicy(local_node, nodes,
+                                                   [](auto) { return true; })
+            .HybridPolicy(ResourceMapToResourceRequest({{"CPU", 1}}, false), 0.51, false,
+                          true, true);
     ASSERT_EQ(to_schedule, remote_node);
   }
   {
     // A GPU request should be scheduled on a GPU node.
     const ResourceRequest req = ResourceMapToResourceRequest({{"GPU", 1}}, false);
     const auto to_schedule =
-        raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-            .HybridPolicy(
-                req, 0.51, false, true, [](auto) { return true; }, true);
+        raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+          return true;
+        }).HybridPolicy(req, 0.51, false, true, true);
     ASSERT_EQ(to_schedule, local_node);
   }
   {
     // A CPU request can be be scheduled on a CPU node.
     const ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
     const auto to_schedule =
-        raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-            .HybridPolicy(
-                req, 0.51, false, true, [](auto) { return true; }, true);
+        raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+          return true;
+        }).HybridPolicy(req, 0.51, false, true, true);
     ASSERT_EQ(to_schedule, remote_node);
   }
   {
@@ -311,9 +319,9 @@ TEST_F(SchedulingPolicyTest, AvoidSchedulingCPURequestsOnGPUNodes) {
     const ResourceRequest req =
         ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
     const auto to_schedule =
-        raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-            .HybridPolicy(
-                req, 0.51, false, true, [](auto) { return true; }, true);
+        raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+          return true;
+        }).HybridPolicy(req, 0.51, false, true, true);
     ASSERT_EQ(to_schedule, local_node);
   }
 }
@@ -326,9 +334,9 @@ TEST_F(SchedulingPolicyTest, SchedulenCPURequestsOnGPUNodeAsALastResort) {
   nodes.emplace(remote_node, CreateNodeResources(1, 1, 0, 0, 1, 1));
 
   const auto to_schedule =
-      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-          .HybridPolicy(
-              req, 0.51, false, true, [](auto) { return true; }, true);
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.51, false, true, true);
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -339,8 +347,10 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackTest) {
   nodes.emplace(local_node, CreateNodeResources(2, 2, 0, 0, 1, 1));
   nodes.emplace(remote_node, CreateNodeResources(0, 2, 0, 0, 0, 1));
 
-  auto to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                         .HybridPolicy(req, 0.51, true, false, [](auto) { return true; });
+  auto to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.51, true, false);
   ASSERT_EQ(to_schedule, remote_node);
 }
 
@@ -352,8 +362,10 @@ TEST_F(SchedulingPolicyTest, ForceSpillbackOnlyFeasibleLocallyTest) {
   nodes.emplace(local_node, CreateNodeResources(2, 2, 0, 0, 1, 1));
   nodes.emplace(remote_node, CreateNodeResources(0, 2, 0, 0, 0, 0));
 
-  auto to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                         .HybridPolicy(req, 0.51, true, false, [](auto) { return true; });
+  auto to_schedule =
+      raylet_scheduling_policy::SchedulingPolicy(local_node, nodes, [](auto) {
+        return true;
+      }).HybridPolicy(req, 0.51, true, false);
   ASSERT_TRUE(to_schedule.IsNil());
 }
 
@@ -368,31 +380,31 @@ TEST_F(SchedulingPolicyTest, NonGpuNodePreferredSchedulingTest) {
   nodes.emplace(remote_node_2, CreateNodeResources(3, 3, 0, 0, 0, 0));
 
   ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
-  auto to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                         .HybridPolicy(
-                             req, 0.51, false, true, [](auto) { return true; },
-                             /*gpu_avoid_scheduling*/ true);
+  auto to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes,
+                                                                [](auto) { return true; })
+                         .HybridPolicy(req, 0.51, false, true,
+                                       /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, remote_node);
 
   req = ResourceMapToResourceRequest({{"CPU", 3}}, false);
-  to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                    .HybridPolicy(
-                        req, 0.51, false, true, [](auto) { return true; },
-                        /*gpu_avoid_scheduling*/ true);
+  to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes,
+                                                           [](auto) { return true; })
+                    .HybridPolicy(req, 0.51, false, true,
+                                  /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, remote_node_2);
 
   req = ResourceMapToResourceRequest({{"CPU", 1}, {"GPU", 1}}, false);
-  to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                    .HybridPolicy(
-                        req, 0.51, false, true, [](auto) { return true; },
-                        /*gpu_avoid_scheduling*/ true);
+  to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes,
+                                                           [](auto) { return true; })
+                    .HybridPolicy(req, 0.51, false, true,
+                                  /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, local_node);
 
   req = ResourceMapToResourceRequest({{"CPU", 2}}, false);
-  to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes)
-                    .HybridPolicy(
-                        req, 0.51, false, true, [](auto) { return true; },
-                        /*gpu_avoid_scheduling*/ true);
+  to_schedule = raylet_scheduling_policy::SchedulingPolicy(local_node, nodes,
+                                                           [](auto) { return true; })
+                    .HybridPolicy(req, 0.51, false, true,
+                                  /*gpu_avoid_scheduling*/ true);
   ASSERT_EQ(to_schedule, remote_node);
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As title. Clean up the scheduling-policy interface.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
