### PR TITLE
[Doc] Add missing runtime context namespace doc

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -118,11 +118,16 @@ class RuntimeContext(object):
 
     @property
     def namespace(self):
+        """Get the current namespace of this worker.
+
+        Returns:
+            The current namespace of this worker.
+        """
         return self.worker.namespace
 
     @property
     def was_current_actor_reconstructed(self):
-        """Check whether this actor has been restarted
+        """Check whether this actor has been restarted.
 
         Returns:
             Whether this actor has been ever restarted.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
The public field `RuntimeContext.namespace` didn't have a docstring so it wasn't showing up at all in the docs.   This PR adds a basic docstring.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
