### PR TITLE
[runtime env] Deletes the proto cache on RuntimeEnv

### DIFF
--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -343,9 +343,10 @@ class RuntimeEnv(dict):
 
         # set py_modules
         py_modules_uris = self.py_modules_uris()
-        proto_runtime_env.python_runtime_env.py_modules.extend(py_modules_uris)
-        # set py_modules uris
-        proto_runtime_env.uris.py_modules_uris.extend(py_modules_uris)
+        if py_modules_uris:
+            proto_runtime_env.python_runtime_env.py_modules.extend(py_modules_uris)
+            # set py_modules uris
+            proto_runtime_env.uris.py_modules_uris.extend(py_modules_uris)
 
         # set conda uri
         conda_uri = self.conda_uri()

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -246,9 +246,7 @@ class RuntimeEnv(dict):
         for option, validate_fn in OPTION_TO_VALIDATION_FN.items():
             option_val = runtime_env.get(option)
             if option_val is not None:
-                validated_option_val = validate_fn(option_val)
-                if validated_option_val is not None:
-                    self[option] = validated_option_val
+                self[option] = option_val
 
         if "_ray_release" in runtime_env:
             self["_ray_release"] = runtime_env["_ray_release"]

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -188,6 +188,12 @@ class RuntimeEnv(dict):
         "eager_install",
     }
 
+    extensions_fields: Set[str] = {
+        "_ray_release",
+        "_ray_commit",
+        "_inject_current_ray",
+    }
+
     def __init__(
         self,
         *,
@@ -532,9 +538,7 @@ class RuntimeEnv(dict):
                 )
             else:
                 # It is impossible for conda_config is None
-                runtime_env.python_runtime_env.conda_runtime_env.config = json.dumps(
-                    conda_config, sort_keys=True
-                )
+                runtime_env.python_runtime_env.conda_runtime_env.config = conda_config
 
     def _build_proto_container_runtime_env(self, runtime_env: ProtoRuntimeEnv):
         """Construct container runtime env protobuf from runtime env dict."""

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -21,19 +21,6 @@ from ray.util.annotations import PublicAPI
 logger = logging.getLogger(__name__)
 
 
-def _build_proto_pip_runtime_env(runtime_env_dict: dict, runtime_env: ProtoRuntimeEnv):
-    """Construct pip runtime env protobuf from runtime env dict."""
-    if runtime_env_dict.get("pip"):
-        if isinstance(runtime_env_dict["pip"], list):
-            runtime_env.python_runtime_env.pip_runtime_env.config.packages.extend(
-                runtime_env_dict["pip"]
-            )
-        else:
-            runtime_env.python_runtime_env.pip_runtime_env.virtual_env_name = (
-                runtime_env_dict["pip"]
-            )
-
-
 def _parse_proto_pip_runtime_env(runtime_env: ProtoRuntimeEnv, runtime_env_dict: dict):
     """Parse pip runtime env protobuf to runtime env dict."""
     if runtime_env.python_runtime_env.HasField("pip_runtime_env"):
