### PR TITLE
[core] Filter out self node from the list of object locations during pull

### DIFF
--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -425,7 +425,19 @@ void PullManager::OnLocationChange(const ObjectID &object_id,
   // NOTE(swang): Since we are overwriting the previous list of clients,
   // we may end up sending a duplicate request to the same client as
   // before.
-  it->second.client_locations = std::vector<NodeID>(client_ids.begin(), client_ids.end());
+  it->second.client_locations.clear();
+  for (const auto &client_id : client_ids) {
+    if (client_id == self_node_id_) {
+      RAY_LOG(WARNING) << "The object manager with ID " << self_node_id_
+                       << " is trying to pull object " << object_id
+                       << " but the object table suggests that this object manager "
+                       << "already has the object. The object may have been evicted. It is "
+                       << "most likely due to memory pressure, object pull has been "
+                       << "requested before object location is updated.";
+    } else {
+      it->second.client_locations.push_back(client_id);
+    }
+  }
   it->second.spilled_url = spilled_url;
   it->second.spilled_node_id = spilled_node_id;
   it->second.pending_object_creation = pending_creation;
@@ -550,6 +562,8 @@ bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
   if (node_vector.empty()) {
     // Pull from remote node, it will be restored prior to push.
     if (!spilled_node_id.IsNil() && spilled_node_id != self_node_id_) {
+      RAY_LOG(DEBUG) << "Sending pull request from " << self_node_id_ << " to spilled location at " << spilled_node_id
+                     << " of object " << object_id;
       send_pull_request_(object_id, spilled_node_id);
       return true;
     }
@@ -558,38 +572,14 @@ bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
   }
 
   RAY_CHECK(!object_is_local_(object_id));
-  // Make sure that there is at least one client which is not the local client.
-  // TODO(rkn): It may actually be possible for this check to fail.
-  if (node_vector.size() == 1 && node_vector[0] == self_node_id_) {
-    RAY_LOG(WARNING) << "The object manager with ID " << self_node_id_
-                     << " is trying to pull object " << object_id
-                     << " but the object table suggests that this object manager "
-                     << "already has the object. The object may have been evicted. It is "
-                     << "most likely due to memory pressure, object pull has been "
-                     << "requested before object location is updated.";
-    return false;
-  }
 
   // Choose a random client to pull the object from.
   // Generate a random index.
   std::uniform_int_distribution<int> distribution(0, node_vector.size() - 1);
   int node_index = distribution(gen_);
   NodeID node_id = node_vector[node_index];
-  // If the object manager somehow ended up choosing itself, choose a different
-  // object manager.
-  if (node_id == self_node_id_) {
-    std::swap(node_vector[node_index], node_vector[node_vector.size() - 1]);
-    node_vector.pop_back();
-    RAY_LOG(WARNING)
-        << "The object manager with ID " << self_node_id_ << " is trying to pull object "
-        << object_id << " but the object table suggests that this object manager "
-        << "already has the object. It is most likely due to memory pressure, object "
-        << "pull has been requested before object location is updated.";
-    node_id = node_vector[node_index % node_vector.size()];
-    RAY_CHECK(node_id != self_node_id_);
-  }
-
-  RAY_LOG(DEBUG) << "Sending pull request from " << self_node_id_ << " to " << node_id
+  RAY_CHECK(node_id != self_node_id_);
+  RAY_LOG(DEBUG) << "Sending pull request from " << self_node_id_ << " to in-memory location at " << node_id
                  << " of object " << object_id;
   send_pull_request_(object_id, node_id);
   return true;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Running Datasets shuffle with 1TB data and 2k partitions sometimes times out due to a failed object fetch. This happens because the object directory notifies the PullManager that the object is already on the local node, even though it isn't. This seems to be a bug in the object directory.

To work around this on the PullManager side, this PR filters out the current node from the list of locations provided by the object directory. @jjyao confirmed that this fixes the issue for Datasets shuffle.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
