### PR TITLE
`map` and `map_unordered` cancel previous tasks before submitting new ones

### DIFF
--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -99,6 +99,27 @@ def test_map_unordered(init):
 
     assert all(elem in [0, 2, 4, 6, 8] for elem in total)
 
+def test_map_gh23107(init):
+    # Reference - https://github.com/ray-project/ray/issues/23107
+    @ray.remote
+    class DummyActor:
+        async def identity(self, s):
+            return s
+
+    def func(a, v):
+        return a.identity.remote(v)
+
+    map_values = [1, 2, 3, 4, 5]
+
+    pool_map = ActorPool([DummyActor.remote() for i in range(2)])
+    pool_map.submit(func, 6)
+    gen = pool_map.map(func, map_values)
+    assert list(gen) == [1, 2, 3, 4, 5]
+
+    pool_map_unordered = ActorPool([DummyActor.remote() for i in range(2)])
+    pool_map_unordered.submit(func, 6)
+    gen = pool_map_unordered.map(func, map_values)
+    assert all(elem in [1, 2, 3, 4, 5] for elem in list(gen))
 
 def test_get_next_timeout(init):
     @ray.remote

--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -99,6 +99,7 @@ def test_map_unordered(init):
 
     assert all(elem in [0, 2, 4, 6, 8] for elem in total)
 
+
 def test_map_gh23107(init):
     # Reference - https://github.com/ray-project/ray/issues/23107
     @ray.remote
@@ -120,6 +121,7 @@ def test_map_gh23107(init):
     pool_map_unordered.submit(func, 6)
     gen = pool_map_unordered.map(func, map_values)
     assert all(elem in [1, 2, 3, 4, 5] for elem in list(gen))
+
 
 def test_get_next_timeout(init):
     @ray.remote

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -59,6 +59,14 @@ class ActorPool:
             ...                     [1, 2, 3, 4])))
             [2, 4, 6, 8]
         """
+        # Ignore/Cancel all the previous submissions
+        # by calling `has_next` and `gen_next` repeteadly.
+        while self.has_next():
+            try:
+                self.get_next(timeout=0)
+            except TimeoutError:
+                pass
+
         for v in values:
             self.submit(fn, v)
         while self.has_next():
@@ -87,6 +95,14 @@ class ActorPool:
             ...                               [1, 2, 3, 4])))
             [6, 2, 4, 8]
         """
+        # Ignore/Cancel all the previous submissions
+        # by calling `has_next` and `gen_next_unordered` repeteadly.
+        while self.has_next():
+            try:
+                self.get_next_unordered(timeout=0)
+            except TimeoutError:
+                pass
+
         for v in values:
             self.submit(fn, v)
         while self.has_next():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

N.B. - https://github.com/ray-project/ray/issues/23107#issuecomment-1068107507

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #23107 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
