### PR TITLE
[runtime]read hdfs file in runtime

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -533,7 +533,8 @@ def download_and_unpack_package(
                         subprocess.check_call(["which", "hdfs"])
                     except ImportError:
                         raise ImportError(
-                            "You must have HDFS command to fetch files from HDFS.")
+                            "You must have HDFS command to fetch files from HDFS."
+                        )
                 else:
                     try:
                         from smart_open import open

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -344,6 +344,7 @@ def test_travel(tmp_path):
         ("s3://bucket/file.zip", Protocol.S3, "s3_bucket_file.zip"),
         ("https://test.com/file.zip", Protocol.HTTPS, "https_test_com_file.zip"),
         ("gs://bucket/file.zip", Protocol.GS, "gs_bucket_file.zip"),
+        ("hdfs://namenode/file.zip", Protocol.HDFS, "hdfs_namenode_file.zip"),
     ],
 )
 def test_parsing(parsing_tuple):
@@ -363,6 +364,7 @@ def test_is_whl_uri():
 def test_is_zip_uri():
     assert is_zip_uri("s3://my-package.zip")
     assert is_zip_uri("gcs://asdf.zip")
+    assert is_zip_uri("hdfs://asdf.zip")
     assert not is_zip_uri("invalid_format")
     assert not is_zip_uri("gcs://a.whl")
 


### PR DESCRIPTION
Change-Id: I4dcbbb7fdfe543ea1af67113b79d880cfa3fe411

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
we want to read hdfs files in runtime.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
