### PR TITLE
[Core] Account for spilled objects when reporting object store memory usage

### DIFF
--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -1,10 +1,27 @@
 import pytest
 import platform
 import numpy as np
+import re
 
 import ray
 from ray._private.test_utils import wait_for_condition
 from ray.cluster_utils import AutoscalingCluster
+
+
+# Triggers the addition of a worker node.
+@ray.remote(num_cpus=1)
+class Actor:
+    def __init__(self):
+        self.data = []
+
+    def f(self):
+        pass
+
+    def recv(self, obj):
+        pass
+
+    def create(self, size):
+        return np.zeros(size)
 
 
 # Tests that we scale down even if secondary copies of objects are present on
@@ -12,7 +29,7 @@ from ray.cluster_utils import AutoscalingCluster
 @pytest.mark.skipif(platform.system() == "Windows", reason="Failing on Windows.")
 def test_scaledown_shared_objects(shutdown_only):
     cluster = AutoscalingCluster(
-        head_resources={"CPU": 1},
+        head_resources={"CPU": 0},
         worker_node_types={
             "cpu_node": {
                 "resources": {
@@ -21,7 +38,7 @@ def test_scaledown_shared_objects(shutdown_only):
                 },
                 "node_config": {},
                 "min_workers": 0,
-                "max_workers": 4,
+                "max_workers": 5,
             },
         },
         idle_timeout_minutes=0.05,
@@ -31,15 +48,6 @@ def test_scaledown_shared_objects(shutdown_only):
         cluster.start(_system_config={"scheduler_report_pinned_bytes_only": True})
         ray.init("auto")
 
-        # Triggers the addition of a GPU node.
-        @ray.remote(num_cpus=1)
-        class Actor:
-            def f(self):
-                pass
-
-            def recv(self, obj):
-                pass
-
         actors = [Actor.remote() for _ in range(5)]
         ray.get([a.f.remote() for a in actors])
         print("All five nodes launched")
@@ -47,7 +55,7 @@ def test_scaledown_shared_objects(shutdown_only):
         # Verify scale-up.
         wait_for_condition(lambda: ray.cluster_resources().get("CPU", 0) == 5)
 
-        data = ray.put(np.zeros(1024 * 1024 * 5))
+        data = actors[0].create.remote(1024 * 1024 * 5)
         ray.get([a.recv.remote(data) for a in actors])
         print("Data broadcast successfully, deleting actors.")
         del actors
@@ -56,6 +64,114 @@ def test_scaledown_shared_objects(shutdown_only):
         wait_for_condition(
             lambda: ray.cluster_resources().get("CPU", 0) == 1, timeout=30
         )
+    finally:
+        cluster.shutdown()
+
+
+def check_memory(local_objs, num_spilled_objects=None, num_plasma_objects=None):
+    def ok():
+        s = ray.internal.internal_api.memory_summary()
+        print(f"\n\nMemory Summary:\n{s}\n")
+
+        actual_objs = re.findall(r"LOCAL_REFERENCE\s+([0-9a-f]+)", s)
+        if sorted(actual_objs) != sorted(local_objs):
+            raise RuntimeError(
+                f"Expect local objects={local_objs}, actual={actual_objs}"
+            )
+
+        if num_spilled_objects is not None:
+            m = re.search(r"Spilled (\d+) MiB, (\d+) objects", s)
+            if m is not None:
+                actual_spilled_objects = int(m.group(2))
+                if actual_spilled_objects < num_spilled_objects:
+                    raise RuntimeError(
+                        f"Expected spilled objects={num_spilled_objects} "
+                        f"greater than actual={actual_spilled_objects}"
+                    )
+
+        if num_plasma_objects is not None:
+            m = re.search(r"Plasma memory usage (\d+) MiB, (\d+) objects", s)
+            if m is None:
+                raise RuntimeError(
+                    "Memory summary does not contain Plasma memory objects count"
+                )
+            actual_plasma_objects = int(m.group(2))
+            if actual_plasma_objects != num_plasma_objects:
+                raise RuntimeError(
+                    f"Expected plasma objects={num_plasma_objects} not equal "
+                    f"to actual={actual_plasma_objects}"
+                )
+
+        return True
+
+    wait_for_condition(ok, timeout=30, retry_interval_ms=5000)
+
+
+# Tests that node with live spilled object does not get scaled down.
+@pytest.mark.skipif(platform.system() == "Windows", reason="Failing on Windows.")
+def test_no_scaledown_with_spilled_objects(shutdown_only):
+    cluster = AutoscalingCluster(
+        head_resources={"CPU": 0},
+        worker_node_types={
+            "cpu_node": {
+                "resources": {
+                    "CPU": 1,
+                    "object_store_memory": 75 * 1024 * 1024,
+                },
+                "node_config": {},
+                "min_workers": 0,
+                "max_workers": 2,
+            },
+        },
+        idle_timeout_minutes=0.05,
+    )
+
+    try:
+        cluster.start(
+            _system_config={
+                "scheduler_report_pinned_bytes_only": True,
+                "min_spilling_size": 0,
+            }
+        )
+        ray.init("auto")
+
+        actors = [Actor.remote() for _ in range(2)]
+        ray.get([a.f.remote() for a in actors])
+
+        # Verify scale-up.
+        wait_for_condition(lambda: ray.cluster_resources().get("CPU", 0) == 2)
+        print("All nodes launched")
+
+        # Put 10 x 80MiB objects into the object store with 75MiB memory limit.
+        obj_size = 10 * 1024 * 1024
+        objs = []
+        for i in range(10):
+            obj = actors[0].create.remote(obj_size)
+            ray.get(actors[1].recv.remote(obj))
+            objs.append(obj)
+            print(f"obj {i}={obj.hex()}")
+            del obj
+
+        # At least 9 out of the 10 objects should have spilled.
+        check_memory([obj.hex() for obj in objs], num_spilled_objects=9)
+        print("Objects spilled, deleting actors and object references.")
+
+        # Assume the 1st object always gets spilled.
+        spilled_obj = objs[0]
+        del objs
+        del actors
+
+        # Verify scale-down to 1 node.
+        def scaledown_to_one():
+            cpu = ray.cluster_resources().get("CPU", 0)
+            assert cpu > 0, "Scale-down should keep at least 1 node"
+            return cpu == 1
+
+        wait_for_condition(scaledown_to_one, timeout=30)
+
+        # Verify the spilled object still exists, and there is no object in the
+        # plasma store.
+        check_memory([spilled_obj.hex()], num_plasma_objects=0)
     finally:
         cluster.shutdown()
 

--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -172,6 +172,12 @@ def test_no_scaledown_with_spilled_objects(shutdown_only):
         # Verify the spilled object still exists, and there is no object in the
         # plasma store.
         check_memory([spilled_obj.hex()], num_plasma_objects=0)
+
+        # Delete the spilled object, the remaining worker node should be scaled
+        # down.
+        del spilled_obj
+        wait_for_condition(lambda: ray.cluster_resources().get("CPU", 0) == 0)
+        check_memory([], num_plasma_objects=0)
     finally:
         cluster.shutdown()
 

--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -73,7 +73,7 @@ def check_memory(local_objs, num_spilled_objects=None, num_plasma_objects=None):
         s = ray.internal.internal_api.memory_summary()
         print(f"\n\nMemory Summary:\n{s}\n")
 
-        actual_objs = re.findall(r"LOCAL_REFERENCE\s+([0-9a-f]+)", s)
+        actual_objs = re.findall(r"LOCAL_REFERENCE[\s|\|]+([0-9a-f]+)", s)
         if sorted(actual_objs) != sorted(local_objs):
             raise RuntimeError(
                 f"Expect local objects={local_objs}, actual={actual_objs}"

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -140,7 +140,7 @@ RAY_CONFIG(float, scheduler_spread_threshold, 0.5);
 /// Whether to only report the usage of pinned copies of objects in the
 /// object_store_memory resource. This means nodes holding secondary copies only
 /// will become eligible for removal in the autoscaler.
-RAY_CONFIG(bool, scheduler_report_pinned_bytes_only, false)
+RAY_CONFIG(bool, scheduler_report_pinned_bytes_only, true)
 
 // The max allowed size in bytes of a return object from direct actor calls.
 // Objects larger than this size will be spilled/promoted to plasma.

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -592,6 +592,18 @@ void LocalObjectManager::RecordMetrics() const {
                                                        "Restored");
 }
 
+int64_t LocalObjectManager::GetPinnedBytes() const {
+  if (pinned_objects_size_ > 0) {
+    return pinned_objects_size_;
+  }
+  // Report non-zero usage when there are spilled / spill-pending live objects, to
+  // prevent this node from being drained. This seems the simplest and affects scheduling
+  // the least, compared to alternatives including
+  // - tracking the total size of spilled objects,
+  // - always add 1 to pinned_objects_size_ when objects are spilled / spill-pending.
+  return (spilled_objects_url_.empty() && objects_pending_spill_.empty()) ? 0 : 1;
+}
+
 std::string LocalObjectManager::DebugString() const {
   std::stringstream result;
   result << "LocalObjectManager:\n";

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -597,10 +597,8 @@ int64_t LocalObjectManager::GetPinnedBytes() const {
     return pinned_objects_size_;
   }
   // Report non-zero usage when there are spilled / spill-pending live objects, to
-  // prevent this node from being drained. This seems the simplest and affects scheduling
-  // the least, compared to alternatives including
-  // - tracking the total size of spilled objects,
-  // - always add 1 to pinned_objects_size_ when objects are spilled / spill-pending.
+  // prevent this node from being drained. Note that the value reported here is also used
+  // for scheduling.
   return (spilled_objects_url_.empty() && objects_pending_spill_.empty()) ? 0 : 1;
 }
 

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -146,8 +146,9 @@ class LocalObjectManager {
   /// In that case, the URL is supposed to be obtained by the object directory.
   std::string GetLocalSpilledObjectURL(const ObjectID &object_id);
 
-  /// Get the current pinned object store memory usage.
-  int64_t GetPinnedBytes() const { return pinned_objects_size_; }
+  /// Get the current pinned object store memory usage to help node scale down decisions.
+  /// A node can only be safely drained when this function reports zero.
+  int64_t GetPinnedBytes() const;
 
   std::string DebugString() const;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In #21870, feature flag `scheduler_report_pinned_bytes_only` was added to report pinned memory usage as object store memory usage. The feature allows nodes with only secondary copies of objects to report 0 memory usage, so autoscaler can drain and scale down these nodes. However, nodes with 0 pinned memory may host spilled primary copies of objects. Draining these nodes can destroy live objects which slows down or fails a workload.

The fix here is to alway reports a non-zero object store memory usage, when there is 0 pinned memory but live spilled objects. A Python unit test is added that reproduced the issued and verified the fix. The nightly test `autoscaling_shuffle_1tb_1000_partitions` also passed with this fix and `scheduler_report_pinned_bytes_only` enabled.

In the longer term, I suspect we may need to use different properties / semantics for object store memory usage for scheduling, vs whether the object store can be drained.

`scheduler_report_pinned_bytes_only` is enabled again.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
