### PR TITLE
[runtime env] Fix release tests by using `pip-install-test` instead of `requests`

### DIFF
--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -208,19 +208,19 @@ class TestValidatePip:
 
         result = parse_and_validate_pip(str(requirements_file))
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"]
+        assert result["pip_check"] == False
         assert "pip_version" not in result
 
     def test_validate_pip_valid_list(self):
         result = parse_and_validate_pip(PIP_LIST)
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"]
+        assert result["pip_check"] == False
         assert "pip_version" not in result
 
     def test_validate_ray(self):
         result = parse_and_validate_pip(["pkg1", "ray", "pkg2"])
         assert result["packages"] == ["pkg1", "ray", "pkg2"]
-        assert result["pip_check"]
+        assert result["pip_check"] == False
         assert "pip_version" not in result
 
 

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -208,19 +208,19 @@ class TestValidatePip:
 
         result = parse_and_validate_pip(str(requirements_file))
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"] == False
+        assert result["pip_check"]
         assert "pip_version" not in result
 
     def test_validate_pip_valid_list(self):
         result = parse_and_validate_pip(PIP_LIST)
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"] == False
+        assert result["pip_check"]
         assert "pip_version" not in result
 
     def test_validate_ray(self):
         result = parse_and_validate_pip(["pkg1", "ray", "pkg2"])
         assert result["packages"] == ["pkg1", "ray", "pkg2"]
-        assert result["pip_check"] == False
+        assert result["pip_check"]
         assert "pip_version" not in result
 
 

--- a/release/runtime_env_tests/workloads/rte_many_tasks_actors.py
+++ b/release/runtime_env_tests/workloads/rte_many_tasks_actors.py
@@ -37,12 +37,12 @@ def _assert_version_matches(expected_version):
 
 
 if __name__ == "__main__":
-    ray.init(address="auto", runtime_env={"pip": ["pip-install-test==0.2"]})
+    ray.init(address="auto", runtime_env={"pip": ["pip-install-test==0.3"]})
     versions = ["0.5", "0.4", "0.3"]
     envs = [
         {"pip": [f"pip-install-test=={versions[i]}"]} for i in range(len(versions) - 1)
     ]
-    # If a task's env is {}, we should have pip-install-test==0.2 from the job's env
+    # If a task's env is {}, we should have pip-install-test==0.3 from the job's env
     envs.append({})
 
     NUM_TASK_ITERATIONS = 10


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes a dependency conflict that was causing release tests to fail.  They were using old hardcoded versions of the `requests` package.  This PR uses `pip-install-test`, which has no dependencies and isn't a dependency of anything on the test cluster.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #23291 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