@@ -45,21 +32,6 @@ def _parse_proto_pip_runtime_env(runtime_env: ProtoRuntimeEnv, runtime_env_dict:
             runtime_env_dict[
                 "pip"
             ] = runtime_env.python_runtime_env.pip_runtime_env.virtual_env_name
-
-
-def _build_proto_conda_runtime_env(
-    runtime_env_dict: dict, runtime_env: ProtoRuntimeEnv
-):
-    """Construct conda runtime env protobuf from runtime env dict."""
-    if runtime_env_dict.get("conda"):
-        if isinstance(runtime_env_dict["conda"], str):
-            runtime_env.python_runtime_env.conda_runtime_env.conda_env_name = (
-                runtime_env_dict["conda"]
-            )
-        else:
-            runtime_env.python_runtime_env.conda_runtime_env.config = json.dumps(
-                runtime_env_dict["conda"], sort_keys=True
-            )
 
 
 def _parse_proto_conda_runtime_env(
@@ -77,23 +49,6 @@ def _parse_proto_conda_runtime_env(
             )
 
 
-def _build_proto_container_runtime_env(
-    runtime_env_dict: dict, runtime_env: ProtoRuntimeEnv
-):
-    """Construct container runtime env protobuf from runtime env dict."""
-    if runtime_env_dict.get("container"):
-        container = runtime_env_dict["container"]
-        runtime_env.python_runtime_env.container_runtime_env.image = container.get(
-            "image", ""
-        )
-        runtime_env.python_runtime_env.container_runtime_env.worker_path = (
-            container.get("worker_path", "")
-        )
-        runtime_env.python_runtime_env.container_runtime_env.run_options.extend(
-            container.get("run_options", [])
-        )
-
-
 def _parse_proto_container_runtime_env(
     runtime_env: ProtoRuntimeEnv, runtime_env_dict: dict
 ):
@@ -109,17 +64,6 @@ def _parse_proto_container_runtime_env(
         runtime_env_dict["container"]["run_options"] = list(
             runtime_env.python_runtime_env.container_runtime_env.run_options
         )
-
-
-def _build_proto_plugin_runtime_env(
-    runtime_env_dict: dict, runtime_env: ProtoRuntimeEnv
-):
-    """Construct plugin runtime env protobuf from runtime env dict."""
-    if runtime_env_dict.get("plugins"):
-        for class_path, plugin_field in runtime_env_dict["plugins"].items():
-            plugin = runtime_env.python_runtime_env.plugin_runtime_env.plugins.add()
-            plugin.class_path = class_path
-            plugin.config = json.dumps(plugin_field, sort_keys=True)
 
 
 def _parse_proto_plugin_runtime_env(
@@ -257,8 +201,6 @@ class RuntimeEnv(dict):
         **kwargs,
     ):
         super().__init__()
-        self._cached_pb = None
-        self.__proto_runtime_env = None
 
         runtime_env = kwargs
         if py_modules is not None:
@@ -373,52 +315,59 @@ class RuntimeEnv(dict):
         return cls.from_proto(proto_runtime_env)
 
     def serialize(self) -> str:
-
+        proto_runtime_env = self.build_proto_runtime_env()
         return json.dumps(
-            json.loads(json_format.MessageToJson(self._proto_runtime_env)),
+            json.loads(json_format.MessageToJson(proto_runtime_env)),
             sort_keys=True,
         )
 
     def to_dict(self) -> Dict:
         return deepcopy(self)
 
-    @property
-    def _proto_runtime_env(self):
-        if self.__proto_runtime_env:
-            return self.__proto_runtime_env
+    def build_proto_runtime_env(self):
         proto_runtime_env = ProtoRuntimeEnv()
-        proto_runtime_env.working_dir = self.get("working_dir", "")
-        if "working_dir" in self:
-            proto_runtime_env.uris.working_dir_uri = self["working_dir"]
-        if "py_modules" in self:
-            proto_runtime_env.python_runtime_env.py_modules.extend(self["py_modules"])
-            for uri in self["py_modules"]:
-                proto_runtime_env.uris.py_modules_uris.append(uri)
-        if "conda" in self:
-            uri = get_conda_uri(self)
-            if uri is not None:
-                proto_runtime_env.uris.conda_uri = uri
-        if "pip" in self:
-            uri = get_pip_uri(self)
-            if uri is not None:
-                proto_runtime_env.uris.pip_uri = uri
-        env_vars = self.get("env_vars", {})
-        proto_runtime_env.env_vars.update(env_vars.items())
-        if "_ray_release" in self:
-            proto_runtime_env.extensions["_ray_release"] = str(self["_ray_release"])
-        if "_ray_commit" in self:
-            proto_runtime_env.extensions["_ray_commit"] = str(self["_ray_commit"])
-        if "_inject_current_ray" in self:
-            proto_runtime_env.extensions["_inject_current_ray"] = str(
-                self["_inject_current_ray"]
-            )
-        _build_proto_pip_runtime_env(self, proto_runtime_env)
-        _build_proto_conda_runtime_env(self, proto_runtime_env)
-        _build_proto_container_runtime_env(self, proto_runtime_env)
-        _build_proto_plugin_runtime_env(self, proto_runtime_env)
 
-        self.__proto_runtime_env = proto_runtime_env
-        return self.__proto_runtime_env
+        # set working_dir
+        proto_runtime_env.working_dir = self.working_dir()
+
+        # set working_dir uri
+        working_dir_uri = self.working_dir_uri()
+        if working_dir_uri is not None:
+            proto_runtime_env.uris.working_dir_uri = working_dir_uri
+
+        # set py_modules
+        py_modules_uris = self.py_modules_uris()
+        proto_runtime_env.python_runtime_env.py_modules.extend(py_modules_uris)
+        # set py_modules uris
+        proto_runtime_env.uris.py_modules_uris.extend(py_modules_uris)
+
+        # set conda uri
+        conda_uri = self.conda_uri()
+        if conda_uri is not None:
+            proto_runtime_env.uris.conda_uri = conda_uri
+
+        # set pip uri
+        pip_uri = self.pip_uri()
+        if pip_uri is not None:
+            proto_runtime_env.uris.pip_uri = pip_uri
+
+        # set env_vars
+        env_vars = self.env_vars()
+        proto_runtime_env.env_vars.update(env_vars.items())
+
+        # set extensions
+        for extensions_field in RuntimeEnv.extensions_fields:
+            if extensions_field in self:
+                proto_runtime_env.extensions[extensions_field] = str(
+                    self[extensions_field]
+                )
+
+        self._build_proto_pip_runtime_env(proto_runtime_env)
+        self._build_proto_conda_runtime_env(proto_runtime_env)
+        self._build_proto_container_runtime_env(proto_runtime_env)
+        self._build_proto_plugin_runtime_env(proto_runtime_env)
+
+        return proto_runtime_env
 
     @classmethod
     def from_proto(cls, proto_runtime_env: ProtoRuntimeEnv):
@@ -440,98 +389,170 @@ class RuntimeEnv(dict):
         return cls(_validate=False, **initialize_dict)
 
     def has_uris(self) -> bool:
-        uris = self._proto_runtime_env.uris
         if (
-            uris.working_dir_uri
-            or uris.py_modules_uris
-            or uris.conda_uri
-            or uris.pip_uri
-            or uris.plugin_uris
+            self.working_dir_uri()
+            or self.py_modules_uris()
+            or self.conda_uri()
+            or self.pip_uri()
+            or self.plugin_uris()
         ):
             return True
         return False
 
-    def working_dir_uri(self) -> str:
-        return self._proto_runtime_env.uris.working_dir_uri
+    def working_dir_uri(self) -> Optional[str]:
+        return self.get("working_dir")
 
     def py_modules_uris(self) -> List[str]:
-        return list(self._proto_runtime_env.uris.py_modules_uris)
+        if "py_modules" in self:
+            return list(self["py_modules"])
+        return []
 
-    def conda_uri(self) -> str:
-        return self._proto_runtime_env.uris.conda_uri
+    def conda_uri(self) -> Optional[str]:
+        if "conda" in self:
+            return get_conda_uri(self)
+        return None
 
-    def pip_uri(self) -> str:
-        return self._proto_runtime_env.uris.pip_uri
+    def pip_uri(self) -> Optional[str]:
+        if "pip" in self:
+            return get_pip_uri(self)
+        return None
 
     def plugin_uris(self) -> List[str]:
-        return list(self._proto_runtime_env.uris.plugin_uris)
+        """Not implemented yet, always return a empty list"""
+        return []
 
     def working_dir(self) -> str:
-        return self._proto_runtime_env.working_dir
+        return self.get("working_dir", "")
 
     def py_modules(self) -> List[str]:
-        return list(self._proto_runtime_env.python_runtime_env.py_modules)
+        if "py_modules" in self:
+            return list(self["py_modules"])
+        return []
 
     def env_vars(self) -> Dict:
-        return dict(self._proto_runtime_env.env_vars)
-
-    def plugins(self) -> List[Tuple[str, str]]:
-        result = list()
-        for (
-            plugin
-        ) in self._proto_runtime_env.python_runtime_env.plugin_runtime_env.plugins:
-            result.append((plugin.class_path, plugin.config))
-        return result
+        return self.get("env_vars", {})
 
     def has_conda(self) -> str:
-        return self._proto_runtime_env.python_runtime_env.HasField("conda_runtime_env")
+        if self.get("conda"):
+            return True
+        return False
 
     def conda_env_name(self) -> str:
-        if not self.has_conda():
+        if not self.has_conda() or not isinstance(self["conda"], str):
             return None
-        if not self._proto_runtime_env.python_runtime_env.conda_runtime_env.HasField(
-            "conda_env_name"
-        ):
-            return None
-        return (
-            self._proto_runtime_env.python_runtime_env.conda_runtime_env.conda_env_name
-        )
+        return self["conda"]
 
     def conda_config(self) -> str:
-        if not self.has_conda():
+        if not self.has_conda() or not isinstance(self["conda"], dict):
             return None
-        if not self._proto_runtime_env.python_runtime_env.conda_runtime_env.HasField(
-            "config"
-        ):
-            return None
-        return self._proto_runtime_env.python_runtime_env.conda_runtime_env.config
+        return json.dumps(self["conda"], sort_keys=True)
 
     def has_pip(self) -> bool:
-        return self._proto_runtime_env.python_runtime_env.HasField("pip_runtime_env")
+        if self.get("pip"):
+            return True
+        return False
 
     def pip_packages(self) -> List:
-        if not self.has_pip():
+        if not self.has_pip() or not isinstance(self["pip"], list):
             return []
-        return list(
-            self._proto_runtime_env.python_runtime_env.pip_runtime_env.config.packages
-        )
+        return self["pip"]
 
-    def get_extension(self, key) -> str:
-        return self._proto_runtime_env.extensions.get(key)
+    def virtualenv_name(self) -> Optional[str]:
+        if not self.has_pip() or not isinstance(self["pip"], str):
+            return None
+        return self["pip"]
+
+    def get_extension(self, key) -> Optional[str]:
+        if key not in RuntimeEnv.extensions_fields:
+            raise ValueError(
+                f"Extension key must be one of {RuntimeEnv.extensions_fields}, "
+                f"got: {key}"
+            )
+        return self.get(key)
 
     def has_py_container(self) -> bool:
-        return self._proto_runtime_env.python_runtime_env.HasField(
-            "container_runtime_env"
-        )
+        if self.get("container"):
+            return True
+        return False
 
-    def py_container_image(self) -> str:
+    def py_container_image(self) -> Optional[str]:
         if not self.has_py_container():
             return None
-        return self._proto_runtime_env.python_runtime_env.container_runtime_env.image
+        return self["container"].get("image", "")
+
+    def py_container_worker_path(self) -> Optional[str]:
+        if not self.has_py_container():
+            return None
+        return self["container"].get("worker_path", "")
 
     def py_container_run_options(self) -> List:
         if not self.has_py_container():
             return None
-        return list(
-            self._proto_runtime_env.python_runtime_env.container_runtime_env.run_options
-        )
+        return self["container"].get("run_options", [])
+
+    def has_plugins(self) -> bool:
+        if self.get("plugins"):
+            return True
+        return False
+
+    def plugins(self) -> List[Tuple[str, str]]:
+        result = list()
+        if self.has_plugins():
+            for class_path, plugin_field in self["plugins"].items():
+                result.append((class_path, json.dumps(plugin_field, sort_keys=True)))
+        return result
+
+    def _build_proto_pip_runtime_env(self, runtime_env: ProtoRuntimeEnv):
+        """Construct pip runtime env protobuf from runtime env dict."""
+        if self.has_pip():
+            pip_packages = self.pip_packages()
+            virtualenv_name = self.virtualenv_name()
+            # It is impossible for pip_packages and virtualenv_name
+            # to be non-null at the same time
+            if pip_packages:
+                runtime_env.python_runtime_env.pip_runtime_env.config.packages.extend(
+                    pip_packages
+                )
+            else:
+                # It is impossible for virtualenv_name is None
+                runtime_env.python_runtime_env.pip_runtime_env.virtual_env_name = (
+                    virtualenv_name
+                )
+
+    def _build_proto_conda_runtime_env(self, runtime_env: ProtoRuntimeEnv):
+        """Construct conda runtime env protobuf from runtime env dict."""
+        if self.has_conda():
+            conda_env_name = self.conda_env_name()
+            conda_config = self.conda_config()
+            # It is impossible for conda_env_name and conda_config
+            # to be non-null at the same time
+            if conda_env_name:
+                runtime_env.python_runtime_env.conda_runtime_env.conda_env_name = (
+                    conda_env_name
+                )
+            else:
+                # It is impossible for conda_config is None
+                runtime_env.python_runtime_env.conda_runtime_env.config = json.dumps(
+                    conda_config, sort_keys=True
+                )
+
+    def _build_proto_container_runtime_env(self, runtime_env: ProtoRuntimeEnv):
+        """Construct container runtime env protobuf from runtime env dict."""
+        if self.has_py_container():
+            runtime_env.python_runtime_env.container_runtime_env.image = (
+                self.py_container_image()
+            )
+            runtime_env.python_runtime_env.container_runtime_env.worker_path = (
+                self.py_container_worker_path()
+            )
+            runtime_env.python_runtime_env.container_runtime_env.run_options.extend(
+                self.py_container_run_options()
+            )
+
+    def _build_proto_plugin_runtime_env(self, runtime_env: ProtoRuntimeEnv):
+        """Construct plugin runtime env protobuf from runtime env dict."""
+        if self.has_plugins():
+            for class_path, plugin_field in self.plugins():
+                plugin = runtime_env.python_runtime_env.plugin_runtime_env.plugins.add()
+                plugin.class_path = class_path
+                plugin.config = plugin_field

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -485,9 +485,11 @@ class Client:
 
         curr_job_env = ray.get_runtime_context().runtime_env
         if "runtime_env" in ray_actor_options:
-            ray_actor_options["runtime_env"].setdefault(
-                "working_dir", curr_job_env.get("working_dir")
-            )
+            # It is illegal to set field A to None.
+            if curr_job_env.get("working_dir") is not None:
+                ray_actor_options["runtime_env"].setdefault(
+                    "working_dir", curr_job_env.get("working_dir")
+                )
         else:
             ray_actor_options["runtime_env"] = curr_job_env
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -485,7 +485,7 @@ class Client:
 
         curr_job_env = ray.get_runtime_context().runtime_env
         if "runtime_env" in ray_actor_options:
-            # It is illegal to set field A to None.
+            # It is illegal to set field working_dir to None.
             if curr_job_env.get("working_dir") is not None:
                 ray_actor_options["runtime_env"].setdefault(
                     "working_dir", curr_job_env.get("working_dir")

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -683,7 +683,7 @@ def test_serialize_deserialize(option):
     else:
         raise ValueError("unexpected option " + str(option))
 
-    proto_runtime_env = RuntimeEnv(**runtime_env, _validate=False)._proto_runtime_env
+    proto_runtime_env = RuntimeEnv(**runtime_env, _validate=False).build_proto_runtime_env()
     cls_runtime_env = RuntimeEnv.from_proto(proto_runtime_env)
     assert cls_runtime_env.to_dict() == runtime_env
 

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -693,6 +693,9 @@ def test_serialize_deserialize(option):
     assert cls_runtime_env.to_dict() == runtime_env
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="conda in runtime_env unsupported on Windows."
+)
 def test_runtime_env_interface():
 
     # Test the interface related to working_dir

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -1,4 +1,3 @@
-from email.policy import default
 import os
 import pytest
 import sys

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -660,6 +660,9 @@ def test_runtime_env_retry(set_runtime_env_retry_times, ray_start_regular):
             )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="conda in runtime_env unsupported on Windows."
+)
 @pytest.mark.parametrize(
     "option",
     ["pip_list", "conda_name", "conda_dict", "container", "plugins"],
@@ -700,13 +703,13 @@ def test_runtime_env_interface():
 
     # Test the interface related to working_dir
     default_working_dir = "s3://bucket/key.zip"
-    modify_workeing_dir = "s3://bucket/key_A.zip"
+    modify_working_dir = "s3://bucket/key_A.zip"
     runtime_env = RuntimeEnv(working_dir=default_working_dir)
     runtime_env_dict = runtime_env.to_dict()
     assert runtime_env.working_dir_uri() == default_working_dir
-    runtime_env["working_dir"] = modify_workeing_dir
-    runtime_env_dict["working_dir"] = modify_workeing_dir
-    assert runtime_env.working_dir_uri() == modify_workeing_dir
+    runtime_env["working_dir"] = modify_working_dir
+    runtime_env_dict["working_dir"] = modify_working_dir
+    assert runtime_env.working_dir_uri() == modify_working_dir
     assert runtime_env.to_dict() == runtime_env_dict
     # Test that the modification of working_dir also works on
     # proto serialization
@@ -853,7 +856,7 @@ def test_runtime_env_interface():
     assert runtime_env.py_container_image() == container_copy["image"]
     assert runtime_env.py_container_worker_path() == container_copy["worker_path"]
     assert runtime_env.py_container_run_options() == container_copy["run_options"]
-    # Test that the modification of concontainerda also works on
+    # Test that the modification of container also works on
     # proto serialization
     assert runtime_env_dict == RuntimeEnv.from_proto(
         runtime_env.build_proto_runtime_env()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Mainly the following things:
- This PR deletes the proto cache on RuntimeEnv, ensuring that the user's modification of RuntimeEnv can take effect in the Proto message.
- validate whole runtime env when serialize runtime_env. 
- overload method `__setitem__` to parse and validate field when it has to modify.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
