### PR TITLE
[Ray DAG][Serve Pipeline] better error messages on .bind and .remote with tests

### DIFF
--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -133,6 +133,15 @@ class _UnboundClassMethodNode(object):
         self._actor._last_call = node
         return node
 
+    def remote(self, *args, **kwargs):
+        raise AttributeError(
+            "All DAGNode types act as intermediate representation (IR) of a "
+            "DAG that can only be produced by .bind() on supported class or "
+            "function, and executed via dag.execute(input). Please do not call "
+            ".remote() on a UnboundClassMethodNode object and use .bind() "
+            "instead."
+        )
+
     def options(self, **options):
         self._options = options
         return self

--- a/python/ray/experimental/dag/class_node.py
+++ b/python/ray/experimental/dag/class_node.py
@@ -133,14 +133,14 @@ class _UnboundClassMethodNode(object):
         self._actor._last_call = node
         return node
 
-    def remote(self, *args, **kwargs):
-        raise AttributeError(
-            "All DAGNode types act as intermediate representation (IR) of a "
-            "DAG that can only be produced by .bind() on supported class or "
-            "function, and executed via dag.execute(input). Please do not call "
-            ".remote() on a UnboundClassMethodNode object and use .bind() "
-            "instead."
-        )
+    def __getattr__(self, attr: str):
+        if attr == "remote":
+            raise AttributeError(
+                ".remote() cannot be used on ClassMethodNodes. Use .bind() instead "
+                "to express an symbolic actor call."
+            )
+        else:
+            return self.__getattribute__(attr)
 
     def options(self, **options):
         self._options = options

--- a/python/ray/experimental/dag/dag_node.py
+++ b/python/ray/experimental/dag/dag_node.py
@@ -278,6 +278,22 @@ class DAGNode:
         """
         raise ValueError(f"DAGNode cannot be serialized. DAGNode: {str(self)}")
 
+    def bind(self, *args, **kwargs):
+        raise AttributeError(
+            "All DAGNode types act as intermediate representation (IR) of a "
+            "DAG that can only be produced by .bind() on supported class or "
+            "function, and executed via dag.execute(input). Please do not call "
+            f".bind() on a DAGNode IR object of type: {type(self)}"
+        )
+
+    def remote(self, *args, **kwargs):
+        raise AttributeError(
+            "All DAGNode types act as intermediate representation (IR) of a "
+            "DAG that can only be produced by .bind() on supported class or "
+            "function, and executed via dag.execute(input). Please do not call "
+            f".remote() on a DAGNode IR object of type: {type(self)}"
+        )
+
     def to_json_base(
         self, encoder_cls: json.JSONEncoder, dag_node_type: str
     ) -> Dict[str, Any]:

--- a/python/ray/experimental/dag/dag_node.py
+++ b/python/ray/experimental/dag/dag_node.py
@@ -286,7 +286,7 @@ class DAGNode:
             )
         elif attr == "remote":
             raise AttributeError(
-                ".remote() cannot be used on {type(self)}. To execute the task "
+                f".remote() cannot be used on {type(self)}. To execute the task "
                 "graph for this node, use .execute()."
             )
         else:

--- a/python/ray/experimental/dag/dag_node.py
+++ b/python/ray/experimental/dag/dag_node.py
@@ -278,21 +278,19 @@ class DAGNode:
         """
         raise ValueError(f"DAGNode cannot be serialized. DAGNode: {str(self)}")
 
