### PR TITLE
Add a `get_if_exists` option for simpler creation of named actors

### DIFF
--- a/doc/source/ray-core/actors/named-actors.rst
+++ b/doc/source/ray-core/actors/named-actors.rst
@@ -125,10 +125,13 @@ exist. See :ref:`actor-lifetimes` for more details.
 Get-Or-Create a Named Actor
 ---------------------------
 
-A common use case is to create an actor only if it doesn't exist. You can achieve this
-with a combination of ``ray.get_actor()`` and falling back to creating it on error.
-Ray also provides a ``get_or_create()`` method that does this out of the box. This
-method is available after you set a name for the actor via ``.options()``.
+A common use case is to create an actor only if it doesn't exist.
+Ray provides a ``get_if_exists`` option for actor creation that does this out of the box.
+This method is available after you set a name for the actor via ``.options()``.
+
+If the actor already exists, a handle to the actor will be returned
+and the arguments will be ignored. Otherwise, a new actor will be
+created with the specified arguments.
 
 .. tabbed:: Python
 

--- a/doc/source/ray-core/actors/named-actors.rst
+++ b/doc/source/ray-core/actors/named-actors.rst
@@ -60,7 +60,8 @@ exist. See :ref:`actor-lifetimes` for more details.
 
 .. note::
 
-     Named actors are only accessible in the same namespace.
+     Named actors are scoped by namespace. If no namespace is assigned, they will
+     be placed in an anonymous namespace by default.
 
 .. tabbed:: Python
 
@@ -118,6 +119,30 @@ exist. See :ref:`actor-lifetimes` for more details.
         // This returns the "orange" actor we created in the first job.
         Optional<ActorHandle<Actor>> actor = Ray.getActor("orange");
         Assert.assertTrue(actor.isPresent());  // actor.isPresent() is true.
+
+Get-Or-Create a Named Actor
+---------------------------
+
+A common use case is to create an actor only if it doesn't exist. You can achieve this
+with a combination of ``ray.get_actor()`` and falling back to creating it on error.
+Ray also provides a ``get_or_create()`` method that does this out of the box. This
+method is available after you set a name for the actor via ``.options()``.
+
+.. tabbed:: Python
+
+    .. literalinclude:: ../doc_code/get_or_create.py
+
+.. tabbed:: Java
+
+    .. code-block:: java
+
+        // This feature is not yet available in Java.
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        // This feature is not yet available in C++.
 
 
 .. _actor-lifetimes:

--- a/doc/source/ray-core/actors/named-actors.rst
+++ b/doc/source/ray-core/actors/named-actors.rst
@@ -83,6 +83,8 @@ exist. See :ref:`actor-lifetimes` for more details.
         ray.init(address="auto", namespace="fruit")
         # This fails because "orange" was defined in the "colors" namespace.
         ray.get_actor("orange")
+        # You can also specify the namespace explicitly.
+        ray.get_actor("orange", namespace="colors")
 
         # driver_3.py
         # Job 3 connects to the original "colors" namespace

--- a/doc/source/ray-core/doc_code/get_or_create.py
+++ b/doc/source/ray-core/doc_code/get_or_create.py
@@ -11,9 +11,9 @@ class Greeter:
 
 
 # Actor `g1` doesn't yet exist, so it is created with the given args.
-a = Greeter.options(name="g1").get_or_create("Hi Alice")
-assert ray.get(a.say_hello.remote()) == "Hi Alice"
+a = Greeter.options(name="g1", get_if_exists=True).remote("Old Greeting")
+assert ray.get(a.say_hello.remote()) == "Old Greeting"
 
 # Actor `g1` already exists, so it is returned (new args are ignored).
-b = Greeter.options(name="g1").get_or_create("Hi Dave")
-assert ray.get(b.say_hello.remote()) == "Hi Alice"
+b = Greeter.options(name="g1", get_if_exists=True).remote("New Greeting")
+assert ray.get(b.say_hello.remote()) == "Old Greeting"

--- a/doc/source/ray-core/doc_code/get_or_create.py
+++ b/doc/source/ray-core/doc_code/get_or_create.py
@@ -14,6 +14,6 @@ class Greeter:
 a = Greeter.options(name="g1").get_or_create("Hi Alice")
 assert ray.get(a.say_hello.remote()) == "Hi Alice"
 
-# Actor `g1` already exists, so the given args ("Hi Alice",) are ignored.
+# Actor `g1` already exists, so the given args ("Hi Dave",) are ignored.
 b = Greeter.options(name="g1").get_or_create("Hi Dave")
 assert ray.get(b.say_hello.remote()) == "Hi Alice"

--- a/doc/source/ray-core/doc_code/get_or_create.py
+++ b/doc/source/ray-core/doc_code/get_or_create.py
@@ -1,5 +1,6 @@
 import ray
 
