### PR TITLE
[scheduling-policy 2/n] refactor scheduling policy API

### DIFF
--- a/src/ray/raylet/scheduling/scheduling_options.h
+++ b/src/ray/raylet/scheduling/scheduling_options.h
@@ -1,0 +1,76 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/common/ray_config.h"
+
+namespace ray {
+namespace raylet {
+class SchedulingPolicyTest;
+}
+namespace raylet_scheduling_policy {
+
+// Different scheduling types. Please refer to
+// scheduling_policy.h to see detailed behaviors.
+enum class SchedulingType {
+  HYBRID = 0,
+  SPREAD = 1,
+  RANDOM = 2,
+};
+
+// Options that controls the scheduling behavior.
+struct SchedulingOptions {
+  static SchedulingOptions Random() {
+    return SchedulingOptions(SchedulingType::RANDOM,
+                             /*spread_threshold*/ 0, /*avoid_local_node*/ false,
+                             /*require_node_available*/ true,
+                             /*avoid_gpu_nodes*/ false);
+  }
+
+  // construct option for spread scheduling policy.
+  static SchedulingOptions Spread(bool avoid_local_node, bool require_node_available) {
+    return SchedulingOptions(SchedulingType::SPREAD,
+                             /*spread_threshold*/ 0, avoid_local_node,
+                             require_node_available,
+                             RayConfig::instance().scheduler_avoid_gpu_nodes());
+  }
+
+  // construct option for hybrid scheduling policy.
+  static SchedulingOptions Hybrid(bool avoid_local_node, bool require_node_available) {
+    return SchedulingOptions(SchedulingType::HYBRID,
+                             RayConfig::instance().scheduler_spread_threshold(),
+                             avoid_local_node, require_node_available,
+                             RayConfig::instance().scheduler_avoid_gpu_nodes());
+  }
+
+  SchedulingType scheduling_type;
+  float spread_threshold;
+  bool avoid_local_node;
+  bool require_node_available;
+  bool avoid_gpu_nodes;
+
+ private:
+  SchedulingOptions(SchedulingType type, float spread_threshold, bool avoid_local_node,
+                    bool require_node_available, bool avoid_gpu_nodes)
+      : scheduling_type(type),
+        spread_threshold(spread_threshold),
+        avoid_local_node(avoid_local_node),
+        require_node_available(require_node_available),
+        avoid_gpu_nodes(avoid_gpu_nodes) {}
+
+  friend class ::ray::raylet::SchedulingPolicyTest;
+};
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -17,6 +17,7 @@
 #include <functional>
 
 #include "ray/util/container_util.h"
+#include "ray/util/util.h"
 
 namespace ray {
 
@@ -38,9 +39,27 @@ bool DoesNodeHaveGPUs(const NodeResources &resources) {
 }
 }  // namespace
 
+scheduling::NodeID SchedulingPolicy::Schedule(const ResourceRequest &resource_request,
+                                              SchedulingOptions options) {
+  switch (options.scheduling_type) {
+  case SchedulingType::SPREAD:
+    return SpreadPolicy(resource_request, options);
+  case SchedulingType::RANDOM:
+    return RandomPolicy(resource_request, options);
+  case SchedulingType::HYBRID:
+    return HybridPolicy(resource_request, options);
+  default:
+    RAY_LOG(FATAL) << "Unsupported scheduling type: "
+                   << static_cast<typename std::underlying_type<SchedulingType>::type>(
+                          options.scheduling_type);
+  }
+  UNREACHABLE;
+}
+
 scheduling::NodeID SchedulingPolicy::SpreadPolicy(const ResourceRequest &resource_request,
-                                                  bool force_spillback,
-                                                  bool require_available) {
+                                                  SchedulingOptions options) {
+  RAY_CHECK(options.spread_threshold == 0)
+      << "SpreadPolicy policy requires spread_threshold = 0";
   std::vector<scheduling::NodeID> round;
   round.reserve(nodes_.size());
   for (const auto &pair : nodes_) {
@@ -52,7 +71,7 @@ scheduling::NodeID SchedulingPolicy::SpreadPolicy(const ResourceRequest &resourc
   for (size_t i = 0; i < round.size(); ++i, ++round_index) {
     const auto &node_id = round[round_index % round.size()];
     const auto &node = map_find_or_die(nodes_, node_id);
-    if (node_id == local_node_id_ && force_spillback) {
+    if (node_id == local_node_id_ && options.avoid_local_node) {
       continue;
     }
     if (!is_node_available_(node_id) ||
@@ -65,12 +84,12 @@ scheduling::NodeID SchedulingPolicy::SpreadPolicy(const ResourceRequest &resourc
     return node_id;
   }
 
-  return HybridPolicy(resource_request, 0, force_spillback, require_available);
+  return HybridPolicy(resource_request, options);
 }
 
 scheduling::NodeID SchedulingPolicy::HybridPolicyWithFilter(
     const ResourceRequest &resource_request, float spread_threshold, bool force_spillback,
-    bool require_available, NodeFilter node_filter) {
+    bool require_node_available, NodeFilter node_filter) {
   // Step 1: Generate the traversal order. We guarantee that the first node is local, to
   // encourage local scheduling. The rest of the traversal order should be globally
   // consistent, to encourage using "warm" workers.
@@ -163,7 +182,7 @@ scheduling::NodeID SchedulingPolicy::HybridPolicyWithFilter(
       }
     } else if (!best_is_available &&
                critical_resource_utilization < best_utilization_score &&
-               !require_available) {
+               !require_node_available) {
       // Pick the best feasible node by critical resource utilization.
       update_best_node = true;
     }
@@ -179,35 +198,40 @@ scheduling::NodeID SchedulingPolicy::HybridPolicyWithFilter(
 }
 
 scheduling::NodeID SchedulingPolicy::HybridPolicy(const ResourceRequest &resource_request,
-                                                  float spread_threshold,
-                                                  bool force_spillback,
-                                                  bool require_available,
-                                                  bool scheduler_avoid_gpu_nodes) {
-  if (!scheduler_avoid_gpu_nodes || IsGPURequest(resource_request)) {
-    return HybridPolicyWithFilter(resource_request, spread_threshold, force_spillback,
-                                  require_available);
+                                                  SchedulingOptions options) {
+  if (!options.avoid_gpu_nodes || IsGPURequest(resource_request)) {
+    return HybridPolicyWithFilter(resource_request, options.spread_threshold,
+                                  options.avoid_local_node,
+                                  options.require_node_available);
   }
 
   // Try schedule on non-GPU nodes.
-  auto best_node_id =
-      HybridPolicyWithFilter(resource_request, spread_threshold, force_spillback,
-                             /*require_available*/ true, NodeFilter::kNonGpu);
+  auto best_node_id = HybridPolicyWithFilter(
+      resource_request, options.spread_threshold, options.avoid_local_node,
+      /*require_node_available*/ true, NodeFilter::kNonGpu);
   if (!best_node_id.IsNil()) {
     return best_node_id;
   }
 
   // If we cannot find any available node from non-gpu nodes, fallback to the original
   // scheduling
-  return HybridPolicyWithFilter(resource_request, spread_threshold, force_spillback,
-                                require_available);
+  return HybridPolicyWithFilter(resource_request, options.spread_threshold,
+                                options.avoid_local_node, options.require_node_available);
 }
 
-scheduling::NodeID SchedulingPolicy::RandomPolicy(
-    const ResourceRequest &resource_request) {
+scheduling::NodeID SchedulingPolicy::RandomPolicy(const ResourceRequest &resource_request,
+                                                  SchedulingOptions options) {
   scheduling::NodeID best_node = scheduling::NodeID::Nil();
   if (nodes_.empty()) {
     return best_node;
   }
+
+  RAY_CHECK(options.spread_threshold == 0 && !options.avoid_local_node &&
+            options.require_node_available && !options.avoid_gpu_nodes)
+      << "Random policy requires spread_threshold = 0, "
+      << "avoid_local_node = false, "
+      << "require_node_available = true, "
+      << "avoid_gpu_nodes = false.";
 
   std::uniform_int_distribution<int> distribution(0, nodes_.size() - 1);
   int idx = distribution(gen_);

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -19,6 +19,7 @@
 #include "ray/common/ray_config.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 #include "ray/raylet/scheduling/cluster_resource_data.h"
+#include "ray/raylet/scheduling/scheduling_options.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
@@ -33,6 +34,10 @@ class SchedulingPolicy {
         gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
         is_node_available_(is_node_available) {}
 
+  scheduling::NodeID Schedule(const ResourceRequest &resource_request,
+                              SchedulingOptions options);
+
+ private:
   /// This scheduling policy was designed with the following assumptions in mind:
   ///   1. Scheduling a task on a new node incurs a cold start penalty (warming the worker
   ///   pool).
@@ -65,22 +70,20 @@ class SchedulingPolicy {
   ///
   /// \return -1 if the task is unfeasible, otherwise the node id (key in `nodes`) to
   /// schedule on.
-  scheduling::NodeID HybridPolicy(
-      const ResourceRequest &resource_request, float spread_threshold,
-      bool force_spillback, bool require_available,
-      bool scheduler_avoid_gpu_nodes = RayConfig::instance().scheduler_avoid_gpu_nodes());
+  scheduling::NodeID HybridPolicy(const ResourceRequest &resource_request,
+                                  SchedulingOptions options);
 
   /// Round robin among available nodes.
   /// If there are no available nodes, fallback to hybrid policy.
   scheduling::NodeID SpreadPolicy(const ResourceRequest &resource_request,
-                                  bool force_spillback, bool require_available);
+                                  SchedulingOptions options);
 
   /// Policy that "randomly" picks a node that could fulfil the request.
   /// TODO(scv119): if there are a lot of nodes died or can't fulfill the resource
   /// requirement, the distribution might not be even.
-  scheduling::NodeID RandomPolicy(const ResourceRequest &resource_request);
+  scheduling::NodeID RandomPolicy(const ResourceRequest &resource_request,
+                                  SchedulingOptions options);
 
- private:
   /// Identifier of local node.
   const scheduling::NodeID local_node_id_;
   /// List of nodes in the clusters and their resources organized as a map.

--- a/src/ray/raylet/scheduling/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/scheduling_policy.h
@@ -64,12 +64,10 @@ class SchedulingPolicy {
   /// will act like a traditional weighted round robin.
   ///
   /// \param resource_request: The resource request we're attempting to schedule.
-  /// \param scheduler_avoid_gpu_nodes: if set, we would try scheduling
-  /// CPU-only requests on CPU-only nodes, and will fallback to scheduling on GPU nodes if
-  /// needed.
+  /// \param scheduling_options: scheduling options.
   ///
-  /// \return -1 if the task is unfeasible, otherwise the node id (key in `nodes`) to
-  /// schedule on.
+  /// \return NodeID::Nil() if the task is unfeasible, otherwise the node id
+  /// to schedule on.
   scheduling::NodeID HybridPolicy(const ResourceRequest &resource_request,
                                   SchedulingOptions options);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Introduce SchedulingOptions to control the scheduling behavior. With this options we can unify the scheduling policy API into following
```
  scheduling::NodeID Schedule(const ResourceRequest &resource_request,
                              SchedulingOptions options);
```

This PR depends on #22880

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
