### PR TITLE
[runtime env] Change `pip_check` default from `True` to `False`

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -316,7 +316,7 @@ The ``runtime_env`` is a Python dictionary or a python class :class:`ray.runtime
 
 - ``pip`` (dict | List[str] | str): Either (1) a list of pip `requirements specifiers <https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers>`_, (2) a string containing the path to a pip
   `“requirements.txt” <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ file, or (3) a python dictionary that has three fields: (a) ``packages`` (required, List[str]): a list of pip packages,
-  (b) ``pip_check`` (optional, bool): whether to enable `pip check <https://pip.pypa.io/en/stable/cli/pip_check/>`_ at the end of pip install, defaults to ``True``.
+  (b) ``pip_check`` (optional, bool): whether to enable `pip check <https://pip.pypa.io/en/stable/cli/pip_check/>`_ at the end of pip install, defaults to ``False``.
   (c) ``pip_version`` (optional, str): the version of pip; Ray will spell the package name "pip" in front of the ``pip_version`` to form the final requirement string.
   The syntax of a requirement specifier is defined in full in `PEP 508 <https://www.python.org/dev/peps/pep-0508/>`_.
   This will be installed in the Ray workers at runtime.  Packages in the preinstalled cluster environment will still be available.

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -333,7 +333,7 @@ class PipProcessor:
                 # Check python environment for conflicts.
                 await self._pip_check(
                     path,
-                    self._pip_config.get("pip_check", True),
+                    self._pip_config.get("pip_check", False),
                     exec_cwd,
                     self._pip_env,
                     logger,

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -111,8 +111,8 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
            file contents will be read split into a list.
         3) A python dictionary that has three fields:
             a) packages (required, List[str]): a list of pip packages, it same as 1).
-            b) pip_check (optional, bool): whether enable pip check at the end of pip
-               install, default True.
+            b) pip_check (optional, bool): whether to enable pip check at the end of pip
+               install, default to False.
             c) pip_version (optional, str): the version of pip, ray will spell
                the package name 'pip' in front of the `pip_version` to form the final
                requirement string, the syntax of a requirement specifier is defined in
@@ -140,9 +140,9 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
     elif isinstance(pip, str):
         # We have been given a path to a requirements.txt file.
         pip_list = _handle_local_pip_requirement_file(pip)
-        result = dict(packages=pip_list, pip_check=True)
+        result = dict(packages=pip_list, pip_check=False)
     elif isinstance(pip, list) and all(isinstance(dep, str) for dep in pip):
-        result = dict(packages=pip, pip_check=True)
+        result = dict(packages=pip, pip_check=False)
     elif isinstance(pip, dict):
         if set(pip.keys()) - {"packages", "pip_check", "pip_version"}:
             raise ValueError(
@@ -163,9 +163,7 @@ def parse_and_validate_pip(pip: Union[str, List[str], Dict]) -> Optional[Dict]:
                     f"got {type(pip['pip_version'])}"
                 )
         result = pip.copy()
-        result["pip_check"] = (
-            True if pip.get("pip_check") is None else pip.get("pip_check")
-        )
+        result["pip_check"] = pip.get("pip_check", False)
         if "packages" not in pip:
             raise ValueError(
                 f"runtime_env['pip'] must include field 'packages', but got {pip}"

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -173,8 +173,8 @@ class RuntimeEnv(dict):
             containing the path to a pip requirements.txt file, or a python
             dictionary that has three fields: 1) ``packages`` (required, List[str]): a
             list of pip packages, 2) ``pip_check`` (optional, bool): whether enable
-            pip check at the end of pip install, default True.
-            3) ``pip_version`` (optional, str): the version of pip, ray will spell
+            pip check at the end of pip install, defaults to False.
+            3) ``pip_version`` (optional, str): the version of pip, Ray will spell
             the package name "pip" in front of the ``pip_version`` to form the final
             requirement string, the syntax of a requirement specifier is defined in
             full in PEP 508.

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -698,7 +698,7 @@ def test_serialize_deserialize(option):
         pip_config_in_runtime_env = runtime_env.pop("pip")
         assert {
             "packages": pip_config_in_runtime_env,
-            "pip_check": True,
+            "pip_check": False,
         } == pip_config_in_cls_runtime_env
 
     assert cls_runtime_env_dict == runtime_env
