### PR TITLE
[KubeRay] Pin autoscaler image

### DIFF
--- a/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
+++ b/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
@@ -101,9 +101,7 @@ spec:
               name: ray-logs
         # The Ray autoscaler sidecar to the head pod
         - name: autoscaler
-          # TODO (short term): Pin the image to a particular Ray commit after
-          #   nightly image with changes from https://github.com/ray-project/ray/pull/22847 is built. 
-          # TODO (longer term): This should be selected based on Ray version.
+          # TODO: Use released Ray version starting with Ray 1.12.0.
           image: rayproject/ray:413fe0
           imagePullPolicy: Always
           env:

--- a/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
+++ b/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
@@ -104,7 +104,7 @@ spec:
           # TODO (short term): Pin the image to a particular Ray commit after
           #   nightly image with changes from https://github.com/ray-project/ray/pull/22847 is built. 
           # TODO (longer term): This should be selected based on Ray version.
-          image: rayproject/ray:nightly
+          image: rayproject/ray:413fe0
           imagePullPolicy: Always
           env:
           - name: RAY_CLUSTER_NAMESPACE


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sets the autoscaler image to the one from this PR's commit.
https://github.com/ray-project/ray/pull/22847

When Ray 1.12.0 is released, we will start using released versions of Ray for the autoscaler image.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
