### PR TITLE
WINDOWS: fix pip activate command

### DIFF
--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -61,7 +61,6 @@ class _PathHelper:
     @classmethod
     def get_virtualenv_activate_command(cls, target_dir: str) -> str:
         virtualenv_path = cls.get_virtualenv_path(target_dir)
-        # TODO(SongGuyang): Support Windows
         if _WIN32:
             return "%s 1>&2" % (os.path.join(virtualenv_path, "Scripts", "activate"))
         else:

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -62,7 +62,10 @@ class _PathHelper:
     def get_virtualenv_activate_command(cls, target_dir: str) -> str:
         virtualenv_path = cls.get_virtualenv_path(target_dir)
         # TODO(SongGuyang): Support Windows
-        return "source %s 1>&2" % (os.path.join(virtualenv_path, "bin/activate"))
+        if _WIN32:
+            return "%s 1>&2" % (os.path.join(virtualenv_path, "Scripts", "activate"))
+        else:
+            return "source %s 1>&2" % (os.path.join(virtualenv_path, "bin/activate"))
 
     @staticmethod
     def get_requirements_file(target_dir: str) -> str:

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -433,10 +433,6 @@ def test_conda_create_ray_client(call_ray_start):
             ray.get(f.remote())
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.parametrize("pip_as_str", [True, False])
 def test_pip_task(shutdown_only, pip_as_str, tmp_path):
     """Tests pip installs in the runtime env specified in f.options()."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Continuation of #22449 

Fix pip activation so something like this will not crash
```
ray.init(runtime_env={"pip": ["toolz", "requests"]})
```

Also enable test that hit this code path.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
