### PR TITLE
[Datasets] [Hotfix] Fix equalized split handling of num_splits == num_blocks case.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -632,7 +632,7 @@ class Dataset(Generic[T]):
             This assume that the given splits are sorted in ascending order.
             """
             if target_size == 0:
-                return splits
+                return splits, []
             new_splits = []
             leftovers = []
             for split in splits:


### PR DESCRIPTION
Fixes the equalized split handling of `num_splits == num_blocks` case. Previously, `_equalize_larger_splits` short-circuited by returning the input split list in this case; however, the callers expect a 2-tuple of `large_splits, leftovers`. When running the `test_split.py::test_split_small` locally, the test failed, so I'm not sure why this wasn't failing in CI, still looking into that.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
