### PR TITLE
[workflow] Deprecate "workflow.step" [Part 1 - most common cases]

### DIFF
--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -345,7 +345,10 @@ class Workflow(Generic[T]):
     def __init__(
         self, workflow_data: WorkflowData, prepare_inputs: Optional[Callable] = None
     ):
-        if workflow_data.step_options.ray_options.get("num_returns", 1) > 1:
+        num_returns = workflow_data.step_options.ray_options.get("num_returns", 1)
+        if num_returns is None:  # ray could use `None` as default value
+            num_returns = 1
+        if num_returns > 1:
             raise ValueError("Workflow steps can only have one return.")
         self._data: WorkflowData = workflow_data
         self._prepare_inputs: Callable = prepare_inputs

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -9,112 +9,100 @@ from ray import workflow
 from ray.workflow import workflow_access
 
 
-@workflow.step
-def identity(x):
-    return x
-
-
-@workflow.step
-def source1():
-    return "[source1]"
-
-
-@workflow.step
-def append1(x):
-    return x + "[append1]"
-
-
-@workflow.step
-def append2(x):
-    return x + "[append2]"
-
-
-@workflow.step
-def simple_sequential():
-    x = source1.step()
-    y = append1.step(x)
-    return append2.step(y)
-
-
-@workflow.step
-def simple_sequential_with_input(x):
-    y = append1.step(x)
-    return append2.step(y)
-
-
-@workflow.step
-def loop_sequential(n):
-    x = source1.step()
-    for _ in range(n):
-        x = append1.step(x)
-    return append2.step(x)
-
-
-@workflow.step
-def nested_step(x):
-    return append2.step(append1.step(x + "~[nested]~"))
-
-
-@workflow.step
-def nested(x):
-    return nested_step.step(x)
-
-
-@workflow.step
-def join(x, y):
-    return f"join({x}, {y})"
-
-
-@workflow.step
-def fork_join():
-    x = source1.step()
-    y = append1.step(x)
-    y = identity.step(y)
-    z = append2.step(x)
-    return join.step(y, z)
-
-
-@workflow.step
-def blocking():
-    time.sleep(10)
-    return 314
-
-
-@workflow.step
-def mul(a, b):
-    return a * b
-
-
-@workflow.step
-def factorial(n):
-    if n == 1:
-        return 1
-    else:
-        return mul.step(n, factorial.step(n - 1))
-
-
 def test_basic_workflows(workflow_start_regular_shared):
+    @ray.remote
+    def source1():
+        return "[source1]"
+
+    @ray.remote
+    def append1(x):
+        return x + "[append1]"
+
+    @ray.remote
+    def append2(x):
+        return x + "[append2]"
+
+    @ray.remote
+    def simple_sequential():
+        x = source1.bind()
+        y = append1.bind(x)
+        return workflow.continuation(append2.bind(y))
+
+    @ray.remote
+    def identity(x):
+        return x
+
+    @ray.remote
+    def simple_sequential_with_input(x):
+        y = append1.bind(x)
+        return workflow.continuation(append2.bind(y))
+
+    @ray.remote
+    def loop_sequential(n):
+        x = source1.bind()
+        for _ in range(n):
+            x = append1.bind(x)
+        return workflow.continuation(append2.bind(x))
+
+    @ray.remote
+    def nested_step(x):
+        return workflow.continuation(append2.bind(append1.bind(x + "~[nested]~")))
+
+    @ray.remote
+    def nested(x):
+        return workflow.continuation(nested_step.bind(x))
+
+    @ray.remote
+    def join(x, y):
+        return f"join({x}, {y})"
+
+    @ray.remote
+    def fork_join():
+        x = source1.bind()
+        y = append1.bind(x)
+        y = identity.bind(y)
+        z = append2.bind(x)
+        return workflow.continuation(join.bind(y, z))
+
+    @workflow.step
+    def mul(a, b):
+        return a * b
+
+    @workflow.step
+    def factorial(n):
+        if n == 1:
+            return 1
+        else:
+            return mul.step(n, factorial.step(n - 1))
+
     # This test also shows different "style" of running workflows.
-    assert simple_sequential.step().run() == "[source1][append1][append2]"
+    assert (
+        workflow.create(simple_sequential.bind()).run() == "[source1][append1][append2]"
+    )
 
