### PR TITLE
[Tune] Move resource updater out of trial executor

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -209,6 +209,14 @@ py_test(
 )
 
 py_test(
+    name = "test_resource_updater",
+    size = "large",
+    srcs = ["tests/test_resource_updater.py"],
+    deps = [":tune_lib"],
+    tags = ["team:ml", "exclusive", "tests_dir_R"],
+)
+
+py_test(
     name = "test_ray_trial_executor",
     size = "large",
     srcs = ["tests/test_ray_trial_executor.py"],

--- a/python/ray/tune/examples/xgboost_dynamic_resources_example.py
+++ b/python/ray/tune/examples/xgboost_dynamic_resources_example.py
@@ -201,7 +201,9 @@ def tune_xgboost(use_class_trainable=True):
         min_cpu = base_trial_resource.required_resources.get("CPU", 0)
 
         # Get the number of CPUs available in total (not just free)
-        total_available_cpus = trial_runner.trial_executor._avail_resources.cpu
+        total_available_cpus = (
+            trial_runner.trial_executor._resource_updater.get_num_cpus()
+        )
 
         # Divide the free CPUs among all live trials
         cpu_to_use = max(

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -735,7 +735,7 @@ class RayTrialExecutor(TrialExecutor):
         return {}
 
     def has_gpus(self) -> bool:
-        return self._resource_updater.has_gpus()
+        return self._resource_updater.get_num_gpus() > 0
 
     def cleanup(self, trials: List[Trial]) -> None:
         while True:

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -22,24 +22,21 @@ from typing import (
 
 import ray
 from ray.exceptions import GetTimeoutError
-from ray import ray_constants
-from ray._private.resource_spec import NODE_ID_PREFIX
 from ray.tune.error import AbortTrialExecution, TuneError
 from ray.tune.logger import NoopLogger
 from ray.tune.result import TRIAL_INFO, STDOUT_FILE, STDERR_FILE
-from ray.tune.resources import Resources
 from ray.tune.utils.placement_groups import PlacementGroupManager, get_tune_pg_prefix
 from ray.tune.utils.trainable import TrainableUtil
 from ray.tune.trial import Trial, Checkpoint, Location, TrialInfo
 from ray.tune.trial_executor import TrialExecutor
 from ray.tune.utils import warn_if_slow
+from ray.tune.utils.resource_updater import ResourceUpdater
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
 from ray.util.placement_group import remove_placement_group, PlacementGroup
 
 logger = logging.getLogger(__name__)
 
-TUNE_STATE_REFRESH_PERIOD = 10  # Refresh resources every 10 s
 DEFAULT_GET_TIMEOUT = 60.0  # seconds
 
 
@@ -189,7 +186,6 @@ class RayTrialExecutor(TrialExecutor):
         reuse_actors: bool = False,
         result_buffer_length: Optional[int] = None,
         refresh_period: Optional[float] = None,
-        wait_for_placement_group: Optional[float] = None,
     ):
         super(RayTrialExecutor, self).__init__()
         # future --> (type, trial/pg)
@@ -203,25 +199,17 @@ class RayTrialExecutor(TrialExecutor):
             self._trial_cleanup = _TrialCleanup(force_trial_cleanup)
         else:
             self._trial_cleanup = None
+
+        self._resource_updater = ResourceUpdater(refresh_period)
+
         self._has_cleaned_up_pgs = False
         self._reuse_actors = reuse_actors
         # The maxlen will be updated when `set_max_pending_trials()` is called
         self._cached_actor_pg = deque(maxlen=1)
-
-        self._avail_resources = Resources(cpu=0, gpu=0)
         self._pg_manager = PlacementGroupManager(prefix=get_tune_pg_prefix())
         self._staged_trials = set()
         self._trial_just_finished = False
         self._trial_just_finished_before = False
-
-        self._resources_initialized = False
-
-        if refresh_period is None:
-            refresh_period = float(
-                os.environ.get("TUNE_STATE_REFRESH_PERIOD", TUNE_STATE_REFRESH_PERIOD)
-            )
-        self._refresh_period = refresh_period
-
         self.last_pg_recon = 0
         self.pg_recon_interval = float(
             os.environ.get("TUNE_PLACEMENT_GROUP_RECON_INTERVAL", "5")
@@ -230,19 +218,10 @@ class RayTrialExecutor(TrialExecutor):
         self._buffer_length = result_buffer_length or int(
             os.getenv("TUNE_RESULT_BUFFER_LENGTH", 1)
         )
-
         self._buffer_min_time_s = float(os.getenv("TUNE_RESULT_BUFFER_MIN_TIME_S", 0.0))
         self._buffer_max_time_s = float(
             os.getenv("TUNE_RESULT_BUFFER_MAX_TIME_S", 100.0)
         )
-
-        self._last_resource_refresh = float("-inf")
-        self._last_ip_refresh = float("-inf")
-        self._last_ip_addresses = set()
-        self._last_nontrivial_wait = time.time()
-
-        if ray.is_initialized():
-            self._update_avail_resources()
 
     def set_max_pending_trials(self, max_pending: int) -> None:
         if len(self._cached_actor_pg) > 0:
@@ -607,51 +586,6 @@ class RayTrialExecutor(TrialExecutor):
                     return False
         return reset_val
 
-    def _update_avail_resources(self, num_retries=5):
-        if time.time() - self._last_resource_refresh < self._refresh_period:
-            return
-        logger.debug("Checking Ray cluster resources.")
-        resources = None
-        for i in range(num_retries):
-            if i > 0:
-                logger.warning(
-                    "Cluster resources not detected or are 0. Attempt #%s...", i + 1
-                )
-                time.sleep(0.5)
-            resources = ray.cluster_resources()
-            if resources:
-                break
-
-        if not resources:
-            # NOTE: This hides the possibility that Ray may be waiting for
-            # clients to connect.
-            resources.setdefault("CPU", 0)
-            resources.setdefault("GPU", 0)
-            logger.warning(
-                "Cluster resources cannot be detected or are 0. "
-                "You can resume this experiment by passing in "
-                "`resume=True` to `run`."
-            )
-
-        resources = resources.copy()
-        num_cpus = resources.pop("CPU", 0)
-        num_gpus = resources.pop("GPU", 0)
-        memory = ray_constants.from_memory_units(resources.pop("memory", 0))
-        object_store_memory = ray_constants.from_memory_units(
-            resources.pop("object_store_memory", 0)
-        )
-        custom_resources = resources
-
-        self._avail_resources = Resources(
-            int(num_cpus),
-            int(num_gpus),
-            memory=int(memory),
-            object_store_memory=int(object_store_memory),
-            custom_resources=custom_resources,
-        )
-        self._last_resource_refresh = time.time()
-        self._resources_initialized = True
-
     def has_resources_for_trial(self, trial: Trial) -> bool:
         """Returns whether there are resources available for this trial.
 
@@ -675,42 +609,11 @@ class RayTrialExecutor(TrialExecutor):
     def debug_string(self) -> str:
         """Returns a human readable message for printing to the console."""
         total_resources = self._pg_manager.occupied_resources()
-
-        if self._resources_initialized:
-            status = (
-                "Resources requested: {}/{} CPUs, {}/{} GPUs, "
-                "{}/{} GiB heap, {}/{} GiB objects".format(
-                    total_resources.pop("CPU", 0),
-                    self._avail_resources.cpu,
-                    total_resources.pop("GPU", 0),
-                    self._avail_resources.gpu,
-                    _to_gb(total_resources.pop("memory", 0.0)),
-                    _to_gb(self._avail_resources.memory),
-                    _to_gb(total_resources.pop("object_store_memory", 0.0)),
-                    _to_gb(self._avail_resources.object_store_memory),
-                )
-            )
-            customs = ", ".join(
-                [
-                    "{}/{} {}".format(
-                        total_resources.get(name, 0.0),
-                        self._avail_resources.get_res_total(name),
-                        name,
-                    )
-                    for name in self._avail_resources.custom_resources
-                    if not name.startswith(NODE_ID_PREFIX)
-                    and (total_resources.get(name, 0.0) > 0 or "_group_" not in name)
-                ]
-            )
-            if customs:
-                status += " ({})".format(customs)
-            return status
-        else:
-            return "Resources requested: ?"
+        return self._resource_updater.debug_string(total_resources)
 
     def on_step_begin(self, trials: List[Trial]) -> None:
         """Before step() is called, update the available resources."""
-        self._update_avail_resources()
+        self._resource_updater.update_avail_resources()
         self._trial_just_finished_before = self._trial_just_finished
         self._trial_just_finished = False
 
@@ -832,9 +735,7 @@ class RayTrialExecutor(TrialExecutor):
         return {}
 
     def has_gpus(self) -> bool:
-        if self._resources_initialized:
-            self._update_avail_resources()
-            return self._avail_resources.gpu > 0
+        return self._resource_updater.has_gpus()
 
     def cleanup(self, trials: List[Trial]) -> None:
         while True:
@@ -1014,7 +915,3 @@ class RayTrialExecutor(TrialExecutor):
                     return ExecutorEvent(
                         ExecutorEventType.ERROR, trial, (e, traceback.format_exc())
                     )
-
-
-def _to_gb(n_bytes):
-    return round(n_bytes / (1024 ** 3), 2)

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -96,11 +96,11 @@ class DistributeResources:
     ) -> Tuple[float, float]:
         """Get the number of CPUs and GPUs avaialble in total (not just free)"""
         total_available_cpus = (
-            trial_runner.trial_executor._avail_resources.cpu
+            trial_runner.trial_executor._resource_updater.get_num_cpus()
             - self.reserve_resources.get("CPU", 0)
         )
         total_available_gpus = (
-            trial_runner.trial_executor._avail_resources.gpu
+            trial_runner.trial_executor._resource_updater.get_num_gpus()
             - self.reserve_resources.get("GPU", 0)
         )
         return total_available_cpus, total_available_gpus

--- a/python/ray/tune/tests/test_resource_updater.py
+++ b/python/ray/tune/tests/test_resource_updater.py
@@ -3,35 +3,37 @@ from ray.tests.conftest import *  # noqa
 from ray.tune.utils.resource_updater import ResourceUpdater
 
 
-def test_resource_updater(shutdown_only):
+def test_resource_updater(ray_start_cluster):
+    cluster = ray_start_cluster
+
     resource_updater = ResourceUpdater(refresh_period=100)
     # Before intialization, all resources are 0.
     assert resource_updater.get_num_cpus() == 0
     assert resource_updater.get_num_gpus() == 0
-    ray.shutdown()
+
+    cluster.add_node(num_cpus=1, num_gpus=2)
+    cluster.wait_for_nodes()
+    ray.init(address=cluster.address)
 
     # Resource updater will update resource immediately
     # after ray is initialized for the first time.
-    ray.init(num_cpus=1, num_gpus=2)
     assert resource_updater.get_num_cpus() == 1
     assert resource_updater.get_num_gpus() == 2
-    ray.shutdown()
 
     # It will not update the resource before "refresh_period".
-    ray.init(num_cpus=2, num_gpus=3)
+    cluster.add_node(num_cpus=1, num_gpus=1)
+    cluster.wait_for_nodes()
     assert resource_updater.get_num_cpus() == 1
     assert resource_updater.get_num_gpus() == 2
-    ray.shutdown()
 
-    ray.init(num_cpus=1, num_gpus=2)
     resource_updater = ResourceUpdater(refresh_period=0)
-    assert resource_updater.get_num_cpus() == 1
-    assert resource_updater.get_num_gpus() == 2
-    ray.shutdown()
-
-    ray.init(num_cpus=2, num_gpus=3)
     assert resource_updater.get_num_cpus() == 2
     assert resource_updater.get_num_gpus() == 3
+
+    cluster.add_node(num_cpus=1, num_gpus=1)
+    cluster.wait_for_nodes()
+    assert resource_updater.get_num_cpus() == 3
+    assert resource_updater.get_num_gpus() == 4
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_resource_updater.py
+++ b/python/ray/tune/tests/test_resource_updater.py
@@ -4,16 +4,26 @@ from ray.tune.utils.resource_updater import ResourceUpdater
 
 
 def test_resource_updater(shutdown_only):
-    resource_updater = ResourceUpdater(refresh_period=10)
-    ray.init(num_cpus=0, num_gpus=0)
+    resource_updater = ResourceUpdater(refresh_period=100)
+    # Before intialization, all resources are 0.
     assert resource_updater.get_num_cpus() == 0
     assert resource_updater.get_num_gpus() == 0
     ray.shutdown()
 
+    # Resource updater will update resource immediately
+    # after ray is initialized for the first time.
     ray.init(num_cpus=1, num_gpus=2)
-    assert resource_updater.get_num_cpus() == 0
-    assert resource_updater.get_num_gpus() == 0
+    assert resource_updater.get_num_cpus() == 1
+    assert resource_updater.get_num_gpus() == 2
+    ray.shutdown()
 
+    # It will not update the resource before "refresh_period".
+    ray.init(num_cpus=2, num_gpus=3)
+    assert resource_updater.get_num_cpus() == 1
+    assert resource_updater.get_num_gpus() == 2
+    ray.shutdown()
+
+    ray.init(num_cpus=1, num_gpus=2)
     resource_updater = ResourceUpdater(refresh_period=0)
     assert resource_updater.get_num_cpus() == 1
     assert resource_updater.get_num_gpus() == 2

--- a/python/ray/tune/tests/test_resource_updater.py
+++ b/python/ray/tune/tests/test_resource_updater.py
@@ -1,0 +1,27 @@
+import ray
+from ray.tune.utils.resource_updater import ResourceUpdater
+
+
+def test_resource_updater(shutdown_only):
+    resource_updater = ResourceUpdater(refresh_period=10)
+    assert resource_updater.get_num_cpus() == 0
+    assert resource_updater.get_num_gpus() == 0
+    ray.init(num_cpus=1, num_gpus=2)
+    assert resource_updater.get_num_cpus() == 0
+    assert resource_updater.get_num_gpus() == 0
+
+    resource_updater = ResourceUpdater(refresh_period=0)
+    assert resource_updater.get_num_cpus() == 1
+    assert resource_updater.get_num_gpus() == 2
+    ray.shutdown()
+
+    ray.init(num_cpus=2, num_gpus=3)
+    assert resource_updater.get_num_cpus() == 2
+    assert resource_updater.get_num_gpus() == 3
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/tests/test_resource_updater.py
+++ b/python/ray/tune/tests/test_resource_updater.py
@@ -1,11 +1,15 @@
 import ray
+from ray.tests.conftest import *  # noqa
 from ray.tune.utils.resource_updater import ResourceUpdater
 
 
 def test_resource_updater(shutdown_only):
     resource_updater = ResourceUpdater(refresh_period=10)
+    ray.init(num_cpus=0, num_gpus=0)
     assert resource_updater.get_num_cpus() == 0
     assert resource_updater.get_num_gpus() == 0
+    ray.shutdown()
+
     ray.init(num_cpus=1, num_gpus=2)
     assert resource_updater.get_num_cpus() == 0
     assert resource_updater.get_num_gpus() == 0

--- a/python/ray/tune/tests/test_trial_runner_3.py
+++ b/python/ray/tune/tests/test_trial_runner_3.py
@@ -46,7 +46,7 @@ class TrialRunnerTest3(unittest.TestCase):
         runner = TrialRunner()
 
         def on_step_begin(self, trialrunner):
-            self._update_avail_resources()
+            self._resource_updater.update_avail_resources()
             cnt = self.pre_step if hasattr(self, "pre_step") else 0
             self.pre_step = cnt + 1
 

--- a/python/ray/tune/tests/test_trial_scheduler_resource_changing.py
+++ b/python/ray/tune/tests/test_trial_scheduler_resource_changing.py
@@ -1,5 +1,4 @@
 import unittest
-from collections import namedtuple
 
 from ray.tune import PlacementGroupFactory
 from ray.tune.schedulers.trial_scheduler import TrialScheduler
@@ -10,12 +9,22 @@ from ray.tune.schedulers.resource_changing_scheduler import (
     DistributeResourcesToTopJob,
 )
 
-avail_resources = namedtuple("avail_resources", ["cpu", "gpu"])
+
+class MockResourceUpdater:
+    def __init__(self, num_cpus, num_gpus):
+        self._num_cpus = num_cpus
+        self._num_gpus = num_gpus
+
+    def get_num_cpus(self) -> int:
+        return self._num_cpus
+
+    def get_num_gpus(self) -> int:
+        return self._num_gpus
 
 
 class MockTrialExecutor:
     def __init__(self, cpu: float, gpu: float) -> None:
-        self._avail_resources = avail_resources(cpu, gpu)
+        self._resource_updater = MockResourceUpdater(cpu, gpu)
 
     def force_reconcilation_on_next_step_end(self):
         return

--- a/python/ray/tune/utils/resource_updater.py
+++ b/python/ray/tune/utils/resource_updater.py
@@ -111,17 +111,14 @@ class ResourceUpdater:
             return "Resources requested: ?"
 
     def get_num_cpus(self) -> int:
-        self.update_avail_resources()
+        if ray.is_initialized():
+            self.update_avail_resources()
         return self._avail_resources.cpu
 
     def get_num_gpus(self) -> int:
-        self.update_avail_resources()
-        return self._avail_resources.gpu
-
-    def has_gpus(self) -> bool:
-        if self._last_resource_refresh > 0:
+        if ray.is_initialized():
             self.update_avail_resources()
-            return self._avail_resources.gpu > 0
+        return self._avail_resources.gpu
 
     def __reduce__(self):
         # Do not need to serialize resources, because we can always

--- a/python/ray/tune/utils/resource_updater.py
+++ b/python/ray/tune/utils/resource_updater.py
@@ -1,0 +1,130 @@
+from typing import Optional, Dict, Any
+import logging
+import os
+import time
+
+import ray
+from ray import ray_constants
+from ray._private.resource_spec import NODE_ID_PREFIX
+from ray.tune.resources import Resources
+
+logger = logging.getLogger(__name__)
+
+TUNE_STATE_REFRESH_PERIOD = 10  # Refresh resources every 10 s
+
+
+def _to_gb(n_bytes):
+    return round(n_bytes / (1024 ** 3), 2)
+
+
+class ResourceUpdater:
+    """Periodic Resource updater for Tune."""
+
+    def __init__(self, refresh_period: Optional[float] = None):
+        self._avail_resources = Resources(cpu=0, gpu=0)
+
+        if refresh_period is None:
+            refresh_period = float(
+                os.environ.get("TUNE_STATE_REFRESH_PERIOD", TUNE_STATE_REFRESH_PERIOD)
+            )
+        self._refresh_period = refresh_period
+        self._last_resource_refresh = float("-inf")
+
+        if ray.is_initialized():
+            self.update_avail_resources()
+
+    def update_avail_resources(self, num_retries=5):
+        if time.time() - self._last_resource_refresh < self._refresh_period:
+            return
+        logger.debug("Checking Ray cluster resources.")
+        resources = None
+        for i in range(num_retries):
+            if i > 0:
+                logger.warning(
+                    f"Cluster resources not detected or are 0. Attempt #{i + 1}...",
+                )
+                time.sleep(0.5)
+            resources = ray.cluster_resources()
+            if resources:
+                break
+
+        if not resources:
+            # NOTE: This hides the possibility that Ray may be waiting for
+            # clients to connect.
+            resources.setdefault("CPU", 0)
+            resources.setdefault("GPU", 0)
+            logger.warning(
+                "Cluster resources cannot be detected or are 0. "
+                "You can resume this experiment by passing in `resume=True` to `run`."
+            )
+
+        resources = resources.copy()
+        num_cpus = resources.pop("CPU", 0)
+        num_gpus = resources.pop("GPU", 0)
+        memory = ray_constants.from_memory_units(resources.pop("memory", 0))
+        object_store_memory = ray_constants.from_memory_units(
+            resources.pop("object_store_memory", 0)
+        )
+        custom_resources = resources
+
+        self._avail_resources = Resources(
+            int(num_cpus),
+            int(num_gpus),
+            memory=int(memory),
+            object_store_memory=int(object_store_memory),
+            custom_resources=custom_resources,
+        )
+        self._last_resource_refresh = time.time()
+
+    def debug_string(self, total_resources: Dict[str, Any]) -> str:
+        """Returns a human readable message for printing to the console."""
+        if self._last_resource_refresh > 0:
+            status = (
+                "Resources requested: {}/{} CPUs, {}/{} GPUs, "
+                "{}/{} GiB heap, {}/{} GiB objects".format(
+                    total_resources.pop("CPU", 0),
+                    self._avail_resources.cpu,
+                    total_resources.pop("GPU", 0),
+                    self._avail_resources.gpu,
+                    _to_gb(total_resources.pop("memory", 0.0)),
+                    _to_gb(self._avail_resources.memory),
+                    _to_gb(total_resources.pop("object_store_memory", 0.0)),
+                    _to_gb(self._avail_resources.object_store_memory),
+                )
+            )
+            customs = ", ".join(
+                [
+                    "{}/{} {}".format(
+                        total_resources.get(name, 0.0),
+                        self._avail_resources.get_res_total(name),
+                        name,
+                    )
+                    for name in self._avail_resources.custom_resources
+                    if not name.startswith(NODE_ID_PREFIX)
+                    and (total_resources.get(name, 0.0) > 0 or "_group_" not in name)
+                ]
+            )
+            if customs:
+                status += f" ({customs})"
+            return status
+        else:
+            return "Resources requested: ?"
+
+    def get_num_cpus(self) -> int:
+        self.update_avail_resources()
+        return self._avail_resources.cpu
+
+    def get_num_gpus(self) -> int:
+        self.update_avail_resources()
+        return self._avail_resources.gpu
+
+    def has_gpus(self) -> bool:
+        if self._last_resource_refresh > 0:
+            self.update_avail_resources()
+            return self._avail_resources.gpu > 0
+
+    def __reduce__(self):
+        # Do not need to serialize resources, because we can always
+        # update it again. This also prevents keeping outdated resources
+        # when deserialized.
+        return ResourceUpdater, (self._refresh_period,)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The resource updater can form a quite independent module. This simplifies trial executor.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
