### PR TITLE
[Rllib] Replay Buffer capacity check

### DIFF
--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -62,7 +62,7 @@ class ReplayBuffer:
         # Caps the number of timesteps stored in this buffer
         if capacity <= 0:
             raise ValueError(
-                "Capacity of Replay Buffer has to be greater than zero "
+                "Capacity of replay buffer has to be greater than zero "
                 "but was set to {}.".format(capacity)
             )
         self.capacity = capacity

--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -60,6 +60,11 @@ class ReplayBuffer:
         self._storage = []
 
         # Caps the number of timesteps stored in this buffer
+        if capacity <= 0:
+            raise ValueError(
+                "Capacity of Replay Buffer has to be greater than zero, "
+                "but was set to {}.".format(capacity)
+            )
         self.capacity = capacity
         # The next index to override in the buffer.
         self._next_idx = 0

--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -62,7 +62,7 @@ class ReplayBuffer:
         # Caps the number of timesteps stored in this buffer
         if capacity <= 0:
             raise ValueError(
-                "Capacity of Replay Buffer has to be greater than zero, "
+                "Capacity of Replay Buffer has to be greater than zero "
                 "but was set to {}.".format(capacity)
             )
         self.capacity = capacity


### PR DESCRIPTION
## Why are these changes needed?

Choosing replay capacity <= 0 leads to no expressive error.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
