### PR TITLE
[WIP] Block out-of-band serialization of object refs and actor handles

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -465,7 +465,9 @@ class FunctionActorManager:
             job_id,
             actor_creation_function_descriptor.function_id.binary(),
         )
+        context = self._worker.get_serialization_context()
         try:
+            context.set_is_export_pinned(True)
             serialized_actor_class = pickle.dumps(Class)
         except TypeError as e:
             msg = (
@@ -475,6 +477,8 @@ class FunctionActorManager:
                 "for more information."
             )
             raise TypeError(msg) from e
+        finally:
+            context.set_is_export_pinned(False)
         actor_class_info = {
             "class_name": actor_creation_function_descriptor.class_name.split(".")[-1],
             "module": actor_creation_function_descriptor.module_name,

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1295,6 +1295,7 @@ class ActorHandle:
             )
 
     def __reduce__(self):
+        """Note: this code path is hit by pickle, but not ray.cloudpickle."""
         raise RuntimeError(
             "Actor handles cannot be pickled except via `ray.put()` or passing "
             "as arguments to Ray tasks and actors. Use the named actors feature "

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1295,9 +1295,11 @@ class ActorHandle:
             )
 
     def __reduce__(self):
-        """This code path is used by pickling but not by Ray forking."""
-        state = self._serialization_helper()
-        return ActorHandle._deserialization_helper, state
+        raise RuntimeError(
+            "Actor handles cannot be pickled except via `ray.put()` or passing "
+            "as arguments to Ray tasks and actors. Use the named actors feature "
+            "to work with Actor handles out-of-band."
+        )
 
 
 def modify_class(cls):

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -141,8 +141,11 @@ cdef class ObjectRef(BaseID):
             "passing as arguments to Ray tasks and actors. Use "
             "`object_ref.export()` to export a reference for out-of-band use.")
 
-    def export(self, pin: bool = False):
+    def export(self, pin: bool = False) -> bytes:
         """Export an ObjectRef for serialization out-of-band to Ray.
+
+        The returned bytestring can be loaded using pickle.loads() anywhere within
+        the current Ray cluster.
 
         Args:
             pin: Whether to current worker should pin the object. If pinned, the

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -134,6 +134,12 @@ cdef class ObjectRef(BaseID):
     def __await__(self):
         return self.as_future(_internal=True).__await__()
 
+    def __reduce__(self):
+        raise RuntimeError(
+            "Object references cannot be pickled except via `ray.put()` or passing "
+            "as arguments to Ray tasks and actors. Use `object_ref.export()` to "
+            "export a reference for out-of-band use.")
+
     def as_future(self, _internal=False) -> asyncio.Future:
         """Wrap ObjectRef with an asyncio.Future.
 

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -145,7 +145,9 @@ cdef class ObjectRef(BaseID):
         """Export an ObjectRef for serialization out-of-band to Ray.
 
         The returned bytestring can be loaded using pickle.loads() anywhere within
-        the current Ray cluster.
+        the current Ray cluster. Note that exported references exist outside the
+        Ray reference counting system. Consider using the `pin` option to prevent
+        the object from being prematurely evicted.
 
         Args:
             pin: Whether to current worker should pin the object. If pinned, the

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -135,6 +135,7 @@ cdef class ObjectRef(BaseID):
         return self.as_future(_internal=True).__await__()
 
     def __reduce__(self):
+        """Note: this code path is hit by pickle, but not ray.cloudpickle."""
         raise RuntimeError(
             "Object references cannot be pickled except via `ray.put()` or "
             "passing as arguments to Ray tasks and actors. Use "

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -315,7 +315,12 @@ class RemoteFunction:
             # first driver. This is an argument for repickling the function,
             # which we do here.
             try:
-                self._pickled_function = pickle.dumps(self._function)
+                context = worker.get_serialization_context()
+                try:
+                    context.set_is_export_pinned(True)
+                    self._pickled_function = pickle.dumps(self._function)
+                finally:
+                    context.set_is_export_pinned(False)
             except TypeError as e:
                 msg = (
                     "Could not serialize the function "

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -210,12 +210,12 @@ class _ParameterRegistry:
     def get(self, k):
         if not ray.is_initialized():
             return self.to_flush[k]
-        return ray.get(self.references[k])
+        return ray.get(pickle.loads(self.references[k]))
 
     def flush(self):
         for k, v in self.to_flush.items():
             if isinstance(v, ray.ObjectRef):
-                self.references[k] = v
+                self.references[k] = v.export(pin=True)
             else:
-                self.references[k] = ray.put(v)
+                self.references[k] = ray.put(v).export(pin=True)
         self.to_flush.clear()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, actor handles and object refs are picklable. This is almost always incorrect behavior, since it's not valid to de-serialize these objects outside a Ray context, and it also bypasses reference-counting.

TODO:
- [x] Allow serialization for the purposes of closure capture by Ray actor/task definitions.
- [x] Add object_ref.export() method.
- [ ] Unit tests.
- [ ] Documentation.