### PR TITLE
[tune] Optuna should ignore additional results after trial termination

### DIFF
--- a/python/ray/tune/suggest/optuna.py
+++ b/python/ray/tune/suggest/optuna.py
@@ -327,6 +327,8 @@ class OptunaSearch(Searcher):
         self._sampler = sampler
         self._seed = seed
 
+        self._completed_trials = set()
+
         self._ot_trials = {}
         self._ot_study = None
         if self._space:
@@ -474,6 +476,12 @@ class OptunaSearch(Searcher):
             # Optuna doesn't support incremental results
             # for multi-objective optimization
             return
+        if trial_id in self._completed_trials:
+            logger.warning(
+                f"Received additional result for trial {trial_id}, but "
+                f"it already finished. Result: {result}"
+            )
+            return
         metric = result[self.metric]
         step = result[TRAINING_ITERATION]
         ot_trial = self._ot_trials[trial_id]
@@ -482,6 +490,13 @@ class OptunaSearch(Searcher):
     def on_trial_complete(
         self, trial_id: str, result: Optional[Dict] = None, error: bool = False
     ):
+        if trial_id in self._completed_trials:
+            logger.warning(
+                f"Received additional completion for trial {trial_id}, but "
+                f"it already finished. Result: {result}"
+            )
+            return
+
         ot_trial = self._ot_trials[trial_id]
 
         if result:
@@ -499,8 +514,10 @@ class OptunaSearch(Searcher):
                 ot_trial_state = OptunaTrialState.PRUNED
         try:
             self._ot_study.tell(ot_trial, val, state=ot_trial_state)
-        except ValueError as exc:
+        except Exception as exc:
             logger.warning(exc)  # E.g. if NaN was reported
+
+        self._completed_trials.add(trial_id)
 
     def add_evaluated_point(
         self,

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -250,7 +250,7 @@ class InvalidValuesTest(unittest.TestCase):
         self.assertLessEqual(best_trial.config["report"], 2.0)
 
     def testOptunaReportTooOften(self):
-        from ray.tune.suggest.optuna import OptunaSearch, logger
+        from ray.tune.suggest.optuna import OptunaSearch
         from optuna.samplers import RandomSampler
 
         searcher = OptunaSearch(
@@ -264,15 +264,9 @@ class InvalidValuesTest(unittest.TestCase):
         searcher.on_trial_complete("trial_1", {"training_iteration": 2, "metric": 1})
 
         # Report after complete should not fail
-        with self.assertLogs(logger, level="WARN") as w:
-            searcher.on_trial_result("trial_1", {"training_iteration": 3, "metric": 1})
-            self.assertIn("Received additional result", w.output[0])
+        searcher.on_trial_result("trial_1", {"training_iteration": 3, "metric": 1})
 
-        with self.assertLogs(logger, level="WARN") as w:
-            searcher.on_trial_complete(
-                "trial_1", {"training_iteration": 4, "metric": 1}
-            )
-            self.assertIn("Received additional completion", w.output[0])
+        searcher.on_trial_complete("trial_1", {"training_iteration": 4, "metric": 1})
 
     def testSkopt(self):
         from ray.tune.suggest.skopt import SkOptSearch

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -250,7 +250,7 @@ class InvalidValuesTest(unittest.TestCase):
         self.assertLessEqual(best_trial.config["report"], 2.0)
 
     def testOptunaReportTooOften(self):
-        from ray.tune.suggest.optuna import OptunaSearch
+        from ray.tune.suggest.optuna import OptunaSearch, logger
         from optuna.samplers import RandomSampler
 
         searcher = OptunaSearch(
@@ -264,11 +264,11 @@ class InvalidValuesTest(unittest.TestCase):
         searcher.on_trial_complete("trial_1", {"training_iteration": 2, "metric": 1})
 
         # Report after complete should not fail
-        with self.assertLogs("ray.tune.suggest.optuna", level="WARN") as w:
+        with self.assertLogs(logger, level="WARN") as w:
             searcher.on_trial_result("trial_1", {"training_iteration": 3, "metric": 1})
             self.assertIn("Received additional result", w.output[0])
 
-        with self.assertLogs("ray.tune.suggest.optuna", level="WARN") as w:
+        with self.assertLogs(logger, level="WARN") as w:
             searcher.on_trial_complete(
                 "trial_1", {"training_iteration": 4, "metric": 1}
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In rare cases (#19274) (and possibly old versions of Ray), buffered results can lead to calling `on_trial_complete` multiple times with the same trial ID. In these cases, Optuna should gracefully handle this case and discard the results.

## Related issue number

Closes #19274

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
