### PR TITLE
[Datasets] Add bulk Parquet file reader API

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -4,6 +4,7 @@ from ray.data.read_api import (
     range_arrow,
     range_tensor,
     read_parquet,
+    read_parquet_bulk,
     read_json,
     read_csv,
     read_binary_files,
@@ -59,5 +60,6 @@ __all__ = [
     "read_json",
     "read_numpy",
     "read_parquet",
+    "read_parquet_bulk",
     "set_progress_bars",
 ]

--- a/python/ray/data/datasource/binary_datasource.py
+++ b/python/ray/data/datasource/binary_datasource.py
@@ -42,13 +42,5 @@ class BinaryDatasource(FileBasedDatasource):
         else:
             return [data]
 
-    def _open_input_source(
-        self,
-        filesystem: "pyarrow.fs.FileSystem",
-        path: str,
-        **open_args,
-    ) -> "pyarrow.NativeFile":
-        return filesystem.open_input_stream(path, **open_args)
-
     def _rows_per_file(self):
         return 1

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -43,14 +43,6 @@ class CSVDatasource(FileBasedDatasource):
             except StopIteration:
                 return
 
-    def _open_input_source(
-        self,
-        filesystem: "pyarrow.fs.FileSystem",
-        path: str,
-        **open_args,
-    ) -> "pyarrow.NativeFile":
-        return filesystem.open_input_stream(path, **open_args)
-
     def _write_block(
         self,
         f: "pyarrow.NativeFile",

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -264,14 +264,14 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
         path: str,
         **open_args,
     ) -> "pyarrow.NativeFile":
-        """Opens a source path for reading and returns the associated Arrow
-        NativeFile.
+        """Opens a source path for reading and returns the associated Arrow NativeFile.
 
-        This method should be implemented by subclasses.
+        The default implementation opens the source path as a sequential input stream.
+
+        Implementations that do not support streaming reads (e.g. that require random
+        access) should override this method.
         """
-        raise NotImplementedError(
-            "Subclasses of FileBasedDatasource must implement _open_input_source()."
-        )
+        return filesystem.open_input_stream(path, **open_args)
 
     def do_write(
         self,

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -31,14 +31,6 @@ class JSONDatasource(FileBasedDatasource):
         )
         return json.read_json(f, read_options=read_options, **reader_args)
 
-    def _open_input_source(
-        self,
-        filesystem: "pyarrow.fs.FileSystem",
-        path: str,
-        **open_args,
-    ) -> "pyarrow.NativeFile":
-        return filesystem.open_input_stream(path, **open_args)
-
     def _write_block(
         self,
         f: "pyarrow.NativeFile",

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -37,14 +37,6 @@ class NumpyDatasource(FileBasedDatasource):
             {"value": TensorArray(np.load(buf, allow_pickle=True))}
         )
 
-    def _open_input_source(
-        self,
-        filesystem: "pyarrow.fs.FileSystem",
-        path: str,
-        **open_args,
-    ) -> "pyarrow.NativeFile":
-        return filesystem.open_input_stream(path, **open_args)
-
     def _write_block(
         self,
         f: "pyarrow.NativeFile",

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -43,9 +43,11 @@ from ray.data.datasource import (
     ReadTask,
     BaseFileMetadataProvider,
     DefaultFileMetadataProvider,
+    FastFileMetadataProvider,
     ParquetMetadataProvider,
     DefaultParquetMetadataProvider,
     PathPartitionFilter,
+    ParquetBaseDatasource,
 )
 from ray.data.datasource.file_based_datasource import (
     _wrap_arrow_serialization_workaround,
@@ -307,34 +309,10 @@ def read_parquet(
     Returns:
         Dataset holding Arrow records read from the specified paths.
     """
-    if tensor_column_schema is not None:
-        existing_block_udf = arrow_parquet_args.pop("_block_udf", None)
-
-        def _block_udf(block: "pyarrow.Table") -> "pyarrow.Table":
-            from ray.data.extensions import ArrowTensorArray
-
-            for tensor_col_name, (dtype, shape) in tensor_column_schema.items():
-                # NOTE(Clark): We use NumPy to consolidate these potentially
-                # non-contiguous buffers, and to do buffer bookkeeping in
-                # general.
-                np_col = np.array(
-                    [
-                        np.ndarray(shape, buffer=buf.as_buffer(), dtype=dtype)
-                        for buf in block.column(tensor_col_name)
-                    ]
-                )
-
-                block = block.set_column(
-                    block._ensure_integer_index(tensor_col_name),
-                    tensor_col_name,
-                    ArrowTensorArray.from_numpy(np_col),
-                )
-            if existing_block_udf is not None:
-                # Apply UDF after casting the tensor columns.
-                block = existing_block_udf(block)
-            return block
-
-        arrow_parquet_args["_block_udf"] = _block_udf
+    arrow_parquet_args = _resolve_parquet_args(
+        tensor_column_schema,
+        **arrow_parquet_args,
+    )
     return read_datasource(
         ParquetDatasource(),
         parallelism=parallelism,
@@ -343,6 +321,98 @@ def read_parquet(
         columns=columns,
         ray_remote_args=ray_remote_args,
         meta_provider=meta_provider,
+        **arrow_parquet_args,
+    )
+
+
+@PublicAPI
+def read_parquet_bulk(
+    paths: Union[str, List[str]],
+    *,
+    filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    columns: Optional[List[str]] = None,
+    parallelism: int = 200,
+    ray_remote_args: Dict[str, Any] = None,
+    arrow_open_file_args: Optional[Dict[str, Any]] = None,
+    tensor_column_schema: Optional[Dict[str, Tuple[np.dtype, Tuple[int, ...]]]] = None,
+    meta_provider: BaseFileMetadataProvider = FastFileMetadataProvider(),
+    partition_filter: PathPartitionFilter = None,
+    **arrow_parquet_args,
+) -> Dataset[ArrowRow]:
+    """Create an Arrow dataset from a large number (e.g. >1K) of parquet files quickly.
+
+    By default, ONLY file paths should be provided as input (i.e. no directory paths),
+    and an OSError will be raised if one or more paths point to directories. If your
+    use-case requires directory paths, then the metadata provider should be changed to
+    one that supports directory expansion (e.g. DefaultFileMetadataProvider).
+
+    Offers improved performance vs. `read_parquet` due to not using PyArrow's
+    `ParquetDataset` abstraction, whose latency scales linearly with the number of
+    input files due to collecting all file metadata on a single node.
+
+    Also supports a wider variety of input Parquet file types than `read_parquet` due
+    to not trying to merge and resolve a unified schema for all files.
+
+    However, unlike `read_parquet`, this does not offer file metadata resolution by
+    default, so a custom metadata provider should be provided if your use-case requires
+    a unified dataset schema, block sizes, row counts, etc.
+
+    Examples:
+        >>> # Read multiple local files. You should always provide only input file
+        >>> # paths (i.e. no directory paths) when known to minimize read latency.
+        >>> ray.data.read_parquet_bulk(["/path/to/file1", "/path/to/file2"])
+
+        >>> # Read a directory of files in remote storage. Caution should be taken
+        >>> # when providing directory paths, since the time to both check each path
+        >>> # type and expand its contents may result in greatly increased latency
+        >>> # and/or request rate throttling from cloud storage service providers.
+        >>> ray.data.read_parquet_bulk(
+        >>>     "s3://bucket/path",
+        >>>     meta_provider=DefaultFileMetadataProvider(),
+        >>> )
+
+    Args:
+        paths: A single file path or a list of file paths. If one or more directories
+            are provided, then `meta_provider` should also be set to an implementation
+            that supports directory expansion (e.g. DefaultFileMetadataProvider).
+        filesystem: The filesystem implementation to read from.
+        columns: A list of column names to read.
+        parallelism: The requested parallelism of the read. Parallelism may be
+            limited by the number of files of the dataset.
+        ray_remote_args: kwargs passed to ray.remote in the read tasks.
+        arrow_open_file_args: kwargs passed to
+            pyarrow.fs.FileSystem.open_input_file
+        tensor_column_schema: A dict of column name --> tensor dtype and shape
+            mappings for converting a Parquet column containing serialized
+            tensors (ndarrays) as their elements to our tensor column extension
+            type. This assumes that the tensors were serialized in the raw
+            NumPy array format in C-contiguous order (e.g. via
+            `arr.tobytes()`).
+        meta_provider: File metadata provider. Defaults to a fast file metadata
+            provider that skips file size collection and requires all input paths to be
+            files. Change to DefaultFileMetadataProvider or a custom metadata provider
+            if directory expansion and/or file metadata resolution is required.
+        partition_filter: Path-based partition filter, if any. Can be used
+            with a custom callback to read only selected partitions of a dataset.
+        arrow_parquet_args: Other parquet read options to pass to pyarrow.
+
+    Returns:
+        Dataset holding Arrow records read from the specified paths.
+    """
+    arrow_parquet_args = _resolve_parquet_args(
+        tensor_column_schema,
+        **arrow_parquet_args,
+    )
+    return read_datasource(
+        ParquetBaseDatasource(),
+        parallelism=parallelism,
+        paths=paths,
+        filesystem=filesystem,
+        columns=columns,
+        ray_remote_args=ray_remote_args,
+        open_stream_args=arrow_open_file_args,
+        meta_provider=meta_provider,
+        partition_filter=partition_filter,
         **arrow_parquet_args,
     )
 
@@ -932,3 +1002,38 @@ def _prepare_read(
     kwargs = _unwrap_arrow_serialization_workaround(kwargs)
     DatasetContext._set_current(ctx)
     return ds.prepare_read(parallelism, **kwargs)
+
+
+def _resolve_parquet_args(
+    tensor_column_schema: Optional[Dict[str, Tuple[np.dtype, Tuple[int, ...]]]] = None,
+    **arrow_parquet_args,
+) -> Dict[str, Any]:
+    if tensor_column_schema is not None:
+        existing_block_udf = arrow_parquet_args.pop("_block_udf", None)
+
+        def _block_udf(block: "pyarrow.Table") -> "pyarrow.Table":
+            from ray.data.extensions import ArrowTensorArray
+
+            for tensor_col_name, (dtype, shape) in tensor_column_schema.items():
+                # NOTE(Clark): We use NumPy to consolidate these potentially
+                # non-contiguous buffers, and to do buffer bookkeeping in
+                # general.
+                np_col = np.array(
+                    [
+                        np.ndarray(shape, buffer=buf.as_buffer(), dtype=dtype)
+                        for buf in block.column(tensor_col_name)
+                    ]
+                )
+
+                block = block.set_column(
+                    block._ensure_integer_index(tensor_col_name),
+                    tensor_col_name,
+                    ArrowTensorArray.from_numpy(np_col),
+                )
+            if existing_block_udf is not None:
+                # Apply UDF after casting the tensor columns.
+                block = existing_block_udf(block)
+            return block
+
+        arrow_parquet_args["_block_udf"] = _block_udf
+    return arrow_parquet_args

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -22,6 +22,7 @@ from ray.data.datasource import (
     Datasource,
     DummyOutputDatasource,
     BaseFileMetadataProvider,
+    DefaultFileMetadataProvider,
     DefaultParquetMetadataProvider,
     FastFileMetadataProvider,
     PathPartitionFilter,
@@ -374,6 +375,137 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     # Expect precomputed row counts and block sizes to be missing.
     assert ds._meta_count() is None
     assert ds._plan._snapshot_blocks.size_bytes() == -1
+
+    # Expect to lazily compute all metadata correctly.
+    assert ds._plan.execute()._num_computed() == 1
+    assert ds.count() == 6
+    assert ds.size_bytes() > 0
+    assert ds.schema() is not None
+    input_files = ds.input_files()
+    assert len(input_files) == 2, input_files
+    assert "test1.parquet" in str(input_files)
+    assert "test2.parquet" in str(input_files)
+    assert (
+        str(ds) == "Dataset(num_blocks=2, num_rows=6, "
+        "schema={one: int64, two: string})"
+    ), ds
+    assert (
+        repr(ds) == "Dataset(num_blocks=2, num_rows=6, "
+        "schema={one: int64, two: string})"
+    ), ds
+    assert ds._plan.execute()._num_computed() == 2
+
+    # Forces a data read.
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    assert ds._plan.execute()._num_computed() == 2
+    assert sorted(values) == [
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+        [4, "e"],
+        [5, "f"],
+        [6, "g"],
+    ]
+
+
+@pytest.mark.parametrize(
+    "fs,data_path",
+    [
+        (None, lazy_fixture("local_path")),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_space"),
+            lazy_fixture("s3_path_with_space"),
+        ),  # Path contains space.
+    ],
+)
+def test_parquet_read_bulk(ray_start_regular_shared, fs, data_path):
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    table = pa.Table.from_pandas(df1)
+    setup_data_path = _unwrap_protocol(data_path)
+    path1 = os.path.join(setup_data_path, "test1.parquet")
+    pq.write_table(table, path1, filesystem=fs)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    table = pa.Table.from_pandas(df2)
+    path2 = os.path.join(setup_data_path, "test2.parquet")
+    pq.write_table(table, path2, filesystem=fs)
+
+    # Expect directory path expansion to fail.
+    with pytest.raises(OSError):
+        ray.data.read_parquet_bulk(data_path, filesystem=fs)
+
+    # Expect individual file paths to be processed successfully.
+    paths = [path1, path2]
+    ds = ray.data.read_parquet_bulk(paths, filesystem=fs)
+
+    # Expect precomputed row counts to be missing.
+    assert ds._meta_count() is None
+
+    # Expect to lazily compute all metadata correctly.
+    assert ds._plan.execute()._num_computed() == 1
+    assert ds.count() == 6
+    assert ds.size_bytes() > 0
+    assert ds.schema() is not None
+    input_files = ds.input_files()
+    assert len(input_files) == 2, input_files
+    assert "test1.parquet" in str(input_files)
+    assert "test2.parquet" in str(input_files)
+    assert (
+        str(ds) == "Dataset(num_blocks=2, num_rows=6, "
+        "schema={one: int64, two: string})"
+    ), ds
+    assert (
+        repr(ds) == "Dataset(num_blocks=2, num_rows=6, "
+        "schema={one: int64, two: string})"
+    ), ds
+    assert ds._plan.execute()._num_computed() == 2
+
+    # Forces a data read.
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    assert ds._plan.execute()._num_computed() == 2
+    assert sorted(values) == [
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+        [4, "e"],
+        [5, "f"],
+        [6, "g"],
+    ]
+
+
+@pytest.mark.parametrize(
+    "fs,data_path",
+    [
+        (None, lazy_fixture("local_path")),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_space"),
+            lazy_fixture("s3_path_with_space"),
+        ),  # Path contains space.
+    ],
+)
+def test_parquet_read_bulk_meta_provider(ray_start_regular_shared, fs, data_path):
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    table = pa.Table.from_pandas(df1)
+    setup_data_path = _unwrap_protocol(data_path)
+    path1 = os.path.join(setup_data_path, "test1.parquet")
+    pq.write_table(table, path1, filesystem=fs)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    table = pa.Table.from_pandas(df2)
+    path2 = os.path.join(setup_data_path, "test2.parquet")
+    pq.write_table(table, path2, filesystem=fs)
+
+    # Expect directory path expansion to succeed with the default metadata provider.
+    ds = ray.data.read_parquet_bulk(
+        data_path,
+        filesystem=fs,
+        meta_provider=DefaultFileMetadataProvider(),
+    )
+
+    # Expect precomputed row counts to be missing.
+    assert ds._meta_count() is None
 
     # Expect to lazily compute all metadata correctly.
     assert ds._plan.execute()._num_computed() == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a reader suitable for quickly reading a large number (e.g. 1-100K+) of Parquet files into a Ray Dataset from either local disk or cloud storage.

Latest Benchmarks:
- Environment 1:
  - Cluster: 5 x r5n.8xlarge (160 vCPUs)
  - Storage: S3
  - 2000 Tiny (~4KB) Parquet Files:
    - Test Case 1 (`read_parquet_fast()` - default fast metadata provider - parallel 200)
      - Read Dataset Latency: 1.646850564982742
      - Write Dataset Latency: 5.7583091059932485
      - Read Dataset Latency: 2.4654725349973887
      - Write Dataset Latency: 6.635675027035177
      - Read Dataset Latency: 2.460472490056418
      - Write Dataset Latency: 6.1093138850992545
    - Test Case 2 (`read_parquet()` - default parquet metadata provider - parallel 200)
      - Read Dataset Latency: 15.828366486006416
      - Write Dataset Latency: 12.378745757043362
      - Read Dataset Latency: 15.968373686890118
      - Write Dataset Latency: 12.28318011702504
      - Read Dataset Latency: 16.455996707081795
      - Write Dataset Latency: 12.62632444105111
  - 10,000 Tiny (~4KB) Parquet Files:
     - Test Case 1 (`read_parquet_fast()` - default fast metadata provider - parallel 160)
       - Read Dataset Latency: 5.766188704059459
       - Write Dataset Latency: 6.506135637057014
      - Test Case 2 (`read_parquet_fast()` - default fast metadata provider - parallel 320)
        - Read Dataset Latency: 3.841439099982381
        - Write Dataset Latency: 6.254379783989862
     - Test Case 3 (`read_parquet_fast()` - default fast metadata provider - parallel 640)
        - Read Dataset Latency: 2.392879810067825
        - Write Dataset Latency: 6.607215114985593
     - Test Case 4 (`read_parquet_fast()` - default fast metadata provider - parallel 1280)
        - Read Dataset Latency: 2.1967075469437987
        - Write Dataset Latency: 9.095152657013386
     - Test Case 5 (`read_parquet_fast()` - default fast metadata provider - parallel 1600)
        - Read Dataset Latency: 2.277380953077227
        - Write Dataset Latency: 9.146176831098273
     - Test Case 6 (`read_parquet_fast()` - default fast metadata provider - parallel 2560)
        - Read Dataset Latency: 2.137215052964166
        - Write Dataset Latency: 14.531858821981587
  - 50,000 Tiny (~4KB) Parquet Files:
    - Test Case 1 (`read_parquet_fast()` - default fast metadata provider - parallel 320)
      - Read Dataset Latency: 11.416414194973186
      - Write Dataset Latency: 12.532715738983825
      - Read Dataset Latency: 11.54179179109633
      - Write Dataset Latency: 12.113915671012364
    - Test Case 2 (`read_parquet_fast()` - default fast metadata provider - parallel 640)
      - Read Dataset Latency: 7.514457287965342
      - Write Dataset Latency: 12.104804654954933
      - Read Dataset Latency: 8.027748159016483
      - Write Dataset Latency: 10.249830988934264
    - Test Case 3 (`read_parquet_fast()` - default fast metadata provider - parallel 1280)
      - Read Dataset Latency: 5.188601649017073
      - Write Dataset Latency: 15.750625844928436
      - Read Dataset Latency: 5.264186333981343
      - Write Dataset Latency: 10.911084560095333
  - 600,000 Tiny (~4KB) Parquet Files:
    - Test Case 1 (`read_parquet_fast()` - default fast metadata provider - parallel 1280)
      - Read Dataset Latency: 42.07806533499979
      - Write Dataset Latency: 202.45852285499996
- Environment 2:
  - Cluster: 5 x c5n.9xlarge (180 vCPUs)
  - Storage: S3
  - 50,000 Tiny (~4KB) Parquet Files:
    - Test Case 1 (`read_parquet_fast()` - default fast metadata provider - parallel 180)
      - Read Dataset Latency: 20.308360855000046
      - Write Dataset Latency: 18.48248909499989
    - Test Case 2 (`read_parquet_fast()` - default fast metadata provider - parallel 360)   
      - Read Dataset Latency: 8.663979919000212
      - Write Dataset Latency: 18.941202082000018
    - Test Case 3 (`read_parquet_fast()` - default fast metadata provider - parallel 720)   
      - Read Dataset Latency: 6.119230162000349
      - Write Dataset Latency: 18.112871180000184
    - Test Case 4 (`read_parquet_fast()` - default fast metadata provider - parallel 1440)   
      - Read Dataset Latency: 4.157292100000177
      - Write Dataset Latency: 18.078249656000025
    - Test Case 5 (`read_parquet_fast()` - default fast metadata provider - parallel 2880)   
      - Read Dataset Latency: 3.098416549999911
      - Write Dataset Latency: 20.54457710700035
  - 600,000 Tiny (~4KB) Parquet Files:
    - Test Case 1 (`read_parquet_fast()` - default fast metadata provider - parallel 1440)
      - Read Dataset Latency: 32.844527049000135
      - Write Dataset Latency: 185.16646222
    - Test Case 2 (`read_parquet_fast()` - default fast metadata provider - parallel 2880)
      - Read Dataset Latency: 18.028459068999837
      - Write Dataset Latency: 181.07565845699992
      
Old Benchmarks:
- Cluster: 5 x r5n.8xlarge
- Storage: S3
- 2000 Tiny (~2KB) Hive-Partitioned Parquet Files:
  - `read_parquet()` not benchmarked due to ParquetDataset merge failure on indexed partition columns: https://issues.apache.org/jira/browse/ARROW-13851
  - Test Case 1 (`read_parquet_fast()` - cached parquet metadata provider - expand paths skipped - no partition filter)
    -  Read Dataset Latency: 3.72136511397548
    -  Write Dataset Latency: 7.245090199983679
    -  Read Dataset Latency: 2.96225255203899
    -  Write Dataset Latency: 6.7958771920530125
    -  Read Dataset Latency: 2.9959744710940868
    -  Write Dataset Latency: 15.850318810902536
    -  Read Dataset Latency: 3.111023452016525
    -  Write Dataset Latency: 10.99442114494741
  - Test Case 2 (`read_parquet_fast()` - cached parquet metadata provider - expand paths skipped -  partition filter keeping 1/7 files - `partition_filter_fn=lambda d: d["day"] == "MO"`)
    - Read Dataset Latency: 1.5806240870151669
    - Write Dataset Latency: 8.724663103889024
    - Read Dataset Latency: 2.334774918970652
    - Write Dataset Latency: 8.310331499087624
  - Test Case 3 (`read_parquet_fast()` - cached parquet metadata provider - expand paths skipped -  partition filter keeping all files - `partition_filter_fn=lambda d: d["day"] != "NA"`)
    - Read Dataset Latency: 3.1833109749713913
    - Write Dataset Latency: 8.957277923938818
    - Read Dataset Latency: 1.950843447004445
    - Write Dataset Latency: 8.899622384924442
    - Read Dataset Latency: 2.891347081051208
    - Write Dataset Latency: 14.80685784202069    
- 2000 Tiny (~4KB) Parquet Files:
  - Test Case 1 (`read_parquet_fast()` - cached parquet metadata provider - expand paths skipped)
      - Read Dataset Latency: 2.8592376470332965
      - Write Dataset Latency: 8.016067871009
      - Read Dataset Latency: 2.98329175892286
      - Write Dataset Latency: 7.4663043189793825
  - Test Case 2 (`read_parquet()` - cached parquet metadata provider - expand paths skipped)
      - Read Dataset Latency: 1.5026919830124825
      - Write Dataset Latency: 17.154331294004805
      - Read Dataset Latency: 1.437328452942893
      - Write Dataset Latency: 21.36053073592484
      - Read Dataset Latency: 1.3846774999983609
      - Write Dataset Latency: 13.24175373907201
  - Test Case 3 (`read_parquet()`)
      - Read Dataset Latency: 18.912850142922252
      - Write Dataset Latency: 12.525802098913118
      - Read Dataset Latency: 17.814308558939956
      - Write Dataset Latency: 13.623326486092992
      - Read Dataset Latency: 15.942234317073599
      - Write Dataset Latency: 13.625373031012714
  - Test Case 4 (`read_parquet_fast()`)
      - Read Dataset Latency: 21.10480642109178
      - Write Dataset Latency: 6.64842400001362
      - Read Dataset Latency: 30.31197776598856
      - Write Dataset Latency: 7.285999955958687

## Related issue number

Closes https://github.com/ray-project/ray/issues/22910

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
