### PR TITLE
[ci/release] Disable infra retries for now

### DIFF
--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -50,7 +50,7 @@ if [ -z "${NO_INSTALL}" ]; then
 fi
 
 RETRY_NUM=0
-MAX_RETRIES=${MAX_RETRIES-3}
+MAX_RETRIES=${MAX_RETRIES-1}
 
 if [ "${BUILDKITE_RETRY_COUNT-0}" -ge 1 ]; then
   echo "This is a manually triggered retry from the Buildkite web UI, so we set the number of infra retries to 1."
@@ -108,7 +108,7 @@ if [ -z "${NO_ARTIFACTS}" ]; then
 fi
 
 echo "----------------------------------------"
-echo "release test finished with final exit code ${EXIT_CODE} after ${RETRY_NUM}/${MAX_RETRIES} tries"
+echo "Release test finished with final exit code ${EXIT_CODE} after ${RETRY_NUM}/${MAX_RETRIES} tries"
 echo "Run results:"
 
 COUNTER=1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Infra errors are tackled with concurrency groups. Thus we can disable old mitigation methods like automatic infra retry for now. 
We keep the script as it does other logic (e.g. checkout local test branch) and infra retry can be enabled via env variable if needed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
