### PR TITLE
[ci/release] Legacy field should be optional

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -274,7 +274,7 @@
       python/ray/tests/test_usage_stats
 
 - label: ":python: Release test package unit tests"
-  conditions: ["RAY_CI_PYTHON_AFFECTED"]
+  conditions: ["ALWAYS"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
     - pip install -e release/

--- a/release/ray_release/reporter/legacy_rds.py
+++ b/release/ray_release/reporter/legacy_rds.py
@@ -41,8 +41,12 @@ class LegacyRDSReporter(Reporter):
         now = datetime.datetime.utcnow()
         rds_data_client = boto3.client("rds-data", region_name="us-west-2")
 
-        test_name = test["legacy"]["test_name"] or ""
-        test_suite = test["legacy"]["test_suite"] or ""
+        if "legacy" in test:
+            test_name = test["legacy"]["test_name"]
+            test_suite = test["legacy"]["test_suite"]
+        else:
+            test_name = test["name"]
+            test_suite = ""
 
         team = test["team"] or ""
 

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -52,7 +52,6 @@
 			"required": [
 				"cluster",
 				"frequency",
-				"legacy",
 				"name",
 				"run",
 				"team",

--- a/release/ray_release/tests/test_alerts.py
+++ b/release/ray_release/tests/test_alerts.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from ray_release.alerts import (
@@ -39,3 +40,9 @@ class AlertsTest(unittest.TestCase):
     def testDefaultAlert(self):
         self.assertTrue(default.handle_result(self.test, Result(status="timeout")))
         self.assertFalse(default.handle_result(self.test, Result(status="finished")))
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 from typing import Dict
 from unittest.mock import patch
@@ -348,3 +349,9 @@ class BuildkiteSettingsTest(unittest.TestCase):
         test_concurrency(1, 0, "tiny")
         test_concurrency(32, 0, "tiny")
         test_concurrency(33, 0, "small")
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import unittest
 from typing import Callable
@@ -629,3 +630,9 @@ class LiveSessionManagerTest(unittest.TestCase):
 
         # Start cluster
         self.cluster_manager.start_cluster(timeout=1200)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 
 from ray_release.config import (
@@ -82,3 +83,9 @@ class ConfigTest(unittest.TestCase):
 
     def testLoadAndValidateTestCollectionFile(self):
         read_and_validate_release_test_collection(self.test_collection_file)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import tempfile
 import time
 import unittest
@@ -585,3 +586,9 @@ class GlueTest(unittest.TestCase):
 
         # Ensure cluster was terminated
         self.assertGreaterEqual(self.sdk.call_counter["terminate_cluster"], 1)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -101,3 +102,9 @@ class RunScriptTest(unittest.TestCase):
         os.unlink(argv_file)
 
         self.assertIn("--smoke-test", data)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -22,6 +22,7 @@ class RunScriptTest(unittest.TestCase):
         os.environ["NO_ARTIFACTS"] = "1"
         os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_run_release_test_sh.py"
         os.environ["OVERRIDE_SLEEP_TIME"] = "0"
+        os.environ["MAX_RETRIES"] = "3"
 
     def tearDown(self) -> None:
         shutil.rmtree(self.tempdir)

--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import unittest
 from unittest.mock import patch
@@ -172,3 +173,9 @@ class WheelsFinderTest(unittest.TestCase):
                 url = find_and_wait_for_ray_wheels_url(commit, timeout=300.0)
 
             self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#22749 broke release unit tests by not providing a `legacy` key - that key should be optional because we will b dealing with non-legacy tests soon.
Additionally, for some reason the unit tests pass on buildkite while they fail locally and in the release test pipeline. I'm investigating this now...

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