@@ -813,8 +813,8 @@ def test_runtime_env_interface():
         assert runtime_env.virtualenv_name() is None
         runtime_env["pip"]["packages"].extend(addition_pip_packages)
         runtime_env_dict["pip"]["packages"].extend(addition_pip_packages)
-        # The default value of pip_check is True
-        runtime_env_dict["pip"]["pip_check"] = True
+        # The default value of pip_check is False
+        runtime_env_dict["pip"]["pip_check"] = False
         assert runtime_env_dict == runtime_env.to_dict()
         assert runtime_env.has_pip()
         assert set(runtime_env.pip_config()["packages"]) == set(
@@ -826,8 +826,10 @@ def test_runtime_env_interface():
         assert runtime_env.has_pip()
         assert set(runtime_env.pip_config()["packages"]) == set(requirement_packages)
         assert runtime_env.virtualenv_name() is None
-        # The default value of pip_check is True
-        runtime_env_dict["pip"] = dict(packages=runtime_env_dict["pip"], pip_check=True)
+        # The default value of pip_check is False
+        runtime_env_dict["pip"] = dict(
+            packages=runtime_env_dict["pip"], pip_check=False
+        )
         assert runtime_env_dict == runtime_env.to_dict()
         # Test that the modification of pip also works on
         # proto serialization

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -208,19 +208,19 @@ class TestValidatePip:
 
         result = parse_and_validate_pip(str(requirements_file))
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"]
+        assert result["pip_check"] == False
         assert "pip_version" not in result
 
     def test_validate_pip_valid_list(self):
         result = parse_and_validate_pip(PIP_LIST)
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"]
+        assert result["pip_check"] == False
         assert "pip_version" not in result
 
     def test_validate_ray(self):
         result = parse_and_validate_pip(["pkg1", "ray", "pkg2"])
         assert result["packages"] == ["pkg1", "ray", "pkg2"]
-        assert result["pip_check"]
+        assert result["pip_check"] == False
         assert "pip_version" not in result
 
 

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -208,19 +208,19 @@ class TestValidatePip:
 
         result = parse_and_validate_pip(str(requirements_file))
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"] == False
+        assert not result["pip_check"]
         assert "pip_version" not in result
 
     def test_validate_pip_valid_list(self):
         result = parse_and_validate_pip(PIP_LIST)
         assert result["packages"] == PIP_LIST
-        assert result["pip_check"] == False
+        assert not result["pip_check"]
         assert "pip_version" not in result
 
     def test_validate_ray(self):
         result = parse_and_validate_pip(["pkg1", "ray", "pkg2"])
         assert result["packages"] == ["pkg1", "ray", "pkg2"]
-        assert result["pip_check"] == False
+        assert not result["pip_check"]
         assert "pip_version" not in result
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
@SongGuyang @Catch-Bull @edoakes  I know we discussed this earlier, but after thinking about it some more I think a more reasonable default is for `pip check` to be `False` by default.  My guess is that a lot of users (including myself) work inside an environment where `python -m pip check` fails, but the environment doesn't cause them any problems otherwise.  So a lot of users will hit an error when trying a simple `runtime_env` `pip` example, and possibly give up.  Another less important piece of evidence is that we had to set `pip_check = False` to make some CI tests pass in the original PR.

This also matches the default behavior of pip which allows this situation to occur in the first place:  `pip install` doesn't error when there's a dependency conflict; rather the command succeeds, the package is installed and usable, and it prints a warning (which is confusingly titled "ERROR")

Example:
```
Installing collected packages: sphinx
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
sphinx-tabs 2.1.0 requires sphinx<4,>=2, but you have sphinx 4.3.2 which is incompatible.
Successfully installed sphinx-4.3.2
❯ echo $?
0
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #23291 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
