### PR TITLE
[Datasets] Add basic data ecosystem overview, user guide links, other data processing options card.

### DIFF
--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -3,16 +3,32 @@
 .. _datasets:
 
 ==================================================
-Ray Datasets: Distributed Data Loading and Compute
+Ray Data: Data Processing on Ray
 ==================================================
 
+The Ray ecosystem offers several solutions for performant, large-scale data processing on Ray. :ref:`Ray Datasets<datasets-intro>` is Ray's first-class Ray-native offering, targeting large-scale data ingest
+for distributed training, scalable and resource-efficient batch inference, and performant last-mile preprocessing for both training and inference pipelines. Datasets is a great post-ETL data processing solution that strongly integrates with the rest of Ray's ML ecosystem.
+
+.. _datasets-intro:
+
+--------------------------------------------------
+Ray Datasets: Distributed Data Loading and Compute
+--------------------------------------------------
+
 Ray Datasets are the standard way to load and exchange data in Ray libraries and applications.
-They provide basic distributed data transformations such as ``map``, ``filter``, and ``repartition``,
+They provide basic distributed data transformations such as maps
+(:meth:`ds.map_batches() <ray.data.Dataset.map_batches>`),
+global and grouped aggregations (:class:`GroupedDataset <ray.data.GroupedDataset>`), and
+shuffling operations (:meth:`ds.random_shuffle() <ray.data.Dataset.random_shuffle>`,
+:meth:`ds.sort() <ray.data.Dataset.sort>`,
+:meth:`ds.repartition() <ray.data.Dataset.repartition>`),
 and are compatible with a variety of file formats, data sources, and distributed frameworks.
 
 Here's an overview of the integrations with other processing frameworks, file formats, and supported operations,
-as well as glimpse at the Ray Datasets API.
-Check our :ref:`compatibility matrix<data-compatibility>` to see if your favorite format is supported already.
+as well as a glimpse at the Ray Datasets API.
+
+Check our :ref:`compatibility matrix<data-compatibility>` to see if your favorite format
+is already supported.
 
 .. image:: images/dataset.svg
 
@@ -20,8 +36,9 @@ Check our :ref:`compatibility matrix<data-compatibility>` to see if your favorit
   https://docs.google.com/drawings/d/16AwJeBNR46_TsrkOmMbGaBK7u-OPsf_V8fHjU-d2PPQ/edit
 
 
-Ray Datasets simplifies general purpose parallel GPU and CPU compute in Ray; for instance, for `GPU batch inference <dataset.html#transforming-datasets>`__.
-It provides a higher level API for Ray tasks and actors in such embarrassingly parallel compute situations,
+Ray Datasets simplifies general purpose parallel GPU and CPU compute in Ray; for
+instance, for :ref:`GPU batch inference <transforming_datasets>`.
+It provides a higher-level API for Ray tasks and actors for such embarrassingly parallel compute,
 internally handling operations like batching, pipelining, and memory management.
 
 .. image:: images/dataset-compute-1.png
@@ -31,9 +48,8 @@ internally handling operations like batching, pipelining, and memory management.
 As part of the Ray ecosystem, Ray Datasets can leverage the full functionality of Ray's distributed scheduler,
 e.g., using actors for optimizing setup time and GPU scheduling.
 
-----------------------------------------------
 Data Loading and Preprocessing for ML Training
-----------------------------------------------
+==============================================
 
 Ray Datasets are designed to load and preprocess data for distributed :ref:`ML training pipelines <train-docs>`.
 Compared to other loading solutions, Datasets are more flexible (e.g., can express higher-quality `per-epoch global shuffles <examples/big_data_ingestion.html>`__) and provides `higher overall performance <https://www.anyscale.com/blog/why-third-generation-ml-platforms-are-more-performant>`__.
@@ -45,9 +61,10 @@ Ray Datasets is not intended as a replacement for more general data processing s
 Where to Go from Here?
 ----------------------
 
-As new user of Ray Datasets, you may want to start with our :ref:`Getting Started Guide<datasets_getting_started>`.
-If you've run your first examples already, you might want to dive into Ray Datasets' key concepts or our User Guide instead.
-Advanced users can utilize the Ray Datasets API reference for their projects.
+As new user of Ray Datasets, you may want to start with our :ref:`Getting Started guide<datasets_getting_started>`.
+If you've run your first examples already, you might want to dive into Ray Datasets'
+:ref:`key concepts <data_key_concepts>` or our :ref:`User Guide <data_user_guide>` instead.
+Advanced users can refer directly to the Ray Datasets :ref:`API reference <data_api>` for their projects.
 
 .. panels::
     :container: text-center
@@ -85,10 +102,11 @@ Advanced users can utilize the Ray Datasets API reference for their projects.
     User Guide
     ^^^
 
