### PR TITLE
[Serve] [CI] Split Serve tests into multiple shards

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -241,7 +241,7 @@
       test_shard_selection=$(
       python ./scripts/bazel-sharding.py
       --exclude_manual
-      --index "${BUILDKITE_PARALLEL_JOB:-'0'}" --count "${BUILDKITE_PARALLEL_JOB_COUNT:-'1'}"
+      --index "${BUILDKITE_PARALLEL_JOB:-0}" --count "${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
       --test_tag_filters=-post_wheel_build
       python/ray/serve/...
       )

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -242,7 +242,6 @@
       python ./scripts/bazel-sharding.py
       --exclude_manual
       --index "${BUILDKITE_PARALLEL_JOB:-0}" --count "${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
-      --test_tag_filters=-post_wheel_build
       python/ray/serve/...
       )
       bazel test --config=ci $(./scripts/bazel_export_options)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -241,7 +241,7 @@
       set -x;
       python ./scripts/bazel-sharding.py
       --exclude_manual
-      --index "${BUILDKITE_PARALLEL_JOB}" --count "${BUILDKITE_PARALLEL_JOB_COUNT}"
+      --index "\${BUILDKITE_PARALLEL_JOB}" --count "\${BUILDKITE_PARALLEL_JOB_COUNT}"
       python/ray/serve/...
       > test_shard.txt
     - cat test_shard.txt

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -238,9 +238,10 @@
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
     - >- 
+      set -x;
       python ./scripts/bazel-sharding.py
       --exclude_manual
-      --index "${BUILDKITE_PARALLEL_JOB:-0}" --count "${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
+      --index "${BUILDKITE_PARALLEL_JOB}" --count "${BUILDKITE_PARALLEL_JOB_COUNT}"
       python/ray/serve/...
       > test_shard.txt
     - cat test_shard.txt

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -238,14 +238,13 @@
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
     - >-
-      set -ex;
-      test_shard_selection=$(
+      export test_shard_selection=$(
       python ./scripts/bazel-sharding.py
       --exclude_manual
       --index "${BUILDKITE_PARALLEL_JOB:-0}" --count "${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
       python/ray/serve/...
       )
-      bazel test --config=ci $(./scripts/bazel_export_options)
+    - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-post_wheel_build
       ${test_shard_selection}
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -237,16 +237,16 @@
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
-    - >-
-      export test_shard_selection=$(
+    - >- 
       python ./scripts/bazel-sharding.py
       --exclude_manual
       --index "${BUILDKITE_PARALLEL_JOB:-0}" --count "${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
       python/ray/serve/...
-      )
+      > test_shard.txt
+    - cat test_shard.txt
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-post_wheel_build
-      ${test_shard_selection}
+      $(cat test_shard.txt)
 
 
 - label: ":python: Minimal install"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -203,25 +203,54 @@
       -//:gcs_server_rpc_test -//:gcs_server_test
       -//:metric_exporter_client_test -//:stats_test -//:worker_pool_test
 
-- label: ":serverless: Dashboard + Serve Tests"
+- label: ":serverless: Dashboard Tests"
+  conditions:
+    [
+        "RAY_CI_DASHBOARD_AFFECTED",
+        "RAY_CI_PYTHON_AFFECTED",
+    ]
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
+    - ./dashboard/tests/run_ui_tests.sh
+    - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/dashboard/...
+- label: ":serverless: Serve Release Tests"
   conditions:
     [
         "RAY_CI_SERVE_AFFECTED",
-        "RAY_CI_DASHBOARD_AFFECTED",
         "RAY_CI_PYTHON_AFFECTED",
     ]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
-    - ./dashboard/tests/run_ui_tests.sh
-    - bazel test --config=ci $(./scripts/bazel_export_options) python/ray/dashboard/...
-    - bazel test --config=ci $(./scripts/bazel_export_options)
-      --test_tag_filters=-post_wheel_build
-      python/ray/serve/...
     - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=team:serve
       release/...
+- label: ":serverless: Serve Tests"
+  parallelism: 3
+  conditions:
+    [
+        "RAY_CI_SERVE_AFFECTED",
+        "RAY_CI_PYTHON_AFFECTED",
+    ]
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
+    - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
+    - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
+    - >-
+      BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB:-'0'}
+      BUILDKITE_PARALLEL_JOB_COUNT=${BUILDKITE_PARALLEL_JOB_COUNT:-'1'}
+      test_shard_selection=$(
+      python ./scripts/bazel-sharding.py
+      --exclude_manual
+      --index "${BUILDKITE_PARALLEL_JOB}" --count "${BUILDKITE_PARALLEL_JOB_COUNT}"
+      --test_tag_filters=-post_wheel_build
+      python/ray/serve/...
+      )
+      bazel test --config=ci $(./scripts/bazel_export_options)
+      --test_tag_filters=-post_wheel_build
+      ${test_shard_selection}
+
 
 - label: ":python: Minimal install"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -238,6 +238,7 @@
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
     - >-
+      set -ex;
       test_shard_selection=$(
       python ./scripts/bazel-sharding.py
       --exclude_manual

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -238,12 +238,10 @@
     - TORCH_VERSION=1.6 ./ci/travis/install-dependencies.sh
     - 'git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd'
     - >-
-      BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB:-'0'}
-      BUILDKITE_PARALLEL_JOB_COUNT=${BUILDKITE_PARALLEL_JOB_COUNT:-'1'}
       test_shard_selection=$(
       python ./scripts/bazel-sharding.py
       --exclude_manual
-      --index "${BUILDKITE_PARALLEL_JOB}" --count "${BUILDKITE_PARALLEL_JOB_COUNT}"
+      --index "${BUILDKITE_PARALLEL_JOB:-'0'}" --count "${BUILDKITE_PARALLEL_JOB_COUNT:-'1'}"
       --test_tag_filters=-post_wheel_build
       python/ray/serve/...
       )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
This PR split Serve tests in Linux builder into (1) just dashboard (2) serve release tests (3) serve tests with 3 shards. 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
