### PR TITLE
[Doc][Serve] Add minimal docs for model wrappers and http adapters

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -47,6 +47,7 @@ sphinx-external-toc==0.2.3
 sphinxcontrib.yt==0.2.2
 sphinx-sitemap==2.2.0
 sphinx-thebe==0.1.1
+autodoc_pydantic==1.6.1
 
 # MyST
 myst-parser==0.15.2

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx_external_toc",
     "sphinx_thebe",
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 myst_enable_extensions = [

--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -101,13 +101,12 @@ Predictors
     :members:
     :show-inheritance:
 
-
+.. _air-serve-integration:
 
 Serving
 ~~~~~~~
 
-.. automodule:: ray.serve.model_wrappers
-    :members:
+.. autoclass:: ray.serve.model_wrappers.ModelWrapper
 
 
 Outputs

--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -106,6 +106,8 @@ Predictors
 Serving
 ~~~~~~~
 
+.. autoclass:: ray.serve.model_wrappers.ModelWrapperDeployment
+
 .. autoclass:: ray.serve.model_wrappers.ModelWrapper
 
 

--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -170,9 +170,9 @@ With :ref:`model wrappers<air-serve-integration>`, you can specify it via the ``
 
     from ray import serve
     from ray.serve.http_adapters import json_to_ndarray
-    from ray.serve.model_wrappers import ModelWrapper
+    from ray.serve.model_wrappers import ModelWrapperDeployment
 
-    ModelWrapper.options(name="my_model").deploy(
+    ModelWrapperDeployment.options(name="my_model").deploy(
         my_ray_air_predictor,
         my_ray_air_checkpoint,
         input_schema=json_to_ndarray
@@ -180,11 +180,12 @@ With :ref:`model wrappers<air-serve-integration>`, you can specify it via the ``
 
 You can also bring the adapter to your own FastAPI app using
 `Depends <https://fastapi.tiangolo.com/tutorial/dependencies/#import-depends>`_.
+The input schema will automatically be part of the generated OpenAPI schema with FastAPI.
 
 .. code-block:: python
 
-    from ray.serve.http_adapters import json_to_ndarray
     from fastapi import FastAPI, Depends
+    from ray.serve.http_adapters import json_to_ndarray
 
     app = FastAPI()
 
@@ -198,7 +199,6 @@ It has the following schema for input:
 
 .. autopydantic_model:: ray.serve.http_adapters.NdArray
 
-The input schema will automatically be part of the generated OpenAPI schema with FastAPI.
 
 Here is a list of adapters and please feel free to `contribute more <https://github.com/ray-project/ray/issues/new/choose>`_!
 

--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -152,6 +152,43 @@ To try it out, save a code snippet in a local python file (i.e. main.py) and in 
     ray start --head
     python main.py
 
+.. _serve-http-adapters:
+
+HTTP Adapters
+^^^^^^^^^^^^^
+
+Ray Serve provides a suite of adapter for input schema conversion. You can directly
+import them and put them into your FastAPI app. Alternatively, just use it with
+:ref:`Ray AI Runtime (AIR) model wrapper<air-serve-integration>` feature to one click deploy pre-trained models.
+
+For example, we provide a simple converter for n-dimensional array. You can bring it
+to your own FastAPI app using `Depends <https://fastapi.tiangolo.com/tutorial/dependencies/#import-depends>`_.
+
+.. code-block:: python
+
+    from ray.serve.http_adapters import array_to_databatch
+    from fastapi import FastAPI, Depends
+
+    app = FastAPI()
+
+    @app.post("/endpoint")
+    async def endpoint(np_array = Depends(array_to_databatch)):
+        ...
+
+It has the following schema for input:
+
+.. _serve-ndarray-schema:
+
+.. autopydantic_model:: ray.serve.http_adapters.NdArray
+
+The input schema will automatically be part of the generated OpenAPI schema with FastAPI.
+
+Here is a list of adapters and please feel free to contribute more!
+
+.. automodule:: ray.serve.http_adapters
+    :members: array_to_databatch, image_to_databatch
+
+
 Configuring HTTP Server Locations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -169,13 +169,13 @@ With :ref:`model wrappers<air-serve-integration>`, you can specify it via the ``
 .. code-block:: python
 
     from ray import serve
-    from ray.serve.http_adapters import array_to_databatch
+    from ray.serve.http_adapters import json_to_ndarray
     from ray.serve.model_wrappers import ModelWrapper
 
-    serve.deployment(name="my_model")(ModelWrapper).deploy(
+    ModelWrapper.options(name="my_model").deploy(
         my_ray_air_predictor,
         my_ray_air_checkpoint,
-        input_schema=array_to_databatch
+        input_schema=json_to_ndarray
     )
 
 You can also bring the adapter to your own FastAPI app using
@@ -183,13 +183,13 @@ You can also bring the adapter to your own FastAPI app using
 
 .. code-block:: python
 
-    from ray.serve.http_adapters import array_to_databatch
+    from ray.serve.http_adapters import json_to_ndarray
     from fastapi import FastAPI, Depends
 
     app = FastAPI()
 
     @app.post("/endpoint")
-    async def endpoint(np_array = Depends(array_to_databatch)):
+    async def endpoint(np_array = Depends(json_to_ndarray)):
         ...
 
 It has the following schema for input:
@@ -203,7 +203,7 @@ The input schema will automatically be part of the generated OpenAPI schema with
 Here is a list of adapters and please feel free to `contribute more <https://github.com/ray-project/ray/issues/new/choose>`_!
 
 .. automodule:: ray.serve.http_adapters
-    :members: array_to_databatch, image_to_databatch
+    :members: json_to_ndarray, image_to_ndarray
 
 
 Configuring HTTP Server Locations

--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -168,9 +168,9 @@ With :ref:`model wrappers<air-serve-integration>`, you can specify it via the ``
 
 .. code-block:: python
 
+    from ray import serve
     from ray.serve.http_adapters import array_to_databatch
     from ray.serve.model_wrappers import ModelWrapper
-    from ray import serve
 
     serve.deployment(name="my_model")(ModelWrapper).deploy(
         my_ray_air_predictor,

--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -157,12 +157,29 @@ To try it out, save a code snippet in a local python file (i.e. main.py) and in 
 HTTP Adapters
 ^^^^^^^^^^^^^
 
-Ray Serve provides a suite of adapter for input schema conversion. You can directly
-import them and put them into your FastAPI app. Alternatively, just use it with
-:ref:`Ray AI Runtime (AIR) model wrapper<air-serve-integration>` feature to one click deploy pre-trained models.
+Ray Serve provides a suite of adapters to convert HTTP requests to ML inputs like `numpy` arrays.
+You can just use it with :ref:`Ray AI Runtime (AIR) model wrapper<air-serve-integration>` feature
+to one click deploy pre-trained models.
+Alternatively, you can directly import them and put them into your FastAPI app.
 
-For example, we provide a simple converter for n-dimensional array. You can bring it
-to your own FastAPI app using `Depends <https://fastapi.tiangolo.com/tutorial/dependencies/#import-depends>`_.
+For example, we provide a simple adapter for n-dimensional array.
+
+With :ref:`model wrappers<air-serve-integration>`, you can specify it via the ``input_schema`` field.
+
+.. code-block:: python
+
+    from ray.serve.http_adapters import array_to_databatch
+    from ray.serve.model_wrappers import ModelWrapper
+    from ray import serve
+
+    serve.deployment(name="my_model")(ModelWrapper).deploy(
+        my_ray_air_predictor,
+        my_ray_air_checkpoint,
+        input_schema=array_to_databatch
+    )
+
+You can also bring the adapter to your own FastAPI app using
+`Depends <https://fastapi.tiangolo.com/tutorial/dependencies/#import-depends>`_.
 
 .. code-block:: python
 
@@ -183,7 +200,7 @@ It has the following schema for input:
 
 The input schema will automatically be part of the generated OpenAPI schema with FastAPI.
 
-Here is a list of adapters and please feel free to contribute more!
+Here is a list of adapters and please feel free to `contribute more <https://github.com/ray-project/ray/issues/new/choose>`_!
 
 .. automodule:: ray.serve.http_adapters
     :members: array_to_databatch, image_to_databatch

--- a/python/ray/serve/http_adapters.py
+++ b/python/ray/serve/http_adapters.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 import numpy as np
 
 from ray.serve.utils import require_packages
-from ray.ml.predictor import DataBatchType
 import starlette.requests
 
 
@@ -41,8 +40,8 @@ class NdArray(BaseModel):
     )
 
 
-def array_to_databatch(payload: NdArray) -> DataBatchType:
-    """Accepts an NdArray from an HTTP body and converts it to a DataBatchType."""
+def array_to_databatch(payload: NdArray) -> np.ndarray:
+    """Accepts an NdArray JSON from an HTTP body and converts it to a numpy array."""
     arr = np.array(payload.array)
     if payload.shape:
         arr = arr.reshape(*payload.shape)
@@ -60,9 +59,9 @@ def starlette_request(
 
 
 @require_packages(["PIL"])
-def image_to_databatch(img: bytes = File(...)) -> DataBatchType:
+def image_to_databatch(img: bytes = File(...)) -> np.ndarray:
     """Accepts a PIL-readable file from an HTTP form and converts
-    it to a DataBatchType.
+    it to a numpy array.
     """
     from PIL import Image
 

--- a/python/ray/serve/http_adapters.py
+++ b/python/ray/serve/http_adapters.py
@@ -40,7 +40,7 @@ class NdArray(BaseModel):
     )
 
 
-def array_to_databatch(payload: NdArray) -> np.ndarray:
+def json_to_ndarray(payload: NdArray) -> np.ndarray:
     """Accepts an NdArray JSON from an HTTP body and converts it to a numpy array."""
     arr = np.array(payload.array)
     if payload.shape:
@@ -59,7 +59,7 @@ def starlette_request(
 
 
 @require_packages(["PIL"])
-def image_to_databatch(img: bytes = File(...)) -> np.ndarray:
+def image_to_ndarray(img: bytes = File(...)) -> np.ndarray:
     """Accepts a PIL-readable file from an HTTP form and converts
     it to a numpy array.
     """

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -38,7 +38,6 @@ def _load_predictor_cls(
     return predictor_cls
 
 
-@serve.deployment
 class ModelWrapper(SimpleSchemaIngress):
     """Serve any Ray AIR predictor from an AIR checkpoint.
 
@@ -103,3 +102,8 @@ class ModelWrapper(SimpleSchemaIngress):
     async def predict(self, inp):
         """Perform inference directly without HTTP."""
         return await self.batched_predict(inp)
+
+
+@serve.deployment
+class ModelWrapperDeployment(ModelWrapper):
+    """Ray Serve Deployment of the ModelWrapper class."""

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -72,7 +72,7 @@ class ModelWrapper(SimpleSchemaIngress):
         checkpoint: Union[Checkpoint, Dict],
         input_schema: Union[
             str, InputSchemaFn
-        ] = "ray.serve.http_adapters.array_to_databatch",
+        ] = "ray.serve.http_adapters.json_to_ndarray",
         batching_params: Optional[Union[Dict[str, int], bool]] = None,
     ):
         predictor_cls = _load_predictor_cls(predictor_cls)

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -39,6 +39,33 @@ def _load_predictor_cls(
 
 
 class ModelWrapper(SimpleSchemaIngress):
+    """Serve any Ray AIR predictor from a AIR checkpoint.
+
+    Args:
+        predictor_cls(str, Type[Predictor]): The class or path for predictor class.
+            The type must be a subclass of :class:`ray.ml.predicotr.Predictor`.
+        checkpoint(Checkpoint, dict): The checkpoint object or a dictionary describe
+            the object.
+
+            - The checkpoint object must be a subclass of
+              :class:`ray.ml.checkpoint.Checkpoint`.
+            - The dictionary should be in the form of
+              ``{"checkpoint_cls": "import.path.MyCheckpoint",
+              "uri": "uri_to_load_from"}``.
+              Serve will then call ``MyCheckpoint.from_uri("uri_to_load_from")`` to
+              instantiate the object.
+
+        input_schema(str, InputSchemaFn, None): The FastAPI input conversion
+            function. By default, Serve will use the
+            :ref:`NdArray <serve-ndarray-schema>` schema and convert to numpy array.
+            You can pass in any FastAPI dependency resolver that returns
+            an array. When you pass in a string, Serve will import it.
+            Please refer to :ref:`Serve HTTP adatpers <serve-http-adapters>`
+            documentation to learn more.
+        batching_params(dict, None, False): override the default parameters to
+            :func:`ray.serve.batch`. Pass ``False`` to disable batching.
+    """
+
     def __init__(
         self,
         predictor_cls: Union[str, Type[Predictor]],
@@ -48,27 +75,6 @@ class ModelWrapper(SimpleSchemaIngress):
         ] = "ray.serve.http_adapters.array_to_databatch",
         batching_params: Optional[Union[Dict[str, int], bool]] = None,
     ):
-        """Serve any Ray ML predictor from checkpoint.
-
-        Args:
-            predictor_cls(str, Type[Predictor]): The class or path for predictor class.
-              The type must be a subclass of ray.ml `Predictor`.
-            checkpoint(Checkpoint, dict): The checkpoint object or a dictionary describe
-              the object.
-                - The checkpoint object must be a subclass of ray.ml `Checkpoint`.
-                - The dictionary should be in the form of
-                  {"checkpoint_cls": "import.path.MyCheckpoint",
-                   "uri": "uri_to_load_from"}.
-                  Serve will then call `MyCheckpoint.from_uri("uri_to_load_from")` to
-                  instantiate the object.
-            input_schema(str, InputSchemaFn, None): The FastAPI input conversion
-              function. By default, Serve will use the `NdArray` schema and convert to
-              numpy array. You can pass in any FastAPI dependency resolver that returns
-              an array. When you pass in a string, Serve will import it.
-              Please refer to Serve HTTP adatper documentation to learn more.
-            batching_params(dict, None, False): override the default parameters to
-              serve.batch. Pass `False` to disable batching.
-        """
         predictor_cls = _load_predictor_cls(predictor_cls)
         checkpoint = _load_checkpoint(checkpoint)
 

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -39,7 +39,7 @@ def _load_predictor_cls(
 
 
 class ModelWrapper(SimpleSchemaIngress):
-    """Serve any Ray AIR predictor from a AIR checkpoint.
+    """Serve any Ray AIR predictor from an AIR checkpoint.
 
     Args:
         predictor_cls(str, Type[Predictor]): The class or path for predictor class.

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -38,6 +38,7 @@ def _load_predictor_cls(
     return predictor_cls
 
 
+@serve.deployment
 class ModelWrapper(SimpleSchemaIngress):
     """Serve any Ray AIR predictor from an AIR checkpoint.
 

--- a/python/ray/serve/tests/test_http_adapters.py
+++ b/python/ray/serve/tests/test_http_adapters.py
@@ -3,7 +3,7 @@ import io
 import numpy as np
 import pytest
 from PIL import Image
-from ray.serve.http_adapters import NdArray, array_to_databatch, image_to_databatch
+from ray.serve.http_adapters import NdArray, json_to_ndarray, image_to_ndarray
 from ray.serve.utils import require_packages
 
 
@@ -16,21 +16,21 @@ def test_require_packages():
         func()
 
 
-def test_array_to_databatch():
+def test_json_to_ndarray():
     np.testing.assert_equal(
-        array_to_databatch(NdArray(array=[1, 2], shape=None, dtype=None)),
+        json_to_ndarray(NdArray(array=[1, 2], shape=None, dtype=None)),
         np.array([1, 2]),
     )
     np.testing.assert_equal(
-        array_to_databatch(NdArray(array=[[1], [2]], shape=None, dtype=None)),
+        json_to_ndarray(NdArray(array=[[1], [2]], shape=None, dtype=None)),
         np.array([[1], [2]]),
     )
     np.testing.assert_equal(
-        array_to_databatch(NdArray(array=[[1], [2]], shape=[1, 2], dtype=None)),
+        json_to_ndarray(NdArray(array=[[1], [2]], shape=[1, 2], dtype=None)),
         np.array([[1, 2]]),
     )
     np.testing.assert_equal(
-        array_to_databatch(NdArray(array=[[1.9], [2.1]], shape=[1, 2], dtype="int")),
+        json_to_ndarray(NdArray(array=[[1.9], [2.1]], shape=[1, 2], dtype="int")),
         np.array([[1.9, 2.1]]).astype("int"),
     )
 
@@ -40,4 +40,4 @@ def test_image_to_databatch():
     arr = (np.random.rand(100, 100, 3) * 255).astype("uint8")
     image = Image.fromarray(arr).convert("RGB")
     image.save(buffer, format="png")
-    np.testing.assert_almost_equal(image_to_databatch(buffer.getvalue()), arr)
+    np.testing.assert_almost_equal(image_to_ndarray(buffer.getvalue()), arr)

--- a/python/ray/serve/tests/test_http_adapters.py
+++ b/python/ray/serve/tests/test_http_adapters.py
@@ -35,7 +35,7 @@ def test_json_to_ndarray():
     )
 
 
-def test_image_to_databatch():
+def test_image_to_ndarray():
     buffer = io.BytesIO()
     arr = (np.random.rand(100, 100, 3) * 255).astype("uint8")
     image = Image.fromarray(arr).convert("RGB")

--- a/python/ray/serve/tests/test_model_wrappers.py
+++ b/python/ray/serve/tests/test_model_wrappers.py
@@ -13,7 +13,7 @@ from ray.serve.model_wrappers import ModelWrapper
 from ray.serve.pipeline.api import build
 from ray.experimental.dag.input_node import InputNode
 from ray.serve.api import RayServeDAGHandle
-from ray.serve.http_adapters import array_to_databatch
+from ray.serve.http_adapters import json_to_ndarray
 import ray
 from ray import serve
 
@@ -87,7 +87,7 @@ class Ingress:
         self.dag = dag
 
     @app.post("/")
-    async def predict(self, data=Depends(array_to_databatch)):
+    async def predict(self, data=Depends(json_to_ndarray)):
         return await self.dag.remote(data)
 
 

--- a/python/ray/serve/tests/test_model_wrappers.py
+++ b/python/ray/serve/tests/test_model_wrappers.py
@@ -9,7 +9,7 @@ from requests.adapters import HTTPAdapter, Retry
 from ray._private.test_utils import wait_for_condition
 from ray.ml.checkpoint import Checkpoint
 from ray.ml.predictor import DataBatchType, Predictor
-from ray.serve.model_wrappers import ModelWrapper
+from ray.serve.model_wrappers import ModelWrapperDeployment
 from ray.serve.pipeline.api import build
 from ray.experimental.dag.input_node import InputNode
 from ray.serve.api import RayServeDAGHandle
@@ -52,7 +52,7 @@ def send_request(**requests_kargs):
 
 
 def test_simple_adder(serve_instance):
-    ModelWrapper.options(name="Adder").deploy(
+    ModelWrapperDeployment.options(name="Adder").deploy(
         predictor_cls=AdderPredictor,
         checkpoint=AdderCheckpoint.from_dict({"increment": 2}),
     )
@@ -61,7 +61,7 @@ def test_simple_adder(serve_instance):
 
 
 def test_batching(serve_instance):
-    ModelWrapper.options(name="Adder").deploy(
+    ModelWrapperDeployment.options(name="Adder").deploy(
         predictor_cls=AdderPredictor,
         checkpoint=AdderCheckpoint.from_dict({"increment": 2}),
         batching_params=dict(max_batch_size=2, batch_wait_timeout_s=1000),
@@ -95,7 +95,7 @@ def test_model_wrappers_in_pipeline(serve_instance):
     checkpoint_cls = "ray.serve.tests.test_model_wrappers.AdderCheckpoint"
 
     with InputNode() as dag_input:
-        m1 = ModelWrapper.bind(
+        m1 = ModelWrapperDeployment.bind(
             predictor_cls=predictor_cls,  # TODO: can't be the raw class right now?
             checkpoint={  # TODO: can't be the raw object right now?
                 "checkpoint_cls": checkpoint_cls,
@@ -135,7 +135,7 @@ def test_yaml_compatibility(serve_instance):
             "deployments": [
                 {
                     "name": "Adder",
-                    "import_path": "ray.serve.model_wrappers.ModelWrapper",
+                    "import_path": "ray.serve.model_wrappers.ModelWrapperDeployment",
                     "init_kwargs": {
                         "predictor_cls": predictor_cls,
                         "checkpoint": {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds minimal documentation for model wrappers and http adapters. It mostly just surface existing docstrings. More end to end tutorials to be added. 

Preview link:
- Adapters: https://ray--23536.org.readthedocs.build/en/23536/serve/http-servehandle.html#http-adapters
- Wrappers: https://ray--23536.org.readthedocs.build/en/23536/ray-air/getting-started.html#serving

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
