### PR TITLE
Move linkcheck into a separate CI build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -143,6 +143,12 @@
     - ./ci/travis/ci.sh lint
     - ./ci/travis/ci.sh build
 
+- label: ":book: LinkCheck"
+  commands:
+    - export LINT=1
+    - ./ci/travis/install-dependencies.sh
+    - ./ci/travis/ci.sh check_sphinx_links
+
 - label: ":java: Java"
   conditions: ["RAY_CI_JAVA_AFFECTED"]
   commands:

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -265,8 +265,18 @@ build_sphinx_docs() {
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
       make html
-      make linkcheck
       make doctest
+    fi
+  )
+}
+
+check_sphinx_links() {
+  (
+    cd "${WORKSPACE_DIR}"/doc
+    if [ "${OSTYPE}" = msys ]; then
+      echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
+    else
+      make linkcheck
     fi
   )
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Linkcheck is inherently flaky, so separate it from the normal LINT build which is never flaky. This also separates the verbose linkcheck logs, making it easier to read the LINT output.