### PR TITLE
[serve] [docs] Add Serve CLI example to quick-start

### DIFF
--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -177,10 +177,11 @@ Note that the count has been reset to zero because the new version of ``Counter`
   {"count": 0}
 
 Serve also lets you set configurations in the ``@serve.deployment`` decorator
-or using a YAML config file. For example, you can set the
+or in a YAML config file. For example, you can set the
 ``max_concurrent_queries`` for your application:
 
 .. code-block:: python
+
   # File name: counter_app.py
 
   @serve.deployment(
@@ -192,8 +193,7 @@ or using a YAML config file. For example, you can set the
 
   Counter.deploy()
 
-Alternatively, instead of modifying the decorator, you can write a YAML
-config file:
+Instead of modifying the decorator, you can write a YAML config file:
 
 .. code-block:: yaml
   
@@ -212,10 +212,9 @@ deploy ``Counter``:
   
   $ serve run counter_config.yaml
 
-This updates ``Counter`` just like using ``Counter.deploy()``, but you don't
-need to write new update scripts in Python. You can modify the deployment's
-settings in the config file, deploy it via CLI, and continue making requests
-to it:
+This updates ``Counter`` just like ``Counter.deploy()``, but it doesn't require
+Python update scripts. You can modify the deployment's settings in the config
+file, deploy it via CLI, and make requests to it:
 
 .. code-block:: bash
 

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -177,8 +177,8 @@ Note that the count has been reset to zero because the new version of ``Counter`
   {"count": 0}
 
 Serve also lets you set configurations in the ``@serve.deployment`` decorator
-or using a YAML config file. For example, you can set the ``max_concurrent_queries`` for
-your application:
+or using a YAML config file. For example, you can set the
+``max_concurrent_queries`` for your application:
 
 .. code-block:: python
   # File name: counter_app.py
@@ -192,8 +192,8 @@ your application:
 
   Counter.deploy()
 
-Alternatively, instead of modifying the decorator, you could write a YAML
-config file and use the Serve CLI to udpate and deploy ``Counter``:
+Alternatively, instead of modifying the decorator, you can write a YAML
+config file:
 
 .. code-block:: yaml
   
@@ -204,6 +204,9 @@ config file and use the Serve CLI to udpate and deploy ``Counter``:
     - name: Counter
       import_path: counter_app.Counter
       max_concurrent_queries: 10
+
+Then you can use the Serve CLI, which is included with Ray Serve, to update and
+deploy ``Counter``:
 
 .. code-block:: bash
   

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -176,6 +176,49 @@ Note that the count has been reset to zero because the new version of ``Counter`
   > curl -X GET localhost:8000/Counter/decr
   {"count": 0}
 
+Serve also lets you set configurations in the ``@serve.deployment`` decorator
+or using a YAML config file. For example, you can set the ``max_concurrent_queries`` for
+your application:
+
+.. code-block:: python
+  # File name: counter_app.py
+
+  @serve.deployment(
+    max_concurrent_queries=10
+  )
+  @serve.ingress(app)
+  class Counter:
+  ...
+
+  Counter.deploy()
+
+Alternatively, instead of modifying the decorator, you could write a YAML
+config file and use the Serve CLI to udpate and deploy ``Counter``:
+
+.. code-block:: yaml
+  
+  # File name: counter_config.yaml
+
+  deployments:
+    
+    - name: Counter
+      import_path: counter_app.Counter
+      max_concurrent_queries: 10
+
+.. code-block:: bash
+  
+  $ serve run counter_config.yaml
+
+This updates ``Counter`` just like using ``Counter.deploy()``, but you don't
+need to write new update scripts in Python. You can modify the deployment's
+settings in the config file, deploy it via CLI, and continue making requests
+to it:
+
+.. code-block:: bash
+
+  > curl -X GET localhost:8000/Counter/
+  {"count": 0}
+
 Congratulations, you just built and ran your first Ray Serve application! You should now have enough context to dive into the :doc:`core-apis` to get a deeper understanding of Ray Serve.
 For more interesting example applications, including integrations with popular machine learning frameworks and Python web servers, be sure to check out :doc:`tutorials/index`. 
 For a high-level view of the architecture underlying Ray Serve, see :doc:`architecture`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change extends the Serve quick-start with a Serve CLI example.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - N/A
