### PR TITLE
[Serve] Improve function deployment API

### DIFF
--- a/python/ray/experimental/dag/py_obj_scanner.py
+++ b/python/ray/experimental/dag/py_obj_scanner.py
@@ -48,7 +48,9 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler):
         from ray.experimental.dag.input_node import InputNode, InputAtrributeNode
         from ray.serve.pipeline.deployment_node import DeploymentNode
         from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
+        from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
         from ray.serve.api import DeploymentNode as UserDeploymentNode
+        from ray.serve.api import DeploymentFunctionNode as UserDeploymentFunctionNode
 
         self.dispatch_table[FunctionNode] = self._reduce_dag_node
         self.dispatch_table[ClassNode] = self._reduce_dag_node
@@ -57,7 +59,9 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler):
         self.dispatch_table[InputAtrributeNode] = self._reduce_dag_node
         self.dispatch_table[DeploymentNode] = self._reduce_dag_node
         self.dispatch_table[DeploymentMethodNode] = self._reduce_dag_node
+        self.dispatch_table[DeploymentFunctionNode] = self._reduce_dag_node
         self.dispatch_table[UserDeploymentNode] = self._reduce_dag_node
+        self.dispatch_table[UserDeploymentFunctionNode] = self._reduce_dag_node
         super().__init__(self._buf)
 
     def find_nodes(self, obj: Any) -> List["DAGNode"]:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1176,8 +1176,8 @@ class Deployment:
         The returned bound deployment can be deployed or bound to other
         deployments to create a multi-deployment application.
         """
-        if not inspect.isclass(self._func_or_class):
-            if not (len(args) == 0 and len(kwargs) == 0):
+        if inspect.isfunction(self._func_or_class):
+            if len(args) != 0 or len(kwargs) != 0:
                 raise ValueError("Function deployment doesn't take any init arguments.")
 
         return DeploymentNode(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -974,6 +974,7 @@ class RayServeDAGHandle:
             self.dag_node = json.loads(
                 self.dag_node_json, object_hook=dagnode_from_json
             )
+        print(f"Executing RayServeDAGHandle with args: {args}, kwargs: {kwargs}")
         return self.dag_node.execute(*args, **kwargs)
 
 
@@ -1759,8 +1760,15 @@ def run(
 
     client = start(detached=True, http_options={"host": host, "port": port})
 
-    if isinstance(target, DeploymentNode):
+    # Take either class or function deployment as entry, matches current
+    # deployment behavior.
+    if isinstance(target, (DeploymentNode)):
         deployments = pipeline_build(target)
+    elif isinstance(target, DAGNode):
+        raise ValueError(
+            "Please provide a driver class and bind it as entrypoint to your "
+            "Serve DAG."
+        )
     else:
         raise NotImplementedError()
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -974,7 +974,6 @@ class RayServeDAGHandle:
             self.dag_node = json.loads(
                 self.dag_node_json, object_hook=dagnode_from_json
             )
-        print(f"Executing RayServeDAGHandle with args: {args}, kwargs: {kwargs}")
         return self.dag_node.execute(*args, **kwargs)
 
 
@@ -1192,8 +1191,8 @@ class Deployment:
         if inspect.isfunction(self._func_or_class):
             return DeploymentFunctionNode(
                 self._func_or_class,
-                args,
-                kwargs,
+                args,  # Used to bind and resolve DAG only, can take user input
+                kwargs,  # Used to bind and resolve DAG only, can take user input
                 {},
                 other_args_to_resolve={
                     "deployment_self": copy(self),
@@ -1758,8 +1757,7 @@ def run(
 
     client = start(detached=True, http_options={"host": host, "port": port})
 
-    # Take either class or function deployment as entry, matches current
-    # deployment behavior.
+    # Each DAG should always provide a valid Driver DeploymentNode
     if isinstance(target, (DeploymentNode)):
         deployments = pipeline_build(target)
     elif isinstance(target, DAGNode):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1190,8 +1190,6 @@ class Deployment:
         deployments to create a multi-deployment application.
         """
         if inspect.isfunction(self._func_or_class):
