### PR TITLE
[runtime env][bug] Fix RuntimEnv ignore eager_install when _validate is True

### DIFF
--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -202,6 +202,13 @@ def parse_and_validate_env_vars(env_vars: Dict[str, str]) -> Optional[Dict[str, 
     return env_vars
 
 
+def parse_and_validate_eager_install(eager_install: bool) -> bool:
+    assert eager_install is not None
+    if not isinstance(eager_install, bool):
+        raise TypeError(f"eager_install must be a boolean. got {type(eager_install)}")
+    return eager_install
+
+
 # Dictionary mapping runtime_env options with the function to parse and
 # validate them.
 OPTION_TO_VALIDATION_FN = {
@@ -212,4 +219,5 @@ OPTION_TO_VALIDATION_FN = {
     "pip": parse_and_validate_pip,
     "env_vars": parse_and_validate_env_vars,
     "container": parse_and_validate_container,
+    "eager_install": parse_and_validate_eager_install,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When _validate is True, RuntimeEnv will ignore field eager_install.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