-    wf = simple_sequential_with_input.step("start:")
-    assert wf.run() == "start:[append1][append2]"
+    wf = simple_sequential_with_input.bind("start:")
+    assert workflow.create(wf).run() == "start:[append1][append2]"
 
-    wf = loop_sequential.step(3)
-    assert wf.run() == "[source1]" + "[append1]" * 3 + "[append2]"
+    wf = loop_sequential.bind(3)
+    assert workflow.create(wf).run() == "[source1]" + "[append1]" * 3 + "[append2]"
 
-    wf = nested.step("nested:")
-    assert wf.run() == "nested:~[nested]~[append1][append2]"
+    wf = nested.bind("nested:")
+    assert workflow.create(wf).run() == "nested:~[nested]~[append1][append2]"
 
-    wf = fork_join.step()
-    assert wf.run() == "join([source1][append1], [source1][append2])"
+    wf = fork_join.bind()
+    assert workflow.create(wf).run() == "join([source1][append1], [source1][append2])"
 
     assert factorial.step(10).run() == 3628800
 
 
 def test_async_execution(workflow_start_regular_shared):
+    @ray.remote
+    def blocking():
+        time.sleep(10)
+        return 314
+
     start = time.time()
-    output = blocking.step().run_async()
+    output = workflow.create(blocking.bind()).run_async()
     duration = time.time() - start
     assert duration < 5  # workflow.run is not blocked
     assert ray.get(output) == 314
@@ -135,7 +123,7 @@ def test_partial(workflow_start_regular_shared):
 
     fs = [partial(add, y=y) for y in ys]
 
-    @ray.workflow.step
+    @ray.remote
     def chain_func(*args, **kw_argv):
         # Get the first function as a start
         wf_step = workflow.step(fs[0]).step(*args, **kw_argv)
@@ -146,14 +134,7 @@ def test_partial(workflow_start_regular_shared):
             wf_step = workflow.step(fs[i]).step(wf_step)
         return wf_step
 
-    assert chain_func.step(1).run() == 7
-
-
-@ray.remote
-def deep_nested(x):
-    if x >= 42:
-        return x
-    return deep_nested.remote(x + 1)
+    assert workflow.create(chain_func.bind(1)).run() == 7
 
 
 def _resolve_workflow_output(workflow_id: str, output: ray.ObjectRef):
@@ -163,6 +144,12 @@ def _resolve_workflow_output(workflow_id: str, output: ray.ObjectRef):
 
 
 def test_workflow_output_resolving(workflow_start_regular_shared):
+    @ray.remote
+    def deep_nested(x):
+        if x >= 42:
+            return x
+        return deep_nested.remote(x + 1)
+
     # deep nested workflow
     nested_ref = deep_nested.remote(30)
     original_func = workflow_access._resolve_workflow_output
@@ -178,9 +165,31 @@ def test_workflow_output_resolving(workflow_start_regular_shared):
 
 
 def test_run_or_resume_during_running(workflow_start_regular_shared):
-    output = simple_sequential.step().run_async(workflow_id="running_workflow")
+    @ray.remote
+    def source1():
+        return "[source1]"
+
+    @ray.remote
+    def append1(x):
+        return x + "[append1]"
+
+    @ray.remote
+    def append2(x):
+        return x + "[append2]"
+
+    @ray.remote
+    def simple_sequential():
+        x = source1.bind()
+        y = append1.bind(x)
+        return workflow.continuation(append2.bind(y))
+
+    output = workflow.create(simple_sequential.bind()).run_async(
+        workflow_id="running_workflow"
+    )
     with pytest.raises(RuntimeError):
-        simple_sequential.step().run_async(workflow_id="running_workflow")
+        workflow.create(simple_sequential.bind()).run_async(
+            workflow_id="running_workflow"
+        )
     with pytest.raises(RuntimeError):
         workflow.resume(workflow_id="running_workflow")
     assert ray.get(output) == "[source1][append1][append2]"
@@ -285,18 +294,20 @@ def test_nested_catch_exception_2(workflow_start_regular_shared, tmp_path):
 
 
 def test_dynamic_output(workflow_start_regular_shared):
-    @workflow.step
+    @ray.remote
     def exponential_fail(k, n):
         if n > 0:
             if n < 3:
                 raise Exception("Failed intentionally")