-    def bind(self, *args, **kwargs):
-        raise AttributeError(
-            "All DAGNode types act as intermediate representation (IR) of a "
-            "DAG that can only be produced by .bind() on supported class or "
-            "function, and executed via dag.execute(input). Please do not call "
-            f".bind() on a DAGNode IR object of type: {type(self)}"
-        )
-
-    def remote(self, *args, **kwargs):
-        raise AttributeError(
-            "All DAGNode types act as intermediate representation (IR) of a "
-            "DAG that can only be produced by .bind() on supported class or "
-            "function, and executed via dag.execute(input). Please do not call "
-            f".remote() on a DAGNode IR object of type: {type(self)}"
-        )
+    def __getattr__(self, attr: str):
+        if attr == "bind":
+            raise AttributeError(
+                f".bind() cannot be used again on {type(self)} "
+                f"(args: {self.get_args()}, kwargs: {self.get_kwargs()})."
+            )
+        elif attr == "remote":
+            raise AttributeError(
+                ".remote() cannot be used on {type(self)}. To execute the task "
+                "graph for this node, use .execute()."
+            )
+        else:
+            return self.__getattribute__(attr)
 
     def to_json_base(
         self, encoder_cls: json.JSONEncoder, dag_node_type: str

--- a/python/ray/experimental/dag/tests/test_class_dag.py
+++ b/python/ray/experimental/dag/tests/test_class_dag.py
@@ -240,6 +240,46 @@ def test_dynamic_pipeline(shared_ray_instance):
     assert ray.get(odd_input.execute()) == "Odd: 21"
 
 
+def test_unsupported_bind():
+    @ray.remote
+    class Actor:
+        def ping(self):
+            return "hello"
+
+    with pytest.raises(
+        AttributeError, match=r"Please do not call \.bind\(\) on a DAGNode IR object"
+    ):
+        _ = Actor.bind().bind()
+
+    with pytest.raises(
+        AttributeError,
+        match=r"Please do not call \.remote\(\) on a UnboundClassMethodNode",
+    ):
+        actor = Actor.bind()
+        _ = actor.ping.remote()
+
+
+def test_unsupported_remote():
+    @ray.remote
+    class Actor:
+        def ping(self):
+            return "hello"
+
+    with pytest.raises(
+        AttributeError, match=r"Please do not call \.remote\(\) on a DAGNode IR object"
+    ):
+        _ = Actor.bind().remote()
+
+    @ray.remote
+    def func():
+        return 1
+
+    with pytest.raises(
+        AttributeError, match=r"Please do not call \.remote\(\) on a DAGNode IR object"
+    ):
+        _ = func.bind().remote()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/experimental/dag/tests/test_class_dag.py
+++ b/python/ray/experimental/dag/tests/test_class_dag.py
@@ -247,13 +247,15 @@ def test_unsupported_bind():
             return "hello"
 
     with pytest.raises(
-        AttributeError, match=r"Please do not call \.bind\(\) on a DAGNode IR object"
+        AttributeError,
+        match="'Actor' has no attribute 'bind'",
     ):
-        _ = Actor.bind().bind()
+        actor = Actor.bind()
+        _ = actor.bind()
 
     with pytest.raises(
         AttributeError,
-        match=r"Please do not call \.remote\(\) on a UnboundClassMethodNode",
+        match=r"\.remote\(\) cannot be used on ClassMethodNodes",
     ):
         actor = Actor.bind()
         _ = actor.ping.remote()
@@ -265,18 +267,14 @@ def test_unsupported_remote():
         def ping(self):
             return "hello"
 
-    with pytest.raises(
-        AttributeError, match=r"Please do not call \.remote\(\) on a DAGNode IR object"
-    ):
+    with pytest.raises(AttributeError, match="'Actor' has no attribute 'remote'"):
         _ = Actor.bind().remote()
 
     @ray.remote
     def func():
         return 1
 
-    with pytest.raises(
-        AttributeError, match=r"Please do not call \.remote\(\) on a DAGNode IR object"
-    ):
+    with pytest.raises(AttributeError, match=r"\.remote\(\) cannot be used on"):
         _ = func.bind().remote()
 
 

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -367,15 +367,13 @@ def test_unsupported_bind():
         def ping(self):
             return "hello"
 
-    with pytest.raises(
-        AttributeError, match=r"Please do not call \.bind\(\) on a DAGNode IR object"
-    ):
+    with pytest.raises(AttributeError, match=r"\.bind\(\) cannot be used again on"):
         # Special for serve: Actor.bind().bind() returns DeploymentMethodNode
         _ = Actor.bind().bind().bind()
 
     with pytest.raises(
         AttributeError,
-        match=r"Please do not call \.remote\(\) on a UnboundClassMethodNode",
+        match=r"\.remote\(\) cannot be used on ClassMethodNodes",
     ):
         actor = Actor.bind()
         _ = actor.ping.remote()
@@ -387,18 +385,14 @@ def test_unsupported_remote():
         def ping(self):
             return "hello"
 
-    with pytest.raises(
-        AttributeError, match=r"Please do not call \.remote\(\) on a DAGNode IR object"
-    ):
+    with pytest.raises(AttributeError, match="'Actor' has no attribute 'remote'"):
         _ = Actor.bind().remote()
 
     @serve.deployment
     def func():
         return 1
 
-    with pytest.raises(
-        AttributeError, match=r"Please do not call \.remote\(\) on a DAGNode IR object"
-    ):
+    with pytest.raises(AttributeError, match="\.remote\(\) cannot be used on"):
         _ = func.bind().remote()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It's very easy for user to try .bind() or .remote() in unexpected way, thus adding actionable error messages.

## Related issue number

closes #23033

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
