### PR TITLE
[Core][Tiny]Shorter thread name

### DIFF
--- a/src/ray/core_worker/gcs_server_address_updater.cc
+++ b/src/ray/core_worker/gcs_server_address_updater.cc
@@ -27,7 +27,7 @@ GcsServerAddressUpdater::GcsServerAddressUpdater(
       update_func_(update_func),
       updater_runner_(updater_io_service_),
       updater_thread_([this] {
-        SetThreadName("gcs_address_upd");
+        SetThreadName("gcs_addr_updater");
         std::thread::id this_id = std::this_thread::get_id();
         RAY_LOG(INFO) << "GCS Server updater thread id: " << this_id;
         /// The asio work to keep io_service_ alive.

--- a/src/ray/core_worker/gcs_server_address_updater.cc
+++ b/src/ray/core_worker/gcs_server_address_updater.cc
@@ -27,7 +27,7 @@ GcsServerAddressUpdater::GcsServerAddressUpdater(
       update_func_(update_func),
       updater_runner_(updater_io_service_),
       updater_thread_([this] {
-        SetThreadName("gcs_address_updater");
+        SetThreadName("gcs_address_upd");
         std::thread::id this_id = std::this_thread::get_id();
         RAY_LOG(INFO) << "GCS Server updater thread id: " << this_id;
         /// The asio work to keep io_service_ alive.

--- a/src/ray/gcs/gcs_server/gcs_resource_report_poller.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_report_poller.cc
@@ -45,7 +45,7 @@ void GcsResourceReportPoller::Initialize(const GcsInitData &gcs_init_data) {
 
 void GcsResourceReportPoller::Start() {
   polling_thread_.reset(new std::thread{[this]() {
-    SetThreadName("resource_report_poller");
+    SetThreadName("resource_poller");
     boost::asio::io_service::work work(polling_service_);
 
     polling_service_.run();

--- a/src/ray/gcs/gcs_server/ray_syncer.h
+++ b/src/ray/gcs/gcs_server/ray_syncer.h
@@ -53,7 +53,7 @@ class RaySyncer {
   void Start() {
     poller_->Start();
     broadcast_thread_ = std::make_unique<std::thread>([this]() {
-      SetThreadName("resource_brdcst");
+      SetThreadName("resource_bcast");
       boost::asio::io_service::work work(broadcast_service_);
       broadcast_service_.run();
     });

--- a/src/ray/gcs/gcs_server/ray_syncer.h
+++ b/src/ray/gcs/gcs_server/ray_syncer.h
@@ -53,7 +53,7 @@ class RaySyncer {
   void Start() {
     poller_->Start();
     broadcast_thread_ = std::make_unique<std::thread>([this]() {
-      SetThreadName("resource_report_broadcaster");
+      SetThreadName("resource_brdcst");
       boost::asio::io_service::work work(broadcast_service_);
       broadcast_service_.run();
     });


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In linux the thread name could not be longer than 15 chars.
When we use command like top, we are easy being confused by similar thread name like `resource_report_poller` and `resource_report_broadcaster` because they are both show `resource_report`.

This pr uses abbr to make the thread names shorter.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