-            return exponential_fail.options(name=f"step_{n}").step(k * 2, n - 1)
+            return workflow.continuation(
+                exponential_fail.options(name=f"step_{n}").bind(k * 2, n - 1)
+            )
         return k
 
     # When workflow fails, the dynamic output should points to the
     # latest successful step.
     try:
-        exponential_fail.options(name="step_0").step(3, 10).run(
+        workflow.create(exponential_fail.options(name="step_0").bind(3, 10)).run(
             workflow_id="dynamic_output"
         )
     except Exception:

--- a/python/ray/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/workflow/tests/test_basic_workflows_2.py
@@ -47,7 +47,7 @@ def test_step_resources(workflow_start_regular, tmp_path):
     # sent from worker to raylet.
     signal_actor = SignalActor.remote()
 
-    @workflow.step
+    @ray.remote
     def step_run():
         ray.wait([signal_actor.send.remote()])
         with FileLock(lock_path):
@@ -59,7 +59,7 @@ def test_step_resources(workflow_start_regular, tmp_path):
 
     lock = FileLock(lock_path)
     lock.acquire()
-    ret = step_run.options(num_cpus=2).step().run_async()
+    ret = workflow.create(step_run.options(num_cpus=2).bind()).run_async()
     ray.wait([signal_actor.wait.remote()])
     obj = remote_run.remote()
     with pytest.raises(ray.exceptions.GetTimeoutError):
@@ -70,11 +70,11 @@ def test_step_resources(workflow_start_regular, tmp_path):
 
 
 def test_get_output_1(workflow_start_regular, tmp_path):
-    @workflow.step
+    @ray.remote
     def simple(v):
         return v
 
-    assert 0 == simple.step(0).run("simple")
+    assert 0 == workflow.create(simple.bind(0)).run("simple")
     assert 0 == ray.get(workflow.get_output("simple"))
 
 
@@ -82,13 +82,13 @@ def test_get_output_2(workflow_start_regular, tmp_path):
     lock_path = str(tmp_path / "lock")
     lock = FileLock(lock_path)
 
-    @workflow.step
+    @ray.remote
     def simple(v):
         with FileLock(lock_path):
             return v
 
     lock.acquire()
-    obj = simple.step(0).run_async("simple")
+    obj = workflow.create(simple.bind(0)).run_async("simple")
     obj2 = workflow.get_output("simple")
     lock.release()
     assert ray.get([obj, obj2]) == [0, 0]
@@ -100,7 +100,7 @@ def test_get_output_3(workflow_start_regular, tmp_path):
     error_flag = tmp_path / "error"
     error_flag.touch()
 
-    @workflow.step
+    @ray.remote
     def incr():
         v = int(cnt_file.read_text())
         cnt_file.write_text(str(v + 1))
@@ -109,7 +109,7 @@ def test_get_output_3(workflow_start_regular, tmp_path):
         return 10
 
     with pytest.raises(ray.exceptions.RaySystemError):
-        incr.options(max_retries=0).step().run("incr")
+        workflow.create(incr.options(max_retries=0).bind()).run("incr")
 
     assert cnt_file.read_text() == "1"
 
@@ -247,7 +247,7 @@ def test_get_named_step_duplicate(workflow_start_regular):
 
 
 def test_no_init(shutdown_only):
-    @workflow.step
+    @ray.remote
     def f():
         pass
 
@@ -256,7 +256,7 @@ def test_no_init(shutdown_only):
     )
 
     with pytest.raises(RuntimeError, match=fail_wf_init_error_msg):
-        f.step().run()
+        workflow.create(f.bind()).run()
     with pytest.raises(RuntimeError, match=fail_wf_init_error_msg):
         workflow.list_all()
     with pytest.raises(RuntimeError, match=fail_wf_init_error_msg):

--- a/python/ray/workflow/tests/test_basic_workflows_3.py
+++ b/python/ray/workflow/tests/test_basic_workflows_3.py
@@ -1,6 +1,8 @@
 import pytest
 from filelock import FileLock
 from pathlib import Path
+
+import ray
 from ray import workflow
 from ray.tests.conftest import *  # noqa
 
@@ -9,30 +11,30 @@ def test_wf_run(workflow_start_regular, tmp_path):
     counter = tmp_path / "counter"
     counter.write_text("0")
 
