### PR TITLE
[Core] make StringIdMap thread safe

### DIFF
--- a/src/ray/raylet/scheduling/scheduling_ids.h
+++ b/src/ray/raylet/scheduling/scheduling_ids.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
 #include "ray/util/logging.h"
 #include "ray/util/util.h"
 
@@ -40,6 +41,7 @@ class StringIdMap {
   absl::flat_hash_map<std::string, int64_t> string_to_int_;
   absl::flat_hash_map<int64_t, std::string> int_to_string_;
   std::hash<std::string> hasher_;
+  mutable absl::Mutex mutex_;
 
  public:
   StringIdMap(){};
@@ -86,13 +88,13 @@ enum class SchedulingIDTag { Node, Resource };
 template <SchedulingIDTag T>
 class BaseSchedulingID {
  public:
-  explicit BaseSchedulingID(const std::string &name) : id_{GetMap()->Insert(name)} {}
+  explicit BaseSchedulingID(const std::string &name) : id_{GetMap().Insert(name)} {}
 
   explicit BaseSchedulingID(int64_t id) : id_{id} {}
 
   int64_t ToInt() const { return id_; }
 
-  std::string Binary() const { return GetMap()->Get(id_); }
+  std::string Binary() const { return GetMap().Get(id_); }
 
   bool operator==(const BaseSchedulingID &rhs) const { return id_ == rhs.id_; }
 
@@ -106,8 +108,8 @@ class BaseSchedulingID {
 
  private:
   /// Meyer's singleton to store the StringIdMap.
-  static ThreadPrivate<StringIdMap> &GetMap() {
-    static ThreadPrivate<StringIdMap> map;
+  static StringIdMap &GetMap() {
+    static StringIdMap map;
     return map;
   }
   int64_t id_ = -1;
@@ -129,15 +131,16 @@ inline std::ostream &operator<<(
 /// Specialization for SchedulingIDTag. Specifically, we populate
 /// the singleton map with PredefinedResources.
 template <>
-inline ThreadPrivate<StringIdMap> &BaseSchedulingID<SchedulingIDTag::Resource>::GetMap() {
-  static ThreadPrivate<StringIdMap> map{[]() {
-    StringIdMap map;
-    return map.InsertOrDie(kCPU_ResourceLabel, CPU)
+inline StringIdMap &BaseSchedulingID<SchedulingIDTag::Resource>::GetMap() {
+  static std::unique_ptr<StringIdMap> map{[]() {
+    std::unique_ptr<StringIdMap> map(new StringIdMap());
+    map->InsertOrDie(kCPU_ResourceLabel, CPU)
         .InsertOrDie(kGPU_ResourceLabel, GPU)
         .InsertOrDie(kObjectStoreMemory_ResourceLabel, OBJECT_STORE_MEM)
         .InsertOrDie(kMemory_ResourceLabel, MEM);
+    return map;
   }()};
-  return map;
+  return *map;
 }
 
 namespace scheduling {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Another PR(https://github.com/ray-project/ray/pull/22817) refactoring the legacy resource data structure from `ResourceSet` to `ResourceRequest` and from `SchedulingResources` to `Node`, which depends on `scheduling::ResourceID`.

But, the `StringIdMap` is wrapped by `ThreadPrivate` inside `BaseSchedulingID`, which means the `scheduling::ResourceID` and `scheduling::NodeID` can only be visited in one single thread. However, many C++ UTs have such a scenario: restarting the GCS server multiple times in the same process, each restart will reset the `GcsServer` object and change a new thread, which will cause multiple threads to access StringIdMap in the different time.

Beside, the GCS may have multi-threads in the future, it is possible that in the future there will be multiple threads accessing the `StringIdMap`

So, this PR make `StringIdMap` thread safe.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