-            # if len(args) != 0 or len(kwargs) != 0:
-            #     raise ValueError("Function deployment doesn't take any init arguments.")
             return DeploymentFunctionNode(
                 self._func_or_class,
                 args,

--- a/python/ray/serve/pipeline/deployment_function_node.py
+++ b/python/ray/serve/pipeline/deployment_function_node.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Dict, List, Union
+from ray import ObjectRef
 
 from ray.experimental.dag.dag_node import DAGNode
 from ray.experimental.dag.format_utils import get_dag_node_str
@@ -8,8 +9,7 @@ from ray.serve.utils import get_deployment_import_path
 
 
 class DeploymentFunctionNode(DAGNode):
-    """Represents a function node decorated by @serve.deployment in a serve DAG.
-    """
+    """Represents a function node decorated by @serve.deployment in a serve DAG."""
 
     def __init__(
         self,
@@ -28,7 +28,7 @@ class DeploymentFunctionNode(DAGNode):
             func_options,
             other_args_to_resolve=other_args_to_resolve,
         )
-        print(f"<<<<<< _bound_other_args_to_resolve: {self._bound_other_args_to_resolve}")
+
         if "deployment_self" in self._bound_other_args_to_resolve:
             original_deployment: Deployment = self._bound_other_args_to_resolve[
                 "deployment_self"
@@ -73,15 +73,13 @@ class DeploymentFunctionNode(DAGNode):
             other_args_to_resolve=new_other_args_to_resolve,
         )
 
-    def _execute_impl(self, *args, **kwargs):
+    def _execute_impl(self, *args, **kwargs) -> ObjectRef:
         """Executor of DeploymentFunctionNode by calling .remote() on the
         deployment handle.
 
         Deployment method always default to __call__.
         """
-        return self._deployment_handle.remote(
-            *self._bound_args, **self._bound_kwargs
-        )
+        return self._deployment_handle.remote(*self._bound_args, **self._bound_kwargs)
 
     def __str__(self) -> str:
         return get_dag_node_str(self, str(self._body))
@@ -97,7 +95,6 @@ class DeploymentFunctionNode(DAGNode):
         return get_deployment_import_path(self._deployment)
 
     def to_json(self, encoder_cls) -> Dict[str, Any]:
-        print(f">>>> Calling to_json on DeploymentFunctionNode")
         if "deployment_self" in self._bound_other_args_to_resolve:
             self._bound_other_args_to_resolve.pop("deployment_self")
         json_dict = super().to_json_base(encoder_cls, DeploymentFunctionNode.__name__)
@@ -109,7 +106,6 @@ class DeploymentFunctionNode(DAGNode):
     def from_json(cls, input_json, object_hook=None):
         assert input_json[DAGNODE_TYPE_KEY] == DeploymentFunctionNode.__name__
         args_dict = super().from_json_base(input_json, object_hook=object_hook)
-        # print(f">>>> module: {module}, vars: {vars(module)}")
         node = cls(
             input_json["import_path"],
             input_json["deployment_name"],

--- a/python/ray/serve/pipeline/deployment_function_node.py
+++ b/python/ray/serve/pipeline/deployment_function_node.py
@@ -1,0 +1,122 @@
+from typing import Any, Callable, Dict, List, Union
+
+from ray.experimental.dag.dag_node import DAGNode
+from ray.experimental.dag.format_utils import get_dag_node_str
+from ray.experimental.dag.constants import DAGNODE_TYPE_KEY
+from ray.serve.api import Deployment, DeploymentConfig
+from ray.serve.utils import get_deployment_import_path
+
+
+class DeploymentFunctionNode(DAGNode):
+    """Represents a function node decorated by @serve.deployment in a serve DAG.
+    """
+
+    def __init__(
+        self,
+        func_body: Union[Callable, str],
+        deployment_name,
+        func_args,
+        func_kwargs,
+        func_options,
+        other_args_to_resolve=None,
+    ):
+        self._body = func_body
+        self._deployment_name = deployment_name
+        super().__init__(
+            func_args,
+            func_kwargs,
+            func_options,
+            other_args_to_resolve=other_args_to_resolve,
+        )
+        print(f"<<<<<< _bound_other_args_to_resolve: {self._bound_other_args_to_resolve}")
+        if "deployment_self" in self._bound_other_args_to_resolve:
+            original_deployment: Deployment = self._bound_other_args_to_resolve[
+                "deployment_self"
+            ]
+            self._deployment = original_deployment.options(
+                name=(
+                    deployment_name
+                    if original_deployment._name
+                    == original_deployment.func_or_class.__name__
+                    else original_deployment._name
+                ),
+                init_args=tuple(),
+                init_kwargs=dict(),
+            )
+        else:
+            self._deployment: Deployment = Deployment(
+                func_body,
+                deployment_name,
+                DeploymentConfig(),
+                init_args=tuple(),
+                init_kwargs=dict(),
+                ray_actor_options=func_options,
+                _internal=True,
+            )
+        # TODO (jiaodong): Change this to lazy handle after the PR merged
+        # TODO (jiaodong): Polish with async handle support later
+        self._deployment_handle = self._deployment.get_handle(sync=True)
+
+    def _copy_impl(
+        self,
+        new_args: List[Any],
+        new_kwargs: Dict[str, Any],
+        new_options: Dict[str, Any],
+        new_other_args_to_resolve: Dict[str, Any],
+    ):
+        return DeploymentFunctionNode(
+            self._body,
+            self._deployment_name,
+            new_args,
+            new_kwargs,
+            new_options,
+            other_args_to_resolve=new_other_args_to_resolve,
+        )
+
+    def _execute_impl(self, *args, **kwargs):
+        """Executor of DeploymentFunctionNode by calling .remote() on the
+        deployment handle.
+
+        Deployment method always default to __call__.
+        """
+        return self._deployment_handle.remote(
+            *self._bound_args, **self._bound_kwargs
+        )
+
+    def __str__(self) -> str:
+        return get_dag_node_str(self, str(self._body))
+
+    def get_deployment_name(self):
+        return self._deployment_name
+
+    def get_import_path(self):
+        if (
+            "is_from_serve_deployment" in self._bound_other_args_to_resolve
+        ):  # built by serve top level api, this is ignored for serve.run
+            return "dummy"
+        return get_deployment_import_path(self._deployment)
+
+    def to_json(self, encoder_cls) -> Dict[str, Any]:
+        print(f">>>> Calling to_json on DeploymentFunctionNode")
+        if "deployment_self" in self._bound_other_args_to_resolve:
+            self._bound_other_args_to_resolve.pop("deployment_self")
+        json_dict = super().to_json_base(encoder_cls, DeploymentFunctionNode.__name__)
+        json_dict["import_path"] = self.get_import_path()
+        json_dict["deployment_name"] = self.get_deployment_name()
+        return json_dict
+
+    @classmethod
+    def from_json(cls, input_json, object_hook=None):
+        assert input_json[DAGNODE_TYPE_KEY] == DeploymentFunctionNode.__name__
+        args_dict = super().from_json_base(input_json, object_hook=object_hook)
+        # print(f">>>> module: {module}, vars: {vars(module)}")
+        node = cls(
+            input_json["import_path"],
+            input_json["deployment_name"],
+            args_dict["args"],
+            args_dict["kwargs"],
+            args_dict["options"],
+            other_args_to_resolve=args_dict["other_args_to_resolve"],
+        )
+        node._stable_uuid = args_dict["uuid"]
+        return node

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Optional, List, Tuple, Union
 from ray.experimental.dag import DAGNode, InputNode
 from ray.serve.handle import RayServeSyncHandle, RayServeHandle
 from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
+from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
 from ray.serve.pipeline.constants import USE_SYNC_HANDLE_KEY
 from ray.experimental.dag.constants import DAGNODE_TYPE_KEY
 from ray.experimental.dag.format_utils import get_dag_node_str
@@ -54,7 +55,8 @@ class DeploymentNode(DAGNode):
                 return node._get_serve_deployment_handle(
                     node._deployment, node._bound_other_args_to_resolve
                 )
-            elif isinstance(node, DeploymentMethodNode):
+            elif isinstance(node, (DeploymentMethodNode, DeploymentFunctionNode)):
+                print(f">>>>> node: {node}")
                 from ray.serve.pipeline.json_serde import DAGNodeEncoder
 
                 serve_dag_root_json = json.dumps(node, cls=DAGNodeEncoder)
@@ -66,7 +68,7 @@ class DeploymentNode(DAGNode):
         ) = self.apply_functional(
             [deployment_init_args, deployment_init_kwargs],
             predictate_fn=lambda node: isinstance(
-                node, (DeploymentNode, DeploymentMethodNode)
+                node, (DeploymentNode, DeploymentMethodNode, DeploymentFunctionNode)
             ),
             apply_fn=replace_with_handle,
         )
@@ -116,7 +118,7 @@ class DeploymentNode(DAGNode):
             other_args_to_resolve=new_other_args_to_resolve,
         )
 
