### PR TITLE
[workflow] Implement workflow continuation unification

### DIFF
--- a/python/ray/workflow/__init__.py
+++ b/python/ray/workflow/__init__.py
@@ -15,6 +15,7 @@ from ray.workflow.api import (
     delete,
     wait,
     create,
+    continuation,
 )
 from ray.workflow.workflow_access import WorkflowExecutionError
 from ray.workflow.common import WorkflowStatus
@@ -39,6 +40,7 @@ __all__ = [
     "delete",
     "wait",
     "create",
+    "continuation",
 ]
 
 globals().update(WorkflowStatus.__members__)

--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -590,6 +590,28 @@ def create(dag_node: "DAGNode", *args, **kwargs) -> Workflow:
     return transform_ray_dag_to_workflow(dag_node, input_context)
 
 
+@PublicAPI(stability="beta")
+def continuation(
+    dag_node: "DAGNode", *args, **kwargs
+) -> Union[Workflow, ray.ObjectRef]:
+    """Converts a DAG into a continuation.
+
+    The result depends on the context. If it is inside a workflow, it
+    returns a workflow; otherwise it executes and get the result of
+    the DAG.
+
+    Args:
+        dag_node: The DAG to be converted.
+        args: Positional arguments of the DAG input node.
+        kwargs: Keyword arguments of the DAG input node.
+    """
+    from ray.workflow.workflow_context import in_workflow_execution
+
+    if in_workflow_execution():
+        return create(dag_node, *args, **kwargs)
+    return ray.get(dag_node.execute(*args, **kwargs))
+
+
 __all__ = (
     "step",
     "virtual_actor",

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -410,9 +410,10 @@ def _workflow_step_executor(
     try:
         step_prerun_metadata = {"start_time": time.time()}
         store.save_step_prerun_metadata(step_id, step_prerun_metadata)
-        persisted_output, volatile_output = _wrap_run(
-            func, runtime_options, *args, **kwargs
-        )
+        with workflow_context.workflow_execution():
+            persisted_output, volatile_output = _wrap_run(
+                func, runtime_options, *args, **kwargs
+            )
         step_postrun_metadata = {"end_time": time.time()}
         store.save_step_postrun_metadata(step_id, step_postrun_metadata)
     except Exception as e:

--- a/python/ray/workflow/tests/test_dag_to_workflow.py
+++ b/python/ray/workflow/tests/test_dag_to_workflow.py
@@ -27,6 +27,9 @@ def test_dag_to_workflow_execution(workflow_start_regular_shared):
     def end(lf, rt, b):
         return f"{lf},{rt};{b}"
 
+    with pytest.raises(TypeError):
+        workflow.create(begin.remote(1, 2, 3))
+
     with InputNode() as dag_input:
         f = begin.bind(2, dag_input[1], a=dag_input.a)
         lf = left.bind(f, "hello", dag_input.a)
@@ -148,8 +151,10 @@ def test_workflow_continuation(workflow_start_regular_shared):
 
     @ray.remote
     def f():
-        with InputNode() as dag_input:
-            return workflow.continuation(g.bind(dag_input.x), x=1)
+        return workflow.continuation(g.bind(1))
+
+    with pytest.raises(TypeError):
+        workflow.continuation(f.remote())
 
     dag = f.bind()
     assert ray.get(dag.execute()) == 43

--- a/python/ray/workflow/workflow_context.py
+++ b/python/ray/workflow/workflow_context.py
@@ -182,3 +182,8 @@ def get_step_status_info(status: WorkflowStatus) -> str:
 
 def get_scope():
     return _context.workflow_scope
+
+
+def in_workflow_execution() -> bool:
+    """Whether we are in workflow step execution."""
+    return get_workflow_step_context() is not None

--- a/python/ray/workflow/workflow_context.py
+++ b/python/ray/workflow/workflow_context.py
@@ -184,6 +184,21 @@ def get_scope():
     return _context.workflow_scope
 
 
+_in_workflow_execution = False
+
+
+@contextmanager
+def workflow_execution() -> None:
+    """Scope for workflow step execution."""
+    global _in_workflow_execution
+    try:
+        _in_workflow_execution = True
+        yield
+    finally:
+        _in_workflow_execution = False
+
+
 def in_workflow_execution() -> bool:
     """Whether we are in workflow step execution."""
-    return get_workflow_step_context() is not None
+    global _in_workflow_execution
+    return _in_workflow_execution


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This workflow continuation API unifies the behavior of Ray DAG inside or outside the workflow context.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
