### PR TITLE
[Datasets] Support dataset metadata provider callbacks in read APIs.

### DIFF
--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -9,13 +9,20 @@ from ray.data.datasource.datasource import (
 from ray.data.datasource.json_datasource import JSONDatasource
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.datasource.numpy_datasource import NumpyDatasource
-from ray.data.datasource.parquet_datasource import ParquetDatasource
+from ray.data.datasource.parquet_datasource import (
+    ParquetDatasource,
+    ParquetBlockMetadataProvider,
+    DefaultParquetBlockMetadataProvider,
+)
 from ray.data.datasource.binary_datasource import BinaryDatasource
 from ray.data.datasource.file_based_datasource import (
     FileBasedDatasource,
     _S3FileSystemWrapper,
     BlockWritePathProvider,
     DefaultBlockWritePathProvider,
+    BlockMetadataProvider,
+    BaseBlockMetadataProvider,
+    DefaultBlockMetadataProvider,
 )
 
 __all__ = [
@@ -34,4 +41,9 @@ __all__ = [
     "WriteResult",
     "BlockWritePathProvider",
     "DefaultBlockWritePathProvider",
+    "BlockMetadataProvider",
+    "BaseBlockMetadataProvider",
+    "DefaultBlockMetadataProvider",
+    "ParquetBlockMetadataProvider",
+    "DefaultParquetBlockMetadataProvider",
 ]

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -11,8 +11,8 @@ from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.datasource.numpy_datasource import NumpyDatasource
 from ray.data.datasource.parquet_datasource import (
     ParquetDatasource,
-    ParquetBlockMetadataProvider,
-    DefaultParquetBlockMetadataProvider,
+    ParquetMetadataProvider,
+    DefaultParquetMetadataProvider,
 )
 from ray.data.datasource.binary_datasource import BinaryDatasource
 from ray.data.datasource.file_based_datasource import (
@@ -20,10 +20,10 @@ from ray.data.datasource.file_based_datasource import (
     _S3FileSystemWrapper,
     BlockWritePathProvider,
     DefaultBlockWritePathProvider,
-    BlockMetadataProvider,
-    BaseBlockMetadataProvider,
-    DefaultBlockMetadataProvider,
+    BaseFileMetadataProvider,
+    DefaultFileMetadataProvider,
 )
+from ray.data.datasource.file_meta_provider import FileMetadataProvider
 
 __all__ = [
     "JSONDatasource",
@@ -41,9 +41,9 @@ __all__ = [
     "WriteResult",
     "BlockWritePathProvider",
     "DefaultBlockWritePathProvider",
-    "BlockMetadataProvider",
-    "BaseBlockMetadataProvider",
-    "DefaultBlockMetadataProvider",
-    "ParquetBlockMetadataProvider",
-    "DefaultParquetBlockMetadataProvider",
+    "FileMetadataProvider",
+    "BaseFileMetadataProvider",
+    "DefaultFileMetadataProvider",
+    "ParquetMetadataProvider",
+    "DefaultParquetMetadataProvider",
 ]

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -1,0 +1,48 @@
+from typing import (
+    List,
+    Optional,
+    Union,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    import pyarrow
+
+from ray.data.block import BlockMetadata
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class FileMetadataProvider:
+    """Abstract callable that provides metadata for files in a list of paths.
+
+    Current subclasses:
+        BaseFileMetadataProvider
+        ParquetMetadataProvider
+    """
+
+    def _get_block_metadata(
+        self,
+        paths: List[str],
+        schema: Optional[Union[type, "pyarrow.lib.Schema"]],
+        **kwargs,
+    ) -> BlockMetadata:
+        """Resolves and returns block metadata for files in the given paths.
+
+        Args:
+            paths: The paths to aggregate block metadata across.
+            schema: The user-provided or inferred schema for the given paths,
+                if any.
+
+        Returns:
+            BlockMetadata aggregated across the given paths.
+        """
+        raise NotImplementedError
+
+    def __call__(
+        self,
+        paths: List[str],
+        schema: Optional[Union[type, "pyarrow.lib.Schema"]],
+        **kwargs,
+    ) -> BlockMetadata:
+        return self._get_block_metadata(paths, schema, **kwargs)

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -3,6 +3,7 @@ import itertools
 from typing import Any, Callable, Dict, Optional, List, Union, Iterator, TYPE_CHECKING
 
 import numpy as np
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
@@ -13,6 +14,7 @@ from ray.data.block import Block, BlockAccessor
 from ray.data.context import DatasetContext
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_based_datasource import (
+    BlockMetadataProvider,
     FileBasedDatasource,
     _resolve_paths_and_filesystem,
     _resolve_kwargs,
@@ -54,6 +56,108 @@ def _deregister_parquet_file_fragment_serialization():
     ray.util.deregister_serializer(ParquetFileFragment)
 
 
+@DeveloperAPI
+class ParquetBlockMetadataProvider(BlockMetadataProvider):
+    """Abstract callable that provides block metadata for datasources
+    constructed from Arrow Parquet file fragments (e.g. ParquetDatasource).
+    Supports optional pre-fetching of ordered metadata for all file fragments
+    in a single batch to help optimize metadata resolution.
+
+    Current subclasses:
+        DefaultParquetBlockMetadataProvider
+    """
+
+    def _get_block_metadata(
+        self,
+        paths: List[str],
+        schema: Optional[Union[type, "pyarrow.lib.Schema"]],
+        *,
+        pieces: List["pyarrow.dataset.ParquetFileFragment"],
+        prefetched_metadata: Optional[List[Any]],
+    ) -> BlockMetadata:
+        """Resolves and returns block metadata for the given file paths.
+
+        Args:
+            paths: The file paths to aggregate block metadata across.
+            schema: The user-provided or inferred schema for the given file
+                paths, if any.
+            pieces: The Parquet file fragments derived from the input file paths.
+            prefetched_metadata: Metadata previously returned from
+                `prefetch_file_metadata()` for each file fragment, where
+                `prefetched_metadata[i]` contains the metadata for `pieces[i]`.
+
+        Returns:
+            BlockMetadata aggregated across the given file paths.
+        """
+        raise NotImplementedError
+
+    def prefetch_file_metadata(
+        self,
+        pieces: List["pyarrow.dataset.ParquetFileFragment"],
+    ) -> Optional[List[Any]]:
+        """Pre-fetches file metadata for all Parquet file fragments in a single
+        batch. Subsets of the metadata returned will be provided as input to
+        subsequent calls to _get_block-metadata() together with their
+        corresponding Parquet file fragments.
+
+        Implementations that don't support pre-fetching file metadata shouldn't
+        override this method.
+
+        Args:
+            pieces: The Parquet file fragments to fetch metadata for.
+
+        Returns:
+            Metadata resolved for each input file fragment, or `None`. Metadata
+            must be returned in the same order as all input file fragments, such
+            that `metadata[i]` always contains the metadata for `pieces[i]`.
+        """
+        return None
+
+
+class DefaultParquetBlockMetadataProvider(ParquetBlockMetadataProvider):
+    """The default block metadata provider for ParquetDatasource. Aggregates
+    total block bytes and number of rows using the Parquet file metadata
+    associated with a list of Arrow Parquet dataset file fragments."""
+
+    def _get_block_metadata(
+        self,
+        paths: List[str],
+        schema: Optional[Union[type, "pyarrow.lib.Schema"]],
+        *,
+        pieces: List["pyarrow.dataset.ParquetFileFragment"],
+        prefetched_metadata: Optional[List["pyarrow.parquet.FileMetaData"]],
+    ) -> BlockMetadata:
+        if prefetched_metadata and len(prefetched_metadata) == len(pieces):
+            # Piece metadata was available, construct a normal
+            # BlockMetadata.
+            block_metadata = BlockMetadata(
+                num_rows=sum(m.num_rows for m in prefetched_metadata),
+                size_bytes=sum(
+                    sum(m.row_group(i).total_byte_size for i in range(m.num_row_groups))
+                    for m in prefetched_metadata
+                ),
+                schema=schema,
+                input_files=paths,
+                exec_stats=None,
+            )  # Exec stats filled in later.
+        else:
+            # Piece metadata was not available, construct an empty
+            # BlockMetadata.
+            block_metadata = BlockMetadata(
+                num_rows=None, size_bytes=None, schema=schema, input_files=paths
+            )
+        return block_metadata
+
+    def prefetch_file_metadata(
+        self,
+        pieces: List["pyarrow.dataset.ParquetFileFragment"],
+    ) -> Optional[List["pyarrow.parquet.FileMetaData"]]:
+        if len(pieces) > PARALLELIZE_META_FETCH_THRESHOLD:
+            return _fetch_metadata_remotely(pieces)
+        else:
+            return _fetch_metadata(pieces)
+
+
 class ParquetDatasource(FileBasedDatasource):
     """Parquet datasource, for reading and writing Parquet files.
 
@@ -70,6 +174,7 @@ class ParquetDatasource(FileBasedDatasource):
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         columns: Optional[List[str]] = None,
         schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None,
+        meta_provider: ParquetBlockMetadataProvider = DefaultParquetBlockMetadataProvider(),
         _block_udf: Optional[Callable[[Block], Block]] = None,
         **reader_args,
     ) -> List[ReadTask]:
@@ -168,21 +273,23 @@ class ParquetDatasource(FileBasedDatasource):
         else:
             inferred_schema = schema
         read_tasks = []
-        if len(pq_ds.pieces) > PARALLELIZE_META_FETCH_THRESHOLD:
-            metadata = _fetch_metadata_remotely(pq_ds.pieces)
-        else:
-            metadata = _fetch_metadata(pq_ds.pieces)
-
+        metadata = meta_provider.prefetch_file_metadata(pq_ds.pieces) or []
         try:
             _register_parquet_file_fragment_serialization()
-            for piece_data in np.array_split(
-                list(zip(pq_ds.pieces, metadata)), parallelism
+            for pieces, metadata in zip(
+                np.array_split(pq_ds.pieces, parallelism),
+                np.array_split(metadata, parallelism),
             ):
-                if len(piece_data) == 0:
+                if len(pieces) <= 0:
                     continue
-                pieces, metadata = zip(*piece_data)
                 serialized_pieces = cloudpickle.dumps(pieces)
-                meta = _build_block_metadata(pieces, metadata, inferred_schema)
+                input_files = [p.path for p in pieces]
+                meta = meta_provider(
+                    input_files,
+                    schema,
+                    pieces=pieces,
+                    prefetched_metadata=metadata,
+                )
                 read_tasks.append(
                     ReadTask(lambda p=serialized_pieces: read_pieces(p), meta)
                 )
@@ -256,31 +363,3 @@ def _fetch_metadata(
         except AttributeError:
             break
     return piece_metadata
-
-
-def _build_block_metadata(
-    pieces: List["pyarrow.dataset.ParquetFileFragment"],
-    metadata: List["pyarrow.parquet.FileMetaData"],
-    schema: Optional[Union[type, "pyarrow.lib.Schema"]],
-) -> BlockMetadata:
-    input_files = [p.path for p in pieces]
-    if len(metadata) == len(pieces):
-        # Piece metadata was available, construct a normal
-        # BlockMetadata.
-        block_metadata = BlockMetadata(
-            num_rows=sum(m.num_rows for m in metadata),
-            size_bytes=sum(
-                sum(m.row_group(i).total_byte_size for i in range(m.num_row_groups))
-                for m in metadata
-            ),
-            schema=schema,
-            input_files=input_files,
-            exec_stats=None,
-        )  # Exec stats filled in later.
-    else:
-        # Piece metadata was not available, construct an empty
-        # BlockMetadata.
-        block_metadata = BlockMetadata(
-            num_rows=None, size_bytes=None, schema=schema, input_files=input_files
-        )
-    return block_metadata


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

These changes add Dataset Read API support for (1) specifying custom block metadata provider callbacks, and (2) skipping path expansion. When paired with a custom block metadata provider that maintains an in-memory cache of BlockMetadata for each input file path, these changes reduced average S3-based dataset read times for production [Redshift Manifests](https://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html) stored in Amazon's internal data catalog by over 90%.  A simple ParquetDatasource benchmark reading 144MM records across 100 ~70MiB (on-disk) Parquet files stored in S3 showed an ~75% reduction in read latency (from 4.62 seconds to 1.18 seconds on 2 r5n.8xlarge EC2 nodes).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/17220

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
