### PR TITLE
[serve] Exclude unset fields from Ray actor options

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -8,7 +8,7 @@ from ray.serve.utils import DEFAULT
 
 class RayActorOptionsSchema(BaseModel, extra=Extra.forbid):
     runtime_env: dict = Field(
-        default=None,
+        default={},
         description=(
             "This deployment's runtime_env. working_dir and "
             "py_modules may contain only remote URIs."
@@ -48,7 +48,7 @@ class RayActorOptionsSchema(BaseModel, extra=Extra.forbid):
         ge=0,
     )
     resources: Dict = Field(
-        default=None, description=("The custom resources required by each replica.")
+        default={}, description=("The custom resources required by each replica.")
     )
     accelerator_type: str = Field(
         default=None,
@@ -341,7 +341,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
     if s.ray_actor_options is None:
         ray_actor_options = None
     else:
-        ray_actor_options = s.ray_actor_options.dict()
+        ray_actor_options = s.ray_actor_options.dict(exclude_unset=True)
 
     return deployment(
         name=s.name,

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -552,9 +552,6 @@ def test_deployment_to_schema_to_deployment():
     serve.shutdown()
 
 
-pytest.mark.parametrize()
-
-
 def test_unset_fields_schema_to_deployment_ray_actor_options():
     # Ensure unset fields are excluded from ray_actor_options
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `schema_to_deployment()` function preserve unset fields with unexpected default argument types. This change excludes unset fields in that function and also changes the dictionaries' default values to empty dicts.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #23052.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - `test_schema.py` expects and tests the new defaults and unset fields.
