### PR TITLE
[core] Deflake test_plasma_unlimited

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -38,6 +38,7 @@ from ray._private.gcs_pubsub import (
 from ray._private.tls_utils import generate_self_signed_tls_certs
 from ray.util.queue import Queue, _QueueActor, Empty
 from ray.scripts.scripts import main as ray_main
+from ray.internal.internal_api import memory_summary
 
 try:
     from prometheus_client.parser import text_string_to_metric_families
@@ -1240,3 +1241,30 @@ def generate_runtime_env_dict(field, spec_format, tmp_path, pip_list=None):
             pip = pip_list
         runtime_env = {"pip": pip}
     return runtime_env
+
+
+def check_spilled_mb(address, spilled=None, restored=None, fallback=None):
+    def ok():
+        s = memory_summary(address=address["address"], stats_only=True)
+        print(s)
+        if restored:
+            if "Restored {} MiB".format(restored) not in s:
+                return False
+        else:
+            if "Restored" in s:
+                return False
+        if spilled:
+            if "Spilled {} MiB".format(spilled) not in s:
+                return False
+        else:
+            if "Spilled" in s:
+                return False
+        if fallback:
+            if "Plasma filesystem mmap usage: {} MiB".format(fallback) not in s:
+                return False
+        else:
+            if "Plasma filesystem mmap usage:" in s:
+                return False
+        return True
+
+    wait_for_condition(ok, timeout=3, retry_interval_ms=1000)

--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -7,41 +7,13 @@ import platform
 import pytest
 
 import ray
-from ray._private.test_utils import wait_for_condition
-from ray.internal.internal_api import memory_summary
+from ray._private.test_utils import check_spilled_mb
 
 MB = 1024 * 1024
 
 
 def _init_ray():
     return ray.init(num_cpus=2, object_store_memory=700e6)
-
-
-def _check_spilled_mb(address, spilled=None, restored=None, fallback=None):
-    def ok():
-        s = memory_summary(address=address["address"], stats_only=True)
-        print(s)
-        if restored:
-            if "Restored {} MiB".format(restored) not in s:
-                return False
-        else:
-            if "Restored" in s:
-                return False
-        if spilled:
-            if "Spilled {} MiB".format(spilled) not in s:
-                return False
-        else:
-            if "Spilled" in s:
-                return False
-        if fallback:
-            if "Plasma filesystem mmap usage: {} MiB".format(fallback) not in s:
-                return False
-        else:
-            if "Plasma filesystem mmap usage:" in s:
-                return False
-        return True
-
-    wait_for_condition(ok, timeout=3, retry_interval_ms=1000)
 
 
 @pytest.mark.skipif(
@@ -57,7 +29,7 @@ def test_fallback_when_spilling_impossible_on_put():
         x2p = ray.get(x2)
         del x1p
         del x2p
-        _check_spilled_mb(address, spilled=None, fallback=400)
+        check_spilled_mb(address, spilled=None, fallback=400)
     finally:
         ray.shutdown()
 
@@ -71,7 +43,7 @@ def test_spilling_when_possible_on_put():
         results = []
         for _ in range(5):
             results.append(ray.put(np.zeros(400 * MB, dtype=np.uint8)))
-        _check_spilled_mb(address, spilled=1600)
+        check_spilled_mb(address, spilled=1600)
     finally:
         ray.shutdown()
 
@@ -85,13 +57,13 @@ def test_fallback_when_spilling_impossible_on_get():
         x1 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
         # x1 will be spilled.
         x2 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
-        _check_spilled_mb(address, spilled=400)
+        check_spilled_mb(address, spilled=400)
         # x1 will be restored, x2 will be spilled.
         x1p = ray.get(x1)
-        _check_spilled_mb(address, spilled=800, restored=400)
+        check_spilled_mb(address, spilled=800, restored=400)
         # x2 will be restored, triggering a fallback allocation.
         x2p = ray.get(x2)
-        _check_spilled_mb(address, spilled=800, restored=800, fallback=400)
+        check_spilled_mb(address, spilled=800, restored=800, fallback=400)
         del x1p
         del x2p
     finally:
@@ -107,13 +79,13 @@ def test_spilling_when_possible_on_get():
         x1 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
         # x1 will be spilled.
         x2 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
-        _check_spilled_mb(address, spilled=400)
+        check_spilled_mb(address, spilled=400)
         # x1 will be restored, x2 will be spilled.
         ray.get(x1)
-        _check_spilled_mb(address, spilled=800, restored=400)
+        check_spilled_mb(address, spilled=800, restored=400)
         # x2 will be restored, spilling x1.
         ray.get(x2)
-        _check_spilled_mb(address, spilled=800, restored=800)
+        check_spilled_mb(address, spilled=800, restored=800)
     finally:
         ray.shutdown()
 
@@ -130,18 +102,19 @@ def test_task_unlimited():
         x2 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
         x2p = ray.get(x2)
         sentinel = ray.put(np.zeros(100 * MB, dtype=np.uint8))
-        _check_spilled_mb(address, spilled=400)
+        check_spilled_mb(address, spilled=400)
 
         @ray.remote
         def consume(refs):
             # triggers fallback allocation, spilling of the sentinel
             ray.get(refs[0])
+            check_spilled_mb(address, spilled=500, restored=400, fallback=400)
             # triggers fallback allocation.
             return ray.put(np.zeros(400 * MB, dtype=np.uint8))
 
         # round 1
-        ray.get(consume.remote(refs))
-        _check_spilled_mb(address, spilled=500, restored=400, fallback=400)
+        _ = ray.get(ray.get(consume.remote(refs)))
+        check_spilled_mb(address, spilled=500, restored=400, fallback=400)
 
         del x2p
         del sentinel
@@ -161,7 +134,7 @@ def test_task_unlimited_multiget_args():
             refs.append(ray.put(np.zeros(200 * MB, dtype=np.uint8)))
         x2 = ray.put(np.zeros(600 * MB, dtype=np.uint8))
         x2p = ray.get(x2)
-        _check_spilled_mb(address, spilled=2000)
+        check_spilled_mb(address, spilled=2000)
 
         @ray.remote
         def consume(refs):
@@ -170,7 +143,7 @@ def test_task_unlimited_multiget_args():
             return os.getpid()
 
         ray.get([consume.remote(refs) for _ in range(1000)])
-        _check_spilled_mb(address, spilled=2000, restored=2000, fallback=2000)
+        check_spilled_mb(address, spilled=2000, restored=2000, fallback=2000)
         del x2p
     finally:
         ray.shutdown()
@@ -277,7 +250,7 @@ def test_plasma_allocate(shutdown_only):
     __ = ray.put(data)  # noqa
 
     # Check fourth object allocate in memory.
-    _check_spilled_mb(address, spilled=180)
+    check_spilled_mb(address, spilled=180)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

test_plasma_unlimited::test_task_unlimited is flaky because one of the assertions is race-y and can trigger after the condition is no longer true (see #22883). This fixes the flake by:
- adding an assertion in between two object allocations to force the object store queue to flush
- keeping one of the ObjectRefs in scope to make sure that the object is still fallback-allocated by the time we reach the failing assertion


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
