### PR TITLE
Uniformly distributed tasks among actors to utilize full concurrency

### DIFF
--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -17,6 +17,7 @@ from ray.util.joblib import register_ray
 
 from joblib import parallel_backend, Parallel, delayed
 
+
 def teardown_function(function):
     # Delete environment variable if set.
     if "RAY_ADDRESS" in os.environ:
@@ -58,12 +59,14 @@ def ray_start_1_cpu():
     # The code after the yield will run as teardown code.
     ray.shutdown()
 
+
 @pytest.fixture
 def ray_start_4_cpu():
     address_info = ray.init(num_cpus=4)
     yield address_info
     # The code after the yield will run as teardown code.
     ray.shutdown()
+
 
 def test_ray_init(shutdown_only):
     def getpid(args):
@@ -593,6 +596,7 @@ def test_deadlock_avoidance_in_recursive_tasks(ray_start_1_cpu):
     result = poolit_b()
     assert result == [[0.0, 1.0], [0.0, 1.0]]
 
+
 def test_task_to_actor_assignment(ray_start_4_cpu):
 
     register_ray()
@@ -607,8 +611,9 @@ def test_task_to_actor_assignment(ray_start_4_cpu):
     num_workers = 4
     output = []
     with parallel_backend("ray", n_jobs=-1):
-        output = Parallel()(delayed(worker_func)(worker_id)
-                            for worker_id in range(num_workers))
+        output = Parallel()(
+            delayed(worker_func)(worker_id) for worker_id in range(num_workers)
+        )
 
     worker_ids = set()
     launch_times = []
@@ -621,6 +626,7 @@ def test_task_to_actor_assignment(ray_start_4_cpu):
     for i in range(num_workers):
         for j in range(i + 1, num_workers):
             assert abs(launch_times[i] - launch_times[j]) < 1
+
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -13,6 +13,9 @@ import ray
 from ray._private.test_utils import SignalActor
 from ray.util.multiprocessing import Pool, TimeoutError, JoinableQueue
 
+from ray.util.joblib import register_ray
+
+from joblib import parallel_backend, Parallel, delayed
 
 def teardown_function(function):
     # Delete environment variable if set.
@@ -55,6 +58,12 @@ def ray_start_1_cpu():
     # The code after the yield will run as teardown code.
     ray.shutdown()
 
+@pytest.fixture
+def ray_start_4_cpu():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
 
 def test_ray_init(shutdown_only):
     def getpid(args):
@@ -584,6 +593,34 @@ def test_deadlock_avoidance_in_recursive_tasks(ray_start_1_cpu):
     result = poolit_b()
     assert result == [[0.0, 1.0], [0.0, 1.0]]
 
+def test_task_to_actor_assignment(ray_start_4_cpu):
+
+    register_ray()
+
+    pause_time = 5
+
+    def worker_func(worker_id):
+        launch_time = time.time()
+        time.sleep(pause_time)
+        return worker_id, launch_time
+
+    num_workers = 4
+    output = []
+    with parallel_backend("ray", n_jobs=-1):
+        output = Parallel()(delayed(worker_func)(worker_id)
+                            for worker_id in range(num_workers))
+
+    worker_ids = set()
+    launch_times = []
+    for worker_id, launch_time in output:
+        worker_ids.add(worker_id)
+        launch_times.append(launch_time)
+
+    assert len(worker_ids) == num_workers
+
+    for i in range(num_workers):
+        for j in range(i + 1, num_workers):
+            assert abs(launch_times[i] - launch_times[j]) < 1
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -495,6 +495,7 @@ class Pool:
         self._actor_deletion_ids = []
         self._registry: List[Tuple[Any, ray.ObjectRef]] = []
         self._registry_hashable: Dict[Hashable, ray.ObjectRef] = {}
+        self._current_index = 0
 
         if context and log_once("context_argument_warning"):
             logger.warning(
@@ -571,8 +572,12 @@ class Pool:
         # due to a limitation in cloudpickle.
         return (PoolActor.remote(self._initializer, self._initargs), 0)
 
-    def _random_actor_index(self):
-        return random.randrange(len(self._actor_pool))
+    def _next_actor_index(self):
+        if self._current_index == len(self._actor_pool) - 1:
+            self._current_index = 0
+        else:
+            self._current_index += 1
+        return self._current_index
 
     # Batch should be a list of tuples: (args, kwargs).
     def _run_batch(self, actor_index, func, batch):
@@ -628,7 +633,7 @@ class Pool:
 
         self._check_running()
         func = self._convert_to_ray_batched_calls_if_needed(func)
-        object_ref = self._run_batch(self._random_actor_index(), func, [(args, kwargs)])
+        object_ref = self._run_batch(self._next_actor_index(), func, [(args, kwargs)])
         return AsyncResult([object_ref], callback, error_callback, single_result=True)
 
     def _convert_to_ray_batched_calls_if_needed(self, func: Callable) -> Callable:

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -3,7 +3,6 @@ import logging
 from multiprocessing import TimeoutError
 import os
 import time
-import random
 import collections
 import threading
 import queue


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

N.B. - https://github.com/ray-project/ray/issues/23184#issuecomment-1074823256

TLDR - `Pool._random_actor_index` produces duplicate values, which reduces the concurrency when number of tasks is lesser than number of actors in the pool. So, there are two ways to fix this. One, keep track of what indices are available and select from them. If no index is available then reset the available indices. In other words while randomly selecting indices, repeat only when there is no index available for the incoming task. Second way is to just uniformly distribute tasks among actors because if number of tasks is very large then uniform distribution should provide maximum concurrency and if number of tasks is very small then randomization and uniform distribution should produce equivalent performance.

**Note** - Adding tests locally, will push a new commit soon.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/23184

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
