### PR TITLE
[RLlib] Delete some unused confusing logics.

### DIFF
--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -25,7 +25,6 @@ from ray.rllib.evaluation.collectors.sample_collector import SampleCollector
 from ray.rllib.evaluation.collectors.simple_list_collector import SimpleListCollector
 from ray.rllib.evaluation.episode import Episode
 from ray.rllib.evaluation.metrics import RolloutMetrics
-from ray.rllib.evaluation.sample_batch_builder import MultiAgentSampleBatchBuilder
 from ray.rllib.env.base_env import BaseEnv, convert_to_base_env, ASYNC_RESET_RETURN
 from ray.rllib.env.wrappers.atari_wrappers import get_wrapper_by_cls, MonitorEnv
 from ray.rllib.models.preprocessors import Preprocessor
@@ -616,21 +615,14 @@ def _env_runner(
         horizon = float("inf")
         logger.debug("No episode horizon specified, assuming inf.")
 
-    # Pool of batch builders, which can be shared across episodes to pack
-    # trajectory data.
-    batch_builder_pool: List[MultiAgentSampleBatchBuilder] = []
-
-    def get_batch_builder():
-        if batch_builder_pool:
-            return batch_builder_pool.pop()
-        else:
-            return None
-
     def new_episode(env_id):
         episode = Episode(
             worker.policy_map,
             worker.policy_mapping_fn,
-            get_batch_builder,
+            # SimpleListCollector will find or create a simple_list_collector._PolicyCollector as
+            # batch_builder for this episode later.
+            # Here we simply provide a None factory.
+            lambda: None,  # batch_builder_factory
             extra_batch_callback,
             env_id=env_id,
             worker=worker,

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -619,9 +619,9 @@ def _env_runner(
         episode = Episode(
             worker.policy_map,
             worker.policy_mapping_fn,
-            # SimpleListCollector will find or create a simple_list_collector._PolicyCollector as
-            # batch_builder for this episode later.
-            # Here we simply provide a None factory.
+            # SimpleListCollector will find or create a
+            # simple_list_collector._PolicyCollector as batch_builder
+            # for this episode later. Here we simply provide a None factory.
             lambda: None,  # batch_builder_factory
             extra_batch_callback,
             env_id=env_id,


### PR DESCRIPTION
## Why are these changes needed?

Sampler never creates usable BatchBuilder.
Episodes get their batch builder later in SimpleListCollector.
Delete related code to not confuse people.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
