### PR TITLE
[docs] fix mobile navigation

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -10,6 +10,24 @@
     margin: auto;
 }
 
+/* Hide confusing "<-" back arrow in navigation for larger displays */
+@media (min-width: 768px) {
+    #navbar-toggler {
+        display: none;
+    }
+}
+
+/* Make navigation scrollable on mobile, by making algolia not overflow */
+@media (max-width: 768px) {
+    #site-navigation {
+        overflow-y: scroll;
+    }
+
+    .algolia-autocomplete .ds-dropdown-menu{
+        min-width: 250px;
+    }
+}
+
 /* sphinx-panels overrides the content width to 1140 for large displays.*/
 @media (min-width: 1200px) {
     .container, .container-lg, .container-md, .container-sm, .container-xl {
@@ -23,6 +41,7 @@
     right: 20px;
     width: 270px;
 }
+
 @media (max-width: 1500px) {
     .bottom-right-promo-banner {
         display: none;


### PR DESCRIPTION
Signed-off-by: Max Pumperla <max.pumperla@googlemail.com>

Algolia search now does not overflow on mobile devices anymore, making the nav scrollable again:

![Screenshot 2022-03-23 at 09 43 59](https://user-images.githubusercontent.com/3462566/159659337-5c2b0807-7a8c-4085-a615-53d3e33453e8.png)

We also got rid of the somewhat confusing "back" arrow to hide the navigation on large devices.
