### PR TITLE
Update error message for @ray.method

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -56,10 +56,15 @@ def method(*args, **kwargs):
         num_returns: The number of object refs that should be returned by
             invocations of this actor method.
     """
-    assert len(args) == 0
-    assert len(kwargs) == 1
-
-    assert "num_returns" in kwargs or "concurrency_group" in kwargs
+    valid_kwargs = ["num_returns", "concurrency_group"]
+    error_string = (
+        "The @ray.method decorator must be applied using at least one of "
+        f"the arguments in the list {valid_kwargs}, for example "
+        "'@ray.method(num_returns=2)'."
+    )
+    assert len(args) == 0 and len(kwargs) > 0, error_string
+    for key in kwargs:
+        assert key in valid_kwargs, error_string
 
     def annotate_method(method):
         if "num_returns" in kwargs:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -16,7 +16,6 @@ from ray.util.scheduling_strategies import (
 
 from ray import ActorClassID, Language
 from ray._raylet import PythonFunctionDescriptor
-from ray._private.client_mode_hook import client_mode_hook
 from ray._private.client_mode_hook import client_mode_should_convert
 from ray._private.client_mode_hook import client_mode_convert_actor
 from ray import cross_language
@@ -36,7 +35,6 @@ logger = logging.getLogger(__name__)
 
 
 @PublicAPI
-@client_mode_hook(auto_init=False)
 def method(*args, **kwargs):
     """Annotate an actor method.
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -64,7 +64,11 @@ def method(*args, **kwargs):
     )
     assert len(args) == 0 and len(kwargs) > 0, error_string
     for key in kwargs:
-        assert key in valid_kwargs, error_string
+        key_error_string = (
+            f"Unexpected keyword argument to @ray.method: '{key}'. The "
+            f"supported keyword arguments are {valid_kwargs}"
+        )
+        assert key in valid_kwargs, key_error_string
 
     def annotate_method(method):
         if "num_returns" in kwargs:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -16,6 +16,7 @@ from ray.util.scheduling_strategies import (
 
 from ray import ActorClassID, Language
 from ray._raylet import PythonFunctionDescriptor
+from ray._private.client_mode_hook import client_mode_hook
 from ray._private.client_mode_hook import client_mode_should_convert
 from ray._private.client_mode_hook import client_mode_convert_actor
 from ray import cross_language
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 @PublicAPI
+@client_mode_hook(auto_init=False)
 def method(*args, **kwargs):
     """Annotate an actor method.
 

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -212,6 +212,40 @@ class ClientAPI:
 
         return self.worker.get_cluster_info(ray_client_pb2.ClusterInfoType.NODES)
 
+    def method(self, *args, **kwargs):
+        """Annotate an actor method
+
+        Args:
+            num_returns: The number of object refs that should be returned by
+                invocations of this actor method.
+        """
+
+        # NOTE: So this follows the same logic as in ray/actor.py::method()
+        # The reason to duplicate it here is to simplify the client mode
+        # redirection logic. As the annotated method gets pickled and sent to
+        # the server from the client it carries this private variable, it
+        # activates the same logic on the server side; so there's no need to
+        # pass anything else. It's inside the class definition that becomes an
+        # actor. Similar annotations would follow the same way.
+        valid_kwargs = ["num_returns", "concurrency_group"]
+        error_string = (
+            "The @ray.method decorator must be applied using at least one of "
+            f"the arguments in the list {valid_kwargs}, for example "
+            "'@ray.method(num_returns=2)'."
+        )
+        assert len(args) == 0 and len(kwargs) > 0, error_string
+        for key in kwargs:
+            assert key in valid_kwargs, error_string
+
+        def annotate_method(method):
+            if "num_returns" in kwargs:
+                method.__ray_num_returns__ = kwargs["num_returns"]
+            if "concurrency_group" in kwargs:
+                method.__ray_concurrency_group__ = kwargs["concurrency_group"]
+            return method
+
+        return annotate_method
+
     def cluster_resources(self):
         """Get the current total cluster resources.
 

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -212,35 +212,6 @@ class ClientAPI:
 
         return self.worker.get_cluster_info(ray_client_pb2.ClusterInfoType.NODES)
 
-    def method(self, *args, **kwargs):
-        """Annotate an actor method
-
-        Args:
-            num_returns: The number of object refs that should be returned by
-                invocations of this actor method.
-        """
-
-        # NOTE: So this follows the same logic as in ray/actor.py::method()
-        # The reason to duplicate it here is to simplify the client mode
-        # redirection logic. As the annotated method gets pickled and sent to
-        # the server from the client it carries this private variable, it
-        # activates the same logic on the server side; so there's no need to
-        # pass anything else. It's inside the class definition that becomes an
-        # actor. Similar annotations would follow the same way.
-        assert len(args) == 0
-        assert len(kwargs) == 1
-
-        assert "num_returns" in kwargs or "concurrency_group" in kwargs
-
-        def annotate_method(method):
-            if "num_returns" in kwargs:
-                method.__ray_num_returns__ = kwargs["num_returns"]
-            if "concurrency_group" in kwargs:
-                method.__ray_concurrency_group__ = kwargs["concurrency_group"]
-            return method
-
-        return annotate_method
-
     def cluster_resources(self):
         """Get the current total cluster resources.
 

--- a/python/ray/util/client/api.py
+++ b/python/ray/util/client/api.py
@@ -235,7 +235,11 @@ class ClientAPI:
         )
         assert len(args) == 0 and len(kwargs) > 0, error_string
         for key in kwargs:
-            assert key in valid_kwargs, error_string
+            key_error_string = (
+                f'Unexpected keyword argument to @ray.method: "{key}". The '
+                f"supported keyword arguments are {valid_kwargs}"
+            )
+            assert key in valid_kwargs, key_error_string
 
         def annotate_method(method):
             if "num_returns" in kwargs:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Updates @ray.method error message to match the one for [@ray.remote](https://github.com/ray-project/ray/blob/master/python/ray/worker.py#L2369-L2379). Since the client mode version of ray.method is identical to the regular ray.method, deletes the client mode version and drops the client_mode_hook decorator (guessing that the client copy was added before client_mode_hook was introduced).

Also fixes what I'm guessing is a bug that doesn't allow both num_returns and concurrency_group to be specified at the same time (`assert len(kwargs) == 1`). 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #23271 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
