### PR TITLE
[ml/air] Checkpoints serialization/deserialization support

### DIFF
--- a/python/ray/ml/checkpoint.py
+++ b/python/ray/ml/checkpoint.py
@@ -445,7 +445,7 @@ def _get_external_path(path: Optional[str]) -> Optional[str]:
 
 def _temporary_checkpoint_dir() -> str:
     """Create temporary checkpoint dir."""
-    return tempfile.mkdtemp(prefix="checkpoint_tmp_", dir=os.getcwd())
+    return tempfile.mkdtemp(prefix="checkpoint_tmp_")  # , dir=os.getcwd())
 
 
 def _pack(path: str) -> bytes:

--- a/python/ray/ml/checkpoint.py
+++ b/python/ray/ml/checkpoint.py
@@ -445,7 +445,7 @@ def _get_external_path(path: Optional[str]) -> Optional[str]:
 
 def _temporary_checkpoint_dir() -> str:
     """Create temporary checkpoint dir."""
-    return tempfile.mkdtemp(prefix="checkpoint_tmp_")  # , dir=os.getcwd())
+    return tempfile.mkdtemp(prefix="checkpoint_tmp_")
 
 
 def _pack(path: str) -> bytes:

--- a/python/ray/ml/checkpoint.py
+++ b/python/ray/ml/checkpoint.py
@@ -400,6 +400,15 @@ class Checkpoint:
                 "Cannot get internal representation of empty checkpoint."
             )
 
+    def __getstate__(self):
+        if self._local_path:
+            blob = self.to_bytes()
+            return Checkpoint.from_bytes(blob).__getstate__()
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
 
 def _get_local_path(path: Optional[str]) -> Optional[str]:
     """Check if path is a local path. Otherwise return None."""

--- a/python/ray/ml/checkpoint.py
+++ b/python/ray/ml/checkpoint.py
@@ -99,6 +99,21 @@ class Checkpoint:
             # It is guaranteed that the original data was recovered
             assert isinstance(clf, RandomForestClassifier)
 
