### PR TITLE
[ci/release] Re-enable commit sanity check

### DIFF
--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import json
 import os
+import re
 from typing import Dict, List, Optional
 
 import jinja2
@@ -194,6 +195,12 @@ def load_test_cluster_env(test: Test, ray_wheels_url: str) -> Optional[Dict]:
     env = get_test_environment()
 
     commit = env.get("RAY_COMMIT", None)
+
+    if not commit:
+        match = re.search(r"/([a-f0-9]{40})/", ray_wheels_url)
+        if match:
+            commit = match.group(1)
+
     env["RAY_WHEELS_SANITY_CHECK"] = get_wheels_sanity_check(commit)
     env["RAY_WHEELS"] = ray_wheels_url
 

--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
+from ray_release.config import Test, load_test_cluster_env
 from ray_release.exception import RayWheelsNotFoundError, RayWheelsTimeoutError
 from ray_release.wheels import (
     get_ray_version,
@@ -173,6 +174,28 @@ class WheelsFinderTest(unittest.TestCase):
                 url = find_and_wait_for_ray_wheels_url(commit, timeout=300.0)
 
             self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
+
+    def testWheelsSanityString(self):
+        this_env = {"env": None}
+
+        def override_env(path, env):
+            this_env["env"] = env
+
+        with patch("ray_release.config.load_and_render_yaml_template", override_env):
+            load_test_cluster_env(
+                Test(cluster=dict(cluster_env="invalid")),
+                ray_wheels_url="https://no-commit-url",
+            )
+            assert (
+                "No commit sanity check" in this_env["env"]["RAY_WHEELS_SANITY_CHECK"]
+            )
+
+            sha = "abcdef1234abcdef1234abcdef1234abcdef1234"
+            load_test_cluster_env(
+                Test(cluster=dict(cluster_env="invalid")),
+                ray_wheels_url=f"https://some/{sha}/binary.whl",
+            )
+            assert sha in this_env["env"]["RAY_WHEELS_SANITY_CHECK"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Commit sanity checks are currently seemingly disabled. This PR re-enables them by parsing wheel URLs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
