### PR TITLE
[ci/release] Only report results for scheduled builds

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -39,6 +39,7 @@ DEFAULT_STEP_TEMPLATE = {
 
 def get_step(
     test: Test,
+    report: bool = False,
     smoke_test: bool = False,
     ray_wheels: Optional[str] = None,
     env: Optional[Dict] = None,
@@ -50,7 +51,7 @@ def get_step(
 
     cmd = f"./release/run_release_test.sh \"{test['name']}\" "
 
-    if not bool(int(os.environ.get("NO_REPORT_OVERRIDE", "0"))):
+    if report and not bool(int(os.environ.get("NO_REPORT_OVERRIDE", "0"))):
         cmd += " --report"
 
     if smoke_test:

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -115,6 +115,12 @@ def main(test_collection_file: Optional[str] = None):
     if no_concurrency_limit:
         logger.warning("Concurrency is not limited for this run!")
 
+    # Report if REPORT=1 or BUILDKITE_SOURCE=schedule
+    report = (
+        bool(int(os.environ.get("REPORT", "0")))
+        or os.environ.get("BUILDKITE_SOURCE", "manual") == "schedule"
+    )
+
     steps = []
     for group in sorted(grouped_tests):
         tests = grouped_tests[group]
@@ -122,6 +128,7 @@ def main(test_collection_file: Optional[str] = None):
         for test, smoke_test in tests:
             step = get_step(
                 test,
+                report=report,
                 smoke_test=smoke_test,
                 ray_wheels=ray_wheels_url,
                 env=env,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, all buildkite runs report per default. Instead, we only want to report when running scheduled builds or when specifically overriding this behavior.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
