### PR TITLE
[workflow]align the behavior of workflow's max_retires with remote function's max_retries

### DIFF
--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -216,12 +216,10 @@ class WorkflowStepRuntimeOptions:
     ):
         if max_retries is None:
             max_retries = 3
-        elif not isinstance(max_retries, int) or max_retries < 1:
-            raise ValueError("max_retries should be greater or equal to 1.")
+        elif not isinstance(max_retries, int) or max_retries < -1:
+            raise ValueError("'max_retries' only accepts 0, -1 or a positive integer.")
         if catch_exceptions is None:
             catch_exceptions = False
-        if max_retries is None:
-            max_retries = 3
         if not isinstance(checkpoint, bool) and checkpoint is not None:
             raise ValueError("'checkpoint' should be None or a boolean.")
         if ray_options is None:

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -320,17 +320,22 @@ def _wrap_run(
     result = None
     # max_retries are for application level failure.
     # For ray failure, we should use max_retries.
-    for i in range(runtime_options.max_retries):
-        logger.info(
-            f"{get_step_status_info(WorkflowStatus.RUNNING)}"
-            f"\t[{i + 1}/{runtime_options.max_retries}]"
-        )
+    for i in range(runtime_options.max_retries + 1):
+        if i == 0:
+            logger.info(
+                f"{get_step_status_info(WorkflowStatus.RUNNING)}"
+            )
+        else:
+            logger.info(
+                f"{get_step_status_info(WorkflowStatus.RUNNING)}"
+                f"\tretries: [{i}/{runtime_options.max_retries}]"
+            )
         try:
             result = func(*args, **kwargs)
             exception = None
             break
         except BaseException as e:
-            if i + 1 == runtime_options.max_retries:
+            if i == runtime_options.max_retries:
                 retry_msg = "Maximum retry reached, stop retry."
             else:
                 retry_msg = "The step will be retried."

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -323,9 +323,7 @@ def _wrap_run(
     if runtime_options.max_retries != -1:
         for i in range(runtime_options.max_retries + 1):
             if i == 0:
-                logger.info(
-                    f"{get_step_status_info(WorkflowStatus.RUNNING)}"
-                )
+                logger.info(f"{get_step_status_info(WorkflowStatus.RUNNING)}")
             else:
                 logger.info(
                     f"{get_step_status_info(WorkflowStatus.RUNNING)}"
@@ -349,9 +347,7 @@ def _wrap_run(
         i = 0
         while True:
             if i == 0:
-                logger.info(
-                    f"{get_step_status_info(WorkflowStatus.RUNNING)}"
-                )
+                logger.info(f"{get_step_status_info(WorkflowStatus.RUNNING)}")
             else:
                 logger.info(
                     f"{get_step_status_info(WorkflowStatus.RUNNING)}"

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -320,31 +320,54 @@ def _wrap_run(
     result = None
     # max_retries are for application level failure.
     # For ray failure, we should use max_retries.
-    for i in range(runtime_options.max_retries + 1):
-        if i == 0:
-            logger.info(
-                f"{get_step_status_info(WorkflowStatus.RUNNING)}"
-            )
-        else:
-            logger.info(
-                f"{get_step_status_info(WorkflowStatus.RUNNING)}"
-                f"\tretries: [{i}/{runtime_options.max_retries}]"
-            )
-        try:
-            result = func(*args, **kwargs)
-            exception = None
-            break
-        except BaseException as e:
-            if i == runtime_options.max_retries:
-                retry_msg = "Maximum retry reached, stop retry."
+    if runtime_options.max_retries != -1:
+        for i in range(runtime_options.max_retries + 1):
+            if i == 0:
+                logger.info(
+                    f"{get_step_status_info(WorkflowStatus.RUNNING)}"
+                )
             else:
+                logger.info(
+                    f"{get_step_status_info(WorkflowStatus.RUNNING)}"
+                    f"\tretries: [{i}/{runtime_options.max_retries}]"
+                )
+            try:
+                result = func(*args, **kwargs)
+                exception = None
+                break
+            except BaseException as e:
+                if i == runtime_options.max_retries:
+                    retry_msg = "Maximum retry reached, stop retry."
+                else:
+                    retry_msg = "The step will be retried."
+                logger.error(
+                    f"{workflow_context.get_name()} failed with error message"
+                    f" {e}. {retry_msg}"
+                )
+                exception = e
+    else:
+        i = 0
+        while True:
+            if i == 0:
+                logger.info(
+                    f"{get_step_status_info(WorkflowStatus.RUNNING)}"
+                )
+            else:
+                logger.info(
+                    f"{get_step_status_info(WorkflowStatus.RUNNING)}"
+                    f"\tretries: [{i}/inf]"
+                )
+            try:
+                result = func(*args, **kwargs)
+                exception = None
+                break
+            except BaseException as e:
                 retry_msg = "The step will be retried."
-            logger.error(
-                f"{workflow_context.get_name()} failed with error message"
-                f" {e}. {retry_msg}"
-            )
-            exception = e
-
+                logger.error(
+                    f"{workflow_context.get_name()} failed with error message"
+                    f" {e}. {retry_msg}"
+                )
+                i += 1
     step_type = runtime_options.step_type
     if runtime_options.catch_exceptions:
         if step_type == StepType.FUNCTION:

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -197,6 +197,9 @@ def test_step_failure(workflow_start_regular_shared, tmp_path):
         return v
 
     with pytest.raises(Exception):
+        unstable_step.options(max_retries=-2).step().run()
+
+    with pytest.raises(Exception):
         unstable_step.options(max_retries=2).step().run()
     assert 10 == unstable_step.options(max_retries=7).step().run()
     (tmp_path / "test").write_text("0")

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -197,19 +197,16 @@ def test_step_failure(workflow_start_regular_shared, tmp_path):
         return v
 
     with pytest.raises(Exception):
-        unstable_step.options(max_retries=-1).step().run()
-
-    with pytest.raises(Exception):
-        unstable_step.options(max_retries=3).step().run()
-    assert 10 == unstable_step.options(max_retries=8).step().run()
+        unstable_step.options(max_retries=2).step().run()
+    assert 10 == unstable_step.options(max_retries=7).step().run()
     (tmp_path / "test").write_text("0")
     (ret, err) = (
-        unstable_step.options(max_retries=3, catch_exceptions=True).step().run()
+        unstable_step.options(max_retries=2, catch_exceptions=True).step().run()
     )
     assert ret is None
     assert isinstance(err, ValueError)
     (ret, err) = (
-        unstable_step.options(max_retries=8, catch_exceptions=True).step().run()
+        unstable_step.options(max_retries=7, catch_exceptions=True).step().run()
     )
     assert ret == 10
     assert err is None
@@ -218,7 +215,7 @@ def test_step_failure(workflow_start_regular_shared, tmp_path):
 def test_step_failure_decorator(workflow_start_regular_shared, tmp_path):
     (tmp_path / "test").write_text("0")
 
-    @workflow.step(max_retries=11)
+    @workflow.step(max_retries=10)
     def unstable_step():
         v = int((tmp_path / "test").read_text())
         (tmp_path / "test").write_text(f"{v + 1}")
@@ -244,7 +241,7 @@ def test_step_failure_decorator(workflow_start_regular_shared, tmp_path):
 
     (tmp_path / "test").write_text("0")
 
-    @workflow.step(catch_exceptions=True, max_retries=4)
+    @workflow.step(catch_exceptions=True, max_retries=3)
     def unstable_step_exception():
         v = int((tmp_path / "test").read_text())
         (tmp_path / "test").write_text(f"{v + 1}")

--- a/python/ray/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/workflow/tests/test_basic_workflows_2.py
@@ -109,7 +109,7 @@ def test_get_output_3(workflow_start_regular, tmp_path):
         return 10
 
     with pytest.raises(ray.exceptions.RaySystemError):
-        incr.options(max_retries=1).step().run("incr")
+        incr.options(max_retries=0).step().run("incr")
 
     assert cnt_file.read_text() == "1"
 

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -92,7 +92,7 @@ class ActorMethod(ActorMethodBase):
     def options(
         self,
         *,
-        max_retries: int = 1,
+        max_retries: int = 0,
         catch_exceptions: bool = False,
         name: str = None,
         metadata: Dict[str, Any] = None,
@@ -262,7 +262,7 @@ class _VirtualActorMethodHelper:
     def options(
         self,
         *,
-        max_retries=1,
+        max_retries=0,
         catch_exceptions=False,
         name=None,
         metadata=None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To address the issue https://github.com/ray-project/ray/issues/22824

Basically the current behavior of `max_retries` in workflow is different from the one in remote functions in the following ways:
1. workflow's max_retries is not the number of retries, but the number of total tries. 
2. workflow's max_retries does not allow "-1" (infinite retries) while remote function's max_retries does.

<!-- Please give a short summary of the change and the problem this solves. -->

This PR altered the behavior of `max_retries` in workflow to be consistent with the `max_retries` in remote functions:
1. make max_retries to be truly max retries (i.e. total tries = original try + max retries)
 - [x] implementation
 - [x] update logging
 - [x] update tests
2. make max_retries accept infinite tries (i.e. `max_retries=-1`)


## Related issue number

https://github.com/ray-project/ray/issues/22824

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
