### PR TITLE
[workflow] More tests for unifying workflow and remote function ObjectRef behavior

### DIFF
--- a/python/ray/workflow/tests/test_dag_to_workflow.py
+++ b/python/ray/workflow/tests/test_dag_to_workflow.py
@@ -109,7 +109,7 @@ def test_same_object_many_dags(workflow_start_regular_shared):
 
 
 def test_dereference_object_refs(workflow_start_regular_shared):
-    """Ensure that object refs are dereferenced like in `ray.remote`"""
+    """Ensure that object refs are dereferenced like in ray tasks."""
 
     @ray.remote
     def f(obj_list):

--- a/python/ray/workflow/tests/test_dag_to_workflow.py
+++ b/python/ray/workflow/tests/test_dag_to_workflow.py
@@ -131,7 +131,7 @@ def test_dereference_object_refs(workflow_start_regular_shared):
 
     # Run with workflow and normal Ray engine.
     workflow.create(dag).run()
-    dag.execute()
+    ray.get(dag.execute())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These tests guarantee that the ObjectRef behavior between workflow and ray task is unified. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