-    Learn how to :ref:`load and process data for ML<datasets-ml-preprocessing>`,
+    Learn how to :ref:`create datasets<creating_datasets>`, :ref:`save
+    datasets<saving_datasets>`, :ref:`transform datasets<transforming_datasets>`,
+    :ref:`access and exchange datasets<accessing_datasets>`, :ref:`pipeline
+    transformations<pipelining_datasets>`, :ref:`load and process data for ML<datasets-ml-preprocessing>`,
     work with :ref:`tensor data<datasets_tensor_support>`, or :ref:`use pipelines<data_pipeline_usage>`.
-    Run your first :ref:`Dask <dask-on-ray>`, :ref:`Spark <spark-on-ray>`, :ref:`Mars <mars-on-ray>`
-    and :ref:`Modin <modin-on-ray>` examples on Ray Datasets.
 
     +++
     .. link-button:: data_user_guide
@@ -107,6 +125,20 @@ Advanced users can utilize the Ray Datasets API reference for their projects.
         :type: ref
         :text: Read the API Reference
         :classes: btn-outline-info btn-block
+    ---
+
+    Other Data Processing Solutions
+    ^^^
+
+    For running ETL pipelines, check out :ref:`Spark-on-Ray <spark-on-ray>`. For scaling
+    up your data science workloads, check out :ref:`Dask-on-Ray <dask-on-ray>`,
+    :ref:`Modin <modin-on-ray>`, and :ref:`Mars-on-Ray <mars-on-ray>`.
+
+    +++
+    .. link-button:: integrations
+        :type: ref
+        :text: Check Out Other Data Processing Options
+        :classes: btn-outline-info btn-block
 
 
 .. _data-compatibility:
@@ -115,8 +147,13 @@ Advanced users can utilize the Ray Datasets API reference for their projects.
 Datasource Compatibility
 ------------------------
 
-Ray Datasets supports reading and writing many formats.
-The following two compatibility matrices will help you understand which formats are currently available.
+Ray Datasets supports reading and writing many file formats.
+The following compatibility matrices will help you understand which formats are currently available.
+
+If none of these meet your needs, please reach out on `Discourse <https://discuss.ray.io/>`__ or open a feature
+request on the `Ray GitHub repo <https://github.com/ray-project/ray>`__, and check out
+our :ref:`guide for implementing a custom Datasets datasource <datasets_custom_datasource>`
+if you're interested in rolling your own integration!
 
 Supported Input Formats
 =======================
@@ -261,7 +298,7 @@ There are many potential improvements, including:
 
 - Supporting more data sources and transforms.
 - Integration with more ecosystem libraries.
-- Adding features that require partitioning such as `groupby()` and `join()`.
+- Adding features such as `join()`.
 - Performance optimizations.
 
 .. include:: /_includes/data/announcement_bottom.rst

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -10,11 +10,11 @@ Ray Datasets: Distributed Data Loading and Compute
 
 Ray Datasets are the standard way to load and exchange data in Ray libraries and applications.
 They provide basic distributed data transformations such as maps
-(:meth:`ds.map_batches() <ray.data.Dataset.map_batches>`),
+(:meth:`map_batches <ray.data.Dataset.map_batches>`),
 global and grouped aggregations (:class:`GroupedDataset <ray.data.GroupedDataset>`), and
-shuffling operations (:meth:`ds.random_shuffle() <ray.data.Dataset.random_shuffle>`,
-:meth:`ds.sort() <ray.data.Dataset.sort>`,
-:meth:`ds.repartition() <ray.data.Dataset.repartition>`),
+shuffling operations (:meth:`random_shuffle <ray.data.Dataset.random_shuffle>`,
+:meth:`sort <ray.data.Dataset.sort>`,
+:meth:`repartition <ray.data.Dataset.repartition>`),
 and are compatible with a variety of file formats, data sources, and distributed frameworks.
 
 Here's an overview of the integrations with other processing frameworks, file formats, and supported operations,

--- a/doc/source/data/dataset.rst
+++ b/doc/source/data/dataset.rst
@@ -3,17 +3,10 @@
 .. _datasets:
 
 ==================================================
-Ray Data: Data Processing on Ray
+Ray Datasets: Distributed Data Loading and Compute
 ==================================================
 
-The Ray ecosystem offers several solutions for performant, large-scale data processing on Ray. :ref:`Ray Datasets<datasets-intro>` is Ray's first-class Ray-native offering, targeting large-scale data ingest
-for distributed training, scalable and resource-efficient batch inference, and performant last-mile preprocessing for both training and inference pipelines. Datasets is a great post-ETL data processing solution that strongly integrates with the rest of Ray's ML ecosystem.
-
 .. _datasets-intro:
-
---------------------------------------------------
-Ray Datasets: Distributed Data Loading and Compute
---------------------------------------------------
 
 Ray Datasets are the standard way to load and exchange data in Ray libraries and applications.
 They provide basic distributed data transformations such as maps


### PR DESCRIPTION
Tweaks the landing page for Datasets to give a (very brief) overview of the data ecosystem. Also includes misc. additions, e.g. to the new user guide pages.

Expanding the data ecosystem overview to include more content can be done in a future PR.

Closes #23089 