### PR TITLE
Update paper links to include exoshuffle and remove whitepaper (moved to docs)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,7 +368,7 @@ More Information
 - `Tutorial`_
 - `Blog`_
 - `Ray 1.0 Architecture whitepaper`_ **(new)**
-- `Exoshuffle Paper`_ **(new)**
+- `Exoshuffle paper`_ **(new)**
 - `RLlib paper`_
 - `RLlib flow paper`_
 - `Tune paper`_

--- a/README.rst
+++ b/README.rst
@@ -368,7 +368,7 @@ More Information
 - `Tutorial`_
 - `Blog`_
 - `Ray 1.0 Architecture whitepaper`_ **(new)**
-- `Exoshuffle Paper`_ **(new)**
+- `Exoshuffle: large-scale data shuffle in Ray`_ **(new)**
 - `RLlib paper`_
 - `RLlib flow paper`_
 - `Tune paper`_
@@ -382,7 +382,7 @@ More Information
 .. _`Tutorial`: https://github.com/ray-project/tutorial
 .. _`Blog`: https://medium.com/distributed-computing-with-ray
 .. _`Ray 1.0 Architecture whitepaper`: https://docs.google.com/document/d/1lAy0Owi-vPz2jEqBSaHNQcy2IBSDEHyXNOQZlGuj93c/preview
-.. _`Exoshuffle paper`: https://arxiv.org/abs/2203.05072
+.. _`Exoshuffle: large-scale data shuffle in Ray`: https://arxiv.org/abs/2203.05072
 .. _`Ray paper`: https://arxiv.org/abs/1712.05889
 .. _`Ray HotOS paper`: https://arxiv.org/abs/1703.03924
 .. _`RLlib paper`: https://arxiv.org/abs/1712.09381

--- a/README.rst
+++ b/README.rst
@@ -368,7 +368,7 @@ More Information
 - `Tutorial`_
 - `Blog`_
 - `Ray 1.0 Architecture whitepaper`_ **(new)**
-- `Ray Design Patterns`_ **(new)**
+- `Exoshuffle Paper`_ **(new)**
 - `RLlib paper`_
 - `RLlib flow paper`_
 - `Tune paper`_
@@ -382,7 +382,7 @@ More Information
 .. _`Tutorial`: https://github.com/ray-project/tutorial
 .. _`Blog`: https://medium.com/distributed-computing-with-ray
 .. _`Ray 1.0 Architecture whitepaper`: https://docs.google.com/document/d/1lAy0Owi-vPz2jEqBSaHNQcy2IBSDEHyXNOQZlGuj93c/preview
-.. _`Ray Design Patterns`: https://docs.google.com/document/d/167rnnDFIVRhHhK4mznEIemOtj63IOhtIPvSYaPgI4Fg/edit
+.. _`Exoshuffle paper`: https://arxiv.org/abs/2203.05072
 .. _`Ray paper`: https://arxiv.org/abs/1712.05889
 .. _`Ray HotOS paper`: https://arxiv.org/abs/1703.03924
 .. _`RLlib paper`: https://arxiv.org/abs/1712.09381

--- a/doc/source/ray-contribute/whitepaper.rst
+++ b/doc/source/ray-contribute/whitepaper.rst
@@ -2,3 +2,5 @@ Architecture Whitepaper
 =======================
 
 For an in-depth overview of Ray internals, check out the `Ray 1.0 Architecture whitepaper <https://docs.google.com/document/d/1lAy0Owi-vPz2jEqBSaHNQcy2IBSDEHyXNOQZlGuj93c/preview>`__.
+
+For more about the scalability and performance of the Ray dataplane, see the `Exoshuffle paper <https://arxiv.org/abs/2203.05072>`__.

--- a/doc/source/ray-overview/learn-more.md
+++ b/doc/source/ray-overview/learn-more.md
@@ -46,7 +46,7 @@ Please raise an issue if any of the below links are broken, or if you'd like to 
 ## Papers
 
 -   [Ray 1.0 Architecture whitepaper](https://docs.google.com/document/d/1lAy0Owi-vPz2jEqBSaHNQcy2IBSDEHyXNOQZlGuj93c/preview)
--   [Exoshuffle paper](https://arxiv.org/abs/2203.05072)
+-   [Exoshuffle: large-scale data shuffle in Ray](https://arxiv.org/abs/2203.05072)
 -   [RLlib paper](https://arxiv.org/abs/1712.09381)
 -   [RLlib flow paper](https://arxiv.org/abs/2011.12719)
 -   [Tune paper](https://arxiv.org/abs/1807.05118)

--- a/doc/source/ray-overview/learn-more.md
+++ b/doc/source/ray-overview/learn-more.md
@@ -46,7 +46,7 @@ Please raise an issue if any of the below links are broken, or if you'd like to 
 ## Papers
 
 -   [Ray 1.0 Architecture whitepaper](https://docs.google.com/document/d/1lAy0Owi-vPz2jEqBSaHNQcy2IBSDEHyXNOQZlGuj93c/preview)
--   [Ray Design Patterns](https://docs.google.com/document/d/167rnnDFIVRhHhK4mznEIemOtj63IOhtIPvSYaPgI4Fg/edit)
+-   [Exoshuffle paper](https://arxiv.org/abs/2203.05072)
 -   [RLlib paper](https://arxiv.org/abs/1712.09381)
 -   [RLlib flow paper](https://arxiv.org/abs/2011.12719)
 -   [Tune paper](https://arxiv.org/abs/1807.05118)


### PR DESCRIPTION
Remove the whitepaper link, which is now included in the docs proper. Add the exoshuffle link to have a paper describing the Ray dataplane.