+
 @ray.remote
 class Counter:
     def __init__(self, value):

--- a/doc/source/ray-core/doc_code/get_or_create.py
+++ b/doc/source/ray-core/doc_code/get_or_create.py
@@ -1,0 +1,19 @@
+import ray
+
+@ray.remote
+class Counter:
+    def __init__(self, value):
+        self.value = value
+
+    def incr(self):
+        self.value += 1
+        return self.value
+
+
+# Actor doesn't yet exist, so it is created with the given args.
+a = Counter.options(name="foo").get_or_create(10)
+assert ray.get(a.incr.remote()) == 11
+
+# Actor already exists, so the given args (100,) are ignored.
+b = Counter.options(name="foo").get_or_create(100)
+assert ray.get(b.incr.remote()) == 12

--- a/doc/source/ray-core/doc_code/get_or_create.py
+++ b/doc/source/ray-core/doc_code/get_or_create.py
@@ -14,6 +14,6 @@ class Greeter:
 a = Greeter.options(name="g1").get_or_create("Hi Alice")
 assert ray.get(a.say_hello.remote()) == "Hi Alice"
 
-# Actor `g1` already exists, so the given args ("Hi Dave",) are ignored.
+# Actor `g1` already exists, so no new actor is created (new args are ignored).
 b = Greeter.options(name="g1").get_or_create("Hi Dave")
 assert ray.get(b.say_hello.remote()) == "Hi Alice"

--- a/doc/source/ray-core/doc_code/get_or_create.py
+++ b/doc/source/ray-core/doc_code/get_or_create.py
@@ -2,19 +2,18 @@ import ray
 
 
 @ray.remote
-class Counter:
+class Greeter:
     def __init__(self, value):
         self.value = value
 
-    def incr(self):
-        self.value += 1
+    def say_hello(self):
         return self.value
 
 
-# Actor doesn't yet exist, so it is created with the given args.
-a = Counter.options(name="foo").get_or_create(10)
-assert ray.get(a.incr.remote()) == 11
+# Actor `g1` doesn't yet exist, so it is created with the given args.
+a = Greeter.options(name="g1").get_or_create("Hi Alice")
+assert ray.get(a.say_hello.remote()) == "Hi Alice"
 
-# Actor already exists, so the given args (100,) are ignored.
-b = Counter.options(name="foo").get_or_create(100)
-assert ray.get(b.incr.remote()) == 12
+# Actor `g1` already exists, so the given args ("Hi Alice",) are ignored.
+b = Greeter.options(name="g1").get_or_create("Hi Dave")
+assert ray.get(b.say_hello.remote()) == "Hi Alice"

--- a/doc/source/ray-core/doc_code/get_or_create.py
+++ b/doc/source/ray-core/doc_code/get_or_create.py
@@ -14,6 +14,6 @@ class Greeter:
 a = Greeter.options(name="g1").get_or_create("Hi Alice")
 assert ray.get(a.say_hello.remote()) == "Hi Alice"
 
