### PR TITLE
[docs] Add oracle to linkcheck ignore list

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -161,6 +161,7 @@ linkcheck_ignore = [
     "https://github.com/serverlessworkflow/specification/blob/main/comparisons/comparison-cadence.md",
     # TODO(richardliaw): The following probably needs to be fixed in the tune_sklearn package
     "https://scikit-optimize.github.io/stable/modules/",
+    "https://www.oracle.com/java/technologies/javase-jdk15-downloads.html",  # forbidden for client
 ]
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This link currently breaks the linter CI.

Btw, should we really keep this in the CI? We even state in the docs:

```
To check if there are broken links, run the following (we are currently not running this
in the CI since there are false positives).
```

cc @pcmoritz 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
