### PR TITLE
USERPROFILE is not always defined, use psutils instead

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -178,6 +178,7 @@ test_python() {
     # shellcheck disable=SC2046,SC2086
     bazel test --config=ci \
       --build_tests_only $(./scripts/bazel_export_options) \
+      --test_env=USERPROFILE=${USERPROFILE} \
       --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
       -- \
       ${test_shard_selection};

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -275,7 +275,10 @@ class ReporterAgent(
             return {
                 "/": psutil._common.sdiskusage(total=1, used=0, free=1, percent=0.0)
             }
-        root = os.environ["USERPROFILE"] if sys.platform == "win32" else os.sep
+        if sys.platform == "win32":
+            root = psutil.disk_partitions()[0].mountpoint
+        else:
+            root = os.sep
         tmp = ray._private.utils.get_user_temp_dir()
         return {
             "/": psutil.disk_usage(root),

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -402,6 +402,9 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
 #elif defined(__linux__)
       static const std::string kLibraryPathEnvName = "LD_LIBRARY_PATH";
 #elif defined(_WIN32)
+      // USERPROFILE is used in pathlib.Path.home()
+      auto userprofile_p = std::getenv("USERPROFILE");
+      env.emplace("USERPROFILE", userprofile_p);
       static const std::string kLibraryPathEnvName = "PATH";
 #endif
       auto path_env_p = std::getenv(kLibraryPathEnvName.c_str());

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -142,9 +142,16 @@ class ProcessFD {
         (void)cmd.c_str();  // We'll need this to be null-terminated (but mutable) below
         TCHAR *cmdline = &*cmd.begin();
         STARTUPINFO si = {sizeof(si)};
-        RAY_UNUSED(
-            new_env_block.c_str());  // Ensure there's a final terminator for Windows
-        char *const envp = &new_env_block[0];
+        LPVOID envp = NULL;
+        if (!new_env_block.empty()) {
+            if (new_env.find("PATH") == new_env.end() ) {
+                RAY_LOG(ERROR) << "Calling spawnvpe with invalid env";
+                break;
+            }
+            RAY_UNUSED(
+                new_env_block.c_str());  // Ensure there's a final terminator for Windows
+            envp = &new_env_block[0];
+        }
         if (CreateProcessA(NULL, cmdline, NULL, NULL, FALSE, 0, envp, NULL, &si, &pi)) {
           succeeded = true;
           break;

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -144,13 +144,13 @@ class ProcessFD {
         STARTUPINFO si = {sizeof(si)};
         LPVOID envp = NULL;
         if (!new_env_block.empty()) {
-            if (new_env.find("PATH") == new_env.end() ) {
-                RAY_LOG(ERROR) << "Calling spawnvpe with invalid env";
-                break;
-            }
-            RAY_UNUSED(
-                new_env_block.c_str());  // Ensure there's a final terminator for Windows
-            envp = &new_env_block[0];
+          if (new_env.find("PATH") == new_env.end()) {
+            RAY_LOG(ERROR) << "Calling spawnvpe with invalid env";
+            break;
+          }
+          RAY_UNUSED(
+              new_env_block.c_str());  // Ensure there's a final terminator for Windows
+          envp = &new_env_block[0];
         }
         if (CreateProcessA(NULL, cmdline, NULL, NULL, FALSE, 0, envp, NULL, &si, &pi)) {
           succeeded = true;
@@ -638,8 +638,8 @@ bool equal_to<ray::Process>::operator()(const ray::Process &x,
              ? !y.IsNull()
                    ? x.IsValid()
                          ? y.IsValid() ? equal_to<pid_t>()(x.GetId(), y.GetId()) : false
-                     : y.IsValid() ? false
-                                   : equal_to<void const *>()(x.Get(), y.Get())
+                         : y.IsValid() ? false
+                                       : equal_to<void const *>()(x.Get(), y.Get())
                    : false
              : y.IsNull();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Occasionally, tests are crashing. Looking through the logs, I see that the reporter is crashing because `USERPROFILE` is not defined, the check fails, and the process crashes. I am not sure how this happens, but we can use `psutils.disk_partitions` which does not fail.

This might be the source of some of the test flakiness.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
