### PR TITLE
Make schema() read non-disruptive to iter_datasets()

### DIFF
--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -498,7 +498,7 @@ class DatasetPipeline(Generic[T]):
             schema is not known.
         """
         if self._first_dataset is None:
-            self._first_dataset, self._dataset_iter = self._peak()
+            self._first_dataset, self._dataset_iter = self._peek()
         return self._first_dataset.schema(fetch_if_missing=fetch_if_missing)
 
     def count(self) -> int:
@@ -647,7 +647,7 @@ class DatasetPipeline(Generic[T]):
 
         return EpochDelimitedIterator(self)
 
-    def _peak(self) -> (Dataset[T], Iterator[Dataset[T]]):
+    def _peek(self) -> (Dataset[T], Iterator[Dataset[T]]):
         self._optimize_stages()
         dataset_iter = PipelineExecutor(self)
         return next(dataset_iter), dataset_iter
@@ -667,7 +667,7 @@ class DatasetPipeline(Generic[T]):
             iter = itertools.chain([self._first_dataset], self._dataset_iter)
             del self._dataset_iter
         else:
-            self._first_dataset, rest = self._peak()
+            self._first_dataset, rest = self._peek()
             iter = itertools.chain([self._first_dataset], rest)
         return iter
 

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -263,30 +263,33 @@ def test_schema(ray_start_regular_shared):
     assert pipe.schema() == int
 
 
-def test_schema_peak(ray_start_regular_shared):
+def test_schema_peek(ray_start_regular_shared):
     # Multiple datasets
     pipe = ray.data.range(6).window(blocks_per_window=2)
     assert pipe.schema() == int
+    assert pipe._first_dataset is not None
     dss = list(pipe.iter_datasets())
     assert len(dss) == 3, dss
-    with pytest.raises(RuntimeError):
-        pipe.schema()
+    assert pipe._first_dataset is None
+    assert pipe.schema() == int
 
     # Only 1 dataset
     pipe = ray.data.range(1).window(blocks_per_window=2)
     assert pipe.schema() == int
+    assert pipe._first_dataset is not None
     dss = list(pipe.iter_datasets())
     assert len(dss) == 1, dss
-    with pytest.raises(RuntimeError):
-        pipe.schema()
+    assert pipe._first_dataset is None
+    assert pipe.schema() == int
 
     # Empty datasets
     pipe = ray.data.range(6).filter(lambda x: x < 0).window(blocks_per_window=2)
     assert pipe.schema() is None
+    assert pipe._first_dataset is not None
     dss = list(pipe.iter_datasets())
     assert len(dss) == 3, dss
-    with pytest.raises(RuntimeError):
-        pipe.schema()
+    assert pipe._first_dataset is None
+    assert pipe.schema() is None
 
 
 def test_split(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -263,45 +263,30 @@ def test_schema(ray_start_regular_shared):
     assert pipe.schema() == int
 
 
-def test_schema_read_is_not_disruptive(ray_start_regular_shared):
-    # Multiple datasets: access schema and then iter_datasets()
+def test_schema_peak(ray_start_regular_shared):
+    # Multiple datasets
     pipe = ray.data.range(6).window(blocks_per_window=2)
     assert pipe.schema() == int
     dss = list(pipe.iter_datasets())
     assert len(dss) == 3, dss
-    assert pipe.schema() == int
+    with pytest.raises(RuntimeError):
+        pipe.schema()
 
-    # Multiple datasets: iter_datasets() and then access schema
-    pipe = ray.data.range(6).window(blocks_per_window=2)
-    dss = list(pipe.iter_datasets())
-    assert len(dss) == 3, dss
-    assert pipe.schema() == int
-
-    # Only 1 dataset: access schema and then iter_datasets()
+    # Only 1 dataset
     pipe = ray.data.range(1).window(blocks_per_window=2)
     assert pipe.schema() == int
     dss = list(pipe.iter_datasets())
     assert len(dss) == 1, dss
-    assert pipe.schema() == int
+    with pytest.raises(RuntimeError):
+        pipe.schema()
 
-    # Only 1 dataset: iter_datasets() and then access schema
-    pipe = ray.data.range(1).window(blocks_per_window=2)
-    dss = list(pipe.iter_datasets())
-    assert len(dss) == 1, dss
-    assert pipe.schema() == int
-
-    # Empty datasets: access schema and then iter_datasets()
+    # Empty datasets
     pipe = ray.data.range(6).filter(lambda x: x < 0).window(blocks_per_window=2)
     assert pipe.schema() is None
     dss = list(pipe.iter_datasets())
     assert len(dss) == 3, dss
-    assert pipe.schema() is None
-
-    # Empty datasets: iter_datasets() and then access schema
-    pipe = ray.data.range(6).filter(lambda x: x < 0).window(blocks_per_window=2)
-    dss = list(pipe.iter_datasets())
-    assert len(dss) == 3, dss
-    assert pipe.schema() is None
+    with pytest.raises(RuntimeError):
+        pipe.schema()
 
 
 def test_split(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -263,6 +263,47 @@ def test_schema(ray_start_regular_shared):
     assert pipe.schema() == int
 
 
+def test_schema_read_is_not_disruptive(ray_start_regular_shared):
+    # Multiple datasets: access schema and then iter_datasets()
+    pipe = ray.data.range(6).window(blocks_per_window=2)
+    assert pipe.schema() == int
+    dss = list(pipe.iter_datasets())
+    assert len(dss) == 3, dss
+    assert pipe.schema() == int
+
+    # Multiple datasets: iter_datasets() and then access schema
+    pipe = ray.data.range(6).window(blocks_per_window=2)
+    dss = list(pipe.iter_datasets())
+    assert len(dss) == 3, dss
+    assert pipe.schema() == int
+
+    # Only 1 dataset: access schema and then iter_datasets()
+    pipe = ray.data.range(1).window(blocks_per_window=2)
+    assert pipe.schema() == int
+    dss = list(pipe.iter_datasets())
+    assert len(dss) == 1, dss
+    assert pipe.schema() == int
+
+    # Only 1 dataset: iter_datasets() and then access schema
+    pipe = ray.data.range(1).window(blocks_per_window=2)
+    dss = list(pipe.iter_datasets())
+    assert len(dss) == 1, dss
+    assert pipe.schema() == int
+
+    # Empty datasets: access schema and then iter_datasets()
+    pipe = ray.data.range(6).filter(lambda x: x < 0).window(blocks_per_window=2)
+    assert pipe.schema() is None
+    dss = list(pipe.iter_datasets())
+    assert len(dss) == 3, dss
+    assert pipe.schema() is None
+
+    # Empty datasets: iter_datasets() and then access schema
+    pipe = ray.data.range(6).filter(lambda x: x < 0).window(blocks_per_window=2)
+    dss = list(pipe.iter_datasets())
+    assert len(dss) == 3, dss
+    assert pipe.schema() is None
+
+
 def test_split(ray_start_regular_shared):
     pipe = ray.data.range(3).map(lambda x: x + 1).repeat(10)
 


### PR DESCRIPTION
## Why are these changes needed?
Currently, reading schema of DatasetPipeline is disruptive and will invalidate the iter_datasets().

## Related issue number

Closes #22328

## Checks

- [Y ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [Y ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
