### PR TITLE
[WINDOWS] add USERPROFILE and stream CI output

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -179,6 +179,8 @@ test_python() {
     bazel test --config=ci \
       --build_tests_only $(./scripts/bazel_export_options) \
       --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
+      --test_env=USERPROFILE="${USERPROFILE}" \
+      --test_output=streamed \
       -- \
       ${test_shard_selection};
   fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

On windows, the `reporter_agent` and some other python code (`rlib` seems to call `pathlib.Path.home()`) needs USERPROFILE. Also try streaming bazel CI output, which implies serializing the tests to ensure clean output, which may make CI run longer but cleaner.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
