### PR TITLE
[CI] Fix usage stats env vars for CI

### DIFF
--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -40,8 +40,6 @@ class ClusterManager(abc.ABC):
         self.cluster_env.setdefault("env_vars", {})
         self.cluster_env["env_vars"]["MATCH_AUTOSCALER_AND_RAY_IMAGES"] = "1"
         self.cluster_env["env_vars"]["RAY_gcs_storage"] = "memory"
-        self.cluster_env["env_vars"]["RAY_USAGE_STATS_ENABLED"] = "1"
-        self.cluster_env["env_vars"]["RAY_USAGE_STATS_SOURCE"] = "nightly-tests"
 
         self.cluster_env_name = (
             f"{self.project_name}_{self.project_id[4:8]}"

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -212,7 +212,10 @@ def run_release_test(
                 raise PrepareCommandTimeout(e)
 
         command = test["run"]["script"]
-        command_env = {}
+        command_env = {
+            "RAY_USAGE_STATS_ENABLED": "1",
+            "RAY_USAGE_STATS_SOURCE": "nightly-tests",
+        }
 
         if smoke_test:
             command = f"{command} --smoke-test"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The previous way of setting the usage stats env vars has the lowest priority and will be overwritten by the same env vars set by the product. This PR fixes that and makes sure the env vars set here has the highest priority.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
