### PR TITLE
[GCS-Ray] remove Redis password from CLI messages

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -737,9 +737,8 @@ def start(
             # NOTE(kfstorm): Java driver rely on this line to get the address
             # of the cluster. Please be careful when updating this line.
             cli_logger.print(
-                cf.bold("  ray start --address='{}'{}"),
+                cf.bold("  ray start --address='{}'"),
                 bootstrap_addresses,
-                f" --redis-password='{redis_password}'" if redis_password else "",
             )
             cli_logger.newline()
             cli_logger.print("Alternatively, use the following Python code:")
@@ -749,15 +748,10 @@ def start(
                 # `address="auto"`, the _node_ip_address parameter is
                 # unnecessary.
                 cli_logger.print(
-                    "ray{}init(address{}{}{}{})",
+                    "ray{}init(address{}{}{})",
                     cf.magenta("."),
                     cf.magenta("="),
                     cf.yellow("'auto'"),
-                    ", _redis_password{}{}".format(
-                        cf.magenta("="), cf.yellow("'" + redis_password + "'")
-                    )
-                    if redis_password
-                    else "",
                     ", _node_ip_address{}{}".format(
                         cf.magenta("="), cf.yellow("'" + node_ip_address + "'")
                     )
@@ -1647,7 +1641,7 @@ def microbenchmark():
     "--address",
     required=False,
     type=str,
-    help="Override the redis address to connect to.",
+    help="Override the Ray address to connect to.",
 )
 def timeline(address):
     """Take a Chrome tracing timeline for a Ray cluster."""

--- a/python/ray/tests/test_cli_patterns/test_ray_start.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_start.txt
@@ -7,11 +7,11 @@ Ray runtime started.
 
 Next steps
   To connect to this Ray runtime from another node, run
-    ray start --address='.+' --redis-password='.+'
+    ray start --address='.+'
 
   Alternatively, use the following Python code:
     import ray
-    ray\.init\(address='auto', _redis_password='.+'\)
+    ray\.init\(address='auto'\)
 
   To connect to this Ray runtime from outside of the cluster, for example to
   connect to a remote cluster from your laptop directly, use the following


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Redis password should not be needed in the connection info printed by `ray start --head`.
We can make another cleanup for removing flags and arguments related to Redis password. But it is a bit more risky (affects external Redis) and needs more care.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
