### PR TITLE
[serve] Raise error in `test_local_store_recovery`

### DIFF
--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -550,12 +550,14 @@ def test_local_store_recovery(ray_shutdown):
     def world(_):
         return "world"
 
-    def check(name):
+    def check(name, raise_error=False):
         try:
             resp = requests.get(f"http://localhost:8000/{name}")
             assert resp.text == name
             return True
-        except Exception:
+        except Exception as e:
+            if raise_error:
+                raise e
             return False
 
     # https://github.com/ray-project/ray/issues/20159
@@ -581,8 +583,8 @@ def test_local_store_recovery(ray_shutdown):
     serve.start(detached=True, _checkpoint_path=f"file://{tmp_path}")
     hello.deploy()
     world.deploy()
-    assert check("hello")
-    assert check("world")
+    assert check("hello", raise_error=True)
+    assert check("world", raise_error=True)
     crash()
 
     # Simulate a crash


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_local_store_recovery` in `test_standalone.py` is [flaky](https://flakey-tests.ray.io/#) on Windows:

<img width="1305" alt="Screen Shot 2022-03-23 at 5 52 45 PM" src="https://user-images.githubusercontent.com/92341594/159820488-ffd9399d-717c-4143-add2-49be10ec4086.png">

It repeatedly fails on `assert check("hello")`, which suppresses errors, making it tough to debug. This change allows `check()` to raise an error for more actionable outputs.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - Modifies `test_local_store_recovery` in `test_standalone.py`.