-    def _execute_impl(self, *args):
+    def _execute_impl(self, *args, **kwargs):
         """Executor of DeploymentNode by ray.remote()"""
         return self._deployment_handle.options(**self._bound_options).remote(
             *self._bound_args, **self._bound_kwargs

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -56,7 +56,6 @@ class DeploymentNode(DAGNode):
                     node._deployment, node._bound_other_args_to_resolve
                 )
             elif isinstance(node, (DeploymentMethodNode, DeploymentFunctionNode)):
-                print(f">>>>> node: {node}")
                 from ray.serve.pipeline.json_serde import DAGNodeEncoder
 
                 serve_dag_root_json = json.dumps(node, cls=DAGNodeEncoder)

--- a/python/ray/serve/pipeline/generate.py
+++ b/python/ray/serve/pipeline/generate.py
@@ -102,7 +102,12 @@ def transform_ray_dag_to_serve_dag(dag_node):
             dag_node.get_options(),
             other_args_to_resolve=dag_node.get_other_args_to_resolve(),
         )
-    elif isinstance(dag_node, FunctionNode):
+    elif isinstance(
+        dag_node,
+        FunctionNode
+        # TODO (jiaodong): We do not convert ray function to deployment function
+        # yet, revisit this later
+    ) and dag_node.get_other_args_to_resolve().get("is_from_serve_deployment"):
         deployment_name = DeploymentNameGenerator.get_deployment_name(dag_node)
         return DeploymentFunctionNode(
             dag_node._body,
@@ -133,9 +138,7 @@ def extract_deployments_from_serve_dag(
     deployments = {}
 
     def extractor(dag_node):
-        if isinstance(
-            dag_node, (DeploymentNode, DeploymentMethodNode, DeploymentFunctionNode)
-        ):
+        if isinstance(dag_node, (DeploymentNode, DeploymentFunctionNode)):
             deployment = dag_node._deployment
             # In case same deployment is used in multiple DAGNodes
             deployments[deployment.name] = deployment

--- a/python/ray/serve/pipeline/generate.py
+++ b/python/ray/serve/pipeline/generate.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 import threading
 
 from ray.experimental.dag import (
@@ -7,10 +7,12 @@ from ray.experimental.dag import (
     ClassMethodNode,
     PARENT_CLASS_NODE_KEY,
 )
+from ray.experimental.dag.function_node import FunctionNode
 from ray.experimental.dag.input_node import InputNode
 from ray.serve.api import Deployment
 from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
 from ray.serve.pipeline.deployment_node import DeploymentNode
+from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
 
 
 class DeploymentNameGenerator(object):
@@ -24,10 +26,11 @@ class DeploymentNameGenerator(object):
     __shared_state = dict()
 
     @classmethod
-    def get_deployment_name(cls, dag_node: ClassNode):
-        assert isinstance(
-            dag_node, ClassNode
-        ), "get_deployment_name() should only be called on ClassNode instances."
+    def get_deployment_name(cls, dag_node: Union[ClassNode, FunctionNode]):
+        assert isinstance(dag_node, (ClassNode, FunctionNode)), (
+            "get_deployment_name() should only be called on ClassNode or "
+            "FunctionNode instances."
+        )
         with cls.__lock:
             deployment_name = (
                 dag_node.get_options().get("name", None) or dag_node._body.__name__
@@ -99,6 +102,16 @@ def transform_ray_dag_to_serve_dag(dag_node):
             dag_node.get_options(),
             other_args_to_resolve=dag_node.get_other_args_to_resolve(),
         )
+    elif isinstance(dag_node, FunctionNode):
+        deployment_name = DeploymentNameGenerator.get_deployment_name(dag_node)
+        return DeploymentFunctionNode(
+            dag_node._body,
+            deployment_name,
+            dag_node.get_args(),
+            dag_node.get_kwargs(),
+            dag_node.get_options(),
+            other_args_to_resolve=dag_node.get_other_args_to_resolve(),
+        )
     else:
         # TODO: (jiaodong) Support FunctionNode or leave it as ray task
         return dag_node
@@ -120,7 +133,9 @@ def extract_deployments_from_serve_dag(
     deployments = {}
 
     def extractor(dag_node):
-        if isinstance(dag_node, DeploymentNode):
+        if isinstance(
+            dag_node, (DeploymentNode, DeploymentMethodNode, DeploymentFunctionNode)
+        ):
             deployment = dag_node._deployment
             # In case same deployment is used in multiple DAGNodes
             deployments[deployment.name] = deployment

--- a/python/ray/serve/pipeline/json_serde.py
+++ b/python/ray/serve/pipeline/json_serde.py
@@ -14,6 +14,7 @@ from ray.experimental.dag import (
 )
 from ray.serve.pipeline.deployment_node import DeploymentNode
 from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
+from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
 from ray.serve.utils import parse_import_path
 from ray.serve.handle import RayServeHandle
 from ray.serve.utils import ServeHandleEncoder, serve_handle_object_hook
@@ -107,9 +108,12 @@ def dagnode_from_json(input_json: Any) -> Union[DAGNode, RayServeHandle, Any]:
         return DeploymentNode.from_json(input_json, object_hook=dagnode_from_json)
     elif input_json[DAGNODE_TYPE_KEY] == DeploymentMethodNode.__name__:
         return DeploymentMethodNode.from_json(input_json, object_hook=dagnode_from_json)
+    elif input_json[DAGNODE_TYPE_KEY] == DeploymentFunctionNode.__name__:
+        return DeploymentFunctionNode.from_json(
+            input_json, object_hook=dagnode_from_json
+        )
     else:
         # Class and Function nodes require original module as body.
-        print(f"import_path: {input_json['import_path']}")
         module_name, attr_name = parse_import_path(input_json["import_path"])
         module = getattr(import_module(module_name), attr_name)
         if input_json[DAGNODE_TYPE_KEY] == FunctionNode.__name__:

--- a/python/ray/serve/pipeline/tests/test_generate.py
+++ b/python/ray/serve/pipeline/tests/test_generate.py
@@ -105,7 +105,7 @@ def test_func_class_with_class_method_dag(serve_instance):
 
     serve_root_dag = ray_dag.apply_recursive(transform_ray_dag_to_serve_dag)
     deployments = extract_deployments_from_serve_dag(serve_root_dag)
-    assert len(deployments) == 3
+    assert len(deployments) == 2
     for deployment in deployments:
         deployment.deploy()
 

--- a/python/ray/serve/pipeline/tests/test_generate.py
+++ b/python/ray/serve/pipeline/tests/test_generate.py
@@ -101,11 +101,11 @@ def test_single_class_with_invalid_deployment_options(serve_instance):
 
 
 def test_func_class_with_class_method_dag(serve_instance):
-    ray_dag, dag_input = get_func_class_with_class_method_dag()
+    ray_dag, _ = get_func_class_with_class_method_dag()
 
     serve_root_dag = ray_dag.apply_recursive(transform_ray_dag_to_serve_dag)
     deployments = extract_deployments_from_serve_dag(serve_root_dag)
-    assert len(deployments) == 2
+    assert len(deployments) == 3
     for deployment in deployments:
         deployment.deploy()
 
@@ -119,7 +119,7 @@ def test_multi_instantiation_class_deployment_in_init_args(serve_instance):
     multiple times for the same class, and we can still correctly replace
     args with deployment handle and parse correct deployment instances.
     """
-    ray_dag, dag_input = get_multi_instantiation_class_deployment_in_init_args_dag()
+    ray_dag, _ = get_multi_instantiation_class_deployment_in_init_args_dag()
 
     serve_root_dag = ray_dag.apply_recursive(transform_ray_dag_to_serve_dag)
     print(f"Serve DAG: \n{serve_root_dag}")
@@ -138,7 +138,7 @@ def test_shared_deployment_handle(serve_instance):
     Test we can re-use the same deployment handle multiple times or in
     multiple places, without incorrectly parsing duplicated deployments.
     """
-    ray_dag, dag_input = get_shared_deployment_handle_dag()
+    ray_dag, _ = get_shared_deployment_handle_dag()
 
     serve_root_dag = ray_dag.apply_recursive(transform_ray_dag_to_serve_dag)
     print(f"Serve DAG: \n{serve_root_dag}")
@@ -158,7 +158,7 @@ def test_multi_instantiation_class_nested_deployment_arg(serve_instance):
     instantiated multiple times for the same class, and we can still correctly
     replace args with deployment handle and parse correct deployment instances.
     """
-    ray_dag, dag_input = get_multi_instantiation_class_nested_deployment_arg_dag()
+    ray_dag, _ = get_multi_instantiation_class_nested_deployment_arg_dag()
 
     serve_root_dag = ray_dag.apply_recursive(transform_ray_dag_to_serve_dag)
     print(f"Serve DAG: \n{serve_root_dag}")

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -355,10 +355,9 @@ def func():
     return 1
 
 
-def test_functional_node(serve_instance):
-    # TODO: Currently in serve, handle.remote("anything") would return 1 even
-    # though the signature doens't match at all.
-    handle = serve.run(NoargDriver.bind(func.bind()))
+def test_single_functional_node_base_case(serve_instance):
+    # Base case should work
+    handle = serve.run(func.bind())
     assert ray.get(handle.remote()) == 1
 
 

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -116,11 +116,12 @@ class NoargDriver:
         self.dag = dag
 
     async def __call__(self):
+        print("<<<<< NoargDriver called !")
         return await self.dag.remote()
 
 
 def test_single_func_no_input(serve_instance):
-    dag = fn_hello.bind().bind()
+    dag = fn_hello.bind()
     serve_dag = NoargDriver.bind(dag)
 
     handle = serve.run(serve_dag)
@@ -129,7 +130,7 @@ def test_single_func_no_input(serve_instance):
 
 def test_single_func_deployment_dag(serve_instance):
     with InputNode() as dag_input:
-        dag = combine.bind().bind(dag_input[0], dag_input[1], kwargs_output=1)
+        dag = combine.bind(dag_input[0], dag_input[1], kwargs_output=1)
         serve_dag = Driver.bind(dag)
     handle = serve.run(serve_dag)
     assert ray.get(handle.remote([1, 2])) == 4
@@ -150,9 +151,7 @@ def test_func_class_with_class_method(serve_instance):
         m2 = Model.bind(2)
         m1_output = m1.forward.bind(dag_input[0])
         m2_output = m2.forward.bind(dag_input[1])
-        combine_output = combine.bind().bind(
-            m1_output, m2_output, kwargs_output=dag_input[2]
-        )
+        combine_output = combine.bind(m1_output, m2_output, kwargs_output=dag_input[2])
         serve_dag = Driver.bind(combine_output)
 
     handle = serve.run(serve_dag)
@@ -338,6 +337,7 @@ def func():
 
 
 def test_functional_node(serve_instance):
+    # TODO (jiaodong): Check on this part
     with pytest.raises(ValueError, match="doesn't take any init arguments"):
         func.bind("something")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before `func.bind(arg)`, this is confusing.
Now `func.bind()` returns `DeploymentNode` and `func.bind().bind(args)`
return method node. User can now `serve.run(func.bind())` direclty or
use `func.bind().bind(arg)` in a dag.

==== new notes added from @jiaodong ====

- Introduced `DeploymentFunctionNode` to take care of `@serve.deployment` decorated function and composability of chained functions depend on user input 
- Banned non `DeploymentNode` as dag entry point, given we don't actually want to or handle init_args in deployment function, enforcing Driver is most consistent with our discussion
  - Only exception is we got `DeploymentFunctionNode` and it's the only deployment of the dag.  
- Skipped transforming `ray.remote` decorated function to `DeploymentFunctionNode` to avoid implications of existing tests or requirement of adding driver. 
- Changed tests back to the follow behavior:
  - `func.bind()` -> returns   `DeploymentFunctionNode` with no args
  - `func.bind(user_input)`  -> returns `DeploymentFunctionNode` that takes user input on execution, composable with other functions 
  - `serve.run(func.bind())` -> works as base case of single deployment

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #23236
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
