### PR TITLE
[serve] Make Serve CLI and serve.build() non-public

### DIFF
--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -8,7 +8,6 @@ try:
         get_deployment,
         list_deployments,
         run,
-        build,
     )
     from ray.serve.batching import batch
     from ray.serve.config import HTTPOptions
@@ -36,5 +35,4 @@ __all__ = [
     "get_deployment",
     "list_deployments",
     "run",
-    "build",
 ]

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -988,7 +988,7 @@ class RayServeDAGHandle:
     """Resolved from a DeploymentNode at runtime.
 
     This can be used to call the DAG from a driver deployment to efficiently
-    orchestrate a multi-deployment pipeline.
+    orchestrate a deployment graph.
     """
 
     def __init__(self, dag_node_json: str) -> None:
@@ -1040,7 +1040,7 @@ class DeploymentNode(ClassNode):
     The bound deployment can be run using serve.run().
 
     A bound deployment can be passed as an argument to other bound deployments
-    to build a multi-deployment application. When the application is deployed, the
+    to build a deployment graph. When the graph is deployed, the
     bound deployments passed into a constructor will be converted to
     RayServeHandles that can be used to send requests.
 
@@ -1226,7 +1226,7 @@ class Deployment:
         """Bind the provided arguments and return a DeploymentNode.
 
         The returned bound deployment can be deployed or bound to other
-        deployments to create a multi-deployment application.
+        deployments to create a deployment graph.
         """
         copied_self = copy(self)
         copied_self._init_args = []

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1037,8 +1037,7 @@ class DeploymentMethodNode(DAGNode):
 class DeploymentNode(ClassNode):
     """Represents a deployment with its bound config options and arguments.
 
-    The bound deployment can be run, deployed, or built to a production config
-    using serve.run, serve.deploy, and serve.build, respectively.
+    The bound deployment can be run using serve.run().
 
     A bound deployment can be passed as an argument to other bound deployments
     to build a multi-deployment application. When the application is deployed, the
@@ -1952,7 +1951,6 @@ def run(
         return ingress.get_handle()
 
 
-@PublicAPI(stability="alpha")
 def build(target: Union[DeploymentNode, DeploymentFunctionNode]) -> Application:
     """Builds a Serve application into a static application.
 
@@ -1973,7 +1971,7 @@ def build(target: Union[DeploymentNode, DeploymentFunctionNode]) -> Application:
 
     if in_interactive_shell():
         raise RuntimeError(
-            "serve.build cannot be called from an interactive shell like "
+            "build cannot be called from an interactive shell like "
             "IPython or Jupyter because it requires all deployments to be "
             "importable to run the app after building."
         )

--- a/python/ray/serve/pipeline/api.py
+++ b/python/ray/serve/pipeline/api.py
@@ -56,8 +56,9 @@ def build(ray_dag_root_node: DAGNode) -> List[Deployment]:
         Assuming we have non-JSON serializable or inline defined class or
         function in local pipeline development.
 
-        >>> deployments = serve.build(ray_dag) # it can be method node
-        >>> deployments = serve.build(m1) # or just a regular node.
+        >>> from ray.serve.api import build_app
+        >>> deployments = build_app(ray_dag) # it can be method node
+        >>> deployments = build_app(m1) # or just a regular node.
     """
     serve_root_dag = ray_dag_root_node.apply_recursive(transform_ray_dag_to_serve_dag)
     deployments = extract_deployments_from_serve_dag(serve_root_dag)

--- a/python/ray/serve/pipeline/api.py
+++ b/python/ray/serve/pipeline/api.py
@@ -56,7 +56,7 @@ def build(ray_dag_root_node: DAGNode) -> List[Deployment]:
         Assuming we have non-JSON serializable or inline defined class or
         function in local pipeline development.
 
-        >>> from ray.serve.api import build_app
+        >>> from ray.serve.api import build as build_app
         >>> deployments = build_app(ray_dag) # it can be method node
         >>> deployments = build_app(m1) # or just a regular node.
     """

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -156,6 +156,7 @@ def shutdown(address: str, namespace: str):
         "Use `serve config` to fetch the current config and `serve status` to "
         "check the status of the deployments after deploying."
     ),
+    hidden=True,
 )
 @click.argument("config_file_name")
 @click.option(
@@ -191,6 +192,7 @@ def deploy(config_file_name: str, address: str):
         "By default, this will block and periodically log status. If you "
         "Ctrl-C the command, it will tear down the app."
     ),