-    @workflow.step
+    @ray.remote
     def f():
         v = int(counter.read_text()) + 1
         counter.write_text(str(v))
 
-    f.step().run("abc")
+    workflow.create(f.bind()).run("abc")
     assert counter.read_text() == "1"
     # This will not rerun the job from beginning
-    f.step().run("abc")
+    workflow.create(f.bind()).run("abc")
     assert counter.read_text() == "1"
 
 
 def test_wf_no_run():
-    @workflow.step
+    @ray.remote
     def f1():
         pass
 
-    f1.step()
+    f1.bind()
 
-    @workflow.step
+    @ray.remote
     def f2(*w):
         pass
 
-    f = f2.step(*[f1.step() for _ in range(10)])
+    f = workflow.create(f2.bind(*[f1.bind() for _ in range(10)]))
 
     with pytest.raises(Exception):
         f.run()
@@ -43,35 +45,35 @@ def test_dedupe_indirect(workflow_start_regular, tmp_path):
     lock = Path(tmp_path) / "lock.txt"
     counter.write_text("0")
 
-    @workflow.step
+    @ray.remote
     def incr():
         with FileLock(str(lock)):
             c = int(counter.read_text())
             c += 1
             counter.write_text(f"{c}")
 
-    @workflow.step
+    @ray.remote
     def identity(a):
         return a
 
-    @workflow.step
+    @ray.remote
     def join(*a):
         return counter.read_text()
 
     # Here a is passed to two steps and we need to ensure
     # it's only executed once
-    a = incr.step()
-    i1 = identity.step(a)
-    i2 = identity.step(a)
-    assert "1" == join.step(i1, i2).run()
-    assert "2" == join.step(i1, i2).run()
+    a = incr.bind()
+    i1 = identity.bind(a)
+    i2 = identity.bind(a)
+    assert "1" == workflow.create(join.bind(i1, i2)).run()
+    assert "2" == workflow.create(join.bind(i1, i2)).run()
     # pass a multiple times
-    assert "3" == join.step(a, a, a, a).run()
-    assert "4" == join.step(a, a, a, a).run()
+    assert "3" == workflow.create(join.bind(a, a, a, a)).run()
+    assert "4" == workflow.create(join.bind(a, a, a, a)).run()
 
 
 def test_run_off_main_thread(workflow_start_regular):
-    @workflow.step
+    @ray.remote
     def fake_data(num: int):
         return list(range(num))
 
@@ -81,7 +83,7 @@ def test_run_off_main_thread(workflow_start_regular):
     def run():
         global succ
         # Setup the workflow.
-        data = fake_data.step(10)
+        data = workflow.create(fake_data.bind(10))
         assert data.run(workflow_id="run") == list(range(10))
 
     import threading

--- a/python/ray/workflow/tests/test_dataset.py
+++ b/python/ray/workflow/tests/test_dataset.py
@@ -6,29 +6,29 @@ import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def gen_dataset():
     # TODO(ekl) seems checkpointing hangs with nested refs of
     # LazyBlockList.
     return ray.data.range(1000).map(lambda x: x)
 
 
-@workflow.step
+@ray.remote
 def transform_dataset(in_data):
     return in_data.map(lambda x: x * 2)
 
 
-@workflow.step
+@ray.remote
 def sum_dataset(ds):
     return ds.sum()
 
 
 def test_dataset(workflow_start_regular):
-    ds_ref = gen_dataset.step()
-    transformed_ref = transform_dataset.step(ds_ref)
-    output_ref = sum_dataset.step(transformed_ref)
+    ds_ref = gen_dataset.bind()
+    transformed_ref = transform_dataset.bind(ds_ref)
+    output_ref = sum_dataset.bind(transformed_ref)
 
-    result = output_ref.run()
+    result = workflow.create(output_ref).run()
     assert result == 2 * sum(range(1000))
 
 

--- a/python/ray/workflow/tests/test_dynamic_workflow_ref.py
+++ b/python/ray/workflow/tests/test_dynamic_workflow_ref.py
@@ -1,20 +1,21 @@
 from ray.tests.conftest import *  # noqa
 
 import pytest
+
+import ray
 from ray import workflow
 from ray.workflow.common import WorkflowRef
 
 
