### PR TITLE
[Java] Add a default config file for log4j2.

### DIFF
--- a/java/runtime/src/main/resources/log4j2.xml
+++ b/java/runtime/src/main/resources/log4j2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--NOTE: This configuration file is important, we shouldn't remove it.
+ In log4j2, if we don't specify the log level, the default value is error.
+ In our case that if we logged before `Ray.init()`, the logs will not printed.
+ -->
+<Configuration status="info" name="RayDefaultLog4j2ConfigBeforeInit">
+    <ThresholdFilter level="debug"/>
+
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %p %c{1} [%t]: %m%n"/>
+            <ThresholdFilter level="debug"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We add a default config file for java worker to make info logs are able to be printed before `Ray.init()` invoked.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Close #23224
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
