### PR TITLE
[Python Worker] add feature flag to support forking from workers

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -399,15 +399,14 @@ class FunctionActorManager:
                     break
             if time.time() - start_time > timeout:
                 warning_message = (
-                    "This worker was asked to execute a "
-                    "function that it does not have "
-                    f"registered ({function_descriptor}, "
+                    "This worker was asked to execute a function "
+                    f"that has not been registered ({function_descriptor}, "
                     f"node={self._worker.node_ip_address}, "
                     f"worker_id={self._worker.worker_id.hex()}, "
-                    f"pid={os.getpid()}). You may have to restart "
-                    "Ray."
+                    f"pid={os.getpid()}). You may have to restart Ray."
                 )
                 if not warning_sent:
+                    logger.error(warning_message)
                     ray._private.utils.push_error_to_driver(
                         self._worker,
                         ray_constants.WAIT_FOR_FUNCTION_PUSH_ERROR,
@@ -415,6 +414,9 @@ class FunctionActorManager:
                         job_id=job_id,
                     )
                 warning_sent = True
+            # Try importing in case the worker did not get notified, or the
+            # importer thread did not run.
+            self._worker.import_thread._do_importing()
             time.sleep(0.001)
 
     def _publish_actor_class_to_key(self, key, actor_class_info):

--- a/python/ray/_private/import_thread.py
+++ b/python/ray/_private/import_thread.py
@@ -38,6 +38,7 @@ class ImportThread:
         self.exception_type = grpc.RpcError
         self.threads_stopped = threads_stopped
         self.imported_collision_identifiers = defaultdict(int)
+        self.t = None
         # Keep track of the number of imports that we've imported.
         self.num_imported = 0
         # Protect writes to self.num_imported.
@@ -53,7 +54,8 @@ class ImportThread:
 
     def join_import_thread(self):
         """Wait for the thread to exit."""
-        self.t.join()
+        if self.t:
+            self.t.join()
 
     def _run(self):
         try:

--- a/python/ray/_private/import_thread.py
+++ b/python/ray/_private/import_thread.py
@@ -40,6 +40,8 @@ class ImportThread:
         self.imported_collision_identifiers = defaultdict(int)
         # Keep track of the number of imports that we've imported.
         self.num_imported = 0
+        # Protect writes to self.num_imported.
+        self._lock = threading.Lock()
 
     def start(self):
         """Start the import thread."""
@@ -74,17 +76,18 @@ class ImportThread:
 
     def _do_importing(self):
         while True:
-            export_key = ray._private.function_manager.make_export_key(
-                self.num_imported + 1, self.worker.current_job_id
-            )
-            key = self.gcs_client.internal_kv_get(
-                export_key, ray_constants.KV_NAMESPACE_FUNCTION_TABLE
-            )
-            if key is not None:
-                self._process_key(key)
-                self.num_imported += 1
-            else:
-                break
+            with self._lock:
+                export_key = ray._private.function_manager.make_export_key(
+                    self.num_imported + 1, self.worker.current_job_id
+                )
+                key = self.gcs_client.internal_kv_get(
+                    export_key, ray_constants.KV_NAMESPACE_FUNCTION_TABLE
+                )
+                if key is not None:
+                    self._process_key(key)
+                    self.num_imported += 1
+                else:
+                    break
 
     def _get_import_info_for_collision_detection(self, key):
         """Retrieve the collision identifier, type, and name of the import."""

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -66,3 +66,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool gcs_grpc_based_pubsub() const
 
         c_bool bootstrap_with_gcs() const
+
+        c_bool start_python_importer_thread() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -103,3 +103,7 @@ cdef class Config:
     @staticmethod
     def record_ref_creation_sites():
         return RayConfig.instance().record_ref_creation_sites()
+
+    @staticmethod
+    def start_python_importer_thread():
+        return RayConfig.instance().start_python_importer_thread()

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -124,11 +124,38 @@ def test_function_unique_export(ray_start_regular):
         else:
             num_exports += 1
     print(f"num_exports after running g(): {num_exports}")
+    assert num_exports > 0, "Function export notification is not received"
 
     ray.get([g.remote() for _ in range(5)])
 
     key = subscriber.poll(timeout=1)
     assert key is None, f"Unexpected function key export: {key}"
+
+
+def test_function_import_without_importer_thread(shutdown_only):
+    """Test that without background importer thread, dependencies can still be
+    imported in workers."""
+    ray.init(
+        _system_config={
+            "start_python_importer_thread": False,
+        },
+    )
+
+    @ray.remote
+    def f():
+        import threading
+
+        assert threading.get_ident() == threading.main_thread().ident
+        # Make sure the importer thread is not running.
+        for thread in threading.enumerate():
+            assert "import" not in thread.name
+
+    @ray.remote
+    def g():
+        ray.get(f.remote())
+
+    ray.get(g.remote())
+    ray.get([g.remote() for _ in range(5)])
 
 
 @pytest.mark.skipif(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1581,7 +1581,8 @@ def connect(
         worker.import_thread = import_thread.ImportThread(
             worker, mode, worker.threads_stopped
         )
-        worker.import_thread.start()
+        if ray._raylet.Config.start_python_importer_thread():
+            worker.import_thread.start()
 
     # If this is a driver running in SCRIPT_MODE, start a thread to print error
     # messages asynchronously in the background. Ideally the scheduler would

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -323,6 +323,10 @@ RAY_CONFIG(uint32_t, cancellation_retry_ms, 2000)
 /// they are needed.
 RAY_CONFIG(bool, start_python_importer_thread, true)
 
+/// Determines if forking in Ray actors / tasks are supported.
+/// Note that this only enables forking in workers, but not drivers.
+RAY_CONFIG(bool, support_fork, false)
+
 /// Maximum timeout for GCS reconnection in seconds.
 /// Each reconnection ping will be retried every 1 second.
 RAY_CONFIG(int32_t, gcs_rpc_server_reconnect_timeout_s, 60)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -318,6 +318,11 @@ RAY_CONFIG(uint32_t, task_retry_delay_ms, 0)
 /// Duration to wait between retrying to kill a task.
 RAY_CONFIG(uint32_t, cancellation_retry_ms, 2000)
 
+/// Whether to start a background thread to import Python dependencies eagerly.
+/// When set to false, Python dependencies will still be imported, only when
+/// they are needed.
+RAY_CONFIG(bool, start_python_importer_thread, true)
+
 /// Maximum timeout for GCS reconnection in seconds.
 /// Each reconnection ping will be retried every 1 second.
 RAY_CONFIG(int32_t, gcs_rpc_server_reconnect_timeout_s, 60)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. Make sure Python dependencies can be imported on demand, without the background importer thread. Use cases are:
   -  If the pubsub notification for a new export is lost, importing can still be done.
   -  Allow not running the background importer thread, without affecting Ray's functionalities.

2. Add a feature flag to support forking from Python workers, by
   -  Enable fork support in gRPC.
   -  Disable importer thread and only leave the main thread in the Python worker. The importer thread will not run after forking anyway.

Closes #22909

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