+        Checkpoints can be pickled and sent to remote processes.
+        Please note that checkpoints pointing to local directories will be
+        pickled as data representations, so the full checkpoint data will be
+        contained in the checkpoint object. If you want to avoid this,
+        consider passing only the checkpoint directory to the remote task
+        and re-construct your checkpoint object in that function. Note that
+        this will only work if the "remote" task is scheduled on the
+        same node or a node that also has access to the local data path (e.g.
+        on a shared file system like NFS).
+
+        Checkpoints pointing to object store references will keep the
+        object reference in tact - this means that these checkpoints cannot
+        be properly deserialized on other Ray clusters or outside a Ray
+        cluster. If you need persistence across clusters, use the ``to_uri()``
+        or ``to_directory()`` methods to persist your checkpoints to disk.
 
     """
 

--- a/python/ray/ml/tests/test_checkpoints.py
+++ b/python/ray/ml/tests/test_checkpoints.py
@@ -162,12 +162,6 @@ class CheckpointsConversionTest(unittest.TestCase):
 
         self.assertDictEqual(local_data, self.checkpoint_dir_data)
 
-        # Checkpoint should lie within current directory
-        self.assertTrue(
-            local_dir.startswith(self.tmpdir),
-            msg=f"Checkpoint dir {local_dir} is not contained in {self.tmpdir}",
-        )
-
     def test_fs_checkpoint_bytes(self):
         """Test conversion from fs to bytes checkpoint and back."""
         checkpoint = self._prepare_fs_checkpoint()
@@ -248,10 +242,6 @@ class CheckpointsSerdeTest(unittest.TestCase):
         if not ray.is_initialized():
             ray.init()
 
-    def tearDown(self) -> None:
-        if ray.is_initialized():
-            ray.shutdown()
-
     def _testCheckpointSerde(
         self, checkpoint: Checkpoint, expected_type: str, expected_data: Any
     ):
@@ -281,7 +271,7 @@ class CheckpointsSerdeTest(unittest.TestCase):
 
         self._testCheckpointSerde(checkpoint, *checkpoint.get_internal_representation())
 
-    def testLocalCheckpointServe(self):
+    def testLocalCheckpointSerde(self):
         # Local checkpoints are converted to bytes on serialization. Currently
         # this is a pickled dict, so we compare with a dict checkpoint.
         source_checkpoint = Checkpoint.from_dict({"checkpoint_data": 5})

--- a/python/ray/ml/tests/test_checkpoints.py
+++ b/python/ray/ml/tests/test_checkpoints.py
@@ -3,8 +3,10 @@ import pickle
 import shutil
 import tempfile
 import unittest
+from typing import Any
 from unittest.mock import patch
 
+import ray
 from ray.ml.checkpoint import Checkpoint
 
 
@@ -29,7 +31,7 @@ def mock_s3_sync(local_path):
     return mocked
 
 
-class CheckpointsTest(unittest.TestCase):
+class CheckpointsConversionTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = os.path.realpath(tempfile.mkdtemp())
 
@@ -110,8 +112,6 @@ class CheckpointsTest(unittest.TestCase):
 
     def test_dict_checkpoint_obj_store(self):
         """Test conversion from fs to obj store checkpoint and back."""
-        import ray
-
         if not ray.is_initialized():
             ray.init()
 
@@ -212,8 +212,6 @@ class CheckpointsTest(unittest.TestCase):
 
     def test_fs_checkpoint_obj_store(self):
         """Test conversion from fs to obj store checkpoint and back."""
-        import ray
-
         if not ray.is_initialized():
             ray.init()
 
@@ -243,6 +241,78 @@ class CheckpointsTest(unittest.TestCase):
             self.assertTrue(checkpoint._uri)
 
             self._assert_fs_checkpoint(checkpoint)
+
+
+class CheckpointsSerdeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        if not ray.is_initialized():
+            ray.init()
+
+    def tearDown(self) -> None:
+        if ray.is_initialized():
+            ray.shutdown()
+
+    def _testCheckpointSerde(
+        self, checkpoint: Checkpoint, expected_type: str, expected_data: Any
+    ):
+        @ray.remote
+        def assert_checkpoint_content(cp: Checkpoint):
+            type_, data = cp.get_internal_representation()
+            assert type_ == expected_type
+            assert data == expected_data
+
+            return True
+
+        self.assertTrue(ray.get(assert_checkpoint_content.remote(checkpoint)))
+
+    def testUriCheckpointSerde(self):
+        # URI checkpoints keep the same internal representation, pointing to
+        # a remote location
+
+        checkpoint = Checkpoint.from_uri("s3://some/bucket")
+
+        self._testCheckpointSerde(checkpoint, *checkpoint.get_internal_representation())
+
+    def testDataCheckpointSerde(self):
+        # Data checkpoints keep the same internal representation, including
+        # their data.
+
+        checkpoint = Checkpoint.from_dict({"checkpoint_data": 5})
+
+        self._testCheckpointSerde(checkpoint, *checkpoint.get_internal_representation())
+
+    def testLocalCheckpointServe(self):
+        # Local checkpoints are converted to bytes on serialization. Currently
+        # this is a pickled dict, so we compare with a dict checkpoint.
+        source_checkpoint = Checkpoint.from_dict({"checkpoint_data": 5})
+        tmpdir = source_checkpoint.to_directory()
+        self.addCleanup(shutil.rmtree, tmpdir)
+
+        checkpoint = Checkpoint.from_directory(tmpdir)
+        self._testCheckpointSerde(
+            checkpoint, *source_checkpoint.get_internal_representation()
+        )
+
+    def testBytesCheckpointSerde(self):
+        # Bytes checkpoints are just dict checkpoints constructed
+        # from pickled data, so we compare with the source dict checkpoint.
+        source_checkpoint = Checkpoint.from_dict({"checkpoint_data": 5})
+        blob = source_checkpoint.to_bytes()
+        checkpoint = Checkpoint.from_bytes(blob)
+
+        self._testCheckpointSerde(
+            checkpoint, *source_checkpoint.get_internal_representation()
+        )
+
+    def testObjRefCheckpointSerde(self):
+        # Obj ref checkpoints are dict checkpoints put into the Ray object
+        # store, but they have their own data representation (the obj ref).
+        # We thus compare with the actual obj ref checkpoint.
+        source_checkpoint = Checkpoint.from_dict({"checkpoint_data": 5})
+        obj_ref = source_checkpoint.to_object_ref()
+        checkpoint = Checkpoint.from_object_ref(obj_ref)
+
+        self._testCheckpointSerde(checkpoint, *checkpoint.get_internal_representation())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds support for checkpoint ser/de. In particular this is special casing the local data representation, which will be converted into a bytes checkpoint on serialization. This way checkpoint objects sent to remote tasks are guaranteed to always point to a valid data location within the remote task.
We are not detecting pickling to/from disk (e.g. to pickle files) for now.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
