### PR TITLE
[runtime env] Keep existing `PYTHONPATH` when using runtime env

### DIFF
--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -16,6 +16,7 @@ from ray._private.runtime_env.packaging import (
     Protocol,
     upload_package_if_needed,
 )
+from ray._private.runtime_env.working_dir import set_pythonpath_in_context
 from ray._private.utils import get_directory_size_bytes
 from ray._private.utils import try_to_create_directory
 
@@ -166,8 +167,4 @@ class PyModulesManager:
                     "downloading or unpacking the py_modules files."
                 )
             module_dirs.append(str(module_dir))
-        # Insert the py_modules directories into the PYTHONPATH.
-        python_path = os.pathsep.join(module_dirs)
-        if "PYTHONPATH" in context.env_vars:
-            python_path += os.pathsep + context.env_vars["PYTHONPATH"]
-        context.env_vars["PYTHONPATH"] = python_path
+        set_pythonpath_in_context(os.pathsep.join(module_dirs), context)

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -87,6 +87,22 @@ def upload_working_dir_if_needed(
     return runtime_env
 
 
+def set_pythonpath_in_context(python_path: str, context: RuntimeEnvContext):
+    """Insert the path as the first entry in PYTHONPATH in the runtime env.
+
+    This is compatible with users providing their own PYTHONPATH in env_vars,
+    and is also compatible with the existing PYTHONPATH in the cluster.
+
+    The import priority is as follows:
+    working_dir > env_vars PYTHONPATH > existing cluster environment PYTHONPATH.
+    """
+    if "PYTHONPATH" in context.env_vars:
+        python_path += os.pathsep + context.env_vars["PYTHONPATH"]
+    if "PYTHONPATH" in os.environ:
+        python_path += os.pathsep + os.environ["PYTHONPATH"]
+    context.env_vars["PYTHONPATH"] = python_path
+
+
 class WorkingDirManager:
     def __init__(self, resources_dir: str):
         self._resources_dir = os.path.join(resources_dir, "working_dir_files")
@@ -148,10 +164,4 @@ class WorkingDirManager:
             )
 
         context.command_prefix += [f"cd {local_dir}"]
-
-        # Insert the working_dir as the first entry in PYTHONPATH. This is
-        # compatible with users providing their own PYTHONPATH in env_vars.
-        python_path = str(local_dir)
-        if "PYTHONPATH" in context.env_vars:
-            python_path += os.pathsep + context.env_vars["PYTHONPATH"]
-        context.env_vars["PYTHONPATH"] = python_path
+        set_pythonpath_in_context(python_path=str(local_dir), context=context)

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -94,7 +94,7 @@ def set_pythonpath_in_context(python_path: str, context: RuntimeEnvContext):
     and is also compatible with the existing PYTHONPATH in the cluster.
 
     The import priority is as follows:
-    working_dir > env_vars PYTHONPATH > existing cluster environment PYTHONPATH.
+    this python_path arg > env_vars PYTHONPATH > existing cluster env PYTHONPATH.
     """
     if "PYTHONPATH" in context.env_vars:
         python_path += os.pathsep + context.env_vars["PYTHONPATH"]

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -38,7 +38,7 @@ TEST_IMPORT_DIR = "test_import_dir"
 
 # Set scope to "module" to force this to run before start_cluster, whose scope
 # is "function".  We need these env vars to be set before Ray is started.
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def insert_test_dir_in_pythonpath():
     with mock.patch.dict(
         os.environ,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using `working_dir` or `py_modules`, the `PYTHONPATH` would be overwritten with the new module directories or working directory.  This caused packages that were preinstalled on the cluster to no longer be importable (because the old `PYTHONPATH` was no longer there.)

This PR makes runtime env prepend the new paths to the `PYTHONPATH` rather than overwriting it.  

The priority for imports is as follows:

`working_dir/py_modules` > `env_vars`'s `PYTHONPATH` > existing cluster environment PYTHONPATH.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #22668 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
