### PR TITLE
[GCS] [1 / n] Refactor gcs_resource_scheduler to cluster_resource_scheduler

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -82,7 +82,7 @@ class MockGcsScheduleStrategy : public GcsScheduleStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -99,7 +99,7 @@ class MockGcsPackStrategy : public GcsPackStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -116,7 +116,7 @@ class MockGcsSpreadStrategy : public GcsSpreadStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -133,7 +133,7 @@ class MockGcsStrictPackStrategy : public GcsStrictPackStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 
@@ -150,7 +150,7 @@ class MockGcsStrictSpreadStrategy : public GcsStrictSpreadStrategy {
       Schedule,
       (const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
        const std::unique_ptr<ScheduleContext> &context,
-       GcsResourceScheduler &gcs_resource_scheduler),
+       ClusterResourceScheduler &cluster_resource_scheduler),
       (override));
 };
 

--- a/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
@@ -36,7 +36,7 @@ GcsBasedActorScheduler::GcsBasedActorScheduler(
     instrumented_io_context &io_context,
     GcsActorTable &gcs_actor_table,
     const GcsNodeManager &gcs_node_manager,
-    std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler,
+    std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
     GcsActorSchedulerFailureCallback schedule_failure_handler,
     GcsActorSchedulerSuccessCallback schedule_success_handler,
     std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
@@ -50,7 +50,7 @@ GcsBasedActorScheduler::GcsBasedActorScheduler(
                         schedule_success_handler,
                         raylet_client_pool,
                         client_factory),
-      gcs_resource_scheduler_(std::move(gcs_resource_scheduler)),
+      cluster_resource_scheduler_(std::move(cluster_resource_scheduler)),
       normal_task_resources_changed_callback_(normal_task_resources_changed_callback) {}
 
 NodeID GcsBasedActorScheduler::SelectNode(std::shared_ptr<GcsActor> actor) {
@@ -105,7 +105,7 @@ GcsBasedActorScheduler::AllocateNewActorWorkerAssignment(
 scheduling::NodeID GcsBasedActorScheduler::AllocateResources(
     const ResourceRequest &required_resources) {
   auto selected_nodes =
-      gcs_resource_scheduler_->Schedule({required_resources}, SchedulingType::SPREAD)
+      cluster_resource_scheduler_->Schedule({required_resources}, SchedulingType::SPREAD)
           .second;
 
   if (selected_nodes.size() == 0) {
@@ -118,7 +118,8 @@ scheduling::NodeID GcsBasedActorScheduler::AllocateResources(
 
   auto selected_node_id = selected_nodes[0];
   if (!selected_node_id.IsNil()) {
-    auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+    auto &cluster_resource_manager =
+        cluster_resource_scheduler_->GetClusterResourceManager();
     // Acquire the resources from the selected node.
     RAY_CHECK(cluster_resource_manager.SubtractNodeAvailableResources(
         selected_node_id, required_resources));
@@ -129,7 +130,8 @@ scheduling::NodeID GcsBasedActorScheduler::AllocateResources(
 
 scheduling::NodeID GcsBasedActorScheduler::GetHighestScoreNodeResource(
     const ResourceRequest &required_resources) const {
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_->GetClusterResourceManager();
   const auto &resource_view = cluster_resource_manager.GetResourceView();
 
   /// Get the highest score node
@@ -151,7 +153,8 @@ scheduling::NodeID GcsBasedActorScheduler::GetHighestScoreNodeResource(
 
 void GcsBasedActorScheduler::WarnResourceAllocationFailure(
     const TaskSpecification &task_spec, const ResourceRequest &required_resources) const {
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_->GetClusterResourceManager();
   auto scheduling_node_id = GetHighestScoreNodeResource(required_resources);
   const NodeResources *node_resources = nullptr;
   if (!scheduling_node_id.IsNil()) {
@@ -237,7 +240,8 @@ void GcsBasedActorScheduler::HandleWorkerLeaseRejectedReply(
     std::shared_ptr<GcsActor> actor, const rpc::RequestWorkerLeaseReply &reply) {
   // The request was rejected because of insufficient resources.
   auto node_id = actor->GetNodeID();
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_->GetClusterResourceManager();
   if (normal_task_resources_changed_callback_) {
     normal_task_resources_changed_callback_(node_id, reply.resources_data());
   }
@@ -261,7 +265,8 @@ void GcsBasedActorScheduler::NotifyClusterResourcesChanged() {
 }
 
 void GcsBasedActorScheduler::ResetActorWorkerAssignment(GcsActor *actor) {
-  auto &cluster_resource_manager = gcs_resource_scheduler_->GetClusterResourceManager();
+  auto &cluster_resource_manager =
+      cluster_resource_scheduler_->GetClusterResourceManager();
   if (cluster_resource_manager.AddNodeAvailableResources(
           scheduling::NodeID(actor->GetActorWorkerAssignment()->GetNodeID().Binary()),
           actor->GetActorWorkerAssignment()->GetResources())) {

--- a/src/ray/gcs/gcs_server/gcs_actor_distribution.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_distribution.h
@@ -31,6 +31,8 @@
 namespace ray {
 namespace gcs {
 
+using ClusterResourceScheduler = gcs::GcsResourceScheduler;
+
 /// `GcsActorWorkerAssignment` represents the assignment from one or multiple actors to a
 /// worker process.
 /// TODO(Chong-Li): It contains multiple slots, and each of them can bind to an actor.
@@ -71,7 +73,7 @@ class GcsBasedActorScheduler : public GcsActorScheduler {
   /// \param io_context The main event loop.
   /// \param gcs_actor_table Used to flush actor info to storage.
   /// \param gcs_node_manager The node manager which is used when scheduling.
-  /// \param gcs_resource_scheduler The scheduler to select nodes based on cluster
+  /// \param cluster_resource_scheduler The scheduler to select nodes based on cluster
   /// resources.
   /// \param schedule_failure_handler Invoked when there are no available nodes to
   /// schedule actors.
@@ -84,7 +86,7 @@ class GcsBasedActorScheduler : public GcsActorScheduler {
       instrumented_io_context &io_context,
       GcsActorTable &gcs_actor_table,
       const GcsNodeManager &gcs_node_manager,
-      std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler,
+      std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
       GcsActorSchedulerFailureCallback schedule_failure_handler,
       GcsActorSchedulerSuccessCallback schedule_success_handler,
       std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
@@ -164,7 +166,7 @@ class GcsBasedActorScheduler : public GcsActorScheduler {
   std::vector<std::function<void()>> resource_changed_listeners_;
 
   /// Gcs resource scheduler
-  std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler_;
+  std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
 
   /// Normal task resources changed callback.
   std::function<void(const NodeID &, const rpc::ResourcesData &)>

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -34,6 +34,8 @@ namespace gcs {
 
 class GcsPlacementGroup;
 
+using ClusterResourceScheduler = gcs::GcsResourceScheduler;
+
 using ReserveResourceClientFactoryFn =
     std::function<std::shared_ptr<ResourceReserveInterface>(const rpc::Address &address)>;
 
@@ -125,7 +127,7 @@ class GcsScheduleStrategy {
   virtual ScheduleResult Schedule(
       const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
       const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) = 0;
+      ClusterResourceScheduler &cluster_resource_scheduler) = 0;
 
  protected:
   /// Get required resources from bundles.
@@ -155,7 +157,7 @@ class GcsPackStrategy : public GcsScheduleStrategy {
   ScheduleResult Schedule(
       const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
       const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
+      ClusterResourceScheduler &cluster_resource_scheduler) override;
 };
 
 /// The `GcsSpreadStrategy` is that spread all bundles in different nodes.
@@ -164,7 +166,7 @@ class GcsSpreadStrategy : public GcsScheduleStrategy {
   ScheduleResult Schedule(
       const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
       const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
+      ClusterResourceScheduler &cluster_resource_scheduler) override;
 };
 
 /// The `GcsStrictPackStrategy` is that all bundles must be scheduled to one node. If one
@@ -174,7 +176,7 @@ class GcsStrictPackStrategy : public GcsScheduleStrategy {
   ScheduleResult Schedule(
       const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
       const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
+      ClusterResourceScheduler &cluster_resource_scheduler) override;
 };
 
 /// The `GcsStrictSpreadStrategy` is that spread all bundles in different nodes.
@@ -185,7 +187,7 @@ class GcsStrictSpreadStrategy : public GcsScheduleStrategy {
   ScheduleResult Schedule(
       const std::vector<std::shared_ptr<const ray::BundleSpecification>> &bundles,
       const std::unique_ptr<ScheduleContext> &context,
-      GcsResourceScheduler &gcs_resource_scheduler) override;
+      ClusterResourceScheduler &cluster_resource_scheduler) override;
 };
 
 enum class LeasingState {
@@ -417,14 +419,14 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param placement_group_info_accessor Used to flush placement_group info to storage.
   /// \param gcs_node_manager The node manager which is used when scheduling.
   /// \param gcs_resource_manager The resource manager which is used when scheduling.
-  /// \param gcs_resource_scheduler The resource scheduler which is used when scheduling.
-  /// \param lease_client_factory Factory to create remote lease client.
+  /// \param cluster_resource_scheduler The resource scheduler which is used when
+  /// scheduling. \param lease_client_factory Factory to create remote lease client.
   GcsPlacementGroupScheduler(
       instrumented_io_context &io_context,
       std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
       const GcsNodeManager &gcs_node_manager,
       GcsResourceManager &gcs_resource_manager,
-      GcsResourceScheduler &gcs_resource_scheduler,
+      ClusterResourceScheduler &cluster_resource_scheduler,
       std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
       syncer::RaySyncer &ray_syncer);
 
@@ -581,8 +583,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// Reference of GcsResourceManager.
   GcsResourceManager &gcs_resource_manager_;
 
-  /// Reference of GcsResourceScheduler.
-  GcsResourceScheduler &gcs_resource_scheduler_;
+  /// Reference of ClusterResourceScheduler.
+  ClusterResourceScheduler &cluster_resource_scheduler_;
 
   /// A vector to store all the schedule strategy.
   std::vector<std::shared_ptr<GcsScheduleStrategy>> scheduler_strategies_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -125,8 +125,8 @@ void GcsServer::Start() {
 }
 
 void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
-  // Init gcs resource scheduler.
-  InitGcsResourceScheduler();
+  // Init cluster resource scheduler.
+  InitClusterResourceScheduler();
 
   // Init gcs resource manager.
   InitGcsResourceManager(gcs_init_data);
@@ -255,9 +255,9 @@ void GcsServer::InitGcsHeartbeatManager(const GcsInitData &gcs_init_data) {
 }
 
 void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
-  RAY_CHECK(gcs_table_storage_ && gcs_resource_scheduler_);
+  RAY_CHECK(gcs_table_storage_ && cluster_resource_scheduler_);
   gcs_resource_manager_ = std::make_shared<GcsResourceManager>(
-      gcs_table_storage_, gcs_resource_scheduler_->GetClusterResourceManager());
+      gcs_table_storage_, cluster_resource_scheduler_->GetClusterResourceManager());
 
   // Initialize by gcs tables data.
   gcs_resource_manager_->Initialize(gcs_init_data);
@@ -267,8 +267,8 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
   rpc_server_.RegisterService(*node_resource_info_service_);
 }
 
-void GcsServer::InitGcsResourceScheduler() {
-  gcs_resource_scheduler_ = std::make_shared<GcsResourceScheduler>();
+void GcsServer::InitClusterResourceScheduler() {
+  cluster_resource_scheduler_ = std::make_shared<ClusterResourceScheduler>();
 }
 
 void GcsServer::InitGcsJobManager(const GcsInitData &gcs_init_data) {
@@ -306,12 +306,12 @@ void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
   };
 
   if (RayConfig::instance().gcs_actor_scheduling_enabled()) {
-    RAY_CHECK(gcs_resource_manager_ && gcs_resource_scheduler_);
+    RAY_CHECK(gcs_resource_manager_ && cluster_resource_scheduler_);
     scheduler = std::make_unique<GcsBasedActorScheduler>(
         main_service_,
         gcs_table_storage_->ActorTable(),
         *gcs_node_manager_,
-        gcs_resource_scheduler_,
+        cluster_resource_scheduler_,
         schedule_failure_handler,
         schedule_success_handler,
         raylet_client_pool_,
@@ -370,13 +370,14 @@ void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
 
 void GcsServer::InitGcsPlacementGroupManager(const GcsInitData &gcs_init_data) {
   RAY_CHECK(gcs_table_storage_ && gcs_node_manager_);
-  auto scheduler = std::make_shared<GcsPlacementGroupScheduler>(main_service_,
-                                                                gcs_table_storage_,
-                                                                *gcs_node_manager_,
-                                                                *gcs_resource_manager_,
-                                                                *gcs_resource_scheduler_,
-                                                                raylet_client_pool_,
-                                                                *ray_syncer_);
+  auto scheduler =
+      std::make_shared<GcsPlacementGroupScheduler>(main_service_,
+                                                   gcs_table_storage_,
+                                                   *gcs_node_manager_,
+                                                   *gcs_resource_manager_,
+                                                   *cluster_resource_scheduler_,
+                                                   raylet_client_pool_,
+                                                   *ray_syncer_);
 
   gcs_placement_group_manager_ = std::make_shared<GcsPlacementGroupManager>(
       main_service_,

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -35,6 +35,8 @@
 namespace ray {
 namespace gcs {
 
+using ClusterResourceScheduler = gcs::GcsResourceScheduler;
+
 struct GcsServerConfig {
   std::string grpc_server_name = "GcsServer";
   uint16_t grpc_server_port = 0;
@@ -102,8 +104,8 @@ class GcsServer {
   /// Initialize synchronization service
   void InitRaySyncer(const GcsInitData &gcs_init_data);
 
-  /// Initialize gcs resource scheduler.
-  void InitGcsResourceScheduler();
+  /// Initialize cluster resource scheduler.
+  void InitClusterResourceScheduler();
 
   /// Initialize gcs job manager.
   void InitGcsJobManager(const GcsInitData &gcs_init_data);
@@ -180,8 +182,8 @@ class GcsServer {
   std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool_;
   /// The gcs resource manager.
   std::shared_ptr<GcsResourceManager> gcs_resource_manager_;
-  /// The gcs resource scheduler.
-  std::shared_ptr<GcsResourceScheduler> gcs_resource_scheduler_;
+  /// The cluster resource scheduler.
+  std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   /// The gcs node manager.
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
   /// The heartbeat manager.

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -28,6 +28,8 @@ enum class GcsPlacementGroupStatus : int32_t {
 };
 
 class GcsPlacementGroupSchedulerTest : public ::testing::Test {
+  using ClusterResourceScheduler = gcs::GcsResourceScheduler;
+
  public:
   void SetUp() override {
     thread_io_service_.reset(new std::thread([this] {
@@ -41,9 +43,9 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     gcs_table_storage_ = std::make_shared<gcs::InMemoryGcsTableStorage>(io_service_);
     gcs_publisher_ = std::make_shared<gcs::GcsPublisher>(
         std::make_unique<GcsServerMocker::MockGcsPubSub>(redis_client_));
-    gcs_resource_scheduler_ = std::make_shared<gcs::GcsResourceScheduler>();
+    cluster_resource_scheduler_ = std::make_shared<ClusterResourceScheduler>();
     gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(
-        gcs_table_storage_, gcs_resource_scheduler_->GetClusterResourceManager());
+        gcs_table_storage_, cluster_resource_scheduler_->GetClusterResourceManager());
     ray_syncer_ = std::make_shared<ray::syncer::RaySyncer>(
         io_service_, nullptr, *gcs_resource_manager_);
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
@@ -56,7 +58,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
         gcs_table_storage_,
         *gcs_node_manager_,
         *gcs_resource_manager_,
-        *gcs_resource_scheduler_,
+        *cluster_resource_scheduler_,
         raylet_client_pool_,
         *ray_syncer_);
   }
@@ -262,7 +264,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
 
   std::vector<std::shared_ptr<GcsServerMocker::MockRayletClient>> raylet_clients_;
   std::shared_ptr<gcs::GcsResourceManager> gcs_resource_manager_;
-  std::shared_ptr<gcs::GcsResourceScheduler> gcs_resource_scheduler_;
+  std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::shared_ptr<GcsServerMocker::MockedGcsPlacementGroupScheduler> scheduler_;
   std::vector<std::shared_ptr<gcs::GcsPlacementGroup>> success_placement_groups_
@@ -1145,7 +1147,6 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestInitialize) {
   ASSERT_EQ(1, bundles[placement_group->GetPlacementGroupID()].size());
   ASSERT_EQ(1, bundles[placement_group->GetPlacementGroupID()][0]);
 }
-
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As we (@scv119 @iycheng @raulchen @Chong-Li @WangTaoTheTonic ) discussed offline,  the `GcsResourceScheduler` on the GCS side should be unified to `ClusterResourceScheduler`.

There is already a big PR( #23268 ) to do this, but in order to make review easy, I will split it to two or mall small PRs.
This is [1/n]:
   - Rename `GcsResourceScheduler/gcs_resource_scheduler` to `ClusterResourceScheduler/cluster_resource_scheduler` 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
