### PR TITLE
[ml/train] Remove `ConvertibleToTrainable` and move `Trainer` to `ray.ml.trainer`

### DIFF
--- a/python/ray/ml/trainer.py
+++ b/python/ray/ml/trainer.py
@@ -1,12 +1,12 @@
 import abc
 import logging
-from typing import Dict, Union, Callable, Optional, TYPE_CHECKING
+from typing import Dict, Union, Callable, Optional, TYPE_CHECKING, Type
 
 from ray.ml.preprocessor import Preprocessor
 from ray.ml.checkpoint import Checkpoint
 from ray.ml.result import Result
 from ray.ml.config import ScalingConfig, RunConfig
-from ray.tune.trainable import ConvertibleToTrainable
+from ray.tune import Trainable
 from ray.util import PublicAPI
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ class TrainingFailedError(RuntimeError):
 
 
 @PublicAPI(stability="alpha")
-class Trainer(ConvertibleToTrainable, abc.ABC):
+class Trainer(abc.ABC):
     """Defines interface for distributed training on Ray.
 
     Args:
@@ -64,4 +64,9 @@ class Trainer(ConvertibleToTrainable, abc.ABC):
             TrainingFailedError: If any failures during the execution of
             ``self.as_trainable()``.
         """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def as_trainable(self) -> Type[Trainable]:
+        """Convert self to a ``tune.Trainable`` class."""
         raise NotImplementedError

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -1,4 +1,3 @@
-import abc
 from contextlib import redirect_stdout, redirect_stderr
 import copy
 from datetime import datetime
@@ -9,7 +8,7 @@ import shutil
 import sys
 import tempfile
 import time
-from typing import Any, Dict, Optional, Union, Callable, Type
+from typing import Any, Dict, Optional, Union, Callable
 import uuid
 
 import ray
@@ -1028,13 +1027,3 @@ class DistributedTrainable(Trainable):
         new_config[STDOUT_FILE] = self._stdout_file
         new_config[STDERR_FILE] = self._stderr_file
         return new_config
-
-
-@PublicAPI(stability="alpha")
-class ConvertibleToTrainable(abc.ABC):
-    """A class that can be converted to a ``tune.Trainable``."""
-
-    @abc.abstractmethod
-    def as_trainable(self) -> Type[Trainable]:
-        """Convert self to a ``tune.Trainable`` class."""
-        raise NotImplementedError


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
As discussed,
- Removes `ConvertibleToTrainable` interface and makes `as_trainable` part of the Trainer interface
- Moves Trainer interface to `ray.ml.trainer` from `ray.ml.train.trainer`
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
