### PR TITLE
[datasets] Fix missing arg in RandomIntRowDatasource

### DIFF
--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -329,6 +329,7 @@ class RandomIntRowDatasource(Datasource[ArrowRow]):
                 size_bytes=8 * count * num_columns,
                 schema=schema,
                 input_files=None,
+                exec_stats=None,
             )
             read_tasks.append(
                 ReadTask(

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3302,6 +3302,13 @@ def test_dataset_retry_exceptions(ray_start_regular, local_path):
         ).take()
 
 
+def test_datasource(ray_start_regular):
+    source = ray.data.datasource.RandomIntRowDatasource()
+    assert len(ray.data.read_datasource(source, n=10, num_columns=2).take()) == 10
+    source = ray.data.datasource.RangeDatasource()
+    assert ray.data.read_datasource(source, n=10).take() == list(range(10))
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously failed with
```
E                       ray.exceptions.RayTaskError(TypeError): ray::_prepare_read() (pid=166631, ip=10.103.212.102)
E                         File "/home/swang/ray/python/ray/data/read_api.py", line 902, in _prepare_read
E                           return ds.prepare_read(parallelism, **kwargs)
E                         File "/home/swang/ray/python/ray/data/datasource/datasource.py", line 331, in prepare_read
E                           input_files=None,
E                       TypeError: __init__() missing 1 required keyword-only argument: 'exec_stats'
```

This PR adds the missing arg.