### PR TITLE
[tune] simpler get_next_trial

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -699,15 +699,13 @@ class TrialRunner:
                 if trial.status == Trial.PENDING:
                     num_pending_trials += 1
 
-        # Create pending trials until it fails.
-        while num_pending_trials < self._max_pending_trials:
-            if not self._update_trial_queue(blocking=False):
-                break
-            wait_for_trial = False
-            num_pending_trials += 1
-
-        if wait_for_trial and not self._search_alg.is_finished():
-            self._update_trial_queue(blocking=True)
+        if not self._search_alg.is_finished():
+            # Create pending trials until it fails.
+            while num_pending_trials < self._max_pending_trials:
+                if not self._update_trial_queue(blocking=wait_for_trial):
+                    break
+                wait_for_trial = False  # wait at most one trial
+                num_pending_trials += 1
 
         with warn_if_slow("choose_trial_to_run"):
             return self._scheduler_alg.choose_trial_to_run(self)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -339,7 +339,6 @@ class TrialRunner:
         self._live_trials = set()  # Set of non-terminated trials
         self._cached_trial_decisions = {}
         self._queued_trial_decisions = {}
-        self._updated_queue = False
 
         self._stop_queue = []
         self._should_stop_experiment = False  # used by TuneServer


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A much simpler `_update_trial_queue_and_get_next_trial` with the same functionality. The original code complicated the problem and is very hard to understand.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
