### PR TITLE
[ci/release] Reload modules after installing matching Ray

### DIFF
--- a/release/ray_release/command_runner/job_runner.py
+++ b/release/ray_release/command_runner/job_runner.py
@@ -14,11 +14,13 @@ from ray_release.exception import (
     LogsError,
     RemoteEnvSetupError,
     ClusterNodesWaitTimeout,
+    LocalEnvSetupError,
 )
 from ray_release.file_manager.file_manager import FileManager
 from ray_release.job_manager import JobManager
 from ray_release.logger import logger
 from ray_release.util import format_link, get_anyscale_sdk
+from ray_release.wheels import install_matching_ray_locally
 
 
 class JobRunner(CommandRunner):
@@ -40,7 +42,13 @@ class JobRunner(CommandRunner):
         self.last_command_scd_id = None
 
     def prepare_local_env(self, ray_wheels_url: Optional[str] = None):
-        pass
+        # Install matching Ray for job submission
+        try:
+            install_matching_ray_locally(
+                ray_wheels_url or os.environ.get("RAY_WHEELS", None)
+            )
+        except Exception as e:
+            raise LocalEnvSetupError(f"Error setting up local environment: {e}") from e
 
     def prepare_remote_env(self):
         # Copy wait script to working dir

--- a/release/ray_release/wheels.py
+++ b/release/ray_release/wheels.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import re
 import subprocess
@@ -27,6 +28,9 @@ INIT_URL_TPL = (
 )
 
 DEFAULT_REPO = REPO_URL_TPL.format(owner=DEFAULT_GIT_OWNER, package=DEFAULT_GIT_PACKAGE)
+
+# Modules to be reloaded after installing a new local ray version
+RELOAD_MODULES = ["ray", "ray.job_submission"]
 
 
 def get_ray_version(repo_url: str, commit: str) -> str:
@@ -239,3 +243,29 @@ def find_ray_wheels_url(ray_wheels: Optional[str] = None) -> str:
     set_test_env_var("RAY_VERSION", ray_version)
 
     return wheels_url
+
+
+def install_matching_ray_locally(ray_wheels: Optional[str]):
+    if not ray_wheels:
+        logger.warning(
+            "No Ray wheels found - can't install matching Ray wheels locally!"
+        )
+        return
+    assert "manylinux2014_x86_64" in ray_wheels, ray_wheels
+    if sys.platform == "darwin":
+        platform = "macosx_10_15_intel"
+    elif sys.platform == "win32":
+        platform = "win_amd64"
+    else:
+        platform = "manylinux2014_x86_64"
+    ray_wheels = ray_wheels.replace("manylinux2014_x86_64", platform)
+    logger.info(f"Installing matching Ray wheels locally: {ray_wheels}")
+    subprocess.check_output(
+        "pip uninstall -y ray", shell=True, env=os.environ, text=True
+    )
+    subprocess.check_output(
+        f"pip install -U {ray_wheels}", shell=True, env=os.environ, text=True
+    )
+    for module_name in RELOAD_MODULES:
+        if module_name in sys.modules:
+            importlib.reload(sys.modules[module_name])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Apparently, ray gets imported somewhere before running the client runner (maybe from an anyscale package). This means that we need to reload the ray package after installing a matching local ray wheel.
Additionally, job submission should also install a matching local ray to match with the job submission server.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
