### PR TITLE
Remove unused /api/ray_config

### DIFF
--- a/dashboard/modules/reporter/reporter_head.py
+++ b/dashboard/modules/reporter/reporter_head.py
@@ -1,7 +1,5 @@
 import json
 import logging
-import yaml
-import os
 import aiohttp.web
 
 import ray
@@ -71,46 +69,6 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
         )
         return dashboard_optional_utils.rest_response(
             success=True, message="Profiling success.", profiling_info=profiling_info
-        )
-
-    @routes.get("/api/ray_config")
-    async def get_ray_config(self, req) -> aiohttp.web.Response:
-        if self._ray_config is None:
-            try:
-                config_path = os.path.expanduser("~/ray_bootstrap_config.yaml")
-                with open(config_path) as f:
-                    cfg = yaml.safe_load(f)
-            except yaml.YAMLError:
-                return dashboard_optional_utils.rest_response(
-                    success=False,
-                    message=f"No config found at {config_path}.",
-                )
-            except FileNotFoundError:
-                return dashboard_optional_utils.rest_response(
-                    success=False, message="Invalid config, could not load YAML."
-                )
-
-            payload = {
-                "min_workers": cfg.get("min_workers", "unspecified"),
-                "max_workers": cfg.get("max_workers", "unspecified"),
-            }
-
-            try:
-                payload["head_type"] = cfg["head_node"]["InstanceType"]
-            except KeyError:
-                payload["head_type"] = "unknown"
-
-            try:
-                payload["worker_type"] = cfg["worker_nodes"]["InstanceType"]
-            except KeyError:
-                payload["worker_type"] = "unknown"
-
-            self._ray_config = payload
-
-        return dashboard_optional_utils.rest_response(
-            success=True,
-            message="Fetched ray config.",
-            **self._ray_config,
         )
 
     @routes.get("/api/cluster_status")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removing the /api/ray_config dashboard endpoint. There are no callers of the endpoint and it no longer makes sense as we the new GCS autoscaler api means that there may not be an autoscaler config in the traditional sense.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
