### PR TITLE
[ci] Clean up artifacts before/after jobs

### DIFF
--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,5 +1,5 @@
-[ -d "/tmp/artifacts" ] || exit
-
-echo "Cleaning up artifacts after upload:"
-ls -alp /tmp/artifacts
-rm -rf /tmp/artifacts/* || true
+if [ -d "/tmp/artifacts" ]; then
+    echo "Cleaning up artifacts after upload:"
+    ls -alp /tmp/artifacts
+    rm -rf /tmp/artifacts/* || true
+fi

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -13,7 +13,7 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    rm -rf /tmp/artifacts/* || true
+    find /tmp/artifacts -depth 1 -exec rm -rf -- {} +
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,10 +1,10 @@
 if [ -d "/tmp/artifacts" ]; then
     echo "Cleaning up artifacts after upload."
-    echo "Contents before cleanup:"
+    echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
     rm -rf /tmp/artifacts/* || true
 
-    echo "Contents after cleanup:"
+    echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true
 fi

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -13,7 +13,8 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    find /tmp/artifacts -depth 1 -exec rm -rf -- {} +
+    rm -rf /tmp/artifacts/* || true
+    rm -rf /tmp/artifacts/.* || true
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -15,7 +15,7 @@ if [ -d "/tmp/artifacts" ]; then
 
     # Need sudo because artifacts were created by root
     # within the docker container
-    sudo rm -rf /tmp/artifacts/{,.[!.],..?}* || true
+    rm -rf /tmp/artifacts/{,.[!.],..?}* || true
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -13,8 +13,9 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    rm -rf /tmp/artifacts/* || true
-    rm -rf /tmp/artifacts/.* || true
+    # Need sudo because artifacts were created by root
+    # within the docker container
+    sudo rm -rf /tmp/artifacts/{,.[!.],..?}* || true
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,5 +1,10 @@
 if [ -d "/tmp/artifacts" ]; then
-    echo "Cleaning up artifacts after upload:"
-    ls -alp /tmp/artifacts
+    echo "Cleaning up artifacts after upload."
+    echo "Contents before cleanup:"
+    find /tmp/artifacts -print || true
+
     rm -rf /tmp/artifacts/* || true
+
+    echo "Contents after cleanup:"
+    find /tmp/artifacts -print || true
 fi

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,2 +1,3 @@
+echo "Cleaning up artifacts after upload:"
+ls -alp /artifact-mount
 rm -rf /artifact-mount/* || true
-

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,0 +1,2 @@
+rm -rf /artifact-mount/* || true
+

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,3 +1,3 @@
 echo "Cleaning up artifacts after upload:"
-ls -alp /artifact-mount
-rm -rf /artifact-mount/* || true
+ls -alp /tmp/artifacts
+rm -rf /tmp/artifacts/* || true

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -3,7 +3,7 @@
 # In contrast, our build jobs are run in Docker containers.
 # This means that even though our build jobs write to
 # `/artifact-mount`, the directory on the host machine is
-# actually ``/tmp/artifacts`.
+# actually `/tmp/artifacts`.
 # We clean up the artifacts directory before any command and
 # after uploading artifacts to make sure no stale artifacts
 # remain on the node when a Buildkite runner is re-used.

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,3 +1,5 @@
+[ -d "/tmp/artifacts" ] || exit
+
 echo "Cleaning up artifacts after upload:"
 ls -alp /tmp/artifacts
 rm -rf /tmp/artifacts/* || true

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,3 +1,13 @@
+#!/bin/bash
+# This script is executed by Buildkite on the host machine.
+# In contrast, our build jobs are run in Docker containers.
+# This means that even though our build jobs write to
+# `/artifact-mount`, the directory on the host machine is
+# actually ``/tmp/artifacts`.
+# We clean up the artifacts directory before any command and
+# after uploading artifacts to make sure no stale artifacts
+# remain on the node when a Buildkite runner is re-used.
+set -ex
 if [ -d "/tmp/artifacts" ]; then
     echo "Cleaning up artifacts after upload."
     echo "Artifact directory contents before cleanup:"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,3 +1,3 @@
 echo "Cleaning up old artifacts before command:"
-ls -alp /artifact-mount
-rm -rf /artifact-mount/* || true
+ls -alp /tmp/artifacts
+rm -rf /tmp/artifacts/* || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,5 +1,10 @@
 if [ -d "/tmp/artifacts" ]; then
-    echo "Cleaning up old artifacts before command:"
-    ls -alp /tmp/artifacts
+    echo "Cleaning up old artifacts before command."
+    echo "Contents before cleanup:"
+    find /tmp/artifacts -print || true
+
     rm -rf /tmp/artifacts/* || true
+
+    echo "Contents after cleanup:"
+    find /tmp/artifacts -print || true
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -13,7 +13,7 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    rm -rf /tmp/artifacts/* || true
+    find /tmp/artifacts -depth 1 -exec rm -rf -- {} +
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,5 +1,5 @@
-[ -d "/tmp/artifacts" ] || exit
-
-echo "Cleaning up old artifacts before command:"
-ls -alp /tmp/artifacts
-rm -rf /tmp/artifacts/* || true
+if [ -d "/tmp/artifacts" ]; then
+    echo "Cleaning up old artifacts before command:"
+    ls -alp /tmp/artifacts
+    rm -rf /tmp/artifacts/* || true
+fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -13,7 +13,8 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    find /tmp/artifacts -depth 1 -exec rm -rf -- {} +
+    rm -rf /tmp/artifacts/* || true
+    rm -rf /tmp/artifacts/.* || true
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,7 +15,7 @@ if [ -d "/tmp/artifacts" ]; then
 
     # Need sudo because artifacts were created by root
     # within the docker container
-    sudo rm -rf /tmp/artifacts/{,.[!.],..?}* || true
+    rm -rf /tmp/artifacts/{,.[!.],..?}* || true
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -13,8 +13,9 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    rm -rf /tmp/artifacts/* || true
-    rm -rf /tmp/artifacts/.* || true
+    # Need sudo because artifacts were created by root
+    # within the docker container
+    sudo rm -rf /tmp/artifacts/{,.[!.],..?}* || true
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,3 +1,13 @@
+#!/bin/bash
+# This script is executed by Buildkite on the host machine.
+# In contrast, our build jobs are run in Docker containers.
+# This means that even though our build jobs write to
+# `/artifact-mount`, the directory on the host machine is
+# actually ``/tmp/artifacts`.
+# We clean up the artifacts directory before any command and
+# after uploading artifacts to make sure no stale artifacts
+# remain on the node when a Buildkite runner is re-used.
+set -ex
 if [ -d "/tmp/artifacts" ]; then
     echo "Cleaning up old artifacts before command."
     echo "Artifact directory contents before cleanup:"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,3 +1,5 @@
+[ -d "/tmp/artifacts" ] || exit
+
 echo "Cleaning up old artifacts before command:"
 ls -alp /tmp/artifacts
 rm -rf /tmp/artifacts/* || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,2 +1,3 @@
+echo "Cleaning up old artifacts before command:"
+ls -alp /artifact-mount
 rm -rf /artifact-mount/* || true
-

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,2 @@
+rm -rf /artifact-mount/* || true
+

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,10 +1,10 @@
 if [ -d "/tmp/artifacts" ]; then
     echo "Cleaning up old artifacts before command."
-    echo "Contents before cleanup:"
+    echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
     rm -rf /tmp/artifacts/* || true
 
-    echo "Contents after cleanup:"
+    echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -3,7 +3,7 @@
 # In contrast, our build jobs are run in Docker containers.
 # This means that even though our build jobs write to
 # `/artifact-mount`, the directory on the host machine is
-# actually ``/tmp/artifacts`.
+# actually `/tmp/artifacts`.
 # We clean up the artifacts directory before any command and
 # after uploading artifacts to make sure no stale artifacts
 # remain on the node when a Buildkite runner is re-used.

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -415,7 +415,7 @@ build_wheels() {
         # Sync the directory to buildkite artifacts
         rm -rf /artifact-mount/.whl || true
         cp -r .whl /artifact-mount/.whl
-        chown -R 1000 /artifact-mount/.whl
+        chmod -R 777 /artifact-mount/.whl
 
         validate_wheels_commit_str
       fi

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -415,6 +415,7 @@ build_wheels() {
         # Sync the directory to buildkite artifacts
         rm -rf /artifact-mount/.whl || true
         cp -r .whl /artifact-mount/.whl
+        chown -R 1000 /artifact-mount/.whl
 
       validate_wheels_commit_str
       fi

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -417,7 +417,7 @@ build_wheels() {
         cp -r .whl /artifact-mount/.whl
         chown -R 1000 /artifact-mount/.whl
 
-      validate_wheels_commit_str
+        validate_wheels_commit_str
       fi
       ;;
     darwin*)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We sometimes end up with stale wheel uploads from previous runs of a Buildkite agent. The result is that commit wheels are being overwritten from old build jobs - effectively breaking the wheel build logic.

Example:

This Agent: https://buildkite.com/organizations/ray-project/agents/4b955117-2f6c-4849-b703-3457daf69f89

- builds wheels (in post-wheels tests) for a35ebc945b
- and then runs both the Ray CPP worker and the Train + Tune tests in 6746e9f
- Usually these two tests shouldn't provide artifacts at all, but they do - these are the wheels from a35ebc945b though! Meaning these are uncleaned leftovers from the first build task.
- See here for proof of artifact upload: https://buildkite.com/ray-project/ray-builders-pr/builds/27622#d11bc514-ebd8-4e0c-a2ce-826b9bad27de

The solution is thus to always clean up the artifacts directory in the worker, i.e. `rm -rf /artifact-mount/*`

This PR adds two of such clean up instructions - once before commands are run and once after artifacts are uploaded. We can probably just do either, but it doesn't hurt to have both.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
