### PR TITLE
Remove predefined resources vector in ResourceRequest

### DIFF
--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -946,8 +946,8 @@ bool LocalTaskManager::ReleaseCpuResourcesFromUnblockedWorker(
   }
 
   if (worker->GetAllocatedInstances() != nullptr) {
-    auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(ResourceID::CPU());
-    if (cpu_instances.size() > 0) {
+    if (worker->GetAllocatedInstances()->Has(ResourceID::CPU())) {
+      auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(ResourceID::CPU());
       std::vector<double> overflow_cpu_instances =
           cluster_resource_scheduler_->GetLocalResourceManager().AddResourceInstances(
               ResourceID::CPU(), cpu_instances);
@@ -968,8 +968,8 @@ bool LocalTaskManager::ReturnCpuResourcesToBlockedWorker(
     return false;
   }
   if (worker->GetAllocatedInstances() != nullptr) {
-    auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(ResourceID::CPU());
-    if (cpu_instances.size() > 0) {
+    if (worker->GetAllocatedInstances()->Has(ResourceID::CPU())) {
+      auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(ResourceID::CPU());
       // Important: we allow going negative here, since otherwise you can use infinite
       // CPU resources by repeatedly blocking / unblocking a task. By allowing it to go
       // negative, at most one task can "borrow" this worker's resources.

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <boost/range/adaptor/map.hpp>
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -47,10 +48,11 @@ class ResourceRequest {
 
   ResourceRequest(absl::flat_hash_map<ResourceID, FixedPoint> resource_map,
                   bool requires_object_store_memory)
-      : predefined_resources_(PredefinedResourcesEnum_MAX, 0),
-        requires_object_store_memory_(requires_object_store_memory) {
+      : equires_object_store_memory_(requires_object_store_memory) {
     for (auto entry : resource_map) {
-      Set(entry.first, entry.second);
+      if (entry.second != 0) {
+        custom_resources_[entry.first] = entry.second;
+      }
     }
   }
 
@@ -61,11 +63,11 @@ class ResourceRequest {
   /// Get the value of a particular resource.
   /// If the resource doesn't exist, return 0.
   FixedPoint Get(ResourceID resource_id) const {
-    auto ptr = GetPointer(resource_id);
-    if (ptr == nullptr) {
+    auto it = custom_resources_.find(resource_id);
+    if (it == custom_resources_.end()) {
       return FixedPoint(0);
     } else {
-      return *ptr;
+      return it->second;
     }
   }
 
@@ -73,43 +75,24 @@ class ResourceRequest {
   /// NOTE: if the new value is 0, the resource will be removed.
   ResourceRequest &Set(ResourceID resource_id, FixedPoint value) {
     if (value == 0) {
-      if (IsPredefinedResource(resource_id)) {
-        predefined_resources_[resource_id.ToInt()] = 0;
-      } else {
-        custom_resources_.erase(resource_id.ToInt());
-      }
+      custom_resources_.erase(resource_id);
     } else {
-      auto ptr = GetPointer(resource_id);
-      if (ptr == nullptr) {
-        custom_resources_[resource_id.ToInt()] = value;
-      } else {
-        *ptr = value;
-      }
+      custom_resources_[resource_id] = value;
     }
     return *this;
   }
 
   /// Check whether a particular resource exist.
   bool Has(ResourceID resource_id) const {
-    auto ptr = GetPointer(resource_id);
-    return ptr != nullptr && *ptr != 0;
+    auto it = custom_resources_.find(resource_id);
+    return it != custom_resources_.end();
   }
 
   /// Clear the whole set.
-  void Clear() {
-    for (size_t i = 0; i < predefined_resources_.size(); i++) {
-      predefined_resources_[i] = 0;
-    }
-    custom_resources_.clear();
-  }
+  void Clear() { custom_resources_.clear(); }
 
   /// Remove the negative values in this set.
   void RemoveNegative() {
-    for (size_t i = 0; i < predefined_resources_.size(); i++) {
-      if (predefined_resources_[i] < 0) {
-        predefined_resources_[i] = 0;
-      }
-    }
     for (auto it = custom_resources_.begin(); it != custom_resources_.end();) {
       if (it->second < 0) {
         custom_resources_.erase(it++);
@@ -120,38 +103,22 @@ class ResourceRequest {
   }
 
   /// Return the number of resources in this set.
-  size_t Size() const {
-    size_t size = custom_resources_.size();
-    for (size_t i = 0; i < PredefinedResourcesEnum_MAX; i++) {
-      if (predefined_resources_[i] != 0) {
-        size++;
-      }
-    }
-    return size;
-  }
+  size_t Size() const { return custom_resources_.size(); }
 
   /// Return true if this set is empty.
-  bool IsEmpty() const { return Size() == 0; }
+  bool IsEmpty() const { return custom_resources_.empty(); }
 
   /// Return a set that contains all resource ids in this set.
-  absl::flat_hash_set<ResourceID> ResourceIds() const {
-    absl::flat_hash_set<ResourceID> res;
-    for (size_t i = 0; i < predefined_resources_.size(); i++) {
-      if (predefined_resources_[i] != 0) {
-        res.insert(ResourceID(i));
-      }
-    }
-    for (auto &entry : custom_resources_) {
-      res.insert(ResourceID(entry.first));
-    }
-    return res;
+  boost::select_first_range<absl::flat_hash_map<ResourceID, FixedPoint>> ResourceIds()
+      const {
+    return boost::adaptors::keys(custom_resources_);
   }
 
   /// Return a map from the resource ids to the values.
   absl::flat_hash_map<ResourceID, FixedPoint> ToMap() const {
     absl::flat_hash_map<ResourceID, FixedPoint> res;
-    for (auto &resource_id : ResourceIds()) {
-      res.emplace(resource_id, Get(resource_id));
+    for (auto entry : custom_resources_) {
+      res.emplace(entry.first, entry.second);
     }
     return res;
   }
@@ -169,10 +136,6 @@ class ResourceRequest {
   }
 
   ResourceRequest &operator+=(const ResourceRequest &other) {
-    for (size_t i = 0; i < predefined_resources_.size(); i++) {
-      predefined_resources_[i] += other.predefined_resources_[i];
-    }
-
     for (auto &entry : other.custom_resources_) {
       auto it = custom_resources_.find(entry.first);
       if (it != custom_resources_.end()) {
@@ -188,10 +151,6 @@ class ResourceRequest {
   }
 
   ResourceRequest &operator-=(const ResourceRequest &other) {
-    for (size_t i = 0; i < predefined_resources_.size(); i++) {
-      predefined_resources_[i] -= other.predefined_resources_[i];
-    }
-
     for (auto &entry : other.custom_resources_) {
       auto it = custom_resources_.find(entry.first);
       if (it != custom_resources_.end()) {
@@ -207,8 +166,7 @@ class ResourceRequest {
   }
 
   bool operator==(const ResourceRequest &other) const {
-    return predefined_resources_ == other.predefined_resources_ &&
-           this->custom_resources_ == other.custom_resources_;
+    return this->custom_resources_ == other.custom_resources_;
   }
 
   bool operator!=(const ResourceRequest &other) const { return !(*this == other); }
@@ -217,11 +175,6 @@ class ResourceRequest {
   /// If A <= B, it means for each resource, its value in A is less than or equqal to that
   /// in B.
   bool operator<=(const ResourceRequest &other) const {
-    for (size_t i = 0; i < predefined_resources_.size(); i++) {
-      if (predefined_resources_[i] > other.predefined_resources_[i]) {
-        return false;
-      }
-    }
     // Check all resources that exist in this.
     for (auto &entry : custom_resources_) {
       auto &this_value = entry.second;
@@ -267,31 +220,8 @@ class ResourceRequest {
   }
 
  private:
-  /// Return a pointer to the given resource, or nullptr if the resource doesn't exist.
-  /// NOTE, this function doesn't mutate values. But it returns non-const pointer, so it's
-  /// not marked as const.
-  FixedPoint *GetPointer(ResourceID id) {
-    if (IsPredefinedResource(id)) {
-      return &predefined_resources_[id.ToInt()];
-    } else {
-      auto it = custom_resources_.find(id.ToInt());
-      if (it == custom_resources_.end()) {
-        return nullptr;
-      } else {
-        return &it->second;
-      }
-    }
-  }
-
-  /// The const version of GetPointer.
-  const FixedPoint *GetPointer(ResourceID id) const {
-    return const_cast<ResourceRequest *>(this)->GetPointer(id);
-  }
-
-  /// The predefined resources.
-  std::vector<FixedPoint> predefined_resources_;
   /// The custom resources.
-  absl::flat_hash_map<int64_t, FixedPoint> custom_resources_;
+  absl::flat_hash_map<ResourceID, FixedPoint> custom_resources_;
   /// Whether this task requires object store memory.
   /// TODO(swang): This should be a quantity instead of a flag.
   bool requires_object_store_memory_ = false;
@@ -306,17 +236,10 @@ class ResourceRequest {
 class TaskResourceInstances {
  public:
   /// Construct an empty TaskResourceInstances.
-  TaskResourceInstances() {
-    for (size_t i = 0; i < PredefinedResourcesEnum_MAX; i++) {
-      this->predefined_resources_.push_back({});
-    }
-  }
+  TaskResourceInstances() {}
 
   /// Construct a TaskResourceInstances with the values from a ResourceRequest.
   TaskResourceInstances(const ResourceRequest &request) {
-    for (size_t i = 0; i < PredefinedResourcesEnum_MAX; i++) {
-      this->predefined_resources_.push_back({});
-    }
     for (auto &resource_id : request.ResourceIds()) {
       std::vector<FixedPoint> instances;
       auto value = request.Get(resource_id);
@@ -336,9 +259,9 @@ class TaskResourceInstances {
   /// NOTE: the resource MUST already exist in this TaskResourceInstances, otherwise a
   /// check fail will occur.
   const std::vector<FixedPoint> &Get(const ResourceID resource_id) const {
-    auto ptr = GetPointer(resource_id);
-    RAY_CHECK(ptr != nullptr) << "Resource ID not found " << resource_id;
-    return *ptr;
+    auto it = custom_resources_.find(resource_id);
+    RAY_CHECK(it != custom_resources_.end()) << "Resource ID not found " << resource_id;
+    return it->second;
   }
 
   /// Get the per-instance double values of a particular resource.
@@ -363,15 +286,15 @@ class TaskResourceInstances {
   /// check fail will occur.
   /// TODO(hchen): We should hide this method, and encapsulate all mutation operations.
   std::vector<FixedPoint> &GetMutable(const ResourceID resource_id) {
-    auto ptr = GetPointer(resource_id);
-    RAY_CHECK(ptr != nullptr) << "Resource ID not found " << resource_id;
-    return *ptr;
+    auto it = custom_resources_.find(resource_id);
+    RAY_CHECK(it != custom_resources_.end()) << "Resource ID not found " << resource_id;
+    return it->second;
   }
 
   /// Check whether a particular resource exists.
   bool Has(ResourceID resource_id) const {
-    auto ptr = GetPointer(resource_id);
-    return ptr != nullptr && ptr->size() > 0;
+    auto it = custom_resources_.find(resource_id);
+    return it != custom_resources_.end();
   }
 
   /// Set the per-instance values for a particular resource.
@@ -380,19 +303,14 @@ class TaskResourceInstances {
     if (instances.size() == 0) {
       Remove(resource_id);
     } else {
-      auto ptr = GetPointer(resource_id);
-      if (ptr != nullptr) {
-        *ptr = instances;
-      } else {
-        custom_resources_.emplace(resource_id.ToInt(), instances);
-      }
+      custom_resources_.emplace(resource_id, instances);
     }
     return *this;
   }
 
   /// Add values for each instance of the given resource.
-  /// Note, if the number of instances in this set is less than the given instance vector,
-  /// more instances will be appended to match the number.
+  /// Note, if the number of instances in this set is less than the given instance
+  /// vector, more instances will be appended to match the number.
   void Add(const ResourceID resource_id, const std::vector<FixedPoint> &instances) {
     if (!Has(resource_id)) {
       Set(resource_id, instances);
@@ -408,49 +326,21 @@ class TaskResourceInstances {
   }
 
   /// Remove a particular resource.
-  void Remove(ResourceID resource_id) {
-    if (IsPredefinedResource(resource_id)) {
-      auto &instances = GetMutable(resource_id);
-      instances.clear();
-    } else {
-      custom_resources_.erase(resource_id.ToInt());
-    }
-  }
+  void Remove(ResourceID resource_id) { custom_resources_.erase(resource_id); }
 
   /// Return a set of all resource ids.
-  absl::flat_hash_set<ResourceID> ResourceIds() const {
-    absl::flat_hash_set<ResourceID> res;
-    for (size_t i = 0; i < predefined_resources_.size(); i++) {
-      if (predefined_resources_[i].size() > 0) {
-        res.insert(ResourceID(i));
-      }
-    }
-    for (auto &entry : custom_resources_) {
-      res.insert(ResourceID(entry.first));
-    }
-    return res;
+  boost::select_first_range<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>
+  ResourceIds() const {
+    return boost::adaptors::keys(custom_resources_);
   }
 
   /// Return the number of resources in this set.
-  size_t Size() const {
-    size_t size = custom_resources_.size();
-    for (size_t i = 0; i < PredefinedResourcesEnum_MAX; i++) {
-      if (predefined_resources_[i].size() > 0) {
-        size++;
-      }
-    }
-    return size;
-  }
+  size_t Size() const { return custom_resources_.size(); }
 
   /// Check whether this set is empty.
-  bool IsEmpty() const { return Size() == 0; }
+  bool IsEmpty() const { return custom_resources_.empty(); }
 
   bool operator==(const TaskResourceInstances &other) const {
-    for (size_t i = 0; i < PredefinedResourcesEnum_MAX; i++) {
-      if (this->predefined_resources_[i] != other.predefined_resources_[i]) {
-        return false;
-      }
-    }
     return this->custom_resources_ == other.custom_resources_;
   }
 
@@ -485,10 +375,11 @@ class TaskResourceInstances {
     std::stringstream buffer;
     buffer << "{";
     for (size_t i = 0; i < PredefinedResourcesEnum_MAX; i++) {
-      std::vector<FixedPoint> resource = predefined_resources_[i];
-      if (resource.empty()) {
+      auto resource_id = ResourceID(i);
+      if (!Has(resource_id)) {
         continue;
       }
+      auto &resource = Get(resource_id);
       if (has_added_resource) {
         buffer << ",";
       }
@@ -514,27 +405,8 @@ class TaskResourceInstances {
   }
 
  private:
-  std::vector<FixedPoint> *GetPointer(ResourceID id) {
-    if (IsPredefinedResource(id)) {
-      return &predefined_resources_[id.ToInt()];
-    } else {
-      auto it = custom_resources_.find(id.ToInt());
-      if (it == custom_resources_.end()) {
-        return nullptr;
-      } else {
-        return &it->second;
-      }
-    }
-  }
-
-  const std::vector<FixedPoint> *GetPointer(ResourceID id) const {
-    return const_cast<TaskResourceInstances *>(this)->GetPointer(id);
-  }
-
-  /// The predefined resources.
-  std::vector<std::vector<FixedPoint>> predefined_resources_;
   /// The custom resources.
-  absl::flat_hash_map<int64_t, std::vector<FixedPoint>> custom_resources_;
+  absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> custom_resources_;
 };
 
 /// Total and available capacities of each resource of a node.

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -39,6 +39,9 @@ bool IsPredefinedResource(scheduling::ResourceID resource_id);
 /// "requires_object_store_memory_" field, and rename this class to ResourceSet.
 class ResourceRequest {
  public:
+  using ResourceIdIterator =
+      boost::select_first_range<absl::flat_hash_map<ResourceID, FixedPoint>>;
+
   /// Construct an empty ResourceRequest.
   ResourceRequest() : ResourceRequest({}, false) {}
 
@@ -48,7 +51,7 @@ class ResourceRequest {
 
   ResourceRequest(absl::flat_hash_map<ResourceID, FixedPoint> resource_map,
                   bool requires_object_store_memory)
-      : equires_object_store_memory_(requires_object_store_memory) {
+      : requires_object_store_memory_(requires_object_store_memory) {
     for (auto entry : resource_map) {
       if (entry.second != 0) {
         resources_[entry.first] = entry.second;
@@ -108,11 +111,8 @@ class ResourceRequest {
   /// Return true if this set is empty.
   bool IsEmpty() const { return resources_.empty(); }
 
-  /// Return a set that contains all resource ids in this set.
-  boost::select_first_range<absl::flat_hash_map<ResourceID, FixedPoint>> ResourceIds()
-      const {
-    return boost::adaptors::keys(resources_);
-  }
+  /// Return a boost::range object that can be used as an iterator of the resource IDs.
+  ResourceIdIterator ResourceIds() const { return boost::adaptors::keys(resources_); }
 
   /// Return a map from the resource ids to the values.
   absl::flat_hash_map<ResourceID, FixedPoint> ToMap() const {
@@ -235,6 +235,9 @@ class ResourceRequest {
 /// ResourceInstanceSet.
 class TaskResourceInstances {
  public:
+  using ResourceIdIterator =
+      boost::select_first_range<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>;
+
   /// Construct an empty TaskResourceInstances.
   TaskResourceInstances() {}
 
@@ -328,11 +331,8 @@ class TaskResourceInstances {
   /// Remove a particular resource.
   void Remove(ResourceID resource_id) { resources_.erase(resource_id); }
 
-  /// Return a set of all resource ids.
-  boost::select_first_range<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>
-  ResourceIds() const {
-    return boost::adaptors::keys(resources_);
-  }
+  /// Return a boost::range object that can be used as an iterator of the resource IDs.
+  ResourceIdIterator ResourceIds() const { return boost::adaptors::keys(resources_); }
 
   /// Return the number of resources in this set.
   size_t Size() const { return resources_.size(); }

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -87,8 +87,7 @@ class ResourceRequest {
 
   /// Check whether a particular resource exist.
   bool Has(ResourceID resource_id) const {
-    auto it = resources_.find(resource_id);
-    return it != resources_.end();
+    return resources_.contains(resource_id);
   }
 
   /// Clear the whole set.
@@ -296,8 +295,7 @@ class TaskResourceInstances {
 
   /// Check whether a particular resource exists.
   bool Has(ResourceID resource_id) const {
-    auto it = resources_.find(resource_id);
-    return it != resources_.end();
+    return resources_.contains(resource_id);
   }
 
   /// Set the per-instance values for a particular resource.

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -300,7 +300,7 @@ class TaskResourceInstances {
     if (instances.size() == 0) {
       Remove(resource_id);
     } else {
-      resources_.emplace(resource_id, instances);
+      resources_[resource_id] = instances;
     }
     return *this;
   }

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -220,7 +220,7 @@ class ResourceRequest {
   }
 
  private:
-  /// The custom resources.
+  /// Map from the resource IDs to the resource values.
   absl::flat_hash_map<ResourceID, FixedPoint> resources_;
   /// Whether this task requires object store memory.
   /// TODO(swang): This should be a quantity instead of a flag.
@@ -405,7 +405,7 @@ class TaskResourceInstances {
   }
 
  private:
-  /// The custom resources.
+  /// Map from the resource IDs to the resource values.
   absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> resources_;
 };
 

--- a/src/ray/raylet/scheduling/cluster_resource_data.h
+++ b/src/ray/raylet/scheduling/cluster_resource_data.h
@@ -86,9 +86,7 @@ class ResourceRequest {
   }
 
   /// Check whether a particular resource exist.
-  bool Has(ResourceID resource_id) const {
-    return resources_.contains(resource_id);
-  }
+  bool Has(ResourceID resource_id) const { return resources_.contains(resource_id); }
 
   /// Clear the whole set.
   void Clear() { resources_.clear(); }
@@ -294,9 +292,7 @@ class TaskResourceInstances {
   }
 
   /// Check whether a particular resource exists.
-  bool Has(ResourceID resource_id) const {
-    return resources_.contains(resource_id);
-  }
+  bool Has(ResourceID resource_id) const { return resources_.contains(resource_id); }
 
   /// Set the per-instance values for a particular resource.
   TaskResourceInstances &Set(const ResourceID resource_id,

--- a/src/ray/raylet/scheduling/resource_request_test.cc
+++ b/src/ray/raylet/scheduling/resource_request_test.cc
@@ -49,8 +49,10 @@ TEST_F(ResourceRequestTest, TestBasic) {
   ASSERT_FALSE(resource_request.IsEmpty());
 
   // Test ResourceIds and ToMap
-  ASSERT_EQ(resource_request.ResourceIds(),
-            absl::flat_hash_set<ResourceID>({cpu_id, custom_id1}));
+  auto resource_ids_it = resource_request.ResourceIds();
+  auto resource_ids =
+      absl::flat_hash_set<ResourceID>(resource_ids_it.begin(), resource_ids_it.end());
+  ASSERT_EQ(resource_ids, absl::flat_hash_set<ResourceID>({cpu_id, custom_id1}));
   ASSERT_EQ(resource_request.ToMap(), resource_map);
 
   // Test Set
@@ -184,8 +186,10 @@ TEST_F(TaskResourceInstancesTest, TestBasic) {
   ASSERT_FALSE(task_resource_instances.Has(custom_id1));
 
   // Test ResourceIds
-  ASSERT_EQ(task_resource_instances.ResourceIds(),
-            absl::flat_hash_set<ResourceID>({cpu_id, gpu_id}));
+  auto resource_ids_it = task_resource_instances.ResourceIds();
+  auto resource_ids =
+      absl::flat_hash_set<ResourceID>(resource_ids_it.begin(), resource_ids_it.end());
+  ASSERT_EQ(resource_ids, absl::flat_hash_set<ResourceID>({cpu_id, gpu_id}));
 
   // Test Size and IsEmpty
   ASSERT_EQ(task_resource_instances.Size(), 2);

--- a/src/ray/raylet/scheduling/resource_request_test.cc
+++ b/src/ray/raylet/scheduling/resource_request_test.cc
@@ -180,6 +180,9 @@ TEST_F(TaskResourceInstancesTest, TestBasic) {
   task_resource_instances.Set(custom_id1, FixedPointVectorFromDouble({1}));
   ASSERT_TRUE(task_resource_instances.Has(custom_id1));
   ASSERT_EQ(task_resource_instances.Get(custom_id1), FixedPointVectorFromDouble({1}));
+  task_resource_instances.Set(custom_id1, FixedPointVectorFromDouble({2}));
+  ASSERT_TRUE(task_resource_instances.Has(custom_id1));
+  ASSERT_EQ(task_resource_instances.Get(custom_id1), FixedPointVectorFromDouble({2}));
 
   // Test Clear
   task_resource_instances.Remove(custom_id1);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

"ResourceRequest" now uses 2 containers: a vector for predefined resources, and a map for custom resources. 
This was intended to be a perf optimization. However, in practice, this makes the code more complex, and, moreover, prevents optimizations for some methods (e.g., "ResourceIds", "Size").

This PR removes the vector and makes ResourceRequest use only one map for all resources. Also, "ResourceIds" now returns a "boost:range" to allow iterating resource IDs without having to construct temporary sets. 

microbenchmark shows a slight perf improvement.
last nightly: `placement group create/removal per second 837.76 +- 16.68`.
this PR: `placement group create/removal per second 895.76 +- 16.99`.

## Related issue number

#22850

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
