### PR TITLE
[Nightly Tests] Readjust the concurrency limit.

### DIFF
--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -6,14 +6,18 @@ from typing import Tuple, Optional, Dict
 from ray_release.config import Test, RELEASE_PACKAGE_DIR, load_test_cluster_compute
 from ray_release.logger import logger
 
+# Keep 10% for the buffer.
+limit = int(15784 * 0.9)
+
 
 CONCURRENY_GROUPS = {
-    "small": 64,
-    "medium": 16,
-    "large": 8,
-    "small-gpu": 8,
-    "large-gpu": 4,
+    "small": 16,
+    "medium": 4,
+    "large": 2,
+    "small-gpu": 4,
+    "large-gpu": 2,
 }
+
 
 Condition = namedtuple(
     "Condition", ["min_gpu", "max_gpu", "min_cpu", "max_cpu", "group"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR reduces the concurrency limit. Based on the back of envelope calculation, the current concurrency limit can easily exceed the service quota. 

Given large == 2048 vCPUs, it will use about 20K vCPUs, which is slightly larger than the limit. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
