### PR TITLE
[Datasets] Add vectorized global and grouped aggregations.

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -227,6 +227,10 @@ class BlockAccessor(Generic[T]):
         """Convert this block into an Arrow table."""
         raise NotImplementedError
 
+    def to_block(self) -> Block:
+        """Return the base block that this accessor wraps."""
+        raise NotImplementedError
+
     def size_bytes(self) -> int:
         """Return the approximate size in bytes of this block."""
         raise NotImplementedError

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -64,7 +64,19 @@ from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
 )
 from ray.data.row import TableRow
-from ray.data.aggregate import AggregateFn, Sum, Max, Min, Mean, Std
+from ray.data.aggregate import (
+    AggregateFn,
+    Sum,
+    Max,
+    Min,
+    Mean,
+    Std,
+    VectorizedAggregation,
+    VectorizedSum,
+    VectorizedMin,
+    VectorizedMax,
+    VectorizedMean,
+)
 from ray.data.random_access_dataset import RandomAccessDataset
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.block_batching import batch_blocks, BatchType
@@ -79,6 +91,7 @@ from ray.data.impl.sort import sort_impl
 from ray.data.impl.block_list import BlockList
 from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
+from ray.data.impl.block_builder import BlockBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -1095,6 +1108,132 @@ class Dataset(Generic[T]):
         ret = self.groupby(None).aggregate(*aggs).take(1)
         return ret[0] if len(ret) > 0 else None
 
+    def aggregate_vectorized(self, *aggs: VectorizedAggregation) -> U:
+        """Aggregate the entire dataset as one group, using vectorized aggregations.
+
+        This is a blocking operation.
+
+        Examples:
+            >>> from ray.data.aggregate import VectorizedMax, VectorizedMean
+            >>> ray.data.range_arrow(100).aggregate_vectorized(
+                VectorizedMax("value"), VectorizedMean("value"))
+
+        Time complexity: O(dataset size / parallelism)
+
+        Args:
+            aggs: Vectorized aggregations to do.
+
+        Returns:
+            If the input dataset is a simple dataset then the output is
+            a tuple of ``(agg1, agg2, ...)`` where each tuple element is
+            the corresponding aggregation result.
+            If the input dataset is an Arrow dataset then the output is
+            an ``ArrowRow`` where each column is the corresponding
+            aggregation result.
+            If the dataset is empty, return ``None``.
+        """
+        ret = self._aggregate_vectorized(*aggs).take(1)
+        return ret[0] if len(ret) > 0 else None
+
+    def _aggregate_vectorized(self, *aggs: VectorizedAggregation) -> "Dataset[T]":
+        # TODO(Clark): Unify this with groupby aggregations.
+        dataset_format = self._dataset_format()
+        if dataset_format not in ("arrow", "pandas"):
+            raise ValueError(
+                "Can only do an optimized tabular sum on a tabular dataset, but "
+                f'dataset format not "arrow" nor "pandas": "{dataset_format}"'
+            )
+
+        def do_agg(blocks: BlockList, clear_input_blocks: bool, *_):
+            def _agg_block(block: Block) -> Tuple[np.ndarray, BlockMetadata]:
+                stats = BlockExecStats.builder()
+
+                block_acc = BlockAccessor.for_block(block)
+
+                if block_acc.num_rows() == 0:
+                    # Block is empty.
+                    return (
+                        None,
+                        block_acc.get_metadata(
+                            input_files=None, exec_stats=stats.build()
+                        ),
+                    )
+
+                results = []
+                for agg in aggs:
+                    results.append(agg.aggregate_block(block_acc))
+
+                meta = BlockAccessor.for_block(block).get_metadata(
+                    input_files=None, exec_stats=stats.build()
+                )
+
+                return results, meta
+
+            def _agg_merge(*blocks_aggs: List) -> Tuple[Block, BlockMetadata]:
+                stats = BlockExecStats.builder()
+
+                # Drop empty blocks.
+                blocks_aggs = [
+                    block_agg for block_agg in blocks_aggs if block_agg is not None
+                ]
+
+                if len(blocks_aggs) == 0:
+                    # Handle empty dataset.
+                    empty = BlockBuilder.for_format(dataset_format)._empty_table()
+                    return (
+                        empty,
+                        BlockAccessor.for_block(empty).get_metadata(
+                            input_files=None, exec_stats=stats.build()
+                        ),
+                    )
+
+                # Merge block results.
+                row = {}
+                counts = collections.defaultdict(int)
+                for agg, block_aggs in zip(aggs, zip(*blocks_aggs)):
+                    name = agg.name
+                    count = counts[name]
+                    if count > 0:
+                        name = f"{name}_{count+1}"
+                    counts[name] += 1
+                    row[name] = agg.merge_block_aggs(block_aggs)
+                # Return table representing row of column-wise sums.
+                builder = BlockBuilder.for_format(dataset_format)
+                builder.add(row)
+                block = builder.build()
+                meta = BlockAccessor.for_block(block).get_metadata(
+                    input_files=None, exec_stats=stats.build()
+                )
+                return block, meta
+
+            agg_block = cached_remote_fn(_agg_block).options(num_returns=2)
+            agg_merge = cached_remote_fn(_agg_merge).options(num_returns=2)
+
+            block_results, metadata = [], []
+            for block in blocks.get_blocks():
+                block_result, meta = agg_block.remote(block)
+                block_results.append(block_result)
+                metadata.append(meta)
+            stage_info = {}
+            map_bar = ProgressBar("Agg Map", len(block_results))
+            if clear_input_blocks:
+                blocks.clear()
+                del blocks
+            metadata = map_bar.fetch_until_complete(metadata)
+            stage_info["map"] = metadata
+            map_bar.close()
+
+            results, metadata = agg_merge.remote(*block_results)
+            results, metadata = [results], [metadata]
+            merge_bar = ProgressBar("Agg Merge", len(results))
+            metadata = merge_bar.fetch_until_complete(metadata)
+            stage_info["merge"] = metadata
+            merge_bar.close()
+            return BlockList(results, metadata), stage_info
+
+        plan = self._plan.with_stage(AllToAllStage("sum", None, do_agg))
+        return Dataset(plan, self._epoch, self._lazy)
+
     def sum(
         self, on: Optional[Union[KeyFn, List[KeyFn]]] = None, ignore_nulls: bool = True
     ) -> U:
