### PR TITLE
[ci/release] Validate smoke test fields, enforce frequency

### DIFF
--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -170,9 +170,24 @@
 		},
 		"SmokeTest": {
 			"type": "object",
-			"additionalProperties": true,
+			"additionalProperties": false,
 			"title": "SmokeTest",
 			"properties": {
+				"working_dir": {
+					"type": "string"
+				},
+                "driver_setup": {
+					"type": "string"
+				},
+				"cluster": {
+					"type": "object"
+				},
+				"run": {
+					"type": "object"
+				},
+                "alert": {
+					"type": "string"
+				},
 				"frequency": {
 					"type": "string",
 					"enum": [

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -18,9 +18,9 @@
 				"legacy": {
 					"$ref": "#/definitions/Legacy"
 				},
-                "stable": {
-                    "type": "boolean"
-                },
+				"stable": {
+					"type": "boolean"
+				},
 				"frequency": {
 					"type": "string",
 					"enum": [
@@ -141,9 +141,9 @@
 				"timeout": {
 					"type": "integer"
 				},
-                "long_running": {
-                    "type": "boolean"
-                }
+				"long_running": {
+					"type": "boolean"
+				}
 			},
 			"required": [
 				"script",
@@ -171,7 +171,21 @@
 		"SmokeTest": {
 			"type": "object",
 			"additionalProperties": true,
-			"title": "SmokeTest"
+			"title": "SmokeTest",
+			"properties": {
+				"frequency": {
+					"type": "string",
+					"enum": [
+						"disabled",
+						"multi",
+						"nightly",
+						"weekly"
+					]
+				}
+			},
+			"required": [
+				"frequency"
+			]
 		}
 	}
 }

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -37,6 +37,7 @@ class ConfigTest(unittest.TestCase):
                     "wait_for_nodes": {"num_nodes": 2, "timeout": 100},
                     "type": "client",
                 },
+                "smoke_test": {"timeout": 20, "frequency": "multi"},
                 "alert": "default",
             }
         )
@@ -70,6 +71,12 @@ class ConfigTest(unittest.TestCase):
         # Faulty file manager type
         invalid_test = test.copy()
         invalid_test["run"]["file_manager"] = "invalid"
+        with self.assertRaises(ReleaseTestConfigError):
+            validate_release_test_collection([invalid_test])
+
+        # Faulty smoke test
+        invalid_test = test.copy()
+        del invalid_test["smoke_test"]["frequency"]
         with self.assertRaises(ReleaseTestConfigError):
             validate_release_test_collection([invalid_test])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Of all smoke test arguments, `frequency` is the only required one, so we should check for it. Additionally, not all fields should be able to be overwritten (e.g. `legacy` or `name`), so we enforce this as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
