### PR TITLE
[core][tests] Mark threaded_actors_stress_test as unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2622,6 +2622,7 @@
       wait_for_nodes:
         num_nodes: 5
         timeout: 600
+  stable: false
 
 - name: dask_on_ray_1tb_sort
   group: core-daily-test


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test was marked as unstable before but I think we lost the flag during the nightly test refactor.

## Related issue number

Closes #23244.