-@workflow.step
-def incr(x):
-    return x + 1
-
-
 def test_dynamic_workflow_ref(workflow_start_regular_shared):
+    @ray.remote
+    def incr(x):
+        return x + 1
+
     # This test also shows different "style" of running workflows.
-    first_step = incr.step(0)
+    first_step = workflow.create(incr.bind(0))
     assert first_step.run("test_dynamic_workflow_ref") == 1
-    second_step = incr.step(WorkflowRef(first_step.step_id))
+    second_step = workflow.create(incr.bind(WorkflowRef(first_step.step_id)))
     # Without rerun, it'll just return the previous result
     assert second_step.run("test_dynamic_workflow_ref") == 1
     # TODO (yic) We need re-run to make this test work

--- a/python/ray/workflow/tests/test_large_intermediate.py
+++ b/python/ray/workflow/tests/test_large_intermediate.py
@@ -6,29 +6,25 @@ import numpy as np
 from ray import workflow
 
 
-@workflow.step
-def large_input():
-    return np.arange(2 ** 24)
-
-
-@workflow.step
-def identity(x):
-    return x
-
-
-@workflow.step
-def average(x):
-    return np.mean(x)
-
-
-@workflow.step
-def simple_large_intermediate():
-    x = large_input.step()
-    y = identity.step(x)
-    return average.step(y)
-
-
 def test_simple_large_intermediate(workflow_start_regular_shared):
+    @workflow.step
+    def large_input():
+        return np.arange(2 ** 24)
+
+    @workflow.step
+    def identity(x):
+        return x
+
+    @workflow.step
+    def average(x):
+        return np.mean(x)
+
+    @workflow.step
+    def simple_large_intermediate():
+        x = large_input.step()
+        y = identity.step(x)
+        return average.step(y)
+
     start = time.time()
     outputs = simple_large_intermediate.step().run()
     print(f"duration = {time.time() - start}")

--- a/python/ray/workflow/tests/test_lifetime.py
+++ b/python/ray/workflow/tests/test_lifetime.py
@@ -12,21 +12,22 @@ from unittest.mock import patch
 
 driver_script = """
 import time
+import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def foo(x):
     time.sleep(1)
     if x < 20:
-        return foo.step(x + 1)
+        return workflow.continuation(foo.bind(x + 1))
     else:
         return 20
 
 
 if __name__ == "__main__":
     workflow.init()
-    output = foo.step(0).run_async(workflow_id="driver_terminated")
+    output = workflow.create(foo.bind(0)).run_async(workflow_id="driver_terminated")
     time.sleep({})
 """
 

--- a/python/ray/workflow/tests/test_recovery.py
+++ b/python/ray/workflow/tests/test_recovery.py
@@ -15,67 +15,12 @@ from ray.workflow.storage.debug import DebugStorage
 from ray.workflow.tests import utils
 
 
-@workflow.step
-def the_failed_step(x):
-    if not utils.check_global_mark():
-        import os
-
-        os.kill(os.getpid(), 9)
-    return "foo(" + x + ")"
-
-
-@workflow.step
-def source1():
-    return "[source1]"
-
-
-@workflow.step
-def append1(x):
-    return x + "[append1]"
-
-
-@workflow.step
-def append2(x):
-    return x + "[append2]"
-
-
-@workflow.step
-def join(x, y):
-    return f"join({x}, {y})"
-
-
-@workflow.step
-def complex(x1):
-    x2 = source1.step()
-    v = join.step(x1, x2)
-    y = append1.step(x1)
-    y = the_failed_step.step(y)
-    z = append2.step(x2)
-    u = join.step(y, z)
-    return join.step(u, v)
-
-
-@workflow.step
-def simple(x):
-    x = append1.step(x)
-    y = the_failed_step.step(x)
-    z = append2.step(y)
-    return z
-
-
-@workflow.step
+@ray.remote
 def identity(x):
     return x
 
 
-@workflow.step
-def recursive(ref, count):
-    if count == 0:
-        return ref
-    return recursive.step(ref, count - 1)
-
-
-@workflow.step
+@ray.remote
 def gather(*args):
     return args
 
@@ -95,9 +40,9 @@ def test_dedupe_downloads_list(workflow_start_regular):
         utils._alter_storage(debug_store)
 
         numbers = [ray.put(i) for i in range(5)]
