### PR TITLE
[workflow]align the behavior of workflow's options() with remote function's options()

### DIFF
--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -229,7 +229,6 @@ class WorkflowStepRuntimeOptions:
         cls,
         *,
         step_type,
-        existing_options: "WorkflowStepRuntimeOptions" = None,
         catch_exceptions=None,
         max_retries=None,
         allow_inplace=False,
@@ -237,21 +236,17 @@ class WorkflowStepRuntimeOptions:
         ray_options=None,
     ):
         if max_retries is None:
-            max_retries = existing_options.max_retries if existing_options else 3
+            max_retries = 3
         elif not isinstance(max_retries, int) or max_retries < -1:
             raise ValueError("'max_retries' only accepts 0, -1 or a positive integer.")
         if catch_exceptions is None:
-            catch_exceptions = (
-                existing_options.catch_exceptions if existing_options else False
-            )
+            catch_exceptions = False
         if not isinstance(checkpoint, bool) and checkpoint is not None:
             raise ValueError("'checkpoint' should be None or a boolean.")
         if ray_options is None:
             ray_options = {}
         elif not isinstance(ray_options, dict):
             raise ValueError("ray_options must be a dict.")
-        if existing_options:
-            ray_options = {**existing_options.ray_options, **ray_options}
         return cls(
             step_type=step_type,
             catch_exceptions=catch_exceptions,

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -1,5 +1,6 @@
 import base64
 import asyncio
+import json
 
 from ray import cloudpickle
 from collections import deque
@@ -45,6 +46,19 @@ def get_qualname(f):
 def ensure_ray_initialized():
     if not ray.is_initialized():
         ray.init()
+
+
+def validate_user_metadata(metadata):
+    if metadata is not None:
+        if not isinstance(metadata, dict):
+            raise ValueError("metadata must be a dict.")
+        try:
+            json.dumps(metadata)
+        except TypeError as e:
+            raise ValueError(
+                "metadata must be JSON serializable, instead, "
+                "we got 'TypeError: {}'".format(e)
+            )
 
 
 @dataclass
@@ -215,6 +229,7 @@ class WorkflowStepRuntimeOptions:
         cls,
         *,
         step_type,
+        existing_options: "WorkflowStepRuntimeOptions" = None,
         catch_exceptions=None,
         max_retries=None,
         allow_inplace=False,
@@ -222,17 +237,21 @@ class WorkflowStepRuntimeOptions:
         ray_options=None,
     ):
         if max_retries is None:
-            max_retries = 3
+            max_retries = existing_options.max_retries if existing_options else 3
         elif not isinstance(max_retries, int) or max_retries < -1:
             raise ValueError("'max_retries' only accepts 0, -1 or a positive integer.")
         if catch_exceptions is None:
-            catch_exceptions = False
+            catch_exceptions = (
+                existing_options.catch_exceptions if existing_options else False
+            )
         if not isinstance(checkpoint, bool) and checkpoint is not None:
             raise ValueError("'checkpoint' should be None or a boolean.")
         if ray_options is None:
             ray_options = {}
         elif not isinstance(ray_options, dict):
             raise ValueError("ray_options must be a dict.")