-# Actor `g1` already exists, so no new actor is created (new args are ignored).
+# Actor `g1` already exists, so it is returned (new args are ignored).
 b = Greeter.options(name="g1").get_or_create("Hi Dave")
 assert ray.get(b.say_hello.remote()) == "Hi Alice"

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -616,6 +616,13 @@ class ActorClass:
             def get_or_create(self, *args, **kwargs):
                 """Get or create a named actor.
 
+                The name of the actor must be set via `Actor.options(name="name")`
+                prior to calling this method.
+
+                If the actor already exists, a handle to the actor will be returned
+                and the arguments will be ignored. Otherwise, a new actor will be
+                created with the specified arguments.
+
                 Args:
                     args: These arguments are forwarded directly to the actor
                         constructor.
@@ -623,7 +630,7 @@ class ActorClass:
                         constructor.
 
                 Returns:
-                    A handle to the named actor.
+                    A handle to the new or existing named actor.
                 """
                 assert "name" in cls_options
                 name = cls_options["name"]

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -632,7 +632,10 @@ class ActorClass:
                 Returns:
                     A handle to the new or existing named actor.
                 """
-                assert "name" in cls_options
+                if not cls_options.get("name"):
+                    raise ValueError(
+                        "The actor name must be specified before use `get_or_create`."
+                    )
                 name = cls_options["name"]
                 try:
                     return ray.get_actor(name, namespace=cls_options.get("namespace"))

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -170,6 +170,7 @@ py_test_module_list(
     "test_environ.py",
     "test_raylet_output.py",
     "test_scheduling_performance.py",
+    "test_get_or_create_actor.py",
   ],
   size = "small",
   extra_srcs = SRCS,

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -67,7 +67,11 @@ print("DONE")
     out_str = proc.stdout.read().decode("ascii") + proc.stderr.read().decode("ascii")
     # Check there's no excessively verbose raylet error messages due to
     # actor creation races.
-    valid = "".join(x for x in out_str.split("\n") if "Ray dashboard" not in x)
+    out = []
+    for line in out_str.split("\n"):
+        if "Ray dashboard" not in line and "The object store" not in line:
+            out.append(line)
+    valid = "".join(out)
     assert valid.strip() == "DONE", out_str
 
 

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -20,14 +20,14 @@ def test_simple(shutdown_only):
             return os.getpid()
 
     for ns in [None, "test"]:
-        a = Actor.options(name="x", namespace=ns).get_or_create()
-        b = Actor.options(name="x", namespace=ns).get_or_create()
+        a = Actor.options(name="x", namespace=ns, get_if_exists=True).remote()
+        b = Actor.options(name="x", namespace=ns, get_if_exists=True).remote()
         assert ray.get(a.ping.remote()) == "ok"
         assert ray.get(b.ping.remote()) == "ok"
         assert ray.get(b.pid.remote()) == ray.get(a.pid.remote())
 
     with pytest.raises(ValueError):
-        Actor.options(num_cpus=1).get_or_create()
+        Actor.options(num_cpus=1, get_if_exists=True).remote()
 
 
 def test_no_verbose_output():
@@ -43,7 +43,7 @@ class Actor:
 @ray.remote
 def getter(name):
     actor = Actor.options(
-        name="foo", lifetime="detached", namespace="n").get_or_create()
+        name="foo", lifetime="detached", namespace="n", get_if_exists=True).remote()
     ray.get(actor.ping.remote())
 
 

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -42,7 +42,7 @@ class Actor:
 
 @ray.remote
 def getter(name):
-    actor = Actor.options(name="foo", lifetime="detached").get_or_create()
+    actor = Actor.options(name="foo", lifetime="detached", namespace="n").get_or_create()
     ray.get(actor.ping.remote())
 
 
@@ -51,7 +51,7 @@ def do_run(name):
     tasks = [getter.remote(name) for i in range(4)]
     ray.get(tasks)
     try:
-        ray.kill(ray.get_actor(name))  # Cleanup
+        ray.kill(ray.get_actor(name, namespace="n"))  # Cleanup
     except:
         pass
 

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -42,7 +42,8 @@ class Actor:
 
 @ray.remote
 def getter(name):
-    actor = Actor.options(name="foo", lifetime="detached", namespace="n").get_or_create()
+    actor = Actor.options(
+        name="foo", lifetime="detached", namespace="n").get_or_create()
     ray.get(actor.ping.remote())
 
 

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -1,0 +1,51 @@
+import sys
+import pytest
+
+from ray._private.test_utils import (
+    run_string_as_driver_nonblocking,
+)
+
+
+def test_get_or_create_actor():
+    script = """
+import ray
+
+@ray.remote
+class Actor:
+    def ping(self):
+        return "ok"
+
+
+@ray.remote
+def getter(name):
+    actor = Actor.options(
+        name="foo", lifetime="detached", namespace="test").get_or_create()
+    ray.get(actor.ping.remote())
+
+
+def do_run(name):
+    name = "actor_" + str(name)
+    tasks = [getter.remote(name) for i in range(4)]
+    ray.get(tasks)
+    try:
+        ray.kill(ray.get_actor(name, namespace="test"))  # Cleanup
+    except:
+        pass
+
+
+for i in range(100):
+    do_run(i)
+
+print("DONE")
+"""
+
+    proc = run_string_as_driver_nonblocking(script)
+    out_str = proc.stdout.read().decode("ascii") + proc.stderr.read().decode("ascii")
+    # Check there's no excessively verbose raylet error messages due to
+    # actor creation races.
+    valid = "".join(x for x in out_str.split("\n") if "Ray dashboard" not in x)
+    assert valid.strip() == "DONE", out_str
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -51,8 +51,8 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
               task_finisher_->CompletePendingTask(
                   task_id, push_task_reply, reply.actor_address());
             } else {
-              RAY_LOG(ERROR) << "Failed to create actor " << actor_id
-                             << " with status: " << status.ToString();
+              RAY_LOG(INFO) << "Failed to create actor " << actor_id
+                            << " with status: " << status.ToString();
               RAY_UNUSED(task_finisher_->FailOrRetryPendingTask(
                   task_id, rpc::ErrorType::ACTOR_CREATION_FAILED, &status));
             }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Getting or creating a named actor is a common pattern, however it is somewhat esoteric in how to achieve this. Add a utility function and test that it doesn't cause any scary error messages.

`Actor.options(name="my_singleton", get_if_exists=True).remote(args)`