### PR TITLE
[Nightly tests] Migrate scalability tests to new infra

### DIFF
--- a/release/.buildkite/build_pipeline.py
+++ b/release/.buildkite/build_pipeline.py
@@ -82,13 +82,13 @@ CORE_NIGHTLY_TESTS = {
         SmokeTest("threaded_actors_stress_test"),
         "pg_long_running_performance_test",
     ],
-    "~/ray/benchmarks/benchmark_tests.yaml": [
-        "single_node",
-        "object_store",
-        "many_actors_smoke_test",
-        "many_tasks_smoke_test",
-        "many_pgs_smoke_test",
-    ],
+    # "~/ray/benchmarks/benchmark_tests.yaml": [
+    #     "single_node",
+    #     "object_store",
+    #     "many_actors_smoke_test",
+    #     "many_tasks_smoke_test",
+    #     "many_pgs_smoke_test",
+    # ],
     "~/ray/release/nightly_tests/dataset/dataset_test.yaml": [
         "inference",
         "shuffle_data_loader",
@@ -144,22 +144,22 @@ CORE_DAILY_TESTS = {
 }
 
 CORE_SCALABILITY_TESTS_DAILY = {
-    "~/ray/benchmarks/benchmark_tests.yaml": [
-        "many_actors",
-        "many_tasks",
-        "many_pgs",
-        "many_nodes",
-    ],
+    # "~/ray/benchmarks/benchmark_tests.yaml": [
+    #     "many_actors",
+    #     "many_tasks",
+    #     "many_pgs",
+    #     "many_nodes",
+    # ],
 }
 
 CORE_SCHEDULING_DAILY = {
-    "~/ray/benchmarks/benchmark_tests.yaml": [
-        "scheduling_test_many_0s_tasks_single_node",
-        "scheduling_test_many_0s_tasks_many_nodes",
-        # Reenable these two once we got right setup
-        # "scheduling_test_many_5s_tasks_single_node",
-        # "scheduling_test_many_5s_tasks_many_nodes",
-    ],
+    # "~/ray/benchmarks/benchmark_tests.yaml": [
+    #     "scheduling_test_many_0s_tasks_single_node",
+    #     "scheduling_test_many_0s_tasks_many_nodes",
+    #     # Reenable these two once we got right setup
+    #     # "scheduling_test_many_5s_tasks_single_node",
+    #     # "scheduling_test_many_5s_tasks_many_nodes",
+    # ],
     "~/ray/release/nightly_tests/nightly_tests.yaml": [
         "many_nodes_actor_test",
         "dask_on_ray_10gb_sort",

--- a/release/benchmarks/README.md
+++ b/release/benchmarks/README.md
@@ -1,0 +1,33 @@
+# Ray Scalability Envelope
+
+## Distributed Benchmarks
+
+All distributed tests are run on 64 nodes with 64 cores/node. Maximum number of nodes is achieved by adding 4 core nodes.
+
+| Dimension                                       | Quantity |
+| ---------                                       | -------- |
+| # nodes in cluster (with trivial task workload) | 250+     |
+| # actors in cluster (with trivial workload)     | 10k+     |
+| # simultaneously running tasks                  | 10k+     |
+| # simultaneously running placement groups       | 1k+      |
+
+## Object Store Benchmarks
+
+| Dimension                           | Quantity |
+| ---------                           | -------- |
+| 1 GiB object broadcast (# of nodes) | 50+      |
+
+
+## Single Node Benchmarks.
+
+All single node benchmarks are run on a single m4.16xlarge.
+
+| Dimension                                      | Quantity   |
+| ---------                                      | --------   |
+| # of object arguments to a single task         | 10000+     |
+| # of objects returned from a single task       | 3000+     |
+| # of plasma objects in a single `ray.get` call | 10000+     |
+| # of tasks queued on a single node             | 1,000,000+ |
+| Maximum `ray.get` numpy object size            | 100GiB+    |
+
+    

--- a/release/benchmarks/app_config.yaml
+++ b/release/benchmarks/app_config.yaml
@@ -1,0 +1,11 @@
+base_image: "anyscale/ray-ml:nightly-py37-gpu"
+env_vars: {}
+
+python:
+  pip_packages: []
+  conda_packages: []
+
+post_build_cmds:
+  - pip3 install tqdm || true
+  - pip3 uninstall ray -y && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/benchmarks/benchmark_tests.yaml
+++ b/release/benchmarks/benchmark_tests.yaml
@@ -1,0 +1,145 @@
+- name: single_node
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: single_node.yaml
+
+  run:
+    timeout: 12000
+    prepare: sleep 0
+    script: python single_node/test_single_node.py
+
+- name: object_store
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: object_store.yaml
+
+  run:
+    timeout: 3600
+    prepare: python distributed/wait_cluster.py --num-nodes=50
+    script: python object_store/test_object_store.py
+
+- name: many_actors
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: distributed.yaml
+
+  run:
+    timeout: 3600 # 1hr
+    prepare: python distributed/wait_cluster.py --num-nodes=65
+    script: python distributed/test_many_actors.py
+
+- name: many_actors_smoke_test
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: distributed_smoke_test.yaml
+
+  run:
+    timeout: 3600 # 1hr
+    prepare: python distributed/wait_cluster.py --num-nodes=2
+    script: SMOKE_TEST=1 python distributed/test_many_actors.py
+
+- name: many_tasks
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: distributed.yaml
+
+  run:
+    timeout: 3600 # 1hr
+    prepare: python distributed/wait_cluster.py --num-nodes=65
+    script: python distributed/test_many_tasks.py --num-tasks=10000
+
+- name: many_tasks_smoke_test
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: distributed_smoke_test.yaml
+
+  run:
+    timeout: 3600 # 1hr
+    prepare: python distributed/wait_cluster.py --num-nodes=2
+    script: python distributed/test_many_tasks.py --num-tasks=100
+
+- name: many_pgs
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: distributed.yaml
+
+  run:
+    timeout: 3600 # 1hr
+    prepare: python distributed/wait_cluster.py --num-nodes=65
+    script: python distributed/test_many_pgs.py
+
+- name: many_pgs_smoke_test
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: distributed_smoke_test.yaml
+
+  run:
+    timeout: 3600 # 1hr
+    prepare: python distributed/wait_cluster.py --num-nodes=2
+    script: SMOKE_TEST=1 python distributed/test_many_pgs.py
+
+# NOTE: No smoke test since this shares a script with the many_tasks_smoke_test
+- name: many_nodes
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: many_nodes.yaml
+
+  run:
+    timeout: 3600 # 1hr
+    prepare: python distributed/wait_cluster.py --num-nodes=250
+    script: python distributed/test_many_tasks.py --num-tasks=1000
+
+- name: scheduling_test_many_0s_tasks_single_node
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: scheduling.yaml
+
+  run:
+    timeout: 3600
+    prepare: python distributed/wait_cluster.py --num-nodes=32
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1 --task-duration-s=0 --total-num-actors=1 --num-actors-per-nodes=1
+
+- name: scheduling_test_many_0s_tasks_many_nodes
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: scheduling.yaml
+
+  run:
+    timeout: 3600
+    prepare: python distributed/wait_cluster.py --num-nodes=32
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1 --task-duration-s=0 --total-num-actors=32 --num-actors-per-nodes=1
+
+- name: scheduling_test_many_5s_tasks_single_node
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: scheduling.yaml
+
+  run:
+    timeout: 3600
+    prepare: python distributed/wait_cluster.py --num-nodes=32
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1 --task-duration-s=5 --total-num-actors=1 --num-actors-per-nodes=1
+  stable: false
+
+- name: scheduling_test_many_5s_tasks_many_nodes
+  team: core
+  cluster:
+    app_config: app_config.yaml
+    compute_template: scheduling.yaml
+
+  run:
+    timeout: 3600
+    prepare: python distributed/wait_cluster.py --num-nodes=32
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1 --task-duration-s=5 --total-num-actors=32 --num-actors-per-nodes=1
+  stable: false

--- a/release/benchmarks/distributed.yaml
+++ b/release/benchmarks/distributed.yaml
@@ -1,0 +1,31 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 999
+
+head_node_type:
+    name: head_node
+    instance_type: r5dn.16xlarge # Network optimized.
+    resources:
+      cpu: 0
+      custom_resources:
+        node: 1
+        small: 1
+
+worker_node_types:
+    - name: worker_node_m
+      instance_type: m5.16xlarge
+      min_workers: 32
+      max_workers: 32
+      use_spot: false
+      resources:
+        custom_resources:
+          node: 1
+    - name: worker_node_r
+      instance_type: r5.16xlarge
+      min_workers: 32
+      max_workers: 32
+      use_spot: false
+      resources:
+        custom_resources:
+          node: 1

--- a/release/benchmarks/distributed/config.yaml
+++ b/release/benchmarks/distributed/config.yaml
@@ -1,0 +1,65 @@
+cluster_name: distributed-benchmarks
+min_workers: 0
+max_workers: 999999
+
+upscaling_speed: 9999999
+
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a, us-west-2b, us-west-2c, us-west-2d
+
+auth:
+    ssh_user: ubuntu
+
+
+available_node_types:
+    head_node:
+        node_config:
+            InstanceType: r5dn.16xlarge # Network optimized.
+            ImageId: ami-0a2363a9cff180a64
+        resources:
+          CPU: 0
+          node: 1
+          small: 1
+        max_workers: 0
+    worker_node:
+        node_config:
+            InstanceType: m5.16xlarge
+            ImageId: ami-0a2363a9cff180a64
+        resources:
+          node: 1
+        min_workers: 64
+        max_workers: 64
+    small_worker_node:
+        node_config:
+            InstanceType: m5.xlarge
+            ImageId: ami-0a2363a9cff180a64
+        resources:
+          node: 1
+        max_workers: 999999
+
+head_node_type: head_node
+
+worker_default_node_type: worker_node
+
+file_mounts: {
+    "~/benchmarks": "."
+}
+
+setup_commands:
+  - pip uninstall -y ray
+  - pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/releases/1.4.0/6ac5e0e5ad45070e27c77aca7267bcee30cc4b4a/ray-1.4.0-cp37-cp37m-manylinux2014_x86_64.whl
+  - pip install tqdm
+  - sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 65535" >> /etc/security/limits.conf; echo "* hard nofile 65535" >> /etc/security/limits.conf;'
+
+idle_timeout_minutes: 1
+
+head_start_ray_commands:
+    - ray stop
+    - ulimit -n 65535; ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+
+# Command to start ray on worker nodes. You don't need to change this.
+worker_start_ray_commands:
+    - ray stop
+    - ulimit -n 65535; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076

--- a/release/benchmarks/distributed/test_many_actors.py
+++ b/release/benchmarks/distributed/test_many_actors.py
@@ -1,0 +1,69 @@
+import json
+import os
+import ray
+import ray._private.test_utils as test_utils
+import time
+import tqdm
+
+if "SMOKE_TEST" in os.environ:
+    MAX_ACTORS_IN_CLUSTER = 100
+else:
+    MAX_ACTORS_IN_CLUSTER = 10000
+
+
+def test_max_actors():
+    # TODO (Alex): Dynamically set this based on number of cores
+    cpus_per_actor = 0.25
+
+    @ray.remote(num_cpus=cpus_per_actor)
+    class Actor:
+        def foo(self):
+            pass
+
+    actors = [
+        Actor.remote()
+        for _ in tqdm.trange(MAX_ACTORS_IN_CLUSTER, desc="Launching actors")
+    ]
+
+    not_ready = [actor.foo.remote() for actor in actors]
+
+    for _ in tqdm.trange(len(actors)):
+        ready, not_ready = ray.wait(not_ready)
+        assert ray.get(*ready) is None
+
+
+def no_resource_leaks():
+    return ray.available_resources() == ray.cluster_resources()
+
+
+ray.init(address="auto")
+
+test_utils.wait_for_condition(no_resource_leaks)
+monitor_actor = test_utils.monitor_memory_usage()
+start_time = time.time()
+test_max_actors()
+end_time = time.time()
+ray.get(monitor_actor.stop_run.remote())
+used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
+print(f"Peak memory usage: {round(used_gb, 2)}GB")
+print(f"Peak memory usage per processes:\n {usage}")
+del monitor_actor
+test_utils.wait_for_condition(no_resource_leaks)
+
+rate = MAX_ACTORS_IN_CLUSTER / (end_time - start_time)
+print(
+    f"Success! Started {MAX_ACTORS_IN_CLUSTER} actors in "
+    f"{end_time - start_time}s. ({rate} actors/s)"
+)
+
+if "TEST_OUTPUT_JSON" in os.environ:
+    out_file = open(os.environ["TEST_OUTPUT_JSON"], "w")
+    results = {
+        "actors_per_second": rate,
+        "num_actors": MAX_ACTORS_IN_CLUSTER,
+        "time": end_time - start_time,
+        "success": "1",
+        "_peak_memory": round(used_gb, 2),
+        "_peak_process_memory": usage,
+    }
+    json.dump(results, out_file)

--- a/release/benchmarks/distributed/test_many_pgs.py
+++ b/release/benchmarks/distributed/test_many_pgs.py
@@ -1,0 +1,95 @@
+import json
+import os
+import ray
+import ray._private.test_utils as test_utils
+from ray.util.placement_group import placement_group, remove_placement_group
+import time
+import tqdm
+
+if "SMOKE_TEST" in os.environ:
+    MAX_PLACEMENT_GROUPS = 20
+else:
+    MAX_PLACEMENT_GROUPS = 1000
+
+
+def test_many_placement_groups():
+    # @ray.remote(num_cpus=1, resources={"node": 0.02})
+    @ray.remote
+    class C1:
+        def ping(self):
+            return "pong"
+
+    # @ray.remote(num_cpus=1)
+    @ray.remote
+    class C2:
+        def ping(self):
+            return "pong"
+
+    # @ray.remote(resources={"node": 0.02})
+    @ray.remote
+    class C3:
+        def ping(self):
+            return "pong"
+
+    bundle1 = {"node": 0.02, "CPU": 1}
+    bundle2 = {"CPU": 1}
+    bundle3 = {"node": 0.02}
+
+    pgs = []
+    for _ in tqdm.trange(MAX_PLACEMENT_GROUPS, desc="Creating pgs"):
+        pg = placement_group(bundles=[bundle1, bundle2, bundle3])
+        pgs.append(pg)
+
+    for pg in tqdm.tqdm(pgs, desc="Waiting for pgs to be ready"):
+        ray.get(pg.ready())
+
+    actors = []
+    for pg in tqdm.tqdm(pgs, desc="Scheduling tasks"):
+        actors.append(C1.options(placement_group=pg).remote())
+        actors.append(C2.options(placement_group=pg).remote())
+        actors.append(C3.options(placement_group=pg).remote())
+
+    not_ready = [actor.ping.remote() for actor in actors]
+    for _ in tqdm.trange(len(actors)):
+        ready, not_ready = ray.wait(not_ready)
+        assert ray.get(*ready) == "pong"
+
+    for pg in tqdm.tqdm(pgs, desc="Cleaning up pgs"):
+        remove_placement_group(pg)
+
+
+def no_resource_leaks():
+    return ray.available_resources() == ray.cluster_resources()
+
+
+ray.init(address="auto")
+
+test_utils.wait_for_condition(no_resource_leaks)
+monitor_actor = test_utils.monitor_memory_usage()
+start_time = time.time()
+test_many_placement_groups()
+end_time = time.time()
+ray.get(monitor_actor.stop_run.remote())
+used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
+print(f"Peak memory usage: {round(used_gb, 2)}GB")
+print(f"Peak memory usage per processes:\n {usage}")
+del monitor_actor
+test_utils.wait_for_condition(no_resource_leaks)
+
+rate = MAX_PLACEMENT_GROUPS / (end_time - start_time)
+print(
+    f"Success! Started {MAX_PLACEMENT_GROUPS} pgs in "
+    f"{end_time - start_time}s. ({rate} pgs/s)"
+)
+
+if "TEST_OUTPUT_JSON" in os.environ:
+    out_file = open(os.environ["TEST_OUTPUT_JSON"], "w")
+    results = {
+        "pgs_per_second": rate,
+        "num_pgs": MAX_PLACEMENT_GROUPS,
+        "time": end_time - start_time,
+        "success": "1",
+        "_peak_memory": round(used_gb, 2),
+        "_peak_process_memory": usage,
+    }
+    json.dump(results, out_file)

--- a/release/benchmarks/distributed/test_many_tasks.py
+++ b/release/benchmarks/distributed/test_many_tasks.py
@@ -1,0 +1,85 @@
+import click
+import json
+import os
+import ray
+import ray._private.test_utils as test_utils
+import time
+import tqdm
+
+sleep_time = 300
+
+
+def test_max_running_tasks(num_tasks):
+    cpus_per_task = 0.25
+
+    @ray.remote(num_cpus=cpus_per_task)
+    def task():
+        time.sleep(sleep_time)
+
+    refs = [task.remote() for _ in tqdm.trange(num_tasks, desc="Launching tasks")]
+
+    max_cpus = ray.cluster_resources()["CPU"]
+    min_cpus_available = max_cpus
+    for _ in tqdm.trange(int(sleep_time / 0.1), desc="Waiting"):
+        try:
+            cur_cpus = ray.available_resources().get("CPU", 0)
+            min_cpus_available = min(min_cpus_available, cur_cpus)
+        except Exception:
+            # There are race conditions `.get` can fail if a new heartbeat
+            # comes at the same time.
+            pass
+        time.sleep(0.1)
+
+    # There are some relevant magic numbers in this check. 10k tasks each
+    # require 1/4 cpus. Therefore, ideally 2.5k cpus will be used.
+    err_str = f"Only {max_cpus - min_cpus_available}/{max_cpus} cpus used."
+    threshold = num_tasks * cpus_per_task * 0.75
+    assert max_cpus - min_cpus_available > threshold, err_str
+
+    for _ in tqdm.trange(num_tasks, desc="Ensuring all tasks have finished"):
+        done, refs = ray.wait(refs)
+        assert ray.get(done[0]) is None
+
+
+def no_resource_leaks():
+    return ray.available_resources() == ray.cluster_resources()
+
+
+@click.command()
+@click.option("--num-tasks", required=True, type=int, help="Number of tasks to launch.")
+def test(num_tasks):
+    ray.init(address="auto")
+
+    test_utils.wait_for_condition(no_resource_leaks)
+    monitor_actor = test_utils.monitor_memory_usage()
+    start_time = time.time()
+    test_max_running_tasks(num_tasks)
+    end_time = time.time()
+    ray.get(monitor_actor.stop_run.remote())
+    used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
+    print(f"Peak memory usage: {round(used_gb, 2)}GB")
+    print(f"Peak memory usage per processes:\n {usage}")
+    del monitor_actor
+    test_utils.wait_for_condition(no_resource_leaks)
+
+    rate = num_tasks / (end_time - start_time - sleep_time)
+    print(
+        f"Success! Started {num_tasks} tasks in {end_time - start_time}s. "
+        f"({rate} tasks/s)"
+    )
+
+    if "TEST_OUTPUT_JSON" in os.environ:
+        out_file = open(os.environ["TEST_OUTPUT_JSON"], "w")
+        results = {
+            "tasks_per_second": rate,
+            "num_tasks": num_tasks,
+            "time": end_time - start_time,
+            "success": "1",
+            "_peak_memory": round(used_gb, 2),
+            "_peak_process_memory": usage,
+        }
+        json.dump(results, out_file)
+
+
+if __name__ == "__main__":
+    test()

--- a/release/benchmarks/distributed/test_scheduling.py
+++ b/release/benchmarks/distributed/test_scheduling.py
@@ -1,0 +1,130 @@
+import ray
+import argparse
+from time import time, sleep
+from math import floor
+import os
+import json
+
+
+@ray.remote
+def simple_task(t):
+    sleep(t)
+
+
+@ray.remote
+class SimpleActor:
+    def __init__(self, job=None):
+        self._job = job
+
+    def ready(self):
+        return
+
+    def do_job(self):
+        if self._job is not None:
+            self._job()
+
+
+def start_tasks(num_task, num_cpu_per_task, task_duration):
+    ray.get(
+        [
+            simple_task.options(num_cpus=num_cpu_per_task).remote(task_duration)
+            for _ in range(num_task)
+        ]
+    )
+
+
+def measure(f):
+    start = time()
+    ret = f()
+    end = time()
+    return (end - start, ret)
+
+
+def start_actor(num_actors, num_actors_per_nodes, job):
+    resources = {"node": floor(1.0 / num_actors_per_nodes)}
+    submission_cost, actors = measure(
+        lambda: [
+            SimpleActor.options(resources=resources, num_cpus=0).remote(job)
+            for _ in range(num_actors)
+        ]
+    )
+    ready_cost, _ = measure(lambda: ray.get([actor.ready.remote() for actor in actors]))
+    actor_job_cost, _ = measure(
+        lambda: ray.get([actor.do_job.remote() for actor in actors])
+    )
+    return (submission_cost, ready_cost, actor_job_cost)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="Test Scheduling")
+    # Task workloads
+    parser.add_argument(
+        "--total-num-task", type=int, help="Total number of tasks.", required=False
+    )
+    parser.add_argument(
+        "--num-cpu-per-task",
+        type=int,
+        help="Resources needed for tasks.",
+        required=False,
+    )
+    parser.add_argument(
+        "--task-duration-s",
+        type=int,
+        help="How long does each task execute.",
+        required=False,
+        default=1,
+    )
+
+    # Actor workloads
+    parser.add_argument(
+        "--total-num-actors", type=int, help="Total number of actors.", required=True
+    )
+    parser.add_argument(
+        "--num-actors-per-nodes",
+        type=int,
+        help="How many actors to allocate for each nodes.",
+        required=True,
+    )
+
+    ray.init(address="auto")
+
+    total_cpus_per_node = [node["Resources"]["CPU"] for node in ray.nodes()]
+    num_nodes = len(total_cpus_per_node)
+    total_cpus = sum(total_cpus_per_node)
+
+    args = parser.parse_args()
+    job = None
+    if args.total_num_task is not None:
+        if args.num_cpu_per_task is None:
+            args.num_cpu_per_task = floor(1.0 * total_cpus / args.total_num_task)
+        job = lambda: start_tasks(  # noqa: E731
+            args.total_num_task, args.num_cpu_per_task, args.task_duration_s
+        )
+
+    submission_cost, ready_cost, actor_job_cost = start_actor(
+        args.total_num_actors, args.num_actors_per_nodes, job
+    )
+
+    output = os.environ.get("TEST_OUTPUT_JSON")
+
+    result = {
+        "total_num_task": args.total_num_task,
+        "num_cpu_per_task": args.num_cpu_per_task,
+        "task_duration_s": args.task_duration_s,
+        "total_num_actors": args.total_num_actors,
+        "num_actors_per_nodes": args.num_actors_per_nodes,
+        "num_nodes": num_nodes,
+        "total_cpus": total_cpus,
+        "submission_cost": submission_cost,
+        "ready_cost": ready_cost,
+        "actor_job_cost": actor_job_cost,
+        "_runtime": submission_cost + ready_cost + actor_job_cost,
+    }
+
+    if output is not None:
+        from pathlib import Path
+
+        p = Path(output)
+        p.write_text(json.dumps(result))
+
+    print(result)

--- a/release/benchmarks/distributed/wait_cluster.py
+++ b/release/benchmarks/distributed/wait_cluster.py
@@ -1,0 +1,24 @@
+import click
+import ray
+import time
+
+
+def num_alive_nodes():
+    n = 0
+    for node in ray.nodes():
+        if node["Alive"]:
+            n += 1
+    return n
+
+
+@click.command()
+@click.option("--num-nodes", required=True, type=int, help="The target number of nodes")
+def wait_cluster(num_nodes: int):
+    ray.init(address="auto")
+    while num_alive_nodes() != num_nodes:
+        print(f"Waiting for nodes: {num_alive_nodes()}/{num_nodes}")
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    wait_cluster()

--- a/release/benchmarks/distributed_smoke_test.yaml
+++ b/release/benchmarks/distributed_smoke_test.yaml
@@ -1,0 +1,23 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 999
+
+head_node_type:
+    name: head_node
+    instance_type: r5dn.16xlarge # Network optimized.
+    resources:
+      cpu: 0
+      custom_resources:
+        node: 1
+        small: 1
+
+worker_node_types:
+    - name: worker_node_m
+      instance_type: m5.16xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+      resources:
+        custom_resources:
+          node: 1

--- a/release/benchmarks/many_nodes.yaml
+++ b/release/benchmarks/many_nodes.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 999
+
+head_node_type:
+    name: head_node
+    instance_type: r5dn.16xlarge # Network optimized.
+    resources:
+      cpu: 0
+      custom_resources:
+        node: 1
+        small: 1
+
+worker_node_types:
+    - name: small_worker
+      instance_type: m5.xlarge
+      min_workers: 249
+      max_workers: 249
+      use_spot: false
+      resources:
+        custom_resources:
+          node: 1
+

--- a/release/benchmarks/object_store.yaml
+++ b/release/benchmarks/object_store.yaml
@@ -1,0 +1,21 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 49
+
+head_node_type:
+    name: head_node
+    instance_type: m4.16xlarge
+    resources:
+      custom_resources:
+        node: 1
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m4.xlarge
+      min_workers: 49
+      max_workers: 49
+      use_spot: false
+      resources:
+        custom_resources:
+          node: 1

--- a/release/benchmarks/object_store/config.yaml
+++ b/release/benchmarks/object_store/config.yaml
@@ -1,0 +1,48 @@
+cluster_name: object-store-benchmarks
+min_workers: 0
+max_workers: 999999
+
+upscaling_speed: 9999999
+
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a
+
+auth:
+    ssh_user: ubuntu
+
+available_node_types:
+    head_node:
+        node_config:
+            InstanceType: m4.4xlarge
+            ImageId: ami-098555c9b343eb09c 
+        resources:
+          node: 1
+        max_workers: 999999
+    worker_node:
+        node_config:
+            InstanceType: m4.xlarge
+            ImageId: ami-098555c9b343eb09c 
+        resources:
+          node: 1
+        max_workers: 999999
+
+head_node_type: head_node
+
+worker_default_node_type: worker_node
+
+setup_commands:
+  - pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/releases/1.4.0/6ac5e0e5ad45070e27c77aca7267bcee30cc4b4a/ray-1.4.0-cp37-cp37m-manylinux2014_x86_64.whl
+  - pip install tqdm numpy
+
+idle_timeout_minutes: 5
+
+head_start_ray_commands:
+    - ray stop
+    - ulimit -n 1000000; ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+
+# Command to start ray on worker nodes. You don't need to change this.
+worker_start_ray_commands:
+    - ray stop
+    - ulimit -n 1000000; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076

--- a/release/benchmarks/object_store/test_object_store.py
+++ b/release/benchmarks/object_store/test_object_store.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+import ray
+import ray.autoscaler.sdk
+
+import json
+import os
+from time import perf_counter
+from tqdm import tqdm
+
+NUM_NODES = 50
+OBJECT_SIZE = 2 ** 30
+
+
+def num_alive_nodes():
+    n = 0
+    for node in ray.nodes():
+        if node["Alive"]:
+            n += 1
+    return n
+
+
+def test_object_broadcast():
+    assert num_alive_nodes() == NUM_NODES
+
+    @ray.remote(num_cpus=1, resources={"node": 1})
+    class Actor:
+        def foo(self):
+            pass
+
+        def sum(self, arr):
+            return np.sum(arr)
+
+    actors = [Actor.remote() for _ in range(NUM_NODES)]
+
+    arr = np.ones(OBJECT_SIZE, dtype=np.uint8)
+    ref = ray.put(arr)
+
+    for actor in tqdm(actors, desc="Ensure all actors have started."):
+        ray.get(actor.foo.remote())
+
+    result_refs = []
+    for actor in tqdm(actors, desc="Broadcasting objects"):
+        result_refs.append(actor.sum.remote(ref))
+
+    results = ray.get(result_refs)
+    for result in results:
+        assert result == OBJECT_SIZE
+
+
+ray.init(address="auto")
+start = perf_counter()
+test_object_broadcast()
+end = perf_counter()
+print(f"Broadcast time: {end - start} ({OBJECT_SIZE} B x {NUM_NODES} nodes)")
+
+if "TEST_OUTPUT_JSON" in os.environ:
+    out_file = open(os.environ["TEST_OUTPUT_JSON"], "w")
+    results = {
+        "broadcast_time": end - start,
+        "object_size": OBJECT_SIZE,
+        "num_nodes": NUM_NODES,
+        "success": "1",
+    }
+    json.dump(results, out_file)

--- a/release/benchmarks/scheduling.yaml
+++ b/release/benchmarks/scheduling.yaml
@@ -1,0 +1,23 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 999
+
+head_node_type:
+    name: head_node
+    instance_type: m5.16xlarge
+    resources:
+      cpu: 64
+      custom_resources:
+        node: 1
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.16xlarge
+      min_workers: 31
+      max_workers: 31
+      use_spot: false
+      resources:
+        cpu: 64
+        custom_resources:
+          node: 1

--- a/release/benchmarks/single_node.yaml
+++ b/release/benchmarks/single_node.yaml
@@ -1,0 +1,25 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 0
+
+aws:
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 500
+
+head_node_type:
+    name: head_node
+    instance_type: m4.16xlarge
+    resources:
+      # 128 GB
+      object_store_memory: 128000000000
+
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false

--- a/release/benchmarks/single_node/config.yaml
+++ b/release/benchmarks/single_node/config.yaml
@@ -1,0 +1,41 @@
+cluster_name: single-node-benchmarks
+min_workers: 0
+max_workers: 0
+
+upscaling_speed: 9999999
+
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a
+
+auth:
+    ssh_user: ubuntu
+
+available_node_types:
+    head_node:
+        node_config:
+            InstanceType: m4.16xlarge
+            ImageId: ami-098555c9b343eb09c 
+        resources:
+          node: 1
+        max_workers: 999999
+    worker_node:
+        node_config:
+            InstanceType: m4.xlarge
+            ImageId: ami-098555c9b343eb09c 
+
+head_node_type: head_node
+
+worker_default_node_type: worker_node
+
+setup_commands:
+  - pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/releases/1.4.0/6ac5e0e5ad45070e27c77aca7267bcee30cc4b4a/ray-1.4.0-cp37-cp37m-manylinux2014_x86_64.whl
+  - pip install numpy tqdm
+  - sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1000000" >> /etc/security/limits.conf; echo "* hard nofile 1000000" >> /etc/security/limits.conf;'
+
+idle_timeout_minutes: 5
+
+head_start_ray_commands:
+    - ray stop
+    - ulimit -n 1000000; ray start --head --port=6379 --object-manager-port=8076 --object-store-memory=128000000000 --autoscaling-config=~/ray_bootstrap_config.yaml

--- a/release/benchmarks/single_node/test_single_node.py
+++ b/release/benchmarks/single_node/test_single_node.py
@@ -1,0 +1,209 @@
+import numpy as np
+import time
+import ray
+import ray.autoscaler.sdk
+from ray._private.test_utils import Semaphore
+
+import json
+import os
+from time import perf_counter
+from tqdm import trange, tqdm
+
+MAX_ARGS = 10000
+MAX_RETURNS = 3000
+MAX_RAY_GET_ARGS = 10000
+MAX_QUEUED_TASKS = 1_000_000
+MAX_RAY_GET_SIZE = 100 * 2 ** 30
+
+
+def assert_no_leaks():
+    total = ray.cluster_resources()
+    current = ray.available_resources()
+    total.pop("memory")
+    total.pop("object_store_memory")
+    current.pop("memory")
+    current.pop("object_store_memory")
+    assert total == current, (total, current)
+
+
+def test_many_args():
+    @ray.remote
+    def sum_args(*args):
+        return sum(sum(arg) for arg in args)
+
+    args = [[1 for _ in range(10000)] for _ in range(MAX_ARGS)]
+    result = ray.get(sum_args.remote(*args))
+    assert result == MAX_ARGS * 10000
+
+
+def test_many_returns():
+    @ray.remote(num_returns=MAX_RETURNS)
+    def f():
+        to_return = []
+        for _ in range(MAX_RETURNS):
+            obj = list(range(10000))
+            to_return.append(obj)
+
+        return tuple(to_return)
+
+    returned_refs = f.remote()
+    assert len(returned_refs) == MAX_RETURNS
+
+    for ref in returned_refs:
+        expected = list(range(10000))
+        obj = ray.get(ref)
+        assert obj == expected
+
+
+def test_ray_get_args():
+    def with_dese():
+        print("Putting test objects:")
+        refs = []
+        for _ in trange(MAX_RAY_GET_ARGS):
+            obj = list(range(10000))
+            refs.append(ray.put(obj))
+
+        print("Getting objects")
+        results = ray.get(refs)
+        assert len(results) == MAX_RAY_GET_ARGS
+
+        print("Asserting correctness")
+        for obj in tqdm(results):
+            expected = list(range(10000))
+            assert obj == expected
+
+    def with_zero_copy():
+        print("Putting test objects:")
+        refs = []
+        for _ in trange(MAX_RAY_GET_ARGS):
+            obj = np.arange(10000)
+            refs.append(ray.put(obj))
+
+        print("Getting objects")
+        results = ray.get(refs)
+        assert len(results) == MAX_RAY_GET_ARGS
+
+        print("Asserting correctness")
+        for obj in tqdm(results):
+            expected = np.arange(10000)
+            assert (obj == expected).all()
+
+    with_dese()
+    print("Done with dese")
+    with_zero_copy()
+    print("Done with zero copy")
+
+
+def test_many_queued_tasks():
+    sema = Semaphore.remote(0)
+
+    @ray.remote(num_cpus=1)
+    def block():
+        ray.get(sema.acquire.remote())
+
+    @ray.remote(num_cpus=1)
+    def f():
+        pass
+
+    num_cpus = int(ray.cluster_resources()["CPU"])
+    blocked_tasks = []
+    for _ in range(num_cpus):
+        blocked_tasks.append(block.remote())
+
+    print("Submitting many tasks")
+    pending_tasks = []
+    for _ in trange(MAX_QUEUED_TASKS):
+        pending_tasks.append(f.remote())
+
+    # Make sure all the tasks can actually run.
+    for _ in range(num_cpus):
+        sema.release.remote()
+
+    print("Unblocking tasks")
+    for ref in tqdm(pending_tasks):
+        assert ray.get(ref) is None
+
+
+def test_large_object():
+    print("Generating object")
+    obj = np.zeros(MAX_RAY_GET_SIZE, dtype=np.int8)
+    print("Putting object")
+    ref = ray.put(obj)
+    del obj
+    print("Getting object")
+    big_obj = ray.get(ref)
+
+    assert big_obj[0] == 0
+    assert big_obj[-1] == 0
+
+
+ray.init(address="auto")
+
+args_start = perf_counter()
+test_many_args()
+args_end = perf_counter()
+
+time.sleep(5)
+assert_no_leaks()
+print("Finished many args")
+
+returns_start = perf_counter()
+test_many_returns()
+returns_end = perf_counter()
+
+time.sleep(5)
+assert_no_leaks()
+print("Finished many returns")
+
+get_start = perf_counter()
+test_ray_get_args()
+get_end = perf_counter()
+
+time.sleep(5)
+assert_no_leaks()
+print("Finished ray.get on many objects")
+
+queued_start = perf_counter()
+test_many_queued_tasks()
+queued_end = perf_counter()
+
+time.sleep(5)
+assert_no_leaks()
+print("Finished queueing many tasks")
+
+large_object_start = perf_counter()
+test_large_object()
+large_object_end = perf_counter()
+
+time.sleep(5)
+assert_no_leaks()
+print("Done")
+
+args_time = args_end - args_start
+returns_time = returns_end - returns_start
+get_time = get_end - get_start
+queued_time = queued_end - queued_start
+large_object_time = large_object_end - large_object_start
+
+print(f"Many args time: {args_time} ({MAX_ARGS} args)")
+print(f"Many returns time: {returns_time} ({MAX_RETURNS} returns)")
+print(f"Ray.get time: {get_time} ({MAX_RAY_GET_ARGS} args)")
+print(f"Queued task time: {queued_time} ({MAX_QUEUED_TASKS} tasks)")
+print(f"Ray.get large object time: {large_object_time} " f"({MAX_RAY_GET_SIZE} bytes)")
+
+if "TEST_OUTPUT_JSON" in os.environ:
+    out_file = open(os.environ["TEST_OUTPUT_JSON"], "w")
+    results = {
+        "args_time": args_time,
+        "num_args": MAX_ARGS,
+        "returns_time": returns_time,
+        "num_returns": MAX_RETURNS,
+        "get_time": get_time,
+        "num_get_args": MAX_RAY_GET_ARGS,
+        "queued_time": queued_time,
+        "num_queued": MAX_QUEUED_TASKS,
+        "large_object_time": large_object_time,
+        "large_object_size": MAX_RAY_GET_SIZE,
+        "success": "1",
+    }
+    json.dump(results, out_file)

--- a/release/benchmarks/wait_cluster.py
+++ b/release/benchmarks/wait_cluster.py
@@ -1,0 +1,54 @@
+import argparse
+import time
+
+import ray
+
+ray.init(address="auto")
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "num_nodes", type=int, help="Wait for this number of nodes (includes head)"
+)
+
+parser.add_argument("max_time_s", type=int, help="Wait for this number of seconds")
+
+parser.add_argument(
+    "--feedback_interval_s",
+    type=int,
+    default=10,
+    help="Wait for this number of seconds",
+)
+
+args = parser.parse_args()
+
+curr_nodes = 0
+start = time.time()
+next_feedback = start
+max_time = start + args.max_time_s
+
+while not curr_nodes >= args.num_nodes:
+    now = time.time()
+
+    if now >= max_time:
+        raise RuntimeError(
+            f"Maximum wait time reached, but only "
+            f"{curr_nodes}/{args.num_nodes} nodes came up. Aborting."
+        )
+
+    if now >= next_feedback:
+        passed = now - start
+        print(
+            f"Waiting for more nodes to come up: "
+            f"{curr_nodes}/{args.num_nodes} "
+            f"({passed:.0f} seconds passed)"
+        )
+        next_feedback = now + args.feedback_interval_s
+
+    time.sleep(5)
+    curr_nodes = len(ray.nodes())
+
+passed = time.time() - start
+print(
+    f"Cluster is up: {curr_nodes}/{args.num_nodes} nodes online after "
+    f"{passed:.0f} seconds"
+)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -803,3 +803,313 @@
   run:
     timeout: 1800
     script: OMP_NUM_THREADS=64 RAY_ADDRESS= python run_microbenchmark.py
+
+#########################
+# Core Scalability Tests
+#########################
+
+- name: single_node
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: single_node
+    test_suite: benchmark_tests
+
+  frequency: multi
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: single_node.yaml
+
+  run:
+    timeout: 12000
+    prepare: sleep 0
+    script: python single_node/test_single_node.py
+    type: sdk_command
+    file_manager: sdk
+
+- name: object_store
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: object_store
+    test_suite: benchmark_tests
+
+  frequency: multi
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: object_store.yaml
+
+  run:
+    timeout: 3600
+    script: python object_store/test_object_store.py
+    wait_for_nodes:
+      num_nodes: 50
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: many_actors
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: many_actors
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: distributed.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_many_actors.py
+    wait_for_nodes:
+      num_nodes: 65
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: many_actors_smoke_test
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: many_actors_smoke_test
+    test_suite: benchmark_tests
+
+  frequency: multi
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: distributed_smoke_test.yaml
+
+  run:
+    timeout: 3600
+    script: SMOKE_TEST=1 python distributed/test_many_actors.py
+    wait_for_nodes:
+      num_nodes: 2
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: many_tasks
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: many_tasks
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: distributed.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_many_tasks.py --num-tasks=10000
+    wait_for_nodes:
+      num_nodes: 65
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: many_tasks_smoke_test
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: many_tasks_smoke_test
+    test_suite: benchmark_tests
+
+  frequency: multi
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: distributed_smoke_test.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_many_tasks.py --num-tasks=100
+    wait_for_nodes:
+      num_nodes: 2
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: many_pgs
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: many_pgs
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: distributed.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_many_pgs.py
+    wait_for_nodes:
+      num_nodes: 65
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: many_pgs_smoke_test
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: many_pgs_smoke_test
+    test_suite: benchmark_tests
+
+  frequency: multi
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: distributed_smoke_test.yaml
+
+  run:
+    timeout: 3600
+    script: SMOKE_TEST=1 python distributed/test_many_pgs.py
+    wait_for_nodes:
+      num_nodes: 2
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: many_nodes
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: many_nodes
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: many_nodes.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_many_tasks.py --num-tasks=1000
+    wait_for_nodes:
+      num_nodes: 250
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: scheduling_test_many_0s_tasks_single_node
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: scheduling_test_many_0s_tasks_single_node
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: scheduling.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1
+      --task-duration-s=0 --total-num-actors=1 --num-actors-per-nodes=1
+
+    wait_for_nodes:
+      num_nodes: 32
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: scheduling_test_many_0s_tasks_many_nodes
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: scheduling_test_many_0s_tasks_many_nodes
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: scheduling.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1
+      --task-duration-s=0 --total-num-actors=32 --num-actors-per-nodes=1
+
+    wait_for_nodes:
+      num_nodes: 32
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+
+- name: scheduling_test_many_5s_tasks_single_node
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: scheduling_test_many_5s_tasks_single_node
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: scheduling.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1
+      --task-duration-s=5 --total-num-actors=1 --num-actors-per-nodes=1
+
+    wait_for_nodes:
+      num_nodes: 32
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+  stable: false
+
+- name: scheduling_test_many_5s_tasks_many_nodes
+  group: core-scalability-test
+  working_dir: benchmarks
+  legacy:
+    test_name: scheduling_test_many_5s_tasks_many_nodes
+    test_suite: benchmark_tests
+
+  frequency: nightly
+  team: core
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: scheduling.yaml
+
+  run:
+    timeout: 3600
+    script: python distributed/test_scheduling.py --total-num-task=1984000 --num-cpu-per-task=1
+      --task-duration-s=5 --total-num-actors=32 --num-actors-per-nodes=1
+
+    wait_for_nodes:
+      num_nodes: 32
+      timeout: 600
+
+    type: sdk_command
+    file_manager: sdk
+  stable: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR migrates scalability tests to the new infra.

I had to copy the benchmarks folder to the release folder to make it work. I will remove some unnecessary files (e.g., benchmark.yaml or wait_for_cluster file) Alternatively we can support a different path than /release from the tool, but I think this way is cleaner. I am open to suggestion though cc @krfricke 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
