### PR TITLE
[runtime env][bugfix] enable test_runtime_env_working_dir_3.py and fix negative cache size

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1286,8 +1286,8 @@ def get_directory_size_bytes(path: Union[str, Path] = ".") -> int:
     for dirpath, dirnames, filenames in os.walk(path):
         for f in filenames:
             fp = os.path.join(dirpath, f)
-            # skip if it is a symbolic link
-            if not os.path.islink(fp):
+            # skip if it is a symbolic link or a .pyc file
+            if not os.path.islink(fp) and not f.endswith(".pyc"):
                 total_size_bytes += os.path.getsize(fp)
 
     return total_size_bytes

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -13,7 +13,6 @@ py_test_module_list(
     "test_dashboard.py",
     "test_ray_cluster_with_external_redis.py",
     "test_k8s_cluster_launcher.py",
-    "test_runtime_env_working_dir_3.py",
   ],
   size = "large",
   extra_srcs = SRCS,
@@ -248,6 +247,7 @@ py_test_module_list(
     "test_runtime_env.py",
     "test_runtime_env_working_dir.py",
     "test_runtime_env_working_dir_2.py",
+    "test_runtime_env_working_dir_3.py",
     "test_runtime_env_working_dir_remote_uri.py"
   ],
   size = "large",

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -597,9 +597,14 @@ def runtime_env_disable_URI_cache():
         {
             "RAY_RUNTIME_ENV_CONDA_CACHE_SIZE_GB": "0",
             "RAY_RUNTIME_ENV_PIP_CACHE_SIZE_GB": "0",
+            "RAY_RUNTIME_ENV_WORKING_DIR_CACHE_SIZE_GB": "0",
+            "RAY_RUNTIME_ENV_PY_MODULES_CACHE_SIZE_GB": "0",
         },
     ):
-        print("URI caching disabled (conda and pip cache size set to 0).")
+        print(
+            "URI caching disabled (conda, pip, working_dir, py_modules cache "
+            "size set to 0)."
+        )
         yield
 
 

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -60,7 +60,7 @@ S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
-def test_task_level_gc(ray_start_cluster, option):
+def test_task_level_gc(runtime_env_disable_URI_cache, ray_start_cluster, option):
     """Tests that task-level working_dir is GC'd when the worker exits."""
 
     cluster = ray_start_cluster


### PR DESCRIPTION

## Why are these changes needed?

- Enable run test test_runtime_env_working_dir_3.py in CI
- Fix negative cache size. This bug encountered because python modues(in working_dir or py_modules) would generate `.pyc` files in `__pycache__`, like:
```
└── test_module
    ├── __init__.py
    ├── __pycache__
    │   ├── __init__.cpython-38.pyc
    │   └── test.cpython-38.pyc
    └── test.py
```
The `.pyc` files will make URI dir size larger after run the test. So cache size will be a negative after remove the URI.


## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
