### PR TITLE
[serve][release tests] Use m5.8xlarge instance types for 1k replica tests

### DIFF
--- a/release/serve_tests/compute_tpl_32_cpu.yaml
+++ b/release/serve_tests/compute_tpl_32_cpu.yaml
@@ -1,21 +1,20 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-# 1k max replicas (1000 / 8 = 125 containers needed)
-max_workers: 130
+# 1k max replicas (ceil(1000 / 32) = 32  nodes needed)
+max_workers: 32
 
 head_node_type:
     name: head_node
-    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-    instance_type: m5.2xlarge
+    # 32 cpus, x86, 128G mem, 10Gb NIC
+    instance_type: m5.8xlarge
 
 worker_node_types:
     - name: worker_node
-      # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-      instance_type: m5.2xlarge
-      min_workers: 130
-      # 1k max replicas
-      max_workers: 130
+      # 32 cpus, x86, 128G mem, 10Gb NIC
+      instance_type: m5.8xlarge
+      min_workers: 32
+      max_workers: 32
       use_spot: false
 
 aws:

--- a/release/serve_tests/serve_tests.yaml
+++ b/release/serve_tests/serve_tests.yaml
@@ -2,7 +2,7 @@
   team: serve
   cluster:
     app_config: app_config.yaml
-    compute_template: compute_tpl_8_cpu.yaml
+    compute_template: compute_tpl_32_cpu.yaml
 
   run:
     timeout: 7200
@@ -16,7 +16,7 @@
   team: serve
   cluster:
     app_config: app_config.yaml
-    compute_template: compute_tpl_8_cpu.yaml
+    compute_template: compute_tpl_32_cpu.yaml
 
   run:
     timeout: 7200

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -30,7 +30,6 @@ import math
 import os
 import random
 
-import ray
 from ray import serve
 from ray.serve.utils import logger
 from serve_test_utils import (
@@ -41,11 +40,10 @@ from serve_test_utils import (
 from serve_test_cluster_utils import (
     setup_local_single_node_cluster,
     setup_anyscale_cluster,
-    warm_up_one_cluster,
     NUM_CPU_PER_NODE,
     NUM_CONNECTIONS,
 )
-from typing import Optional
+from typing import List, Optional
 
 # Experiment configs
 DEFAULT_SMOKE_TEST_NUM_REPLICA = 4
@@ -65,7 +63,7 @@ DEFAULT_SMOKE_TEST_TRIAL_LENGTH = "5s"
 DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 
 
-def setup_multi_deployment_replicas(num_replicas, num_deployments):
+def setup_multi_deployment_replicas(num_replicas, num_deployments) -> List[str]:
     num_replica_per_deployment = num_replicas // num_deployments
     all_deployment_names = [f"Echo_{i+1}" for i in range(num_deployments)]
 
@@ -146,19 +144,17 @@ def main(
     logger.info(f"Ray serve http_host: {http_host}, http_port: {http_port}")
 
     logger.info(f"Deploying with {num_replicas} target replicas ....\n")
-    setup_multi_deployment_replicas(num_replicas, num_deployments)
+    all_endpoints = setup_multi_deployment_replicas(num_replicas, num_deployments)
 
-    logger.info("Warming up cluster ....\n")
-    rst_ray_refs = []
-    all_endpoints = list(serve.list_deployments().keys())
-    for endpoint in all_endpoints:
-        rst_ray_refs.append(
-            warm_up_one_cluster.options(num_cpus=0).remote(
-                10, http_host, http_port, endpoint
-            )
-        )
-    for endpoint in ray.get(rst_ray_refs):
-        logger.info(f"Finished warming up {endpoint}")
+    logger.info("Warming up cluster...\n")
+    run_wrk_on_all_nodes(
+        DEFAULT_SMOKE_TEST_TRIAL_LENGTH,
+        NUM_CONNECTIONS,
+        http_host,
+        http_port,
+        all_endpoints=all_endpoints,
+        ignore_output=True,
+    )
 
     logger.info(f"Starting wrk trial on all nodes for {trial_length} ....\n")
     # For detailed discussion, see https://github.com/wg/wrk/issues/205

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -255,6 +255,7 @@ def run_wrk_on_all_nodes(
     http_host: str,
     http_port: str,
     all_endpoints: List[str] = None,
+    ignore_output: bool = False,
 ):
     """
     Use ray task to run one wrk trial on each node alive, picked randomly
@@ -279,6 +280,14 @@ def run_wrk_on_all_nodes(
                     num_cpus=0, resources={node_resource: 0.01}
                 ).remote(trial_length, num_connections, http_host, http_port, endpoint)
             )
+
+    print("Waiting for wrk trials to finish...")
+    ray.wait(rst_ray_refs, num_returns=len(rst_ray_refs))
+    print("Trials finished!")
+
+    if ignore_output:
+        return
+
     for decoded_output in ray.get(rst_ray_refs):
         all_wrk_stdout.append(decoded_output)
         parsed_metrics = parse_wrk_decoded_stdout(decoded_output)

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -28,11 +28,9 @@ import click
 import json
 import math
 import os
-import time
 
 from ray import serve
 from ray.serve.utils import logger
-from ray.serve.api import _get_global_client
 from serve_test_utils import (
     aggregate_all_metrics,
     run_wrk_on_all_nodes,
@@ -60,9 +58,7 @@ DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 
 
 def deploy_replicas(num_replicas, max_batch_size):
-    name = "echo"
-
-    @serve.deployment(name=name, num_replicas=num_replicas)
+    @serve.deployment(name="echo", num_replicas=num_replicas)
     class Echo:
         @serve.batch(max_batch_size=max_batch_size)
         async def handle_batch(self, requests):
@@ -71,26 +67,7 @@ def deploy_replicas(num_replicas, max_batch_size):
         async def __call__(self, request):
             return await self.handle_batch(request)
 
-    # Set _blocking=False to allow for a custom extended grace period for the
-    # health check, which is necessary to prevent this test from being flaky.
-    Echo.deploy(_blocking=False)
-
-    start = time.time()
-    client = _get_global_client()
-    # Wait for up to 10 minutes for the deployment to be healthy, allowing
-    # time for any actors that crashed to restart.
-    while time.time() - start < 10 * 60:
-        try:
-            # Raises RuntimeError if deployment enters the "UNHEALTHY" state.
-            client._wait_for_deployment_healthy(name)
-            break
-        except RuntimeError:
-            time.sleep(1)
-            pass
-
-    # If the deployment is still unhealthy at this point, allow RuntimeError
-    # to be raised and let this test fail.
-    client._wait_for_deployment_healthy(name)
+    Echo.deploy()
 
 
 def save_results(final_result, default_name):

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -83,6 +83,7 @@ def deploy_replicas(num_replicas, max_batch_size):
         try:
             # Raises RuntimeError if deployment enters the "UNHEALTHY" state.
             client._wait_for_deployment_healthy(name)
+            break
         except RuntimeError:
             time.sleep(1)
             pass


### PR DESCRIPTION
We see failures due to nodes crashing in the 1k replica tests, this should reduce the load on the autoscaler / cluster management components (and is a more realistic workload).

Closes https://github.com/ray-project/ray/issues/22928