### PR TITLE
Bytecode check to verify imported function correctness in `test_pipeline_driver::test_loading_check`

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -341,7 +341,7 @@ py_test(
 
 py_test(
     name = "test_pipeline_driver",
-    size = "small",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],

--- a/python/ray/serve/tests/test_pipeline_driver.py
+++ b/python/ray/serve/tests/test_pipeline_driver.py
@@ -15,7 +15,6 @@ def my_resolver(a: int):
     return a
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Import behavior different.")
 def test_loading_check():
     with pytest.raises(ValueError, match="callable"):
         load_input_schema(["not function"])
@@ -25,9 +24,12 @@ def test_loading_check():
             return a
 
         load_input_schema(func)
+
+    loaded_my_resolver = load_input_schema("ray.serve.tests.test_pipeline_driver.my_resolver")
     assert (
-        load_input_schema("ray.serve.tests.test_pipeline_driver.my_resolver")
-        == my_resolver
+        (loaded_my_resolver == my_resolver)
+        or
+        (loaded_my_resolver.__code__.co_code == my_resolver.__code__.co_code)
     )
 
 

--- a/python/ray/serve/tests/test_pipeline_driver.py
+++ b/python/ray/serve/tests/test_pipeline_driver.py
@@ -25,11 +25,11 @@ def test_loading_check():
 
         load_input_schema(func)
 
-    loaded_my_resolver = load_input_schema("ray.serve.tests.test_pipeline_driver.my_resolver")
-    assert (
-        (loaded_my_resolver == my_resolver)
-        or
-        (loaded_my_resolver.__code__.co_code == my_resolver.__code__.co_code)
+    loaded_my_resolver = load_input_schema(
+        "ray.serve.tests.test_pipeline_driver.my_resolver"
+    )
+    assert (loaded_my_resolver == my_resolver) or (
+        loaded_my_resolver.__code__.co_code == my_resolver.__code__.co_code
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I noticed that the above test fails because `my_resolver` loaded by `load_input_schema("ray.serve.tests.test_pipeline_driver.my_resolver")` occupies a different memory location than `my_resolver` present in `test_pipeline_driver.py` file, a thing very much possible in CI.

I added a check which passes if the bytecode of imported function is the same even though the memory location is different. See https://stackoverflow.com/a/20059029 for the reasoning.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
