### PR TITLE
Enable conda runtime creation in workers on windows

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -167,9 +167,6 @@ test_python() {
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?
     install_ray
-    # DEBUG: are there wheels for runtime_env testing?
-    echo "${PWD}"
-    ls .whl
 
     # Shard the args.
     BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB:-'0'}
@@ -184,9 +181,9 @@ test_python() {
     bazel test --config=ci \
       --build_tests_only $(./ci/run/bazel_export_options) \
       --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
+      --test_env=CI="1" \
+      --test_env=RAY_CI_POST_WHEEL_TESTS="1" \
       --test_env=USERPROFILE="${USERPROFILE}" \
-      --test_env=CI=1 \
-      --test_env=RAY_CI_POST_WHEEL_TESTS=1 \
       --test_output=streamed \
       -- \
       ${test_shard_selection};

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -167,6 +167,9 @@ test_python() {
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?
     install_ray
+    # DEBUG: are there wheels for runtime_env testing?
+    echo "${PWD}"
+    ls .whl
 
     # Shard the args.
     BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB:-'0'}
@@ -341,6 +344,11 @@ install_ray() {
     cd "${WORKSPACE_DIR}"/python
     build_dashboard_front_end
     keep_alive pip install -v -e .
+  )
+  (
+    # For runtime_env tests, wheels are needed
+    cd "${WORKSPACE_DIR}"
+    keep_alive pip wheel -e python -w .whl
   )
 }
 

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -71,7 +71,11 @@ def _inject_ray_to_conda_site(
         python_binary = os.path.join(conda_path, "bin/python")
     site_packages_path = (
         subprocess.check_output(
-            [python_binary, "-c", "import site; print(site.getsitepackages()[0])"]
+            [
+                python_binary,
+                "-c",
+                "import sysconfig; print(sysconfig.get_paths()['purelib'])",
+            ]
         )
         .decode()
         .strip()
@@ -79,7 +83,7 @@ def _inject_ray_to_conda_site(
 
     ray_path = _resolve_current_ray_path()
     logger.warning(
-        f"Injecting {ray_path} to environment {conda_path} "
+        f"Injecting {ray_path} to environment site-packages {site_packages_path} "
         "because _inject_current_ray flag is on."
     )
 
@@ -90,7 +94,7 @@ def _inject_ray_to_conda_site(
 
     # See usage of *.pth file at
     # https://docs.python.org/3/library/site.html
-    with open(os.path.join(site_packages_path, "ray.pth"), "w") as f:
+    with open(os.path.join(site_packages_path, "ray_shared.pth"), "w") as f:
         f.write(ray_path)
 
 

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -612,9 +612,6 @@ def test_runtime_env_retry(set_runtime_env_retry_times, ray_start_regular):
             )
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="conda in runtime_env unsupported on Windows."
-)
 @pytest.mark.parametrize(
     "option",
     ["pip_list", "pip_dict", "conda_name", "conda_dict", "container", "plugins"],
@@ -664,9 +661,6 @@ def test_serialize_deserialize(option):
     assert cls_runtime_env_dict == runtime_env
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="conda in runtime_env unsupported on Windows."
-)
 def test_runtime_env_interface():
 
     # Test the interface related to working_dir

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -181,10 +181,6 @@ def test_client_tasks_and_actors_inherit_from_driver(conda_envs, call_ray_start)
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment",
 )
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 def test_task_actor_conda_env(conda_envs, shutdown_only):
     ray.init()
 
@@ -221,10 +217,6 @@ def test_task_actor_conda_env(conda_envs, shutdown_only):
 @pytest.mark.skipif(
     os.environ.get("CONDA_DEFAULT_ENV") is None,
     reason="must be run from within a conda environment",
-)
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
 )
 def test_job_config_conda_env(conda_envs, shutdown_only):
     for package_version in REQUEST_VERSIONS:
@@ -301,10 +293,6 @@ def test_get_conda_env_dir(tmp_path):
         assert env_dir == str(tmp_path / "envs" / "tf2")
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
-)
 @pytest.mark.skipif(
     os.environ.get("CONDA_EXE") is None,
     reason="Requires properly set-up conda shell",
@@ -399,8 +387,8 @@ def test_inject_dependencies():
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform == "win32",
-    reason=r"Requires wheel in .whl\ray-2.0.0.dev0-cp38-cp38-win_amd64.whl",
+    os.environ.get("CI") and sys.platform != "linux",
+    reason="This test is only run on linux CI machines.",
 )
 @pytest.mark.parametrize(
     "call_ray_start",

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -399,8 +399,8 @@ def test_inject_dependencies():
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="This test is only run on linux CI machines.",
+    os.environ.get("CI") and sys.platform == "win32",
+    reason=r"Requires wheel in .whl\ray-2.0.0.dev0-cp38-cp38-win_amd64.whl",
 )
 @pytest.mark.parametrize(
     "call_ray_start",

--- a/python/ray/tests/test_runtime_env_conda_and_pip.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip.py
@@ -19,7 +19,7 @@ import subprocess
 
 import ray
 
-if sys.platform == "win32" or not os.environ.get("CI"):
+if not os.environ.get("CI"):
     # This flags turns on the local development that link against current ray
     # packages and fall back all the dependencies to current python's site.
     os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
@@ -106,6 +106,10 @@ def test_requirements_files(start_cluster, field):
 
 
 class TestGC:
+    @pytest.mark.skipif(
+        os.environ.get("CI") and sys.platform != "linux",
+        reason="Needs PR wheels built in CI, so only run on linux CI machines.",
+    )
     @pytest.mark.parametrize("field", ["conda", "pip"])
     @pytest.mark.parametrize("spec_format", ["file", "python_object"])
     def test_job_level_gc(

--- a/python/ray/tests/test_runtime_env_conda_and_pip.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip.py
@@ -19,7 +19,7 @@ import subprocess
 
 import ray
 
-if not os.environ.get("CI"):
+if sys.platform == "win32" or not os.environ.get("CI"):
     # This flags turns on the local development that link against current ray
     # packages and fall back all the dependencies to current python's site.
     os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
@@ -106,10 +106,6 @@ def test_requirements_files(start_cluster, field):
 
 
 class TestGC:
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason="Needs PR wheels built in CI, so only run on linux CI machines.",
-    )
     @pytest.mark.parametrize("field", ["conda", "pip"])
     @pytest.mark.parametrize("spec_format", ["file", "python_object"])
     def test_job_level_gc(

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -12,10 +12,6 @@ if not os.environ.get("CI"):
     os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform not in ("linux", "win32"),
-    reason="Requires PR wheels built in CI",
-)
 def test_in_virtualenv(start_cluster):
     assert (
         PipProcessor._is_in_virtualenv() is False and "IN_VIRTUALENV" not in os.environ

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -13,8 +13,8 @@ if not os.environ.get("CI"):
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") and sys.platform != "linux",
-    reason="Requires PR wheels built in CI, so only run on linux CI machines.",
+    os.environ.get("CI") and sys.platform not in ("linux", "win32"),
+    reason="Requires PR wheels built in CI",
 )
 def test_in_virtualenv(start_cluster):
     assert (
@@ -60,7 +60,7 @@ class TestGC:
         ray.shutdown()
 
         # It should be OK if cluster ray meets the installing ray version.
-        ray.init(address, runtime_env={"pip": ["pip-install-test==0.5", "ray>1.6.0"]})
+        ray.init(address, runtime_env={"pip": ["pip-install-test==0.5", "ray>=1.12.0"]})
 
         @ray.remote
         def f():

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -38,6 +38,8 @@ def ray_start_client_server_pair(metadata=None, ray_connect_handler=None, **kwar
                 time.sleep(1)
                 if time.monotonic() - start > 30:
                     raise RuntimeError("Failed to terminate Ray")
+        # Allow windows to close processes before moving on
+        time.sleep(3)
 
 
 @contextmanager


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Continuation of #22449 

Fix the way a conda environment is created for a local worker to reuse the ray installation. The base problem was that `site.getsitepackages()[0]` did not return the site-packages library on windows. So I changed the call to use the more accepted `sysconfig.get_paths()['purelib']`. 

Along the way, I also made the test pass when using a `pip install -e .` which does not actually install ray into the site-packages directory, but uses a shim.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
