### PR TITLE
[WIP] [GCS] replace gcs_resource_scheduler with cluster_resource_scheduler

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -82,7 +82,7 @@ class MockGcsScheduleStrategy : public GcsScheduleStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -99,7 +99,7 @@ class MockGcsPackStrategy : public GcsPackStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -116,7 +116,7 @@ class MockGcsSpreadStrategy : public GcsSpreadStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -133,7 +133,7 @@ class MockGcsStrictPackStrategy : public GcsStrictPackStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -150,7 +150,7 @@ class MockGcsStrictSpreadStrategy : public GcsStrictSpreadStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 

--- a/src/ray/common/placement_group.h
+++ b/src/ray/common/placement_group.h
@@ -21,6 +21,18 @@
 
 namespace ray {
 
+struct pair_hash {
+  template <class T1, class T2>
+  std::size_t operator()(const std::pair<T1, T2> &pair) const {
+    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+  }
+};
+
+using BundleLocations =
+    absl::flat_hash_map<BundleID,
+                        std::pair<NodeID, std::shared_ptr<const BundleSpecification>>,
+                        pair_hash>;
+
 class PlacementGroupSpecification : public MessageWrapper<rpc::PlacementGroupSpec> {
  public:
   /// Construct from a protobuf message object.

--- a/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
@@ -36,7 +36,7 @@ GcsBasedActorScheduler::GcsBasedActorScheduler(
     instrumented_io_context &io_context,
     GcsActorTable &gcs_actor_table,
     const GcsNodeManager &gcs_node_manager,
-    std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler,
+    std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
     GcsActorSchedulerFailureCallback schedule_failure_handler,
     GcsActorSchedulerSuccessCallback schedule_success_handler,
     std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
@@ -50,7 +50,7 @@ GcsBasedActorScheduler::GcsBasedActorScheduler(
                         schedule_success_handler,
                         raylet_client_pool,
                         client_factory),
-      gcs_resource_scheduler_(std::move(gcs_resource_scheduler)),
+      cluster_resource_scheduler_(std::move(cluster_resource_scheduler)),
       normal_task_resources_changed_callback_(normal_task_resources_changed_callback) {}
 
 NodeID GcsBasedActorScheduler::SelectNode(std::shared_ptr<GcsActor> actor) {
@@ -104,21 +104,25 @@ GcsBasedActorScheduler::AllocateNewActorWorkerAssignment(
 
 scheduling::NodeID GcsBasedActorScheduler::AllocateResources(
     const ResourceRequest &required_resources) {
-  auto selected_nodes =
-      gcs_resource_scheduler_->Schedule({required_resources}, SchedulingType::SPREAD)
-          .second;
+  auto scheduling_options = SchedulingOptions::Spread(
+      /*avoid_local_node*/ false,
+      /*require_node_available*/ true);
+  auto result = cluster_resource_scheduler_->Schedule(
+      {&required_resources}, scheduling_options, /*scheduling_context*/ nullptr);
 
-  if (selected_nodes.size() == 0) {
+  if (!result.status.IsSuccess()) {
     RAY_LOG(INFO)
         << "Scheduling resources failed, schedule type = SchedulingType::SPREAD";
     return scheduling::NodeID::Nil();
   }
 
+  const auto &selected_nodes = result.selected_nodes;
   RAY_CHECK(selected_nodes.size() == 1);
 
   auto selected_node_id = selected_nodes[0];
   if (!selected_node_id.IsNil()) {
-    auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+    auto &cluster_resource_manager =
+        cluster_resource_scheduler_->GetClusterResourceManager();
     // Acquire the resources from the selected node.
     RAY_CHECK(cluster_resource_manager.SubtractNodeAvailableResources(
         selected_node_id, required_resources));
@@ -129,29 +133,33 @@ scheduling::NodeID GcsBasedActorScheduler::AllocateResources(
 
 scheduling::NodeID GcsBasedActorScheduler::GetHighestScoreNodeResource(
     const ResourceRequest &required_resources) const {
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
-  const auto &resource_view = cluster_resource_manager.GetResourceView();
+  // TODO(Shanly): To be implemented.
+  // auto &cluster_resource_manager =
+  //     cluster_resource_scheduler_->GetClusterResourceManager();
+  // const auto &resource_view = cluster_resource_manager.GetResourceView();
 
-  /// Get the highest score node
-  LeastResourceScorer scorer;
+  // /// Get the highest score node
+  // LeastResourceScorer scorer;
 
-  double highest_score = std::numeric_limits<double>::lowest();
-  auto highest_score_node = scheduling::NodeID::Nil();
-  for (const auto &pair : resource_view) {
-    double least_resource_val =
-        scorer.Score(required_resources, pair.second.GetLocalView());
-    if (least_resource_val > highest_score) {
-      highest_score = least_resource_val;
-      highest_score_node = pair.first;
-    }
-  }
+  // double highest_score = std::numeric_limits<double>::lowest();
+  // auto highest_score_node = scheduling::NodeID::Nil();
+  // for (const auto &pair : resource_view) {
+  //   double least_resource_val =
+  //       scorer.Score(required_resources, pair.second.GetLocalView());
+  //   if (least_resource_val > highest_score) {
+  //     highest_score = least_resource_val;
+  //     highest_score_node = pair.first;
+  //   }
+  // }
 
-  return highest_score_node;
+  // return highest_score_node;
+  return scheduling::NodeID();
 }
 
 void GcsBasedActorScheduler::WarnResourceAllocationFailure(
     const TaskSpecification &task_spec, const ResourceRequest &required_resources) const {
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_->GetClusterResourceManager();
   auto scheduling_node_id = GetHighestScoreNodeResource(required_resources);
   const NodeResources *node_resources = nullptr;
   if (!scheduling_node_id.IsNil()) {
@@ -237,7 +245,8 @@ void GcsBasedActorScheduler::HandleWorkerLeaseRejectedReply(
     std::shared_ptr<GcsActor> actor, const rpc::RequestWorkerLeaseReply &reply) {
   // The request was rejected because of insufficient resources.
   auto node_id = actor->GetNodeID();
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_->GetClusterResourceManager();
   if (normal_task_resources_changed_callback_) {
     normal_task_resources_changed_callback_(node_id, reply.resources_data());
   }
@@ -261,7 +270,8 @@ void GcsBasedActorScheduler::NotifyClusterResourcesChanged() {
 }
 
 void GcsBasedActorScheduler::ResetActorWorkerAssignment(GcsActor *actor) {
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_->GetClusterResourceManager();
   if (cluster_resource_manager.AddNodeAvailableResources(
           scheduling::NodeID(actor->GetActorWorkerAssignment()->GetNodeID().Binary()),
           actor->GetActorWorkerAssignment()->GetResources())) {

--- a/src/ray/gcs/gcs_server/gcs_actor_distribution.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_distribution.h
@@ -22,9 +22,9 @@
 #include "ray/gcs/gcs_server/gcs_actor_manager.h"
 #include "ray/gcs/gcs_server/gcs_actor_scheduler.h"
 #include "ray/gcs/gcs_server/gcs_node_manager.h"
-#include "ray/gcs/gcs_server/gcs_resource_scheduler.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
 #include "ray/raylet/scheduling/cluster_resource_manager.h"
+#include "ray/raylet/scheduling/cluster_resource_scheduler.h"
 #include "ray/raylet/scheduling/scheduling_ids.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
@@ -71,7 +71,7 @@ class GcsBasedActorScheduler : public GcsActorScheduler {
   /// \param io_context The main event loop.
   /// \param gcs_actor_table Used to flush actor info to storage.
   /// \param gcs_node_manager The node manager which is used when scheduling.
-  /// \param gcs_resource_scheduler The scheduler to select nodes based on cluster
+  /// \param cluster_resource_scheduler The scheduler to select nodes based on cluster
   /// resources.
   /// \param schedule_failure_handler Invoked when there are no available nodes to
   /// schedule actors.
@@ -84,7 +84,7 @@ class GcsBasedActorScheduler : public GcsActorScheduler {
       instrumented_io_context &io_context,
       GcsActorTable &gcs_actor_table,
       const GcsNodeManager &gcs_node_manager,
-      std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler,
+      std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
       GcsActorSchedulerFailureCallback schedule_failure_handler,
       GcsActorSchedulerSuccessCallback schedule_success_handler,
       std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
@@ -163,8 +163,8 @@ class GcsBasedActorScheduler : public GcsActorScheduler {
   /// The resource changed listeners.
   std::vector<std::function<void()>> resource_changed_listeners_;
 
-  /// Gcs resource scheduler
-  std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler_;
+  /// Cluster resource scheduler
+  std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
 
   /// Normal task resources changed callback.
   std::function<void(const NodeID &, const rpc::ResourcesData &)>

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -458,9 +458,10 @@ SchedulingOptions GcsPlacementGroupScheduler::CreateSchedulingOptions(
   case rpc::PlacementStrategy::STRICT_SPREAD:
     return SchedulingOptions::BundleStrictSpread();
   default:
-    break;
+    RAY_LOG(FATAL) << "Unsupported scheduling type: "
+                   << rpc::PlacementStrategy_Name(strategy);
   }
-  return SchedulingOptions::BundleSpread();
+  UNREACHABLE;
 }
 
 absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -17,31 +17,6 @@
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
-namespace {
-
-using ray::BundleSpecification;
-using ray::NodeID;
-
-// Get a set of bundle specifications grouped by the node.
-std::unordered_map<NodeID, std::vector<std::shared_ptr<const BundleSpecification>>>
-GetUnplacedBundlesPerNode(
-    const std::vector<std::shared_ptr<const BundleSpecification>> &bundles,
-    const ray::gcs::ScheduleMap &selected_nodes) {
-  std::unordered_map<NodeID, std::vector<std::shared_ptr<const BundleSpecification>>>
-      node_to_bundles;
-  for (const auto &bundle : bundles) {
-    const auto &bundle_id = bundle->BundleId();
-    const auto &iter = selected_nodes.find(bundle_id);
-    RAY_CHECK(iter != selected_nodes.end());
-    if (node_to_bundles.find(iter->second) == node_to_bundles.end()) {
-      node_to_bundles[iter->second] = {};
-    }
-    node_to_bundles[iter->second].push_back(bundle);
-  }
-  return node_to_bundles;
-}
-}  // namespace
-
 namespace ray {
 namespace gcs {
 
@@ -50,110 +25,16 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
     std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
     const gcs::GcsNodeManager &gcs_node_manager,
     GcsResourceManager &gcs_resource_manager,
-    GcsResourceScheduler &gcs_resource_scheduler,
+    ClusterResourceScheduler &cluster_resource_scheduler,
     std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
     syncer::RaySyncer &ray_syncer)
     : return_timer_(io_context),
       gcs_table_storage_(std::move(gcs_table_storage)),
       gcs_node_manager_(gcs_node_manager),
       gcs_resource_manager_(gcs_resource_manager),
-      gcs_resource_scheduler_(gcs_resource_scheduler),
+      cluster_resource_scheduler_(cluster_resource_scheduler),
       raylet_client_pool_(raylet_client_pool),
-      ray_syncer_(ray_syncer) {
-  scheduler_strategies_.push_back(std::make_shared<GcsPackStrategy>());
-  scheduler_strategies_.push_back(std::make_shared<GcsSpreadStrategy>());
-  scheduler_strategies_.push_back(std::make_shared<GcsStrictPackStrategy>());
-  scheduler_strategies_.push_back(std::make_shared<GcsStrictSpreadStrategy>());
-}
-
-std::vector<ResourceRequest> GcsScheduleStrategy::GetRequiredResourcesFromBundles(
-    const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles) {
-  std::vector<ResourceRequest> required_resources;
-  for (const auto &bundle : bundles) {
-    required_resources.push_back(bundle->GetRequiredResources());
-  }
-  return required_resources;
-}
-
-ScheduleResult GcsScheduleStrategy::GenerateScheduleResult(
-    const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-    const std::vector<scheduling::NodeID> &selected_nodes,
-    const SchedulingResultStatus &status) {
-  ScheduleMap schedule_map;
-  if (status == SchedulingResultStatus::SUCCESS && !selected_nodes.empty()) {
-    RAY_CHECK(bundles.size() == selected_nodes.size());
-    int index = 0;
-    for (const auto &bundle : bundles) {
-      schedule_map[bundle->BundleId()] =
-          NodeID::FromBinary(selected_nodes[index++].Binary());
-    }
-  }
-  return std::make_pair(status, schedule_map);
-}
-
-ScheduleResult GcsStrictPackStrategy::Schedule(
-    const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-    const std::unique_ptr<ScheduleContext> &context,
-    GcsResourceScheduler &gcs_resource_scheduler) {
-  const auto &required_resources = GetRequiredResourcesFromBundles(bundles);
-  const auto &scheduling_result =
-      gcs_resource_scheduler.Schedule(required_resources, SchedulingType::STRICT_PACK);
-  return GenerateScheduleResult(
-      bundles, scheduling_result.second, scheduling_result.first);
-}
-
-ScheduleResult GcsPackStrategy::Schedule(
-    const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-    const std::unique_ptr<ScheduleContext> &context,
-    GcsResourceScheduler &gcs_resource_scheduler) {
-  // The current algorithm is to select a node and deploy as many bundles as possible.
-  // First fill up a node. If the node resource is insufficient, select a new node.
-  // TODO(ffbin): We will speed this up in next PR. Currently it is a double for loop.
-  const auto &required_resources = GetRequiredResourcesFromBundles(bundles);
-  const auto &scheduling_result =
-      gcs_resource_scheduler.Schedule(required_resources, SchedulingType::PACK);
-  return GenerateScheduleResult(
-      bundles, scheduling_result.second, scheduling_result.first);
-}
-
-ScheduleResult GcsSpreadStrategy::Schedule(
-    const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-    const std::unique_ptr<ScheduleContext> &context,
-    GcsResourceScheduler &gcs_resource_scheduler) {
-  const auto &required_resources = GetRequiredResourcesFromBundles(bundles);
-  const auto &scheduling_result =
-      gcs_resource_scheduler.Schedule(required_resources, SchedulingType::SPREAD);
-  return GenerateScheduleResult(
-      bundles, scheduling_result.second, scheduling_result.first);
-}
-
-ScheduleResult GcsStrictSpreadStrategy::Schedule(
-    const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-    const std::unique_ptr<ScheduleContext> &context,
-    GcsResourceScheduler &gcs_resource_scheduler) {
-  // TODO(ffbin): A bundle may require special resources, such as GPU. We need to
-  // schedule bundles with special resource requirements first, which will be implemented
-  // in the next pr.
-
-  // Filter out the nodes already scheduled by this placement group.
-  absl::flat_hash_set<scheduling::NodeID> nodes_in_use;
-  if (context->bundle_locations_.has_value()) {
-    const auto &bundle_locations = context->bundle_locations_.value();
-    for (auto &bundle : *bundle_locations) {
-      nodes_in_use.insert(scheduling::NodeID(bundle.second.first.Binary()));
-    }
-  }
-
-  const auto &required_resources = GetRequiredResourcesFromBundles(bundles);
-  const auto &scheduling_result = gcs_resource_scheduler.Schedule(
-      required_resources,
-      SchedulingType::STRICT_SPREAD,
-      /*node_filter_func=*/[&nodes_in_use](const scheduling::NodeID &node_id) {
-        return nodes_in_use.count(node_id) == 0;
-      });
-  return GenerateScheduleResult(
-      bundles, scheduling_result.second, scheduling_result.first);
-}
+      ray_syncer_(ray_syncer) {}
 
 void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     std::shared_ptr<GcsPlacementGroup> placement_group,
@@ -176,35 +57,56 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
   RAY_LOG(DEBUG) << "Scheduling placement group " << placement_group->GetName()
                  << ", id: " << placement_group->GetPlacementGroupID()
                  << ", bundles size = " << bundles.size();
-  auto scheduling_result = scheduler_strategies_[strategy]->Schedule(
-      bundles,
-      GetScheduleContext(placement_group->GetPlacementGroupID()),
-      gcs_resource_scheduler_);
 
-  auto result_status = scheduling_result.first;
-  auto selected_nodes = scheduling_result.second;
+  std::vector<const ResourceRequest *> resource_request_list;
+  resource_request_list.reserve(bundles.size());
+  for (const auto &bundle : bundles) {
+    resource_request_list.emplace_back(&bundle->GetRequiredResources());
+  }
 
-  if (result_status != SchedulingResultStatus::SUCCESS) {
+  auto scheduling_options = CreateSchedulingOptions(strategy);
+  auto schedule_context = CreateSchedulingContext(placement_group->GetPlacementGroupID());
+  auto scheduling_result = cluster_resource_scheduler_.Schedule(
+      resource_request_list, scheduling_options, schedule_context.get());
+
+  auto result_status = scheduling_result.status;
+  const auto &selected_nodes = scheduling_result.selected_nodes;
+
+  if (!result_status.IsSuccess()) {
     RAY_LOG(DEBUG) << "Failed to schedule placement group " << placement_group->GetName()
                    << ", id: " << placement_group->GetPlacementGroupID()
                    << ", because current reource can't satisfy the required resource.";
-    bool infeasible = result_status == SchedulingResultStatus::INFEASIBLE;
+    bool infeasible = result_status.IsInfeasible();
     // If the placement group creation has failed,
     // but if it is not infeasible, it is retryable to create.
     failure_callback(placement_group, /*is_feasible*/ !infeasible);
     return;
   }
 
+  RAY_CHECK(bundles.size() == selected_nodes.size());
+
+  // Covert to a map of bundle to node.
+  ScheduleMap bundle_to_node;
+  for (size_t i = 0; i < selected_nodes.size(); ++i) {
+    bundle_to_node[bundles[i]->BundleId()] =
+        NodeID::FromBinary(selected_nodes[i].Binary());
+  }
+
   auto lease_status_tracker =
-      std::make_shared<LeaseStatusTracker>(placement_group, bundles, selected_nodes);
+      std::make_shared<LeaseStatusTracker>(placement_group, bundles, bundle_to_node);
   RAY_CHECK(placement_group_leasing_in_progress_
                 .emplace(placement_group->GetPlacementGroupID(), lease_status_tracker)
                 .second);
 
-  const auto &pending_bundles = GetUnplacedBundlesPerNode(bundles, selected_nodes);
-  for (const auto &node_to_bundles : pending_bundles) {
-    const auto &node_id = node_to_bundles.first;
-    const auto &bundles_per_node = node_to_bundles.second;
+  // Covert to a set of bundle specifications grouped by the node.
+  std::unordered_map<NodeID, std::vector<std::shared_ptr<const BundleSpecification>>>
+      node_to_bundles;
+  for (size_t i = 0; i < selected_nodes.size(); ++i) {
+    node_to_bundles[NodeID::FromBinary(selected_nodes[i].Binary())].emplace_back(
+        bundles[i]);
+  }
+
+  for (const auto &[node_id, bundles_per_node] : node_to_bundles) {
     for (const auto &bundle : bundles_per_node) {
       lease_status_tracker->MarkPreparePhaseStarted(node_id, bundle);
     }
@@ -521,7 +423,8 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
   }
 }
 
-std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
+std::unique_ptr<BundleSchedulingContext>
+GcsPlacementGroupScheduler::CreateSchedulingContext(
     const PlacementGroupID &placement_group_id) {
   auto &alive_nodes = gcs_node_manager_.GetAllAliveNodes();
   committed_bundle_location_index_.AddNodes(alive_nodes);
@@ -539,8 +442,25 @@ std::unique_ptr<ScheduleContext> GcsPlacementGroupScheduler::GetScheduleContext(
 
   auto &bundle_locations =
       committed_bundle_location_index_.GetBundleLocations(placement_group_id);
-  return std::unique_ptr<ScheduleContext>(
-      new ScheduleContext(std::move(node_to_bundles), bundle_locations));
+  return std::make_unique<BundleSchedulingContext>(std::move(node_to_bundles),
+                                                   bundle_locations);
+}
+
+SchedulingOptions GcsPlacementGroupScheduler::CreateSchedulingOptions(
+    rpc::PlacementStrategy strategy) {
+  switch (strategy) {
+  case rpc::PlacementStrategy::PACK:
+    return SchedulingOptions::BundlePack();
+  case rpc::PlacementStrategy::SPREAD:
+    return SchedulingOptions::BundleSpread();
+  case rpc::PlacementStrategy::STRICT_PACK:
+    return SchedulingOptions::BundleStrictPack();
+  case rpc::PlacementStrategy::STRICT_SPREAD:
+    return SchedulingOptions::BundleStrictSpread();
+  default:
+    break;
+  }
+  return SchedulingOptions::BundleSpread();
 }
 
 absl::flat_hash_map<PlacementGroupID, std::vector<int64_t>>
@@ -656,7 +576,8 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
 void GcsPlacementGroupScheduler::AcquireBundleResources(
     const std::shared_ptr<BundleLocations> &bundle_locations) {
   // Acquire bundle resources from gcs resources manager.
-  auto &cluster_resource_manager = gcs_resource_scheduler_.GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_.GetClusterResourceManager();
   for (auto &bundle : *bundle_locations) {
     cluster_resource_manager.SubtractNodeAvailableResources(
         scheduling::NodeID(bundle.second.first.Binary()),
@@ -667,7 +588,8 @@ void GcsPlacementGroupScheduler::AcquireBundleResources(
 void GcsPlacementGroupScheduler::ReturnBundleResources(
     const std::shared_ptr<BundleLocations> &bundle_locations) {
   // Release bundle resources to gcs resources manager.
-  auto &cluster_resource_manager = gcs_resource_scheduler_.GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_.GetClusterResourceManager();
   for (auto &bundle : *bundle_locations) {
     cluster_resource_manager.AddNodeAvailableResources(
         scheduling::NodeID(bundle.second.first.Binary()),

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -19,9 +19,10 @@
 #include "ray/common/id.h"
 #include "ray/gcs/gcs_server/gcs_node_manager.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
-#include "ray/gcs/gcs_server/gcs_resource_scheduler.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
 #include "ray/gcs/gcs_server/ray_syncer.h"
+#include "ray/raylet/scheduling/cluster_resource_scheduler.h"
+#include "ray/raylet/scheduling/policy/scheduling_context.h"
 #include "ray/raylet/scheduling/scheduling_ids.h"
 #include "ray/raylet_client/raylet_client.h"
 #include "ray/rpc/node_manager/node_manager_client.h"
@@ -42,18 +43,11 @@ using PGSchedulingFailureCallback =
 using PGSchedulingSuccessfulCallback =
     std::function<void(std::shared_ptr<GcsPlacementGroup>)>;
 
-struct pair_hash {
-  template <class T1, class T2>
-  std::size_t operator()(const std::pair<T1, T2> &pair) const {
-    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
-  }
-};
+using raylet_scheduling_policy::BundleSchedulingContext;
+using raylet_scheduling_policy::SchedulingOptions;
+using raylet_scheduling_policy::SchedulingResultStatus;
+
 using ScheduleMap = absl::flat_hash_map<BundleID, NodeID, pair_hash>;
-using ScheduleResult = std::pair<SchedulingResultStatus, ScheduleMap>;
-using BundleLocations =
-    absl::flat_hash_map<BundleID,
-                        std::pair<NodeID, std::shared_ptr<const BundleSpecification>>,
-                        pair_hash>;
 
 class GcsPlacementGroupSchedulerInterface {
  public:
@@ -103,89 +97,6 @@ class GcsPlacementGroupSchedulerInterface {
           &group_to_bundles) = 0;
 
   virtual ~GcsPlacementGroupSchedulerInterface() {}
-};
-
-/// ScheduleContext provides information that are needed for bundle scheduling decision.
-class ScheduleContext {
- public:
-  ScheduleContext(std::shared_ptr<absl::flat_hash_map<NodeID, int64_t>> node_to_bundles,
-                  const absl::optional<std::shared_ptr<BundleLocations>> bundle_locations)
-      : node_to_bundles_(std::move(node_to_bundles)),
-        bundle_locations_(bundle_locations) {}
-
-  // Key is node id, value is the number of bundles on the node.
-  const std::shared_ptr<absl::flat_hash_map<NodeID, int64_t>> node_to_bundles_;
-  // The locations of existing bundles for this placement group.
-  const absl::optional<std::shared_ptr<BundleLocations>> bundle_locations_;
-};
-
-class GcsScheduleStrategy {
- public:
-  virtual ~GcsScheduleStrategy() {}
-  virtual ScheduleResult Schedule(
-      const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-      const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) = 0;
-
- protected:
-  /// Get required resources from bundles.
-  ///
-  /// \param bundles Bundles to be scheduled.
-  /// \return Required resources.
-  std::vector<ResourceRequest> GetRequiredResourcesFromBundles(
-      const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles);
-
-  /// Generate `ScheduleResult` from bundles and nodes .
-  ///
-  /// \param bundles Bundles to be scheduled.
-  /// \param selected_nodes selected_nodes to be scheduled.
-  /// \param status Status of the scheduling result.
-  /// \return The scheduling result from the required resource.
-  ScheduleResult GenerateScheduleResult(
-      const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-      const std::vector<scheduling::NodeID> &selected_nodes,
-      const SchedulingResultStatus &status);
-};
-
-/// The `GcsPackStrategy` is that pack all bundles in one node as much as possible.
-/// If one node does not have enough resources, we need to divide bundles to multiple
-/// nodes.
-class GcsPackStrategy : public GcsScheduleStrategy {
- public:
-  ScheduleResult Schedule(
-      const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-      const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
-};
-
-/// The `GcsSpreadStrategy` is that spread all bundles in different nodes.
-class GcsSpreadStrategy : public GcsScheduleStrategy {
- public:
-  ScheduleResult Schedule(
-      const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-      const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
-};
-
-/// The `GcsStrictPackStrategy` is that all bundles must be scheduled to one node. If one
-/// node does not have enough resources, it will fail to schedule.
-class GcsStrictPackStrategy : public GcsScheduleStrategy {
- public:
-  ScheduleResult Schedule(
-      const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-      const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
-};
-
-/// The `GcsStrictSpreadStrategy` is that spread all bundles in different nodes.
-/// A node can only deploy one bundle.
-/// If the node resource is insufficient, it will fail to schedule.
-class GcsStrictSpreadStrategy : public GcsScheduleStrategy {
- public:
-  ScheduleResult Schedule(
-      const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
-      const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
 };
 
 enum class LeasingState {
@@ -417,14 +328,15 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param placement_group_info_accessor Used to flush placement_group info to storage.
   /// \param gcs_node_manager The node manager which is used when scheduling.
   /// \param gcs_resource_manager The resource manager which is used when scheduling.
-  /// \param gcs_resource_scheduler The resource scheduler which is used when scheduling.
+  /// \param cluster_resource_scheduler The resource scheduler which is used when
+  /// scheduling.
   /// \param lease_client_factory Factory to create remote lease client.
   GcsPlacementGroupScheduler(
       instrumented_io_context &io_context,
       std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
       const GcsNodeManager &gcs_node_manager,
       GcsResourceManager &gcs_resource_manager,
-      GcsResourceScheduler &gcs_resource_scheduler,
+      ClusterResourceScheduler &cluster_resource_scheduler,
       std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
       syncer::RaySyncer &ray_syncer);
 
@@ -565,9 +477,12 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// Return the bundle resources to the cluster resources.
   void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
 
-  /// Generate schedule context.
-  std::unique_ptr<ScheduleContext> GetScheduleContext(
+  /// Generate scheduling context.
+  std::unique_ptr<BundleSchedulingContext> CreateSchedulingContext(
       const PlacementGroupID &placement_group_id);
+
+  /// Generate scheduling options.
+  SchedulingOptions CreateSchedulingOptions(rpc::PlacementStrategy strategy);
 
   /// A timer that ticks every cancel resource failure milliseconds.
   boost::asio::deadline_timer return_timer_;
@@ -581,11 +496,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// Reference of GcsResourceManager.
   GcsResourceManager &gcs_resource_manager_;
 
-  /// Reference of GcsResourceScheduler.
-  GcsResourceScheduler &gcs_resource_scheduler_;
-
-  /// A vector to store all the schedule strategy.
-  std::vector<std::shared_ptr<GcsScheduleStrategy>> scheduler_strategies_;
+  /// Reference of ClusterResourceScheduler.
+  ClusterResourceScheduler &cluster_resource_scheduler_;
 
   /// Index to lookup committed bundle locations of node or placement group.
   BundleLocationIndex committed_bundle_location_index_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -126,7 +126,7 @@ void GcsServer::Start() {
 
 void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
   // Init gcs resource scheduler.
-  InitGcsResourceScheduler();
+  InitClusterResourceScheduler();
 
   // Init gcs resource manager.
   InitGcsResourceManager(gcs_init_data);
@@ -255,9 +255,9 @@ void GcsServer::InitGcsHeartbeatManager(const GcsInitData &gcs_init_data) {
 }
 
 void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
-  RAY_CHECK(gcs_table_storage_ && gcs_resource_scheduler_);
+  RAY_CHECK(gcs_table_storage_ && cluster_resource_scheduler_);
   gcs_resource_manager_ = std::make_shared<GcsResourceManager>(
-      gcs_table_storage_, gcs_resource_scheduler_->GetClusterResourceManager());
+      gcs_table_storage_, cluster_resource_scheduler_->GetClusterResourceManager());
 
   // Initialize by gcs tables data.
   gcs_resource_manager_->Initialize(gcs_init_data);
@@ -267,8 +267,8 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
   rpc_server_.RegisterService(*node_resource_info_service_);
 }
 
-void GcsServer::InitGcsResourceScheduler() {
-  gcs_resource_scheduler_ = std::make_shared<GcsResourceScheduler>();
+void GcsServer::InitClusterResourceScheduler() {
+  cluster_resource_scheduler_ = std::make_shared<ClusterResourceScheduler>();
 }
 
 void GcsServer::InitGcsJobManager(const GcsInitData &gcs_init_data) {
@@ -306,12 +306,12 @@ void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
   };
 
   if (RayConfig::instance().gcs_actor_scheduling_enabled()) {
-    RAY_CHECK(gcs_resource_manager_ && gcs_resource_scheduler_);
+    RAY_CHECK(gcs_resource_manager_ && cluster_resource_scheduler_);
     scheduler = std::make_unique<GcsBasedActorScheduler>(
         main_service_,
         gcs_table_storage_->ActorTable(),
         *gcs_node_manager_,
-        gcs_resource_scheduler_,
+        cluster_resource_scheduler_,
         schedule_failure_handler,
         schedule_success_handler,
         raylet_client_pool_,
@@ -370,13 +370,14 @@ void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
 
 void GcsServer::InitGcsPlacementGroupManager(const GcsInitData &gcs_init_data) {
   RAY_CHECK(gcs_table_storage_ && gcs_node_manager_);
-  auto scheduler = std::make_shared<GcsPlacementGroupScheduler>(main_service_,
-                                                                gcs_table_storage_,
-                                                                *gcs_node_manager_,
-                                                                *gcs_resource_manager_,
-                                                                *gcs_resource_scheduler_,
-                                                                raylet_client_pool_,
-                                                                *ray_syncer_);
+  auto scheduler =
+      std::make_shared<GcsPlacementGroupScheduler>(main_service_,
+                                                   gcs_table_storage_,
+                                                   *gcs_node_manager_,
+                                                   *gcs_resource_manager_,
+                                                   *cluster_resource_scheduler_,
+                                                   raylet_client_pool_,
+                                                   *ray_syncer_);
 
   gcs_placement_group_manager_ = std::make_shared<GcsPlacementGroupManager>(
       main_service_,

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -21,13 +21,13 @@
 #include "ray/gcs/gcs_server/gcs_init_data.h"
 #include "ray/gcs/gcs_server/gcs_kv_manager.h"
 #include "ray/gcs/gcs_server/gcs_redis_failure_detector.h"
-#include "ray/gcs/gcs_server/gcs_resource_scheduler.h"
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
 #include "ray/gcs/gcs_server/grpc_based_resource_broadcaster.h"
 #include "ray/gcs/gcs_server/pubsub_handler.h"
 #include "ray/gcs/gcs_server/ray_syncer.h"
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
 #include "ray/gcs/redis_client.h"
+#include "ray/raylet/scheduling/cluster_resource_scheduler.h"
 #include "ray/rpc/client_call.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
@@ -102,8 +102,8 @@ class GcsServer {
   /// Initialize synchronization service
   void InitRaySyncer(const GcsInitData &gcs_init_data);
 
-  /// Initialize gcs resource scheduler.
-  void InitGcsResourceScheduler();
+  /// Initialize cluster resource scheduler.
+  void InitClusterResourceScheduler();
 
   /// Initialize gcs job manager.
   void InitGcsJobManager(const GcsInitData &gcs_init_data);
@@ -180,8 +180,8 @@ class GcsServer {
   std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool_;
   /// The gcs resource manager.
   std::shared_ptr<GcsResourceManager> gcs_resource_manager_;
-  /// The gcs resource scheduler.
-  std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler_;
+  /// The cluster resource scheduler.
+  std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   /// The gcs node manager.
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
   /// The heartbeat manager.

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -19,6 +19,7 @@
 #include "ray/gcs/gcs_server/ray_syncer.h"
 #include "ray/gcs/gcs_server/test/gcs_server_test_util.h"
 #include "ray/gcs/test/gcs_test_util.h"
+#include "ray/raylet/scheduling/cluster_resource_scheduler.h"
 
 namespace ray {
 
@@ -41,9 +42,9 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_publisher_ = std::make_shared<gcs::GcsPublisher>(
         std::make_unique<GcsServerMocker::MockGcsPubSub>(redis_client_));
-    gcs_resource_scheduler_ = std::make_shared<gcs::GcsResourceScheduler>();
+    cluster_resource_scheduler_ = std::make_shared<ClusterResourceScheduler>();
     gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(
-        gcs_table_storage_, gcs_resource_scheduler_->GetClusterResourceManager());
+        gcs_table_storage_, cluster_resource_scheduler_->GetClusterResourceManager());
     ray_syncer_ = std::make_shared<ray::syncer::RaySyncer>(
         io_service_, nullptr, *gcs_resource_manager_);
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
@@ -56,7 +57,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
         gcs_table_storage_,
         *gcs_node_manager_,
         *gcs_resource_manager_,
-        *gcs_resource_scheduler_,
+        *cluster_resource_scheduler_,
         raylet_client_pool_,
         *ray_syncer_);
   }
@@ -262,7 +263,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
 
   std::vector<std::shared_ptr<GcsServerMocker::MockRayletClient>> raylet_clients_;
   std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
-  std::shared_ptr<gcs::GcsResourceScheduler> gcs_resource_scheduler_;
+  std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<GcsServerMocker::MockedGcsPlacementGroupScheduler> scheduler_;
   std::vector<std::shared_ptr<gcs::GcsPlacementGroup>> success_placement_groups_

--- a/src/ray/raylet/placement_group_resource_manager.h
+++ b/src/ray/raylet/placement_group_resource_manager.h
@@ -19,6 +19,7 @@
 #include "ray/common/id.h"
 #include "ray/common/task/scheduling_resources.h"
 #include "ray/raylet/scheduling/cluster_resource_scheduler.h"
+#include "ray/util/util.h"
 
 namespace ray {
 
@@ -29,13 +30,6 @@ enum CommitState {
   PREPARED,
   /// Resources are COMMITTED.
   COMMITTED
-};
-
-struct pair_hash {
-  template <class T1, class T2>
-  std::size_t operator()(const std::pair<T1, T2> &pair) const {
-    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
-  }
 };
 
 struct BundleTransactionState {

--- a/src/ray/raylet/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/placement_group_resource_manager_test.cc
@@ -33,16 +33,20 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
       new_placement_group_resource_manager_;
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   std::unique_ptr<gcs::MockGcsClient> gcs_client_;
+  std::function<bool(scheduling::NodeID)> is_node_available_fn_;
   rpc::GcsNodeInfo node_info_;
   void SetUp() {
     gcs_client_ = std::make_unique<gcs::MockGcsClient>();
-    EXPECT_CALL(*gcs_client_->mock_node_accessor, Get(::testing::_, ::testing::_))
+    is_node_available_fn_ = [this](scheduling::NodeID node_id) {
+      return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+    };
+    EXPECT_CALL(gcs_client_->mock_node_accessor, Get(::testing::_, ::testing::_))
         .WillRepeatedly(::testing::Return(&node_info_));
   }
   void InitLocalAvailableResource(
       absl::flat_hash_map<std::string, double> &unit_resource) {
     cluster_resource_scheduler_ = std::make_shared<ClusterResourceScheduler>(
-        scheduling::NodeID("local"), unit_resource, *gcs_client_);
+        scheduling::NodeID("local"), unit_resource, is_node_available_fn_);
     new_placement_group_resource_manager_ =
         std::make_unique<raylet::NewPlacementGroupResourceManager>(
             cluster_resource_scheduler_);
@@ -119,7 +123,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewCommitBundleResource) {
       {"bundle_group_1_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 1000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -148,7 +152,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewReturnBundleResource) {
   new_placement_group_resource_manager_->ReturnBundle(bundle_spec);
   /// 5. check remaining resources is correct.
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), unit_resource, *gcs_client_);
+      scheduling::NodeID("remaining"), unit_resource, is_node_available_fn_);
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -185,7 +189,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
       {"bundle_group_2_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 2000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -205,7 +209,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
                          {"bundle_group_1_" + group_id.Hex(), 1000},
                          {"bundle_group_" + group_id.Hex(), 2000}};
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   ASSERT_TRUE(
       remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
           {{"CPU_group_" + group_id.Hex(), 1.0},
@@ -221,7 +225,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
   /// 8. check remaining resources is correct after all bundle returned.
   remaining_resources = {{"CPU", 2.0}};
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -245,7 +249,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithMultiPrepare)
   /// 4. check remaining resources is correct.
   absl::flat_hash_map<std::string, double> remaining_resources = {{"CPU", 3.0}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -282,7 +286,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithRandomOrder) 
       {"bundle_group_1_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 1000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -311,7 +315,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithRandomOrder) 
       ConvertSingleSpecToVectorPtrs(bundle_spec));
   // 8. check remaining resources is correct.
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), available_resource, *gcs_client_);
+      scheduling::NodeID("remaining"), available_resource, is_node_available_fn_);
   remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -335,7 +339,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestPreparedResourceBatched) {
   // 4. check remaining resources is correct.
   absl::flat_hash_map<std::string, double> remaining_resources = {{"CPU", 3.0}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -361,7 +365,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestPreparedResourceBatched) {
                          {"bundle_group_4_" + group_id.Hex(), 1000},
                          {"bundle_group_" + group_id.Hex(), 4000}};
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> allocating_resource;
@@ -407,7 +411,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestCommiteResourceBatched) {
       {"bundle_group_4_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 4000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> allocating_resource;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -239,4 +239,12 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
       is_infeasible);
 }
 
+SchedulingResult ClusterResourceScheduler::Schedule(
+    const std::vector<const ResourceRequest *> &resource_request_list,
+    SchedulingOptions schedule_options,
+    SchedulingContext *schedule_context) {
+  return scheduling_policy_->Schedule(
+      resource_request_list, schedule_options, schedule_context);
+}
+
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -37,6 +37,9 @@
 
 namespace ray {
 
+using raylet_scheduling_policy::SchedulingContext;
+using raylet_scheduling_policy::SchedulingOptions;
+using raylet_scheduling_policy::SchedulingResult;
 using rpc::HeartbeatTableData;
 
 /// Class encapsulating the cluster resources and the logic to assign
@@ -60,6 +63,20 @@ class ClusterResourceScheduler {
       gcs::GcsClient &gcs_client,
       std::function<int64_t(void)> get_used_object_store_memory = nullptr,
       std::function<bool(void)> get_pull_manager_at_capacity = nullptr);
+
+  /// Schedule the specified resources to the cluster nodes.
+  ///
+  /// \param resource_request_list The resource request list we're attempting to schedule.
+  /// \param scheduling_options: scheduling options.
+  /// \param schedule_context: The context of current scheduling. Each policy can
+  /// correspond to a different type of context.
+  /// \return `SchedulingResult`, including the
+  /// selected nodes if schedule successful, otherwise, it will return an empty vector and
+  /// a flag to indicate whether this request can be retry or not.
+  SchedulingResult Schedule(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      SchedulingOptions schedule_options,
+      SchedulingContext *schedule_context);
 
   ///  Find a node in the cluster on which we can schedule a given resource request.
   ///  In hybrid mode, see `scheduling_policy.h` for a description of the policy.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -156,6 +156,9 @@ class ClusterResourceSchedulerTest : public ::testing::Test {
     // `scheduling_policy_test.cc` for comprehensive testing of the hybrid scheduling
     // policy.
     gcs_client_ = std::make_unique<gcs::MockGcsClient>();
+    is_node_available_fn_ = [this](scheduling::NodeID node_id) {
+      return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+    };
     node_name = NodeID::FromRandom().Binary();
     node_info.set_node_id(node_name);
     ON_CALL(*gcs_client_->mock_node_accessor, Get(::testing::_, ::testing::_))
@@ -206,6 +209,7 @@ class ClusterResourceSchedulerTest : public ::testing::Test {
     ASSERT_EQ(ray::kMemory_ResourceLabel, scheduling::ResourceID(MEM).Binary());
   }
   std::unique_ptr<gcs::MockGcsClient> gcs_client_;
+  std::function<bool(scheduling::NodeID)> is_node_available_fn_;
   std::string node_name;
   rpc::GcsNodeInfo node_info;
 };
@@ -378,7 +382,7 @@ TEST_F(ClusterResourceSchedulerTest, SpreadSchedulingStrategyTest) {
   absl::flat_hash_map<std::string, double> resource_total({{"CPU", 10}});
   auto local_node_id = scheduling::NodeID(NodeID::FromRandom().Binary());
   ClusterResourceScheduler resource_scheduler(
-      local_node_id, resource_total, *gcs_client_);
+      local_node_id, resource_total, is_node_available_fn_);
   AssertPredefinedNodeResources();
   auto remote_node_id = scheduling::NodeID(NodeID::FromRandom().Binary());
   resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
@@ -418,7 +422,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
   vector<FixedPoint> cust_capacities{5, 5};
   initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(1), node_resources, *gcs_client_);
+      scheduling::NodeID(1), node_resources, is_node_available_fn_);
   AssertPredefinedNodeResources();
 
   {
@@ -472,7 +476,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateTotalResourcesTest) {
       {ray::kCPU_ResourceLabel, 1}, {"custom", 1}};
   std::string name = NodeID::FromRandom().Binary();
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(name), initial_resources, *gcs_client_, nullptr, nullptr);
+      scheduling::NodeID(name), initial_resources, is_node_available_fn_);
 
   resource_scheduler.GetLocalResourceManager().AddLocalResourceInstances(
       scheduling::ResourceID(ray::kCPU_ResourceLabel), {0, 1, 1});
@@ -543,7 +547,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingResourceRequestTest) {
   vector<FixedPoint> cust_capacities{10};
   initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(0), node_resources, *gcs_client_);
+      scheduling::NodeID(0), node_resources, is_node_available_fn_);
   auto node_id = NodeID::FromRandom();
   rpc::SchedulingStrategy scheduling_strategy;
   scheduling_strategy.mutable_default_scheduling_strategy();
@@ -652,7 +656,7 @@ TEST_F(ClusterResourceSchedulerTest, GetLocalAvailableResourcesWithCpuUnitTest) 
   vector<FixedPoint> cust_capacities{8};
   initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(0), node_resources, *gcs_client_);
+      scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
   TaskResourceInstances available_cluster_resources =
       resource_scheduler.GetLocalResourceManager()
@@ -685,7 +689,7 @@ TEST_F(ClusterResourceSchedulerTest, GetLocalAvailableResourcesTest) {
   vector<FixedPoint> cust_capacities{8};
   initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(0), node_resources, *gcs_client_);
+      scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
   TaskResourceInstances available_cluster_resources =
       resource_scheduler.GetLocalResourceManager()
@@ -721,7 +725,8 @@ TEST_F(ClusterResourceSchedulerTest, AvailableResourceInstancesOpsTest) {
   vector<FixedPoint> pred_capacities{3 /* CPU */};
   initNodeResources(
       node_resources, pred_capacities, EmptyIntVector, EmptyFixedPointVector);
-  ClusterResourceScheduler cluster(scheduling::NodeID(0), node_resources, *gcs_client_);
+  ClusterResourceScheduler cluster(
+      scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
   ResourceInstanceCapacities instances;
 
@@ -755,7 +760,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
     initNodeResources(
         node_resources, pred_capacities, EmptyIntVector, EmptyFixedPointVector);
     ClusterResourceScheduler resource_scheduler(
-        scheduling::NodeID(0), node_resources, *gcs_client_);
+        scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
     ResourceRequest resource_request;
     vector<FixedPoint> pred_demands = {3. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
@@ -788,7 +793,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
     initNodeResources(
         node_resources, pred_capacities, EmptyIntVector, EmptyFixedPointVector);
     ClusterResourceScheduler resource_scheduler(
-        scheduling::NodeID(0), node_resources, *gcs_client_);
+        scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
     ResourceRequest resource_request;
     vector<FixedPoint> pred_demands = {4. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
@@ -817,7 +822,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
     vector<FixedPoint> cust_capacities{4, 4};
     initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
     ClusterResourceScheduler resource_scheduler(
-        scheduling::NodeID(0), node_resources, *gcs_client_);
+        scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
     ResourceRequest resource_request;
     vector<FixedPoint> pred_demands = {3. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
@@ -850,7 +855,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest) {
     vector<FixedPoint> cust_capacities{4, 4};
     initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
     ClusterResourceScheduler resource_scheduler(
-        scheduling::NodeID(0), node_resources, *gcs_client_);
+        scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
     ResourceRequest resource_request;
     vector<FixedPoint> pred_demands = {3. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
@@ -880,7 +885,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesAllocationFailureTest)
   vector<FixedPoint> cust_capacities{4, 4, 4};
   initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(0), node_resources, *gcs_client_);
+      scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
   ResourceRequest resource_request;
   vector<FixedPoint> pred_demands = {0. /* CPU */, 0. /* MEM */, 0. /* GPU */};
@@ -911,7 +916,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest2) {
     vector<FixedPoint> cust_capacities{4., 4.};
     initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
     ClusterResourceScheduler resource_scheduler(
-        scheduling::NodeID(0), node_resources, *gcs_client_);
+        scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
     ResourceRequest resource_request;
     vector<FixedPoint> pred_demands = {2. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
@@ -942,7 +947,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesTest2) {
 TEST_F(ClusterResourceSchedulerTest, DeadNodeTest) {
   ClusterResourceScheduler resource_scheduler(scheduling::NodeID("local"),
                                               absl::flat_hash_map<std::string, double>{},
-                                              *gcs_client_);
+                                              is_node_available_fn_);
   absl::flat_hash_map<std::string, double> resource;
   resource["CPU"] = 10000.0;
   auto node_id = NodeID::FromRandom();
@@ -982,7 +987,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskGPUResourceInstancesTest) {
     vector<FixedPoint> cust_capacities{8};
     initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
     ClusterResourceScheduler resource_scheduler(
-        scheduling::NodeID(0), node_resources, *gcs_client_);
+        scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
     std::vector<double> allocate_gpu_instances{0.5, 0.5, 0.5, 0.5};
     resource_scheduler.GetLocalResourceManager().SubtractResourceInstances(
@@ -1050,7 +1055,7 @@ TEST_F(ClusterResourceSchedulerTest,
     vector<FixedPoint> cust_capacities{8};
     initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
     ClusterResourceScheduler resource_scheduler(
-        scheduling::NodeID(0), node_resources, *gcs_client_);
+        scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
     {
       std::vector<double> allocate_gpu_instances{0.5, 0.5, 2, 0.5};
@@ -1104,7 +1109,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstanceWithHardRequestTest) {
   initNodeResources(
       node_resources, pred_capacities, EmptyIntVector, EmptyFixedPointVector);
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(0), node_resources, *gcs_client_);
+      scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
   ResourceRequest resource_request;
   vector<FixedPoint> pred_demands = {2. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
@@ -1131,7 +1136,7 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstanceWithoutCpuUnitTest) {
   initNodeResources(
       node_resources, pred_capacities, EmptyIntVector, EmptyFixedPointVector);
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID(0), node_resources, *gcs_client_);
+      scheduling::NodeID(0), node_resources, is_node_available_fn_);
 
   ResourceRequest resource_request;
   vector<FixedPoint> pred_demands = {2. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
@@ -1156,7 +1161,7 @@ TEST_F(ClusterResourceSchedulerTest, TestAlwaysSpillInfeasibleTask) {
   absl::flat_hash_map<std::string, double> resource_spec({{"CPU", 1}});
   ClusterResourceScheduler resource_scheduler(scheduling::NodeID("local"),
                                               absl::flat_hash_map<std::string, double>{},
-                                              *gcs_client_);
+                                              is_node_available_fn_);
   for (int i = 0; i < 100; i++) {
     resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
         scheduling::NodeID(NodeID::FromRandom().Binary()), {}, {});
@@ -1214,7 +1219,7 @@ TEST_F(ClusterResourceSchedulerTest, ResourceUsageReportTest) {
   absl::flat_hash_map<std::string, double> initial_resources(
       {{"CPU", 1}, {"GPU", 2}, {"memory", 3}, {"1", 1}, {"2", 2}, {"3", 3}});
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("0"), initial_resources, *gcs_client_);
+      scheduling::NodeID("0"), initial_resources, is_node_available_fn_);
   NodeResources other_node_resources;
   vector<FixedPoint> other_pred_capacities{1. /* CPU */, 1. /* MEM */, 1. /* GPU */};
   vector<FixedPoint> other_cust_capacities{5., 4., 3., 2., 1.};
@@ -1298,7 +1303,9 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
   int64_t used_object_store_memory = 250 * 1024 * 1024;
   int64_t *ptr = &used_object_store_memory;
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("0"), initial_resources, *gcs_client_, [&] { return *ptr; });
+      scheduling::NodeID("0"), initial_resources, is_node_available_fn_, [&] {
+        return *ptr;
+      });
   NodeResources other_node_resources;
   vector<FixedPoint> other_pred_capacities{1. /* CPU */, 1. /* MEM */, 1. /* GPU */};
   vector<FixedPoint> other_cust_capacities{10.};
@@ -1395,7 +1402,7 @@ TEST_F(ClusterResourceSchedulerTest, ObjectStoreMemoryUsageTest) {
 TEST_F(ClusterResourceSchedulerTest, DirtyLocalViewTest) {
   absl::flat_hash_map<std::string, double> initial_resources({{"CPU", 1}});
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("local"), initial_resources, *gcs_client_);
+      scheduling::NodeID("local"), initial_resources, is_node_available_fn_);
   auto remote = scheduling::NodeID(NodeID::FromRandom().Binary());
   resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
       remote, {{"CPU", 2.}}, {{"CPU", 2.}});
@@ -1450,7 +1457,7 @@ TEST_F(ClusterResourceSchedulerTest, DirtyLocalViewTest) {
 
 TEST_F(ClusterResourceSchedulerTest, DynamicResourceTest) {
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("local"), {{"CPU", 2}}, *gcs_client_);
+      scheduling::NodeID("local"), {{"CPU", 2}}, is_node_available_fn_);
 
   absl::flat_hash_map<std::string, double> resource_request = {{"CPU", 1},
                                                                {"custom123", 2}};
@@ -1490,7 +1497,7 @@ TEST_F(ClusterResourceSchedulerTest, DynamicResourceTest) {
 
 TEST_F(ClusterResourceSchedulerTest, AvailableResourceEmptyTest) {
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("local"), {{"custom123", 5}}, *gcs_client_);
+      scheduling::NodeID("local"), {{"custom123", 5}}, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> resource_request = {{"custom123", 5}};
@@ -1505,7 +1512,7 @@ TEST_F(ClusterResourceSchedulerTest, AvailableResourceEmptyTest) {
 TEST_F(ClusterResourceSchedulerTest, TestForceSpillback) {
   absl::flat_hash_map<std::string, double> resource_spec({{"CPU", 1}});
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("local"), resource_spec, *gcs_client_);
+      scheduling::NodeID("local"), resource_spec, is_node_available_fn_);
   std::vector<scheduling::NodeID> node_ids;
   for (int i = 0; i < 100; i++) {
     node_ids.emplace_back(NodeID::FromRandom().Binary());
@@ -1568,7 +1575,7 @@ TEST_F(ClusterResourceSchedulerTest, CustomResourceInstanceTest) {
 }
   )");
   ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("local"), {{"CPU", 4}, {"FPGA", 2}}, *gcs_client_);
+      scheduling::NodeID("local"), {{"CPU", 4}, {"FPGA", 2}}, is_node_available_fn_);
 
   StringIdMap mock_string_to_int_map;
   int64_t fpga_resource_id = mock_string_to_int_map.Insert("FPGA");
@@ -1599,8 +1606,9 @@ TEST_F(ClusterResourceSchedulerTest, CustomResourceInstanceTest) {
 }
 
 TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesSerializedStringTest) {
-  ClusterResourceScheduler resource_scheduler(
-      scheduling::NodeID("local"), {{"CPU", 4}, {"memory", 4}, {"GPU", 2}}, *gcs_client_);
+  ClusterResourceScheduler resource_scheduler(scheduling::NodeID("local"),
+                                              {{"CPU", 4}, {"memory", 4}, {"GPU", 2}},
+                                              is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> cluster_resources =
       std::make_shared<TaskResourceInstances>();
   addTaskResourceInstances(true, {2.}, 0, cluster_resources.get());
@@ -1625,7 +1633,9 @@ TEST_F(ClusterResourceSchedulerTest, TaskResourceInstancesSerializedStringTest) 
   addTaskResourceInstances(true, {4.}, 1, cluster_instance_resources.get());
   addTaskResourceInstances(true, {1., 1.}, 2, cluster_instance_resources.get());
   ClusterResourceScheduler resource_scheduler_cpu_instance(
-      scheduling::NodeID("local"), {{"CPU", 4}, {"memory", 4}, {"GPU", 2}}, *gcs_client_);
+      scheduling::NodeID("local"),
+      {{"CPU", 4}, {"memory", 4}, {"GPU", 2}},
+      is_node_available_fn_);
   std::string instance_serialized_string =
       resource_scheduler_cpu_instance.GetLocalResourceManager()
           .SerializedTaskResourceInstances(cluster_instance_resources);

--- a/src/ray/raylet/scheduling/policy/bundle_pack_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_pack_scheduling_policy.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/bundle_pack_scheduling_policy.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
 
-SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
+SchedulingResult BundlePackSchedulingPolicy::Schedule(
     const std::vector<const ResourceRequest *> &resource_request_list,
     SchedulingOptions options,
     SchedulingContext *context) {

--- a/src/ray/raylet/scheduling/policy/bundle_pack_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_pack_scheduling_policy.h
@@ -22,9 +22,9 @@
 namespace ray {
 namespace raylet_scheduling_policy {
 
-class BundleSpreadSchedulingPolicy : public ISchedulingPolicy {
+class BundlePackSchedulingPolicy : public ISchedulingPolicy {
  public:
-  explicit BundleSpreadSchedulingPolicy(
+  explicit BundlePackSchedulingPolicy(
       const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
       std::function<bool(scheduling::NodeID)> is_node_available,
       std::function<bool(scheduling::NodeID, const ResourceRequest &)>

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/bundle_scheduling_policy.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
@@ -26,15 +26,8 @@ class BundleSpreadSchedulingPolicy : public ISchedulingPolicy {
  public:
   explicit BundleSpreadSchedulingPolicy(
       const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
-      std::function<bool(scheduling::NodeID)> is_node_available,
-      std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-          add_node_available_resources_fn,
-      std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-          subtract_node_available_resources_fn)
-      : nodes_(nodes),
-        is_node_available_(is_node_available),
-        add_node_available_resources_fn_(add_node_available_resources_fn),
-        subtract_node_available_resources_fn_(subtract_node_available_resources_fn) {}
+      std::function<bool(scheduling::NodeID)> is_node_available)
+      : nodes_(nodes), is_node_available_(is_node_available) {}
 
   SchedulingResult Schedule(
       const std::vector<const ResourceRequest *> &resource_request_list,
@@ -46,10 +39,7 @@ class BundleSpreadSchedulingPolicy : public ISchedulingPolicy {
   const absl::flat_hash_map<scheduling::NodeID, Node> &nodes_;
   /// Function Checks if node is alive.
   std::function<bool(scheduling::NodeID)> is_node_available_;
-  std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-      add_node_available_resources_fn_;
-  std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-      subtract_node_available_resources_fn_;
 };
+
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.cc
@@ -12,35 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/scheduling/policy/composite_scheduling_policy.h"
-
-#include <functional>
-
-#include "ray/util/container_util.h"
-#include "ray/util/util.h"
+#include "ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h"
 
 namespace ray {
-
 namespace raylet_scheduling_policy {
 
-scheduling::NodeID CompositeSchedulingPolicy::Schedule(
-    const ResourceRequest &resource_request, SchedulingOptions options) {
-  switch (options.scheduling_type) {
-  case SchedulingType::SPREAD:
-    return spread_policy_.Schedule(resource_request, options);
-  case SchedulingType::RANDOM:
-    return random_policy_.Schedule(resource_request, options);
-  case SchedulingType::HYBRID:
-    return hybrid_policy_.Schedule(resource_request, options);
-  default:
-    RAY_LOG(FATAL) << "Unsupported scheduling type: "
-                   << static_cast<typename std::underlying_type<SchedulingType>::type>(
-                          options.scheduling_type);
-  }
-  UNREACHABLE;
-}
-
-SchedulingResult CompositeSchedulingPolicy::Schedule(
+SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
     const std::vector<const ResourceRequest *> &resource_request_list,
     SchedulingOptions schedule_options,
     SchedulingContext *schedule_context) {

--- a/src/ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h
@@ -1,0 +1,44 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "ray/raylet/scheduling/policy/scheduling_context.h"
+#include "ray/raylet/scheduling/policy/scheduling_policy.h"
+
+namespace ray {
+namespace raylet_scheduling_policy {
+
+class BundleSpreadSchedulingPolicy : public ISchedulingPolicy {
+ public:
+  explicit BundleSpreadSchedulingPolicy(
+      const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
+      std::function<bool(scheduling::NodeID)> is_node_available)
+      : nodes_(nodes), is_node_available_(is_node_available) {}
+
+  SchedulingResult Schedule(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      SchedulingOptions schedule_options,
+      SchedulingContext *schedule_context) override;
+
+  /// List of nodes in the clusters and their resources organized as a map.
+  /// The key of the map is the node ID.
+  const absl::flat_hash_map<scheduling::NodeID, Node> &nodes_;
+  /// Function Checks if node is alive.
+  std::function<bool(scheduling::NodeID)> is_node_available_;
+};
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/policy/bundle_strict_pack_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_strict_pack_scheduling_policy.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/bundle_strict_pack_scheduling_policy.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
 
-SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
+SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
     const std::vector<const ResourceRequest *> &resource_request_list,
     SchedulingOptions options,
     SchedulingContext *context) {

--- a/src/ray/raylet/scheduling/policy/bundle_strict_pack_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_strict_pack_scheduling_policy.h
@@ -22,19 +22,12 @@
 namespace ray {
 namespace raylet_scheduling_policy {
 
-class BundleSpreadSchedulingPolicy : public ISchedulingPolicy {
+class BundleStrictPackSchedulingPolicy : public ISchedulingPolicy {
  public:
-  explicit BundleSpreadSchedulingPolicy(
+  explicit BundleStrictPackSchedulingPolicy(
       const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
-      std::function<bool(scheduling::NodeID)> is_node_available,
-      std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-          add_node_available_resources_fn,
-      std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-          subtract_node_available_resources_fn)
-      : nodes_(nodes),
-        is_node_available_(is_node_available),
-        add_node_available_resources_fn_(add_node_available_resources_fn),
-        subtract_node_available_resources_fn_(subtract_node_available_resources_fn) {}
+      std::function<bool(scheduling::NodeID)> is_node_available)
+      : nodes_(nodes), is_node_available_(is_node_available) {}
 
   SchedulingResult Schedule(
       const std::vector<const ResourceRequest *> &resource_request_list,
@@ -46,10 +39,6 @@ class BundleSpreadSchedulingPolicy : public ISchedulingPolicy {
   const absl::flat_hash_map<scheduling::NodeID, Node> &nodes_;
   /// Function Checks if node is alive.
   std::function<bool(scheduling::NodeID)> is_node_available_;
-  std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-      add_node_available_resources_fn_;
-  std::function<bool(scheduling::NodeID, const ResourceRequest &)>
-      subtract_node_available_resources_fn_;
 };
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/policy/bundle_strict_spread_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_strict_spread_scheduling_policy.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/bundle_strict_spread_scheduling_policy.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
 
-SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
+SchedulingResult BundleStrictSpreadSchedulingPolicy::Schedule(
     const std::vector<const ResourceRequest *> &resource_request_list,
     SchedulingOptions options,
     SchedulingContext *context) {

--- a/src/ray/raylet/scheduling/policy/bundle_strict_spread_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_strict_spread_scheduling_policy.h
@@ -22,9 +22,9 @@
 namespace ray {
 namespace raylet_scheduling_policy {
 
-class BundleSpreadSchedulingPolicy : public ISchedulingPolicy {
+class BundleStrictSpreadSchedulingPolicy : public ISchedulingPolicy {
  public:
-  explicit BundleSpreadSchedulingPolicy(
+  explicit BundleStrictSpreadSchedulingPolicy(
       const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
       std::function<bool(scheduling::NodeID)> is_node_available,
       std::function<bool(scheduling::NodeID, const ResourceRequest &)>

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
@@ -42,11 +42,23 @@ scheduling::NodeID CompositeSchedulingPolicy::Schedule(
 
 SchedulingResult CompositeSchedulingPolicy::Schedule(
     const std::vector<const ResourceRequest *> &resource_request_list,
-    SchedulingOptions schedule_options,
-    SchedulingContext *schedule_context) {
-  SchedulingResult result;
-  // TODO(Shanly): To be implemented.
-  return result;
+    SchedulingOptions options,
+    SchedulingContext *context) {
+  switch (options.scheduling_type) {
+  case SchedulingType::BUNDLE_PACK:
+    return bundle_pack_policy_.Schedule(resource_request_list, options, context);
+  case SchedulingType::BUNDLE_SPREAD:
+    return bundle_spread_policy_.Schedule(resource_request_list, options, context);
+  case SchedulingType::BUNDLE_STRICT_PACK:
+    return bundle_strict_pack_policy_.Schedule(resource_request_list, options, context);
+  case SchedulingType::BUNDLE_STRICT_SPREAD:
+    return bundle_strict_spread_policy_.Schedule(resource_request_list, options, context);
+  default:
+    RAY_LOG(FATAL) << "Unsupported scheduling type: "
+                   << static_cast<typename std::underlying_type<SchedulingType>::type>(
+                          options.scheduling_type);
+  }
+  UNREACHABLE;
 }
 
 }  // namespace raylet_scheduling_policy

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
@@ -37,10 +37,16 @@ class CompositeSchedulingPolicy : public ISchedulingPolicy {
   scheduling::NodeID Schedule(const ResourceRequest &resource_request,
                               SchedulingOptions options) override;
 
+  SchedulingResult Schedule(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      SchedulingOptions schedule_options,
+      SchedulingContext *schedule_context) override;
+
  private:
   HybridSchedulingPolicy hybrid_policy_;
   RandomSchedulingPolicy random_policy_;
   SpreadSchedulingPolicy spread_policy_;
+
 };
 
 }  // namespace raylet_scheduling_policy

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
@@ -16,6 +16,10 @@
 
 #include <vector>
 
+#include "ray/raylet/scheduling/policy/bundle_pack_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/bundle_spread_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/bundle_strict_pack_scheduling_policy.h"
+#include "ray/raylet/scheduling/policy/bundle_strict_spread_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/hybrid_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/random_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/spread_scheduling_policy.h"
@@ -27,26 +31,47 @@ namespace raylet_scheduling_policy {
 /// scheduling_policy according to the scheduling_type.
 class CompositeSchedulingPolicy : public ISchedulingPolicy {
  public:
-  CompositeSchedulingPolicy(scheduling::NodeID local_node_id,
-                            const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
-                            std::function<bool(scheduling::NodeID)> is_node_available)
+  CompositeSchedulingPolicy(
+      scheduling::NodeID local_node_id,
+      const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
+      std::function<bool(scheduling::NodeID)> is_node_available,
+      std::function<bool(scheduling::NodeID, const ResourceRequest &)>
+          add_node_available_resources_fn,
+      std::function<bool(scheduling::NodeID, const ResourceRequest &)>
+          subtract_node_available_resources_fn)
       : hybrid_policy_(local_node_id, nodes, is_node_available),
         random_policy_(local_node_id, nodes, is_node_available),
-        spread_policy_(local_node_id, nodes, is_node_available) {}
+        spread_policy_(local_node_id, nodes, is_node_available),
+        bundle_pack_policy_(nodes,
+                            is_node_available,
+                            add_node_available_resources_fn,
+                            subtract_node_available_resources_fn),
+        bundle_spread_policy_(nodes,
+                              is_node_available,
+                              add_node_available_resources_fn,
+                              subtract_node_available_resources_fn),
+        bundle_strict_spread_policy_(nodes,
+                                     is_node_available,
+                                     add_node_available_resources_fn,
+                                     subtract_node_available_resources_fn),
+        bundle_strict_pack_policy_(nodes, is_node_available) {}
 
   scheduling::NodeID Schedule(const ResourceRequest &resource_request,
                               SchedulingOptions options) override;
 
   SchedulingResult Schedule(
       const std::vector<const ResourceRequest *> &resource_request_list,
-      SchedulingOptions schedule_options,
-      SchedulingContext *schedule_context) override;
+      SchedulingOptions options,
+      SchedulingContext *context) override;
 
  private:
   HybridSchedulingPolicy hybrid_policy_;
   RandomSchedulingPolicy random_policy_;
   SpreadSchedulingPolicy spread_policy_;
-
+  BundlePackSchedulingPolicy bundle_pack_policy_;
+  BundleSpreadSchedulingPolicy bundle_spread_policy_;
+  BundleStrictSpreadSchedulingPolicy bundle_strict_spread_policy_;
+  BundleStrictPackSchedulingPolicy bundle_strict_pack_policy_;
 };
 
 }  // namespace raylet_scheduling_policy

--- a/src/ray/raylet/scheduling/policy/scheduling_context.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_context.h
@@ -1,0 +1,48 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ray/common/bundle_spec.h"
+#include "ray/common/id.h"
+#include "ray/common/placement_group.h"
+
+namespace ray {
+namespace raylet_scheduling_policy {
+
+// Options that controls the scheduling behavior.
+struct SchedulingContext {
+  virtual ~SchedulingContext() = default;
+};
+
+struct BundleSchedulingContext : public SchedulingContext {
+ public:
+  explicit BundleSchedulingContext(
+      std::shared_ptr<absl::flat_hash_map<NodeID, int64_t>> node_to_bundles,
+      const absl::optional<std::shared_ptr<BundleLocations>> bundle_locations)
+      : node_to_bundles_(std::move(node_to_bundles)),
+        bundle_locations_(bundle_locations) {}
+
+  /// Key is node id, value is the number of bundles on the node.
+  const std::shared_ptr<absl::flat_hash_map<NodeID, int64_t>> node_to_bundles_;
+  /// The locations of existing bundles for this placement group.
+  const absl::optional<std::shared_ptr<BundleLocations>> bundle_locations_;
+  /// Nodes in use.
+  absl::flat_hash_set<scheduling::NodeID> nodes_in_use_;
+};
+
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -28,6 +28,10 @@ enum class SchedulingType {
   HYBRID = 0,
   SPREAD = 1,
   RANDOM = 2,
+  BUNDLE_PACK = 3,
+  BUNDLE_SPREAD = 4,
+  BUNDLE_STRICT_PACK = 5,
+  BUNDLE_STRICT_SPREAD = 6,
 };
 
 // Options that controls the scheduling behavior.
@@ -56,6 +60,42 @@ struct SchedulingOptions {
                              avoid_local_node,
                              require_node_available,
                              RayConfig::instance().scheduler_avoid_gpu_nodes());
+  }
+
+  // construct option for soft pack scheduling policy.
+  static SchedulingOptions BundlePack() {
+    return SchedulingOptions(SchedulingType::BUNDLE_PACK,
+                             /*spread_threshold*/ 0,
+                             /*avoid_local_node*/ false,
+                             /*require_node_available*/ true,
+                             /*avoid_gpu_nodes*/ false);
+  }
+
+  // construct option for strict spread scheduling policy.
+  static SchedulingOptions BundleSpread() {
+    return SchedulingOptions(SchedulingType::BUNDLE_SPREAD,
+                             /*spread_threshold*/ 0,
+                             /*avoid_local_node*/ false,
+                             /*require_node_available*/ true,
+                             /*avoid_gpu_nodes*/ false);
+  }
+
+  // construct option for strict pack scheduling policy.
+  static SchedulingOptions BundleStrictPack() {
+    return SchedulingOptions(SchedulingType::BUNDLE_STRICT_PACK,
+                             /*spread_threshold*/ 0,
+                             /*avoid_local_node*/ false,
+                             /*require_node_available*/ true,
+                             /*avoid_gpu_nodes*/ false);
+  }
+
+  // construct option for strict spread scheduling policy.
+  static SchedulingOptions BundleStrictSpread() {
+    return SchedulingOptions(SchedulingType::BUNDLE_STRICT_SPREAD,
+                             /*spread_threshold*/ 0,
+                             /*avoid_local_node*/ false,
+                             /*require_node_available*/ true,
+                             /*avoid_gpu_nodes*/ false);
   }
 
   SchedulingType scheduling_type;

--- a/src/ray/raylet/scheduling/policy/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy.h
@@ -17,11 +17,36 @@
 #include <vector>
 
 #include "ray/raylet/scheduling/cluster_resource_data.h"
+#include "ray/raylet/scheduling/policy/scheduling_context.h"
 #include "ray/raylet/scheduling/policy/scheduling_options.h"
 #include "ray/raylet/scheduling/scheduling_ids.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
+
+// Status of resource scheduling result.
+struct SchedulingResultStatus {
+  bool IsFailed() const { return code == SchedulingResultStatusCode::FAILED; }
+  bool IsInfeasible() const { return code == SchedulingResultStatusCode::INFEASIBLE; }
+  bool IsSuccess() const { return code == SchedulingResultStatusCode::SUCCESS; }
+
+  enum class SchedulingResultStatusCode {
+    // Scheduling failed but retryable.
+    FAILED = 0,
+    // Scheduling failed and non-retryable.
+    INFEASIBLE = 1,
+    // Scheduling successful.
+    SUCCESS = 2,
+  };
+  SchedulingResultStatusCode code = SchedulingResultStatusCode::SUCCESS;
+};
+
+struct SchedulingResult {
+  // The status of scheduling.
+  SchedulingResultStatus status;
+  // The nodes successfully scheduled.
+  std::vector<scheduling::NodeID> selected_nodes;
+};
 
 /// ISchedulingPolicy picks a node to from the cluster, according to the resource
 /// requirment as well as the scheduling options.
@@ -34,7 +59,25 @@ class ISchedulingPolicy {
   /// \return NodeID::Nil() if the task is unfeasible, otherwise the node id
   /// to schedule on.
   virtual scheduling::NodeID Schedule(const ResourceRequest &resource_request,
-                                      SchedulingOptions options) = 0;
+                                      SchedulingOptions options) {
+    return scheduling::NodeID();
+  }
+
+  /// Schedule the specified resources to the cluster nodes.
+  ///
+  /// \param resource_request_list The resource request list we're attempting to schedule.
+  /// \param scheduling_options: scheduling options.
+  /// \param schedule_context: The context of current scheduling. Each policy can
+  /// correspond to a different type of context.
+  /// \return `SchedulingResult`, including the
+  /// selected nodes if schedule successful, otherwise, it will return an empty vector and
+  /// a flag to indicate whether this request can be retry or not.
+  virtual SchedulingResult Schedule(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      SchedulingOptions schedule_options,
+      SchedulingContext *schedule_context) {
+    return SchedulingResult();
+  }
 };
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/policy/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy.h
@@ -54,7 +54,7 @@ class ISchedulingPolicy {
  public:
   virtual ~ISchedulingPolicy() = default;
   /// \param resource_request: The resource request we're attempting to schedule.
-  /// \param scheduling_options: scheduling options.
+  /// \param options: scheduling options.
   ///
   /// \return NodeID::Nil() if the task is unfeasible, otherwise the node id
   /// to schedule on.
@@ -66,16 +66,16 @@ class ISchedulingPolicy {
   /// Schedule the specified resources to the cluster nodes.
   ///
   /// \param resource_request_list The resource request list we're attempting to schedule.
-  /// \param scheduling_options: scheduling options.
-  /// \param schedule_context: The context of current scheduling. Each policy can
+  /// \param options: scheduling options.
+  /// \param context: The context of current scheduling. Each policy can
   /// correspond to a different type of context.
   /// \return `SchedulingResult`, including the
   /// selected nodes if schedule successful, otherwise, it will return an empty vector and
   /// a flag to indicate whether this request can be retry or not.
   virtual SchedulingResult Schedule(
       const std::vector<const ResourceRequest *> &resource_request_list,
-      SchedulingOptions schedule_options,
-      SchedulingContext *schedule_context) {
+      SchedulingOptions options,
+      SchedulingContext *context) {
     return SchedulingResult();
   }
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As we (@scv119 @iycheng @raulchen @Chong-Li @WangTaoTheTonic ) discussed offline, the GcsResourceScheduler on the GCS side should be unified to ClusterResourceScheduler.

BTW: This PR is just an overview, it will be split to several small ones.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
