### PR TITLE
[syncer] skip ray_syncer_test on windows temporarily 

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -125,6 +125,7 @@ test_core() {
         -//:gcs_pub_sub_test
         -//:gcs_server_test
         -//:gcs_server_rpc_test
+        -//:ray_syncer_test # TODO (iycheng): it's flaky on windows. Add it back once we figure out the cause
       )
       ;;
   esac
@@ -206,7 +207,7 @@ test_cpp() {
   # run cluster mode test with external cluster
   bazel test //cpp:cluster_mode_test --test_arg=--external_cluster=true --test_arg=--redis_password="1234" \
     --test_arg=--ray_redis_password="1234"
-  
+
   bazel test --test_output=all //cpp:test_python_call_cpp
 
   # run the cpp example

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -207,7 +207,6 @@ test_cpp() {
   # run cluster mode test with external cluster
   bazel test //cpp:cluster_mode_test --test_arg=--external_cluster=true --test_arg=--redis_password="1234" \
     --test_arg=--ray_redis_password="1234"
-
   bazel test --test_output=all //cpp:test_python_call_cpp
 
   # run the cpp example


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
ray_syncer_test is flaky on windows. It's not so easy to investigate what's happening there.  The test timeout  somehow.
We disable it for short time.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
