### PR TITLE
[serve] Remove dashboard's dependency on Serve

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -275,6 +275,13 @@
     - bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 $(./scripts/bazel_export_options)
       python/ray/tests/test_usage_stats
 
+- label: ":python: Default install"
+  conditions: ["RAY_CI_PYTHON_AFFECTED"]
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
+    - bazel test --test_output=streamed --config=ci --test_env=RAY_DEFAULT=1 $(./scripts/bazel_export_options)
+      python/ray/dashboard/test_dashboard
+
 - label: ":python: Release test package unit tests"
   conditions: ["ALWAYS"]
   commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -279,6 +279,8 @@
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/travis/upload_build_info.sh; fi }; trap cleanup EXIT
+    - ./ci/travis/install-default.sh
+    - ./ci/travis/env_info.sh
     - bazel test --test_output=streamed --config=ci --test_env=RAY_DEFAULT=1 $(./scripts/bazel_export_options)
       python/ray/dashboard/test_dashboard
 

--- a/ci/travis/install-default.sh
+++ b/ci/travis/install-default.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Installs default dependencies ("ray[default]") on top of minimal install
+
+# Get script's directory: https://stackoverflow.com/a/246128
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Installs minimal dependencies
+"$SCRIPT_DIR"/install-minimal.sh
+
+# Installs default dependencies
+python -m pip install -U "ray[default]"

--- a/dashboard/modules/serve/serve_head.py
+++ b/dashboard/modules/serve/serve_head.py
@@ -5,14 +5,6 @@ import logging
 import ray.dashboard.utils as dashboard_utils
 import ray.dashboard.optional_utils as optional_utils
 
