### PR TITLE
Restore use_gcs_for_bootstrap

### DIFF
--- a/python/ray/_private/gcs_utils.py
+++ b/python/ray/_private/gcs_utils.py
@@ -244,3 +244,12 @@ class GcsClient:
                 f"Failed to list prefix {prefix} "
                 f"due to error {reply.status.message}"
             )
+
+
+def use_gcs_for_bootstrap():
+    """In the current version of Ray, we always use the GCS to bootstrap.
+    (This was previously controlled by a feature flag.)
+
+    This function is included for the purposes of backwards compatibility.
+    """
+    return True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Certain external integrations rely on `ray._private.use_gcs_for_bootstrap` to determine if Ray is using the gcs to bootstrap. The current version of Ray always uses the gcs to bootstrap, so this should just return True.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
