### PR TITLE
[Job submission] Set headers when establishing websocket

### DIFF
--- a/dashboard/modules/job/sdk.py
+++ b/dashboard/modules/job/sdk.py
@@ -143,7 +143,9 @@ class JobSubmissionClient(SubmissionClient):
 
     @PublicAPI(stability="beta")
     async def tail_job_logs(self, job_id: str) -> Iterator[str]:
-        async with aiohttp.ClientSession(cookies=self._cookies) as session:
+        async with aiohttp.ClientSession(
+            cookies=self._cookies, headers=self._headers
+        ) as session:
             ws = await session.ws_connect(
                 f"{self._address}/api/jobs/{job_id}/logs/tail"
             )


### PR DESCRIPTION
This brings this code path to feature parity with `SubmissionClient._do_request`. Important for those of us whose deployments require to set custom HTTP headers.