### PR TITLE
[GCS] [2 / n] Refactor gcs_resource_scheduler to cluster_resource_scheduler

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -15,6 +15,8 @@
 namespace ray {
 namespace gcs {
 
+using ScheduleContext = raylet_scheduling_policy::BundleSchedulingContext;
+
 class Mockpair_hash : public pair_hash {
  public:
 };

--- a/src/ray/common/placement_group.h
+++ b/src/ray/common/placement_group.h
@@ -21,6 +21,18 @@
 
 namespace ray {
 
+struct pair_hash {
+  template <class T1, class T2>
+  std::size_t operator()(const std::pair<T1, T2> &pair) const {
+    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+  }
+};
+
+using BundleLocations =
+    absl::flat_hash_map<BundleID,
+                        std::pair<NodeID, std::shared_ptr<const BundleSpecification>>,
+                        pair_hash>;
+
 class PlacementGroupSpecification : public MessageWrapper<rpc::PlacementGroupSpec> {
  public:
   /// Construct from a protobuf message object.

--- a/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_distribution.cc
@@ -104,16 +104,16 @@ GcsBasedActorScheduler::AllocateNewActorWorkerAssignment(
 
 scheduling::NodeID GcsBasedActorScheduler::AllocateResources(
     const ResourceRequest &required_resources) {
-  auto selected_nodes =
-      cluster_resource_scheduler_->Schedule({required_resources}, SchedulingType::SPREAD)
-          .second;
+  auto scheduling_result =
+      cluster_resource_scheduler_->Schedule({required_resources}, SchedulingType::SPREAD);
 
-  if (selected_nodes.size() == 0) {
+  if (!scheduling_result.status.IsSuccess()) {
     RAY_LOG(INFO)
         << "Scheduling resources failed, schedule type = SchedulingType::SPREAD";
     return scheduling::NodeID::Nil();
   }
 
+  const auto &selected_nodes = scheduling_result.selected_nodes;
   RAY_CHECK(selected_nodes.size() == 1);
 
   auto selected_node_id = selected_nodes[0];

--- a/src/ray/gcs/gcs_server/gcs_resource_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_scheduler.cc
@@ -110,12 +110,12 @@ double LeastResourceScorer::Calculate(const FixedPoint &requested,
 
 SchedulingResult SortSchedulingResult(const SchedulingResult &result,
                                       const std::vector<int> &sorted_index) {
-  if (result.first == SchedulingResultStatus::SUCCESS) {
-    std::vector<scheduling::NodeID> sorted_nodes(result.second.size());
+  if (result.status.IsSuccess()) {
+    std::vector<scheduling::NodeID> sorted_nodes(result.selected_nodes.size());
     for (int i = 0; i < (int)sorted_index.size(); i++) {
-      sorted_nodes[sorted_index[i]] = result.second[i];
+      sorted_nodes[sorted_index[i]] = result.selected_nodes[i];
     }
-    return std::make_pair(result.first, sorted_nodes);
+    return SchedulingResult::Success(std::move(sorted_nodes));
   } else {
     return result;
   }
@@ -129,8 +129,7 @@ SchedulingResult GcsResourceScheduler::Schedule(
   auto candidate_nodes = FilterCandidateNodes(node_filter_func);
   if (candidate_nodes.empty()) {
     RAY_LOG(DEBUG) << "The candidate nodes is empty, return directly.";
-    return std::make_pair(SchedulingResultStatus::INFEASIBLE,
-                          std::vector<scheduling::NodeID>());
+    return SchedulingResult::Infeasible();
   }
 
   // If scheduling type is strict pack, we do not need to sort resources of each placement
@@ -246,8 +245,7 @@ SchedulingResult GcsResourceScheduler::StrictSpreadSchedule(
                    << required_resources_list.size()
                    << " is greater than the number of candidate nodes "
                    << candidate_nodes.size() << ", scheduling fails.";
-    return std::make_pair(SchedulingResultStatus::INFEASIBLE,
-                          std::vector<scheduling::NodeID>());
+    return SchedulingResult::Infeasible();
   }
 
   std::vector<scheduling::NodeID> result_nodes;
@@ -268,10 +266,9 @@ SchedulingResult GcsResourceScheduler::StrictSpreadSchedule(
 
   if (result_nodes.size() != required_resources_list.size()) {
     // Can't meet the scheduling requirements temporarily.
-    return std::make_pair(SchedulingResultStatus::FAILED,
-                          std::vector<scheduling::NodeID>());
+    return SchedulingResult::Failed();
   }
-  return std::make_pair(SchedulingResultStatus::SUCCESS, result_nodes);
+  return SchedulingResult::Success(std::move(result_nodes));
 }
 
 SchedulingResult GcsResourceScheduler::SpreadSchedule(
@@ -307,10 +304,9 @@ SchedulingResult GcsResourceScheduler::SpreadSchedule(
 
   if (result_nodes.size() != required_resources_list.size()) {
     // Can't meet the scheduling requirements temporarily.
-    return std::make_pair(SchedulingResultStatus::FAILED,
-                          std::vector<scheduling::NodeID>());
+    return SchedulingResult::Failed();
   }
-  return std::make_pair(SchedulingResultStatus::SUCCESS, result_nodes);
+  return SchedulingResult::Success(std::move(result_nodes));
 }
 
 SchedulingResult GcsResourceScheduler::StrictPackSchedule(
@@ -344,8 +340,7 @@ SchedulingResult GcsResourceScheduler::StrictPackSchedule(
   if (right_node_it == resource_view.end()) {
     RAY_LOG(DEBUG) << "The required resource is bigger than the maximum resource in the "
                       "whole cluster, schedule failed.";
-    return std::make_pair(SchedulingResultStatus::INFEASIBLE,
-                          std::vector<scheduling::NodeID>());
+    return SchedulingResult::Infeasible();
   }
 
   std::vector<scheduling::NodeID> result_nodes;
@@ -362,11 +357,10 @@ SchedulingResult GcsResourceScheduler::StrictPackSchedule(
   }
   if (result_nodes.empty()) {
     // Can't meet the scheduling requirements temporarily.
-    return std::make_pair(SchedulingResultStatus::FAILED,
-                          std::vector<scheduling::NodeID>());
+    return SchedulingResult::Failed();
   }
 
-  return std::make_pair(SchedulingResultStatus::SUCCESS, result_nodes);
+  return SchedulingResult::Success(std::move(result_nodes));
 }
 
 SchedulingResult GcsResourceScheduler::PackSchedule(
@@ -412,10 +406,9 @@ SchedulingResult GcsResourceScheduler::PackSchedule(
 
   if (!required_resources_list_copy.empty()) {
     // Can't meet the scheduling requirements temporarily.
-    return std::make_pair(SchedulingResultStatus::FAILED,
-                          std::vector<scheduling::NodeID>());
+    return SchedulingResult::Failed();
   }
-  return std::make_pair(SchedulingResultStatus::SUCCESS, result_nodes);
+  return SchedulingResult::Success(std::move(result_nodes));
 }
 
 scheduling::NodeID GcsResourceScheduler::GetBestNode(

--- a/src/ray/gcs/gcs_server/gcs_resource_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_scheduler.h
@@ -21,6 +21,7 @@
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/raylet/scheduling/cluster_resource_data.h"
 #include "ray/raylet/scheduling/cluster_resource_manager.h"
+#include "ray/raylet/scheduling/policy/scheduling_policy.h"
 
 namespace ray {
 namespace gcs {
@@ -39,19 +40,9 @@ enum SchedulingType {
   SchedulingType_MAX = 4,
 };
 
-// Status of resource scheduling result.
-enum class SchedulingResultStatus {
-  // Scheduling failed but retryable.
-  FAILED = 0,
-  // Scheduling failed and non-retryable.
-  INFEASIBLE = 1,
-  // Scheduling successful.
-  SUCCESS = 2,
-};
-
+using SchedulingResultStatus = raylet_scheduling_policy::SchedulingResultStatus;
+using SchedulingResult = raylet_scheduling_policy::SchedulingResult;
 using NodeScore = std::pair<scheduling::NodeID, double>;
-typedef std::pair<SchedulingResultStatus, std::vector<scheduling::NodeID>>
-    SchedulingResult;
 
 /// NodeScorer is a scorer to make a grade to the node, which is used for scheduling
 /// decision.

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -767,8 +767,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestBundleLocationIndex) {
   const std::shared_ptr<BundleSpecification> bundle_node2_pg1 =
       std::make_shared<BundleSpecification>(
           BundleSpecification(request_pg1.placement_group_spec().bundles(1)));
-  std::shared_ptr<gcs::BundleLocations> bundle_locations_pg1 =
-      std::make_shared<gcs::BundleLocations>();
+  std::shared_ptr<BundleLocations> bundle_locations_pg1 =
+      std::make_shared<BundleLocations>();
   (*bundle_locations_pg1)
       .emplace(bundle_node1_pg1->BundleId(), std::make_pair(node1, bundle_node1_pg1));
   (*bundle_locations_pg1)
@@ -784,8 +784,8 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestBundleLocationIndex) {
   const std::shared_ptr<BundleSpecification> bundle_node2_pg2 =
       std::make_shared<BundleSpecification>(
           BundleSpecification(request_pg2.placement_group_spec().bundles(1)));
-  std::shared_ptr<gcs::BundleLocations> bundle_locations_pg2 =
-      std::make_shared<gcs::BundleLocations>();
+  std::shared_ptr<BundleLocations> bundle_locations_pg2 =
+      std::make_shared<BundleLocations>();
   (*bundle_locations_pg2)[bundle_node1_pg2->BundleId()] =
       std::make_pair(node1, bundle_node1_pg2);
   (*bundle_locations_pg2)[bundle_node2_pg2->BundleId()] =

--- a/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_scheduler_test.cc
@@ -100,8 +100,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     }
     const auto &result1 =
         gcs_resource_scheduler_->Schedule(required_resources_list, scheduling_type);
-    ASSERT_TRUE(result1.first == gcs::SchedulingResultStatus::SUCCESS);
-    ASSERT_EQ(result1.second.size(), 3);
+    ASSERT_TRUE(result1.status.IsSuccess());
+    ASSERT_EQ(result1.selected_nodes.size(), 3);
 
     // Check for resource leaks.
     CheckClusterAvailableResources(node_id, cpu_resource, node_cpu_num);
@@ -113,8 +113,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
                                      /*requires_object_store_memory=*/false));
     const auto &result2 =
         gcs_resource_scheduler_->Schedule(required_resources_list, scheduling_type);
-    ASSERT_TRUE(result2.first == gcs::SchedulingResultStatus::FAILED);
-    ASSERT_EQ(result2.second.size(), 0);
+    ASSERT_TRUE(result2.status.IsFailed());
+    ASSERT_EQ(result2.selected_nodes.size(), 0);
 
     // Check for resource leaks.
     CheckClusterAvailableResources(node_id, cpu_resource, node_cpu_num);
@@ -159,8 +159,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
 
     const auto &result1 =
         gcs_resource_scheduler_->Schedule(required_resources_list, scheduling_type);
-    ASSERT_TRUE(result1.first == gcs::SchedulingResultStatus::SUCCESS);
-    ASSERT_EQ(result1.second.size(), resources_list.size());
+    ASSERT_TRUE(result1.status.IsSuccess());
+    ASSERT_EQ(result1.selected_nodes.size(), resources_list.size());
   }
 
   std::shared_ptr<gcs::GcsResourceScheduler> gcs_resource_scheduler_;
@@ -206,16 +206,16 @@ TEST_F(GcsResourceSchedulerTest, TestNodeFilter) {
       gcs_resource_scheduler_->Schedule(required_resources_list,
                                         gcs::SchedulingType::STRICT_SPREAD,
                                         [](const scheduling::NodeID &) { return false; });
-  ASSERT_TRUE(result1.first == gcs::SchedulingResultStatus::INFEASIBLE);
-  ASSERT_EQ(result1.second.size(), 0);
+  ASSERT_TRUE(result1.status.IsInfeasible());
+  ASSERT_EQ(result1.selected_nodes.size(), 0);
 
   // Scheduling succeeded.
   const auto &result2 =
       gcs_resource_scheduler_->Schedule(required_resources_list,
                                         gcs::SchedulingType::STRICT_SPREAD,
                                         [](const scheduling::NodeID &) { return true; });
-  ASSERT_TRUE(result2.first == gcs::SchedulingResultStatus::SUCCESS);
-  ASSERT_EQ(result2.second.size(), 1);
+  ASSERT_TRUE(result2.status.IsSuccess());
+  ASSERT_EQ(result2.selected_nodes.size(), 1);
 }
 
 TEST_F(GcsResourceSchedulerTest, TestSchedulingResultStatusForStrictStrategy) {
@@ -238,8 +238,8 @@ TEST_F(GcsResourceSchedulerTest, TestSchedulingResultStatusForStrictStrategy) {
 
   const auto &result1 = gcs_resource_scheduler_->Schedule(
       required_resources_list, gcs::SchedulingType::STRICT_SPREAD);
-  ASSERT_TRUE(result1.first == gcs::SchedulingResultStatus::INFEASIBLE);
-  ASSERT_EQ(result1.second.size(), 0);
+  ASSERT_TRUE(result1.status.IsInfeasible());
+  ASSERT_EQ(result1.selected_nodes.size(), 0);
 
   // Check for resource leaks.
   CheckClusterAvailableResources(node_one_id, cpu_resource, node_cpu_num);
@@ -255,8 +255,8 @@ TEST_F(GcsResourceSchedulerTest, TestSchedulingResultStatusForStrictStrategy) {
 
   const auto &result2 = gcs_resource_scheduler_->Schedule(
       required_resources_list, gcs::SchedulingType::STRICT_PACK);
-  ASSERT_TRUE(result2.first == gcs::SchedulingResultStatus::INFEASIBLE);
-  ASSERT_EQ(result2.second.size(), 0);
+  ASSERT_TRUE(result2.status.IsInfeasible());
+  ASSERT_EQ(result2.selected_nodes.size(), 0);
 
   // Check for resource leaks.
   CheckClusterAvailableResources(node_one_id, cpu_resource, node_cpu_num);

--- a/src/ray/raylet/placement_group_resource_manager.h
+++ b/src/ray/raylet/placement_group_resource_manager.h
@@ -17,6 +17,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "ray/common/bundle_spec.h"
 #include "ray/common/id.h"
+#include "ray/common/placement_group.h"
 #include "ray/common/task/scheduling_resources.h"
 #include "ray/raylet/scheduling/cluster_resource_scheduler.h"
 
@@ -29,13 +30,6 @@ enum CommitState {
   PREPARED,
   /// Resources are COMMITTED.
   COMMITTED
-};
-
-struct pair_hash {
-  template <class T1, class T2>
-  std::size_t operator()(const std::pair<T1, T2> &pair) const {
-    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
-  }
 };
 
 struct BundleTransactionState {

--- a/src/ray/raylet/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/placement_group_resource_manager_test.cc
@@ -33,16 +33,20 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
       new_placement_group_resource_manager_;
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   std::unique_ptr<gcs::MockGcsClient> gcs_client_;
+  std::function<bool(scheduling::NodeID)> is_node_available_fn_;
   rpc::GcsNodeInfo node_info_;
   void SetUp() {
     gcs_client_ = std::make_unique<gcs::MockGcsClient>();
+    is_node_available_fn_ = [this](scheduling::NodeID node_id) {
+      return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+    };
     EXPECT_CALL(*gcs_client_->mock_node_accessor, Get(::testing::_, ::testing::_))
         .WillRepeatedly(::testing::Return(&node_info_));
   }
   void InitLocalAvailableResource(
       absl::flat_hash_map<std::string, double> &unit_resource) {
     cluster_resource_scheduler_ = std::make_shared<ClusterResourceScheduler>(
-        scheduling::NodeID("local"), unit_resource, *gcs_client_);
+        scheduling::NodeID("local"), unit_resource, is_node_available_fn_);
     new_placement_group_resource_manager_ =
         std::make_unique<raylet::NewPlacementGroupResourceManager>(
             cluster_resource_scheduler_);
@@ -119,7 +123,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewCommitBundleResource) {
       {"bundle_group_1_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 1000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -148,7 +152,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewReturnBundleResource) {
   new_placement_group_resource_manager_->ReturnBundle(bundle_spec);
   /// 5. check remaining resources is correct.
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), unit_resource, *gcs_client_);
+      scheduling::NodeID("remaining"), unit_resource, is_node_available_fn_);
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -185,7 +189,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
       {"bundle_group_2_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 2000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -205,7 +209,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
                          {"bundle_group_1_" + group_id.Hex(), 1000},
                          {"bundle_group_" + group_id.Hex(), 2000}};
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   ASSERT_TRUE(
       remaining_resource_scheduler->GetLocalResourceManager().AllocateLocalTaskResources(
           {{"CPU_group_" + group_id.Hex(), 1.0},
@@ -221,7 +225,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
   /// 8. check remaining resources is correct after all bundle returned.
   remaining_resources = {{"CPU", 2.0}};
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -245,7 +249,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithMultiPrepare)
   /// 4. check remaining resources is correct.
   absl::flat_hash_map<std::string, double> remaining_resources = {{"CPU", 3.0}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -282,7 +286,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithRandomOrder) 
       {"bundle_group_1_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 1000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(
@@ -311,7 +315,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithRandomOrder) 
       ConvertSingleSpecToVectorPtrs(bundle_spec));
   // 8. check remaining resources is correct.
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), available_resource, *gcs_client_);
+      scheduling::NodeID("remaining"), available_resource, is_node_available_fn_);
   remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -335,7 +339,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestPreparedResourceBatched) {
   // 4. check remaining resources is correct.
   absl::flat_hash_map<std::string, double> remaining_resources = {{"CPU", 3.0}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   auto remaining_resource_instance =
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
@@ -361,7 +365,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestPreparedResourceBatched) {
                          {"bundle_group_4_" + group_id.Hex(), 1000},
                          {"bundle_group_" + group_id.Hex(), 4000}};
   remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> allocating_resource;
@@ -407,7 +411,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestCommiteResourceBatched) {
       {"bundle_group_4_" + group_id.Hex(), 1000},
       {"bundle_group_" + group_id.Hex(), 4000}};
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID("remaining"), remaining_resources, *gcs_client_);
+      scheduling::NodeID("remaining"), remaining_resources, is_node_available_fn_);
   std::shared_ptr<TaskResourceInstances> resource_instances =
       std::make_shared<TaskResourceInstances>();
   absl::flat_hash_map<std::string, double> allocating_resource;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -23,8 +23,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "ray/common/task/scheduling_resources.h"
-#include "ray/gcs/gcs_client/accessor.h"
-#include "ray/gcs/gcs_client/gcs_client.h"
 #include "ray/raylet/scheduling/cluster_resource_data.h"
 #include "ray/raylet/scheduling/cluster_resource_manager.h"
 #include "ray/raylet/scheduling/fixed_point.h"
@@ -37,6 +35,9 @@
 
 namespace ray {
 
+using raylet_scheduling_policy::SchedulingContext;
+using raylet_scheduling_policy::SchedulingOptions;
+using raylet_scheduling_policy::SchedulingResult;
 using rpc::HeartbeatTableData;
 
 /// Class encapsulating the cluster resources and the logic to assign
@@ -52,14 +53,28 @@ class ClusterResourceScheduler {
   /// with the local node.
   ClusterResourceScheduler(scheduling::NodeID local_node_id,
                            const NodeResources &local_node_resources,
-                           gcs::GcsClient &gcs_client);
+                           std::function<bool(scheduling::NodeID)> is_node_available_fn);
 
   ClusterResourceScheduler(
       scheduling::NodeID local_node_id,
       const absl::flat_hash_map<std::string, double> &local_node_resources,
-      gcs::GcsClient &gcs_client,
+      std::function<bool(scheduling::NodeID)> is_node_available_fn,
       std::function<int64_t(void)> get_used_object_store_memory = nullptr,
       std::function<bool(void)> get_pull_manager_at_capacity = nullptr);
+
+  /// Schedule the specified resources to the cluster nodes.
+  ///
+  /// \param resource_request_list The resource request list we're attempting to schedule.
+  /// \param options: scheduling options.
+  /// \param context: The context of current scheduling. Each policy can
+  /// correspond to a different type of context.
+  /// \return `SchedulingResult`, including the
+  /// selected nodes if schedule successful, otherwise, it will return an empty vector and
+  /// a flag to indicate whether this request can be retry or not.
+  SchedulingResult Schedule(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      SchedulingOptions options,
+      SchedulingContext *context);
 
   ///  Find a node in the cluster on which we can schedule a given resource request.
   ///  In hybrid mode, see `scheduling_policy.h` for a description of the policy.
@@ -171,8 +186,8 @@ class ClusterResourceScheduler {
 
   /// Identifier of local node.
   scheduling::NodeID local_node_id_;
-  /// Gcs client. It's not owned by this class.
-  gcs::GcsClient *gcs_client_;
+  /// Callback to check if node is available.
+  std::function<bool(scheduling::NodeID)> is_node_available_fn_;
   /// Resources of local node.
   std::unique_ptr<LocalResourceManager> local_resource_manager_;
   /// Resources of the entire cluster.

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -270,20 +270,21 @@ class ClusterTaskManagerTest : public ::testing::Test {
             },
             /*max_pinned_task_arguments_bytes=*/1000,
             /*get_time=*/[this]() { return current_time_ms_; })),
-        task_manager_(id_,
-                      scheduler_,
-                      /* get_node_info= */
-                      [this](const NodeID &node_id) -> const rpc::GcsNodeInfo * {
-                        node_info_calls_++;
-                        if (node_info_.count(node_id) != 0) {
-                          return &node_info_[node_id];
-                        }
-                        return nullptr;
-                      },
-                      /* announce_infeasible_task= */
-                      [this](const RayTask &task) { announce_infeasible_task_calls_++; },
-                      local_task_manager_,
-                      /*get_time=*/[this]() { return current_time_ms_; }) {}
+        task_manager_(
+            id_,
+            scheduler_,
+            /* get_node_info= */
+            [this](const NodeID &node_id) -> const rpc::GcsNodeInfo * {
+              node_info_calls_++;
+              if (node_info_.count(node_id) != 0) {
+                return &node_info_[node_id];
+              }
+              return nullptr;
+            },
+            /* announce_infeasible_task= */
+            [this](const RayTask &task) { announce_infeasible_task_calls_++; },
+            local_task_manager_,
+            /*get_time=*/[this]() { return current_time_ms_; }) {}
 
   void SetUp() {
     static rpc::GcsNodeInfo node_info;

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -133,7 +133,11 @@ std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
   local_node_resources[ray::kMemory_ResourceLabel] = 128;
 
   auto scheduler = std::make_shared<ClusterResourceScheduler>(
-      scheduling::NodeID(id), local_node_resources, gcs_client);
+      scheduling::NodeID(id),
+      local_node_resources,
+      /*is_node_available_fn*/ [&gcs_client](scheduling::NodeID node_id) {
+        return gcs_client.Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+      });
 
   return scheduler;
 }
@@ -266,21 +270,20 @@ class ClusterTaskManagerTest : public ::testing::Test {
             },
             /*max_pinned_task_arguments_bytes=*/1000,
             /*get_time=*/[this]() { return current_time_ms_; })),
-        task_manager_(
-            id_,
-            scheduler_,
-            /* get_node_info= */
-            [this](const NodeID &node_id) -> const rpc::GcsNodeInfo * {
-              node_info_calls_++;
-              if (node_info_.count(node_id) != 0) {
-                return &node_info_[node_id];
-              }
-              return nullptr;
-            },
-            /* announce_infeasible_task= */
-            [this](const RayTask &task) { announce_infeasible_task_calls_++; },
-            local_task_manager_,
-            /*get_time=*/[this]() { return current_time_ms_; }) {}
+        task_manager_(id_,
+                      scheduler_,
+                      /* get_node_info= */
+                      [this](const NodeID &node_id) -> const rpc::GcsNodeInfo * {
+                        node_info_calls_++;
+                        if (node_info_.count(node_id) != 0) {
+                          return &node_info_[node_id];
+                        }
+                        return nullptr;
+                      },
+                      /* announce_infeasible_task= */
+                      [this](const RayTask &task) { announce_infeasible_task_calls_++; },
+                      local_task_manager_,
+                      /*get_time=*/[this]() { return current_time_ms_; }) {}
 
   void SetUp() {
     static rpc::GcsNodeInfo node_info;

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
@@ -40,5 +40,13 @@ scheduling::NodeID CompositeSchedulingPolicy::Schedule(
   UNREACHABLE;
 }
 
+SchedulingResult CompositeSchedulingPolicy::Schedule(
+    const std::vector<const ResourceRequest *> &resource_request_list,
+    SchedulingOptions options,
+    SchedulingContext *context) {
+  // TODO(Shanly): To be implemented.
+  return SchedulingResult();
+}
+
 }  // namespace raylet_scheduling_policy
 }  // namespace ray

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
@@ -37,6 +37,11 @@ class CompositeSchedulingPolicy : public ISchedulingPolicy {
   scheduling::NodeID Schedule(const ResourceRequest &resource_request,
                               SchedulingOptions options) override;
 
+  SchedulingResult Schedule(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      SchedulingOptions options,
+      SchedulingContext *context) override;
+
  private:
   HybridSchedulingPolicy hybrid_policy_;
   RandomSchedulingPolicy random_policy_;

--- a/src/ray/raylet/scheduling/policy/scheduling_context.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_context.h
@@ -1,0 +1,45 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ray/common/bundle_spec.h"
+#include "ray/common/id.h"
+#include "ray/common/placement_group.h"
+
+namespace ray {
+namespace raylet_scheduling_policy {
+
+// Options that controls the scheduling behavior.
+struct SchedulingContext {
+  virtual ~SchedulingContext() = default;
+};
+
+struct BundleSchedulingContext : public SchedulingContext {
+ public:
+  explicit BundleSchedulingContext(
+      std::shared_ptr<absl::flat_hash_map<NodeID, int64_t>> node_to_bundles,
+      const absl::optional<std::shared_ptr<BundleLocations>> bundle_locations)
+      : node_to_bundles_(std::move(node_to_bundles)),
+        bundle_locations_(bundle_locations) {}
+
+  /// Key is node id, value is the number of bundles on the node.
+  const std::shared_ptr<absl::flat_hash_map<NodeID, int64_t>> node_to_bundles_;
+  /// The locations of existing bundles for this placement group.
+  const absl::optional<std::shared_ptr<BundleLocations>> bundle_locations_;
+};
+
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/policy/scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy.h
@@ -17,11 +17,55 @@
 #include <vector>
 
 #include "ray/raylet/scheduling/cluster_resource_data.h"
+#include "ray/raylet/scheduling/policy/scheduling_context.h"
 #include "ray/raylet/scheduling/policy/scheduling_options.h"
 #include "ray/raylet/scheduling/scheduling_ids.h"
 
 namespace ray {
 namespace raylet_scheduling_policy {
+
+// Status of resource scheduling result.
+struct SchedulingResultStatus {
+  bool IsFailed() const { return code == SchedulingResultStatusCode::FAILED; }
+  bool IsInfeasible() const { return code == SchedulingResultStatusCode::INFEASIBLE; }
+  bool IsSuccess() const { return code == SchedulingResultStatusCode::SUCCESS; }
+
+  enum class SchedulingResultStatusCode {
+    // Scheduling failed but retryable.
+    FAILED = 0,
+    // Scheduling failed and non-retryable.
+    INFEASIBLE = 1,
+    // Scheduling successful.
+    SUCCESS = 2,
+  };
+  SchedulingResultStatusCode code = SchedulingResultStatusCode::SUCCESS;
+};
+
+struct SchedulingResult {
+  static SchedulingResult Infeasible() {
+    SchedulingResult result;
+    result.status.code = SchedulingResultStatus::SchedulingResultStatusCode::INFEASIBLE;
+    return result;
+  }
+
+  static SchedulingResult Failed() {
+    SchedulingResult result;
+    result.status.code = SchedulingResultStatus::SchedulingResultStatusCode::FAILED;
+    return result;
+  }
+
+  static SchedulingResult Success(std::vector<scheduling::NodeID> &&nodes) {
+    SchedulingResult result;
+    result.status.code = SchedulingResultStatus::SchedulingResultStatusCode::SUCCESS;
+    result.selected_nodes = std::move(nodes);
+    return result;
+  }
+
+  // The status of scheduling.
+  SchedulingResultStatus status;
+  // The nodes successfully scheduled.
+  std::vector<scheduling::NodeID> selected_nodes;
+};
 
 /// ISchedulingPolicy picks a node to from the cluster, according to the resource
 /// requirment as well as the scheduling options.
@@ -29,12 +73,30 @@ class ISchedulingPolicy {
  public:
   virtual ~ISchedulingPolicy() = default;
   /// \param resource_request: The resource request we're attempting to schedule.
-  /// \param scheduling_options: scheduling options.
+  /// \param options: scheduling options.
   ///
   /// \return NodeID::Nil() if the task is unfeasible, otherwise the node id
   /// to schedule on.
   virtual scheduling::NodeID Schedule(const ResourceRequest &resource_request,
-                                      SchedulingOptions options) = 0;
+                                      SchedulingOptions options) {
+    return scheduling::NodeID();
+  }
+
+  /// Schedule the specified resources to the cluster nodes.
+  ///
+  /// \param resource_request_list The resource request list we're attempting to schedule.
+  /// \param options: scheduling options.
+  /// \param context: The context of current scheduling. Each policy can
+  /// correspond to a different type of context.
+  /// \return `SchedulingResult`, including the
+  /// selected nodes if schedule successful, otherwise, it will return an empty vector and
+  /// a flag to indicate whether this request can be retry or not.
+  virtual SchedulingResult Schedule(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      SchedulingOptions options,
+      SchedulingContext *context) {
+    return SchedulingResult();
+  }
 };
 }  // namespace raylet_scheduling_policy
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As we (@scv119 @iycheng @raulchen @Chong-Li @WangTaoTheTonic ) discussed offline, the GcsResourceScheduler on the GCS side should be unified to ClusterResourceScheduler.

There is already a big PR( https://github.com/ray-project/ray/pull/23268 ) to do this, but in order to make review easy, I will split it to two or mall small PRs.
This is [2/n]:

- Add new interface to policy for batch scheduling and unify the scheduling result and context
- Remove the dependence of `GcsClient` on `ClusterResourceScheduler`  as `ClusterResourceScheduler` doesn't need to depend on `GcsClient on the GCS side.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
