### PR TITLE
[ci/release] Unstable tests should only soft fail the build

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 
 from ray_release.buildkite.concurrency import CONCURRENY_GROUPS, get_concurrency_group
 from ray_release.config import Test, get_test_env_var
@@ -8,7 +8,7 @@ from ray_release.exception import ReleaseTestConfigError
 
 DEFAULT_ARTIFACTS_DIR_HOST = "/tmp/ray_release_test_artifacts"
 
-DEFAULT_STEP_TEMPLATE = {
+DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
     "env": {
         "ANYSCALE_CLOUD_ID": "cld_4F7k8814aZzGG8TNUGPKnc",
         "ANYSCALE_PROJECT": "prj_2xR6uT6t7jJuu1aCwWMsle",
@@ -84,12 +84,18 @@ def get_step(
     step["priority"] = priority_val
 
     # If a test is not stable, allow to soft fail
-    if not test.get("stable", True):
+    stable = test.get("stable", True)
+    if not stable:
         step["soft_fail"] = True
+        full_label = "(unstable) "
+    else:
+        full_label = ""
 
-    step["label"] = test["name"]
+    full_label += test["name"]
     if smoke_test:
-        step["label"] += " [smoke test] "
-    step["label"] += f" ({label})"
+        full_label += " [smoke test] "
+    full_label += f" ({label})"
+
+    step["label"] = full_label
 
     return step

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -83,6 +83,10 @@ def get_step(
 
     step["priority"] = priority_val
 
+    # If a test is not stable, allow to soft fail
+    if not test.get("stable", True):
+        step["soft_fail"] = True
+
     step["label"] = test["name"]
     if smoke_test:
         step["label"] += " [smoke test] "

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -87,7 +87,7 @@ def get_step(
     stable = test.get("stable", True)
     if not stable:
         step["soft_fail"] = True
-        full_label = "(unstable) "
+        full_label = "[unstable] "
     else:
         full_label = ""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This will leave the tests green if the test is failing but marked as unstable.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
