### PR TITLE
[RLlib] Slate-Q +GPU torch bug fix.

### DIFF
--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -487,7 +487,7 @@ slateq-interest-evolution-recsim-env:
                 convert_to_discrete_action_space: false
                 seed: 0
 
-        num_gpus: 0
+        num_gpus: 1
 
         exploration_config:
             warmup_timesteps: 20000

--- a/rllib/agents/slateq/slateq_torch_policy.py
+++ b/rllib/agents/slateq/slateq_torch_policy.py
@@ -17,8 +17,11 @@ from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.policy_template import build_policy_class
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.framework import try_import_torch
-from ray.rllib.utils.torch_utils import apply_grad_clipping, convert_to_torch_tensor, \
-    huber_loss
+from ray.rllib.utils.torch_utils import (
+    apply_grad_clipping,
+    convert_to_torch_tensor,
+    huber_loss,
+)
 from ray.rllib.utils.typing import TensorType, TrainerConfigDict
 
 torch, nn = try_import_torch()
@@ -92,7 +95,8 @@ def build_slateq_losses(
     actions = train_batch[SampleBatch.ACTIONS]
 
     observation = convert_to_torch_tensor(
-        train_batch[SampleBatch.OBS], device=actions.device)
+        train_batch[SampleBatch.OBS], device=actions.device
+    )
     # user.shape: [B, E]
     user_obs = observation["user"]
     batch_size, embedding_size = user_obs.shape
@@ -118,7 +122,8 @@ def build_slateq_losses(
     # Target computations.
     # --------------------
     next_obs = convert_to_torch_tensor(
-        train_batch[SampleBatch.NEXT_OBS], device=actions.device)
+        train_batch[SampleBatch.NEXT_OBS], device=actions.device
+    )
 
     # user.shape: [B, E]
     user_next_obs = next_obs["user"]

--- a/rllib/agents/slateq/slateq_torch_policy.py
+++ b/rllib/agents/slateq/slateq_torch_policy.py
@@ -17,7 +17,8 @@ from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.policy_template import build_policy_class
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.framework import try_import_torch
-from ray.rllib.utils.torch_utils import apply_grad_clipping, huber_loss
+from ray.rllib.utils.torch_utils import apply_grad_clipping, convert_to_torch_tensor, \
+    huber_loss
 from ray.rllib.utils.typing import TensorType, TrainerConfigDict
 
 torch, nn = try_import_torch()
@@ -87,14 +88,17 @@ def build_slateq_losses(
 
     # Q-value computations.
     # ---------------------
-    observation = train_batch[SampleBatch.OBS]
+    # action.shape: [B, S]
+    actions = train_batch[SampleBatch.ACTIONS]
+
+    observation = convert_to_torch_tensor(
+        train_batch[SampleBatch.OBS], device=actions.device)
     # user.shape: [B, E]
     user_obs = observation["user"]
     batch_size, embedding_size = user_obs.shape
     # doc.shape: [B, C, E]
     doc_obs = list(observation["doc"].values())
-    # action.shape: [B, S]
-    actions = train_batch[SampleBatch.ACTIONS]
+
     A, S = policy.slates.shape
 
     # click_indicator.shape: [B, S]
@@ -113,7 +117,8 @@ def build_slateq_losses(
 
     # Target computations.
     # --------------------
-    next_obs = train_batch[SampleBatch.NEXT_OBS]
+    next_obs = convert_to_torch_tensor(
+        train_batch[SampleBatch.NEXT_OBS], device=actions.device)
 
     # user.shape: [B, E]
     user_next_obs = next_obs["user"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Slate-Q +GPU torch bug fix.
- observations and next-observations were not properly auto-copied to GPU by the SampleBatch's `get_interceptor`. This is probably due to the nested dict structure (preprocessor off for SlateQ) arriving in the loss function

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
