### PR TITLE
Disable KubeRay tests on windows.

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -161,7 +161,7 @@ test_python() {
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_operator_unit_tests
       -python/ray/tests:test_tracing  # tracing not enabled on windows
-      -python/ray/tests/kuberay/...
+      -python/ray/tests:kuberay/test_autoscaling_e2e # irrelevant on windows
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -161,6 +161,7 @@ test_python() {
       -python/ray/tests:test_stress_sharded  # timeout
       -python/ray/tests:test_k8s_operator_unit_tests
       -python/ray/tests:test_tracing  # tracing not enabled on windows
+      -python/ray/tests/kuberay/...
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?


### PR DESCRIPTION
This PR disables KubeRay tests on windows, because they're not relevant there.