### PR TITLE
[tune] Adjust release test timeouts

### DIFF
--- a/release/ray_release/alerts/tune_tests.py
+++ b/release/ray_release/alerts/tune_tests.py
@@ -38,13 +38,13 @@ def handle_result(
         target_time = 800
     elif test_name == "durable_trainable":
         target_terminated = 16
-        target_time = 600
+        target_time = 650
     elif test_name == "network_overhead":
         target_terminated = 100 if not was_smoke_test else 20
         target_time = 900 if not was_smoke_test else 400
     elif test_name == "result_throughput_cluster":
         target_terminated = 1000
-        target_time = 120
+        target_time = 130
     elif test_name == "result_throughput_single_node":
         target_terminated = 96
         target_time = 120

--- a/release/tune_tests/scalability_tests/workloads/test_durable_trainable.py
+++ b/release/tune_tests/scalability_tests/workloads/test_durable_trainable.py
@@ -65,7 +65,7 @@ def main(bucket):
     results_per_second = 10 / 60
     trial_length_s = 300
 
-    max_runtime = 500
+    max_runtime = 650
 
     timed_tune_run(
         name="durable trainable",

--- a/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
+++ b/release/tune_tests/scalability_tests/workloads/test_result_throughput_cluster.py
@@ -8,7 +8,7 @@ Cluster: cluster_16x64.yaml
 
 Test owner: krfricke
 
-Acceptance criteria: Should run faster than 120 seconds.
+Acceptance criteria: Should run faster than 130 seconds.
 
 Theoretical minimum time: 100 seconds
 """
@@ -31,11 +31,11 @@ def main():
     results_per_second = 0.5
     trial_length_s = 100
 
-    max_runtime = 120
+    max_runtime = 130
 
     if is_ray_cluster():
         # Add constant overhead for SSH connection
-        max_runtime = 120
+        max_runtime = 130
 
     timed_tune_run(
         name="result throughput cluster",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently release tests fail because they exceed the (rather arbitrary) timeout by 1-2 seconds.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
