### PR TITLE
[RLlib] Changed if-block in the example callback to become more readable.

### DIFF
--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -80,7 +80,7 @@ class MyCallbacks(DefaultCallbacks):
     ):
         # Check if there are multiple episodes in a batch, i.e.
         # "batch_mode": "truncate_episodes".
-        if worker.sampler.sample_collector.multiple_episodes_in_batch:
+        if worker.policy_config["batch_mode"] == "truncate_episodes":
             # Make sure this episode is really done.
             assert episode.batch_builder.policy_collectors["default_policy"].batches[
                 -1


### PR DESCRIPTION
## Why are these changes needed?

It ensures that the example can also be run in `"batch_mode": "truncate_episodes"` and makes it for users less error-prone and transparent when they cosntruct their own custom callbacks from this example. 

## Related issue number
Closes #22683 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
