### PR TITLE
[tune] Fix docstrings according to code style guide

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -363,9 +363,8 @@ class ExperimentAnalysis:
         ``metric=None`` or ``mode=None``, the last result will be returned.
 
         Args:
-            metric (str): Key for trial info to order on.
-                If None, uses last result.
-            mode (None|str): One of [None, "min", "max"].
+            metric: Key for trial info to order on. If None, uses last result.
+            mode: One of [None, "min", "max"].
 
         Returns:
             pd.DataFrame: Constructed from a result dict of each trial.
@@ -396,8 +395,8 @@ class ExperimentAnalysis:
         """Gets paths and metrics of all persistent checkpoints of a trial.
 
         Args:
-            trial (Trial): The log directory of a trial, or a trial instance.
-            metric (str): key for trial info to return, e.g. "mean_accuracy".
+            trial: The log directory of a trial, or a trial instance.
+            metric: key for trial info to return, e.g. "mean_accuracy".
                 "training_iteration" is used by default if no value was
                 passed to ``self.default_metric``.
 
@@ -433,11 +432,11 @@ class ExperimentAnalysis:
         """Gets best persistent checkpoint path of provided trial.
 
         Args:
-            trial (Trial): The log directory of a trial, or a trial instance.
-            metric (str): key of trial info to return, e.g. "mean_accuracy".
+            trial: The log directory of a trial, or a trial instance.
+            metric: key of trial info to return, e.g. "mean_accuracy".
                 "training_iteration" is used by default if no value was
                 passed to ``self.default_metric``.
-            mode (str): One of [min, max]. Defaults to ``self.default_mode``.
+            mode: One of [min, max]. Defaults to ``self.default_mode``.
 
         Returns:
             :class:`Checkpoint <ray.ml.Checkpoint>` object.
@@ -479,7 +478,7 @@ class ExperimentAnalysis:
         """Returns a list of all configurations.
 
         Args:
-            prefix (bool): If True, flattens the config dict
+            prefix: If True, flattens the config dict
                 and prepends `config/`.
 
         Returns:
@@ -518,10 +517,10 @@ class ExperimentAnalysis:
         ``mode`` parameters to ``tune.run()``.
 
         Args:
-            metric (str): Key for trial info to order on. Defaults to
+            metric: Key for trial info to order on. Defaults to
                 ``self.default_metric``.
-            mode (str): One of [min, max]. Defaults to ``self.default_mode``.
-            scope (str): One of [all, last, avg, last-5-avg, last-10-avg].
+            mode: One of [min, max]. Defaults to ``self.default_mode``.
+            scope: One of [all, last, avg, last-5-avg, last-10-avg].
                 If `scope=last`, only look at each trial's final step for
                 `metric`, and compare across trials based on `mode=[min,max]`.
                 If `scope=avg`, consider the simple average over all steps
@@ -531,7 +530,7 @@ class ExperimentAnalysis:
                 `metric` and compare across trials based on `mode=[min,max]`.
                 If `scope=all`, find each trial's min/max score for `metric`
                 based on `mode`, and compare trials based on `mode=[min,max]`.
-            filter_nan_and_inf (bool): If True (default), NaN or infinite
+            filter_nan_and_inf: If True (default), NaN or infinite
                 values are disregarded and these trials are never selected as
                 the best trial.
         """
@@ -600,10 +599,10 @@ class ExperimentAnalysis:
         ``mode`` parameters to ``tune.run()``.
 
         Args:
-            metric (str): Key for trial info to order on. Defaults to
+            metric: Key for trial info to order on. Defaults to
                 ``self.default_metric``.
-            mode (str): One of [min, max]. Defaults to ``self.default_mode``.
-            scope (str): One of [all, last, avg, last-5-avg, last-10-avg].
+            mode: One of [min, max]. Defaults to ``self.default_mode``.
+            scope: One of [all, last, avg, last-5-avg, last-10-avg].
                 If `scope=last`, only look at each trial's final step for
                 `metric`, and compare across trials based on `mode=[min,max]`.
                 If `scope=avg`, consider the simple average over all steps
@@ -632,10 +631,10 @@ class ExperimentAnalysis:
         ``mode`` parameters to ``tune.run()``.
 
         Args:
-            metric (str): Key for trial info to order on. Defaults to
+            metric: Key for trial info to order on. Defaults to
                 ``self.default_metric``.
-            mode (str): One of [min, max]. Defaults to ``self.default_mode``.
-            scope (str): One of [all, last, avg, last-5-avg, last-10-avg].
+            mode: One of [min, max]. Defaults to ``self.default_mode``.
+            scope: One of [all, last, avg, last-5-avg, last-10-avg].
                 If `scope=last`, only look at each trial's final step for
                 `metric`, and compare across trials based on `mode=[min,max]`.
                 If `scope=avg`, consider the simple average over all steps
@@ -657,12 +656,12 @@ class ExperimentAnalysis:
         provided metric and mode (defaults to max. training iteration).
 
         Args:
-            trial (Trial): The log directory or an instance of a trial.
-            If None, load the latest trial automatically.
-            metric (str): If no trial is specified, use this metric to identify
-            the best trial and load the last checkpoint from this trial.
-            mode (str): If no trial is specified, use the metric and this mode
-            to identify the best trial and load the last checkpoint from it.
+            trial: The log directory or an instance of a trial.
+                If None, load the latest trial automatically.
+            metric: If no trial is specified, use this metric to identify
+                the best trial and load the last checkpoint from this trial.
+            mode: If no trial is specified, use the metric and this mode
+                to identify the best trial and load the last checkpoint from it.
 
         Returns:
             Path for last checkpoint of trial

--- a/python/ray/tune/callback.py
+++ b/python/ray/tune/callback.py
@@ -60,16 +60,16 @@ class Callback(ABC):
         variables, etc.)
 
         Arguments:
-            stop (dict | callable | :class:`Stopper`): Stopping criteria.
+            stop: Stopping criteria.
                 If ``time_budget_s`` was passed to ``tune.run``, a
                 ``TimeoutStopper`` will be passed here, either by itself
                 or as a part of a ``CombinedStopper``.
-            num_samples (int): Number of times to sample from the
+            num_samples: Number of times to sample from the
                 hyperparameter space. Defaults to 1. If `grid_search` is
                 provided as an argument, the grid will be repeated
                 `num_samples` of times. If this is -1, (virtually) infinite
                 samples are generated until a stopping condition is met.
-            total_num_samples (int): Total number of samples factoring
+            total_num_samples: Total number of samples factoring
                 in grid search samplers.
             **info: Kwargs dict for forward compatibility.
         """
@@ -79,8 +79,8 @@ class Callback(ABC):
         """Called at the start of each tuning loop step.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
             **info: Kwargs dict for forward compatibility.
         """
         pass
@@ -91,8 +91,8 @@ class Callback(ABC):
         The iteration counter is increased before this hook is called.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
             **info: Kwargs dict for forward compatibility.
         """
         pass
@@ -103,9 +103,9 @@ class Callback(ABC):
         """Called after starting a trial instance.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
-            trial (Trial): Trial that just has been started.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
+            trial: Trial that just has been started.
             **info: Kwargs dict for forward compatibility.
 
         """
@@ -117,9 +117,9 @@ class Callback(ABC):
         """Called after restoring a trial instance.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
-            trial (Trial): Trial that just has been restored.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
+            trial: Trial that just has been restored.
             **info: Kwargs dict for forward compatibility.
         """
         pass
@@ -130,9 +130,9 @@ class Callback(ABC):
         """Called after receiving a checkpoint from a trial.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
-            trial (Trial): Trial that just saved a checkpoint.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
+            trial: Trial that just saved a checkpoint.
             **info: Kwargs dict for forward compatibility.
         """
         pass
@@ -151,10 +151,10 @@ class Callback(ABC):
         hook is called.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
-            trial (Trial): Trial that just sent a result.
-            result (Dict): Result that the trial sent.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
+            trial: Trial that just sent a result.
+            result: Result that the trial sent.
             **info: Kwargs dict for forward compatibility.
         """
         pass
@@ -168,9 +168,9 @@ class Callback(ABC):
         hook is called.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
-            trial (Trial): Trial that just has been completed.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
+            trial: Trial that just has been completed.
             **info: Kwargs dict for forward compatibility.
         """
         pass
@@ -184,9 +184,9 @@ class Callback(ABC):
         hook is called.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
-            trial (Trial): Trial that just has errored.
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
+            trial: Trial that just has errored.
             **info: Kwargs dict for forward compatibility.
         """
         pass
@@ -202,10 +202,10 @@ class Callback(ABC):
         """Called after a trial saved a checkpoint with Tune.
 
         Arguments:
-            iteration (int): Number of iterations of the tuning loop.
-            trials (List[Trial]): List of trials.
-            trial (Trial): Trial that just has errored.
-            checkpoint (Checkpoint): Checkpoint object that has been saved
+            iteration: Number of iterations of the tuning loop.
+            trials: List of trials.
+            trial: Trial that just has errored.
+            checkpoint: Checkpoint object that has been saved
                 by the trial.
             **info: Kwargs dict for forward compatibility.
         """
@@ -215,7 +215,7 @@ class Callback(ABC):
         """Called after experiment is over and all trials have concluded.
 
         Arguments:
-            trials (List[Trial]): List of trials.
+            trials: List of trials.
             **info: Kwargs dict for forward compatibility.
         """
         pass

--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -2,6 +2,7 @@
 import heapq
 import gc
 import logging
+from typing import Any, Callable
 
 from ray.tune.utils.util import flatten_dict
 
@@ -14,8 +15,8 @@ class Checkpoint:
     Checkpoint may be saved in different storage.
 
     Attributes:
-        storage (str): Storage type.
-        value (str): If storage==MEMORY, it is a Python object.
+        storage: Storage type.
+        value: If storage==MEMORY, it is a Python object.
             If storage==PERSISTENT, it is a path to persistent storage,
             or a future that will be resolved to such a path.
     """
@@ -23,7 +24,7 @@ class Checkpoint:
     MEMORY = "memory"
     PERSISTENT = "persistent"
 
-    def __init__(self, storage, value, result=None):
+    def __init__(self, storage: str, value: Any, result=None):
         self.storage = storage
         self.value = value
         self.result = result or {}
@@ -68,17 +69,22 @@ class QueueItem:
 class CheckpointManager:
     """Manages checkpoints on the driver for a trial."""
 
-    def __init__(self, keep_checkpoints_num, checkpoint_score_attr, delete_fn):
+    def __init__(
+        self,
+        keep_checkpoints_num: int,
+        checkpoint_score_attr: str,
+        delete_fn: Callable[[str], None],
+    ):
         """Initializes a new CheckpointManager.
 
         `newest_persistent_checkpoint` and `newest_memory_checkpoint` are
         initialized to Checkpoint objects with values of None.
 
         Args:
-            keep_checkpoints_num (int): Keep at least this many checkpoints.
-            checkpoint_score_attr (str): Attribute to use to determine which
+            keep_checkpoints_num: Keep at least this many checkpoints.
+            checkpoint_score_attr: Attribute to use to determine which
                 checkpoints to keep.
-            delete_fn (function): Function that deletes checkpoints. Must be
+            delete_fn: Function that deletes checkpoints. Must be
                 idempotent.
         """
         self.keep_checkpoints_num = keep_checkpoints_num or float("inf")
@@ -118,7 +124,7 @@ class CheckpointManager:
         gc.collect()
         self._newest_memory_checkpoint = new_checkpoint
 
-    def on_checkpoint(self, checkpoint):
+    def on_checkpoint(self, checkpoint: Checkpoint):
         """Starts tracking checkpoint metadata on checkpoint.
 
         Checkpoints get assigned with an `order` as they come in.
@@ -129,7 +135,7 @@ class CheckpointManager:
         deletes the worst checkpoint if at capacity.
 
         Args:
-            checkpoint (Checkpoint): Trial state checkpoint.
+            checkpoint: Trial state checkpoint.
         """
         self._cur_order += 1
         checkpoint.order = self._cur_order

--- a/python/ray/tune/cloud.py
+++ b/python/ray/tune/cloud.py
@@ -95,11 +95,11 @@ class _TrialCheckpoint(os.PathLike):
         is unset, it will be set to ``local_path``.
 
         Args:
-            cloud_path (Optional[str]): Cloud path to load checkpoint from.
+            cloud_path: Cloud path to load checkpoint from.
                 Defaults to ``self.cloud_path``.
-            local_path (Optional[str]): Local path to save checkpoint at.
+            local_path: Local path to save checkpoint at.
                 Defaults to ``self.local_path``.
-            overwrite (bool): If True, overwrites potential existing local
+            overwrite: If True, overwrites potential existing local
                 checkpoint. If False, exits if ``self.local_dir`` already
                 exists and has files in it.
 
@@ -166,11 +166,11 @@ class _TrialCheckpoint(os.PathLike):
         is unset, it will be set to ``cloud_path``.
 
         Args:
-            cloud_path (Optional[str]): Cloud path to load checkpoint from.
+            cloud_path: Cloud path to load checkpoint from.
                 Defaults to ``self.cloud_path``.
-            local_path (Optional[str]): Local path to save checkpoint at.
+            local_path: Local path to save checkpoint at.
                 Defaults to ``self.local_path``.
-            clean_before (bool): If True, deletes potentially existing
+            clean_before: If True, deletes potentially existing
                 cloud bucket before storing new data.
 
         """
@@ -218,10 +218,10 @@ class _TrialCheckpoint(os.PathLike):
         That way checkpoints can be transferred across cloud storage providers.
 
         Args:
-            path (Optional[str]): Path to save checkpoint at. If empty,
+            path: Path to save checkpoint at. If empty,
                 the default cloud storage path is saved to the default
                 local directory.
-            force_download (bool): If ``True``, forces (re-)download of
+            force_download: If ``True``, forces (re-)download of
                 the checkpoint. Defaults to ``False``.
         """
         temp_dirs = set()

--- a/python/ray/tune/commands.py
+++ b/python/ray/tune/commands.py
@@ -1,3 +1,5 @@
+from typing import Optional, List
+
 import click
 import logging
 import operator
@@ -57,9 +59,9 @@ def print_format_output(dataframe):
     """Prints output of given dataframe to fit into terminal.
 
     Returns:
-        table (pd.DataFrame): Final outputted dataframe.
-        dropped_cols (list): Columns dropped due to terminal size.
-        empty_cols (list): Empty columns (dropped on default).
+        table: Final outputted dataframe.
+        dropped_cols: Columns dropped due to terminal size.
+        empty_cols: Empty columns (dropped on default).
     """
     print_df = pd.DataFrame()
     dropped_cols = []
@@ -92,26 +94,26 @@ def print_format_output(dataframe):
 
 
 def list_trials(
-    experiment_path,
-    sort=None,
-    output=None,
-    filter_op=None,
-    info_keys=None,
-    limit=None,
-    desc=False,
+    experiment_path: str,
+    sort: Optional[List[str]] = None,
+    output: Optional[str] = None,
+    filter_op: Optional[str] = None,
+    info_keys: Optional[List[str]] = None,
+    limit: int = None,
+    desc: bool = False,
 ):
     """Lists trials in the directory subtree starting at the given path.
 
     Args:
-        experiment_path (str): Directory where trials are located.
+        experiment_path: Directory where trials are located.
             Like Experiment.local_dir/Experiment.name/experiment*.json.
-        sort (list): Keys to sort by.
-        output (str): Name of file where output is saved.
-        filter_op (str): Filter operation in the format
+        sort: Keys to sort by.
+        output: Name of file where output is saved.
+        filter_op: Filter operation in the format
             "<column> <operator> <value>".
-        info_keys (list): Keys that are displayed.
-        limit (int): Number of rows to display.
-        desc (bool): Sort ascending vs. descending.
+        info_keys: Keys that are displayed.
+        limit: Number of rows to display.
+        desc: Sort ascending vs. descending.
     """
     _check_tabulate()
 