-from ray import serve
-from ray.serve.api import (
-    Application,
-    get_deployment_statuses,
-    internal_get_global_client,
-    serve_application_status_to_schema,
-)
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -26,7 +18,9 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @routes.get("/api/serve/deployments/")
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def get_all_deployments(self, req: Request) -> Response:
-        app = Application(list(serve.list_deployments().values()))
+        from ray.serve.api import Application, list_deployments
+
+        app = Application(list(list_deployments().values()))
         return Response(
             text=json.dumps(app.to_dict()),
             content_type="application/json",
@@ -35,6 +29,11 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @routes.get("/api/serve/deployments/status")
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def get_all_deployment_statuses(self, req: Request) -> Response:
+        from ray.serve.api import (
+            serve_application_status_to_schema,
+            get_deployment_statuses,
+        )
+
         serve_application_status_schema = serve_application_status_to_schema(
             get_deployment_statuses()
         )
@@ -46,12 +45,20 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @routes.delete("/api/serve/deployments/")
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def delete_serve_application(self, req: Request) -> Response:
+        from ray import serve
+
         serve.shutdown()
         return Response()
 
     @routes.put("/api/serve/deployments/")
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def put_all_deployments(self, req: Request) -> Response:
+        from ray import serve
+        from ray.serve.api import (
+            Application,
+            internal_get_global_client,
+        )
+
         app = Application.from_dict(await req.json())
         serve.run(app, _blocking=False)
 

--- a/dashboard/optional_utils.py
+++ b/dashboard/optional_utils.py
@@ -18,7 +18,6 @@ from typing import Any, Callable
 import ray
 import ray.dashboard.consts as dashboard_consts
 from ray.ray_constants import env_bool
-from ray import serve
 
 try:
     create_task = asyncio.create_task
@@ -269,6 +268,8 @@ def init_ray_and_catch_exceptions(connect_to_serve: bool = False) -> Callable:
                         raise e from None
 
                 if connect_to_serve:
+                    from ray import serve
+
                     serve.start(detached=True, _override_controller_namespace="serve")
 
                 return await f(self, *args, **kwargs)

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -87,7 +87,7 @@ def check_agent_register(raylet_proc, agent_pid):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_DEFAULT") == "1",
     reason="This test may not work for default installation.",
 )
 @pytest.mark.parametrize(
@@ -143,7 +143,7 @@ def test_basic(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_DEFAULT") == "1",
     reason="This test may not work for default installation.",
 )
 def test_raylet_and_agent_share_fate(shutdown_only):
@@ -184,6 +184,10 @@ def test_raylet_and_agent_share_fate(shutdown_only):
     raylet_proc.wait(5)
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_DEFAULT") == "1",
+    reason="This test may not work with default installation.",
+)
 @pytest.mark.parametrize(
     "ray_start_with_dashboard",
     [
@@ -207,7 +211,7 @@ def test_dashboard_address(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_http_get(enable_test_module, ray_start_with_dashboard):
@@ -255,7 +259,7 @@ def test_http_get(enable_test_module, ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_class_method_route_table(enable_test_module):
@@ -342,7 +346,7 @@ def test_class_method_route_table(enable_test_module):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_async_loop_forever():
@@ -377,7 +381,7 @@ def test_async_loop_forever():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_dashboard_module_decorator(enable_test_module):
@@ -408,7 +412,7 @@ print("success")
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
@@ -479,7 +483,7 @@ def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_get_cluster_status(ray_start_with_dashboard):
@@ -524,7 +528,7 @@ def test_get_cluster_status(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_immutable_types():
@@ -604,7 +608,7 @@ def test_immutable_types():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_http_proxy(enable_test_module, set_http_proxy, shutdown_only):
@@ -638,7 +642,7 @@ def test_http_proxy(enable_test_module, set_http_proxy, shutdown_only):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_dashboard_port_conflict(ray_start_with_dashboard):
@@ -688,7 +692,7 @@ def test_dashboard_port_conflict(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
     reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_gcs_check_alive(fast_gcs_failure_detection, ray_start_with_dashboard):

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -705,10 +705,10 @@ def test_gcs_check_alive(fast_gcs_failure_detection, ray_start_with_dashboard):
     assert dashboard_proc.wait(10) == 255
 
 
-@pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") != "1",
-    reason="This test only works for minimal installation.",
-)
+# @pytest.mark.skipif(
+#     os.environ.get("RAY_MINIMAL") != "1",
+#     reason="This test only works for minimal installation.",
+# )
 def test_dashboard_does_not_depend_on_serve():
     """Check that the dashboard can start without Serve."""
 

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -86,6 +86,10 @@ def check_agent_register(raylet_proc, agent_pid):
         time.sleep(1)
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test may not work for default installation.",
+)
 @pytest.mark.parametrize(
     "ray_start_with_dashboard",
     [{"_system_config": {"agent_register_timeout_ms": 5000}}],
@@ -138,6 +142,10 @@ def test_basic(ray_start_with_dashboard):
     assert agent_ports is not None
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test may not work for default installation.",
+)
 def test_raylet_and_agent_share_fate(shutdown_only):
     """Test raylet and agent share fate."""
 
@@ -199,8 +207,8 @@ def test_dashboard_address(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_http_get(enable_test_module, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -247,8 +255,8 @@ def test_http_get(enable_test_module, ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_class_method_route_table(enable_test_module):
     head_cls_list = dashboard_utils.get_all_modules(dashboard_utils.DashboardHeadModule)
@@ -334,8 +342,8 @@ def test_class_method_route_table(enable_test_module):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_async_loop_forever():
     counter = [0]
@@ -369,8 +377,8 @@ def test_async_loop_forever():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_dashboard_module_decorator(enable_test_module):
     head_cls_list = dashboard_utils.get_all_modules(dashboard_utils.DashboardHeadModule)
@@ -400,8 +408,8 @@ print("success")
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -471,8 +479,8 @@ def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_get_cluster_status(ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -516,8 +524,8 @@ def test_get_cluster_status(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_immutable_types():
     d = {str(i): i for i in range(1000)}
@@ -596,8 +604,8 @@ def test_immutable_types():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_http_proxy(enable_test_module, set_http_proxy, shutdown_only):
     address_info = ray.init(num_cpus=1, include_dashboard=True)
@@ -630,8 +638,8 @@ def test_http_proxy(enable_test_module, set_http_proxy, shutdown_only):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_dashboard_port_conflict(ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -680,8 +688,8 @@ def test_dashboard_port_conflict(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1",
-    reason="This test is not supposed to work for minimal installation.",
+    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == 1,
+    reason="This test is not supposed to work for minimal or default installation.",
 )
 def test_gcs_check_alive(fast_gcs_failure_detection, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -706,8 +714,8 @@ def test_gcs_check_alive(fast_gcs_failure_detection, ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") != "1",
-    reason="This test only works for minimal installation.",
+    os.environ.get("RAY_DEFAULT") != "1",
+    reason="This test only works for default installation.",
 )
 def test_dashboard_does_not_depend_on_serve():
     """Check that the dashboard can start without Serve."""

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -713,7 +713,7 @@ def test_dashboard_does_not_depend_on_serve():
     """Check that the dashboard can start without Serve."""
 
     with pytest.raises(ImportError):
-        from ray import serve  # noqa F401
+        from ray import serve  # noqa: F401
 
     ray.init(include_dashboard=True)
 

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -718,7 +718,7 @@ def test_dashboard_does_not_depend_on_serve():
     ctx = ray.init(include_dashboard=True)
 
     # Ensure standard dashboard features, like snapshot, still work
-    response = requests.get(f"http://{ctx.dashboard_url}/api/snapshot/")
+    response = requests.get(f"http://{ctx.dashboard_url}/api/snapshot")
     assert response.status_code == 200
     assert response.json()["result"] is True
     assert "snapshot" in response.json()["data"]

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -705,5 +705,18 @@ def test_gcs_check_alive(fast_gcs_failure_detection, ray_start_with_dashboard):
     assert dashboard_proc.wait(10) == 255
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test only works for minimal installation.",
+)
+def test_dashboard_does_not_depend_on_serve():
+    """Check that the dashboard can start without Serve."""
+
+    with pytest.raises(ImportError):
+        from ray import serve  # noqa F401
+
+    ray.init(include_dashboard=True)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -86,10 +86,6 @@ def check_agent_register(raylet_proc, agent_pid):
         time.sleep(1)
 
 
-@pytest.mark.skipif(
-    os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test may not work for default installation.",
-)
 @pytest.mark.parametrize(
     "ray_start_with_dashboard",
     [{"_system_config": {"agent_register_timeout_ms": 5000}}],
@@ -142,10 +138,6 @@ def test_basic(ray_start_with_dashboard):
     assert agent_ports is not None
 
 
-@pytest.mark.skipif(
-    os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test may not work for default installation.",
-)
 def test_raylet_and_agent_share_fate(shutdown_only):
     """Test raylet and agent share fate."""
 
@@ -184,10 +176,6 @@ def test_raylet_and_agent_share_fate(shutdown_only):
     raylet_proc.wait(5)
 
 
-@pytest.mark.skipif(
-    os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test may not work with default installation.",
-)
 @pytest.mark.parametrize(
     "ray_start_with_dashboard",
     [
@@ -211,8 +199,8 @@ def test_dashboard_address(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_http_get(enable_test_module, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -259,8 +247,8 @@ def test_http_get(enable_test_module, ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_class_method_route_table(enable_test_module):
     head_cls_list = dashboard_utils.get_all_modules(dashboard_utils.DashboardHeadModule)
@@ -346,8 +334,8 @@ def test_class_method_route_table(enable_test_module):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_async_loop_forever():
     counter = [0]
@@ -381,8 +369,8 @@ def test_async_loop_forever():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_dashboard_module_decorator(enable_test_module):
     head_cls_list = dashboard_utils.get_all_modules(dashboard_utils.DashboardHeadModule)
@@ -412,8 +400,8 @@ print("success")
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -483,8 +471,8 @@ def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_get_cluster_status(ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -528,8 +516,8 @@ def test_get_cluster_status(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_immutable_types():
     d = {str(i): i for i in range(1000)}
@@ -608,8 +596,8 @@ def test_immutable_types():
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_http_proxy(enable_test_module, set_http_proxy, shutdown_only):
     address_info = ray.init(num_cpus=1, include_dashboard=True)
@@ -642,8 +630,8 @@ def test_http_proxy(enable_test_module, set_http_proxy, shutdown_only):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_dashboard_port_conflict(ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
@@ -692,8 +680,8 @@ def test_dashboard_port_conflict(ray_start_with_dashboard):
 
 
 @pytest.mark.skipif(
-    os.environ.get("RAY_MINIMAL") == "1" or os.environ.get("RAY_DEFAULT") == "1",
-    reason="This test is not supposed to work for minimal or default installation.",
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
 )
 def test_gcs_check_alive(fast_gcs_failure_detection, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -705,10 +705,10 @@ def test_gcs_check_alive(fast_gcs_failure_detection, ray_start_with_dashboard):
     assert dashboard_proc.wait(10) == 255
 
 
-# @pytest.mark.skipif(
-#     os.environ.get("RAY_MINIMAL") != "1",
-#     reason="This test only works for minimal installation.",
-# )
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test only works for minimal installation.",
+)
 def test_dashboard_does_not_depend_on_serve():
     """Check that the dashboard can start without Serve."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Ray dashboard imports Serve even when it doesn't need to start the Serve controller. This change makes this a delayed import and removes the hard dependency.

It also adds a new job to the CI that uses Ray's default dependencies (i.e. the ones installed by "pip install ray[default]").

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #23309.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
     - New unit tests are added to `test_dashboard.py`.
