### PR TITLE
[rllib] numpy generators should now use integers from generators rather then …

### DIFF
--- a/rllib/utils/spaces/repeated.py
+++ b/rllib/utils/spaces/repeated.py
@@ -24,7 +24,7 @@ class Repeated(gym.Space):
     def sample(self):
         return [
             self.child_space.sample()
-            for _ in range(self.np_random.randint(1, self.max_len + 1))
+            for _ in range(self.np_random.integers(1, self.max_len + 1))
         ]
 
     def contains(self, x):


### PR DESCRIPTION
…np_random.randint


## Why are these changes needed?

gym spaces use generators. Based on the numpy documentation (https://numpy.org/doc/stable/reference/random/generated/numpy.random.randint.html) 
random.randint mentions: 'New code should use the integers method of a default_rng() instance instead'
This is all. Otherwise env checks fail

## Related issue number

Did not file one :(

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