@@ -195,26 +197,26 @@ def list_trials(
 
 
 def list_experiments(
-    project_path,
-    sort=None,
-    output=None,
-    filter_op=None,
-    info_keys=None,
-    limit=None,
-    desc=False,
+    project_path: str,
+    sort: Optional[List[str]] = None,
+    output: str = None,
+    filter_op: str = None,
+    info_keys: Optional[List[str]] = None,
+    limit: int = None,
+    desc: bool = False,
 ):
     """Lists experiments in the directory subtree.
 
     Args:
-        project_path (str): Directory where experiments are located.
+        project_path: Directory where experiments are located.
             Corresponds to Experiment.local_dir.
-        sort (list): Keys to sort by.
-        output (str): Name of file where output is saved.
-        filter_op (str): Filter operation in the format
+        sort: Keys to sort by.
+        output: Name of file where output is saved.
+        filter_op: Filter operation in the format
             "<column> <operator> <value>".
-        info_keys (list): Keys that are displayed.
-        limit (int): Number of rows to display.
-        desc (bool): Sort ascending vs. descending.
+        info_keys: Keys that are displayed.
+        limit: Number of rows to display.
+        desc: Sort ascending vs. descending.
     """
     _check_tabulate()
     base, experiment_folders, _ = next(os.walk(project_path))
@@ -282,12 +284,12 @@ def list_experiments(
         click.secho("Output saved at {}".format(output), fg="green")
 
 
-def add_note(path, filename="note.txt"):
+def add_note(path: str, filename: str = "note.txt"):
     """Opens a txt file at the given path where user can add and save notes.
 
     Args:
-        path (str): Directory where note will be saved.
-        filename (str): Name of note. Defaults to "note.txt"
+        path: Directory where note will be saved.
+        filename: Name of note. Defaults to "note.txt"
     """
     path = os.path.expanduser(path)
     assert os.path.isdir(path), "{} is not a valid directory.".format(path)

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -169,16 +169,18 @@ def to_argv(config):
 _cached_pgf = {}
 
 
-def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
+def create_trial_from_spec(
+    spec: dict, output_path: str, parser: argparse.ArgumentParser, **trial_kwargs
+):
     """Creates a Trial object from parsing the spec.
 
     Args:
-        spec (dict): A resolved experiment specification. Arguments should
+        spec: A resolved experiment specification. Arguments should
             The args here should correspond to the command line flags
             in ray.tune.config_parser.
-        output_path (str); A specific output path within the local_dir.
+        output_path: A specific output path within the local_dir.
             Typically the name of the experiment.
-        parser (ArgumentParser): An argument parser object from
+        parser: An argument parser object from
             make_parser.
         trial_kwargs: Extra keyword arguments used in instantiating the Trial.
 

--- a/python/ray/tune/examples/xgboost_dynamic_resources_example.py
+++ b/python/ray/tune/examples/xgboost_dynamic_resources_example.py
@@ -176,12 +176,11 @@ def tune_xgboost(use_class_trainable=True):
         robust approach.
 
         Args:
-            trial_runner (TrialRunner): Trial runner for this Tune run.
+            trial_runner: Trial runner for this Tune run.
                 Can be used to obtain information about other trials.
-            trial (Trial): The trial to allocate new resources to.
-            result (Dict[str, Any]): The latest results of trial.
-            scheduler (ResourceChangingScheduler): The scheduler calling
-                the function.
+            trial: The trial to allocate new resources to.
+            result: The latest results of trial.
+            scheduler: The scheduler calling the function.
         """
 
         # Get base trial resources as defined in

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from pickle import PicklingError
 import traceback
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Union, Callable, Type, List
 
 from ray.tune.error import TuneError
 from ray.tune.registry import register_trainable
@@ -258,12 +258,12 @@ class Experiment:
         self.spec = spec
 
     @classmethod
-    def from_json(cls, name, spec):
+    def from_json(cls, name: str, spec: dict):
         """Generates an Experiment object from JSON.
 
         Args:
-            name (str): Name of Experiment.
-            spec (dict): JSON configuration of experiment.
+            name: Name of Experiment.
+            spec: JSON configuration of experiment.
         """
         if "run" not in spec:
             raise TuneError("No trainable specified!")
@@ -288,11 +288,11 @@ class Experiment:
         return exp
 
     @classmethod
-    def get_trainable_name(cls, run_object):
+    def get_trainable_name(cls, run_object: Union[str, Callable, Type]):
         """Get Trainable name.
 
         Args:
-            run_object (str|function|class): Trainable to run. If string,
+            run_object: Trainable to run. If string,
                 assumes it is an ID and does not modify it. Otherwise,
                 returns a string corresponding to the run_object name.
 
@@ -329,14 +329,14 @@ class Experiment:
             raise TuneError("Improper 'run' - not string nor trainable.")
 
     @classmethod
-    def register_if_needed(cls, run_object):
+    def register_if_needed(cls, run_object: Union[str, Callable, Type]):
         """Registers Trainable or Function at runtime.
 
         Assumes already registered if run_object is a string.
         Also, does not inspect interface of given run_object.
 
         Args:
-            run_object (str|function|class): Trainable to run. If string,
+            run_object: Trainable to run. If string,
                 assumes it is an ID and does not modify it. Otherwise,
                 returns a string corresponding to the run_object name.
 
@@ -363,15 +363,20 @@ class Experiment:
         return name
 
     @classmethod
-    def get_experiment_checkpoint_dir(cls, run_obj, local_dir=None, name=None):
+    def get_experiment_checkpoint_dir(
+        cls,
+        run_obj: Union[str, Callable, Type],
+        local_dir: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
         """Get experiment checkpoint dir without setting up an experiment.
 
         This is only used internally for better support of Tuner API.
 
         Args:
-            run_obj (str|function|class): Trainable to run.
-            name (str): The name of the experiment specified by user.
-            local_dir (str): The local_dir path.
+            run_obj: Trainable to run.
+            local_dir: The local_dir path.
+            name: The name of the experiment specified by user.
 
         Returns:
             Checkpoint directory for experiment.
@@ -416,7 +421,7 @@ class Experiment:
         return {k: v for k, v in self.spec.items() if k in self.PUBLIC_KEYS}
 
 
-def convert_to_experiment_list(experiments):
+def convert_to_experiment_list(experiments: Union[Experiment, List[Experiment], Dict]):
     """Produces a list of Experiment objects.
 
     Converts input from dict, single experiment, or list of
@@ -424,7 +429,7 @@ def convert_to_experiment_list(experiments):
     will return an empty list.
 
     Arguments:
-        experiments (Experiment | list | dict): Experiments to run.
+        experiments: Experiments to run.
 
     Returns:
         List of experiments.

--- a/python/ray/tune/integration/comet.py
+++ b/python/ray/tune/integration/comet.py
@@ -39,9 +39,9 @@ class CometLoggerCallback(LoggerCallback):
     ``CometLoggerCallback(api_key=<Your API Key>)``
 
     Args:
-            online (bool, optional): Whether to make use of an Online or
+            online: Whether to make use of an Online or
                 Offline Experiment. Defaults to True.
-            tags (List[str], optional): Tags to add to the logged Experiment.
+            tags: Tags to add to the logged Experiment.
                 Defaults to None.
             **experiment_kwargs: Other keyword arguments will be passed to the
                 constructor for comet_ml.Experiment (or OfflineExperiment if
@@ -126,7 +126,7 @@ class CometLoggerCallback(LoggerCallback):
         and start logging to Comet.
 
         Args:
-            trial:
+            trial: Trial object.
 
         """
         _import_comet()  # is this necessary?

--- a/python/ray/tune/integration/horovod.py
+++ b/python/ray/tune/integration/horovod.py
@@ -43,8 +43,8 @@ def distributed_checkpoint_dir(step: int, disable: bool = False):
     redundant work.
 
     Args:
-        step (int): Used to label the checkpoint
-        disable (bool): Disable for prototyping.
+        step: Used to label the checkpoint
+        disable: Disable for prototyping.
 
     Yields:
         str: A path to a directory. This path will be used
@@ -160,7 +160,7 @@ class _HorovodTrainable(DistributedTrainable):
 
 
 def DistributedTrainableCreator(
-    func: Callable,
+    func: Callable[[Dict], None],
     use_gpu: bool = False,
     num_hosts: Optional[int] = None,
     num_workers: int = 1,
@@ -196,20 +196,19 @@ def DistributedTrainableCreator(
     support function checkpointing.
 
     Args:
-        func (Callable[[dict], None]): A training function that takes in
+        func: A training function that takes in
             a config dict for hyperparameters and should initialize
             horovod via horovod.init.
-        use_gpu (bool); Whether to allocate a GPU per worker.
-        num_cpus_per_worker (int): Number of CPUs to request
+        use_gpu: Whether to allocate a GPU per worker.
+        num_cpus_per_worker: Number of CPUs to request
             from Ray per worker.
-        num_hosts (int): Number of hosts that each trial is expected
+        num_hosts: Number of hosts that each trial is expected
             to use.
-        num_workers (int): Number of workers to start on each host.
-        timeout_s (int): Seconds for Horovod rendezvous to timeout.
-        replicate_pem (bool): THIS MAY BE INSECURE. If true, this will
+        num_workers: Number of workers to start on each host.
+        timeout_s: Seconds for Horovod rendezvous to timeout.
+        replicate_pem: THIS MAY BE INSECURE. If true, this will
             replicate the underlying Ray cluster ssh key across all hosts.
             This may be useful if using the Ray Autoscaler.
-
 
     Returns:
         Trainable class that can be passed into `tune.run`.

--- a/python/ray/tune/integration/keras.py
+++ b/python/ray/tune/integration/keras.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 from tensorflow.keras.callbacks import Callback
 from ray import tune
@@ -116,13 +116,13 @@ class TuneReportCallback(TuneCallback):
     Reports metrics to Ray Tune.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to Keras,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to Keras. If this is None,
             all Keras logs will be reported.
-        on (str|list): When to trigger checkpoint creations. Must be one of
+        on: When to trigger checkpoint creations. Must be one of
             the Keras event hooks (less the ``on_``), e.g.
             "train_start", or "predict_end". Defaults to "epoch_end".
 
@@ -147,7 +147,7 @@ class TuneReportCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         on: Union[str, List[str]] = "epoch_end",
     ):
         super(TuneReportCallback, self).__init__(on)
@@ -179,13 +179,13 @@ class _TuneCheckpointCallback(TuneCallback):
     instead.
 
     Args:
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint".
-        frequency (int|list): Checkpoint frequency. If this is an integer `n`,
+        frequency: Checkpoint frequency. If this is an integer `n`,
             checkpoints are saved every `n` times each hook was called. If
             this is a list, it specifies the checkpoint frequencies for each
             hook individually.
-        on (str|list): When to trigger checkpoint creations. Must be one of
+        on: When to trigger checkpoint creations. Must be one of
             the Keras event hooks (less the ``on_``), e.g.
             "train_start", or "predict_end". Defaults to "epoch_end".
 
@@ -246,19 +246,19 @@ class TuneReportCheckpointCallback(TuneCallback):
     but doesn't register them with Ray Tune.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to Keras,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to Keras. If this is None,
             all Keras logs will be reported.
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint".
-        frequency (int|list): Checkpoint frequency. If this is an integer `n`,
+        frequency: Checkpoint frequency. If this is an integer `n`,
             checkpoints are saved every `n` times each hook was called. If
             this is a list, it specifies the checkpoint frequencies for each
             hook individually.
-        on (str|list): When to trigger checkpoint creations. Must be one of
+        on: When to trigger checkpoint creations. Must be one of
             the Keras event hooks (less the ``on_``), e.g.
             "train_start", or "predict_end". Defaults to "epoch_end".
 
@@ -287,7 +287,7 @@ class TuneReportCheckpointCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         filename: str = "checkpoint",
         frequency: Union[int, List[int]] = 1,
         on: Union[str, List[str]] = "epoch_end",

--- a/python/ray/tune/integration/kubernetes.py
+++ b/python/ray/tune/integration/kubernetes.py
@@ -20,11 +20,11 @@ def try_import_kubernetes():
 kubernetes = try_import_kubernetes()
 
 
-def NamespacedKubernetesSyncer(namespace):
+def NamespacedKubernetesSyncer(namespace: str):
     """Wrapper to return a ``KubernetesSyncer`` for a Kubernetes namespace.
 
     Args:
-        namespace (str): Kubernetes namespace.
+        namespace: Kubernetes namespace.
 
     Returns:
         A ``KubernetesSyncer`` class to be passed to ``tune.run()``.
@@ -110,7 +110,7 @@ class KubernetesSyncClient(SyncClient):
     KubernetesCommandRunner.
 
     Args:
-        namespace (str): Namespace in which the pods live.
+        namespace: Namespace in which the pods live.
         process_runner: How commands should be called.
             Defaults to ``subprocess``.
 

--- a/python/ray/tune/integration/lightgbm.py
+++ b/python/ray/tune/integration/lightgbm.py
@@ -18,14 +18,14 @@ class TuneReportCallback(TuneCallback):
     """Create a callback that reports metrics to Ray Tune.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to LightGBM,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to LightGBM. If this is None,
             all metrics will be reported to Tune under their default names as
             obtained from LightGBM.
-        results_postprocessing_fn (Callable): An optional Callable that takes in
+        results_postprocessing_fn: An optional Callable that takes in
             the dict that will be reported to Tune (after it has been flattened)
             and returns a modified dict that will be reported instead.
 
@@ -55,7 +55,7 @@ class TuneReportCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         results_postprocessing_fn: Optional[
             Callable[[Dict[str, Union[float, List[float]]]], Dict[str, float]]
         ] = None,
@@ -114,9 +114,9 @@ class _TuneCheckpointCallback(TuneCallback):
     instead.
 
     Args:
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint".
-        frequency (int): How often to save checkpoints. Per default, a
+        frequency: How often to save checkpoints. Per default, a
             checkpoint is saved every five iterations.
 
     """
@@ -147,18 +147,18 @@ class TuneReportCheckpointCallback(TuneCallback):
     which is needed for checkpoint registration.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to LightGBM,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to LightGBM.
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint". If this is None,
             all metrics will be reported to Tune under their default names as
             obtained from LightGBM.
-        frequency (int): How often to save checkpoints. Per default, a
+        frequency: How often to save checkpoints. Per default, a
             checkpoint is saved every five iterations.
-        results_postprocessing_fn (Callable): An optional Callable that takes in
+        results_postprocessing_fn: An optional Callable that takes in
             the dict that will be reported to Tune (after it has been flattened)
             and returns a modified dict that will be reported instead.
 

--- a/python/ray/tune/integration/mlflow.py
+++ b/python/ray/tune/integration/mlflow.py
@@ -21,20 +21,20 @@ class MLflowLoggerCallback(LoggerCallback):
     and artifacts) to MLflow for automatic experiment tracking.
 
     Args:
-        tracking_uri (str): The tracking URI for where to manage experiments
+        tracking_uri: The tracking URI for where to manage experiments
             and runs. This can either be a local file path or a remote server.
             This arg gets passed directly to mlflow
             initialization. When using Tune in a multi-node setting, make sure
             to set this to a remote server and not a local file path.
-        registry_uri (str): The registry URI that gets passed directly to
+        registry_uri: The registry URI that gets passed directly to
             mlflow initialization.
-        experiment_name (str): The experiment name to use for this Tune run.
+        experiment_name: The experiment name to use for this Tune run.
             If the experiment with the name already exists with MLflow,
             it will be reused. If not, a new experiment will be created with
             that name.
-        tags (Dict):  An optional dictionary of string keys and values to set
+        tags: An optional dictionary of string keys and values to set
             as tags on the run
-        save_artifact (bool): If set to True, automatically save the entire
+        save_artifact: If set to True, automatically save the entire
             contents of the Tune local_dir as an artifact to the
             corresponding run in MlFlow.
 

--- a/python/ray/tune/integration/mxnet.py
+++ b/python/ray/tune/integration/mxnet.py
@@ -23,7 +23,7 @@ class TuneReportCallback(TuneCallback):
     This has to be passed to MXNet as the ``eval_end_callback``.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to MXNet,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
@@ -80,9 +80,9 @@ class TuneCheckpointCallback(TuneCallback):
     ``TuneReportCallback`` to work!
 
     Args:
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint".
-        frequency (int): Integer indicating how often checkpoints should be
+        frequency: Integer indicating how often checkpoints should be
             saved.
 
     Example:

--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -173,12 +173,12 @@ class TuneReportCallback(TuneCallback):
     Reports metrics to Ray Tune.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to PyTorch Lightning,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to PyTorch Lightning.
-        on (str|list): When to trigger checkpoint creations. Must be one of
+        on: When to trigger checkpoint creations. Must be one of
             the PyTorch Lightning event hooks (less the ``on_``), e.g.
             "batch_start", or "train_end". Defaults to "validation_end".
 
@@ -249,9 +249,9 @@ class _TuneCheckpointCallback(TuneCallback):
     instead.
 
     Args:
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint".
-        on (str|list): When to trigger checkpoint creations. Must be one of
+        on: When to trigger checkpoint creations. Must be one of
             the PyTorch Lightning event hooks (less the ``on_``), e.g.
             "batch_start", or "train_end". Defaults to "validation_end".
 
@@ -279,14 +279,14 @@ class TuneReportCheckpointCallback(TuneCallback):
     which is needed for checkpoint registration.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to PyTorch Lightning,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to PyTorch Lightning.
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint".
-        on (str|list): When to trigger checkpoint creations. Must be one of
+        on: When to trigger checkpoint creations. Must be one of
             the PyTorch Lightning event hooks (less the ``on_``), e.g.
             "batch_start", or "train_end". Defaults to "validation_end".
 

--- a/python/ray/tune/integration/tensorflow.py
+++ b/python/ray/tune/integration/tensorflow.py
@@ -12,17 +12,17 @@ from ray.tune.utils import detect_checkpoint_function
 from ray.tune.utils.placement_groups import PlacementGroupFactory
 from ray.tune.utils.trainable import PlacementGroupUtil, TrainableUtil
 from ray.util.placement_group import remove_placement_group
-from typing import Callable, Dict, Type, Optional
+from typing import Callable, Dict, Type, Optional, List
 
 logger = logging.getLogger(__name__)
 
 
-def setup_process_group(worker_addresses, index):
+def setup_process_group(worker_addresses: List[str], index: int):
     """Set up distributed training info for training task.
 
     Args:
-        worker_addresses (list): addresses of the workers.
-        index (int): index of current worker
+        worker_addresses: addresses of the workers.
+        index: index of current worker
     """
     tf_config = {
         "cluster": {"worker": worker_addresses},
@@ -122,7 +122,7 @@ class _TensorFlowTrainable(DistributedTrainable):
 
 
 def DistributedTrainableCreator(
-    func: Callable,
+    func: Callable[[Dict], None],
     num_workers: int = 2,
     num_gpus_per_worker: int = 0,
     num_cpus_per_worker: int = 1,
@@ -140,18 +140,18 @@ def DistributedTrainableCreator(
     Note: there is no fault tolerance at the moment.
 
     Args:
-        func (Callable[[dict], None]): A training function that takes in
+        func: A training function that takes in
             a config dict for hyperparameters and should initialize
             horovod via horovod.init.
-        num_gpus_per_worker (int); Number of GPUs to request
+        num_gpus_per_worker: Number of GPUs to request
             from Ray per worker.
-        num_cpus_per_worker (int): Number of CPUs to request
+        num_cpus_per_worker: Number of CPUs to request
             from Ray per worker.
-        num_workers (int): Number of hosts that each trial is expected
+        num_workers: Number of hosts that each trial is expected
             to use.
-        num_workers_per_host (Optional[int]): Number of workers to
-            colocate per host. None if not specified.
-        timeout_s (float): Seconds before triggering placement timeouts
+        num_workers_per_host: Number of workers to colocate per host.
+            None if not specified.
+        timeout_s: Seconds before triggering placement timeouts
             if forcing colocation. Default to 15 minutes.
 
 

--- a/python/ray/tune/integration/torch.py
+++ b/python/ray/tune/integration/torch.py
@@ -5,7 +5,7 @@ import os
 import logging
 import shutil
 import tempfile
-from typing import Callable, Dict, Generator, Optional, Type
+from typing import Callable, Dict, Generator, Optional, Type, Any
 
 import torch
 from datetime import timedelta
@@ -149,7 +149,7 @@ class _TorchTrainable(DistributedTrainable):
 
 
 def DistributedTrainableCreator(
-    func: Callable,
+    func: Callable[[Dict, Optional[str]], Any],
     num_workers: int = 1,
     num_cpus_per_worker: int = 1,
     num_gpus_per_worker: int = 0,
@@ -166,20 +166,20 @@ def DistributedTrainableCreator(
     created.
 
     Args:
-        func (callable): This function is a Tune trainable function.
+        func: This function is a Tune trainable function.
             This function must have 2 args in the signature, and the
             latter arg must contain `checkpoint_dir`. For example:
             `func(config, checkpoint_dir=None)`.
-        num_workers (int): Number of training workers to include in
+        num_workers: Number of training workers to include in
             world.
-        num_cpus_per_worker (int): Number of CPU resources to reserve
+        num_cpus_per_worker: Number of CPU resources to reserve
             per training worker.
-        num_gpus_per_worker (int): Number of GPU resources to reserve
+        num_gpus_per_worker: Number of GPU resources to reserve
             per training worker.
         num_workers_per_host: Optional[int]: Number of workers to
             colocate per host.
-        backend (str): One of "gloo", "nccl".
-        timeout_s (float): Seconds before the torch process group
+        backend: One of "gloo", "nccl".
+        timeout_s: Seconds before the torch process group
             times out. Useful when machines are unreliable. Defaults
             to 1800 seconds. This value is also reused for triggering
             placement timeouts if forcing colocation.
@@ -241,8 +241,8 @@ def distributed_checkpoint_dir(
     redundant work.
 
     Args:
-        step (int): Used to label the checkpoint
-        disable (bool): Disable for prototyping.
+        step: Used to label the checkpoint
+        disable: Disable for prototyping.
 
     Yields:
         str: A path to a directory. This path will be used

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -242,16 +242,16 @@ class WandbLoggerCallback(LoggerCallback):
     visualization.
 
     Args:
-        project (str): Name of the Wandb project. Mandatory.
-        group (str): Name of the Wandb group. Defaults to the trainable
+        project: Name of the Wandb project. Mandatory.
+        group: Name of the Wandb group. Defaults to the trainable
             name.
-        api_key_file (str): Path to file containing the Wandb API KEY. This
+        api_key_file: Path to file containing the Wandb API KEY. This
             file only needs to be present on the node running the Tune script
             if using the WandbLogger.
-        api_key (str): Wandb API Key. Alternative to setting ``api_key_file``.
-        excludes (list): List of metrics that should be excluded from
+        api_key: Wandb API Key. Alternative to setting ``api_key_file``.
+        excludes: List of metrics that should be excluded from
             the log.
-        log_config (bool): Boolean indicating if the ``config`` parameter of
+        log_config: Boolean indicating if the ``config`` parameter of
             the ``results`` dict should be logged. This makes sense if
             parameters will change during training, e.g. with
             PopulationBasedTraining. Defaults to False.

--- a/python/ray/tune/integration/xgboost.py
+++ b/python/ray/tune/integration/xgboost.py
@@ -34,14 +34,14 @@ class TuneReportCallback(TuneCallback):
     Reports metrics to Ray Tune.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to XGBoost,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to XGBoost. If this is None,
             all metrics will be reported to Tune under their default names as
             obtained from XGBoost.
-        results_postprocessing_fn (Callable): An optional Callable that takes in
+        results_postprocessing_fn: An optional Callable that takes in
             the dict that will be reported to Tune (after it has been flattened)
             and returns a modified dict that will be reported instead. Can be used
             to eg. average results across CV fold when using ``xgboost.cv``.
@@ -121,9 +121,9 @@ class _TuneCheckpointCallback(TuneCallback):
     instead.
 
     Args:
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint".
-        frequency (int): How often to save checkpoints. Per default, a
+        frequency: How often to save checkpoints. Per default, a
             checkpoint is saved every five iterations.
 
     """
@@ -150,18 +150,18 @@ class TuneReportCheckpointCallback(TuneCallback):
     which is needed for checkpoint registration.
 
     Args:
-        metrics (str|list|dict): Metrics to report to Tune. If this is a list,
+        metrics: Metrics to report to Tune. If this is a list,
             each item describes the metric key reported to XGBoost,
             and it will reported under the same name to Tune. If this is a
             dict, each key will be the name reported to Tune and the respective
             value will be the metric key reported to XGBoost.
-        filename (str): Filename of the checkpoint within the checkpoint
+        filename: Filename of the checkpoint within the checkpoint
             directory. Defaults to "checkpoint". If this is None,
             all metrics will be reported to Tune under their default names as
             obtained from XGBoost.
-        frequency (int): How often to save checkpoints. Per default, a
+        frequency: How often to save checkpoints. Per default, a
             checkpoint is saved every five iterations.
-        results_postprocessing_fn (Callable): An optional Callable that takes in
+        results_postprocessing_fn: An optional Callable that takes in
             the dict that will be reported to Tune (after it has been flattened)
             and returns a modified dict that will be reported instead. Can be used
             to eg. average results across CV fold when using ``xgboost.cv``.

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -43,7 +43,7 @@ class Logger:
     Arguments:
         config: Configuration passed to all logger creators.
         logdir: Directory for all logger creators to log to.
-        trial (Trial): Trial object for the logger to access.
+        trial: Trial object for the logger to access.
     """
 
     def __init__(self, config: Dict, logdir: str, trial: Optional["Trial"] = None):
@@ -292,7 +292,7 @@ class UnifiedLogger(Logger):
     Arguments:
         config: Configuration passed to all logger creators.
         logdir: Directory for all logger creators to log to.
-        loggers (list): List of logger creators. Defaults to CSV, Tensorboard,
+        loggers: List of logger creators. Defaults to CSV, Tensorboard,
             and JSON loggers.
     """
 
@@ -361,7 +361,7 @@ class LoggerCallback(Callback):
         """Handle logging when a trial starts.
 
         Args:
-            trial (Trial): Trial object.
+            trial: Trial object.
         """
         pass
 
@@ -369,7 +369,7 @@ class LoggerCallback(Callback):
         """Handle logging when a trial restores.
 
         Args:
-            trial (Trial): Trial object.
+            trial: Trial object.
         """
         pass
 
@@ -377,7 +377,7 @@ class LoggerCallback(Callback):
         """Handle logging when a trial saves a checkpoint.
 
         Args:
-            trial (Trial): Trial object.
+            trial: Trial object.
         """
         pass
 
@@ -385,8 +385,8 @@ class LoggerCallback(Callback):
         """Handle logging when a trial reports a result.
 
         Args:
-            trial (Trial): Trial object.
-            result (dict): Result dictionary.
+            trial: Trial object.
+            result: Result dictionary.
         """
         pass
 
@@ -394,8 +394,8 @@ class LoggerCallback(Callback):
         """Handle logging when a trial ends.
 
         Args:
-            trial (Trial): Trial object.
-            failed (bool): True if the Trial finished gracefully, False if
+            trial: Trial object.
+            failed: True if the Trial finished gracefully, False if
                 it failed (e.g. when it raised an exception).
         """
         pass
@@ -445,7 +445,7 @@ class LegacyLoggerCallback(LoggerCallback):
     and logging to them.
 
     Args:
-        logger_classes (Iterable[Type[Logger]]): Logger classes that should
+        logger_classes: Logger classes that should
             be instantiated for each trial.
 
     """

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -64,8 +64,8 @@ class ProgressReporter:
         """Returns whether or not progress should be reported.
 
         Args:
-            trials (list[Trial]): Trials to report on.
-            done (bool): Whether this is the last progress report attempt.
+            trials: Trials to report on.
+            done: Whether this is the last progress report attempt.
         """
         raise NotImplementedError
 
@@ -73,8 +73,8 @@ class ProgressReporter:
         """Reports progress across trials.
 
         Args:
-            trials (list[Trial]): Trials to report on.
-            done (bool): Whether this is the last progress report attempt.
+            trials: Trials to report on.
+            done: Whether this is the last progress report attempt.
             sys_info: System info.
         """
         raise NotImplementedError
@@ -95,35 +95,35 @@ class TuneReporterBase(ProgressReporter):
     metrics.
 
     Args:
-        metric_columns (dict[str, str]|list[str]): Names of metrics to
+        metric_columns: Names of metrics to
             include in progress table. If this is a dict, the keys should
             be metric names and the values should be the displayed names.
             If this is a list, the metric name is used directly.
-        parameter_columns (dict[str, str]|list[str]): Names of parameters to
+        parameter_columns: Names of parameters to
             include in progress table. If this is a dict, the keys should
             be parameter names and the values should be the displayed names.
             If this is a list, the parameter name is used directly. If empty,
             defaults to all available parameters.
-        max_progress_rows (int): Maximum number of rows to print
+        max_progress_rows: Maximum number of rows to print
             in the progress table. The progress table describes the
             progress of each trial. Defaults to 20.
-        max_error_rows (int): Maximum number of rows to print in the
+        max_error_rows: Maximum number of rows to print in the
             error table. The error table lists the error file, if any,
             corresponding to each trial. Defaults to 20.
-        max_report_frequency (int): Maximum report frequency in seconds.
+        max_report_frequency: Maximum report frequency in seconds.
             Defaults to 5s.
-        infer_limit (int): Maximum number of metrics to automatically infer
+        infer_limit: Maximum number of metrics to automatically infer
             from tune results.
-        print_intermediate_tables (bool|None): Print intermediate result
+        print_intermediate_tables: Print intermediate result
             tables. If None (default), will be set to True for verbosity
             levels above 3, otherwise False. If True, intermediate tables
             will be printed with experiment progress. If False, tables
             will only be printed at then end of the tuning run for verbosity
             levels greater than 2.
-        metric (str): Metric used to determine best current trial.
-        mode (str): One of [min, max]. Determines whether objective is
+        metric: Metric used to determine best current trial.
+        mode: One of [min, max]. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        sort_by_metric (bool): Sort terminated trials by metric in the
+        sort_by_metric: Sort terminated trials by metric in the
             intermediate table. Defaults to False.
     """
 
@@ -225,9 +225,9 @@ class TuneReporterBase(ProgressReporter):
         """Adds a metric to the existing columns.
 
         Args:
-            metric (str): Metric to add. This must be a metric being returned
+            metric: Metric to add. This must be a metric being returned
                 in training step results.
-            representation (str): Representation to use in table. Defaults to
+            representation: Representation to use in table. Defaults to
                 `metric`.
         """
         self._metrics_override = True
@@ -252,9 +252,9 @@ class TuneReporterBase(ProgressReporter):
         """Adds a parameter to the existing columns.
 
         Args:
-            parameter (str): Parameter to add. This must be a parameter
+            parameter: Parameter to add. This must be a parameter
                 specified in the configuration.
-            representation (str): Representation to use in table. Defaults to
+            representation: Representation to use in table. Defaults to
                 `parameter`.
         """
         if parameter in self._parameter_columns:
@@ -288,10 +288,10 @@ class TuneReporterBase(ProgressReporter):
         exists if errors have occurred.
 
         Args:
-            trials (list[Trial]): Trials to report on.
-            done (bool): Whether this is the last progress report attempt.
-            fmt (str): Table format. See `tablefmt` in tabulate API.
-            delim (str): Delimiter between messages.
+            trials: Trials to report on.
+            done: Whether this is the last progress report attempt.
+            fmt: Table format. See `tablefmt` in tabulate API.
+            delim: Delimiter between messages.
         """
         if not self._metrics_override:
             user_metrics = self._infer_user_metrics(trials, self._infer_limit)
@@ -387,36 +387,36 @@ class JupyterNotebookReporter(TuneReporterBase):
     """Jupyter notebook-friendly Reporter that can update display in-place.
 
     Args:
-        overwrite (bool): Flag for overwriting the last reported progress.
-        metric_columns (dict[str, str]|list[str]): Names of metrics to
+        overwrite: Flag for overwriting the last reported progress.
+        metric_columns: Names of metrics to
             include in progress table. If this is a dict, the keys should
             be metric names and the values should be the displayed names.
             If this is a list, the metric name is used directly.
-        parameter_columns (dict[str, str]|list[str]): Names of parameters to
+        parameter_columns: Names of parameters to
             include in progress table. If this is a dict, the keys should
             be parameter names and the values should be the displayed names.
             If this is a list, the parameter name is used directly. If empty,
             defaults to all available parameters.
-        max_progress_rows (int): Maximum number of rows to print
+        max_progress_rows: Maximum number of rows to print
             in the progress table. The progress table describes the
             progress of each trial. Defaults to 20.
-        max_error_rows (int): Maximum number of rows to print in the
+        max_error_rows: Maximum number of rows to print in the
             error table. The error table lists the error file, if any,
             corresponding to each trial. Defaults to 20.
-        max_report_frequency (int): Maximum report frequency in seconds.
+        max_report_frequency: Maximum report frequency in seconds.
             Defaults to 5s.
-        infer_limit (int): Maximum number of metrics to automatically infer
+        infer_limit: Maximum number of metrics to automatically infer
             from tune results.
-        print_intermediate_tables (bool|None): Print intermediate result
+        print_intermediate_tables: Print intermediate result
             tables. If None (default), will be set to True for verbosity
             levels above 3, otherwise False. If True, intermediate tables
             will be printed with experiment progress. If False, tables
             will only be printed at then end of the tuning run for verbosity
             levels greater than 2.
-        metric (str): Metric used to determine best current trial.
-        mode (str): One of [min, max]. Determines whether objective is
+        metric: Metric used to determine best current trial.
+        mode: One of [min, max]. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        sort_by_metric (bool): Sort terminated trials by metric in the
+        sort_by_metric: Sort terminated trials by metric in the
             intermediate table. Defaults to False.
     """
 
@@ -494,35 +494,35 @@ class CLIReporter(TuneReporterBase):
     """Command-line reporter
 
     Args:
-        metric_columns (dict[str, str]|list[str]): Names of metrics to
+        metric_columns: Names of metrics to
             include in progress table. If this is a dict, the keys should
             be metric names and the values should be the displayed names.
             If this is a list, the metric name is used directly.
-        parameter_columns (dict[str, str]|list[str]): Names of parameters to
+        parameter_columns: Names of parameters to
             include in progress table. If this is a dict, the keys should
             be parameter names and the values should be the displayed names.
             If this is a list, the parameter name is used directly. If empty,
             defaults to all available parameters.
-        max_progress_rows (int): Maximum number of rows to print
+        max_progress_rows: Maximum number of rows to print
             in the progress table. The progress table describes the
             progress of each trial. Defaults to 20.
-        max_error_rows (int): Maximum number of rows to print in the
+        max_error_rows: Maximum number of rows to print in the
             error table. The error table lists the error file, if any,
             corresponding to each trial. Defaults to 20.
-        max_report_frequency (int): Maximum report frequency in seconds.
+        max_report_frequency: Maximum report frequency in seconds.
             Defaults to 5s.
-        infer_limit (int): Maximum number of metrics to automatically infer
+        infer_limit: Maximum number of metrics to automatically infer
             from tune results.
-        print_intermediate_tables (bool|None): Print intermediate result
+        print_intermediate_tables: Print intermediate result
             tables. If None (default), will be set to True for verbosity
             levels above 3, otherwise False. If True, intermediate tables
             will be printed with experiment progress. If False, tables
             will only be printed at then end of the tuning run for verbosity
             levels greater than 2.
-        metric (str): Metric used to determine best current trial.
-        mode (str): One of [min, max]. Determines whether objective is
+        metric: Metric used to determine best current trial.
+        mode: One of [min, max]. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        sort_by_metric (bool): Sort terminated trials by metric in the
+        sort_by_metric: Sort terminated trials by metric in the
             intermediate table. Defaults to False.
     """
 
@@ -639,28 +639,28 @@ def trial_progress_str(
     and the current values of its metrics.
 
     Args:
-        trials (list[Trial]): List of trials to get progress string for.
-        metric_columns (dict[str, str]|list[str]): Names of metrics to include.
+        trials: List of trials to get progress string for.
+        metric_columns: Names of metrics to include.
             If this is a dict, the keys are metric names and the values are
             the names to use in the message. If this is a list, the metric
             name is used in the message directly.
-        parameter_columns (dict[str, str]|list[str]): Names of parameters to
+        parameter_columns: Names of parameters to
             include. If this is a dict, the keys are parameter names and the
             values are the names to use in the message. If this is a list,
             the parameter name is used in the message directly. If this is
             empty, all parameters are used in the message.
-        total_samples (int): Total number of trials that will be generated.
-        force_table (bool): Force printing a table. If False, a table will
+        total_samples: Total number of trials that will be generated.
+        force_table: Force printing a table. If False, a table will
             be printed only at the end of the training for verbosity levels
             above `Verbosity.V2_TRIAL_NORM`.
-        fmt (str): Output format (see tablefmt in tabulate API).
-        max_rows (int): Maximum number of rows in the trial table. Defaults to
+        fmt: Output format (see tablefmt in tabulate API).
+        max_rows: Maximum number of rows in the trial table. Defaults to
             unlimited.
-        done (bool): True indicates that the tuning run finished.
-        metric (str): Metric used to sort trials.
-        mode (str): One of [min, max]. Determines whether objective is
+        done: True indicates that the tuning run finished.
+        metric: Metric used to sort trials.
+        mode: One of [min, max]. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        sort_by_metric (bool): Sort terminated trials by metric in the
+        sort_by_metric: Sort terminated trials by metric in the
             intermediate table. Defaults to False.
     """
     messages = []
@@ -818,9 +818,9 @@ def trial_errors_str(
     """Returns a readable message regarding trial errors.
 
     Args:
-        trials (list[Trial]): List of trials to get progress string for.
-        fmt (str): Output format (see tablefmt in tabulate API).
-        max_rows (int): Maximum number of rows in the error table. Defaults to
+        trials: List of trials to get progress string for.
+        fmt: Output format (see tablefmt in tabulate API).
+        max_rows: Maximum number of rows in the error table. Defaults to
             unlimited.
     """
     messages = []
@@ -874,8 +874,7 @@ def _fair_filter_trials(
     The oldest trials are truncated if necessary.
 
     Args:
-        trials_by_state (dict[str, list[Trial]]: Trials by state.
-        max_trials (int): Maximum number of trials to return.
+        trials_by_state: Maximum number of trials to return.
     Returns:
         Dict mapping state to List of fairly represented trials.
     """
@@ -924,9 +923,9 @@ def _get_trial_info(trial: Trial, parameters: List[str], metrics: List[str]):
     name | status | loc | params... | metrics...
 
     Args:
-        trial (Trial): Trial to get information for.
-        parameters (list[str]): Names of trial parameters to include.
-        metrics (list[str]): Names of metrics to include.
+        trial: Trial to get information for.
+        parameters: Names of trial parameters to include.
+        metrics: Names of metrics to include.
     """
     result = trial.last_result
     config = trial.config

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -399,11 +399,11 @@ class RayTrialExecutor(TrialExecutor):
         trial_item = self._find_future(trial)
         assert len(trial_item) < 2, trial_item
 
-    def _start_trial(self, trial) -> bool:
+    def _start_trial(self, trial: Trial) -> bool:
         """Starts trial and restores last result if trial was paused.
 
         Args:
-            trial (Trial): The trial to start.
+            trial: The trial to start.
 
         Returns:
             True if trial was started successfully, False otherwise.
@@ -433,8 +433,8 @@ class RayTrialExecutor(TrialExecutor):
         exception will be thrown.
 
         Args:
-            error (bool): Whether to mark this trial as terminated in error.
-            error_msg (str): Optional error message.
+            error: Whether to mark this trial as terminated in error.
+            error_msg: Optional error message.
 
         """
         self.set_status(trial, Trial.ERROR if error else Trial.TERMINATED)
@@ -498,7 +498,7 @@ class RayTrialExecutor(TrialExecutor):
         Will not return resources if trial repeatedly fails on start.
 
         Args:
-            trial (Trial): Trial to be started.
+            trial: Trial to be started.
 
         Returns:
             True if the remote runner has been started. False if trial was
@@ -553,11 +553,11 @@ class RayTrialExecutor(TrialExecutor):
         """Tries to invoke `Trainable.reset()` to reset trial.
 
         Args:
-            trial (Trial): Trial to be reset.
-            new_config (dict): New configuration for Trial trainable.
-            new_experiment_tag (str): New experiment name for trial.
-            logger_creator (Optional[Callable[[Dict], Logger]]): Function
-                that instantiates a logger on the actor process.
+            trial: Trial to be reset.
+            new_config: New configuration for Trial trainable.
+            new_experiment_tag: New experiment name for trial.
+            logger_creator: Function that instantiates a logger on the
+                actor process.
 
         Returns:
             True if `reset_config` is successful else False.
@@ -645,15 +645,18 @@ class RayTrialExecutor(TrialExecutor):
         self.last_pg_recon = -float("inf")
 
     def save(
-        self, trial, storage=Checkpoint.PERSISTENT, result: Optional[Dict] = None
+        self,
+        trial: Trial,
+        storage: str = Checkpoint.PERSISTENT,
+        result: Optional[Dict] = None,
     ) -> Checkpoint:
         """Saves the trial's state to a checkpoint asynchronously.
 
         Args:
-            trial (Trial): The trial to be saved.
-            storage (str): Where to store the checkpoint. Defaults to
+            trial: The trial to be saved.
+            storage: Where to store the checkpoint. Defaults to
                 PERSISTENT.
-            result (dict): The state of this trial as a dictionary to be saved.
+            result: The state of this trial as a dictionary to be saved.
                 If result is None, the trial's last result will be used.
 
         Returns:
@@ -673,11 +676,11 @@ class RayTrialExecutor(TrialExecutor):
                 self._futures[value] = (ExecutorEventType.SAVING_RESULT, trial)
         return checkpoint
 
-    def restore(self, trial) -> None:
+    def restore(self, trial: Trial) -> None:
         """Restores training state from a given model checkpoint.
 
         Args:
-            trial (Trial): The trial to be restored.
+            trial: The trial to be restored.
 
         Raises:
             RuntimeError: This error is raised if no runner is found.

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -3,7 +3,7 @@ import uuid
 from functools import partial
 
 from types import FunctionType
-from typing import Optional
+from typing import Optional, Type, Union
 
 import ray
 import ray.cloudpickle as pickle
@@ -54,15 +54,15 @@ def validate_trainable(trainable_name):
             raise TuneError("Unknown trainable: " + trainable_name)
 
 
-def register_trainable(name, trainable, warn=True):
+def register_trainable(name: str, trainable: Union[Callable, Type], warn: bool = True):
     """Register a trainable function or class.
 
     This enables a class or function to be accessed on every Ray process
     in the cluster.
 
     Args:
-        name (str): Name to register.
-        trainable (obj): Function or tune.Trainable class. Functions must
+        name: Name to register.
+        trainable: Function or tune.Trainable class. Functions must
             take (config, status_reporter) as arguments and will be
             automatically converted into a class during registration.
     """
@@ -84,15 +84,15 @@ def register_trainable(name, trainable, warn=True):
     _global_registry.register(TRAINABLE_CLASS, name, trainable)
 
 
-def register_env(name, env_creator):
+def register_env(name: str, env_creator: Callable):
     """Register a custom environment for use with RLlib.
 
     This enables the environment to be accessed on every Ray process
     in the cluster.
 
     Args:
-        name (str): Name to register.
-        env_creator (obj): Callable that creates an env.
+        name: Name to register.
+        env_creator: Callable that creates an env.
     """
 
     if not callable(env_creator):
@@ -104,8 +104,8 @@ def register_input(name: str, input_creator: Callable):
     """Register a custom input api for RLLib.
 
     Args:
-        name (str): Name to register.
-        input_creator (IOContext -> InputReader): Callable that creates an
+        name: Name to register.
+        input_creator: Callable that creates an
             input reader.
     """
     if not callable(input_creator):
@@ -125,13 +125,13 @@ def check_serializability(key, value):
     _global_registry.register(TEST, key, value)
 
 
-def _make_key(prefix, category, key):
+def _make_key(prefix: str, category: str, key: str):
     """Generate a binary key for the given category and key.
 
     Args:
-        prefix (str): Prefix
-        category (str): The category of the item
-        key (str): The unique identifier for the item
+        prefix: Prefix
+        category: The category of the item
+        key: The unique identifier for the item
 
     Returns:
         The key to use for storing a the value.

--- a/python/ray/tune/resources.py
+++ b/python/ray/tune/resources.py
@@ -35,25 +35,25 @@ class Resources(
     """Ray resources required to schedule a trial.
 
     Parameters:
-        cpu (float): Number of CPUs to allocate to the trial.
-        gpu (float): Number of GPUs to allocate to the trial.
-        memory (float): Memory to reserve for the trial.
-        object_store_memory (float): Object store memory to reserve.
-        extra_cpu (float): Extra CPUs to reserve in case the trial needs to
+        cpu: Number of CPUs to allocate to the trial.
+        gpu: Number of GPUs to allocate to the trial.
+        memory: Memory to reserve for the trial.
+        object_store_memory: Object store memory to reserve.
+        extra_cpu: Extra CPUs to reserve in case the trial needs to
             launch additional Ray actors that use CPUs.
-        extra_gpu (float): Extra GPUs to reserve in case the trial needs to
+        extra_gpu: Extra GPUs to reserve in case the trial needs to
             launch additional Ray actors that use GPUs.
-        extra_memory (float): Memory to reserve for the trial launching
+        extra_memory: Memory to reserve for the trial launching
             additional Ray actors that use memory.
-        extra_object_store_memory (float): Object store memory to reserve for
+        extra_object_store_memory: Object store memory to reserve for
             the trial launching additional Ray actors that use object store
             memory.
-        custom_resources (dict): Mapping of resource to quantity to allocate
+        custom_resources: Mapping of resource to quantity to allocate
             to the trial.
-        extra_custom_resources (dict): Extra custom resources to reserve in
+        extra_custom_resources: Extra custom resources to reserve in
             case the trial needs to launch additional Ray actors that use
             any of these custom resources.
-        has_placement_group (bool): Bool indicating if the trial also
+        has_placement_group: Bool indicating if the trial also
             has an associated placement group.
 
     """
@@ -62,17 +62,17 @@ class Resources(
 
     def __new__(
         cls,
-        cpu,
-        gpu,
-        memory=0,
-        object_store_memory=0,
-        extra_cpu=0,
-        extra_gpu=0,
-        extra_memory=0,
-        extra_object_store_memory=0,
-        custom_resources=None,
-        extra_custom_resources=None,
-        has_placement_group=False,
+        cpu: float,
+        gpu: float,
+        memory: float = 0,
+        object_store_memory: float = 0.0,
+        extra_cpu: float = 0.0,
+        extra_gpu: float = 0.0,
+        extra_memory: float = 0.0,
+        extra_object_store_memory: float = 0.0,
+        custom_resources: Optional[dict] = None,
+        extra_custom_resources: Optional[dict] = None,
+        has_placement_group: bool = False,
     ):
         custom_resources = custom_resources or {}
         extra_custom_resources = extra_custom_resources or {}

--- a/python/ray/tune/sample.py
+++ b/python/ray/tune/sample.py
@@ -570,9 +570,9 @@ def loguniform(lower: float, upper: float, base: float = 10):
     """Sugar for sampling in different orders of magnitude.
 
     Args:
-        lower (float): Lower boundary of the output interval (e.g. 1e-4)
-        upper (float): Upper boundary of the output interval (e.g. 1e-2)
-        base (int): Base of the log. Defaults to 10.
+        lower: Lower boundary of the output interval (e.g. 1e-4)
+        upper: Upper boundary of the output interval (e.g. 1e-2)
+        base: Base of the log. Defaults to 10.
 
     """
     return Float(lower, upper).loguniform(base)
@@ -586,11 +586,11 @@ def qloguniform(lower: float, upper: float, q: float, base: float = 10):
     Quantization makes the upper bound inclusive.
 
     Args:
-        lower (float): Lower boundary of the output interval (e.g. 1e-4)
-        upper (float): Upper boundary of the output interval (e.g. 1e-2)
-        q (float): Quantization number. The result will be rounded to an
+        lower: Lower boundary of the output interval (e.g. 1e-4)
+        upper: Upper boundary of the output interval (e.g. 1e-2)
+        q: Quantization number. The result will be rounded to an
             integer increment of this value.
-        base (int): Base of the log. Defaults to 10.
+        base: Base of the log. Defaults to 10.
 
     """
     return Float(lower, upper).loguniform(base).quantized(q)
@@ -677,8 +677,8 @@ def randn(mean: float = 0.0, sd: float = 1.0):
     """Sample a float value normally with ``mean`` and ``sd``.
 
     Args:
-        mean (float): Mean of the normal distribution. Defaults to 0.
-        sd (float): SD of the normal distribution. Defaults to 1.
+        mean: Mean of the normal distribution. Defaults to 0.
+        sd: SD of the normal distribution. Defaults to 1.
 
     """
     return Float(None, None).normal(mean, sd)
@@ -690,9 +690,9 @@ def qrandn(mean: float, sd: float, q: float):
     The value will be quantized, i.e. rounded to an integer increment of ``q``.
 
     Args:
-        mean (float): Mean of the normal distribution.
-        sd (float): SD of the normal distribution.
-        q (float): Quantization number. The result will be rounded to an
+        mean: Mean of the normal distribution.
+        sd: SD of the normal distribution.
+        q: Quantization number. The result will be rounded to an
             integer increment of this value.
 
     """

--- a/python/ray/tune/schedulers/async_hyperband.py
+++ b/python/ray/tune/schedulers/async_hyperband.py
@@ -23,22 +23,22 @@ class AsyncHyperBandScheduler(FIFOScheduler):
     See https://arxiv.org/abs/1810.05934
 
     Args:
-        time_attr (str): A training result attr to use for comparing time.
+        time_attr: A training result attr to use for comparing time.
             Note that you can pass in something non-temporal such as
             `training_iteration` as a measure of progress, the only requirement
             is that the attribute should increase monotonically.
-        metric (str): The training result objective value attribute. Stopping
+        metric: The training result objective value attribute. Stopping
             procedures will use this attribute. If None but a mode was passed,
             the `ray.tune.result.DEFAULT_METRIC` will be used per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        max_t (float): max time units per trial. Trials will be stopped after
+        max_t: max time units per trial. Trials will be stopped after
             max_t time units (determined by time_attr) have passed.
-        grace_period (float): Only stop trials at least this old in time.
+        grace_period: Only stop trials at least this old in time.
             The units are the same as the attribute named by `time_attr`.
-        reduction_factor (float): Used to set halving rate and amount. This
+        reduction_factor: Used to set halving rate and amount. This
             is simply a unit-less scalar.
-        brackets (int): Number of brackets. Each bracket has a different
+        brackets: Number of brackets. Each bracket has a different
             halving rate, specified by the reduction factor.
     """
 

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -60,23 +60,23 @@ class HyperBandScheduler(FIFOScheduler):
     See also: https://homes.cs.washington.edu/~jamieson/hyperband.html
 
     Args:
-        time_attr (str): The training result attr to use for comparing time.
+        time_attr: The training result attr to use for comparing time.
             Note that you can pass in something non-temporal such as
             `training_iteration` as a measure of progress, the only requirement
             is that the attribute should increase monotonically.
-        metric (str): The training result objective value attribute. Stopping
+        metric: The training result objective value attribute. Stopping
             procedures will use this attribute. If None but a mode was passed,
             the `ray.tune.result.DEFAULT_METRIC` will be used per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        max_t (int): max time units per trial. Trials will be stopped after
+        max_t: max time units per trial. Trials will be stopped after
             max_t time units (determined by time_attr) have passed.
             The scheduler will terminate trials after this time has passed.
             Note that this is different from the semantics of `max_t` as
             mentioned in the original HyperBand paper.
-        reduction_factor (float): Same as `eta`. Determines how sharp
+        reduction_factor: Same as `eta`. Determines how sharp
             the difference is between bracket space-time allocation ratios.
-        stop_last_trials (bool): Whether to terminate the trials after
+        stop_last_trials: Whether to terminate the trials after
             reaching max_t. Defaults to True.
     """
 

--- a/python/ray/tune/schedulers/median_stopping_rule.py
+++ b/python/ray/tune/schedulers/median_stopping_rule.py
@@ -18,26 +18,26 @@ class MedianStoppingRule(FIFOScheduler):
     https://research.google.com/pubs/pub46180.html
 
     Args:
-        time_attr (str): The training result attr to use for comparing time.
+        time_attr: The training result attr to use for comparing time.
             Note that you can pass in something non-temporal such as
             `training_iteration` as a measure of progress, the only requirement
             is that the attribute should increase monotonically.
-        metric (str): The training result objective value attribute. Stopping
+        metric: The training result objective value attribute. Stopping
             procedures will use this attribute. If None but a mode was passed,
             the `ray.tune.result.DEFAULT_METRIC` will be used per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        grace_period (float): Only stop trials at least this old in time.
+        grace_period: Only stop trials at least this old in time.
             The mean will only be computed from this time onwards. The units
             are the same as the attribute named by `time_attr`.
-        min_samples_required (int): Minimum number of trials to compute median
+        min_samples_required: Minimum number of trials to compute median
             over.
-        min_time_slice (float): Each trial runs at least this long before
+        min_time_slice: Each trial runs at least this long before
             yielding (assuming it isn't stopped). Note: trials ONLY yield if
             there are not enough samples to evaluate performance for the
             current result AND there are other trials waiting to run.
             The units are the same as the attribute named by `time_attr`.
-        hard_stop (bool): If False, pauses trials instead of stopping
+        hard_stop: If False, pauses trials instead of stopping
             them. When all other trials are complete, paused trials will be
             resumed and allowed to run FIFO.
     """

--- a/python/ray/tune/schedulers/pb2.py
+++ b/python/ray/tune/schedulers/pb2.py
@@ -35,28 +35,35 @@ if GPy and has_sklearn:
 logger = logging.getLogger(__name__)
 
 
-def select_config(Xraw, yraw, current, newpoint, bounds, num_f):
+def select_config(
+    Xraw: np.array,
+    yraw: np.array,
+    current: list,
+    newpoint: np.array,
+    bounds: dict,
+    num_f: int,
+):
     """Selects the next hyperparameter config to try.
 
     This function takes the formatted data, fits the GP model and optimizes the
     UCB acquisition function to select the next point.
 
     Args:
-        Xraw (np.array): The un-normalized array of hyperparams, Time and
+        Xraw: The un-normalized array of hyperparams, Time and
             Reward
-        yraw (np.array): The un-normalized vector of reward changes.
-        current (list): The hyperparams of trials currently running. This is
+        yraw: The un-normalized vector of reward changes.
+        current: The hyperparams of trials currently running. This is
             important so we do not select the same config twice. If there is
             data here then we fit a second GP including it
             (with fake y labels). The GP variance doesn't depend on the y
             labels so it is ok.
-        newpoint (np.array): The Reward and Time for the new point.
+        newpoint: The Reward and Time for the new point.
             We cannot change these as they are based on the *new weights*.
-        bounds (dict): Bounds for the hyperparameters. Used to normalize.
-        num_f (int): The number of fixed params. Almost always 2 (reward+time)
+        bounds: Bounds for the hyperparameters. Used to normalize.
+        num_f: The number of fixed params. Almost always 2 (reward+time)
 
     Return:
-        xt (np.array): A vector of new hyperparameters.
+        xt: A vector of new hyperparameters.
     """
     length = select_length(Xraw, yraw, bounds, num_f)
 
@@ -224,32 +231,32 @@ class PB2(PopulationBasedTraining):
     on each perturbation step.
 
     Args:
-        time_attr (str): The training result attr to use for comparing time.
+        time_attr: The training result attr to use for comparing time.
             Note that you can pass in something non-temporal such as
             `training_iteration` as a measure of progress, the only requirement
             is that the attribute should increase monotonically.
-        metric (str): The training result objective value attribute. Stopping
+        metric: The training result objective value attribute. Stopping
             procedures will use this attribute.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        perturbation_interval (float): Models will be considered for
+        perturbation_interval: Models will be considered for
             perturbation at this interval of `time_attr`. Note that
             perturbation incurs checkpoint overhead, so you shouldn't set this
             to be too frequent.
-        hyperparam_bounds (dict): Hyperparameters to mutate. The format is
+        hyperparam_bounds: Hyperparameters to mutate. The format is
             as follows: for each key, enter a list of the form [min, max]
             representing the minimum and maximum possible hyperparam values.
-        quantile_fraction (float): Parameters are transferred from the top
+        quantile_fraction: Parameters are transferred from the top
             `quantile_fraction` fraction of trials to the bottom
             `quantile_fraction` fraction. Needs to be between 0 and 0.5.
             Setting it to 0 essentially implies doing no exploitation at all.
-        log_config (bool): Whether to log the ray config of each model to
+        log_config: Whether to log the ray config of each model to
             local_dir at each exploit. Allows config schedule to be
             reconstructed.
-        require_attrs (bool): Whether to require time_attr and metric to appear
+        require_attrs: Whether to require time_attr and metric to appear
             in result for every iteration. If True, error will be raised
             if these values are not present in trial result.
-        synch (bool): If False, will use asynchronous implementation of
+        synch: If False, will use asynchronous implementation of
             PBT. Trial perturbations occur every perturbation_interval for each
             trial independently. If True, will use synchronous implementation
             of PBT. Perturbations will occur only after all trials are

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -53,12 +53,12 @@ def explore(
     """Return a config perturbed as specified.
 
     Args:
-        config (dict): Original hyperparameter configuration.
-        mutations (dict): Specification of mutations to perform as documented
+        config: Original hyperparameter configuration.
+        mutations: Specification of mutations to perform as documented
             in the PopulationBasedTraining scheduler.
-        resample_probability (float): Probability of allowing resampling of a
+        resample_probability: Probability of allowing resampling of a
             particular variable.
-        custom_explore_fn (func): Custom explore fn applied after built-in
+        custom_explore_fn: Custom explore fn applied after built-in
             config perturbations are.
     """
     new_config = copy.deepcopy(config)
@@ -151,24 +151,24 @@ class PopulationBasedTraining(FIFOScheduler):
     on each perturbation step.
 
     Args:
-        time_attr (str): The training result attr to use for comparing time.
+        time_attr: The training result attr to use for comparing time.
             Note that you can pass in something non-temporal such as
             `training_iteration` as a measure of progress, the only requirement
             is that the attribute should increase monotonically.
-        metric (str): The training result objective value attribute. Stopping
+        metric: The training result objective value attribute. Stopping
             procedures will use this attribute. If None but a mode was passed,
             the `ray.tune.result.DEFAULT_METRIC` will be used per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        perturbation_interval (float): Models will be considered for
+        perturbation_interval: Models will be considered for
             perturbation at this interval of `time_attr`. Note that
             perturbation incurs checkpoint overhead, so you shouldn't set this
             to be too frequent.
-        burn_in_period (float): Models will not be considered for
+        burn_in_period: Models will not be considered for
             perturbation before this interval of `time_attr` has passed. This
             guarantees that models are trained for at least a certain amount
             of time or timesteps before being perturbed.
-        hyperparam_mutations (dict): Hyperparams to mutate. The format is
+        hyperparam_mutations: Hyperparams to mutate. The format is
             as follows: for each key, either a list, function,
             or a tune search space object (tune.loguniform, tune.uniform,
             etc.) can be provided. A list specifies an allowed set of
@@ -181,26 +181,26 @@ class PopulationBasedTraining(FIFOScheduler):
             Tune will use the search space provided by
             `hyperparam_mutations` for the initial samples if the
             corresponding attributes are not present in `config`.
-        quantile_fraction (float): Parameters are transferred from the top
+        quantile_fraction: Parameters are transferred from the top
             `quantile_fraction` fraction of trials to the bottom
             `quantile_fraction` fraction. Needs to be between 0 and 0.5.
             Setting it to 0 essentially implies doing no exploitation at all.
-        resample_probability (float): The probability of resampling from the
+        resample_probability: The probability of resampling from the
             original distribution when applying `hyperparam_mutations`. If not
             resampled, the value will be perturbed by a factor of 1.2 or 0.8
             if continuous, or changed to an adjacent value if discrete.
-        custom_explore_fn (func): You can also specify a custom exploration
+        custom_explore_fn: You can also specify a custom exploration
             function. This function is invoked as `f(config)` after built-in
             perturbations from `hyperparam_mutations` are applied, and should
             return `config` updated as needed. You must specify at least one of
             `hyperparam_mutations` or `custom_explore_fn`.
-        log_config (bool): Whether to log the ray config of each model to
+        log_config: Whether to log the ray config of each model to
             local_dir at each exploit. Allows config schedule to be
             reconstructed.
-        require_attrs (bool): Whether to require time_attr and metric to appear
+        require_attrs: Whether to require time_attr and metric to appear
             in result for every iteration. If True, error will be raised
             if these values are not present in trial result.
-        synch (bool): If False, will use asynchronous implementation of
+        synch: If False, will use asynchronous implementation of
             PBT. Trial perturbations occur every perturbation_interval for each
             trial independently. If True, will use synchronous implementation
             of PBT. Perturbations will occur only after all trials are
@@ -491,10 +491,10 @@ class PopulationBasedTraining(FIFOScheduler):
     ):
         """Saves necessary trial information when result is received.
         Args:
-            state (PBTTrialState): The state object for the trial.
-            time (int): The current timestep of the trial.
-            result (dict): The trial's result dictionary.
-            trial (dict): The trial object.
+            state: The state object for the trial.
+            time: The current timestep of the trial.
+            result: The trial's result dictionary.
+            trial: The trial object.
         """
 
         # This trial has reached its perturbation interval.
@@ -743,7 +743,7 @@ class PopulationBasedTrainingReplay(FIFOScheduler):
     config according to the schedule.
 
     Args:
-        policy_file (str): The PBT policy file. Usually this is
+        policy_file: The PBT policy file. Usually this is
             stored in ``~/ray_results/experiment_name/pbt_policy_xxx.txt``
             where ``xxx`` is the trial ID.
 

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -43,17 +43,17 @@ class DistributeResources:
     generic methods. You can also implement a function instead.
 
     Args:
-        add_bundles (bool): If True, create new bundles from free resources.
+        add_bundles: If True, create new bundles from free resources.
             Otherwise, spread them among base_trial_resource bundles.
-        increase_by (Optional[Dict[str, float]]): A dict with key-value
+        increase_by: A dict with key-value
             pairs representing an atomic unit of resources (name-amount)
             the trial will be increased by. If not set, the trial will
             increase by 1 CPU/GPU.
-        increase_by_times (int): If set to >=1 and ``increase_by`` is set,
+        increase_by_times: If set to >=1 and ``increase_by`` is set,
             the trial will increase by maximum of
             ``increase_by_times * increase_by`` resources. If set to <1,
             no upper limit is set. Ignored if ``increase_by`` is not set.
-        reserve_resources (Optional[Dict[str, float]]): A dict of
+        reserve_resources: A dict of
             resource_name-amount pairs representing the resources
             that will not be allocated to resized trials.
     """
@@ -395,11 +395,11 @@ class DistributeResources:
         internally (same with None).
 
         Args:
-            trial_runner (TrialRunner): Trial runner for this Tune run.
+            trial_runner: Trial runner for this Tune run.
                 Can be used to obtain information about other trials.
-            trial (Trial): The trial to allocate new resources to.
-            result (Dict[str, Any]): The latest results of trial.
-            scheduler (ResourceChangingScheduler): The scheduler calling
+            trial: The trial to allocate new resources to.
+            result: The latest results of trial.
+            scheduler: The scheduler calling
                 the function.
         """
         # Get base trial resources as defined in
@@ -479,24 +479,24 @@ class DistributeResourcesToTopJob(DistributeResources):
     internally (same with None).
 
     Args:
-        add_bundles (bool): If True, create new bundles from free resources.
+        add_bundles: If True, create new bundles from free resources.
             Otherwise, spread them among base_trial_resource bundles.
-        increase_by (Optional[Dict[str, float]]): A dict with key-value
+        increase_by: A dict with key-value
             pairs representing an atomic unit of resources (name-amount)
             the trial will be increased by. If not set, the trial will
             increase by 1 CPU/GPU.
-        increase_by_times (int): If set to >=1 and ``increase_by`` is set,
+        increase_by_times: If set to >=1 and ``increase_by`` is set,
             the trial will increase by maximum of
             ``increase_by_times * increase_by`` resources. If set to <1,
             no upper limit is set. Ignored if ``increase_by`` is not set.
-        reserve_resources (Optional[Dict[str, float]]): A dict of
+        reserve_resources: A dict of
             resource_name-amount pairs representing the resources
             that will not be allocated to resized trials.
             is that the attribute should increase monotonically.
-        metric (Optional[str]): The training result objective value attribute. Stopping
+        metric: The training result objective value attribute. Stopping
             procedures will use this attribute. If None, will use the metric
             of the scheduler.
-        mode (Optional[str]): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute. If None, will use the metric
             of the scheduler.
 
@@ -613,11 +613,11 @@ def evenly_distribute_cpus_gpus(
     this function.
 
     Args:
-        trial_runner (TrialRunner): Trial runner for this Tune run.
+        trial_runner: Trial runner for this Tune run.
             Can be used to obtain information about other trials.
-        trial (Trial): The trial to allocate new resources to.
-        result (Dict[str, Any]): The latest results of trial.
-        scheduler (ResourceChangingScheduler): The scheduler calling
+        trial: The trial to allocate new resources to.
+        result: The latest results of trial.
+        scheduler: The scheduler calling
             the function.
     """
 
@@ -663,11 +663,11 @@ def evenly_distribute_cpus_gpus_distributed(
     this function.
 
     Args:
-        trial_runner (TrialRunner): Trial runner for this Tune run.
+        trial_runner: Trial runner for this Tune run.
             Can be used to obtain information about other trials.
-        trial (Trial): The trial to allocate new resources to.
-        result (Dict[str, Any]): The latest results of trial.
-        scheduler (ResourceChangingScheduler): The scheduler calling
+        trial: The trial to allocate new resources to.
+        result: The latest results of trial.
+        scheduler: The scheduler calling
             the function.
     """
 
@@ -714,9 +714,9 @@ class ResourceChangingScheduler(TrialScheduler):
     will be raised in that case.
 
     Args:
-        base_scheduler (TrialScheduler): The scheduler to provide decisions
+        base_scheduler: The scheduler to provide decisions
             about trials. If None, a default FIFOScheduler will be used.
-        resources_allocation_function (Callable): The callable used to change
+        resources_allocation_function: The callable used to change
             live trial resource requiements during tuning. This callable
             will be called on each trial as it finishes one step of training.
             The callable must take four arguments: ``TrialRunner``, current

--- a/python/ray/tune/schedulers/trial_scheduler.py
+++ b/python/ray/tune/schedulers/trial_scheduler.py
@@ -38,8 +38,8 @@ class TrialScheduler:
         that react to metrics with their own `metric` and `mode` parameters.
 
         Args:
-            metric (str): Metric to optimize
-            mode (str): One of ["min", "max"]. Direction to optimize.
+            metric: Metric to optimize
+            mode: One of ["min", "max"]. Direction to optimize.
             **spec: Any kwargs for forward compatiblity.
                 Info like Experiment.PUBLIC_KEYS is provided through here.
         """

--- a/python/ray/tune/session.py
+++ b/python/ray/tune/session.py
@@ -127,7 +127,7 @@ def save_checkpoint(checkpoint):
 
 @PublicAPI
 @contextmanager
-def checkpoint_dir(step):
+def checkpoint_dir(step: int):
     """Returns a checkpoint dir inside a context.
 
     Store any files related to restoring state within the
@@ -142,7 +142,7 @@ def checkpoint_dir(step):
     inconsistencies.
 
     Args:
-        step (int): Index for the checkpoint. Expected to be a
+        step: Index for the checkpoint. Expected to be a
             monotonically increasing quantity.
 
     .. code-block:: python
@@ -171,7 +171,7 @@ def checkpoint_dir(step):
                 tune.report(hello="world", ray="tune")
 
     Yields:
-        checkpoint_dir (str): Directory for checkpointing.
+        checkpoint_dir: Directory for checkpointing.
 
     .. versionadded:: 0.8.7
     """

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional
+import datetime
+from typing import Dict, Optional, Callable, Union
 import time
 from collections import defaultdict, deque
 import numpy as np
@@ -95,13 +96,13 @@ class FunctionStopper(Stopper):
     True, the trial will be stopped.
 
     Args:
-        function (Callable[[str, Dict], bool): Function that checks if a trial
+        function: Function that checks if a trial
             should be stopped. Must accept the `trial_id` string  and `result`
             dictionary as arguments. Must return a boolean.
 
     """
 
-    def __init__(self, function):
+    def __init__(self, function: Callable[[str, Dict], bool]):
         self._fn = function
 
     def __call__(self, trial_id, result):
@@ -126,7 +127,7 @@ class MaximumIterationStopper(Stopper):
     """Stop trials after reaching a maximum number of iterations
 
     Args:
-        max_iter (int): Number of iterations before stopping a trial.
+        max_iter: Number of iterations before stopping a trial.
     """
 
     def __init__(self, max_iter: int):
@@ -150,13 +151,13 @@ class ExperimentPlateauStopper(Stopper):
     the patience parameter.
 
     Args:
-        metric (str): The metric to be monitored.
-        std (float): The minimal standard deviation after which
+        metric: The metric to be monitored.
+        std: The minimal standard deviation after which
             the tuning process has to stop.
-        top (int): The number of best models to consider.
-        mode (str): The mode to select the top results.
+        top: The number of best models to consider.
+        mode: The mode to select the top results.
             Can either be "min" or "max".
-        patience (int): Number of epochs to wait for
+        patience: Number of epochs to wait for
             a change in the top models.
 
     Raises:
@@ -169,7 +170,14 @@ class ExperimentPlateauStopper(Stopper):
             a strictly positive integer.
     """
 
-    def __init__(self, metric, std=0.001, top=10, mode="min", patience=0):
+    def __init__(
+        self,
+        metric: str,
+        std: float = 0.001,
+        top: int = 10,
+        mode: str = "min",
+        patience: int = 0,
+    ):
         if mode not in ("min", "max"):
             raise ValueError("The mode parameter can only be either min or max.")
         if not isinstance(top, int) or top <= 1:
@@ -230,17 +238,17 @@ class TrialPlateauStopper(Stopper):
     early.
 
     Args:
-        metric (str): Metric to check for convergence.
-        std (float): Maximum metric standard deviation to decide if a
+        metric: Metric to check for convergence.
+        std: Maximum metric standard deviation to decide if a
             trial plateaued. Defaults to 0.01.
-        num_results (int): Number of results to consider for stdev
+        num_results: Number of results to consider for stdev
             calculation.
-        grace_period (int): Minimum number of timesteps before a trial
+        grace_period: Minimum number of timesteps before a trial
             can be early stopped
         metric_threshold (Optional[float]):
             Minimum or maximum value the result has to exceed before it can
             be stopped early.
-        mode (Optional[str]): If a `metric_threshold` argument has been
+        mode: If a `metric_threshold` argument has been
             passed, this must be one of [min, max]. Specifies if we optimize
             for a large metric (max) or a small metric (min). If max, the
             `metric_threshold` has to be exceeded, if min the value has to
@@ -316,11 +324,11 @@ class TimeoutStopper(Stopper):
     argument is passed to `tune.run()`.
 
     Args:
-        timeout (int|float|datetime.timedelta): Either a number specifying
-            the timeout in seconds, or a `datetime.timedelta` object.
+        timeout: Either a number specifying the timeout in seconds, or
+            a `datetime.timedelta` object.
     """
 
-    def __init__(self, timeout):
+    def __init__(self, timeout: Union[int, float, datetime.timedelta]):
         from datetime import timedelta
 
         if isinstance(timeout, timedelta):

--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -47,34 +47,34 @@ class AxSearch(Searcher):
         $ pip install ax-platform sqlalchemy
 
     Parameters:
-        space (list[dict]): Parameters in the experiment search space.
+        space: Parameters in the experiment search space.
             Required elements in the dictionaries are: "name" (name of
             this parameter, string), "type" (type of the parameter: "range",
             "fixed", or "choice", string), "bounds" for range parameters
             (list of two values, lower bound first), "values" for choice
             parameters (list of values), and "value" for fixed parameters
             (single value).
-        metric (str): Name of the metric used as objective in this
+        metric: Name of the metric used as objective in this
             experiment. This metric must be present in `raw_data` argument
             to `log_data`. This metric must also be present in the dict
             reported/returned by the Trainable. If None but a mode was passed,
             the `ray.tune.result.DEFAULT_METRIC` will be used per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute. Defaults to "max".
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        parameter_constraints (list[str]): Parameter constraints, such as
+        parameter_constraints: Parameter constraints, such as
             "x3 >= x4" or "x3 + x4 >= 2".
-        outcome_constraints (list[str]): Outcome constraints of form
+        outcome_constraints: Outcome constraints of form
             "metric_name >= bound", like "m1 <= 3."
-        ax_client (AxClient): Optional AxClient instance. If this is set, do
+        ax_client: Optional AxClient instance. If this is set, do
             not pass any values to these parameters: `space`, `metric`,
             `parameter_constraints`, `outcome_constraints`.
         use_early_stopped_trials: Deprecated.
-        max_concurrent (int): Deprecated.
+        max_concurrent: Deprecated.
         **ax_kwargs: Passed to AxClient instance. Ignored if `AxClient` is not
             None.
 

--- a/python/ray/tune/suggest/basic_variant.py
+++ b/python/ray/tune/suggest/basic_variant.py
@@ -66,19 +66,19 @@ class _TrialIterator:
     """Generates trials from the spec.
 
     Args:
-        uuid_prefix (str): Used in creating the trial name.
-        num_samples (int): Number of samples from distribution
+        uuid_prefix: Used in creating the trial name.
+        num_samples: Number of samples from distribution
              (same as tune.run).
-        unresolved_spec (dict): Experiment specification
+        unresolved_spec: Experiment specification
             that might have unresolved distributions.
-        constant_grid_search (bool): Should random variables be sampled
+        constant_grid_search: Should random variables be sampled
             first before iterating over grid variants (True) or not (False).
-        output_path (str): A specific output path within the local_dir.
-        points_to_evaluate (list): Same as tune.run.
-        lazy_eval (bool): Whether variants should be generated
+        output_path: A specific output path within the local_dir.
+        points_to_evaluate: Same as tune.run.
+        lazy_eval: Whether variants should be generated
             lazily or eagerly. This is toggled depending
             on the size of the grid search.
-        start (int): index at which to start counting trials.
+        start: index at which to start counting trials.
         random_state (int | np.random.Generator | np.random.RandomState):
             Seed or numpy random generator to use for reproducible results.
             If None (default), will use the global numpy random generator
@@ -192,23 +192,23 @@ class BasicVariantGenerator(SearchAlgorithm):
 
 
     Args:
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        max_concurrent (int): Maximum number of concurrently running trials.
+        max_concurrent: Maximum number of concurrently running trials.
             If 0 (default), no maximum is enforced.
-        constant_grid_search (bool): If this is set to ``True``, Ray Tune will
+        constant_grid_search: If this is set to ``True``, Ray Tune will
             *first* try to sample random values and keep them constant over
             grid search parameters. If this is set to ``False`` (default),
             Ray Tune will sample new random parameters in each grid search
             condition.
-        random_state (int | np.random.Generator | np.random.RandomState):
+        random_state:
             Seed or numpy random generator to use for reproducible results.
             If None (default), will use the global numpy random generator
             (``np.random``). Please note that full reproducibility cannot
-            be guaranteed in a distributed enviroment.
+            be guaranteed in a distributed environment.
 
 
     Example:
@@ -314,7 +314,7 @@ class BasicVariantGenerator(SearchAlgorithm):
         """Chains generator given experiment specifications.
 
         Arguments:
-            experiments (Experiment | list | dict): Experiments to run.
+            experiments: Experiments to run.
         """
         experiment_list = convert_to_experiment_list(experiments)
         for experiment in experiment_list:

--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -55,30 +55,30 @@ class BayesOptSearch(Searcher):
     `BayesianOptimization search space specification`_.
 
     Args:
-        space (dict): Continuous search space. Parameters will be sampled from
+        space: Continuous search space. Parameters will be sampled from
             this space which will be used to run trials.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        utility_kwargs (dict): Parameters to define the utility function.
+        utility_kwargs: Parameters to define the utility function.
             The default value is a dictionary with three keys:
             - kind: ucb (Upper Confidence Bound)
             - kappa: 2.576
             - xi: 0.0
-        random_state (int): Used to initialize BayesOpt.
-        random_search_steps (int): Number of initial random searches.
+        random_state: Used to initialize BayesOpt.
+        random_search_steps: Number of initial random searches.
             This is necessary to avoid initial local overfitting
             of the Bayesian process.
-        analysis (ExperimentAnalysis): Optionally, the previous analysis
+        analysis: Optionally, the previous analysis
             to integrate.
-        verbose (int): Sets verbosity level for BayesOpt packages.
+        verbose: Sets verbosity level for BayesOpt packages.
         max_concurrent: Deprecated.
         use_early_stopped_trials: Deprecated.
 
@@ -235,7 +235,7 @@ class BayesOptSearch(Searcher):
         """Return new point to be explored by black box function.
 
         Args:
-            trial_id (str): Id of the trial.
+            trial_id: Id of the trial.
                 This is a short alphanumerical string.
 
         Returns:
@@ -299,7 +299,7 @@ class BayesOptSearch(Searcher):
         """Integrate the given analysis into the gaussian process.
 
         Args:
-            analysis (ExperimentAnalysis): Optionally, the previous analysis
+            analysis: Optionally, the previous analysis
                 to integrate.
         """
         for (_, report), params in zip(
@@ -316,11 +316,11 @@ class BayesOptSearch(Searcher):
         """Notification for the completion of trial.
 
         Args:
-            trial_id (str): Id of the trial.
+            trial_id: Id of the trial.
                 This is a short alphanumerical string.
-            result (dict): Dictionary of result.
+            result: Dictionary of result.
                 May be none when some error occurs.
-            error (bool): Boolean representing a previous error state.
+            error: Boolean representing a previous error state.
                 The result should be None when error is True.
         """
         # We try to get the parameters used for this trial

--- a/python/ray/tune/suggest/bohb.py
+++ b/python/ray/tune/suggest/bohb.py
@@ -57,23 +57,23 @@ class TuneBOHB(Searcher):
     This should be used in conjunction with HyperBandForBOHB.
 
     Args:
-        space (ConfigurationSpace): Continuous ConfigSpace search space.
+        space: Continuous ConfigSpace search space.
             Parameters will be sampled from this space which will be used
             to run trials.
-        bohb_config (dict): configuration for HpBandSter BOHB algorithm
-        max_concurrent (int): Deprecated. Use
+        bohb_config: configuration for HpBandSter BOHB algorithm
+        max_concurrent: Deprecated. Use
             ``tune.suggest.ConcurrencyLimiter()``.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        seed (int): Optional random seed to initialize the random number
+        seed: Optional random seed to initialize the random number
             generator. Setting this should lead to identical initial
             configurations at each run.
 

--- a/python/ray/tune/suggest/dragonfly.py
+++ b/python/ray/tune/suggest/dragonfly.py
@@ -59,34 +59,34 @@ class DragonflySearch(Searcher):
     results.
 
     Parameters:
-        optimizer (dragonfly.opt.BlackboxOptimiser|str): Optimizer provided
+        optimizer: Optimizer provided
             from dragonfly. Choose an optimiser that extends BlackboxOptimiser.
             If this is a string, `domain` must be set and `optimizer` must be
             one of [random, bandit, genetic].
-        domain (str): Optional domain. Should only be set if you don't pass
+        domain: Optional domain. Should only be set if you don't pass
             an optimizer as the `optimizer` argument.
             Has to be one of [cartesian, euclidean].
-        space (list|dict): Search space. Should only be set if you don't pass
+        space: Search space. Should only be set if you don't pass
             an optimizer as the `optimizer` argument. Defines the search space
             and requires a `domain` to be set. Can be automatically converted
             from the `config` dict passed to `tune.run()`.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        evaluated_rewards (list): If you have previously evaluated the
+        evaluated_rewards: If you have previously evaluated the
             parameters passed in as points_to_evaluate you can avoid
             re-running those trials by passing in the reward attributes
             as a list so the optimiser can be told the results without
             needing to re-compute the trial. Must be the same length as
             points_to_evaluate.
-        random_state_seed (int, None): Seed for reproducible
+        random_state_seed: Seed for reproducible
             results. Defaults to None. Please note that setting this to a value
             will change global random state for `numpy`
             on initalization and loading from checkpoint.

--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -61,30 +61,29 @@ class HEBOSearch(Searcher):
     here.
 
     Args:
-        space (dict|hebo.design_space.design_space.DesignSpace):
-            A dict mapping parameter names to Tune search spaces or a
+        space: A dict mapping parameter names to Tune search spaces or a
             HEBO DesignSpace object.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        evaluated_rewards (list): If you have previously evaluated the
+        evaluated_rewards: If you have previously evaluated the
             parameters passed in as points_to_evaluate you can avoid
             re-running those trials by passing in the reward attributes
             as a list so the optimiser can be told the results without
             needing to re-compute the trial. Must be the same length as
             points_to_evaluate. (See tune/examples/hebo_example.py)
-        random_state_seed (int, None): Seed for reproducible
+        random_state_seed: Seed for reproducible
             results. Defaults to None. Please note that setting this to a value
             will change global random states for `numpy` and `torch`
             on initalization and loading from checkpoint.
-        max_concurrent (int, 8): Number of maximum concurrent trials.
+        max_concurrent: Number of maximum concurrent trials.
             If this Searcher is used in a ``ConcurrencyLimiter``, the
             ``max_concurrent`` value passed to it will override the
             value passed here.

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -58,25 +58,25 @@ class HyperOptSearch(Searcher):
 
 
     Parameters:
-        space (dict): HyperOpt configuration. Parameters will be sampled
+        space: HyperOpt configuration. Parameters will be sampled
             from this configuration and will be used to override
             parameters generated in the variant generation process.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        n_initial_points (int): number of random evaluations of the
+        n_initial_points: number of random evaluations of the
             objective function before starting to aproximate it with
             tree parzen estimators. Defaults to 20.
-        random_state_seed (int, array_like, None): seed for reproducible
+        random_state_seed: seed for reproducible
             results. Defaults to None.
-        gamma (float in range (0,1)): parameter governing the tree parzen
+        gamma: parameter governing the tree parzen
             estimators suggestion algorithm. Defaults to 0.25.
         max_concurrent: Deprecated.
         use_early_stopped_trials: Deprecated.

--- a/python/ray/tune/suggest/nevergrad.py
+++ b/python/ray/tune/suggest/nevergrad.py
@@ -44,17 +44,17 @@ class NevergradSearch(Searcher):
         $ pip install nevergrad
 
     Parameters:
-        optimizer (nevergrad.optimization.Optimizer|class): Optimizer provided
+        optimizer: Optimizer provided
             from Nevergrad. Alter
-        space (list|nevergrad.parameter.Parameter): Nevergrad parametrization
+        space: Nevergrad parametrization
             to be passed to optimizer on instantiation, or list of parameter
             names if you passed an optimizer object.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the

--- a/python/ray/tune/suggest/optuna.py
+++ b/python/ray/tune/suggest/optuna.py
@@ -89,7 +89,7 @@ class OptunaSearch(Searcher):
     Multi-objective optimization is supported.
 
     Args:
-        space (dict|Callable): Hyperparameter search space definition for
+        space: Hyperparameter search space definition for
             Optuna's sampler. This can be either a :class:`dict` with
             parameter names as keys and ``optuna.distributions`` as values,
             or a Callable - in which case, it should be a define-by-run
@@ -104,20 +104,20 @@ class OptunaSearch(Searcher):
                 function. Instead, put the training logic inside the function
                 or class trainable passed to ``tune.run``.
 
-        metric (str|list): The training result objective value attribute. If
+        metric: The training result objective value attribute. If
             None but a mode was passed, the anonymous metric ``_metric``
             will be used per default. Can be a list of metrics for
             multi-objective optimization.
-        mode (str|list): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute. Can be a list of
             modes for multi-objective optimization (corresponding to
             ``metric``).
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        sampler (optuna.samplers.BaseSampler): Optuna sampler used to
+        sampler: Optuna sampler used to
             draw hyperparameter configurations. Defaults to ``MOTPESampler``
             for multi-objective optimization with Optuna<2.9.0, and
             ``TPESampler`` in every other case.
@@ -131,10 +131,10 @@ class OptunaSearch(Searcher):
                 This is an Optuna issue and may be fixed in a future
                 Optuna release.
 
-        seed (int): Seed to initialize sampler with. This parameter is only
+        seed: Seed to initialize sampler with. This parameter is only
             used when ``sampler=None``. In all other cases, the sampler
             you pass should be initialized with the seed already.
-        evaluated_rewards (list): If you have previously evaluated the
+        evaluated_rewards: If you have previously evaluated the
             parameters passed in as points_to_evaluate you can avoid
             re-running those trials by passing in the reward attributes
             as a list so the optimiser can be told the results without

--- a/python/ray/tune/suggest/repeater.py
+++ b/python/ray/tune/suggest/repeater.py
@@ -30,11 +30,11 @@ class _TrialGroup:
     This is used when repeating trials for reducing training variance.
 
     Args:
-        primary_trial_id (str): Trial ID of the "primary trial".
+        primary_trial_id: Trial ID of the "primary trial".
             This trial is the one that the Searcher is aware of.
-        config (dict): Suggested configuration shared across all trials
+        config: Suggested configuration shared across all trials
             in the trial group.
-        max_trials (int): Max number of trials to execute within this group.
+        max_trials: Max number of trials to execute within this group.
 
     """
 
@@ -82,14 +82,14 @@ class Repeater(Searcher):
     simultaneously.
 
     Args:
-        searcher (Searcher): Searcher object that the
+        searcher: Searcher object that the
             Repeater will optimize. Note that the Searcher
             will only see 1 trial among multiple repeated trials.
             The result/metric passed to the Searcher upon
             trial completion will be averaged among all repeats.
-        repeat (int): Number of times to generate a trial with a repeated
+        repeat: Number of times to generate a trial with a repeated
             configuration. Defaults to 1.
-        set_index (bool): Sets a tune.suggest.repeater.TRIAL_INDEX in
+        set_index: Sets a tune.suggest.repeater.TRIAL_INDEX in
             Trainable/Function config which corresponds to the index of the
             repeated trial. This can be used for seeds. Defaults to True.
 

--- a/python/ray/tune/suggest/search.py
+++ b/python/ray/tune/suggest/search.py
@@ -37,9 +37,9 @@ class SearchAlgorithm:
         ``Searcher`` instance.
 
         Args:
-            metric (str): Metric to optimize
-            mode (str): One of ["min", "max"]. Direction to optimize.
-            config (Dict): Tune config dict.
+            metric: Metric to optimize
+            mode: One of ["min", "max"]. Direction to optimize.
+            config: Tune config dict.
             **spec: Any kwargs for forward compatiblity.
                 Info like Experiment.PUBLIC_KEYS is provided through here.
         """
@@ -60,7 +60,7 @@ class SearchAlgorithm:
         """Tracks given experiment specifications.
 
         Arguments:
-            experiments (Experiment | list | dict): Experiments to run.
+            experiments: Experiments to run.
         """
         raise NotImplementedError
 
@@ -68,7 +68,7 @@ class SearchAlgorithm:
         """Returns single Trial object to be queued into the TrialRunner.
 
         Returns:
-            trial (Trial): Returns a Trial object.
+            trial: Returns a Trial object.
         """
         raise NotImplementedError
 
@@ -90,11 +90,11 @@ class SearchAlgorithm:
 
         Arguments:
             trial_id: Identifier for the trial.
-            result (dict): Defaults to None. A dict will
+            result: Defaults to None. A dict will
                 be provided with this notification when the trial is in
                 the RUNNING state AND either completes naturally or
                 by manual termination.
-            error (bool): Defaults to False. True if the trial is in
+            error: Defaults to False. True if the trial is in
                 the RUNNING state and errors.
         """
         pass

--- a/python/ray/tune/suggest/search_generator.py
+++ b/python/ray/tune/suggest/search_generator.py
@@ -72,7 +72,7 @@ class SearchGenerator(SearchAlgorithm):
         """Registers experiment specifications.
 
         Arguments:
-            experiments (Experiment | list | dict): Experiments to run.
+            experiments: Experiments to run.
         """
         assert not self._experiment
         logger.debug("added configurations")
@@ -168,8 +168,8 @@ class SearchGenerator(SearchAlgorithm):
         The save operation is atomic (write/swap).
 
         Args:
-            dirpath (str): Filepath to experiment dir.
-            session_str (str): Unique identifier of the current run
+            dirpath: Filepath to experiment dir.
+            session_str: Unique identifier of the current run
                 session.
         """
         searcher = self.searcher

--- a/python/ray/tune/suggest/sigopt.py
+++ b/python/ray/tune/suggest/sigopt.py
@@ -38,28 +38,28 @@ class SigOptSearch(Searcher):
     here.
 
     Parameters:
-        space (list of dict): SigOpt configuration. Parameters will be sampled
+        space: SigOpt configuration. Parameters will be sampled
             from this configuration and will be used to override
             parameters generated in the variant generation process.
             Not used if existing experiment_id is given
-        name (str): Name of experiment. Required by SigOpt.
-        max_concurrent (int): Number of maximum concurrent trials supported
+        name: Name of experiment. Required by SigOpt.
+        max_concurrent: Number of maximum concurrent trials supported
             based on the user's SigOpt plan. Defaults to 1.
             If this Searcher is used in a ``ConcurrencyLimiter``, the
             ``max_concurrent`` value passed to it will override the
             value passed here.
-        connection (Connection): An existing connection to SigOpt.
-        experiment_id (str): Optional, if given will connect to an existing
+        connection: An existing connection to SigOpt.
+        experiment_id: Optional, if given will connect to an existing
             experiment. This allows for a more interactive experience with
             SigOpt, such as prior beliefs and constraints.
-        observation_budget (int): Optional, can improve SigOpt performance.
-        project (str): Optional, Project name to assign this experiment to.
+        observation_budget: Optional, can improve SigOpt performance.
+        project: Optional, Project name to assign this experiment to.
             SigOpt can group experiments by project
         metric (str or list(str)): If str then the training result
             objective value attribute. If list(str) then a list of
             metrics that can be optimized together. SigOpt currently
             supports up to 2 metrics.
-        mode (str or list(str)): If experiment_id is given then this
+        mode: If experiment_id is given then this
             field is ignored, If str then must be one of {min, max}.
             If list then must be comprised of {min, max, obs}. Determines
             whether objective is minimizing or maximizing the metric

--- a/python/ray/tune/suggest/skopt.py
+++ b/python/ray/tune/suggest/skopt.py
@@ -42,30 +42,30 @@ class SkOptSearch(Searcher):
     results.
 
     Parameters:
-        optimizer (skopt.optimizer.Optimizer): Optimizer provided
+        optimizer: Optimizer provided
             from skopt.
-        space (dict|list): A dict mapping parameter names to valid parameters,
+        space: A dict mapping parameter names to valid parameters,
             i.e. tuples for numerical parameters and lists for categorical
             parameters. If you passed an optimizer instance as the
             `optimizer` argument, this should be a list of parameter names
             instead.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        evaluated_rewards (list): If you have previously evaluated the
+        evaluated_rewards: If you have previously evaluated the
             parameters passed in as points_to_evaluate you can avoid
             re-running those trials by passing in the reward attributes
             as a list so the optimiser can be told the results without
             needing to re-compute the trial. Must be the same length as
             points_to_evaluate. (See tune/examples/skopt_example.py)
-        convert_to_python (bool): SkOpt outputs numpy primitives (e.g.
+        convert_to_python: SkOpt outputs numpy primitives (e.g.
             ``np.int64``) instead of Python types. If this setting is set
             to ``True``, the values will be converted to Python primitives.
         max_concurrent: Deprecated.

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -53,9 +53,9 @@ class Searcher:
     Not all implementations support multi objectives.
 
     Args:
-        metric (str or list): The training result objective value attribute. If
+        metric: The training result objective value attribute. If
             list then list of training result objective value attributes
-        mode (str or list): If string One of {min, max}. If list then
+        mode: If string One of {min, max}. If list then
             list of max and min, determines whether objective is minimizing
             or maximizing the metric attribute. Must match type of metric.
 
@@ -136,9 +136,9 @@ class Searcher:
         unsuccessful, e.g. when the search space has already been set.
 
         Args:
-            metric (str): Metric to optimize
-            mode (str): One of ["min", "max"]. Direction to optimize.
-            config (dict): Tune config dict.
+            metric: Metric to optimize
+            mode: One of ["min", "max"]. Direction to optimize.
+            config: Tune config dict.
             **spec: Any kwargs for forward compatiblity.
                 Info like Experiment.PUBLIC_KEYS is provided through here.
         """
@@ -153,8 +153,8 @@ class Searcher:
         avoid breaking the optimization process.
 
         Args:
-            trial_id (str): A unique string ID for the trial.
-            result (dict): Dictionary of metrics for current training progress.
+            trial_id: A unique string ID for the trial.
+            result: Dictionary of metrics for current training progress.
                 Note that the result dict may include NaNs or
                 may not include the optimization metric. It is up to the
                 subclass implementation to preprocess the result to
@@ -171,14 +171,14 @@ class Searcher:
         optimizer of the result.
 
         Args:
-            trial_id (str): A unique string ID for the trial.
-            result (dict): Dictionary of metrics for current training progress.
+            trial_id: A unique string ID for the trial.
+            result: Dictionary of metrics for current training progress.
                 Note that the result dict may include NaNs or
                 may not include the optimization metric. It is up to the
                 subclass implementation to preprocess the result to
                 avoid breaking the optimization process. Upon errors, this
                 may also be None.
-            error (bool): True if the training process raised an error.
+            error: True if the training process raised an error.
 
         """
         raise NotImplementedError
@@ -187,7 +187,7 @@ class Searcher:
         """Queries the algorithm to retrieve the next set of parameters.
 
         Arguments:
-            trial_id (str): Trial ID used for subsequent notifications.
+            trial_id: Trial ID used for subsequent notifications.
 
         Returns:
             dict | FINISHED | None: Configuration for a trial, if possible.
@@ -216,11 +216,11 @@ class Searcher:
         and may not be always available.
 
         Args:
-            parameters (dict): Parameters used for the trial.
-            value (float): Metric value obtained in the trial.
-            error (bool): True if the training process raised an error.
-            pruned (bool): True if trial was pruned.
-            intermediate_values (list): List of metric values for
+            parameters: Parameters used for the trial.
+            value: Metric value obtained in the trial.
+            error: True if the training process raised an error.
+            pruned: True if trial was pruned.
+            intermediate_values: List of metric values for
                 intermediate iterations of the result. None if not
                 applicable.
 
@@ -241,9 +241,8 @@ class Searcher:
         and may not be always available (same as ``add_evaluated_point``.)
 
         Args:
-            trials_or_analysis (Trial|List[Trial]|ExperimentAnalysis):
-                Trials to pass results form to the searcher.
-            metric (str): Metric name reported by trials used for
+            trials_or_analysis: Trials to pass results form to the searcher.
+            metric: Metric name reported by trials used for
                 determining the objective value.
 
         """
@@ -300,7 +299,7 @@ class Searcher:
         """Save state to path for this search algorithm.
 
         Args:
-            checkpoint_path (str): File where the search algorithm
+            checkpoint_path: File where the search algorithm
                 state is saved. This path should be used later when
                 restoring from file.
 
@@ -332,7 +331,7 @@ class Searcher:
 
 
         Args:
-            checkpoint_path (str): File where the search algorithm
+            checkpoint_path: File where the search algorithm
                 state is saved. This path should be the same
                 as the one provided to "save".
 
@@ -362,7 +361,7 @@ class Searcher:
         logic for handling this case is present in the searcher.
 
         Args:
-            max_concurrent (int): Number of maximum concurrent trials.
+            max_concurrent: Number of maximum concurrent trials.
         """
         return False
 
@@ -378,8 +377,8 @@ class Searcher:
         This is automatically used by tune.run during a Tune job.
 
         Args:
-            checkpoint_dir (str): Filepath to experiment dir.
-            session_str (str): Unique identifier of the current run
+            checkpoint_dir: Filepath to experiment dir.
+            session_str: Unique identifier of the current run
                 session.
         """
         tmp_search_ckpt_path = os.path.join(checkpoint_dir, ".tmp_searcher_ckpt")
@@ -449,11 +448,11 @@ class ConcurrencyLimiter(Searcher):
     Searcher's internal logic take over.
 
     Args:
-        searcher (Searcher): Searcher object that the
+        searcher: Searcher object that the
             ConcurrencyLimiter will manage.
-        max_concurrent (int): Maximum concurrent samples from the underlying
+        max_concurrent: Maximum concurrent samples from the underlying
             searcher.
-        batch (bool): Whether to wait for all concurrent samples
+        batch: Whether to wait for all concurrent samples
             to finish before updating the underlying searcher.
 
     Example:

--- a/python/ray/tune/suggest/zoopt.py
+++ b/python/ray/tune/suggest/zoopt.py
@@ -109,25 +109,25 @@ class ZOOptSearch(Searcher):
             stop={"timesteps_total": 10})
 
     Parameters:
-        algo (str): To specify an algorithm in zoopt you want to use.
+        algo: To specify an algorithm in zoopt you want to use.
             Only support ASRacos currently.
-        budget (int): Number of samples.
-        dim_dict (dict): Dimension dictionary.
+        budget: Number of samples.
+        dim_dict: Dimension dictionary.
             For continuous dimensions: (continuous, search_range, precision);
             For discrete dimensions: (discrete, search_range, has_order);
             For grid dimensions: (grid, grid_list).
             More details can be found in zoopt package.
-        metric (str): The training result objective value attribute. If None
+        metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
-        mode (str): One of {min, max}. Determines whether objective is
+        mode: One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        points_to_evaluate (list): Initial parameter suggestions to be run
+        points_to_evaluate: Initial parameter suggestions to be run
             first. This is for when you already have some good parameters
             you want to run first to help the algorithm make better suggestions
             for future parameters. Needs to be a list of dicts containing the
             configurations.
-        parallel_num (int): How many workers to parallel. Note that initial
+        parallel_num: How many workers to parallel. Note that initial
             phase may start less workers than this number. More details can
             be found in zoopt package.
     """

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -24,6 +24,7 @@ from ray.tune.sync_client import (
     get_sync_client,
     get_cloud_sync_client,
     NOOP,
+    SyncClient,
 )
 from ray.util.annotations import PublicAPI
 
@@ -102,13 +103,13 @@ def validate_sync_config(sync_config: "SyncConfig"):
         )
 
 
-def log_sync_template(options=""):
+def log_sync_template(options: str = ""):
     """Template enabling syncs between driver and worker when possible.
     Requires ray cluster to be started with the autoscaler. Also requires
     rsync to be installed.
 
     Args:
-        options (str): Additional rsync options.
+        options: Additional rsync options.
 
     Returns:
         Sync template with source and target parameters. None if rsync
@@ -142,10 +143,10 @@ class SyncConfig:
     happens via this remote storage.
 
     Args:
-        upload_dir (str): Optional URI to sync training results and checkpoints
+        upload_dir: Optional URI to sync training results and checkpoints
             to (e.g. ``s3://bucket``, ``gs://bucket`` or ``hdfs://path``).
             Specifying this will enable cloud-based checkpointing.
-        syncer (None|func|str): Function for syncing the local_dir to and
+        syncer: Function for syncing the local_dir to and
             from remote storage. If string, then it must be a string template
             that includes ``{source}`` and ``{target}`` for the syncer to run.
             If not provided, it defaults to rsync for non cloud-based storage,
@@ -153,12 +154,12 @@ class SyncConfig:
             storage.
             If set to ``None``, no syncing will take place.
             Defaults to ``"auto"`` (auto detect).
-        sync_on_checkpoint (bool): Force sync-down of trial checkpoint to
+        sync_on_checkpoint: Force sync-down of trial checkpoint to
             driver (only non cloud-storage).
             If set to False, checkpoint syncing from worker to driver
             is asynchronous and best-effort. This does not affect persistent
             storage syncing. Defaults to True.
-        sync_period (int): Syncing period for syncing between nodes.
+        sync_period: Syncing period for syncing between nodes.
 
     """
 
@@ -179,13 +180,13 @@ class SyncConfig:
 
 
 class Syncer:
-    def __init__(self, local_dir, remote_dir, sync_client=NOOP):
+    def __init__(self, local_dir: str, remote_dir: str, sync_client: SyncClient = NOOP):
         """Syncs between two directories with the sync_function.
 
         Arguments:
-            local_dir (str): Directory to sync. Uniquely identifies the syncer.
-            remote_dir (str): Remote directory to sync with.
-            sync_client (SyncClient): Client for syncing between local_dir and
+            local_dir: Directory to sync. Uniquely identifies the syncer.
+            remote_dir: Remote directory to sync with.
+            sync_client: Client for syncing between local_dir and
                 remote_dir. Defaults to a Noop.
         """
         self._local_dir = os.path.join(local_dir, "") if local_dir else local_dir
@@ -198,8 +199,8 @@ class Syncer:
         """Syncs up if time since last sync up is greather than sync_period.
 
         Args:
-            sync_period (int): Time period between subsequent syncs.
-            exclude (List[str]): Pattern of files to exclude, e.g.
+            sync_period: Time period between subsequent syncs.
+            exclude: Pattern of files to exclude, e.g.
                 ``["*/checkpoint_*]`` to exclude trial checkpoints.
         """
 
@@ -210,8 +211,8 @@ class Syncer:
         """Syncs down if time since last sync down is greather than sync_period.
 
         Args:
-            sync_period (int): Time period between subsequent syncs.
-            exclude (List[str]): Pattern of files to exclude, e.g.
+            sync_period: Time period between subsequent syncs.
+            exclude: Pattern of files to exclude, e.g.
                 ``["*/checkpoint_*]`` to exclude trial checkpoints.
         """
         if time.time() - self.last_sync_down_time > sync_period:
@@ -221,7 +222,7 @@ class Syncer:
         """Attempts to start the sync-up to the remote path.
 
         Args:
-            exclude (List[str]): Pattern of files to exclude, e.g.
+            exclude: Pattern of files to exclude, e.g.
                 ``["*/checkpoint_*]`` to exclude trial checkpoints.
 
         Returns:
@@ -242,7 +243,7 @@ class Syncer:
         """Attempts to start the sync-down from the remote path.
 
         Args:
-            exclude (List[str]): Pattern of files to exclude, e.g.
+            exclude: Pattern of files to exclude, e.g.
                 ``["*/checkpoint_*]`` to exclude trial checkpoints.
 
         Returns:
@@ -369,7 +370,11 @@ class NodeSyncer(Syncer):
         return "{}@{}:{}/".format(ssh_user, self.worker_ip, self._remote_dir)
 
 
-def get_cloud_syncer(local_dir, remote_dir=None, sync_function=None) -> CloudSyncer:
+def get_cloud_syncer(
+    local_dir: str,
+    remote_dir: Optional[str] = None,
+    sync_function: Optional[Union[Callable, str]] = None,
+) -> CloudSyncer:
     """Returns a Syncer.
 
     This syncer is in charge of syncing the local_dir with upload_dir.
@@ -381,10 +386,10 @@ def get_cloud_syncer(local_dir, remote_dir=None, sync_function=None) -> CloudSyn
     return a CloudSyncer with default templates for s3/gs/hdfs.
 
     Args:
-        local_dir (str): Source directory for syncing.
-        remote_dir (str): Target directory for syncing. If not provided, a
+        local_dir: Source directory for syncing.
+        remote_dir: Target directory for syncing. If not provided, a
             no-op Syncer is returned.
-        sync_function (func | str): Function for syncing the local_dir to
+        sync_function: Function for syncing the local_dir to
             remote_dir. If string, then it must be a string template for
             syncer to run. If not provided, it defaults
             to standard S3, gsutil or HDFS sync commands.
@@ -418,14 +423,18 @@ def get_cloud_syncer(local_dir, remote_dir=None, sync_function=None) -> CloudSyn
     return _syncers[key]
 
 
-def get_node_syncer(local_dir, remote_dir=None, sync_function=None):
+def get_node_syncer(
+    local_dir: str,
+    remote_dir: Optional[str] = None,
+    sync_function: Optional[Union[Callable, str, bool]] = None,
+):
     """Returns a NodeSyncer.
 
     Args:
-        local_dir (str): Source directory for syncing.
-        remote_dir (str): Target directory for syncing. If not provided, a
+        local_dir: Source directory for syncing.
+        remote_dir: Target directory for syncing. If not provided, a
             noop Syncer is returned.
-        sync_function (func|str|bool): Function for syncing the local_dir to
+        sync_function: Function for syncing the local_dir to
             remote_dir. If string, then it must be a string template for
             syncer to run. If True or not provided, it defaults rsync. If
             False, a noop Syncer is returned.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 import tempfile
 import time
-from typing import Any, Dict, Optional, Union, Callable
+from typing import Any, Dict, Optional, Union, Callable, List
 import uuid
 
 import ray
@@ -103,14 +103,14 @@ class Trainable:
         ``__init__()`` directly.
 
         Args:
-            config (dict): Trainable-specific configuration data. By default
+            config: Trainable-specific configuration data. By default
                 will be saved as ``self.config``.
-            logger_creator (func): Function that creates a ray.tune.Logger
+            logger_creator: Function that creates a ray.tune.Logger
                 object. If unspecified, a default logger is created.
-            remote_checkpoint_dir (str): Upload directory (S3 or GS path).
+            remote_checkpoint_dir: Upload directory (S3 or GS path).
                 This is **per trial** directory,
                 which is different from **per checkpoint** directory.
-            sync_function_tpl (str): Sync function template to use. Defaults
+            sync_function_tpl: Sync function template to use. Defaults
               to `cls._sync_function` (which defaults to `None`).
         """
 
@@ -209,11 +209,11 @@ class Trainable:
         return None
 
     @classmethod
-    def resource_help(cls, config):
+    def resource_help(cls, config: Dict):
         """Returns a help string for configuring this trainable's resources.
 
         Args:
-            config (dict): The Trainer's config dict.
+            config: The Trainer's config dict.
         """
         return ""
 
@@ -274,10 +274,10 @@ class Trainable:
         block until at least one result is received.
 
         Args:
-            buffer_time_s (float): Maximum time to buffer. The next result
+            buffer_time_s: Maximum time to buffer. The next result
                 received after this amount of time has passed will return
                 the whole buffer.
-            max_buffer_length (int): Maximum number of results to buffer.
+            max_buffer_length: Maximum number of results to buffer.
 
         """
         results = []
@@ -415,7 +415,7 @@ class Trainable:
             "ray_version": ray.__version__,
         }
 
-    def save(self, checkpoint_dir=None) -> str:
+    def save(self, checkpoint_dir: Optional[str] = None) -> str:
         """Saves the current model state to a checkpoint.
 
         Subclasses should override ``save_checkpoint()`` instead to save state.
@@ -425,7 +425,7 @@ class Trainable:
         storage.
 
         Args:
-            checkpoint_dir (str): Optional dir to place the checkpoint.
+            checkpoint_dir: Optional dir to place the checkpoint.
 
         Returns:
             str: path that points to xxx.pkl file.
@@ -552,11 +552,11 @@ class Trainable:
         self.restore(checkpoint_path)
         shutil.rmtree(tmpdir)
 
-    def delete_checkpoint(self, checkpoint_path):
+    def delete_checkpoint(self, checkpoint_path: str):
         """Deletes local copy of checkpoint.
 
         Args:
-            checkpoint_path (str): Path to checkpoint.
+            checkpoint_path: Path to checkpoint.
         """
         # Ensure TrialCheckpoints are converted
         if isinstance(checkpoint_path, TrialCheckpoint):
@@ -580,16 +580,18 @@ class Trainable:
         if os.path.exists(checkpoint_dir):
             shutil.rmtree(checkpoint_dir)
 
-    def export_model(self, export_formats, export_dir=None):
+    def export_model(
+        self, export_formats: Union[List[str], str], export_dir: Optional[str] = None
+    ):
         """Exports model based on export_formats.
 
         Subclasses should override _export_model() to actually
         export model to local directory.
 
         Args:
-            export_formats (Union[list,str]): Format or list of (str) formats
+            export_formats: Format or list of (str) formats
                 that should be exported.
-            export_dir (str): Optional dir to place the exported model.
+            export_dir: Optional dir to place the exported model.
                 Defaults to self.logdir.
 
         Returns:
@@ -646,7 +648,7 @@ class Trainable:
 
         return True
 
-    def reset_config(self, new_config):
+    def reset_config(self, new_config: Dict):
         """Resets configuration without restarting the trial.
 
         This method is optional, but can be implemented to speed up algorithms
@@ -654,7 +656,7 @@ class Trainable:
         experiments with reuse_actors=True.
 
         Args:
-            new_config (dict): Updated hyperparameter configuration
+            new_config: Updated hyperparameter configuration
                 for the trainable.
 
         Returns:
@@ -846,7 +848,7 @@ class Trainable:
             )
         raise NotImplementedError
 
-    def save_checkpoint(self, tmp_checkpoint_dir):
+    def save_checkpoint(self, tmp_checkpoint_dir: str):
         """Subclasses should override this to implement ``save()``.
 
         Warning:
@@ -863,7 +865,7 @@ class Trainable:
         .. versionadded:: 0.8.7
 
         Args:
-            tmp_checkpoint_dir (str): The directory where the checkpoint
+            tmp_checkpoint_dir: The directory where the checkpoint
                 file must be stored. In a Tune run, if the trial is paused,
                 the provided path may be temporary and moved.
 
@@ -889,7 +891,7 @@ class Trainable:
             )
         raise NotImplementedError
 
-    def load_checkpoint(self, checkpoint):
+    def load_checkpoint(self, checkpoint: Union[Dict, str]):
         """Subclasses should override this to implement restore().
 
         Warning:
@@ -926,7 +928,7 @@ class Trainable:
         .. versionadded:: 0.8.7
 
         Args:
-            checkpoint (str|dict): If dict, the return value is as
+            checkpoint: If dict, the return value is as
                 returned by `save_checkpoint`. If a string, then it is
                 a checkpoint path that may have a different prefix than that
                 returned by `save_checkpoint`. The directory structure
@@ -939,13 +941,13 @@ class Trainable:
             )
         raise NotImplementedError
 
-    def setup(self, config):
+    def setup(self, config: Dict):
         """Subclasses should override this for custom initialization.
 
         .. versionadded:: 0.8.7
 
         Args:
-            config (dict): Hyperparameters and other configs given.
+            config: Hyperparameters and other configs given.
                 Copy of `self.config`.
 
         """
@@ -956,7 +958,7 @@ class Trainable:
             )
         pass
 
-    def log_result(self, result):
+    def log_result(self, result: Dict):
         """Subclasses can optionally override this to customize logging.
 
         The logging here is done on the worker process rather than
@@ -966,7 +968,7 @@ class Trainable:
         .. versionadded:: 0.8.7
 
         Args:
-            result (dict): Training result returned by step().
+            result: Training result returned by step().
         """
         if self._implements_method("_log_result") and log_once("_log_result"):
             raise DeprecationWarning(
@@ -993,12 +995,12 @@ class Trainable:
             )
         pass
 
-    def _export_model(self, export_formats, export_dir):
+    def _export_model(self, export_formats: List[str], export_dir: str):
         """Subclasses should override this to export model.
 
         Args:
-            export_formats (list): List of formats that should be exported.
-            export_dir (str): Directory to place exported models.
+            export_formats: List of formats that should be exported.
+            export_dir: Directory to place exported models.
 
         Return:
             A dict that maps ExportFormats to successfully exported models.

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -8,7 +8,7 @@ import platform
 import re
 import shutil
 import time
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Union, Callable, List
 import uuid
 
 import ray
@@ -99,11 +99,11 @@ class CheckpointDeleter:
         self.trial_id = trial_id
         self.runner = runner
 
-    def __call__(self, checkpoint):
+    def __call__(self, checkpoint: Checkpoint):
         """Requests checkpoint deletion asynchronously.
 
         Args:
-            checkpoint (Checkpoint): Checkpoint to delete.
+            checkpoint: Checkpoint to delete.
         """
         if not self.runner:
             return
@@ -133,10 +133,9 @@ class TrialInfo:
     """Serializable struct for holding information for a Trial.
 
     Attributes:
-        trial_name (str): String name of the current trial.
-        trial_id (str): trial_id of the trial
-        trial_resources (Resources|PlacementGroupFactory): resources used
-            by trial.
+        trial_name: String name of the current trial.
+        trial_id: trial_id of the trial
+        trial_resources: resources used by trial.
     """
 
     def __init__(self, trial: "Trial"):
@@ -208,15 +207,15 @@ class Trial:
     which is being deprecated.
 
     Attributes:
-        trainable_name (str): Name of the trainable object to be executed.
-        config (dict): Provided configuration dictionary with evaluated params.
-        trial_id (str): Unique identifier for the trial.
-        local_dir (str): Local_dir as passed to tune.run.
-        logdir (str): Directory where the trial logs are saved.
-        evaluated_params (dict): Evaluated parameters by search algorithm,
-        experiment_tag (str): Identifying trial name to show in the console
-        status (str): One of PENDING, RUNNING, PAUSED, TERMINATED, ERROR/
-        error_file (str): Path to the errors that this trial has raised.
+        trainable_name: Name of the trainable object to be executed.
+        config: Provided configuration dictionary with evaluated params.
+        trial_id: Unique identifier for the trial.
+        local_dir: Local_dir as passed to tune.run.
+        logdir: Directory where the trial logs are saved.
+        evaluated_params: Evaluated parameters by search algorithm,
+        experiment_tag: Identifying trial name to show in the console
+        status: One of PENDING, RUNNING, PAUSED, TERMINATED, ERROR/
+        error_file: Path to the errors that this trial has raised.
 
     """
 
@@ -236,29 +235,29 @@ class Trial:
 
     def __init__(
         self,
-        trainable_name,
-        config=None,
-        trial_id=None,
-        local_dir=DEFAULT_RESULTS_DIR,
-        evaluated_params=None,
-        experiment_tag="",
-        resources=None,
-        placement_group_factory=None,
-        stopping_criterion=None,
-        remote_checkpoint_dir=None,
-        sync_function_tpl=None,
-        checkpoint_freq=0,
-        checkpoint_at_end=False,
-        sync_on_checkpoint=True,
-        keep_checkpoints_num=None,
-        checkpoint_score_attr=TRAINING_ITERATION,
-        export_formats=None,
-        restore_path=None,
-        trial_name_creator=None,
-        trial_dirname_creator=None,
-        log_to_file=None,
-        max_failures=0,
-        stub=False,
+        trainable_name: str,
+        config: Optional[Dict] = None,
+        trial_id: Optional[str] = None,
+        local_dir: Optional[str] = DEFAULT_RESULTS_DIR,
+        evaluated_params: Optional[Dict] = None,
+        experiment_tag: str = "",
+        resources: Optional[Resources] = None,
+        placement_group_factory: Optional[PlacementGroupFactory] = None,
+        stopping_criterion: Optional[Dict[str, float]] = None,
+        remote_checkpoint_dir: Optional[str] = None,
+        sync_function_tpl: Optional[str] = None,
+        checkpoint_freq: int = 0,
+        checkpoint_at_end: bool = False,
+        sync_on_checkpoint: bool = True,
+        keep_checkpoints_num: Optional[int] = None,
+        checkpoint_score_attr: str = TRAINING_ITERATION,
+        export_formats: Optional[List[str]] = None,
+        restore_path: Optional[str] = None,
+        trial_name_creator: Optional[Callable[["Trial"], str]] = None,
+        trial_dirname_creator: Optional[Callable[["Trial"], str]] = None,
+        log_to_file: Optional[str] = None,
+        max_failures: int = 0,
+        stub: bool = False,
     ):
         """Initialize a new trial.
 
@@ -637,11 +636,11 @@ class Trial:
         self.restoring_from = None
         self.invalidate_json_state()
 
-    def on_checkpoint(self, checkpoint):
+    def on_checkpoint(self, checkpoint: Checkpoint):
         """Hook for handling checkpoints taken by the Trainable.
 
         Args:
-            checkpoint (Checkpoint): Checkpoint taken.
+            checkpoint: Checkpoint taken.
         """
         self.checkpoint_manager.on_checkpoint(checkpoint)
         self.invalidate_json_state()

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -55,8 +55,8 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         in the TrialRunner.
 
         Args:
-            trial (Trial): Trial to checkpoint.
-            status (Trial.status): Status to set trial to.
+            trial: Trial to checkpoint.
+            status: Status to set trial to.
         """
         if trial.status == status:
             logger.debug("Trial %s: Status %s unchanged.", trial, trial.status)
@@ -83,7 +83,7 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         """Starts the trial restoring from checkpoint if checkpoint is provided.
 
         Args:
-            trial (Trial): Trial to be started.
+            trial: Trial to be started.
 
         Returns:
             True if trial started successfully, False otherwise.
@@ -101,8 +101,8 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         in error, but no exception will be thrown.
 
         Args:
-            error (bool): Whether to mark this trial as terminated in error.
-            error_msg (str): Optional error message.
+            error: Whether to mark this trial as terminated in error.
+            error_msg: Optional error message.
 
         """
         pass
@@ -133,10 +133,10 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         """Tries to invoke `Trainable.reset()` to reset trial.
 
         Args:
-            trial (Trial): Trial to be reset.
-            new_config (dict): New configuration for Trial
+            trial: Trial to be reset.
+            new_config: New configuration for Trial
                 trainable.
-            new_experiment_tag (str): New experiment name
+            new_experiment_tag: New experiment name
                 for trial.
 
         Returns:
@@ -148,7 +148,7 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         """A hook called before running one step of the trial event loop.
 
         Args:
-            trials (List[Trial]): The list of trials. Note, refrain from
+            trials: The list of trials. Note, refrain from
                 providing TrialRunner directly here.
         """
         pass
@@ -157,7 +157,7 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         """A hook called after running one step of the trial event loop.
 
         Args:
-            trials (List[Trial]): The list of trials. Note, refrain from
+            trials: The list of trials. Note, refrain from
                 providing TrialRunner directly here.
         """
         pass
@@ -178,7 +178,7 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         If restoring fails, the trial status will be set to ERROR.
 
         Args:
-            trial (Trial): Trial to be restored.
+            trial: Trial to be restored.
 
         Returns:
             False if error occurred, otherwise return True.
@@ -187,17 +187,20 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
 
     @abstractmethod
     def save(
-        self, trial, storage: str = Checkpoint.PERSISTENT, result: Optional[Dict] = None
+        self,
+        trial: Trial,
+        storage: str = Checkpoint.PERSISTENT,
+        result: Optional[Dict] = None,
     ) -> Checkpoint:
         """Saves training state of this trial to a checkpoint.
 
         If result is None, this trial's last result will be used.
 
         Args:
-            trial (Trial): The state of this trial to be saved.
-            storage (str): Where to store the checkpoint. Defaults to
+            trial: The state of this trial to be saved.
+            storage: Where to store the checkpoint. Defaults to
                 PERSISTENT.
-            result (dict): The state of this trial as a dictionary to be saved.
+            result: The state of this trial as a dictionary to be saved.
 
         Returns:
             A Checkpoint object.
@@ -209,7 +212,7 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         """Exports model of this trial based on trial.export_formats.
 
         Args:
-            trial (Trial): The state of this trial to be saved.
+            trial: The state of this trial to be saved.
 
         Returns:
             A dict that maps ExportFormats to successfully exported models.
@@ -224,7 +227,7 @@ class TrialExecutor(metaclass=_WarnOnDirectInheritanceMeta):
         """Ensures that trials are cleaned up after stopping.
 
         Args:
-            trials (List[Trial]): The list of trials. Note, refrain from
+            trials: The list of trials. Note, refrain from
                 providing TrialRunner directly here.
         """
         pass

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -13,7 +13,7 @@ import ray
 from ray.tune.impl.out_of_band_serialize_dataset import out_of_band_serialize_dataset
 from ray.util import get_node_ip_address
 from ray.tune import TuneError
-from ray.tune.callback import CallbackList
+from ray.tune.callback import CallbackList, Callback
 from ray.tune.experiment import Experiment
 from ray.tune.insufficient_resources_manager import InsufficientResourcesManager
 from ray.tune.ray_trial_executor import RayTrialExecutor, ExecutorEventType
@@ -26,7 +26,7 @@ from ray.tune.result import (
     SHOULD_CHECKPOINT,
 )
 from ray.tune.schedulers import FIFOScheduler, TrialScheduler
-from ray.tune.stopper import NoopStopper
+from ray.tune.stopper import NoopStopper, Stopper
 from ray.tune.suggest import BasicVariantGenerator, SearchAlgorithm
 from ray.tune.syncer import CloudSyncer, get_cloud_syncer, SyncConfig
 from ray.tune.trial import Checkpoint, Trial
@@ -124,7 +124,7 @@ class _ExperimentCheckpointManager:
         trial_runner: "TrialRunner",
         trial_executor: RayTrialExecutor,
         search_alg: SearchAlgorithm,
-        force=False,
+        force: bool = False,
     ):
         """Saves execution state to `self._local_checkpoint_dir`.
 
@@ -135,7 +135,7 @@ class _ExperimentCheckpointManager:
         checkpoint dir.
 
         Args:
-            force (bool): Forces a checkpoint despite checkpoint_period.
+            force: Forces a checkpoint despite checkpoint_period.
         """
         if not self._checkpoint_dir:
             return
@@ -213,32 +213,32 @@ class TrialRunner:
     misleading benchmark results.
 
     Args:
-        search_alg (SearchAlgorithm): SearchAlgorithm for generating
+        search_alg: SearchAlgorithm for generating
             Trial objects.
-        scheduler (TrialScheduler): Defaults to FIFOScheduler.
-        local_checkpoint_dir (str): Path where
+        scheduler: Defaults to FIFOScheduler.
+        local_checkpoint_dir: Path where
             global checkpoints are stored and restored from.
-        remote_checkpoint_dir (str): Remote path where
+        remote_checkpoint_dir: Remote path where
             global checkpoints are stored and restored from. Used
             if `resume` == REMOTE.
-        sync_config (SyncConfig): See `tune.py:run`.
+        sync_config: See `tune.py:run`.
         stopper: Custom class for stopping whole experiments. See
             ``Stopper``.
-        resume (str|False): see `tune.py:run`.
-        server_port (int): Port number for launching TuneServer.
-        fail_fast (bool | str): Finishes as soon as a trial fails if True.
+        resume: see `tune.py:run`.
+        server_port: Port number for launching TuneServer.
+        fail_fast: Finishes as soon as a trial fails if True.
             If fail_fast='raise' provided, Tune will automatically
             raise the exception received by the Trainable. fail_fast='raise'
             can easily leak resources and should be used with caution.
-        checkpoint_period (int|str): Trial runner checkpoint periodicity in
+        checkpoint_period: Trial runner checkpoint periodicity in
             seconds. Defaults to ``"auto"``, which adjusts checkpointing
             time so that at most 5% of the time is spent on writing
             checkpoints.
-        trial_executor (TrialExecutor): Defaults to RayTrialExecutor.
-        callbacks (list): List of callbacks that will be called at different
+        trial_executor: Defaults to RayTrialExecutor.
+        callbacks: List of callbacks that will be called at different
             times in the training loop. Must be instances of the
             ``ray.tune.trial_runner.Callback`` class.
-        metric (str): Metric used to check received results. If a result is
+        metric: Metric used to check received results. If a result is
             reported without this metric, an error will be raised. The error
             can be omitted by not providing a metric or by setting the env
             variable ``TUNE_DISABLE_STRICT_METRIC_CHECKING=0``
@@ -251,21 +251,21 @@ class TrialRunner:
 
     def __init__(
         self,
-        search_alg=None,
-        scheduler=None,
-        local_checkpoint_dir=None,
-        remote_checkpoint_dir=None,
-        sync_config=None,
-        stopper=None,
-        resume=False,
-        server_port=None,
-        fail_fast=False,
-        checkpoint_period=None,
-        trial_executor=None,
-        callbacks=None,
-        metric=None,
+        search_alg: Optional[SearchAlgorithm] = None,
+        scheduler: Optional[TrialScheduler] = None,
+        local_checkpoint_dir: Optional[str] = None,
+        remote_checkpoint_dir: Optional[str] = None,
+        sync_config: Optional[SyncConfig] = None,
+        stopper: Optional[Stopper] = None,
+        resume: Union[str, bool] = False,
+        server_port: Optional[int] = None,
+        fail_fast: bool = False,
+        checkpoint_period: Union[str, int] = None,
+        trial_executor: Optional[RayTrialExecutor] = None,
+        callbacks: Optional[List[Callback]] = None,
+        metric: Optional[str] = None,
         # Deprecate on next refactor
-        driver_sync_trial_checkpoints=False,
+        driver_sync_trial_checkpoints: bool = False,
     ):
         self._search_alg = search_alg or BasicVariantGenerator()
         self._scheduler_alg = scheduler or FIFOScheduler()
@@ -407,9 +407,9 @@ class TrialRunner:
         Mainly used to setup callbacks.
 
         Args:
-            experiments (List[Experiment]): List of Experiments
+            experiments: List of Experiments
                 to use.
-            total_num_samples (int): Total number of samples
+            total_num_samples: Total number of samples
                 factoring in grid search samplers.
         """
         experiment = experiments[0]
@@ -586,7 +586,7 @@ class TrialRunner:
             for fname in os.listdir(directory)
         )
 
-    def checkpoint(self, force=False):
+    def checkpoint(self, force: bool = False):
         """Saves execution state to `self._local_checkpoint_dir`.
 
         Overwrites the current session checkpoint, which starts when self
@@ -596,7 +596,7 @@ class TrialRunner:
         checkpoint dir.
 
         Args:
-            force (bool): Forces a checkpoint despite checkpoint_period.
+            force: Forces a checkpoint despite checkpoint_period.
         """
         with warn_if_slow(
             "experiment_checkpoint",
@@ -892,13 +892,13 @@ class TrialRunner:
         """Returns the set of trials that are not in Trial.TERMINATED state."""
         return self._live_trials
 
-    def add_trial(self, trial):
+    def add_trial(self, trial: Trial):
         """Adds a new trial to this TrialRunner.
 
         Trials may be added at any time.
 
         Args:
-            trial (Trial): Trial to queue.
+            trial: Trial to queue.
         """
         self._trials.append(trial)
         if trial.status != Trial.TERMINATED:
@@ -1111,13 +1111,13 @@ class TrialRunner:
                     )
                 )
 
-    def _process_trial_save(self, trial, result):
+    def _process_trial_save(self, trial: Trial, result: Union[ray.ObjectRef, str]):
         """Processes a trial save.
 
         Acts on the decision cached during the last `_process_trial` call.
 
         Args:
-            trial (Trial): Trial being saved.
+            trial: Trial being saved.
         """
         logger.debug("Trial %s: Processing trial save.", trial)
 
@@ -1142,11 +1142,11 @@ class TrialRunner:
         if decision and result:
             self._queue_decision(trial, decision)
 
-    def _process_trial_restore(self, trial):
+    def _process_trial_restore(self, trial: Trial):
         """Processes a trial restore.
 
         Args:
-            trial (Trial): Trial being restored.
+            trial: Trial being restored.
         """
         logger.debug("Trial %s: Processing trial restore.", trial)
         trial.on_restore()
@@ -1155,14 +1155,14 @@ class TrialRunner:
         self.trial_executor.continue_training(trial)
         self._live_trials.add(trial)
 
-    def _process_trial_failure(self, trial, error_msg):
+    def _process_trial_failure(self, trial: Trial, error_msg: str):
         """Handle trial failure.
 
         Attempt trial recovery if possible, clean up state otherwise.
 
         Args:
-            trial (Trial): Failed trial.
-            error_msg (str): Error message prior to invoking this method.
+            trial: Failed trial.
+            error_msg: Error message prior to invoking this method.
         """
         self._has_errored = True
         if trial.status == Trial.RUNNING:
@@ -1190,12 +1190,12 @@ class TrialRunner:
         if decision is TrialScheduler.STOP or decision is TrialScheduler.PAUSE:
             self._queued_trial_decisions[trial.trial_id] = decision
 
-    def _execute_action(self, trial, decision):
+    def _execute_action(self, trial: Trial, decision: str):
         """Executes action based on decision.
 
         Args:
-            trial (Trial): Trial to act on.
-            decision (str): Scheduling decision to undertake.
+            trial: Trial to act on.
+            decision: Scheduling decision to undertake.
         """
         if decision == TrialScheduler.CONTINUE:
             self.trial_executor.continue_training(trial)
@@ -1215,14 +1215,14 @@ class TrialRunner:
             if trial.runner:
                 self.trial_executor.save(trial, storage=Checkpoint.PERSISTENT)
 
-    def _try_recover(self, trial, error_msg):
+    def _try_recover(self, trial: Trial, error_msg: str):
         """Tries to recover trial.
 
         Notifies SearchAlgorithm and Scheduler if failure to recover.
 
         Args:
-            trial (Trial): Trial to recover.
-            error_msg (str): Error message from prior to invoking this method.
+            trial: Trial to recover.
+            error_msg: Error message from prior to invoking this method.
         """
         self._cached_trial_decisions.pop(trial.trial_id, None)
         # Resetting this, in case that the trial is in saving status when it crashes.
@@ -1297,9 +1297,9 @@ class TrialRunner:
         Note that the timeout is currently unexposed to the user.
 
         Args:
-            blocking (bool): Blocks until either a trial is available
+            blocking: Blocks until either a trial is available
                 or is_finished (timeout or search algorithm finishes).
-            timeout (int): Seconds before blocking times out.
+            timeout: Seconds before blocking times out.
 
         Returns:
             Boolean indicating if a new trial was created or not.

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -69,13 +69,15 @@ def _check_default_resources_override(run_identifier):
     )
 
 
-def _report_progress(runner, reporter, done=False):
+def _report_progress(
+    runner: TrialRunner, reporter: ProgressReporter, done: bool = False
+):
     """Reports experiment progress.
 
     Args:
-        runner (TrialRunner): Trial runner to report on.
-        reporter (ProgressReporter): Progress reporter.
-        done (bool): Whether this is the last progress report attempt.
+        runner: Trial runner to report on.
+        reporter: Progress reporter.
+        done: Whether this is the last progress report attempt.
     """
     trials = runner.get_trials()
     if reporter.should_report(trials, done=done):
@@ -166,9 +168,8 @@ def run(
                  local_dir=<path/to/dir>, resume="ERRORED_ONLY")
 
     Args:
-        run_or_experiment (function | class | str | :class:`Experiment`): If
-            function|class|str, this is the algorithm or model to train.
-            This may refer to the name of a built-on algorithm
+        run_or_experiment: If function|class|str, this is the algorithm or
+            model to train. This may refer to the name of a built-on algorithm
             (e.g. RLLib's DQN or PPO), a user-defined trainable
             function or class, or the string identifier of a
             trainable function or class registered in the tune registry.
@@ -177,14 +178,14 @@ def run(
             will need to first register the function:
             ``tune.register_trainable("lambda_id", lambda x: ...)``. You can
             then use ``tune.run("lambda_id")``.
-        metric (str): Metric to optimize. This metric should be reported
+        metric: Metric to optimize. This metric should be reported
             with `tune.report()`. If set, will be passed to the search
             algorithm and scheduler.
-        mode (str): Must be one of [min, max]. Determines whether objective is
+        mode: Must be one of [min, max]. Determines whether objective is
             minimizing or maximizing the metric attribute. If set, will be
             passed to the search algorithm and scheduler.
-        name (str): Name of experiment.
-        stop (dict | callable | :class:`Stopper`): Stopping criteria. If dict,
+        name: Name of experiment.
+        stop: Stopping criteria. If dict,
             the keys may be any field in the return result of 'train()',
             whichever is reached first. If function, it must take (trial_id,
             result) as arguments and return a boolean (True if trial should be
@@ -192,54 +193,54 @@ def run(
             ``ray.tune.Stopper``, which allows users to implement
             custom experiment-wide stopping (i.e., stopping an entire Tune
             run based on some time constraint).
-        time_budget_s (int|float|datetime.timedelta): Global time budget in
+        time_budget_s: Global time budget in
             seconds after which all trials are stopped. Can also be a
             ``datetime.timedelta`` object.
-        config (dict): Algorithm-specific configuration for Tune variant
+        config: Algorithm-specific configuration for Tune variant
             generation (e.g. env, hyperparams). Defaults to empty dict.
             Custom search algorithms may ignore this.
-        resources_per_trial (dict|PlacementGroupFactory): Machine resources
+        resources_per_trial: Machine resources
             to allocate per trial, e.g. ``{"cpu": 64, "gpu": 8}``.
             Note that GPUs will not be assigned unless you specify them here.
             Defaults to 1 CPU and 0 GPUs in
             ``Trainable.default_resource_request()``. This can also
             be a PlacementGroupFactory object wrapping arguments to create a
             per-trial placement group.
-        num_samples (int): Number of times to sample from the
+        num_samples: Number of times to sample from the
             hyperparameter space. Defaults to 1. If `grid_search` is
             provided as an argument, the grid will be repeated
             `num_samples` of times. If this is -1, (virtually) infinite
             samples are generated until a stopping condition is met.
-        local_dir (str): Local dir to save training results to.
+        local_dir: Local dir to save training results to.
             Defaults to ``~/ray_results``.
-        search_alg (Searcher|SearchAlgorithm|str): Search algorithm for
+        search_alg: Search algorithm for
             optimization. You can also use the name of the algorithm.
-        scheduler (TrialScheduler|str): Scheduler for executing
+        scheduler: Scheduler for executing
             the experiment. Choose among FIFO (default), MedianStopping,
             AsyncHyperBand, HyperBand and PopulationBasedTraining. Refer to
             ray.tune.schedulers for more options. You can also use the
             name of the scheduler.
-        keep_checkpoints_num (int): Number of checkpoints to keep. A value of
+        keep_checkpoints_num: Number of checkpoints to keep. A value of
             `None` keeps all checkpoints. Defaults to `None`. If set, need
             to provide `checkpoint_score_attr`.
-        checkpoint_score_attr (str): Specifies by which attribute to rank the
+        checkpoint_score_attr: Specifies by which attribute to rank the
             best checkpoint. Default is increasing order. If attribute starts
             with `min-` it will rank attribute in decreasing order, i.e.
             `min-validation_loss`.
-        checkpoint_freq (int): How many training iterations between
+        checkpoint_freq: How many training iterations between
             checkpoints. A value of 0 (default) disables checkpointing.
             This has no effect when using the Functional Training API.
-        checkpoint_at_end (bool): Whether to checkpoint at the end of the
+        checkpoint_at_end: Whether to checkpoint at the end of the
             experiment regardless of the checkpoint_freq. Default is False.
             This has no effect when using the Functional Training API.
-        verbose (Union[int, Verbosity]): 0, 1, 2, or 3. Verbosity mode.
+        verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief trial
             results, 3 = status and detailed trial results. Defaults to 3.
-        progress_reporter (ProgressReporter): Progress reporter for reporting
+        progress_reporter: Progress reporter for reporting
             intermediate experiment progress. Defaults to CLIReporter if
             running in command-line, or JupyterNotebookReporter if running in
             a Jupyter notebook.
-        log_to_file (bool|str|Sequence): Log stdout and stderr to files in
+        log_to_file: Log stdout and stderr to files in
             Tune's trial directories. If this is `False` (default), no files
             are written. If `true`, outputs are written to `trialdir/stdout`
             and `trialdir/stderr`, respectively. If this is a single string,
@@ -247,29 +248,29 @@ def run(
             both streams are written. If this is a Sequence (e.g. a Tuple),
             it has to have length 2 and the elements indicate the files to
             which stdout and stderr are written, respectively.
-        trial_name_creator (Callable[[Trial], str]): Optional function
+        trial_name_creator: Optional function
             for generating the trial string representation.
-        trial_dirname_creator (Callable[[Trial], str]): Function
+        trial_dirname_creator: Function
             for generating the trial dirname. This function should take
             in a Trial object and return a string representing the
             name of the directory. The return value cannot be a path.
-        sync_config (SyncConfig): Configuration object for syncing. See
+        sync_config: Configuration object for syncing. See
             tune.SyncConfig.
-        export_formats (list): List of formats that exported at the end of
+        export_formats: List of formats that exported at the end of
             the experiment. Default is None.
-        max_failures (int): Try to recover a trial at least this many times.
+        max_failures: Try to recover a trial at least this many times.
             Ray will recover from the latest checkpoint if present.
             Setting to -1 will lead to infinite recovery retries.
             Setting to 0 will disable retries. Defaults to 0.
-        fail_fast (bool | str): Whether to fail upon the first error.
+        fail_fast: Whether to fail upon the first error.
             If fail_fast='raise' provided, Tune will automatically
             raise the exception received by the Trainable. fail_fast='raise'
             can easily leak resources and should be used with caution (it
             is best used with `ray.init(local_mode=True)`).
-        restore (str): Path to checkpoint. Only makes sense to set if
+        restore: Path to checkpoint. Only makes sense to set if
             running 1 trial. Defaults to None.
-        server_port (int): Port number for launching TuneServer.
-        resume (str|bool): One of "LOCAL", "REMOTE", "PROMPT", "ERRORED_ONLY", "AUTO",
+        server_port: Port number for launching TuneServer.
+        resume: One of "LOCAL", "REMOTE", "PROMPT", "ERRORED_ONLY", "AUTO",
             or bool. "LOCAL"/True restores the checkpoint from the
             local experiment directory, determined
             by ``name`` and ``local_dir``. "REMOTE" restores the checkpoint
@@ -282,25 +283,25 @@ def run(
             start a new experiment.
             If resume is set but checkpoint does not exist,
             ValueError will be thrown.
-        reuse_actors (bool): Whether to reuse actors between different trials
+        reuse_actors: Whether to reuse actors between different trials
             when possible. This can drastically speed up experiments that start
             and stop actors often (e.g., PBT in time-multiplexing mode). This
             requires trials to have the same resource requirements.
-        trial_executor (TrialExecutor): Manage the execution of trials.
-        raise_on_failed_trial (bool): Raise TuneError if there exists failed
+        trial_executor: Manage the execution of trials.
+        raise_on_failed_trial: Raise TuneError if there exists failed
             trial (of ERROR state) when the experiments complete.
-        callbacks (list): List of callbacks that will be called at different
+        callbacks: List of callbacks that will be called at different
             times in the training loop. Must be instances of the
             ``ray.tune.callback.Callback`` class. If not passed,
             `LoggerCallback` and `SyncerCallback` callbacks are automatically
             added.
-        max_concurrent_trials (int): Maximum number of trials to run
+        max_concurrent_trials: Maximum number of trials to run
             concurrently. Must be non-negative. If None or 0, no limit will
             be applied. This is achieved by wrapping the ``search_alg`` in
             a :class:`ConcurrencyLimiter`, and thus setting this argument
             will raise an exception if the ``search_alg`` is already a
             :class:`ConcurrencyLimiter`. Defaults to None.
-        _remote (bool): Whether to run the Tune driver in a remote function.
+        _remote: Whether to run the Tune driver in a remote function.
             This is disabled automatically if a custom trial executor is
             passed in. This is enabled by default in Ray client mode.
 

--- a/python/ray/tune/utils/placement_groups.py
+++ b/python/ray/tune/utils/placement_groups.py
@@ -287,7 +287,7 @@ class PlacementGroupManager:
     placement groups with their factory methods.
 
     Args:
-        prefix (str): Prefix for the placement group names that are created.
+        prefix: Prefix for the placement group names that are created.
     """
 
     def __init__(self, prefix: str = "__tune__", max_staging: int = 1000):
@@ -338,7 +338,7 @@ class PlacementGroupManager:
         """Schedule placement group for (delayed) removal.
 
         Args:
-            pg (PlacementGroup): Placement group object.
+            pg: Placement group object.
 
         """
         self._pgs_for_removal[pg] = time.time()
@@ -352,7 +352,7 @@ class PlacementGroupManager:
         groups are removed instead.
 
         Args:
-            force (bool): If True, all placement groups scheduled for removal
+            force: If True, all placement groups scheduled for removal
                 will be removed, disregarding any removal conditions.
 
         """
@@ -382,7 +382,7 @@ class PlacementGroupManager:
         same driver script.
 
         Args:
-            block (bool): If True, will wait until all placement groups are
+            block: If True, will wait until all placement groups are
                 shut down.
         """
         should_cleanup = not int(
@@ -417,7 +417,7 @@ class PlacementGroupManager:
         placement groups is not exhausted.
 
         Args:
-            trial (Trial): Trial whose placement group to stage.
+            trial: Trial whose placement group to stage.
 
         Returns:
             False if placement group has not been staged, True otherwise.
@@ -484,7 +484,7 @@ class PlacementGroupManager:
         `self._ready`.
 
         Args:
-            trial ("Trial"): "Trial" object to start
+            trial: "Trial" object to start
             actor_cls: Ray actor class.
 
         Returns:
@@ -532,8 +532,8 @@ class PlacementGroupManager:
         """Return True if placement group for trial is ready.
 
         Args:
-            trial (Trial): :obj:`Trial` object.
-            update (bool): Update status first.
+            trial: :obj:`Trial` object.
+            update: Update status first.
 
         Returns:
             Boolean.
@@ -563,7 +563,7 @@ class PlacementGroupManager:
         cached and None will be returned.
 
         Args:
-            trial (Trial): Trial object with the (currently in use) placement
+            trial: Trial object with the (currently in use) placement
                 group that should be cached.
 
         Returns:
@@ -614,7 +614,7 @@ class PlacementGroupManager:
         """Return pg back to Core scheduling.
 
         Args:
-            trial (Trial): Return placement group of this trial.
+            trial: Return placement group of this trial.
         """
 
         pg = self._in_use_trials.pop(trial)
@@ -636,7 +636,7 @@ class PlacementGroupManager:
         group directly, but sometimes we would like to enqueue removal.)
 
         Args:
-            pgf (PlacementGroupFactory): Placement group factory object.
+            pgf: Placement group factory object.
                 This method will try to remove a staged PG of this factory
                 first, then settle for a ready but unused. If none exist,
                 no placement group will be removed and None will be returned.
@@ -684,7 +684,7 @@ class PlacementGroupManager:
         (paused+running+pending) should be in staging, use, or the cache.
 
         Args:
-            trials (List[Trial]): List of trials.
+            trials: List of trials.
 
         """
         # Keep track of the currently tracked placement groups

--- a/python/ray/tune/utils/trainable.py
+++ b/python/ray/tune/utils/trainable.py
@@ -5,7 +5,7 @@ import logging
 import os
 import pandas as pd
 import shutil
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, Optional
 
 import ray
 import ray.cloudpickle as pickle
@@ -133,14 +133,16 @@ class TrainableUtil:
         return os.path.join(tokens[0], "")
 
     @staticmethod
-    def make_checkpoint_dir(checkpoint_dir, index, override=False):
+    def make_checkpoint_dir(
+        checkpoint_dir: str, index: Union[int, str], override=False
+    ):
         """Creates a checkpoint directory within the provided path.
 
         Args:
-            checkpoint_dir (str): Path to checkpoint directory.
-            index (int|str): A subdirectory will be created
+            checkpoint_dir: Path to checkpoint directory.
+            index: A subdirectory will be created
                 at the checkpoint directory named 'checkpoint_{index}'.
-            override (bool): Deletes checkpoint_dir before creating
+            override: Deletes checkpoint_dir before creating
                 a new one.
         """
         suffix = "checkpoint"
@@ -213,33 +215,33 @@ class TrainableUtil:
 class PlacementGroupUtil:
     @staticmethod
     def get_remote_worker_options(
-        num_workers,
-        num_cpus_per_worker,
-        num_gpus_per_worker,
-        num_workers_per_host,
-        timeout_s,
+        num_workers: int,
+        num_cpus_per_worker: int,
+        num_gpus_per_worker: int,
+        num_workers_per_host: Optional[int],
+        timeout_s: Optional[int],
     ) -> (Dict[str, Any], placement_group):
         """Returns the option for remote workers.
 
         Args:
-            num_workers (int): Number of training workers to include in
+            num_workers: Number of training workers to include in
                 world.
-            num_cpus_per_worker (int): Number of CPU resources to reserve
+            num_cpus_per_worker: Number of CPU resources to reserve
                 per training worker.
-            num_gpus_per_worker (int): Number of GPU resources to reserve
+            num_gpus_per_worker: Number of GPU resources to reserve
                 per training worker.
             num_workers_per_host: Optional[int]: Number of workers to
                 colocate per host.
-            timeout_s (Optional[int]): Seconds before the torch process group
+            timeout_s: Seconds before the torch process group
                 times out. Useful when machines are unreliable. Defaults
                 to 60 seconds. This value is also reused for triggering
                 placement timeouts if forcing colocation.
 
 
         Returns:
-            type(Dict[Str, Any]): option that contains CPU/GPU count of
+            type: option that contains CPU/GPU count of
                 the remote worker and the placement group information.
-            pg(placement_group): return a reference to the placement group
+            pg: return a reference to the placement group
         """
         pg = None
         options = dict(num_cpus=num_cpus_per_worker, num_gpus=num_gpus_per_worker)

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Callable, Type
 import copy
 import glob
 import logging
@@ -243,11 +243,11 @@ def _from_pinnable(obj):
     return obj[0]
 
 
-def diagnose_serialization(trainable):
+def diagnose_serialization(trainable: Callable):
     """Utility for detecting why your trainable function isn't serializing.
 
     Args:
-        trainable (func): The trainable object passed to
+        trainable: The trainable object passed to
             tune.run(trainable). Currently only supports
             Function API.
 
@@ -344,10 +344,10 @@ def atomic_save(state: Dict, checkpoint_dir: str, file_name: str, tmp_file_name:
     This is automatically used by tune.run during a Tune job.
 
     Args:
-        state (dict): Object state to be serialized.
-        checkpoint_dir (str): Directory location for the checkpoint.
-        file_name (str): Final name of file.
-        tmp_file_name (str): Temporary name of file.
+        state: Object state to be serialized.
+        checkpoint_dir: Directory location for the checkpoint.
+        file_name: Final name of file.
+        tmp_file_name: Temporary name of file.
     """
     import ray.cloudpickle as cloudpickle
 
@@ -365,8 +365,8 @@ def load_newest_checkpoint(dirpath: str, ckpt_pattern: str) -> dict:
     :obj:atomic_save.
 
     Args:
-        dirpath (str): Directory in which to look for the checkpoint file.
-        ckpt_pattern (str): File name pattern to match to find checkpoint
+        dirpath: Directory in which to look for the checkpoint file.
+        ckpt_pattern: File name pattern to match to find checkpoint
             files.
 
     Returns:
@@ -384,22 +384,26 @@ def load_newest_checkpoint(dirpath: str, ckpt_pattern: str) -> dict:
 
 
 def wait_for_gpu(
-    gpu_id=None, target_util=0.01, retry=20, delay_s=5, gpu_memory_limit=None
+    gpu_id: Optional[Union[int, str]] = None,
+    target_util: float = 0.01,
+    retry: int = 20,
+    delay_s: int = 5,
+    gpu_memory_limit: Optional[float] = None,
 ):
     """Checks if a given GPU has freed memory.
 
     Requires ``gputil`` to be installed: ``pip install gputil``.
 
     Args:
-        gpu_id (Optional[Union[int, str]]): GPU id or uuid to check.
+        gpu_id: GPU id or uuid to check.
             Must be found within GPUtil.getGPUs(). If none, resorts to
             the first item returned from `ray.get_gpu_ids()`.
-        target_util (float): The utilization threshold to reach to unblock.
+        target_util: The utilization threshold to reach to unblock.
             Set this to 0 to block until the GPU is completely free.
-        retry (int): Number of times to check GPU limit. Sleeps `delay_s`
+        retry: Number of times to check GPU limit. Sleeps `delay_s`
             seconds between checks.
-        delay_s (int): Seconds to wait before check.
-        gpu_memory_limit (float): Deprecated.
+        delay_s: Seconds to wait before check.
+        gpu_memory_limit: Deprecated.
 
     Returns:
         bool: True if free.
@@ -474,15 +478,18 @@ def wait_for_gpu(
 
 
 def validate_save_restore(
-    trainable_cls, config=None, num_gpus=0, use_object_store=False
+    trainable_cls: Type,
+    config: Optional[Dict] = None,
+    num_gpus: int = 0,
+    use_object_store: bool = False,
 ):
     """Helper method to check if your Trainable class will resume correctly.
 
     Args:
         trainable_cls: Trainable class for evaluation.
-        config (dict): Config to pass to Trainable when testing.
-        num_gpus (int): GPU resources to allocate when testing.
-        use_object_store (bool): Whether to save and restore to Ray's object
+        config: Config to pass to Trainable when testing.
+        num_gpus: GPU resources to allocate when testing.
+        use_object_store: Whether to save and restore to Ray's object
             store. Recommended to set this to True if planning to use
             algorithms that pause training (i.e., PBT, HyperBand).
     """
@@ -572,8 +579,8 @@ def create_logdir(dirname: str, local_dir: str):
     to the dirname.
 
     Args:
-        dirname (str): Dirname to create in `local_dir`
-        local_dir (str): Root directory for the log dir
+        dirname: Dirname to create in `local_dir`
+        local_dir: Root directory for the log dir
 
     Returns:
         full path to the newly created logdir.

--- a/python/ray/tune/web_server.py
+++ b/python/ray/tune/web_server.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import threading
+from typing import Tuple, List, TYPE_CHECKING
 
 from urllib.parse import urljoin, urlparse
 from http.server import SimpleHTTPRequestHandler, HTTPServer
@@ -9,6 +10,9 @@ import ray.cloudpickle as cloudpickle
 from ray.tune import TuneError
 from ray.tune.suggest import BasicVariantGenerator
 from ray._private.utils import binary_to_hex, hex_to_binary
+
+if TYPE_CHECKING:
+    from ray.tune.trial_runner import TrialRunner
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +32,11 @@ class TuneClient:
     Requires a TuneServer to have started running.
 
     Attributes:
-        tune_address (str): Address of running TuneServer
-        port_forward (int): Port number of running TuneServer
+        tune_address: Address of running TuneServer
+        port_forward: Port number of running TuneServer
     """
 
-    def __init__(self, tune_address, port_forward):
+    def __init__(self, tune_address: str, port_forward: int):
         self._tune_address = tune_address
         self._port_forward = port_forward
         self._path = "http://{}:{}".format(tune_address, port_forward)
@@ -97,12 +101,12 @@ def RunnerHandler(runner):
         the TuneServer.
         """
 
-        def _do_header(self, response_code=200, headers=None):
+        def _do_header(self, response_code: int = 200, headers: List[Tuple] = None):
             """Sends the header portion of the HTTP response.
 
             Parameters:
-                response_code (int): Standard HTTP response code
-                headers (list[tuples]): Standard HTTP response headers
+                response_code: Standard HTTP response code
+                headers: Standard HTTP response headers
             """
             if headers is None:
                 headers = [("Content-type", "application/json")]
@@ -226,13 +230,13 @@ class TuneServer(threading.Thread):
     The server handles requests from a TuneClient.
 
     Attributes:
-        runner (TrialRunner): Runner that modifies and accesses trials.
-        port_forward (int): Port number of TuneServer.
+        runner: Runner that modifies and accesses trials.
+        port_forward: Port number of TuneServer.
     """
 
     DEFAULT_PORT = 4321
 
-    def __init__(self, runner, port=None):
+    def __init__(self, runner: "TrialRunner", port: int = None):
         """Initialize HTTPServer and serve forever by invoking self.run()"""
         threading.Thread.__init__(self)
         self._port = port if port else self.DEFAULT_PORT


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

According to https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#code-style, typed arguments should not repeat thetypes in the docstrings. This PR removes these annotations and adds further annotations in some places where they were missing before.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
