### PR TITLE
[serve][release tests] Mark long-running failure test as non-stable

### DIFF
--- a/release/long_running_tests/long_running_tests.yaml
+++ b/release/long_running_tests/long_running_tests.yaml
@@ -192,3 +192,5 @@
   smoke_test:
     run:
       timeout: 600
+
+  stable: False


### PR DESCRIPTION
Test is unstable but not worthy of P0 interrupt, it'll be a P1 bug to fix it.

Closes https://github.com/ray-project/ray/issues/22512