### PR TITLE
[serve] Cherry-pick #23504

### DIFF
--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -8,7 +8,6 @@ try:
         get_deployment,
         list_deployments,
         run,
-        build,
     )
     from ray.serve.batching import batch
     from ray.serve.config import HTTPOptions
@@ -36,5 +35,4 @@ __all__ = [
     "get_deployment",
     "list_deployments",
     "run",
-    "build",
 ]

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -980,7 +980,7 @@ class RayServeDAGHandle:
     """Resolved from a DeploymentNode at runtime.
 
     This can be used to call the DAG from a driver deployment to efficiently
-    orchestrate a multi-deployment pipeline.
+    orchestrate a deployment graph.
     """
 
     def __init__(self, dag_node_json: str) -> None:
@@ -1029,11 +1029,10 @@ class DeploymentMethodNode(DAGNode):
 class DeploymentNode(ClassNode):
     """Represents a deployment with its bound config options and arguments.
 
-    The bound deployment can be run, deployed, or built to a production config
-    using serve.run, serve.deploy, and serve.build, respectively.
+    The bound deployment can be run using serve.run().
 
     A bound deployment can be passed as an argument to other bound deployments
-    to build a multi-deployment application. When the application is deployed, the
+    to build a deployment graph. When the graph is deployed, the
     bound deployments passed into a constructor will be converted to
     RayServeHandles that can be used to send requests.
 
@@ -1219,7 +1218,7 @@ class Deployment:
         """Bind the provided arguments and return a DeploymentNode.
 
         The returned bound deployment can be deployed or bound to other
-        deployments to create a multi-deployment application.
+        deployments to create a deployment graph.
         """
         copied_self = copy(self)
         copied_self._init_args = []
@@ -1945,8 +1944,7 @@ def run(
         return ingress.get_handle()
 
 
-@PublicAPI(stability="alpha")
-def build(target: DeploymentNode) -> Application:
+def build(target: Union[DeploymentNode, DeploymentFunctionNode]) -> Application:
     """Builds a Serve application into a static application.
 
     Takes in a DeploymentNode and converts it to a Serve application

--- a/python/ray/serve/pipeline/api.py
+++ b/python/ray/serve/pipeline/api.py
@@ -56,8 +56,9 @@ def build(ray_dag_root_node: DAGNode) -> List[Deployment]:
         Assuming we have non-JSON serializable or inline defined class or
         function in local pipeline development.
 
-        >>> deployments = serve.build(ray_dag) # it can be method node
-        >>> deployments = serve.build(m1) # or just a regular node.
+        >>> from ray.serve.api import build as build_app
+        >>> deployments = build_app(ray_dag) # it can be method node
+        >>> deployments = build_app(m1) # or just a regular node.
     """
     serve_root_dag = ray_dag_root_node.apply_recursive(transform_ray_dag_to_serve_dag)
     deployments = extract_deployments_from_serve_dag(serve_root_dag)

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -152,6 +152,7 @@ def shutdown(address: str, namespace: str):
         "Use `serve config` to fetch the current config and `serve status` to "
         "check the status of the deployments after deploying."
     ),
+    hidden=True,
 )
 @click.argument("config_file_name")
 @click.option(
@@ -310,6 +311,7 @@ def run(
 
 @cli.command(
     help="Get the current config of the running Serve app.",
+    hidden=True,
 )
 @click.option(
     "--address",
@@ -354,6 +356,7 @@ def status(address: str):
 
 @cli.command(
     help="Deletes all deployments in the Serve app.",
+    hidden=True,
 )
 @click.option(
     "--address",

--- a/python/ray/serve/tests/test_pipeline_driver.py
+++ b/python/ray/serve/tests/test_pipeline_driver.py
@@ -15,6 +15,7 @@ def my_resolver(a: int):
     return a
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Import behavior different.")
 def test_loading_check():
     with pytest.raises(ValueError, match="callable"):
         load_input_schema(["not function"])


### PR DESCRIPTION
This change makes `serve.build()` non-public and hides the following Serve CLI commands:
* `deploy`
* `config`
* `delete`
* `build`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#23504 made these changes on the `Master` branch. This change cherry-picks #23504 into `releases/1.12.0rc1`.

## Related issue number

<!-- For example: "Closes #1234" -->

#23504

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
