### PR TITLE
[autoscaler] Enable creating multiple clusters in one resource group …

### DIFF
--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -72,25 +72,14 @@ class AzureNodeProvider(NodeProvider):
     def _get_filtered_nodes(self, tag_filters):
         """In addition to tag_filters, here add an extra filter tag: TAG_RAY_CLUSTER_NAME
         to filter some specific cluster. """
-
-        update_tag_filters = [
-            {
-                TAG_RAY_CLUSTER_NAME: self.cluster_name,
-            },
-        ]
-        for key, value in tag_filters.items():
-            update_tag_filters.append(
-                {
-                    key: value
-                }
-            )
+        update_tag_filters = tag_filters.copy()
+        update_tag_filters.update({TAG_RAY_CLUSTER_NAME: self.cluster_name})
 
         def match_tags(vm):
-            for each_tag_filter in update_tag_filters:
-                for k, v in each_tag_filter.items():
-                    if vm.tags.get(k) != v:
-                        return False
-                return True
+            for k, v in update_tag_filters.items():
+                if vm.tags.get(k) != v:
+                    return False
+            return True
 
         vms = self.compute_client.virtual_machines.list(
             resource_group_name=self.provider_config["resource_group"]

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -136,9 +136,11 @@ class AzureNodeProvider(NodeProvider):
         nodes() must be called again to refresh results.
 
         Examples:
-            >>> provider.non_terminated_nodes({TAG_RAY_NODE_KIND: "worker"})
+            >>> provider.non_terminated_nodes({TAG_RAY_NODE_KIND: "worker", TAG_RAY_CLUSTER_NAME: "cluster_name"})
             ["node-1", "node-2"]
         """
+        tag_cluster_name = {TAG_RAY_CLUSTER_NAME: self.cluster_name}
+        tag_filters.update(tag_cluster_name)
         nodes = self._get_filtered_nodes(tag_filters=tag_filters)
         return [k for k, v in nodes.items() if not v["status"].startswith("deallocat")]
 


### PR DESCRIPTION
…on Azure

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is to fix #22996, then enables Ray autoscaler creating multiple clusters in the same resource group on Azure.

When Ray autoscaler decides whether to create or update a cluster, it will list/filter non-terminated node. On GCP and AWS, there is an extra filter condition about cluster name, but there misses such condition on Azure. So when there are existing cluster nodes, autoscaler will not create a new head node because it detect there is already a node with tag " TAG_RAY_NODE_KIND: "head"

## Related issue number

Closes #22996

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
 