### PR TITLE
[serve] Make Dashboard start Serve in the "serve" namespace

### DIFF
--- a/dashboard/modules/serve/tests/test_serve_head.py
+++ b/dashboard/modules/serve/tests/test_serve_head.py
@@ -7,6 +7,8 @@ from typing import List, Dict, Set
 import pytest
 
 import requests
+import ray
+from ray import serve
 
 
 GET_OR_PUT_URL = "http://localhost:8265/api/serve/deployments/"
@@ -226,6 +228,26 @@ def test_get_status_info(ray_start_stop):
     assert len(expected_deployment_names) == 0
 
     print(statuses)
+
+
+def test_serve_namespace(ray_start_stop):
+    # Check that dashboard starts Serve in the Serve namespace
+
+    one = dict(
+        name="one",
+        num_replicas=1,
+        route_prefix="/one",
+        ray_actor_options={"runtime_env": {"py_modules": [test_module_uri]}},
+        import_path="test_module.test.one",
+    )
+    put_response = requests.put(GET_OR_PUT_URL, json={"deployments": [one]}, timeout=30)
+    assert put_response.status_code == 200
+    ray.init(address="auto", namespace="serve")
+    serve.start()
+    deployments = serve.list_deployments()
+    assert len(deployments) == 1
+    assert "one" in deployments
+    serve.shutdown()
 
 
 if __name__ == "__main__":

--- a/dashboard/modules/serve/tests/test_serve_head.py
+++ b/dashboard/modules/serve/tests/test_serve_head.py
@@ -231,7 +231,10 @@ def test_get_status_info(ray_start_stop):
 
 
 def test_serve_namespace(ray_start_stop):
