### PR TITLE
WINDOWS: make default node startup timeout longer

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -32,6 +32,9 @@ import psutil
 resource = None
 if sys.platform != "win32":
     import resource
+    _timeout = 30
+else:
+    _timeout = 60
 
 EXE_SUFFIX = ".exe" if sys.platform == "win32" else ""
 
@@ -359,7 +362,7 @@ def wait_for_node(
     gcs_address,
     node_plasma_store_socket_name,
     redis_password=None,
-    timeout=30,
+    timeout=_timeout,
 ):
     """Wait until this node has appeared in the client table.
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -32,6 +32,7 @@ import psutil
 resource = None
 if sys.platform != "win32":
     import resource
+
     _timeout = 30
 else:
     _timeout = 60


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Timeouts when starting nodes rank high on https://flakey-tests.ray.io/#owner=core. The default timeout should be longer on windows. For instance, [here](https://buildkite.com/ray-project/ray-builders-branch/builds/6720#d4cf497e-13d5-4b6b-9354-2dd8828bd0e7/2835-3259) is one such error.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