-        workflows = [identity.step(numbers) for _ in range(100)]
+        workflows = [identity.bind(numbers) for _ in range(100)]
 
-        gather.step(*workflows).run()
+        workflow.create(gather.bind(*workflows)).run()
 
         ops = debug_store._logged_storage.get_op_counter()
         get_objects_count = 0
@@ -122,9 +67,9 @@ def test_dedupe_download_raw_ref(workflow_start_regular):
         utils._alter_storage(debug_store)
 
         ref = ray.put("hello")
-        workflows = [identity.step(ref) for _ in range(100)]
+        workflows = [identity.bind(ref) for _ in range(100)]
 
-        gather.step(*workflows).run()
+        workflow.create(gather.bind(*workflows)).run()
 
         ops = debug_store._logged_storage.get_op_counter()
         get_objects_count = 0
@@ -148,12 +93,19 @@ def test_nested_workflow_no_download(workflow_start_regular):
     step, we should checkpoint the input/output, but continue to reuse the
     in-memory value.
     """
+
+    @ray.remote
+    def recursive(ref, count):
+        if count == 0:
+            return ref
+        return workflow.continuation(recursive.bind(ref, count - 1))
+
     with tempfile.TemporaryDirectory() as temp_dir:
         debug_store = DebugStorage(get_global_storage(), temp_dir)
         utils._alter_storage(debug_store)
 
         ref = ray.put("hello")
-        result = recursive.step([ref], 10).run()
+        result = workflow.create(recursive.bind([ref], 10)).run()
 
         ops = debug_store._logged_storage.get_op_counter()
         get_objects_count = 0
@@ -172,12 +124,36 @@ def test_nested_workflow_no_download(workflow_start_regular):
         assert ray.get(result) == ["hello"]
 
 
+@ray.remote
+def the_failed_step(x):
+    if not utils.check_global_mark():
+        import os
+
+        os.kill(os.getpid(), 9)
+    return "foo(" + x + ")"
+
+
 def test_recovery_simple(workflow_start_regular):
+    @ray.remote
+    def append1(x):
+        return x + "[append1]"
+
+    @ray.remote
+    def append2(x):
+        return x + "[append2]"
+
+    @ray.remote
+    def simple(x):
+        x = append1.bind(x)
+        y = the_failed_step.bind(x)
+        z = append2.bind(y)
+        return workflow.continuation(z)
+
     utils.unset_global_mark()
     workflow_id = "test_recovery_simple"
     with pytest.raises(RaySystemError):
         # internally we get WorkerCrashedError
-        simple.step("x").run(workflow_id=workflow_id)
+        workflow.create(simple.bind("x")).run(workflow_id=workflow_id)
 
     assert workflow.get_status(workflow_id) == workflow.WorkflowStatus.RESUMABLE
 
@@ -191,11 +167,37 @@ def test_recovery_simple(workflow_start_regular):
 
 
 def test_recovery_complex(workflow_start_regular):
+    @ray.remote
+    def source1():
+        return "[source1]"
+
+    @ray.remote
+    def append1(x):
+        return x + "[append1]"
+
+    @ray.remote
+    def append2(x):
+        return x + "[append2]"
+
+    @ray.remote
+    def join(x, y):
+        return f"join({x}, {y})"
+
+    @ray.remote
+    def complex(x1):
+        x2 = source1.bind()
+        v = join.bind(x1, x2)
+        y = append1.bind(x1)
+        y = the_failed_step.bind(y)
+        z = append2.bind(x2)
+        u = join.bind(y, z)
+        return workflow.continuation(join.bind(u, v))
+
     utils.unset_global_mark()
     workflow_id = "test_recovery_complex"
     with pytest.raises(RaySystemError):
         # internally we get WorkerCrashedError
-        complex.step("x").run(workflow_id=workflow_id)
+        workflow.create(complex.bind("x")).run(workflow_id=workflow_id)
     utils.set_global_mark()
     output = workflow.resume(workflow_id)
     r = "join(join(foo(x[append1]), [source1][append2]), join(x, [source1]))"
@@ -212,32 +214,28 @@ def test_recovery_non_exists_workflow(workflow_start_regular):
         ray.get(workflow.resume("this_workflow_id_does_not_exist"))
 
 
-driver_script = """
-import time
-from ray import workflow
-
-
-@workflow.step
-def foo(x):
-    print("Executing", x)
-    time.sleep(1)
-    if x < 20:
-        return foo.step(x + 1)
-    else:
-        return 20
-
-
-if __name__ == "__main__":
-    workflow.init("{tmp_path}")
-    assert foo.step(0).run(workflow_id="cluster_failure") == 20
-"""
-
-
 def test_recovery_cluster_failure(reset_workflow, tmp_path):
     subprocess.check_call(["ray", "start", "--head"])
     time.sleep(1)
     proc = run_string_as_driver_nonblocking(
-        driver_script.format(tmp_path=str(tmp_path))
+        f"""
+import time
+import ray
+from ray import workflow
+
+@ray.remote
+def foo(x):
+    print("Executing", x)
+    time.sleep(1)
+    if x < 20:
+        return workflow.continuation(foo.bind(x + 1))
+    else:
+        return 20
+
+if __name__ == "__main__":
+    workflow.init("{tmp_path}")
+    assert workflow.create(foo.bind(0)).run(workflow_id="cluster_failure") == 20
+"""
     )
     time.sleep(10)
     subprocess.check_call(["ray", "stop"])
@@ -255,23 +253,26 @@ def test_recovery_cluster_failure_resume_all(reset_workflow, tmp_path):
     time.sleep(1)
     workflow_dir = tmp_path / "workflow"
     lock_file = tmp_path / "lock_file"
-    driver_script = f"""
+    lock = FileLock(lock_file)
+    lock.acquire()
+
+    proc = run_string_as_driver_nonblocking(
+        f"""
 import time
+import ray
 from ray import workflow
 from filelock import FileLock
-@workflow.step
+
+@ray.remote
 def foo(x):
     with FileLock("{str(lock_file)}"):
         return 20
 
 if __name__ == "__main__":
     workflow.init("{str(workflow_dir)}")
-    assert foo.step(0).run(workflow_id="cluster_failure") == 20
+    assert workflow.create(foo.bind(0)).run(workflow_id="cluster_failure") == 20
 """
-    lock = FileLock(lock_file)
-    lock.acquire()
-
-    proc = run_string_as_driver_nonblocking(driver_script)
+    )
     time.sleep(10)
     subprocess.check_call(["ray", "stop"])
     proc.kill()