+        if existing_options:
+            ray_options = {**existing_options.ray_options, **ray_options}
         return cls(
             step_type=step_type,
             catch_exceptions=catch_exceptions,

--- a/python/ray/workflow/execution.py
+++ b/python/ray/workflow/execution.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import time
 from typing import Set, List, Tuple, Optional, TYPE_CHECKING, Dict, Any
@@ -14,6 +13,7 @@ from ray.workflow.common import (
     WorkflowMetaData,
     StepType,
     WorkflowNotFoundError,
+    validate_user_metadata,
 )
 from ray.workflow.step_executor import commit_step
 from ray.workflow.storage import get_global_storage
@@ -35,17 +35,7 @@ def run(
     metadata: Optional[Dict] = None,
 ) -> ray.ObjectRef:
     """Run a workflow asynchronously."""
-    if metadata is not None:
-        if not isinstance(metadata, dict):
-            raise ValueError("metadata must be a dict.")
-        for k, v in metadata.items():
-            try:
-                json.dumps(v)
-            except TypeError as e:
-                raise ValueError(
-                    "metadata values must be JSON serializable, "
-                    "however '{}' has a value whose {}.".format(k, e)
-                )
+    validate_user_metadata(metadata)
     metadata = metadata or {}
 
     store = get_global_storage()

--- a/python/ray/workflow/step_function.py
+++ b/python/ray/workflow/step_function.py
@@ -122,20 +122,16 @@ class WorkflowStepFunction:
         Returns:
             The step function itself.
         """
-        name = name or self._name
         validate_user_metadata(metadata)
-        if metadata is not None:
-            metadata = {**self._user_metadata, **metadata}
-        else:
-            metadata = self._user_metadata
+        name = name or self._name
+        metadata = {**self._user_metadata, **(metadata or {})}
         step_options = WorkflowStepRuntimeOptions.make(
             step_type=StepType.FUNCTION,
-            existing_options=self._step_options,
-            catch_exceptions=catch_exceptions,
-            max_retries=max_retries,
-            allow_inplace=allow_inplace,
+            catch_exceptions=catch_exceptions or self._step_options.catch_exceptions,
+            max_retries=max_retries or self._step_options.max_retries,
+            allow_inplace=allow_inplace or self._step_options.allow_inplace,
             checkpoint=_inherit_checkpoint_option(checkpoint),
-            ray_options=ray_options,
+            ray_options={**self._step_options.ray_options, **(ray_options or {})},
         )
         return WorkflowStepFunction(
             self._func, step_options=step_options, name=name, metadata=metadata

--- a/python/ray/workflow/step_function.py
+++ b/python/ray/workflow/step_function.py
@@ -123,15 +123,24 @@ class WorkflowStepFunction:
             The step function itself.
         """
         validate_user_metadata(metadata)
-        name = name or self._name
-        metadata = {**self._user_metadata, **(metadata or {})}
+        name = name if name is not None else self._name
+        metadata = {**self._user_metadata, **(metadata if metadata is not None else {})}
         step_options = WorkflowStepRuntimeOptions.make(
             step_type=StepType.FUNCTION,
-            catch_exceptions=catch_exceptions or self._step_options.catch_exceptions,
-            max_retries=max_retries or self._step_options.max_retries,
-            allow_inplace=allow_inplace or self._step_options.allow_inplace,
+            catch_exceptions=catch_exceptions
+            if catch_exceptions is not None
+            else self._step_options.catch_exceptions,
+            max_retries=max_retries
+            if max_retries is not None
+            else self._step_options.max_retries,
+            allow_inplace=allow_inplace
+            if allow_inplace is not None
+            else self._step_options.allow_inplace,
             checkpoint=_inherit_checkpoint_option(checkpoint),
-            ray_options={**self._step_options.ray_options, **(ray_options or {})},
+            ray_options={
+                **self._step_options.ray_options,
+                **(ray_options if ray_options is not None else {}),
+            },
         )
         return WorkflowStepFunction(
             self._func, step_options=step_options, name=name, metadata=metadata

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -326,21 +326,23 @@ def test_workflow_error_message():
 def test_options_update(workflow_start_regular_shared):
     # Options are given in decorator first, then in the first .options()
     # and finally in the second .options()
-    @workflow.step(name="old_name", metadata={"k": "v"},
-                   max_retries=1, num_cpus=2)
+    @workflow.step(name="old_name", metadata={"k": "v"}, max_retries=1, num_cpus=2)
     def f():
         return
-    new_f = f.options(name="new_name", metadata={"extra_k1": "extra_v1"})\
-        .options(num_returns=2, metadata={"extra_k2": "extra_v2"})
+
+    new_f = f.options(name="new_name", metadata={"extra_k1": "extra_v1"}).options(
+        num_returns=2, metadata={"extra_k2": "extra_v2"}
+    )
     # name is updated from the old name in the decorator to the new
     # name in the first .options(), then preserved in the second options.
     assert new_f._name == "new_name"
     # metadata and ray_options are "updated"
     assert new_f._user_metadata == {
-        "k": "v", "extra_k1": "extra_v1", "extra_k2": "extra_v2"}
-    assert new_f._step_options.ray_options == {
-        'num_cpus': 2, 'num_returns': 2
+        "k": "v",
+        "extra_k1": "extra_v1",
+        "extra_k2": "extra_v2",
     }
+    assert new_f._step_options.ray_options == {"num_cpus": 2, "num_returns": 2}
     # max_retries only defined in the decorator and it got preserved all the way
     assert new_f._step_options.max_retries == 1
 

--- a/python/ray/workflow/tests/test_metadata.py
+++ b/python/ray/workflow/tests/test_metadata.py
@@ -296,11 +296,8 @@ def test_nested_virtual_actor(workflow_start_regular):
             return self.n
 
     counter = Counter.get_or_create("counter")
-    counter.incr.options(name="incr", metadata={"outer_k": "outer_v"}).run(5)
+    counter.incr.options(name="incr").run(5)
 
-    assert workflow.get_metadata("counter", "incr")["user_metadata"] == {
-        "outer_k": "outer_v"
-    }
     assert workflow.get_metadata("counter", "incr_1")["user_metadata"] == {
         "current_n": 1
     }

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -272,9 +272,16 @@ class _VirtualActorMethodHelper:
         validate_user_metadata(metadata)
         options = WorkflowStepRuntimeOptions.make(
             step_type=self._options.step_type,
-            catch_exceptions=catch_exceptions or self._options.catch_exceptions,
-            max_retries=max_retries or self._options.max_retries,
-            ray_options={**self._options.ray_options, **(ray_options or {})},
+            catch_exceptions=catch_exceptions
+            if catch_exceptions is not None
+            else self._options.catch_exceptions,
+            max_retries=max_retries
+            if max_retries is not None
+            else self._options.max_retries,
+            ray_options={
+                **self._options.ray_options,
+                **(ray_options if ray_options is not None else {}),
+            },
         )
         _self = _VirtualActorMethodHelper(
             self._original_class,
@@ -282,8 +289,11 @@ class _VirtualActorMethodHelper:
             self._method_name,
             runtime_options=options,
         )
-        _self._name = name if name else self._name
-        _self._user_metadata = {**self._user_metadata, **(metadata or {})}
+        _self._name = name if name is not None else self._name
+        _self._user_metadata = {
+            **self._user_metadata,
+            **(metadata if metadata is not None else {}),
+        }
         return _self
 
     def __call__(self, *args, **kwargs):

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -272,10 +272,9 @@ class _VirtualActorMethodHelper:
         validate_user_metadata(metadata)
         options = WorkflowStepRuntimeOptions.make(
             step_type=self._options.step_type,
-            existing_options=self._options,
-            catch_exceptions=catch_exceptions,
-            max_retries=max_retries,
-            ray_options=ray_options,
+            catch_exceptions=catch_exceptions or self._options.catch_exceptions,
+            max_retries=max_retries or self._options.max_retries,
+            ray_options={**self._options.ray_options, **(ray_options or {})},
         )
         _self = _VirtualActorMethodHelper(
             self._original_class,
@@ -284,10 +283,7 @@ class _VirtualActorMethodHelper:
             runtime_options=options,
         )
         _self._name = name if name else self._name
-        if metadata is not None:
-            _self._user_metadata = {**self._user_metadata, **metadata}
-        else:
-            _self._user_metadata = self._user_metadata
+        _self._user_metadata = {**self._user_metadata, **(metadata or {})}
         return _self
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current behavior of workflow's `.options()` is to **completely rewrite all the options** rather than **update options**, this is less intuitive and inconsistent with the behavior of `.options()` in remote functions.

For example:
```
# Remote Function
@ray.remote(num_cpus=2, max_retries=2)
f.options(num_cpus=1)
```
`options()` here **updated** num_cpus while **the rest options are untouched**, i.e. max_retires is still 2. This is the expected behavior and more intuitive.

```
# Workflow Step
@workflow.step(num_cpus=2, max_retries=2)
f.options(num_cpus=1)
```
`options()` here **completely drop all existing options** and only set num_cpus, i.e. previous value of max_retires (2) is dropped and reverted to default (3).  This will also drop other fields like `name` and `metadata` if name and metadata are given in the decorator but not in the options().


## Related issue number

https://github.com/ray-project/ray/issues/22825

## Fix
Add `existing_options` in `WorkflowStepRuntimeOptions.make` to memorize existing options and only update the ones that need update.

The **rule of update** acts like:
- for **ray_options** and **metadata**, it performs like a "dict.update"
- for everything else, it performs like a replace update.
```
@workflow.step(num_returns=2, num_gpus=2)
def f():
    pass
f.options(num_gpus=1)   =>  ray_options = {num_returns=2, num_gpus=1}

@workflow.step(metadata={static_k: static_v})
def g():
    pass
g.options(metadata={runtime_k1: runtime_v1)   =>   metadata = {static_k: static_v, runtime_k1: runtime_v1}
g.options(metadata={runtime_k2: runtime_v2)   =>   metadata = {static_k: static_v, runtime_k2: runtime_v2}
```

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
