### PR TITLE
[serve] [docs] Add tip about `serve status`

### DIFF
--- a/doc/source/serve/deployment.rst
+++ b/doc/source/serve/deployment.rst
@@ -243,6 +243,14 @@ You can also customize how frequently the health check is run and the timeout wh
                 # The specific type of exception is not important.
                 raise RuntimeError("uh-oh, DB connection is broken.")
 
+.. tip::
+
+    You can use the Serve CLI command ``serve status`` to get status info
+    about your live deployments. The CLI was included with Serve when you did
+    ``pip install "ray[serve]"``. If you're checking your deployments on a
+    remote Ray cluster, make sure to include the Ray cluster's dashboard address
+    in the command: ``serve status --address [dashboard_address]``.
+
 Failure Recovery
 ================
 Ray Serve is resilient to any component failures within the Ray cluster out of the box.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `serve status` command allows users to get their deployments' status info through the CLI. This change adds a tip to the health-checking documentation to inform users about `serve status`.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - Docs change; N/A