@@ -1151,7 +1290,13 @@ class Dataset(Generic[T]):
             If the dataset is empty, all values are null, or any value is null
             AND ``ignore_nulls`` is ``False``, then the output will be None.
         """
-        ret = self._aggregate_on(Sum, on, ignore_nulls)
+        dataset_format = self._dataset_format()
+        if dataset_format in ("arrow", "pandas"):
+            # Tabular data fast path.
+            ret = self._aggregate_vectorized_on(VectorizedSum, on, ignore_nulls)
+        else:
+            # Fall back to groupby + accumulator implementation for simple datasets.
+            ret = self._aggregate_on(Sum, on, ignore_nulls)
         return self._aggregate_result(ret)
 
     def min(
@@ -1210,7 +1355,13 @@ class Dataset(Generic[T]):
             If the dataset is empty, all values are null, or any value is null
             AND ``ignore_nulls`` is ``False``, then the output will be None.
         """
-        ret = self._aggregate_on(Min, on, ignore_nulls)
+        dataset_format = self._dataset_format()
+        if dataset_format in ("arrow", "pandas"):
+            # Tabular data fast path.
+            ret = self._aggregate_vectorized_on(VectorizedMin, on, ignore_nulls)
+        else:
+            # Fall back to groupby + accumulator implementation for simple datasets.
+            ret = self._aggregate_on(Min, on, ignore_nulls)
         return self._aggregate_result(ret)
 
     def max(
@@ -1269,7 +1420,13 @@ class Dataset(Generic[T]):
             If the dataset is empty, all values are null, or any value is null
             AND ``ignore_nulls`` is ``False``, then the output will be None.
         """
-        ret = self._aggregate_on(Max, on, ignore_nulls)
+        dataset_format = self._dataset_format()
+        if dataset_format in ("arrow", "pandas"):
+            # Tabular data fast path.
+            ret = self._aggregate_vectorized_on(VectorizedMax, on, ignore_nulls)
+        else:
+            # Fall back to groupby + accumulator implementation for simple datasets.
+            ret = self._aggregate_on(Max, on, ignore_nulls)
         return self._aggregate_result(ret)
 
     def mean(
@@ -1328,7 +1485,13 @@ class Dataset(Generic[T]):
             If the dataset is empty, all values are null, or any value is null
             AND ``ignore_nulls`` is ``False``, then the output will be None.
         """
-        ret = self._aggregate_on(Mean, on, ignore_nulls)
+        dataset_format = self._dataset_format()
+        if dataset_format in ("arrow", "pandas"):
+            # Tabular data fast path.
+            ret = self._aggregate_vectorized_on(VectorizedMean, on, ignore_nulls)
+        else:
+            # Fall back to groupby + accumulator implementation for simple datasets.
+            ret = self._aggregate_on(Mean, on, ignore_nulls)
         return self._aggregate_result(ret)
 
     def std(
@@ -1400,6 +1563,7 @@ class Dataset(Generic[T]):
             If the dataset is empty, all values are null, or any value is null
             AND ``ignore_nulls`` is ``False``, then the output will be None.
         """
+        # TODO(Clark): Enable vectorized stddev calculation.
         ret = self._aggregate_on(Std, on, ignore_nulls, ddof=ddof)
         return self._aggregate_result(ret)
 
@@ -2896,6 +3060,20 @@ Dict[str, List[str]]]): The names of the columns
         aggs = self._build_multicolumn_aggs(agg_cls, on, *args, **kwargs)
         return self.aggregate(*aggs)
 
+    def _aggregate_vectorized_on(
+        self, agg_cls: type, on: Optional[Union[KeyFn, List[KeyFn]]], *args, **kwargs
+    ):
+        """Helper for aggregating on a particular subset of the dataset using vectorized
+        aggregation.
+
+        This validates the `on` argument, and converts a list of column names
+        or lambdas to a multi-aggregation. A null `on` results in a
+        multi-aggregation on all columns for an Arrow Dataset, and vectorized
+        aggregation on a simple dataset isn't supported.
+        """
+        aggs = self._build_multicolumn_aggs(agg_cls, on, *args, **kwargs)
+        return self.aggregate_vectorized(*aggs)
+
     def _build_multicolumn_aggs(
         self,
         agg_cls: type,
@@ -2908,7 +3086,14 @@ Dict[str, List[str]]]): The names of the columns
         """Build set of aggregations for applying a single aggregation to
         multiple columns.
         """
+        on = self._coerce_on(on, skip_cols)
+        return [agg_cls(on_, *args, ignore_nulls=ignore_nulls, **kwargs) for on_ in on]
 
+    def _coerce_on(
+        self,
+        on: Optional[Union[KeyFn, List[KeyFn]]],
+        skip_cols: Optional[List[str]] = None,
+    ) -> Optional[List[KeyFn]]:
         # Expand None into an aggregation for each column.
         if on is None:
             try:
@@ -2926,19 +3111,30 @@ Dict[str, List[str]]]): The names of the columns
 
         if not isinstance(on, list):
             on = [on]
-        return [agg_cls(on_, *args, ignore_nulls=ignore_nulls, **kwargs) for on_ in on]
+        return on
+
+    def _validate_tabular_on(self, on: KeyFn):
+        if not isinstance(on, str):
+            raise ValueError(
+                "Must select column to aggregate on using column name, got {type(on)}: "
+                f"{on}",
+            )
 
     def _aggregate_result(self, result: Union[Tuple, TableRow]) -> U:
         if result is not None and len(result) == 1:
             if isinstance(result, tuple):
-                return result[0]
+                result = result[0]
             else:
                 # NOTE (kfstorm): We cannot call `result[0]` directly on
                 # `PandasRow` because indexing a column with position is not
                 # supported by pandas.
-                return list(result.values())[0]
-        else:
-            return result
+                result = list(result.values())[0]
+        try:
+            if np.isnan(result):
+                result = None
+        except TypeError:
+            pass
+        return result
 
     def __repr__(self) -> str:
         schema = self.schema()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2919,6 +2919,7 @@ Dict[str, List[str]]]): The names of the columns
                 # This should be cached from the ._dataset_format() check, so we
                 # don't fetch and we assert that the schema is not None.
                 schema = self.schema(fetch_if_missing=False)
+                assert schema is not None
                 if not skip_cols:
                     skip_cols = []
                 if len(schema.names) > 0:

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -321,11 +321,11 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 f"got: {type(key)}."
             )
 
-        def iter_groups() -> Iterator[Tuple[KeyType, BlockAccessor]]:
+        def iter_groups() -> Iterator[Tuple[KeyType, Block]]:
             """Creates an iterator over zero-copy group views."""
             if key is None:
                 # Global aggregation consists of a single "group", so we short-circuit.
-                yield None, self
+                yield None, self.to_block()
                 return
 
             start = end = 0
@@ -343,9 +343,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                         except StopIteration:
                             next_row = None
                             break
-                    yield next_key, BlockAccessor.for_block(
-                        self.slice(start, end, copy=False)
-                    )
+                    yield next_key, self.slice(start, end, copy=False)
                     start = end
                 except StopIteration:
                     break

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -1,7 +1,17 @@
 import collections
 import random
 import heapq
-from typing import Dict, List, Tuple, Iterator, Any, TypeVar, Optional, TYPE_CHECKING
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Tuple,
+    Iterator,
+    Any,
+    TypeVar,
+    Optional,
+    TYPE_CHECKING,
+)
 
 import numpy as np
 
@@ -10,7 +20,15 @@ try:
 except ImportError:
     pyarrow = None
 
-from ray.data.block import Block, BlockAccessor, BlockMetadata, BlockExecStats, U, KeyFn
+from ray.data.block import (
+    Block,
+    BlockAccessor,
+    BlockMetadata,
+    BlockExecStats,
+    U,
+    KeyFn,
+    KeyType,
+)
 from ray.data.row import TableRow
 from ray.data.impl.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data.aggregate import AggregateFn
@@ -156,48 +174,46 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def count(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
         import pyarrow.compute as pac
 
+        if self.num_rows() == 0:
+            return None
+
         col = self._table[on]
         return pac.count(col).as_py()
 
-    def sum(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+    def _apply_arrow_compute(
+        self, compute_fn: Callable, on: KeyFn, ignore_nulls: bool
+    ) -> Optional[U]:
+        """Helper providing null handling around applying an aggregation to a column."""
         import pyarrow as pa
-        import pyarrow.compute as pac
+
+        if self.num_rows() == 0:
+            return None
 
         col = self._table[on]
         if pa.types.is_null(col.type):
             return None
         else:
-            return pac.sum(col, skip_nulls=ignore_nulls).as_py()
+            return compute_fn(col, skip_nulls=ignore_nulls).as_py()
+
+    def sum(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        import pyarrow.compute as pac
+
+        return self._apply_arrow_compute(pac.sum, on, ignore_nulls)
 
     def min(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
-        import pyarrow as pa
         import pyarrow.compute as pac
 
-        col = self._table[on]
-        if pa.types.is_null(col.type):
-            return None
-        else:
-            return pac.min(col, skip_nulls=ignore_nulls).as_py()
+        return self._apply_arrow_compute(pac.min, on, ignore_nulls)
 
     def max(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
-        import pyarrow as pa
         import pyarrow.compute as pac
 
-        col = self._table[on]
-        if pa.types.is_null(col.type):
-            return None
-        else:
-            return pac.max(col, skip_nulls=ignore_nulls).as_py()
+        return self._apply_arrow_compute(pac.max, on, ignore_nulls)
 
     def mean(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
-        import pyarrow as pa
         import pyarrow.compute as pac
 
-        col = self._table[on]
-        if pa.types.is_null(col.type):
-            return None
-        else:
-            return pac.mean(col, skip_nulls=ignore_nulls).as_py()
+        return self._apply_arrow_compute(pac.mean, on, ignore_nulls)
 
     def sum_of_squared_diffs_from_mean(
         self,
@@ -205,19 +221,19 @@ class ArrowBlockAccessor(TableBlockAccessor):
         ignore_nulls: bool,
         mean: Optional[U] = None,
     ) -> Optional[U]:
-        import pyarrow as pa
         import pyarrow.compute as pac
 
         if mean is None:
+            # If precomputed mean not given, we compute it ourselves.
             mean = self.mean(on, ignore_nulls)
-        col = self._table[on]
-        if pa.types.is_null(col.type):
-            return None
-        return pac.sum(pac.power(pac.subtract(col, mean), 2)).as_py()
-        # col = self._table[on]
-        # if pa.types.is_null(col.type):
-        #     return None
-        # return (pac.count(col) + 1) * pac.variance(col)
+        return self._apply_arrow_compute(
+            lambda col, skip_nulls: pac.sum(
+                pac.power(pac.subtract(col, mean), 2),
+                skip_nulls=skip_nulls,
+            ),
+            on,
+            ignore_nulls,
+        )
 
     def sort_and_partition(
         self, boundaries: List[T], key: "SortKeyT", descending: bool
@@ -287,51 +303,79 @@ class ArrowBlockAccessor(TableBlockAccessor):
             aggregation.
             If key is None then the k column is omitted.
         """
-        # TODO(jjyao) This can be implemented natively in Arrow
-        key_fn = (lambda r: r[key]) if key is not None else (lambda r: None)
-        iter = self.iter_rows()
-        next_row = None
-        builder = ArrowBlockBuilder()
-        while True:
-            try:
-                if next_row is None:
-                    next_row = next(iter)
-                next_key = key_fn(next_row)
 
-                def gen():
-                    nonlocal iter
-                    nonlocal next_row
-                    while key_fn(next_row) == next_key:
-                        yield next_row
+        def iter_groups() -> Iterator[Tuple[KeyType, BlockAccessor]]:
+            """Creates an iterator over zero-copy group views."""
+            if key is None:
+                # Global aggregation consists of a single "group", so we short-circuit.
+                yield None, self
+                return
+
+            start = end = 0
+            iter = self.iter_rows()
+            next_row = None
+            while True:
+                try:
+                    if next_row is None:
+                        next_row = next(iter)
+                    next_key = next_row[key]
+                    while next_row[key] == next_key:
+                        end += 1
                         try:
                             next_row = next(iter)
                         except StopIteration:
                             next_row = None
                             break
+                    yield next_key, BlockAccessor.for_block(
+                        self.slice(start, end, copy=False)
+                    )
+                    start = end
+                except StopIteration:
+                    break
 
-                # Accumulate.
-                accumulators = [agg.init(next_key) for agg in aggs]
-                for r in gen():
-                    for i in range(len(aggs)):
-                        accumulators[i] = aggs[i].accumulate(accumulators[i], r)
+        builder = ArrowBlockBuilder()
+        for group_key, group_view in iter_groups():
+            # Aggregate.
+            accumulators = [agg.init(group_key) for agg in aggs]
+            for i in range(len(aggs)):
+                agg = aggs[i]
+                # Apply vectorized aggregation on group, if available.
+                if agg.can_vectorize_for_block(group_view):
+                    if agg.vectorized_aggregate is None:
+                        raise ValueError(
+                            f"Aggregation {agg} indicates that vectorized "
+                            f"processing of {type(group_view)} block is possible, but "
+                            "agg.vectorized_aggregate() is not defined."
+                        )
+                    accumulators[i] = agg.vectorized_aggregate(
+                        accumulators[i], group_view
+                    )
+                else:
+                    if agg.accumulate is None:
+                        raise ValueError(
+                            f"Aggregation {agg} doesn't support vectorized "
+                            f"processing of {type(group_view)} block, but "
+                            "agg.accumulate() is not defined."
+                        )
+                    for row in group_view.iter_rows():
+                        accumulators[i] = agg.accumulate(accumulators[i], row)
 
-                # Build the row.
-                row = {}
-                if key is not None:
-                    row[key] = next_key
+            # Build the row.
+            row = {}
+            if key is not None:
+                row[key] = group_key
 
-                count = collections.defaultdict(int)
-                for agg, accumulator in zip(aggs, accumulators):
-                    name = agg.name
-                    # Check for conflicts with existing aggregation name.
-                    if count[name] > 0:
-                        name = self._munge_conflict(name, count[name])
-                    count[name] += 1
-                    row[name] = accumulator
+            count = collections.defaultdict(int)
+            for agg, accumulator in zip(aggs, accumulators):
+                name = agg.name
+                # Check for conflicts with existing aggregation name.
+                if count[name] > 0:
+                    name = self._munge_conflict(name, count[name])
+                count[name] += 1
+                row[name] = accumulator
 
-                builder.add(row)
-            except StopIteration:
-                break
+            builder.add(row)
+
         return builder.build()
 
     @staticmethod

--- a/python/ray/data/impl/block_builder.py
+++ b/python/ray/data/impl/block_builder.py
@@ -10,26 +10,6 @@ class BlockBuilder(Generic[T]):
     def for_block(block: Block) -> "BlockBuilder[T]":
         return BlockAccessor.for_block(block).builder()
 
-    @staticmethod
-    def for_format(dataset_format: str) -> "BlockBuilder[T]":
-        if dataset_format == "arrow":
-            from ray.data.impl.arrow_block import ArrowBlockBuilder
-
-            return ArrowBlockBuilder()
-        elif dataset_format == "pandas":
-            from ray.data.impl.pandas_block import PandasBlockBuilder
-
-            return PandasBlockBuilder()
-        elif dataset_format == "simple":
-            from ray.data.impl.simple_block import SimpleBlockBuilder
-
-            return SimpleBlockBuilder()
-        else:
-            raise ValueError(
-                'Valid dataset formats are "arrow", "pandas", and "simple", got '
-                f'"{dataset_format}"'
-            )
-
     def add(self, item: T) -> None:
         """Append a single row to the block being built."""
         raise NotImplementedError

--- a/python/ray/data/impl/block_builder.py
+++ b/python/ray/data/impl/block_builder.py
@@ -10,6 +10,26 @@ class BlockBuilder(Generic[T]):
     def for_block(block: Block) -> "BlockBuilder[T]":
         return BlockAccessor.for_block(block).builder()
 
+    @staticmethod
+    def for_format(dataset_format: str) -> "BlockBuilder[T]":
+        if dataset_format == "arrow":
+            from ray.data.impl.arrow_block import ArrowBlockBuilder
+
+            return ArrowBlockBuilder()
+        elif dataset_format == "pandas":
+            from ray.data.impl.pandas_block import PandasBlockBuilder
+
+            return PandasBlockBuilder()
+        elif dataset_format == "simple":
+            from ray.data.impl.simple_block import SimpleBlockBuilder
+
+            return SimpleBlockBuilder()
+        else:
+            raise ValueError(
+                'Valid dataset formats are "arrow", "pandas", and "simple", got '
+                f'"{dataset_format}"'
+            )
+
     def add(self, item: T) -> None:
         """Append a single row to the block being built."""
         raise NotImplementedError

--- a/python/ray/data/impl/null_aggregate.py
+++ b/python/ray/data/impl/null_aggregate.py
@@ -3,7 +3,7 @@ from types import ModuleType
 
 import numpy as np
 
-from ray.data.block import T, U, KeyType, AggType
+from ray.data.block import T, U, BlockAccessor, KeyType, AggType
 
 
 # This module contains aggregation helpers for handling nulls.
@@ -85,6 +85,54 @@ def _null_wrap_init(init: Callable[[KeyType], AggType]) -> Callable[[KeyType], A
     return _init
 
 
+def _null_wrap_merge(
+    ignore_nulls: bool,
+    merge: Callable[[AggType, AggType], AggType],
+) -> AggType:
+    """
+    Wrap merge function with null handling.
+
+    The returned merge function expects a1 and a2 to be either None or of the form:
+    a = [acc_data_1, ..., acc_data_2, has_data].
+
+    This merges two accumulations subject to the following null rules:
+    1. If a1 is empty and a2 is empty, return empty accumulation.
+    2. If a1 (a2) is empty and a2 (a1) is None, return None.
+    3. If a1 (a2) is empty and a2 (a1) is non-None, return a2 (a1).
+    4. If a1 (a2) is None, return a2 (a1) if ignoring nulls, None otherwise.
+    5. If a1 and a2 are both non-null, return merge(a1, a2).
+
+    Args:
+        ignore_nulls: Whether nulls should be ignored or cause a None result.
+        merge: The core merge function to wrap.
+
+    Returns:
+        A new merge function that handles nulls.
+    """
+
+    def _merge(a1: AggType, a2: AggType) -> AggType:
+        if a1 is None:
+            # If we're ignoring nulls, propagate a2; otherwise, propagate None.
+            return a2 if ignore_nulls else None
+        unwrapped_a1, a1_has_data = _unwrap_acc(a1)
+        if not a1_has_data:
+            # If a1 is empty, propagate a2.
+            # No matter whether a2 is a real value, empty, or None,
+            # propagating each of these is correct if a1 is empty.
+            return a2
+        if a2 is None:
+            # If we're ignoring nulls, propagate a1; otherwise, propagate None.
+            return a1 if ignore_nulls else None
+        unwrapped_a2, a2_has_data = _unwrap_acc(a2)
+        if not a2_has_data:
+            # If a2 is empty, propagate a1.
+            return a1
+        a = merge(unwrapped_a1, unwrapped_a2)
+        return _wrap_acc(a, has_data=True)
+
+    return _merge
+
+
 def _null_wrap_accumulate(
     ignore_nulls: bool,
     on_fn: Callable[[T], T],
@@ -135,52 +183,35 @@ def _null_wrap_accumulate(
     return _accum
 
 
-def _null_wrap_merge(
+def _null_wrap_vectorized_aggregate(
     ignore_nulls: bool,
-    merge: Callable[[AggType, AggType], AggType],
-) -> AggType:
+    vec_agg: Callable[[BlockAccessor[T]], AggType],
+) -> Callable[[BlockAccessor[T]], AggType]:
     """
-    Wrap merge function with null handling.
-
-    The returned merge function expects a1 and a2 to be either None or of the form:
-    a = [acc_data_1, ..., acc_data_2, has_data].
-
-    This merges two accumulations subject to the following null rules:
-    1. If a1 is empty and a2 is empty, return empty accumulation.
-    2. If a1 (a2) is empty and a2 (a1) is None, return None.
-    3. If a1 (a2) is empty and a2 (a1) is non-None, return a2 (a1).
-    4. If a1 (a2) is None, return a2 (a1) if ignoring nulls, None otherwise.
-    5. If a1 and a2 are both non-null, return merge(a1, a2).
+    Wrap vectorized aggregate function with null handling.
 
     Args:
         ignore_nulls: Whether nulls should be ignored or cause a None result.
-        merge: The core merge function to wrap.
+        vec_agg: The core vectorized aggregate function to wrap.
 
     Returns:
-        A new merge function that handles nulls.
+        A new vectorized aggregate function that handles nulls.
     """
 
-    def _merge(a1: AggType, a2: AggType) -> AggType:
-        if a1 is None:
-            # If we're ignoring nulls, propagate a2; otherwise, propagate None.
-            return a2 if ignore_nulls else None
-        unwrapped_a1, a1_has_data = _unwrap_acc(a1)
-        if not a1_has_data:
-            # If a1 is empty, propagate a2.
-            # No matter whether a2 is a real value, empty, or None,
-            # propagating each of these is correct if a1 is empty.
-            return a2
-        if a2 is None:
-            # If we're ignoring nulls, propagate a1; otherwise, propagate None.
-            return a1 if ignore_nulls else None
-        unwrapped_a2, a2_has_data = _unwrap_acc(a2)
-        if not a2_has_data:
-            # If a2 is empty, propagate a1.
-            return a1
-        a = merge(unwrapped_a1, unwrapped_a2)
-        return _wrap_acc(a, has_data=True)
+    def _vec_agg(init: AggType, block_acc: BlockAccessor[T]) -> AggType:
+        ret = vec_agg(block_acc)
+        if ret is None:
+            if ignore_nulls:
+                # This can happen if we're ignoring nulls but the entire block only
+                # consists of nulls. We treat the block as if it were empty in this
+                # case.
+                return init
+            else:
+                return ret
+        else:
+            return _wrap_acc(ret, has_data=True)
 
-    return _merge
+    return _vec_agg
 
 
 def _null_wrap_finalize(

--- a/python/ray/data/impl/null_aggregate.py
+++ b/python/ray/data/impl/null_aggregate.py
@@ -183,10 +183,10 @@ def _null_wrap_accumulate(
     return _accum
 
 
-def _null_wrap_vectorized_aggregate(
+def _null_wrap_accumulate_block(
     ignore_nulls: bool,
     vec_agg: Callable[[BlockAccessor[T]], AggType],
-) -> Callable[[BlockAccessor[T]], AggType]:
+) -> Callable[[AggType, BlockAccessor[T]], AggType]:
     """
     Wrap vectorized aggregate function with null handling.
 
@@ -198,14 +198,14 @@ def _null_wrap_vectorized_aggregate(
         A new vectorized aggregate function that handles nulls.
     """
 
-    def _vec_agg(init: AggType, block_acc: BlockAccessor[T]) -> AggType:
+    def _vec_agg(a: AggType, block_acc: BlockAccessor[T]) -> AggType:
         ret = vec_agg(block_acc)
         if ret is None:
             if ignore_nulls:
                 # This can happen if we're ignoring nulls but the entire block only
                 # consists of nulls. We treat the block as if it were empty in this
                 # case.
-                return init
+                return a
             else:
                 return ret
         else:

--- a/python/ray/data/impl/null_aggregate.py
+++ b/python/ray/data/impl/null_aggregate.py
@@ -185,7 +185,7 @@ def _null_wrap_accumulate_row(
 
 def _null_wrap_accumulate_block(
     ignore_nulls: bool,
-    accum_block: Callable[[BlockAccessor[T]], AggType],
+    accum_block: Callable[[AggType, BlockAccessor[T]], AggType],
 ) -> Callable[[AggType, BlockAccessor[T]], AggType]:
     """
     Wrap vectorized aggregate function with null handling.
@@ -206,7 +206,8 @@ def _null_wrap_accumulate_block(
     """
 
     def _accum_block_null(a: AggType, block_acc: BlockAccessor[T]) -> AggType:
-        ret = accum_block(block_acc)
+        a_data, _ = _unwrap_acc(a)
+        ret = accum_block(a_data, block_acc)
         if ret is None:
             if ignore_nulls:
                 # This can happen if we're ignoring nulls but the entire block only

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -176,10 +176,22 @@ class PandasBlockAccessor(TableBlockAccessor):
         return self._table[[k[0] for k in key]].sample(n_samples, ignore_index=True)
 
     def count(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        if on is not None and not isinstance(on, str):
+            raise ValueError(
+                "on must be a string or None when aggregating on Pandas blocks, but "
+                f"got: {type(on)}."
+            )
+
         col = self._table[on]
         return col.count()
 
     def sum(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        if on is not None and not isinstance(on, str):
+            raise ValueError(
+                "on must be a string or None when aggregating on Pandas blocks, but "
+                f"got: {type(on)}."
+            )
+
         col = self._table[on]
         if col.isnull().all():
             # Short-circuit on an all-null column, returning None.
@@ -190,6 +202,12 @@ class PandasBlockAccessor(TableBlockAccessor):
         self, agg_fn: Callable[["pandas.Series", bool], U], on: KeyFn
     ) -> Optional[U]:
         """Helper providing null handling around applying an aggregation to a column."""
+        if on is not None and not isinstance(on, str):
+            raise ValueError(
+                "on must be a string or None when aggregating on Pandas blocks, but "
+                f"got: {type(on)}."
+            )
+
         col = self._table[on]
         try:
             return agg_fn(col)

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple, Iterator, Any, TypeVar, Optional, TYPE_CHE
 import collections
 import numpy as np
 
-from ray.data.block import BlockAccessor, BlockMetadata, KeyFn
+from ray.data.block import BlockAccessor, BlockMetadata, KeyFn, U
 from ray.data.row import TableRow
 from ray.data.impl.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data.impl.arrow_block import ArrowBlockAccessor
@@ -164,6 +164,76 @@ class PandasBlockAccessor(TableBlockAccessor):
 
     def _sample(self, n_samples: int, key: "SortKeyT") -> "pandas.DataFrame":
         return self._table[[k[0] for k in key]].sample(n_samples, ignore_index=True)
+
+    def count(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        col = self._table[on]
+        return col.count()
+
+    def sum(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        col = self._table[on]
+        if col.isnull().all():
+            # Short-circuit on an all-null column, returning None.
+            return None
+        return col.sum(skipna=ignore_nulls)
+
+    def min(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        col = self._table[on]
+        try:
+            return col.min(skipna=ignore_nulls)
+        except TypeError as e:
+            # Converting an all-null column in an Arrow Table to a Pandas DataFrame
+            # column will result in an all-None column of object type, which will raise
+            # a type error when attempting to do most binary operations. We explicitly
+            # check for this type failure here so we can properly propagate a null.
+            if np.issubdtype(col.dtype, np.object_) and col.isnull().all():
+                return None
+            raise e from None
+
+    def max(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        col = self._table[on]
+        try:
+            return col.max(skipna=ignore_nulls)
+        except TypeError as e:
+            # Converting an all-null column in an Arrow Table to a Pandas DataFrame
+            # column will result in an all-None column of object type, which will raise
+            # a type error when attempting to do most binary operations. We explicitly
+            # check for this type failure here so we can properly propagate a null.
+            if np.issubdtype(col.dtype, np.object_) and col.isnull().all():
+                return None
+            raise e from None
+
+    def mean(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        col = self._table[on]
+        try:
+            return col.mean(skipna=ignore_nulls)
+        except TypeError as e:
+            # Converting an all-null column in an Arrow Table to a Pandas DataFrame
+            # column will result in an all-None column of object type, which will raise
+            # a type error when attempting to do most binary operations. We explicitly
+            # check for this type failure here so we can properly propagate a null.
+            if np.issubdtype(col.dtype, np.object_) and col.isnull().all():
+                return None
+            raise e from None
+
+    def sum_of_squared_diffs_from_mean(
+        self,
+        on: KeyFn,
+        ignore_nulls: bool,
+        mean: Optional[U] = None,
+    ) -> Optional[U]:
+        if mean is None:
+            mean = self.mean(on, ignore_nulls)
+        col = self._table[on]
+        try:
+            return ((col - mean) ** 2).sum()
+        except TypeError as e:
+            # Converting an all-null column in an Arrow Table to a Pandas DataFrame
+            # column will result in an all-None column of object type, which will raise
+            # a type error when attempting to do most binary operations. We explicitly
+            # check for this type failure here so we can properly propagate a null.
+            if np.issubdtype(col.dtype, np.object_) and col.isnull().all():
+                return None
+            raise e from None
 
     def sort_and_partition(
         self, boundaries: List[T], key: "SortKeyT", descending: bool

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -197,7 +197,7 @@ class PandasBlockAccessor(TableBlockAccessor):
                 return None
             raise e from None
 
-    def count(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+    def count(self, on: KeyFn) -> Optional[U]:
         return self._apply_agg(lambda col: col.count(), on)
 
     def sum(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
@@ -209,7 +209,9 @@ class PandasBlockAccessor(TableBlockAccessor):
 
         col = self._table[on]
         if col.isnull().all():
-            # Short-circuit on an all-null column, returning None.
+            # Short-circuit on an all-null column, returning None. This is required for
+            # sum() since it will otherwise return 0 when summing on an all-null column,
+            # which is not what we want.
             return None
         return col.sum(skipna=ignore_nulls)
 

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -1,7 +1,7 @@
 import random
 import sys
 import heapq
-from typing import Iterator, List, Tuple, Any, Optional, TYPE_CHECKING
+from typing import Callable, Iterator, List, Tuple, Any, Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -126,6 +126,102 @@ class SimpleBlockAccessor(BlockAccessor):
             return ret
         return [key(x) for x in ret]
 
+    def count(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        if on is not None and not callable(on):
+            raise ValueError(
+                "on must be a callable or None when aggregating on Simple blocks, but "
+                f"got: {type(on)}."
+            )
+
+        if self.num_rows() == 0:
+            return None
+        count = 0
+        for r in self.iter_rows():
+            if on is not None:
+                r = on(r)
+            if r is not None:
+                count += 1
+        return count
+
+    def _apply_accum(
+        self,
+        init: AggType,
+        accum: Callable[[AggType, T], AggType],
+        on: KeyFn,
+        ignore_nulls: bool,
+    ) -> Optional[U]:
+        """Helper providing null handling around applying an aggregation."""
+        if on is not None and not callable(on):
+            raise ValueError(
+                "on must be a callable or None when aggregating on Simple blocks, but "
+                f"got: {type(on)}."
+            )
+
+        if self.num_rows() == 0:
+            return None
+
+        has_data = False
+        a = init
+        for r in self.iter_rows():
+            if on is not None:
+                r = on(r)
+            if r is None:
+                if ignore_nulls:
+                    continue
+                else:
+                    return None
+            else:
+                has_data = True
+                a = accum(a, r)
+        return a if has_data else None
+
+    def sum(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        return self._apply_accum(0, lambda a, r: a + r, on, ignore_nulls)
+
+    def min(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        return self._apply_accum(float("inf"), min, on, ignore_nulls)
+
+    def max(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        return self._apply_accum(float("-inf"), max, on, ignore_nulls)
+
+    def mean(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        return self._apply_accum(
+            [0, 0],
+            lambda a, r: [a[0] + r, a[1] + 1],
+            on,
+            ignore_nulls,
+        )
+
+    def std(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        def accum(a: List[float], r: float) -> List[float]:
+            # Accumulates the current count, the current mean, and the sum of
+            # squared differences from the current mean (M2).
+            M2, mean, count = a
+            count += 1
+            delta = r - mean
+            mean += delta / count
+            delta2 = r - mean
+            M2 += delta * delta2
+            return [M2, mean, count]
+
+        return self._apply_accum([0, 0, 0], accum, on, ignore_nulls)
+
+    def sum_of_squared_diffs_from_mean(
+        self,
+        on: KeyFn,
+        ignore_nulls: bool,
+        mean: Optional[U] = None,
+    ) -> Optional[U]:
+        if mean is None:
+            # If precomputed mean not given, we compute it ourselves.
+            mean = self.mean(on, ignore_nulls)
+        return self._apply_accum(
+            0,
+            lambda a, r: a + (r - mean) ** 2,
+            on,
+            ignore_nulls,
+        )
+
     def sort_and_partition(
         self, boundaries: List[T], key: "SortKeyT", descending: bool
     ) -> List["Block[T]"]:
@@ -181,45 +277,59 @@ class SimpleBlockAccessor(BlockAccessor):
             aggregation.
             If key is None then the k element of tuple is omitted.
         """
-        key_fn = key if key else lambda r: None
-        iter = self.iter_rows()
-        next_row = None
-        # Use a bool to indicate if next_row is valid
-        # instead of checking if next_row is None
-        # since a row can have None value.
-        has_next_row = False
-        ret = []
-        while True:
-            try:
-                if not has_next_row:
-                    next_row = next(iter)
-                    has_next_row = True
-                next_key = key_fn(next_row)
+        if key is not None and not callable(key):
+            raise ValueError(
+                "key must be a callable or None when aggregating on Simple blocks, but "
+                f"got: {type(key)}."
+            )
 
-                def gen():
-                    nonlocal iter
-                    nonlocal next_row
-                    nonlocal has_next_row
-                    assert has_next_row
-                    while key_fn(next_row) == next_key:
-                        yield next_row
+        def iter_groups() -> Iterator[Tuple[KeyType, BlockAccessor]]:
+            """Creates an iterator over zero-copy group views."""
+            if key is None:
+                # Global aggregation consists of a single "group", so we short-circuit.
+                yield None, self
+                return
+
+            start = end = 0
+            iter = self.iter_rows()
+            next_row = None
+            # Use a bool to indicate if next_row is valid
+            # instead of checking if next_row is None
+            # since a row can have None value.
+            has_next_row = False
+            while True:
+                try:
+                    if not has_next_row:
+                        next_row = next(iter)
+                        has_next_row = True
+                    next_key = key(next_row)
+                    while key(next_row) == next_key:
+                        end += 1
                         try:
                             next_row = next(iter)
                         except StopIteration:
                             has_next_row = False
                             next_row = None
                             break
+                    yield next_key, BlockAccessor.for_block(
+                        self.slice(start, end, copy=False)
+                    )
+                    start = end
+                except StopIteration:
+                    break
 
-                accumulators = [agg.init(next_key) for agg in aggs]
-                for r in gen():
-                    for i in range(len(aggs)):
-                        accumulators[i] = aggs[i].accumulate(accumulators[i], r)
-                if key is None:
-                    ret.append(tuple(accumulators))
-                else:
-                    ret.append((next_key,) + tuple(accumulators))
-            except StopIteration:
-                break
+        ret = []
+        for group_key, group_view in iter_groups():
+            # Aggregate.
+            accumulators = [agg.init(group_key) for agg in aggs]
+            for i in range(len(aggs)):
+                accumulators[i] = aggs[i].accumulate_block(accumulators[i], group_view)
+
+            # Build the row.
+            if key is None:
+                ret.append(tuple(accumulators))
+            else:
+                ret.append((group_key,) + tuple(accumulators))
         return ret
 
     @staticmethod

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -129,7 +129,7 @@ class SimpleBlockAccessor(BlockAccessor):
             return ret
         return [key(x) for x in ret]
 
-    def count(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+    def count(self, on: KeyFn) -> Optional[U]:
         if on is not None and not callable(on):
             raise ValueError(
                 "on must be a callable or None when aggregating on Simple blocks, but "
@@ -138,6 +138,7 @@ class SimpleBlockAccessor(BlockAccessor):
 
         if self.num_rows() == 0:
             return None
+
         count = 0
         for r in self.iter_rows():
             if on is not None:

--- a/python/ray/data/impl/table_block.py
+++ b/python/ray/data/impl/table_block.py
@@ -100,6 +100,9 @@ class TableBlockAccessor(BlockAccessor):
     def _create_table_row(self, row: Any) -> TableRow:
         raise NotImplementedError
 
+    def to_block(self) -> Block:
+        return self._table
+
     def iter_rows(self) -> Iterator[TableRow]:
         outer = self
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3103,12 +3103,9 @@ def test_groupby_simple_multilambda(ray_start_regular_shared, num_parts):
     assert ray.data.from_items([[x, 2 * x] for x in xs]).repartition(num_parts).mean(
         [lambda x: x[0], lambda x: x[1]]
     ) == (49.5, 99.0)
-    assert (
-        ray.data.from_items([[x, 2 * x] for x in range(10)])
-        .filter(lambda r: r[0] > 10)
-        .mean([lambda x: x[0], lambda x: x[1]])
-        is None
-    )
+    assert ray.data.from_items([[x, 2 * x] for x in range(10)]).filter(
+        lambda r: r[0] > 10
+    ).mean([lambda x: x[0], lambda x: x[1]]) == (None, None)
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1939,27 +1939,46 @@ def test_groupby_arrow_sum(ray_start_regular_shared, num_parts):
         {"A": 2, "sum(B)": None},
     ]
 
+
+@pytest.mark.parametrize("num_parts", [1, 30])
+@pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+def test_global_tabular_sum(ray_start_regular_shared, ds_format, num_parts):
+    seed = int(time.time())
+    print(f"Seeding RNG for test_global_arrow_sum with: {seed}")
+    random.seed(seed)
+    xs = list(range(100))
+    random.shuffle(xs)
+
+    def _to_pandas(ds):
+        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
+
     # Test built-in global sum aggregation
-    assert (
-        ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts).sum("A")
-        == 4950
-    )
+    ds = ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.sum("A") == 4950
 
     # Test empty dataset
-    assert (
-        ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).sum("value") is None
-    )
+    ds = ray.data.range_arrow(10)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.filter(lambda r: r["value"] > 10).sum("value") is None
 
     # Test built-in global sum aggregation with nans
     nan_ds = ray.data.from_items([{"A": x} for x in xs] + [{"A": None}]).repartition(
         num_parts
     )
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.sum("A") == 4950
     # Test ignore_nulls=False
     assert nan_ds.sum("A", ignore_nulls=False) is None
     # Test all nans
     nan_ds = ray.data.from_items([{"A": None}] * len(xs)).repartition(num_parts)
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.sum("A") is None
+    assert nan_ds.sum("A", ignore_nulls=False) is None
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -2018,26 +2037,46 @@ def test_groupby_arrow_min(ray_start_regular_shared, num_parts):
         {"A": 2, "min(B)": None},
     ]
 
+
+@pytest.mark.parametrize("num_parts", [1, 30])
+@pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+def test_global_tabular_min(ray_start_regular_shared, ds_format, num_parts):
+    seed = int(time.time())
+    print(f"Seeding RNG for test_global_arrow_min with: {seed}")
+    random.seed(seed)
+    xs = list(range(100))
+    random.shuffle(xs)
+
+    def _to_pandas(ds):
+        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
+
     # Test built-in global min aggregation
-    assert (
-        ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts).min("A") == 0
-    )
+    ds = ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.min("A") == 0
 
     # Test empty dataset
-    assert (
-        ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).min("value") is None
-    )
+    ds = ray.data.range_arrow(10)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.filter(lambda r: r["value"] > 10).min("value") is None
 
     # Test built-in global min aggregation with nans
     nan_ds = ray.data.from_items([{"A": x} for x in xs] + [{"A": None}]).repartition(
         num_parts
     )
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.min("A") == 0
     # Test ignore_nulls=False
     assert nan_ds.min("A", ignore_nulls=False) is None
     # Test all nans
     nan_ds = ray.data.from_items([{"A": None}] * len(xs)).repartition(num_parts)
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.min("A") is None
+    assert nan_ds.min("A", ignore_nulls=False) is None
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -2096,27 +2135,46 @@ def test_groupby_arrow_max(ray_start_regular_shared, num_parts):
         {"A": 2, "max(B)": None},
     ]
 
+
+@pytest.mark.parametrize("num_parts", [1, 30])
+@pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+def test_global_tabular_max(ray_start_regular_shared, ds_format, num_parts):
+    seed = int(time.time())
+    print(f"Seeding RNG for test_global_arrow_max with: {seed}")
+    random.seed(seed)
+    xs = list(range(100))
+    random.shuffle(xs)
+
+    def _to_pandas(ds):
+        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
+
     # Test built-in global max aggregation
-    assert (
-        ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts).max("A")
-        == 99
-    )
+    ds = ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.max("A") == 99
 
     # Test empty dataset
-    assert (
-        ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).max("value") is None
-    )
+    ds = ray.data.range_arrow(10)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.filter(lambda r: r["value"] > 10).max("value") is None
 
     # Test built-in global max aggregation with nans
     nan_ds = ray.data.from_items([{"A": x} for x in xs] + [{"A": None}]).repartition(
         num_parts
     )
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.max("A") == 99
     # Test ignore_nulls=False
     assert nan_ds.max("A", ignore_nulls=False) is None
     # Test all nans
     nan_ds = ray.data.from_items([{"A": None}] * len(xs)).repartition(num_parts)
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.max("A") is None
+    assert nan_ds.max("A", ignore_nulls=False) is None
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -2176,27 +2234,46 @@ def test_groupby_arrow_mean(ray_start_regular_shared, num_parts):
         {"A": 2, "mean(B)": None},
     ]
 
+
+@pytest.mark.parametrize("num_parts", [1, 30])
+@pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+def test_global_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
+    seed = int(time.time())
+    print(f"Seeding RNG for test_global_arrow_mean with: {seed}")
+    random.seed(seed)
+    xs = list(range(100))
+    random.shuffle(xs)
+
+    def _to_pandas(ds):
+        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
+
     # Test built-in global mean aggregation
-    assert (
-        ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts).mean("A")
-        == 49.5
-    )
+    ds = ray.data.from_items([{"A": x} for x in xs]).repartition(num_parts)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.mean("A") == 49.5
 
     # Test empty dataset
-    assert (
-        ray.data.range_arrow(10).filter(lambda r: r["value"] > 10).mean("value") is None
-    )
+    ds = ray.data.range_arrow(10)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    assert ds.filter(lambda r: r["value"] > 10).mean("value") is None
 
     # Test built-in global mean aggregation with nans
     nan_ds = ray.data.from_items([{"A": x} for x in xs] + [{"A": None}]).repartition(
         num_parts
     )
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.mean("A") == 49.5
     # Test ignore_nulls=False
     assert nan_ds.mean("A", ignore_nulls=False) is None
     # Test all nans
     nan_ds = ray.data.from_items([{"A": None}] * len(xs)).repartition(num_parts)
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.mean("A") is None
+    assert nan_ds.mean("A", ignore_nulls=False) is None
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -2250,31 +2327,55 @@ def test_groupby_arrow_std(ray_start_regular_shared, num_parts):
     expected = pd.Series([None] * 3)
     np.testing.assert_array_equal(result, expected)
 
-    # Test built-in global std aggregation
+
+@pytest.mark.parametrize("num_parts", [1, 30])
+@pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+def test_global_tabular_std(ray_start_regular_shared, ds_format, num_parts):
+    seed = int(time.time())
+    print(f"Seeding RNG for test_global_arrow_std with: {seed}")
+    random.seed(seed)
+    xs = list(range(100))
+    random.shuffle(xs)
+
+    def _to_arrow(ds):
+        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pyarrow")
+
+    def _to_pandas(ds):
+        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
+
+    # Test built-in global max aggregation
     df = pd.DataFrame({"A": xs})
-    assert math.isclose(
-        ray.data.from_pandas(df).repartition(num_parts).std("A"), df["A"].std()
-    )
-    # ddof of 0
-    assert math.isclose(
-        ray.data.from_pandas(df).repartition(num_parts).std("A", ddof=0),
-        df["A"].std(ddof=0),
-    )
+    ds = ray.data.from_pandas(df).repartition(num_parts)
+    if ds_format == "arrow":
+        ds = _to_arrow(ds)
+    assert math.isclose(ds.std("A"), df["A"].std())
+    assert math.isclose(ds.std("A", ddof=0), df["A"].std(ddof=0))
 
     # Test empty dataset
-    assert ray.data.from_pandas(pd.DataFrame({"A": []})).std("A") is None
+    ds = ray.data.from_pandas(pd.DataFrame({"A": []}))
+    if ds_format == "arrow":
+        ds = _to_arrow(ds)
+    assert ds.std("A") is None
     # Test edge cases
-    assert ray.data.from_pandas(pd.DataFrame({"A": [3]})).std("A") == 0
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [3]}))
+    if ds_format == "arrow":
+        ds = _to_arrow(ds)
+    assert ds.std("A") == 0
 
     # Test built-in global std aggregation with nans
     nan_df = pd.DataFrame({"A": xs + [None]})
     nan_ds = ray.data.from_pandas(nan_df).repartition(num_parts)
-    assert math.isclose(nan_ds.std("A"), df["A"].std())
+    if ds_format == "arrow":
+        nan_ds = _to_arrow(nan_ds)
+    assert math.isclose(nan_ds.std("A"), nan_df["A"].std())
     # Test ignore_nulls=False
     assert nan_ds.std("A", ignore_nulls=False) is None
     # Test all nans
     nan_ds = ray.data.from_items([{"A": None}] * len(xs)).repartition(num_parts)
+    if ds_format == "pandas":
+        nan_ds = _to_pandas(nan_ds)
     assert nan_ds.std("A") is None
+    assert nan_ds.std("A", ignore_nulls=False) is None
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])


### PR DESCRIPTION
This PR adds support for vectorized global and grouped aggregations, porting the built-in aggregations to vectorized block aggregations for tabular datasets.

The `AggregateFn` abstraction is extended to have an optional `vectorized_aggregate` function that performs a vectorized aggregation on a single block, allowing aggregations to opt-in to vectorized block aggregation. The `AggregateFn` also exposes a `can_vectorize_for_block()` API, which allows aggregations to opt-in for vectorized block aggregation for only certain block types, e.g. only for Arrow and Pandas blocks. The built-in set of aggregations currently only opts-in to vectorized block aggregation on tabular datasets, i.e. only for Arrow and Pandas blocks, since vectorized aggregation of simple blocks will amount to the accumulator loop with extra copying for each group slice (no zero-copy views possible for Python lists).

For Arrow blocks, vectorized block aggregation is supported by creating zero-copy views on each group slice within each partition and applying the vectorized aggregation on these group slice views. This currently entails two scans of each block partition: one to determine the group view boundaries, and one to process each group. As a future optimization, we could eliminate this extra scan by gathering group boundaries while sorting and partitioning each block along the sample boundaries.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
