### PR TITLE
[RLlib] Add support for complex observations in CQL

### DIFF
--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -47,11 +47,11 @@ MEAN_MIN = -9.0
 MEAN_MAX = 9.0
 
 
-def _repeat_tensor(t, n):
+def _repeat_tensor(t: tf.Tensor, n: int):
     # Insert new axis at position 1 into tensor t
     t_rep = tf.expand_dims(t, 1)
     # Repeat tensor t_rep along new axis n times
-    multiples = tf.concat([[1, 2], tf.tile([1], tf.expand_dims(tf.rank(t) - 1, 0))], 0)
+    multiples = tf.concat([[1, n], tf.tile([1], tf.expand_dims(tf.rank(t) - 1, 0))], 0)
     t_rep = tf.tile(t_rep, multiples)
     # Merge new axis into batch axis
     t_rep = tf.reshape(t_rep, tf.concat([[-1], tf.shape(t)[1:]], 0))

--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -49,7 +49,7 @@ MEAN_MAX = 9.0
 
 def _repeat_tensor(t, n):
     t_rep = tf.expand_dims(t, 1)
-    t_rep = tf.repeat(t_rep, n, axis=1)
+    t_rep = tf.tile(t_rep, [1, n] + ([1] * (tf.rank(t) - 1)))
     t_rep = tf.reshape(t_rep, tf.concat([tf.constant([-1]), tf.shape(t)[1:]], 0))
     return t_rep
 

--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -48,8 +48,11 @@ MEAN_MAX = 9.0
 
 
 def _repeat_tensor(t, n):
+    # Insert new axis at position 1 into tensor t
     t_rep = tf.expand_dims(t, 1)
+    # Repeat tensor t_rep along new axis n times
     t_rep = tf.tile(t_rep, [1, n] + ([1] * (tf.rank(t) - 1)))
+    # Merge new axis into batch axis
     t_rep = tf.reshape(t_rep, tf.concat([tf.constant([-1]), tf.shape(t)[1:]], 0))
     return t_rep
 

--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -51,9 +51,10 @@ def _repeat_tensor(t, n):
     # Insert new axis at position 1 into tensor t
     t_rep = tf.expand_dims(t, 1)
     # Repeat tensor t_rep along new axis n times
-    t_rep = tf.tile(t_rep, [1, n] + ([1] * (tf.rank(t) - 1)))
+    multiples = tf.concat([[1, 2], tf.tile([1], tf.expand_dims(tf.rank(t) - 1, 0))], 0)
+    t_rep = tf.tile(t_rep, multiples)
     # Merge new axis into batch axis
-    t_rep = tf.reshape(t_rep, tf.concat([tf.constant([-1]), tf.shape(t)[1:]], 0))
+    t_rep = tf.reshape(t_rep, tf.concat([[-1], tf.shape(t)[1:]], 0))
     return t_rep
 
 

--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -5,6 +5,7 @@ from functools import partial
 import numpy as np
 import gym
 import logging
+import tree
 from typing import Dict, List, Type, Union
 
 import ray
@@ -46,30 +47,34 @@ MEAN_MIN = -9.0
 MEAN_MAX = 9.0
 
 
+def _repeat_tensor(t, n):
+    t_rep = tf.expand_dims(t, 1)
+    t_rep = tf.repeat(t_rep, n, axis=1)
+    t_rep = tf.reshape(t_rep, tf.concat([tf.constant([-1]), tf.shape(t)[1:]], 0))
+    return t_rep
+
+
 # Returns policy tiled actions and log probabilities for CQL Loss
 def policy_actions_repeat(model, action_dist, obs, num_repeat=1):
-    obs_temp = tf.reshape(
-        tf.tile(tf.expand_dims(obs, 1), [1, num_repeat, 1]), [-1, obs.shape[1]]
-    )
+    batch_size = tf.shape(tree.flatten(obs)[0])[0]
+    obs_temp = tree.map_structure(lambda t: _repeat_tensor(t, num_repeat), obs)
     logits = model.get_policy_output(obs_temp)
     policy_dist = action_dist(logits, model)
     actions, logp_ = policy_dist.sample_logp()
     logp = tf.expand_dims(logp_, -1)
-    return actions, tf.reshape(logp, [tf.shape(obs)[0], num_repeat, 1])
+    return actions, tf.reshape(logp, [batch_size, num_repeat, 1])
 
 
 def q_values_repeat(model, obs, actions, twin=False):
     action_shape = tf.shape(actions)[0]
-    obs_shape = tf.shape(obs)[0]
+    obs_shape = tf.shape(tree.flatten(obs)[0])[0]
     num_repeat = action_shape // obs_shape
-    obs_temp = tf.reshape(
-        tf.tile(tf.expand_dims(obs, 1), [1, num_repeat, 1]), [-1, tf.shape(obs)[1]]
-    )
+    obs_temp = tree.map_structure(lambda t: _repeat_tensor(t, num_repeat), obs)
     if not twin:
         preds_ = model.get_q_values(obs_temp, actions)
     else:
         preds_ = model.get_twin_q_values(obs_temp, actions)
-    preds = tf.reshape(preds_, [tf.shape(obs)[0], num_repeat, 1])
+    preds = tf.reshape(preds_, [obs_shape, num_repeat, 1])
     return preds
 
 

--- a/rllib/agents/cql/cql_torch_policy.py
+++ b/rllib/agents/cql/cql_torch_policy.py
@@ -44,8 +44,11 @@ MEAN_MAX = 9.0
 
 
 def _repeat_tensor(t, n):
+    # Insert new dimension at posotion 1 into tensor t
     t_rep = t.unsqueeze(1)
+    # Repeat tensor t_rep along new dimension n times
     t_rep = torch.repeat_interleave(t_rep, n, dim=1)
+    # Merge new dimension into batch dimension
     t_rep = t_rep.view(-1, *t.shape[1:])
     return t_rep
 
@@ -108,8 +111,6 @@ def cql_loss(
     next_obs = train_batch[SampleBatch.NEXT_OBS]
     terminals = train_batch[SampleBatch.DONES]
 
-    batch_size = tree.flatten(obs)[0].shape[0]
-
     model_out_t, _ = model(SampleBatch(obs=obs, _is_training=True), [], None)
 
     model_out_tp1, _ = model(SampleBatch(obs=next_obs, _is_training=True), [], None)
@@ -129,6 +130,7 @@ def cql_loss(
     # Alpha Loss
     alpha_loss = -(model.log_alpha * (log_pis_t + model.target_entropy).detach()).mean()
 
+    batch_size = tree.flatten(obs)[0].shape[0]
     if batch_size == policy.config["train_batch_size"]:
         policy.alpha_optim.zero_grad()
         alpha_loss.backward()

--- a/rllib/agents/cql/cql_torch_policy.py
+++ b/rllib/agents/cql/cql_torch_policy.py
@@ -43,7 +43,7 @@ MEAN_MIN = -9.0
 MEAN_MAX = 9.0
 
 
-def _repeat_tensor(t, n):
+def _repeat_tensor(t: torch.Tensor, n: int):
     # Insert new dimension at posotion 1 into tensor t
     t_rep = t.unsqueeze(1)
     # Repeat tensor t_rep along new dimension n times


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When training CQL with complex observations, i.e. structures consisting of `gym.spaces.Dict` or `gym.spaces.Tuple`, `CQLTrainer` throws an error during loss computation. This PR resolves the problem.

## Related issue number

Closes #23331

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