@@ -287,16 +288,15 @@ if __name__ == "__main__":
     ray.shutdown()
 
 
-@workflow.step
-def recursive_chain(x):
-    if x < 100:
-        return recursive_chain.step(x + 1)
-    else:
-        return 100
-
-
 def test_shortcut(workflow_start_regular):
-    assert recursive_chain.step(0).run(workflow_id="shortcut") == 100
+    @ray.remote
+    def recursive_chain(x):
+        if x < 100:
+            return workflow.continuation(recursive_chain.bind(x + 1))
+        else:
+            return 100
+
+    assert workflow.create(recursive_chain.bind(0)).run(workflow_id="shortcut") == 100
     # the shortcut points to the step with output checkpoint
     store = workflow_storage.get_workflow_storage("shortcut")
     step_id = store.get_entrypoint_step_id()
@@ -304,14 +304,13 @@ def test_shortcut(workflow_start_regular):
     assert store.inspect_step(output_step_id).output_object_valid
 
 
-@workflow.step
-def constant():
-    return 31416
-
-
 def test_resume_different_storage(ray_start_regular, tmp_path, reset_workflow):
+    @ray.remote
+    def constant():
+        return 31416
+
     workflow.init(storage=str(tmp_path))
-    constant.step().run(workflow_id="const")
+    workflow.create(constant.bind()).run(workflow_id="const")
     assert ray.get(workflow.resume(workflow_id="const")) == 31416
     workflow.storage.set_global_storage(None)
 

--- a/python/ray/workflow/tests/test_signature_check.py
+++ b/python/ray/workflow/tests/test_signature_check.py
@@ -1,10 +1,11 @@
 import pytest
 
 from ray.tests.conftest import *  # noqa
+import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def signature_check(a, b, c=1):
     pass
 
@@ -14,21 +15,21 @@ def test_signature_check(workflow_start_regular):
         signature_check(1, 2)
 
     with pytest.raises(TypeError):