-    # Check that dashboard starts Serve in the Serve namespace
+    """
+    Check that the Dashboard's Serve can interact with the Python API
+    when they both start in the "serve namespace"
+    """
 
     one = dict(
         name="one",

--- a/dashboard/optional_utils.py
+++ b/dashboard/optional_utils.py
@@ -269,9 +269,7 @@ def init_ray_and_catch_exceptions(connect_to_serve: bool = False) -> Callable:
                         raise e from None
 
                 if connect_to_serve:
-                    # TODO(edoakes): this should probably run in the `serve`
-                    # namespace.
-                    serve.start(detached=True)
+                    serve.start(detached=True, _override_controller_namespace="serve")
                 return await f(self, *args, **kwargs)
             except Exception as e:
                 logger.exception(f"Unexpected error in handler: {e}")

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -636,7 +636,7 @@ def start(
     http_options: Optional[Union[dict, HTTPOptions]] = None,
     dedicated_cpu: bool = False,
     _checkpoint_path: str = DEFAULT_CHECKPOINT_PATH,
-    _override_controller_namespace: str = None,
+    _override_controller_namespace: Optional[str] = None,
     **kwargs,
 ) -> Client:
     """Initialize a serve instance.

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -67,6 +67,7 @@ class ServeController:
         http_config: HTTPOptions,
         checkpoint_path: str,
         detached: bool = False,
+        _override_controller_namespace: Optional[str] = None,
     ):
         # Used to read/write checkpoints.
         self.controller_namespace = ray.get_runtime_context().namespace
@@ -85,7 +86,12 @@ class ServeController:
 
         self.long_poll_host = LongPollHost()
 
-        self.http_state = HTTPState(controller_name, detached, http_config)
+        self.http_state = HTTPState(
+            controller_name,
+            detached,
+            http_config,
+            _override_controller_namespace=_override_controller_namespace,
+        )
         self.endpoint_state = EndpointState(self.kv_store, self.long_poll_host)
         # Fetch all running actors in current cluster as source of current
         # replica state for controller failure recovery
@@ -96,6 +102,7 @@ class ServeController:
             self.kv_store,
             self.long_poll_host,
             all_current_actor_names,
+            _override_controller_namespace=_override_controller_namespace,
         )
 
         # TODO(simon): move autoscaling related stuff into a manager.

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -136,12 +136,15 @@ class ActorReplicaWrapper:
         controller_name: str,
         replica_tag: ReplicaTag,
         deployment_name: str,
+        _override_controller_namespace: Optional[str] = None,
     ):
         self._actor_name = actor_name
         self._placement_group_name = self._actor_name + "_placement_group"
         self._detached = detached
         self._controller_name = controller_name
-        self._controller_namespace = ray.serve.api._get_controller_namespace(detached)
+        self._controller_namespace = ray.serve.api._get_controller_namespace(
+            detached, _override_controller_namespace=_override_controller_namespace
+        )
 
         self._replica_tag = replica_tag
         self._deployment_name = deployment_name
@@ -609,6 +612,7 @@ class DeploymentReplica(VersionedReplica):
         replica_tag: ReplicaTag,
         deployment_name: str,
         version: DeploymentVersion,
+        _override_controller_namespace: Optional[str] = None,
     ):
         self._actor = ActorReplicaWrapper(
             f"{ReplicaName.prefix}{format_actor_name(replica_tag)}",
@@ -616,6 +620,7 @@ class DeploymentReplica(VersionedReplica):
             controller_name,
             replica_tag,
             deployment_name,
+            _override_controller_namespace=_override_controller_namespace,
         )
         self._controller_name = controller_name
         self._deployment_name = deployment_name
@@ -907,6 +912,7 @@ class DeploymentState:
         detached: bool,
         long_poll_host: LongPollHost,
         _save_checkpoint_func: Callable,
+        _override_controller_namespace: Optional[str] = None,
     ):
 
         self._name = name
@@ -914,6 +920,9 @@ class DeploymentState:
         self._detached: bool = detached
         self._long_poll_host: LongPollHost = long_poll_host
         self._save_checkpoint_func = _save_checkpoint_func
+        self._override_controller_namespace: Optional[
+            str
+        ] = _override_controller_namespace
 
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.
@@ -973,6 +982,7 @@ class DeploymentState:
                 replica_name.replica_tag,
                 replica_name.deployment_tag,
                 None,
+                _override_controller_namespace=self._override_controller_namespace,
             )
             new_deployment_replica.recover()
             self._replicas.add(ReplicaState.RECOVERING, new_deployment_replica)
@@ -1210,6 +1220,7 @@ class DeploymentState:
                     replica_name.replica_tag,
                     replica_name.deployment_tag,
                     self._target_version,
+                    _override_controller_namespace=self._override_controller_namespace,
                 )
                 new_deployment_replica.start(self._target_info, self._target_version)
 
@@ -1525,6 +1536,7 @@ class DeploymentStateManager:
         kv_store: KVStoreBase,
         long_poll_host: LongPollHost,
         all_current_actor_names: List[str],
+        _override_controller_namespace: Optional[str] = None,
     ):
 
         self._controller_name = controller_name
@@ -1537,6 +1549,7 @@ class DeploymentStateManager:
             detached,
             long_poll_host,
             self._save_checkpoint_func,
+            _override_controller_namespace=_override_controller_namespace,
         )
         self._deployment_states: Dict[str, DeploymentState] = dict()
         self._deleted_deployment_metadata: Dict[str, DeploymentInfo] = OrderedDict()

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -1,6 +1,6 @@
 import asyncio
 import random
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 import ray
 from ray.actor import ActorHandle
@@ -28,13 +28,17 @@ class HTTPState:
         controller_name: str,
         detached: bool,
         config: HTTPOptions,
+        _override_controller_namespace: Optional[str] = None,
         # Used by unit testing
         _start_proxies_on_init: bool = True,
     ):
         self._controller_name = controller_name
-        self._controller_namespace = ray.serve.api._get_controller_namespace(detached)
+        self._controller_namespace = ray.serve.api._get_controller_namespace(
+            detached, _override_controller_namespace=_override_controller_namespace
+        )
         self._detached = detached
         self._config = config
+        self._override_controller_namespace = _override_controller_namespace
         self._proxy_actors: Dict[NodeId, ActorHandle] = dict()
 
         # Will populate self.proxy_actors with existing actors.

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -11,7 +11,6 @@ import ray
 from ray import serve
 from ray.tests.conftest import tmp_working_dir  # noqa: F401, E501
 from ray._private.test_utils import wait_for_condition
-from ray.dashboard.optional_utils import RAY_INTERNAL_DASHBOARD_NAMESPACE
 from ray.serve.scripts import _process_args_and_kwargs, _configure_runtime_env
 
 
@@ -255,7 +254,7 @@ def test_deploy(ray_start_stop):
     # Deploys some valid config files and checks that the deployments work
 
     # Initialize serve in test to enable calling serve.list_deployments()
-    ray.init(address="auto", namespace=RAY_INTERNAL_DASHBOARD_NAMESPACE)
+    ray.init(address="auto", namespace="serve")
     serve.start(detached=True)
 
     # Create absolute file names to YAML config files

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -1,9 +1,19 @@
 import pytest
 import time
+import requests
 
 import ray
 from ray import serve
 from ray.serve.api import internal_get_global_client
+
+
+@pytest.fixture
+def shutdown_ray():
+    if ray.is_initialized():
+        ray.shutdown()
+    yield
+    if ray.is_initialized():
+        ray.shutdown()
 
 
 def test_redeploy_start_time(serve_instance):
@@ -33,11 +43,8 @@ def test_redeploy_start_time(serve_instance):
 
 
 @pytest.mark.parametrize("detached", [True, False])
-def test_override_namespace(detached):
+def test_override_namespace(shutdown_ray, detached):
     """Test the _override_controller_namespace flag in serve.start()."""
-
-    if ray.is_initialized():
-        ray.shutdown()
 
     ray_namespace = "ray_namespace"
     controller_namespace = "controller_namespace"
@@ -47,6 +54,28 @@ def test_override_namespace(detached):
 
     controller_name = internal_get_global_client()._controller_name
     ray.get_actor(controller_name, namespace=controller_namespace)
+
+    serve.shutdown()
+
+
+@pytest.mark.parametrize("detached", [True, False])
+def test_deploy_with_overriden_namespace(shutdown_ray, detached):
+    """Test deployments with overriden namespace."""
+
+    ray_namespace = "ray_namespace"
+    controller_namespace = "controller_namespace"
+
+    ray.init(namespace=ray_namespace)
+    serve.start(detached=detached, _override_controller_namespace=controller_namespace)
+
+    for iteration in range(2):
+
+        @serve.deployment
+        def f(*args):
+            return f"{iteration}"
+
+        f.deploy()
+        assert requests.get("http://localhost:8000/f").text == f"{iteration}"
 
     serve.shutdown()
 

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -1,19 +1,8 @@
 import pytest
 import time
-import requests
 
 import ray
 from ray import serve
-from ray.serve.api import internal_get_global_client
-
-
-@pytest.fixture
-def shutdown_ray():
-    if ray.is_initialized():
-        ray.shutdown()
-    yield
-    if ray.is_initialized():
-        ray.shutdown()
 
 
 def test_redeploy_start_time(serve_instance):
@@ -40,44 +29,6 @@ def test_redeploy_start_time(serve_instance):
     start_time_ms_2 = deployment_info_2.start_time_ms
 
     assert start_time_ms_1 == start_time_ms_2
-
-
-@pytest.mark.parametrize("detached", [True, False])
-def test_override_namespace(shutdown_ray, detached):
-    """Test the _override_controller_namespace flag in serve.start()."""
-
-    ray_namespace = "ray_namespace"
-    controller_namespace = "controller_namespace"
-
-    ray.init(namespace=ray_namespace)
-    serve.start(detached=detached, _override_controller_namespace=controller_namespace)
-
-    controller_name = internal_get_global_client()._controller_name
-    ray.get_actor(controller_name, namespace=controller_namespace)
-
-    serve.shutdown()
-
-
-@pytest.mark.parametrize("detached", [True, False])
-def test_deploy_with_overriden_namespace(shutdown_ray, detached):
-    """Test deployments with overriden namespace."""
-
-    ray_namespace = "ray_namespace"
-    controller_namespace = "controller_namespace"
-
-    ray.init(namespace=ray_namespace)
-    serve.start(detached=detached, _override_controller_namespace=controller_namespace)
-
-    for iteration in range(2):
-
-        @serve.deployment
-        def f(*args):
-            return f"{iteration}"
-
-        f.deploy()
-        assert requests.get("http://localhost:8000/f").text == f"{iteration}"
-
-    serve.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -3,6 +3,7 @@ import time
 
 import ray
 from ray import serve
+from ray.serve.api import internal_get_global_client
 
 
 def test_redeploy_start_time(serve_instance):
@@ -29,6 +30,25 @@ def test_redeploy_start_time(serve_instance):
     start_time_ms_2 = deployment_info_2.start_time_ms
 
     assert start_time_ms_1 == start_time_ms_2
+
+
+@pytest.mark.parametrize("detached", [True, False])
+def test_override_namespace(detached):
+    """Test the _override_controller_namespace flag in serve.start()."""
+
+    if ray.is_initialized():
+        ray.shutdown()
+
+    ray_namespace = "ray_namespace"
+    controller_namespace = "controller_namespace"
+
+    ray.init(namespace=ray_namespace)
+    serve.start(detached=detached, _override_controller_namespace=controller_namespace)
+
+    controller_name = internal_get_global_client()._controller_name
+    ray.get_actor(controller_name, namespace=controller_namespace)
+
+    serve.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_deployment_state.py
+++ b/python/ray/serve/tests/test_deployment_state.py
@@ -40,6 +40,7 @@ class MockReplicaActorWrapper:
         controller_name: str,
         replica_tag: ReplicaTag,
         deployment_name: str,
+        _override_controller_namespace: Optional[str] = None,
     ):
         self._actor_name = actor_name
         self._replica_tag = replica_tag

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -1,9 +1,20 @@
 import sys
 
 import pytest
+import requests
 
 import ray
 from ray import serve
+from ray.serve.api import internal_get_global_client
+
+
+@pytest.fixture
+def shutdown_ray():
+    if ray.is_initialized():
+        ray.shutdown()
+    yield
+    if ray.is_initialized():
+        ray.shutdown()
 
 
 def test_standalone_actor_outside_serve():
@@ -24,6 +35,44 @@ def test_standalone_actor_outside_serve():
 
     ray.get(a.ready.remote())
     ray.shutdown()
+
+
+@pytest.mark.parametrize("detached", [True, False])
+def test_override_namespace(shutdown_ray, detached):
+    """Test the _override_controller_namespace flag in serve.start()."""
+
+    ray_namespace = "ray_namespace"
+    controller_namespace = "controller_namespace"
+
+    ray.init(namespace=ray_namespace)
+    serve.start(detached=detached, _override_controller_namespace=controller_namespace)
+
+    controller_name = internal_get_global_client()._controller_name
+    ray.get_actor(controller_name, namespace=controller_namespace)
+
+    serve.shutdown()
+
+
+@pytest.mark.parametrize("detached", [True, False])
+def test_deploy_with_overriden_namespace(shutdown_ray, detached):
+    """Test deployments with overriden namespace."""
+
+    ray_namespace = "ray_namespace"
+    controller_namespace = "controller_namespace"
+
+    ray.init(namespace=ray_namespace)
+    serve.start(detached=detached, _override_controller_namespace=controller_namespace)
+
+    for iteration in range(2):
+
+        @serve.deployment
+        def f(*args):
+            return f"{iteration}"
+
+        f.deploy()
+        assert requests.get("http://localhost:8000/f").text == f"{iteration}"
+
+    serve.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Ray Dashboard starts Serve in the `"_ray_internal_dashboard"` namespace. However, Serve by default starts in the `"serve"` namespace. This causes surprising behavior when working with the Serve CLI and REST API.

This change make the Ray Dashboard start Serve in the `"serve"` namespace, allowing the REST API to work intuitively with the Python API.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #23058.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - New unit tests are added to `test_serve_head.py`.
