### PR TITLE
[RFC][Doc] add a page describe actor execution order.

### DIFF
--- a/doc/source/ray-core/actors.rst
+++ b/doc/source/ray-core/actors.rst
@@ -350,4 +350,5 @@ More about Ray Actors
     actors/actor-utils.rst
     actors/fault-tolerance.rst
     actors/scheduling.rst
+    actors/task-orders.rst
     actors/patterns/index.rst

--- a/doc/source/ray-core/actors/task-orders.rst
+++ b/doc/source/ray-core/actors/task-orders.rst
@@ -1,5 +1,13 @@
 Actor Tasks Execution Orders
 ============
 
-Normal actors execute tasks according to their initial submission order.
-Concurrent actors (async and threaded actors) might execute tasks out of order.
+Synchronous, single-threaded actors execute tasks according
+to their initial submission order. Any submitted task will not
+execute until previously submitted tasks have finished execution.
+Note that actor task execution could fail. Upon failure, the following
+tasks submitted to the same actor will not execute until the failed
+task is successfully retried or the retry is exhausted.
+
+:ref:`Async or threaded actors <async-actors>` does not guarantee the
+task execution order. For example, the system might execute a task
+even though previously submitted tasks are pending execution.

--- a/doc/source/ray-core/actors/task-orders.rst
+++ b/doc/source/ray-core/actors/task-orders.rst
@@ -1,13 +1,90 @@
 Actor Tasks Execution Orders
 ============================
 
-Synchronous, single-threaded actors execute tasks according
-to their initial submission order. Any submitted task will not
-execute until previously submitted tasks have finished execution.
-Note that actor task execution could fail. Upon failure, the following
-tasks submitted to the same actor will not execute until the failed
-task is successfully retried or the retry is exhausted.
+Synchronous, Single-Threaded Actor
+----------------------------------
+In Ray, an actor receives tasks from multiple submitters (including driver and workers).
+Synchronous, single-threaded actors execute tasks following the submission order
+if the same submitter submits the tasks.
+Precisely, for tasks received from the same submitter,
+any task will not be executed until previously submitted tasks have finished execution.
 
-:ref:`Async or threaded actors <async-actors>` does not guarantee the
+.. tabbed:: Python
+
+    .. code-block:: python
+
+        import ray
+
+        @ray.remote
+        class Counter:
+            def __init__(self):
+                self.value = 0
+
+            def add(self, addition):
+                self.value += addition
+                return self.value
+
+        counter = Counter.remote()
+
+        # For tasks from the same submitter,
+        # their are executed according to submission order.
+        value0 = counter.add.remote(1)
+        value1 = counter.add.remote(2)
+
+        # Output: 1. The first submitted task is executed first.
+        print(ray.get(value0))
+        # Output: 3. The later submitted task is executed later.
+        print(ray.get(value1))
+
+
+However, the system could reorder actor tasks execution if they come from different
+submitters. The reorder could happen when a previously submitted task is blocked
+by unfulfilled dependence. In this case, the actor might execute a later
+received task from a different submitter.
+
+.. tabbed:: Python
+
+    .. code-block:: python
+
+        import time
+        import ray
+
+        @ray.remote
+        class Counter:
+            def __init__(self):
+                self.value = 0
+
+            def add(self, addition):
+                self.value += addition
+                return self.value
+
+        counter = Counter.remote()
+
+        # Submit task from a worker
+        @ray.remote
+        def submitter(value):
+            return ray.get(counter.add.remote(value))
+
+        # Simulate delayed result resolution.
+        @ray.remote
+        def delayed_resolution(value):
+            time.sleep(5)
+            return value
+
+        # Submit tasks from different workers, with
+        # the first submitted task waiting for
+        # dependency resolution.
+        value0 = submitter.remote(delayed_resolution.remote(1))
+        value1 = submitter.remote(2)
+
+        # Output: 3. The first submitted task is executed later.
+        print(ray.get(value0))
+        # Output: 2. The later submitted task is executed first.
+        print(ray.get(value1))
+
+
+Asynchronous or Threaded Actor
+------------------------------
+:ref:`Asynchronous or threaded actors <async-actors>` does not guarantee the
 task execution order. For example, the system might execute a task
 even though previously submitted tasks are pending execution.

--- a/doc/source/ray-core/actors/task-orders.rst
+++ b/doc/source/ray-core/actors/task-orders.rst
@@ -1,0 +1,5 @@
+Actor Tasks Execution Orders
+============
+
+Normal actors execute tasks according to their initial submission order.
+Concurrent actors (async and threaded actors) might execute tasks out of order.

--- a/doc/source/ray-core/actors/task-orders.rst
+++ b/doc/source/ray-core/actors/task-orders.rst
@@ -4,9 +4,9 @@ Actor Tasks Execution Orders
 Synchronous, Single-Threaded Actor
 ----------------------------------
 In Ray, an actor receives tasks from multiple submitters (including driver and workers).
-For tasks received from the same submitter, synchronous, single-threaded actor executes
+For tasks received from the same submitter, a synchronous, single-threaded actor executes
 them following the submission order.
-In other words, any task will not be executed until previously submitted tasks from
+In other words, a given task will not be executed until previously submitted tasks from
 the same submitter have finished execution.
 
 .. tabbed:: Python
@@ -84,7 +84,7 @@ task. In this case, the actor can still execute tasks submitted by a different w
 
 Asynchronous or Threaded Actor
 ------------------------------
-:ref:`Asynchronous or threaded actors <async-actors>` does not guarantee the
+:ref:`Asynchronous or threaded actors <async-actors>` do not guarantee the
 task execution order. This means the system might execute a task
 even though previously submitted tasks are pending execution.
 

--- a/doc/source/ray-core/actors/task-orders.rst
+++ b/doc/source/ray-core/actors/task-orders.rst
@@ -1,5 +1,5 @@
 Actor Tasks Execution Orders
-============
+============================
 
 Synchronous, single-threaded actors execute tasks according
 to their initial submission order. Any submitted task will not


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The execution order is kinda of short. Should we merge this with fault-tolerance, or expand it a bit more with examples?
Also we don't guarantee orders if tasks are submitted by different workers. Not sure if we should put it here as well.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
