### PR TITLE
[ml] Don't require `preprocessor` in `TorchPredictor`

### DIFF
--- a/python/ray/ml/predictors/integrations/torch/torch_predictor.py
+++ b/python/ray/ml/predictors/integrations/torch/torch_predictor.py
@@ -44,7 +44,13 @@ class TorchPredictor(Predictor):
                 ``model``.
         """
         checkpoint_dict = checkpoint.to_dict()
-        preprocessor = checkpoint_dict[PREPROCESSOR_KEY]
+        preprocessor = checkpoint_dict.get(PREPROCESSOR_KEY, None)
+        if MODEL_KEY not in checkpoint_dict:
+            raise RuntimeError(
+                f"No item with key: {MODEL_KEY} is found in the "
+                f"Checkpoint. Make sure this key exists when saving the "
+                f"checkpoint in ``TorchTrainer``."
+            )
         model = load_torch_model(
             saved_model=checkpoint_dict[MODEL_KEY], model_definition=model
         )
@@ -113,7 +119,9 @@ class TorchPredictor(Predictor):
         Returns:
             DataBatchType: Prediction result.
         """
-        data = self.preprocessor.transform_batch(data)
+        if self.preprocessor:
+            data = self.preprocessor.transform_batch(data)
+
         if isinstance(data, np.ndarray):
             # If numpy array, then convert to pandas dataframe.
             data = pd.DataFrame(data)

--- a/python/ray/ml/tests/test_torch_predictor.py
+++ b/python/ray/ml/tests/test_torch_predictor.py
@@ -53,3 +53,14 @@ def test_predict_feature_columns():
 
     assert len(predictions) == 3
     assert predictions.to_numpy().flatten().tolist() == [4, 8, 12]
+
+
+def test_predict_no_preprocessor():
+    checkpoint = Checkpoint.from_dict({MODEL_KEY: model})
+    predictor = TorchPredictor.from_checkpoint(checkpoint)
+
+    data_batch = np.array([[1], [2], [3]])
+    predictions = predictor.predict(data_batch)
+
+    assert len(predictions) == 3
+    assert predictions.to_numpy().flatten().tolist() == [2, 4, 6]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
