### PR TITLE
[CI] pin click version to fix broken test.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@
 aiohttp>=3.7
 aioredis < 2
 aiosignal
-click >= 7.0
+click >= 7.0, <= 8.0.4
 cloudpickle
 filelock
 frozenlist

--- a/python/setup.py
+++ b/python/setup.py
@@ -265,7 +265,7 @@ if setup_spec.type == SetupType.RAY:
 if setup_spec.type == SetupType.RAY:
     setup_spec.install_requires = [
         "attrs",
-        "click >= 7.0",
+        "click >= 7.0, <= 8.0.4",
         "dataclasses; python_version < '3.7'",
         "filelock",
         "grpcio >= 1.28.1, <= 1.43.0",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

test_runtime_env_complicated.py failed because latest click missed an API. Pin click to a specific version to address the issue.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
