### PR TITLE
[docs] Fix malformatted list in "Advanced Pattern: Fault Tolerance with Actor Checkpointing"

### DIFF
--- a/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
+++ b/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
@@ -6,9 +6,9 @@ Ray offers support for task and actor `fault tolerance <https://docs.ray.io/en/l
 There are several ways to checkpoint:
 
 - Write the state to local disk. This can cause troubles when actors are instantiated in multi-node clusters.
-- Write the state to local disk and use cluster launcher to sync file across cluster
-- Write the state to Ray internal kv store. (this is an experimental feature and not suitable for large files)
-- Write the state to a Ray actor placed on head node (using custom resource constraints)
+- Write the state to local disk and use cluster launcher to sync file across cluster.
+- Write the state to Ray internal kv store. (This is an experimental feature and not suitable for large files).
+- Write the state to a Ray actor placed on head node (using custom resource constraints).
 
 
 Code example

--- a/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
+++ b/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
@@ -5,7 +5,7 @@ Ray offers support for task and actor `fault tolerance <https://docs.ray.io/en/l
 
 There are several ways to checkpoint:
 
-- Write the state to local disk. This can cause troubles when actors are instantiated in multi-node clusters.
+- Write the state to local disk. This can cause trouble when actors are instantiated in multi-node clusters.
 - Write the state to local disk and use cluster launcher to sync file across cluster.
 - Write the state to Ray internal kv store. (This is an experimental feature and not suitable for large files).
 - Write the state to a Ray actor placed on head node (using custom resource constraints).

--- a/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
+++ b/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
@@ -7,7 +7,7 @@ There are several ways to checkpoint:
 
 - Write the state to local disk. This can cause troubles when actors are instantiated in multi-node clusters.
 - Write the state to local disk and use cluster launcher to sync file across cluster
-- Write the state to ray internal kv store. (this is an experimental feature and not suitable for large files)
+- Write the state to Ray internal kv store. (this is an experimental feature and not suitable for large files)
 - Write the state to a Ray actor placed on head node (using custom resource constraints)
 
 

--- a/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
+++ b/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
@@ -4,6 +4,7 @@ Pattern: Fault Tolerance with Actor Checkpointing
 Ray offers support for task and actor `fault tolerance <https://docs.ray.io/en/latest/fault-tolerance.html>`__. Specifically for actors, you can specify max_restarts to automatically enable restart for Ray actors. This means when your actor or the node hosting that actor crashed, the actor will be automatically reconstructed. However, this doesn’t provide ways for you to restore application level states in your actor. You checkpoint your actor periodically and read from the checkpoint if possible.
 
 There are several ways to checkpoint:
+
 - Write the state to local disk. This can cause troubles when actors are instantiated in multi-node clusters.
 - Write the state to local disk and use cluster launcher to sync file across cluster
 - Write the state to ray internal kv store. (this is an experimental feature and not suitable for large files)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The list in ["Advanced Pattern: Fault Tolerance with Actor Checkpointing"](https://docs.ray.io/en/releases-1.11.0/ray-design-patterns/fault-tolerance-actor-checkpointing.html) is malformatted:

<img width="751" alt="Screen Shot 2022-03-17 at 11 19 41 PM" src="https://user-images.githubusercontent.com/92341594/158948084-c44b1684-5461-4d54-a45c-fbec4ea2b915.png">

This change corrects the list's formatting.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - N/A
