### PR TITLE
[C++ API][Doc] Add doc and error log to notice C++ API is not supported on Windows

### DIFF
--- a/doc/source/ray-core/walkthrough.rst
+++ b/doc/source/ray-core/walkthrough.rst
@@ -31,7 +31,7 @@ Installation
 
 .. tabbed:: C++
 
-    The C++ Ray API is currently experimental with limited support. You can track its development `here <https://github.com/ray-project/ray/milestone/17>`__ and report issues on GitHub.
+    The C++ Ray API is currently experimental with limited support and it's not supported on Windows. You can track its development `here <https://github.com/ray-project/ray/milestone/17>`__ and report issues on GitHub.
     Run the following commands to get started:
 
     Install ray with C++ API support and generate a bazel project with the ray command.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2171,6 +2171,9 @@ def install_nightly(verbose, dryrun):
 @add_click_logging_options
 def cpp(show_library_path, generate_bazel_project_template_to):
     """Show the cpp library path and generate the bazel project template."""
+    if sys.platform == "win32":
+        cli_logger.error("Ray C++ API is not supported on Windows currently.")
+        sys.exit(1)
     if not show_library_path and not generate_bazel_project_template_to:
         raise ValueError(
             "Please input at least one option of '--show-library-path'"


### PR DESCRIPTION
## Why are these changes needed?
We don't support Windows entirely now.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
