### PR TITLE
[Rllib] Change type to tensortype for cql policies. 

### DIFF
--- a/rllib/agents/bandit/bandit_tf_model.py
+++ b/rllib/agents/bandit/bandit_tf_model.py
@@ -5,11 +5,12 @@ from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.tf.tf_modelv2 import TFModelV2
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.typing import TensorType
 
 tf1, tf, tfv = try_import_tf()
 
 
-class OnlineLinearRegression(tf.Module):
+class OnlineLinearRegression(tf.Module if tf else object):
     def __init__(self, feature_dim, alpha=1, lambda_=1):
         super(OnlineLinearRegression, self).__init__()
 
@@ -59,7 +60,7 @@ class OnlineLinearRegression(tf.Module):
         theta = self.dist.sample()
         return theta
 
-    def get_ucbs(self, x: tf.Tensor):
+    def get_ucbs(self, x: TensorType):
         """Calculate upper confidence bounds using covariance matrix according
         to algorithm 1: LinUCB
         (http://proceedings.mlr.press/v15/chu11a/chu11a.pdf).
@@ -90,7 +91,7 @@ class OnlineLinearRegression(tf.Module):
             batch_dots = tf.reshape(batch_dots, [B, C])
         return batch_dots
 
-    def __call__(self, x: tf.Tensor, sample_theta=False):
+    def __call__(self, x: TensorType, sample_theta=False):
         """Predict scores on input batch using the underlying linear model.
 
         Args:

--- a/rllib/agents/cql/cql_tf_policy.py
+++ b/rllib/agents/cql/cql_tf_policy.py
@@ -47,7 +47,7 @@ MEAN_MIN = -9.0
 MEAN_MAX = 9.0
 
 
-def _repeat_tensor(t: tf.Tensor, n: int):
+def _repeat_tensor(t: TensorType, n: int):
     # Insert new axis at position 1 into tensor t
     t_rep = tf.expand_dims(t, 1)
     # Repeat tensor t_rep along new axis n times

--- a/rllib/agents/cql/cql_torch_policy.py
+++ b/rllib/agents/cql/cql_torch_policy.py
@@ -43,7 +43,7 @@ MEAN_MIN = -9.0
 MEAN_MAX = 9.0
 
 
-def _repeat_tensor(t: torch.Tensor, n: int):
+def _repeat_tensor(t: TensorType, n: int):
     # Insert new dimension at posotion 1 into tensor t
     t_rep = t.unsqueeze(1)
     # Repeat tensor t_rep along new dimension n times

--- a/rllib/tests/test_dependency_tf.py
+++ b/rllib/tests/test_dependency_tf.py
@@ -7,6 +7,13 @@ if __name__ == "__main__":
     # Do not import tf for testing purposes.
     os.environ["RLLIB_TEST_NO_TF_IMPORT"] = "1"
 
+    # Test registering (includes importing) all Trainers.
+    from ray.rllib import _register_all
+
+    # This should surface any dependency on tf, e.g. inside function
+    # signatures/typehints.
+    _register_all()
+
     from ray.rllib.agents.a3c import A2CTrainer
 
     assert (

--- a/rllib/tests/test_dependency_torch.py
+++ b/rllib/tests/test_dependency_torch.py
@@ -7,6 +7,13 @@ if __name__ == "__main__":
     # Do not import torch for testing purposes.
     os.environ["RLLIB_TEST_NO_TORCH_IMPORT"] = "1"
 
+    # Test registering (includes importing) all Trainers.
+    from ray.rllib import _register_all
+
+    # This should surface any dependency on torch, e.g. inside function
+    # signatures/typehints.
+    _register_all()
+
     from ray.rllib.agents.a3c import A2CTrainer
 
     assert "torch" not in sys.modules, "`torch` initially present, when it shouldn't!"


### PR DESCRIPTION
This makes it so that torch and tensorflow don't need to be installed by default with RLlib

I found this bug while trying to run experiments on a cluster and torch wasn't installed, but torch was needed for typing, causing RLlib imports to fail

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
