### PR TITLE
[minor] Leave a big of wiggle room when calculating shared memory max

### DIFF
--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -214,7 +214,8 @@ class ResourceSpec(
             # Cap by shm size by default to avoid low performance, but don't
             # go lower than REQUIRE_SHM_SIZE_THRESHOLD.
             if sys.platform == "linux" or sys.platform == "linux2":
-                shm_avail = ray._private.utils.get_shared_memory_bytes()
+                # Multiple by 0.95 to give a bit of wiggle-room.
+                shm_avail = ray._private.utils.get_shared_memory_bytes() * 0.95
                 max_cap = min(
                     max(ray_constants.REQUIRE_SHM_SIZE_THRESHOLD, shm_avail), max_cap
                 )

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -215,6 +215,7 @@ class ResourceSpec(
             # go lower than REQUIRE_SHM_SIZE_THRESHOLD.
             if sys.platform == "linux" or sys.platform == "linux2":
                 # Multiple by 0.95 to give a bit of wiggle-room.
+                # https://github.com/ray-project/ray/pull/23034/files
                 shm_avail = ray._private.utils.get_shared_memory_bytes() * 0.95
                 max_cap = min(
                     max(ray_constants.REQUIRE_SHM_SIZE_THRESHOLD, shm_avail), max_cap


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes a user issue where " ValueError: The configured object store size (63.999983616 GB) exceeds /dev/shm size (63.999520768 GB)."

Possibly due to floating point error or a process using a tiny bit of extra shm memory during the startup process.