### PR TITLE
[ci/release] Fix result output in Buildkite pipeline run

### DIFF
--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -12,15 +12,15 @@ reason() {
   # Keep in sync with e2e.py ExitCode enum
   if [ "$1" -eq 0 ]; then
     REASON="success"
-  elif [ "$1" -ge 1 ] && [ "$1" -le 10 ]; then
+  elif [ "$1" -ge 1 ] && [ "$1" -lt 10 ]; then
     REASON="runtime error"
-  elif [ "$1" -gt 10 ] && [ "$1" -le 20 ]; then
+  elif [ "$1" -ge 10 ] && [ "$1" -lt 20 ]; then
     REASON="infra error"
-  elif [ "$1" -gt 30 ] && [ "$1" -le 40 ]; then
+  elif [ "$1" -ge 30 ] && [ "$1" -lt 40 ]; then
     REASON="infra timeout"
   elif [ "$1" -eq 42 ]; then
     REASON="command timeout"
-  elif [ "$1" -gt 40 ] && [ "$1" -le 50 ]; then
+  elif [ "$1" -ge 40 ] && [ "$1" -lt 50 ]; then
     REASON="command error"
   fi
   echo "${REASON}"

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -125,7 +125,7 @@ echo "Final release test exit code is ${EXIT_CODE} (${REASON})"
 
 if [ "$EXIT_CODE" -eq 0 ]; then
   echo "RELEASE MANAGER: This test seems to have passed."
-elif [ "$EXIT_CODE" -gt 30 ] && [ "$EXIT_CODE" -le 40 ]; then
+elif [ "$EXIT_CODE" -ge 30 ] && [ "$EXIT_CODE" -lt 40 ]; then
   echo "RELEASE MANAGER: This is likely an infra error that can be solved by RESTARTING this test."
 else
   echo "RELEASE MANAGER: This could be an error in the test. Please REVIEW THE LOGS and ping the test owner."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The new buildkite pipeline prints out faulty results due to a confusion of `-ge/-gt` and `-le/-lt` in the retry script. This is a cosmetic error (so behavior was still correct) that is resolved with this PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
