### PR TITLE
[ml/checkpoint] Fix checkpoint location on remote node

### DIFF
--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -350,8 +350,8 @@ class TrialCheckpoint(Checkpoint, _TrialCheckpoint):
             locations.add(local_path)
         if cloud_path:
             self._cloud_path_tcp = cloud_path
-            locations.add(cloud_path)
             self._uri = cloud_path
+            locations.add(cloud_path)
         self._locations = locations
 
     @property

--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -27,7 +27,7 @@ class _TrialCheckpoint(os.PathLike):
         self, local_path: Optional[str] = None, cloud_path: Optional[str] = None
     ):
         self._local_path = local_path
-        self._cloud_path = cloud_path
+        self._cloud_path_tcp = cloud_path
 
     @property
     def local_path(self):
@@ -39,11 +39,11 @@ class _TrialCheckpoint(os.PathLike):
 
     @property
     def cloud_path(self):
-        return self._cloud_path
+        return self._cloud_path_tcp
 
     @cloud_path.setter
     def cloud_path(self, path: str):
-        self._cloud_path = path
+        self._cloud_path_tcp = path
 
     # The following magic methods are implemented to keep backwards
     # compatibility with the old path-based return values.
@@ -331,27 +331,27 @@ class TrialCheckpoint(Checkpoint, _TrialCheckpoint):
 
         # Checkpoint does not allow empty data, but TrialCheckpoint
         # did. To keep backwards compatibility, we use a placeholder URI
-        # here, and manually set self._uri to empty later if it's not
-        # overwritten.
+        # here, and manually set self._uri and self._local_dir later.
         PLACEHOLDER = "s3://placeholder"
-        uri = PLACEHOLDER
+        Checkpoint.__init__(self, uri=PLACEHOLDER)
 
-        self._cloud_path = None
+        # Reset local variables
+        self._uri = None
+        self._local_path = None
+
+        self._cloud_path_tcp = None
         self._local_path_tcp = None
 
         locations = set()
         if local_path:
             # Add _tcp to not conflict with Checkpoint._local_path
             self._local_path_tcp = local_path
+            self._local_path = local_path
             locations.add(local_path)
-            uri = f"file://{local_path}"
         if cloud_path:
-            self._cloud_path = cloud_path
+            self._cloud_path_tcp = cloud_path
             locations.add(cloud_path)
-            uri = cloud_path
-        Checkpoint.__init__(self, uri=uri)
-        if self._uri == PLACEHOLDER:
-            self._uri = None
+            self._uri = cloud_path
         self._locations = locations
 
     @property
@@ -379,11 +379,11 @@ class TrialCheckpoint(Checkpoint, _TrialCheckpoint):
                 cloud_path = _get_external_path(candidate)
                 if cloud_path:
                     break
-        return cloud_path or self._cloud_path
+        return cloud_path or self._cloud_path_tcp
 
     @cloud_path.setter
     def cloud_path(self, path: str):
-        self._cloud_path = path
+        self._cloud_path_tcp = path
         if not self._uri:
             self._uri = path
         self._locations.add(path)

--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -346,7 +346,8 @@ class TrialCheckpoint(Checkpoint, _TrialCheckpoint):
         if local_path:
             # Add _tcp to not conflict with Checkpoint._local_path
             self._local_path_tcp = local_path
-            self._local_path = local_path
+            if os.path.exists(local_path):
+                self._local_path = local_path
             locations.add(local_path)
         if cloud_path:
             self._cloud_path_tcp = cloud_path

--- a/python/ray/tune/tests/test_cloud.py
+++ b/python/ray/tune/tests/test_cloud.py
@@ -19,6 +19,13 @@ class TrialCheckpointApiTest(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.local_dir)
 
+    def testConstructTrialCheckpoint(self):
+        # All these constructions should work
+        TrialCheckpoint(None, None)
+        TrialCheckpoint("/tmp", None)
+        TrialCheckpoint(None, "s3://invalid")
+        TrialCheckpoint("/remote/node/dir", None)
+
     def ensureCheckpointFile(self):
         with open(os.path.join(self.local_dir, "checkpoint.txt"), "wt") as f:
             f.write("checkpoint\n")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently breaks tests where the checkpoint is stored on a remote node (e.g. via Ray client), e.g.: https://buildkite.com/ray-project/release-tests-branch/builds/132#6a4936a8-41dd-4fd2-9f02-976855cbd9b7
Instead, we can set the properties manually. 
In the future, we need a story on how to refer to checkpoints kept on remote nodes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
