### PR TITLE
[tests] Enable chaos testing for Dask-on-Ray

### DIFF
--- a/release/nightly_tests/chaos_test.yaml
+++ b/release/nightly_tests/chaos_test.yaml
@@ -33,7 +33,8 @@
 
   run:
     timeout: 7200
-    prepare: python wait_cluster.py 21 600
+    # Total run time without failures is about 300-400s.
+    prepare: python wait_cluster.py 21 600; python setup_chaos.py --node-kill-interval 100
     script: python dask_on_ray/large_scale_test.py --num_workers 20 --worker_obj_store_size_in_gb 20 --error_rate 0  --data_save_path /tmp/ray
 
 # Test large scale dask on ray test with spilling.
@@ -45,7 +46,8 @@
 
   run:
     timeout: 7200
-    prepare: python wait_cluster.py 21 600
+    # Total run time without failures is about 300-400s.
+    prepare: python wait_cluster.py 21 600; python setup_chaos.py --node-kill-interval 100
     script: python dask_on_ray/large_scale_test.py --num_workers 150 --worker_obj_store_size_in_gb 70 --error_rate 0  --data_save_path /tmp/ray
 
 - name: chaos_pipelined_ingestion_1500_gb_15_windows


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Turns on failures for Dask-on-Ray chaos tests.

## Related issue number

Closes #17383.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