+    hidden=True,
 )
 @click.argument("config_or_import_path")
 @click.option(
@@ -314,6 +316,7 @@ def run(
 
 @cli.command(
     help="Get the current config of the running Serve app.",
+    hidden=True,
 )
 @click.option(
     "--address",
@@ -358,6 +361,7 @@ def status(address: str):
 
 @cli.command(
     help="Deletes all deployments in the Serve app.",
+    hidden=True,
 )
 @click.option(
     "--address",
@@ -391,6 +395,7 @@ def delete(address: str, yes: bool):
         "and generates a structured config for it that can be used by "
         "`serve deploy` or the REST API. "
     ),
+    hidden=True,
 )
 @click.option(
     "--app-dir",

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -192,7 +192,6 @@ def deploy(config_file_name: str, address: str):
         "By default, this will block and periodically log status. If you "
         "Ctrl-C the command, it will tear down the app."
     ),
-    hidden=True,
 )
 @click.argument("config_or_import_path")
 @click.option(

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -28,6 +28,7 @@ from ray.serve.api import (
     get_deployment_statuses,
     serve_application_status_to_schema,
 )
+from ray.serve.api import build as build_app
 
 APP_DIR_HELP_STR = (
     "Local directory to look for the IMPORT_PATH (will be inserted into "
@@ -419,7 +420,7 @@ def build(app_dir: str, output_path: Optional[str], import_path: str):
             f"DeploymentFunctionNode, but got {type(node)}."
         )
 
-    app = serve.build(node)
+    app = build_app(node)
 
     if output_path is not None:
         if not output_path.endswith(".yaml"):

--- a/python/ray/serve/tests/test_application.py
+++ b/python/ray/serve/tests/test_application.py
@@ -10,6 +10,7 @@ import numpy as np
 import ray
 from ray import serve
 from ray.serve.api import Application
+from ray.serve.api import build as build_app
 from ray._private.test_utils import wait_for_condition
 
 
@@ -282,13 +283,13 @@ class TestServeBuild:
         with pytest.raises(
             TypeError, match="must be JSON-serializable to build.*init_args"
         ):
-            serve.build(self.A.bind(np.zeros(100))).to_dict()
+            build_app(self.A.bind(np.zeros(100))).to_dict()
 
     def test_build_non_json_serializable_kwargs(self, serve_instance):
         with pytest.raises(
             TypeError, match="must be JSON-serializable to build.*init_kwargs"
         ):
-            serve.build(self.A.bind(kwarg=np.zeros(100))).to_dict()
+            build_app(self.A.bind(kwarg=np.zeros(100))).to_dict()
 
     def test_build_non_importable(self, serve_instance):
         def gen_deployment():
@@ -299,7 +300,7 @@ class TestServeBuild:
             return f
 
         with pytest.raises(RuntimeError, match="must be importable"):
-            serve.build(gen_deployment().bind()).to_dict()
+            build_app(gen_deployment().bind()).to_dict()
 
 
 def compare_specified_options(deployments1: Dict, deployments2: Dict):

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -23,7 +23,7 @@ def maybe_build(
     node: DeploymentNode, use_build: bool
 ) -> Union[Application, DeploymentNode]:
     if use_build:
-        return Application.from_dict(serve.build(node).to_dict())
+        return Application.from_dict(pipeline_build(node).to_dict())
     else:
         return node
 

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -10,6 +10,7 @@ import ray
 from ray import serve
 from ray.experimental.dag.input_node import InputNode
 from ray.serve.api import Application, DeploymentNode, RayServeDAGHandle
+from ray.serve.api import build as build_app
 from ray.serve.pipeline.api import build as pipeline_build
 from ray.serve.drivers import DAGDriver
 import starlette.requests
@@ -23,7 +24,7 @@ def maybe_build(
     node: DeploymentNode, use_build: bool
 ) -> Union[Application, DeploymentNode]:
     if use_build:
-        return Application.from_dict(pipeline_build(node).to_dict())
+        return Application.from_dict(build_app(node).to_dict())
     else:
         return node
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change makes `serve.build()` non-public and hides the following Serve CLI commands:
* `deploy`
* `config`
* `delete`
* `build`

## Related issue number

<!-- For example: "Closes #1234" -->

`serve.build()` was introduced recently in #23232.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change refactors unit tests to use `build()` as a non-public API.
