### PR TITLE
[serve] Fix `TestGetDeploymentImportPath` on Windows

### DIFF
--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -42,12 +42,18 @@ class DecoratedActor:
 class TestGetDeploymentImportPath:
     def test_get_import_path_basic(self):
         d = decorated_f.options()
-        assert get_deployment_import_path(d) == "ray.serve.tests.test_util.decorated_f"
+
+        # CI may change the parent path, so check only that the suffix matches.
+        assert get_deployment_import_path(d).endswith(
+            "ray.serve.tests.test_util.decorated_f"
+        )
 
     def test_get_import_path_nested_actor(self):
         d = serve.deployment(name="actor")(DecoratedActor)
-        assert (
-            get_deployment_import_path(d) == "ray.serve.tests.test_util.DecoratedActor"
+
+        # CI may change the parent path, so check only that the suffix matches.
+        assert get_deployment_import_path(d).endswith(
+            "ray.serve.tests.test_util.DecoratedActor"
         )
 
     @pytest.mark.skipif(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_get_import_path_basic` and `test_get_import_path_nested_actor` from `test_util.py` are [failing on Windows](https://flakey-tests.ray.io/#) because the CI adds a prefix to the import paths. ([Build example](https://buildkite.com/ray-project/ray-builders-branch/builds/6549#d75a86b5-17b2-44c2-b829-a09871e27697))

This change makes the tests check only import path suffixes rather than looking for exact equality, similar to `test_use_deployment_import_path` from `test_schema.py`.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change updates `test_get_import_path_basic` and `test_get_import_path_nested_actor`.
