### PR TITLE
[Java] Add per job runtime env env vars.

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
@@ -114,11 +114,9 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
                 .addAllCodeSearchPath(rayConfig.codeSearchPath)
                 .setRayNamespace(rayConfig.namespace);
         RuntimeEnvInfo.Builder runtimeEnvInfoBuilder = RuntimeEnvInfo.newBuilder();
-        if (!rayConfig.workerEnv.isEmpty()) {
-          // TODO(SongGuyang): Suppport complete runtime env interface for users.
-          // Set worker env to the serialized runtime env json.
+        if (rayConfig.runtimeEnvImpl != null && !rayConfig.runtimeEnvImpl.getEnvVars().isEmpty()) {
           RuntimeEnv.Builder runtimeEnvBuilder = RuntimeEnv.newBuilder();
-          runtimeEnvBuilder.putAllEnvVars(rayConfig.workerEnv);
+          runtimeEnvBuilder.putAllEnvVars(rayConfig.runtimeEnvImpl.getEnvVars());
           Printer printer = JsonFormat.printer();
           try {
             runtimeEnvInfoBuilder.setSerializedRuntimeEnv(printer.print(runtimeEnvBuilder));

--- a/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java
@@ -2,15 +2,12 @@ package io.ray.runtime.config;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
-import com.typesafe.config.ConfigValue;
 import io.ray.api.id.JobId;
 import io.ray.api.options.ActorLifetime;
-import io.ray.api.runtimeenv.RuntimeEnv;
 import io.ray.runtime.generated.Common.WorkerType;
 import io.ray.runtime.runtimeenv.RuntimeEnvImpl;
 import io.ray.runtime.util.NetworkUtil;
@@ -208,7 +205,12 @@ public class RayConfig {
       if (config.hasPath(envVarsPath)) {
         Map<String, String> envVars = new HashMap<>();
         Config envVarsConfig = config.getConfig(envVarsPath);
-        envVarsConfig.entrySet().forEach((entry) -> { envVars.put(entry.getKey(), ((String) entry.getValue().unwrapped())); });
+        envVarsConfig
+            .entrySet()
+            .forEach(
+                (entry) -> {
+                  envVars.put(entry.getKey(), ((String) entry.getValue().unwrapped()));
+                });
         runtimeEnvImpl = new RuntimeEnvImpl(envVars);
       }
     }

--- a/java/runtime/src/main/java/io/ray/runtime/runtimeenv/RuntimeEnvImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runtimeenv/RuntimeEnvImpl.java
@@ -15,6 +15,10 @@ public class RuntimeEnvImpl implements RuntimeEnv {
     this.envVars = envVars;
   }
 
+  public Map<String, String> getEnvVars() {
+    return envVars;
+  }
+
   @Override
   public String toJsonBytes() {
     // Get serializedRuntimeEnv

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -38,11 +38,6 @@ ray {
            // key1: "value11"
            // key2: "value22"
          }
-
-         "jars":[
-             // Job agent will download these jars, add them to the classpath.
-             "https://host/a.jar"
-         ]
     }
 
     /// The namespace of this job. It's used for isolation between jobs.

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -31,11 +31,20 @@ ray {
     num-java-workers-per-process: 1
     /// The jvm options for java workers of the job.
     jvm-options: []
-    // Environment variables to be set on worker processes.
-    worker-env {
-      // key1 : "value1"
-      // key2 : "value2"
+
+    runtime-env: {
+         // Environment variables to be set on worker processes in current job.
+         "env-vars": {
+           // key1: "value11"
+           // key2: "value22"
+         }
+
+         "jars":[
+             // Job agent will download these jars, add them to the classpath.
+             "https://host/a.jar"
+         ]
     }
+
     /// The namespace of this job. It's used for isolation between jobs.
     /// Jobs in different namespaces cannot access each other.
     /// If it's not specified, a randomized value will be used instead.

--- a/java/test/src/main/java/io/ray/test/JobConfigTest.java
+++ b/java/test/src/main/java/io/ray/test/JobConfigTest.java
@@ -15,16 +15,10 @@ public class JobConfigTest extends BaseTest {
     System.setProperty("ray.raylet.startup-token", "0");
     System.setProperty("ray.job.jvm-options.0", "-DX=999");
     System.setProperty("ray.job.jvm-options.1", "-DY=998");
-    System.setProperty("ray.job.worker-env.foo1", "bar1");
-    System.setProperty("ray.job.worker-env.foo2", "bar2");
   }
 
   public static String getJvmOptions(String propertyName) {
     return System.getProperty(propertyName);
-  }
-
-  public static String getEnvVariable(String key) {
-    return System.getenv(key);
   }
 
   public static class MyActor {
@@ -32,20 +26,11 @@ public class JobConfigTest extends BaseTest {
     public String getJvmOptions(String propertyName) {
       return System.getProperty(propertyName);
     }
-
-    public static String getEnvVariable(String key) {
-      return System.getenv(key);
-    }
   }
 
   public void testJvmOptions() {
     Assert.assertEquals("999", Ray.task(JobConfigTest::getJvmOptions, "X").remote().get());
     Assert.assertEquals("998", Ray.task(JobConfigTest::getJvmOptions, "Y").remote().get());
-  }
-
-  public void testWorkerEnvVariable() {
-    Assert.assertEquals("bar1", Ray.task(JobConfigTest::getEnvVariable, "foo1").remote().get());
-    Assert.assertEquals("bar2", Ray.task(JobConfigTest::getEnvVariable, "foo2").remote().get());
   }
 
   public void testNumJavaWorkersPerProcess() {
@@ -58,9 +43,5 @@ public class JobConfigTest extends BaseTest {
     // test jvm options.
     Assert.assertEquals("999", actor.task(MyActor::getJvmOptions, "X").remote().get());
     Assert.assertEquals("998", actor.task(MyActor::getJvmOptions, "Y").remote().get());
-
-    // test worker env variables
-    Assert.assertEquals("bar1", Ray.task(MyActor::getEnvVariable, "foo1").remote().get());
-    Assert.assertEquals("bar2", Ray.task(MyActor::getEnvVariable, "foo2").remote().get());
   }
 }

--- a/java/test/src/main/java/io/ray/test/RuntimeEnvTest.java
+++ b/java/test/src/main/java/io/ray/test/RuntimeEnvTest.java
@@ -5,7 +5,6 @@ import io.ray.api.Ray;
 import io.ray.api.runtimeenv.RuntimeEnv;
 import io.ray.runtime.util.SystemUtil;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "cluster")
@@ -29,11 +28,11 @@ public class RuntimeEnvTest {
 
     try {
       Ray.init();
-        ActorHandle<A> actor = Ray.actor(A::new).remote();
-        String val = actor.task(A::getEnv, "KEY1").remote().get();
-        Assert.assertEquals(val, "A");
-        val = actor.task(A::getEnv, "KEY2").remote().get();
-        Assert.assertEquals(val, "B");
+      ActorHandle<A> actor = Ray.actor(A::new).remote();
+      String val = actor.task(A::getEnv, "KEY1").remote().get();
+      Assert.assertEquals(val, "A");
+      val = actor.task(A::getEnv, "KEY2").remote().get();
+      Assert.assertEquals(val, "B");
     } finally {
       Ray.shutdown();
     }
@@ -48,11 +47,11 @@ public class RuntimeEnvTest {
       int pid2 = 0;
       {
         RuntimeEnv runtimeEnv =
-          new RuntimeEnv.Builder()
-            .addEnvVar("KEY1", "A")
-            .addEnvVar("KEY2", "B")
-            .addEnvVar("KEY1", "C")
-            .build();
+            new RuntimeEnv.Builder()
+                .addEnvVar("KEY1", "A")
+                .addEnvVar("KEY2", "B")
+                .addEnvVar("KEY1", "C")
+                .build();
 
         ActorHandle<A> actor1 = Ray.actor(A::new).setRuntimeEnv(runtimeEnv).remote();
         String val = actor1.task(A::getEnv, "KEY1").remote().get();
@@ -91,10 +90,7 @@ public class RuntimeEnvTest {
     try {
       Ray.init();
       {
-        RuntimeEnv runtimeEnv =
-          new RuntimeEnv.Builder()
-            .addEnvVar("KEY1", "C")
-            .build();
+        RuntimeEnv runtimeEnv = new RuntimeEnv.Builder().addEnvVar("KEY1", "C").build();
 
         ActorHandle<A> actor1 = Ray.actor(A::new).setRuntimeEnv(runtimeEnv).remote();
         String val = actor1.task(A::getEnv, "KEY1").remote().get();
@@ -122,5 +118,4 @@ public class RuntimeEnvTest {
       Ray.shutdown();
     }
   }
-
 }

--- a/java/test/src/main/java/io/ray/test/RuntimeEnvTest.java
+++ b/java/test/src/main/java/io/ray/test/RuntimeEnvTest.java
@@ -9,13 +9,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "cluster")
-public class RuntimeEnvTest extends BaseTest {
-
-  @BeforeClass
-  public void setUp() {
-    /// This is used to test that actors with runtime envs will not reuse worker process.
-    System.setProperty("ray.job.num-java-workers-per-process", "2");
-  }
+public class RuntimeEnvTest {
 
   private static class A {
 
@@ -28,38 +22,105 @@ public class RuntimeEnvTest extends BaseTest {
     }
   }
 
-  public void testEnvironmentVariable() {
+  public void testPerJobEnvVars() {
+    System.setProperty("ray.job.num-java-workers-per-process", "1");
+    System.setProperty("ray.job.runtime-env.env-vars.KEY1", "A");
+    System.setProperty("ray.job.runtime-env.env-vars.KEY2", "B");
+
+    try {
+      Ray.init();
+        ActorHandle<A> actor = Ray.actor(A::new).remote();
+        String val = actor.task(A::getEnv, "KEY1").remote().get();
+        Assert.assertEquals(val, "A");
+        val = actor.task(A::getEnv, "KEY2").remote().get();
+        Assert.assertEquals(val, "B");
+    } finally {
+      Ray.shutdown();
+    }
+  }
+
+  public void testPerActorEnvVars() {
+    /// This is used to test that actors with runtime envs will not reuse worker process.
+    System.setProperty("ray.job.num-java-workers-per-process", "2");
+    try {
+      Ray.init();
+      int pid1 = 0;
+      int pid2 = 0;
+      {
+        RuntimeEnv runtimeEnv =
+          new RuntimeEnv.Builder()
+            .addEnvVar("KEY1", "A")
+            .addEnvVar("KEY2", "B")
+            .addEnvVar("KEY1", "C")
+            .build();
+
+        ActorHandle<A> actor1 = Ray.actor(A::new).setRuntimeEnv(runtimeEnv).remote();
+        String val = actor1.task(A::getEnv, "KEY1").remote().get();
+        Assert.assertEquals(val, "C");
+        val = actor1.task(A::getEnv, "KEY2").remote().get();
+        Assert.assertEquals(val, "B");
+
+        pid1 = actor1.task(A::getPid).remote().get();
+      }
+
+      {
+        /// Because we didn't set them for actor2 , all should be null.
+        ActorHandle<A> actor2 = Ray.actor(A::new).remote();
+        String val = actor2.task(A::getEnv, "KEY1").remote().get();
+        Assert.assertNull(val);
+        val = actor2.task(A::getEnv, "KEY2").remote().get();
+        Assert.assertNull(val);
+        pid2 = actor2.task(A::getPid).remote().get();
+      }
+
+      // actor1 and actor2 shouldn't be in one process because they have
+      // different runtime env.
+      Assert.assertNotEquals(pid1, pid2);
+    } finally {
+      Ray.shutdown();
+    }
+  }
+
+  public void testPerActorEnvVarsOverwritePerJobEnvVars() {
+    System.setProperty("ray.job.num-java-workers-per-process", "2");
+    System.setProperty("ray.job.runtime-env.env-vars.KEY1", "A");
+    System.setProperty("ray.job.runtime-env.env-vars.KEY2", "B");
+
     int pid1 = 0;
     int pid2 = 0;
-    {
-      RuntimeEnv runtimeEnv =
+    try {
+      Ray.init();
+      {
+        RuntimeEnv runtimeEnv =
           new RuntimeEnv.Builder()
-              .addEnvVar("KEY1", "A")
-              .addEnvVar("KEY2", "B")
-              .addEnvVar("KEY1", "C")
-              .build();
+            .addEnvVar("KEY1", "C")
+            .build();
 
-      ActorHandle<A> actor1 = Ray.actor(A::new).setRuntimeEnv(runtimeEnv).remote();
-      String val = actor1.task(A::getEnv, "KEY1").remote().get();
-      Assert.assertEquals(val, "C");
-      val = actor1.task(A::getEnv, "KEY2").remote().get();
-      Assert.assertEquals(val, "B");
+        ActorHandle<A> actor1 = Ray.actor(A::new).setRuntimeEnv(runtimeEnv).remote();
+        String val = actor1.task(A::getEnv, "KEY1").remote().get();
+        Assert.assertEquals(val, "C");
+        val = actor1.task(A::getEnv, "KEY2").remote().get();
+        Assert.assertEquals(val, "B");
+        pid1 = actor1.task(A::getPid).remote().get();
+      }
 
-      pid1 = actor1.task(A::getPid).remote().get();
+      {
+        /// Because we didn't set them for actor2 explicitly, it should use the per job
+        /// runtime env.
+        ActorHandle<A> actor2 = Ray.actor(A::new).remote();
+        String val = actor2.task(A::getEnv, "KEY1").remote().get();
+        Assert.assertEquals(val, "A");
+        val = actor2.task(A::getEnv, "KEY2").remote().get();
+        Assert.assertEquals(val, "B");
+        pid2 = actor2.task(A::getPid).remote().get();
+      }
+
+      // actor1 and actor2 shouldn't be in one process because they have
+      // different runtime env.
+      Assert.assertNotEquals(pid1, pid2);
+    } finally {
+      Ray.shutdown();
     }
-
-    {
-      /// Because we didn't set them for actor2 , all should be null.
-      ActorHandle<A> actor2 = Ray.actor(A::new).remote();
-      String val = actor2.task(A::getEnv, "KEY1").remote().get();
-      Assert.assertNull(val);
-      val = actor2.task(A::getEnv, "KEY2").remote().get();
-      Assert.assertNull(val);
-      pid2 = actor2.task(A::getPid).remote().get();
-    }
-
-    // actor1 and actor2 shouldn't be in one process because they have
-    // different runtime env.
-    Assert.assertNotEquals(pid1, pid2);
   }
+
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. Support setting environment variables in runtime env for a job, like:
```yaml
ray : {
  job : {
    runtime-env: {
         // Environment variables to be set on worker processes in current job.
         "env-vars": {
           // key1: "value11"
           // key2: "value22"
         }
      }
   }
}
```
It could be set by system properties before `Ray.init()` as well:
```java
  System.setProperty("ray.job.runtime-env.env-vars.KEY1", "A");
  System.setProperty("ray.job.runtime-env.env-vars.KEY2", "B");

  Ray.init();
```

2. Setting environment variables for an actor will overwrite and merge to the environment variables of job.
```java
System.setProperty("ray.job.runtime-env.env-vars.KEY1", "A");
System.setProperty("ray.job.runtime-env.env-vars.KEY2", "B");

Ray.init();
  
RuntimeEnv runtimeEnv = new RuntimeEnv.Builder().addEnvVar("KEY1", "C").build();

/// actor1 has the env vars: {"KEY1" : "C", "KEY2" : "B"}
ActorHandle<A> actor1 = Ray.actor(A::new).setRuntimeEnv(runtimeEnv).remote();
/// actor2 has the env vars: {"KEY1" : "A", "KEY2" : "B"} 
ActorHandle<A> actor2 = Ray.actor(A::new).remote();
```



## Related issue number
#20425
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