-        signature_check.step(1)
+        workflow.create(signature_check.bind(1))
 
     with pytest.raises(TypeError):
-        signature_check.step(1, c=2)
+        workflow.create(signature_check.bind(1, c=2))
 
     with pytest.raises(TypeError):
-        signature_check.step(1, 2, d=3)
+        workflow.create(signature_check.bind(1, 2, d=3))
 
     with pytest.raises(TypeError):
-        signature_check.step(1, 2, 3, 4)
+        workflow.create(signature_check.bind(1, 2, 3, 4))
 
-    signature_check.step(1, 2, 3)
-    signature_check.step(1, 2, c=3)
-    signature_check.step(1, b=2, c=3)
-    signature_check.step(a=1, b=2, c=3)
+    workflow.create(signature_check.bind(1, 2, 3))
+    workflow.create(signature_check.bind(1, 2, c=3))
+    workflow.create(signature_check.bind(1, b=2, c=3))
+    workflow.create(signature_check.bind(a=1, b=2, c=3))
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -53,13 +53,13 @@ def test_delete(workflow_start_regular):
         workflow.delete(workflow_id="never_existed")
 
     # Delete a workflow that has not finished and is not running.
-    @workflow.step
+    @ray.remote
     def never_ends(x):
         utils.set_global_mark()
         time.sleep(1000000)
         return x
 
-    never_ends.step("hello world").run_async("never_finishes")
+    workflow.create(never_ends.bind("hello world")).run_async("never_finishes")
 
     # Make sure the step is actualy executing before killing the cluster
     while not utils.check_global_mark():
@@ -88,11 +88,11 @@ def test_delete(workflow_start_regular):
         workflow.delete(workflow_id="never_finishes")
 
     # Delete a workflow which has finished.
-    @workflow.step
+    @ray.remote
     def basic_step(arg):
         return arg
 
-    result = basic_step.step("hello world").run(workflow_id="finishes")
+    result = workflow.create(basic_step.bind("hello world")).run(workflow_id="finishes")
     assert result == "hello world"
     ouput = workflow.get_output("finishes")
     assert ray.get(ouput) == "hello world"
@@ -113,7 +113,7 @@ def test_delete(workflow_start_regular):
     assert workflow.list_all() == []
 
     # The workflow can be re-run as if it was never run before.
-    assert basic_step.step("123").run(workflow_id="finishes") == "123"
+    assert workflow.create(basic_step.bind("123")).run(workflow_id="finishes") == "123"
 
     # utils.unset_global_mark()
     # never_ends.step("123").run_async(workflow_id="never_finishes")

--- a/python/ray/workflow/tests/test_variable_mutable.py
+++ b/python/ray/workflow/tests/test_variable_mutable.py
@@ -1,25 +1,25 @@
 from ray.tests.conftest import *  # noqa
+
+import ray
 from ray import workflow
 import pytest
 
 
-@workflow.step
-def identity(x):
-    return x
-
-
-@workflow.step
-def projection(x, _):
-    return x
-
-
 @pytest.mark.skip(reason="Variable mutable is not supported right now.")
 def test_variable_mutable(workflow_start_regular):
+    @ray.remote
+    def identity(x):
+        return x
+
+    @ray.remote
+    def projection(x, _):
+        return x
+
     x = []
-    a = identity.step(x)
+    a = identity.bind(x)
     x.append(1)
-    b = identity.step(x)
-    assert projection.step(a, b).run() == []
+    b = identity.bind(x)
+    assert workflow.create(projection.bind(a, b)).run() == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After supporting converting DAG to workflow and unifying the behavior between workflow and ray.remote, we will deprecate `workflow.step` gradually. This is the first part that covers most common use cases.

Not included in the PR:
* Docs - will do it soon in another PR to make PR review easier
* Events - we need a DAG version
* Virtual actors
* workflow with workflow options (because (1) @ray.remote rejects workflow options (2) “name” keyword for workflow option conflicts with the ray.remote name option)
* workflow.wait - we need a DAG version
* Nested input workflow
    * For example, `step_1.bind(deep_nested_step.bind())`
    * This is because for the new semantics, `deep_nested_step.bind` is only resolved once, we still get a nested object ref inside `step_1`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
