### PR TITLE
[datasets] Unify Datasets primitives on a common shuffle op

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -73,7 +73,7 @@ from ray.data.impl.stats import DatasetStats
 from ray.data.impl.compute import cache_wrapper, CallableClass, ComputeStrategy
 from ray.data.impl.output_buffer import BlockOutputBuffer
 from ray.data.impl.progress_bar import ProgressBar
-from ray.data.impl.shuffle import simple_shuffle
+from ray.data.impl.shuffle import shuffle_partitions
 from ray.data.impl.fast_repartition import fast_repartition
 from ray.data.impl.sort import sort_impl
 from ray.data.impl.block_list import BlockList
@@ -492,8 +492,9 @@ class Dataset(Generic[T]):
                     block_list.clear()
                 else:
                     blocks = block_list
-                return simple_shuffle(
+                return shuffle_partitions(
                     blocks,
+                    clear_input_blocks,
                     block_udf,
                     num_blocks,
                     map_ray_remote_args=remote_args,
@@ -561,8 +562,9 @@ class Dataset(Generic[T]):
                 block_list.clear()
             else:
                 blocks = block_list
-            new_blocks, stage_info = simple_shuffle(
+            new_blocks, stage_info = shuffle_partitions(
                 blocks,
+                clear_input_blocks,
                 block_udf,
                 num_blocks,
                 random_shuffle=True,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1445,7 +1445,7 @@ class Dataset(Generic[T]):
                     _validate_key_fn(self, subkey)
             else:
                 _validate_key_fn(self, key)
-            return sort_impl(blocks, key, descending)
+            return sort_impl(blocks, clear_input_blocks, key, descending)
 
         plan = self._plan.with_stage(AllToAllStage("sort", None, do_sort))
         return Dataset(plan, self._epoch, self._lazy)

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -12,7 +12,42 @@ from ray.data.impl.block_list import BlockList
 from ray.data.impl.compute import CallableClass, ComputeStrategy
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.progress_bar import ProgressBar
+from ray.data.impl.shuffle import ShuffleOp
 from ray.data.block import Block, BlockAccessor, BlockMetadata, T, U, KeyType
+
+
+class GroupbyOp(ShuffleOp):
+    @staticmethod
+    def map(
+        idx: int,
+        block: Block,
+        output_num_blocks: int,
+        boundaries: List[KeyType], key: KeyFn, aggs: Tuple[AggregateFn]
+    ) -> List[Union[BlockMetadata, Block]]:
+        """Partition the block and combine rows with the same key."""
+        stats = BlockExecStats.builder()
+        if key is None:
+            partitions = [block]
+        else:
+            partitions = BlockAccessor.for_block(block).sort_and_partition(
+                boundaries,
+                [(key, "ascending")] if isinstance(key, str) else key,
+                descending=False,
+            )
+        parts = [BlockAccessor.for_block(p).combine(key, aggs) for p in partitions]
+        meta = BlockAccessor.for_block(block).get_metadata(
+            input_files=None, exec_stats=stats.build()
+        )
+        return [meta] + parts
+
+    @staticmethod
+    def reduce(
+        key: KeyFn, aggs: Tuple[AggregateFn], *mapper_outputs: List[Block]
+    ) -> (Block, BlockMetadata):
+        """Aggregate sorted and partially combined blocks."""
+        return BlockAccessor.for_block(mapper_outputs[0]).aggregate_combined_blocks(
+            list(mapper_outputs), key, aggs
+        )
 
 
 @PublicAPI
@@ -86,42 +121,14 @@ class GroupedDataset(Generic[T]):
                     else self._key,
                     num_reducers,
                 )
-
-            partition_and_combine_block = cached_remote_fn(
-                _partition_and_combine_block
-            ).options(num_returns=num_reducers + 1)
-            aggregate_combined_blocks = cached_remote_fn(
-                _aggregate_combined_blocks, num_returns=2
-            )
-
-            map_results = np.empty((num_mappers, num_reducers), dtype=object)
-            map_meta = []
-            for i, block in enumerate(blocks.get_blocks()):
-                results = partition_and_combine_block.remote(
-                    block, boundaries, self._key, aggs
-                )
-                map_results[i, :] = results[:-1]
-                map_meta.append(results[-1])
-            map_bar = ProgressBar("GroupBy Map", len(map_results))
-            map_bar.block_until_complete(map_meta)
-            stage_info["map"] = ray.get(map_meta)
-            map_bar.close()
-
-            blocks = []
-            metadata = []
-            for j in range(num_reducers):
-                block, meta = aggregate_combined_blocks.remote(
-                    num_reducers, self._key, aggs, *map_results[:, j].tolist()
-                )
-                blocks.append(block)
-                metadata.append(meta)
-            reduce_bar = ProgressBar("GroupBy Reduce", len(blocks))
-            reduce_bar.block_until_complete(blocks)
-            reduce_bar.close()
-
-            metadata = ray.get(metadata)
-            stage_info["reduce"] = metadata
-            return BlockList(blocks, metadata), stage_info
+            shuffle_op = GroupbyOp(
+                    map_args=[boundaries, self._key, aggs],
+                    reduce_args=[self._key, aggs])
+            return shuffle_op.execute(
+                    blocks,
+                    num_reducers,
+                    clear_input_blocks,
+                    )
 
         plan = self._dataset._plan.with_stage(AllToAllStage("aggregate", None, do_agg))
         return Dataset(
@@ -603,32 +610,3 @@ class GroupedDataset(Generic[T]):
             If groupby key is ``None`` then the key part of return is omitted.
         """
         return self._aggregate_on(Std, on, ignore_nulls, ddof=ddof)
-
-
-def _partition_and_combine_block(
-    block: Block[T], boundaries: List[KeyType], key: KeyFn, aggs: Tuple[AggregateFn]
-) -> List[Union[Block, BlockMetadata]]:
-    """Partition the block and combine rows with the same key."""
-    stats = BlockExecStats.builder()
-    if key is None:
-        partitions = [block]
-    else:
-        partitions = BlockAccessor.for_block(block).sort_and_partition(
-            boundaries,
-            [(key, "ascending")] if isinstance(key, str) else key,
-            descending=False,
-        )
-    parts = [BlockAccessor.for_block(p).combine(key, aggs) for p in partitions]
-    meta = BlockAccessor.for_block(block).get_metadata(
-        input_files=None, exec_stats=stats.build()
-    )
-    return parts + [meta]
-
-
-def _aggregate_combined_blocks(
-    num_reducers: int, key: KeyFn, aggs: Tuple[AggregateFn], *blocks: Tuple[Block, ...]
-) -> Tuple[Block[U], BlockMetadata]:
-    """Aggregate sorted and partially combined blocks."""
-    return BlockAccessor.for_block(blocks[0]).aggregate_combined_blocks(
-        list(blocks), key, aggs
-    )

--- a/python/ray/data/impl/fast_repartition.py
+++ b/python/ray/data/impl/fast_repartition.py
@@ -35,7 +35,7 @@ def fast_repartition(blocks, num_blocks):
     reduce_task = cached_remote_fn(ShufflePartitionOp.reduce).options(num_returns=2)
     reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))
     reduce_out = [
-        reduce_task.remote(*s.get_internal_block_refs())
+        reduce_task.remote(False, None, *s.get_internal_block_refs())
         for s in splits
         if s.num_blocks() > 0
     ]

--- a/python/ray/data/impl/fast_repartition.py
+++ b/python/ray/data/impl/fast_repartition.py
@@ -5,7 +5,7 @@ from ray.data.impl.block_list import BlockList
 from ray.data.impl.plan import ExecutionPlan
 from ray.data.impl.progress_bar import ProgressBar
 from ray.data.impl.remote_fn import cached_remote_fn
-from ray.data.impl.shuffle import _shuffle_reduce
+from ray.data.impl.shuffle import ShufflePartitionOp
 from ray.data.impl.stats import DatasetStats
 
 
@@ -32,7 +32,7 @@ def fast_repartition(blocks, num_blocks):
     # consider combining the split and coalesce tasks as an optimization.
 
     # Coalesce each split into a single block.
-    reduce_task = cached_remote_fn(_shuffle_reduce).options(num_returns=2)
+    reduce_task = cached_remote_fn(ShufflePartitionOp.reduce).options(num_returns=2)
     reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))
     reduce_out = [
         reduce_task.remote(*s.get_internal_block_refs())

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -89,7 +89,7 @@ class ShuffleOp:
         shuffle_map_metadata = map_bar.fetch_until_complete(shuffle_map_metadata)
         map_bar.close()
 
-        reduce_bar = ProgressBar("Shuffle Reduce", position=0, total=output_num_blocks)
+        reduce_bar = ProgressBar("Shuffle Reduce", total=output_num_blocks)
         shuffle_reduce_out = [
             shuffle_reduce.options(**reduce_ray_remote_args, num_returns=2,).remote(
                 *self._reduce_args,

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -13,164 +13,158 @@ from ray.data.impl.remote_fn import cached_remote_fn
 T = TypeVar("T")
 
 
-def simple_shuffle(shuffle_map, shuffle_reduce,
+class ShuffleOp:
+    def __init__(self, *map_args: List[Any]):
+        self._map_args = map_args
+
+    @staticmethod
+    def map(
+        idx: int, block: Block, output_num_blocks: int, *args: List[Any]
+    ) -> List[Union[BlockMetadata, Block]]:
+        raise NotImplementedError
+
+    @staticmethod
+    def reduce(*mapper_outputs: List[Block]) -> (Block, BlockMetadata):
+        raise NotImplementedError
+
+    def execute(
+        self,
         input_blocks: BlockList,
         output_num_blocks: int,
         clear_input_blocks: bool,
-        map_args: List[Any],
-        #reduce_args: List[Any],
         *,
         map_ray_remote_args: Optional[Dict[str, Any]] = None,
-        reduce_ray_remote_args: Optional[Dict[str, Any]] = None):
-    input_blocks_list = input_blocks.get_blocks()
-    input_num_blocks = len(input_blocks_list)
+        reduce_ray_remote_args: Optional[Dict[str, Any]] = None
+    ) -> Tuple[BlockList, Dict[str, List[BlockMetadata]]]:
+        input_blocks_list = input_blocks.get_blocks()
+        input_num_blocks = len(input_blocks_list)
 
-    if map_ray_remote_args is None:
-        map_ray_remote_args = {}
-    if reduce_ray_remote_args is None:
-        reduce_ray_remote_args = {}
-    if "scheduling_strategy" not in reduce_ray_remote_args:
-        reduce_ray_remote_args = reduce_ray_remote_args.copy()
-        reduce_ray_remote_args["scheduling_strategy"] = "SPREAD"
+        if map_ray_remote_args is None:
+            map_ray_remote_args = {}
+        if reduce_ray_remote_args is None:
+            reduce_ray_remote_args = {}
+        if "scheduling_strategy" not in reduce_ray_remote_args:
+            reduce_ray_remote_args = reduce_ray_remote_args.copy()
+            reduce_ray_remote_args["scheduling_strategy"] = "SPREAD"
 
-    map_bar = ProgressBar("Shuffle Map", position=0, total=input_num_blocks)
+        shuffle_map = cached_remote_fn(self.map)
+        shuffle_reduce = cached_remote_fn(self.reduce)
 
-    shuffle_map_out = [
-        shuffle_map.options(
-            **map_ray_remote_args,
-            num_returns=1 + output_num_blocks,
-        ).remote(i, block, output_num_blocks, *map_args)
-        for i, block in enumerate(input_blocks_list)
-    ]
+        map_bar = ProgressBar("Shuffle Map", position=0, total=input_num_blocks)
 
-    # The first item returned is the BlockMetadata.
-    shuffle_map_metadata = []
-    for i, refs in enumerate(shuffle_map_out):
-        shuffle_map_metadata.append(refs[0])
-        shuffle_map_out[i] = refs[1:]
+        shuffle_map_out = [
+            shuffle_map.options(
+                **map_ray_remote_args,
+                num_returns=1 + output_num_blocks,
+            ).remote(i, block, output_num_blocks, *self._map_args)
+            for i, block in enumerate(input_blocks_list)
+        ]
 
-    # Eagerly delete the input block references in order to eagerly release
-    # the blocks' memory.
-    del input_blocks_list
-    if clear_input_blocks:
-        input_blocks.clear()
-    shuffle_map_metadata = map_bar.fetch_until_complete(shuffle_map_metadata)
-    map_bar.close()
+        # The first item returned is the BlockMetadata.
+        shuffle_map_metadata = []
+        for i, refs in enumerate(shuffle_map_out):
+            shuffle_map_metadata.append(refs[0])
+            shuffle_map_out[i] = refs[1:]
 
-    reduce_bar = ProgressBar("Shuffle Reduce", position=0, total=output_num_blocks)
-    shuffle_reduce_out = [
-        shuffle_reduce.options(
-            **reduce_ray_remote_args,
-            num_returns=2,
-        ).remote(*[shuffle_map_out[i][j] for i in range(input_num_blocks)])
-        for j in range(output_num_blocks)
-    ]
-    # Eagerly delete the map block references in order to eagerly release
-    # the blocks' memory.
-    del shuffle_map_out
-    new_blocks, new_metadata = zip(*shuffle_reduce_out)
-    reduce_bar.block_until_complete(list(new_blocks))
-    new_metadata = ray.get(list(new_metadata))
-    reduce_bar.close()
+        # Eagerly delete the input block references in order to eagerly release
+        # the blocks' memory.
+        del input_blocks_list
+        if clear_input_blocks:
+            input_blocks.clear()
+        shuffle_map_metadata = map_bar.fetch_until_complete(shuffle_map_metadata)
+        map_bar.close()
 
-    stats = {
-        "map": shuffle_map_metadata,
-        "reduce": new_metadata,
-    }
+        reduce_bar = ProgressBar("Shuffle Reduce", position=0, total=output_num_blocks)
+        shuffle_reduce_out = [
+            shuffle_reduce.options(
+                **reduce_ray_remote_args,
+                num_returns=2,
+            ).remote(*[shuffle_map_out[i][j] for i in range(input_num_blocks)])
+            for j in range(output_num_blocks)
+        ]
+        # Eagerly delete the map block references in order to eagerly release
+        # the blocks' memory.
+        del shuffle_map_out
+        new_blocks, new_metadata = zip(*shuffle_reduce_out)
+        reduce_bar.block_until_complete(list(new_blocks))
+        new_metadata = ray.get(list(new_metadata))
+        reduce_bar.close()
 
-    return BlockList(list(new_blocks), list(new_metadata)), stats
+        stats = {
+            "map": shuffle_map_metadata,
+            "reduce": new_metadata,
+        }
 
-
-def shuffle_partitions(
-    input_blocks: BlockList,
-    clear_input_blocks: bool,
-    block_udf: Optional[Callable[[Block], Iterable[Block]]],
-    output_num_blocks: int,
-    *,
-    random_shuffle: bool = False,
-    random_seed: Optional[int] = None,
-    map_ray_remote_args: Optional[Dict[str, Any]] = None,
-    reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
-) -> Tuple[BlockList, Dict[str, List[BlockMetadata]]]:
-    """Implements shuffle for Dataset.random_shuffle and Dataset.partition
-    calls.
-
-    Rows get shuffled from all input blocks into the specified number of output
-    blocks. If the `random_shuffle` flag is set, then rows in the input blocks
-    will also be randomly shuffled so that each final output block contains a
-    random unique subset of the input rows.
-    """
-    shuffle_map = cached_remote_fn(_shuffle_partitions_map)
-    shuffle_reduce = cached_remote_fn(_shuffle_partitions_reduce)
-    map_args = [block_udf, random_shuffle, random_seed]
-    return _simple_shuffle(
-            shuffle_map,
-            shuffle_reduce,
-            input_blocks,
-            output_num_blocks,
-            clear_input_blocks,
-            map_args,
-            map_ray_remote_args=map_ray_remote_args,
-            reduce_ray_remote_args=reduce_ray_remote_args)
+        return BlockList(list(new_blocks), list(new_metadata)), stats
 
 
-def _shuffle_partitions_map(
-    idx: int,
-    block: Block,
-    output_num_blocks: int,
-    block_udf: Optional[Callable[[Block], Iterable[Block]]],
-    random_shuffle: bool,
-    random_seed: Optional[int],
-) -> List[Union[BlockMetadata, Block]]:
-    """Returns list of [BlockMetadata, O1, O2, O3, ...output_num_blocks]."""
-    stats = BlockExecStats.builder()
-    if block_udf:
-        # TODO(ekl) note that this effectively disables block splitting.
-        blocks = list(block_udf(block))
-        if len(blocks) > 1:
-            builder = BlockAccessor.for_block(blocks[0]).builder()
-            for b in blocks:
-                builder.add_block(b)
-            block = builder.build()
-        else:
-            block = blocks[0]
-    block = BlockAccessor.for_block(block)
+class ShufflePartitionOp(ShuffleOp):
+    def __init__(
+        self,
+        block_udf=None,
+        random_shuffle: bool = False,
+        random_seed: Optional[int] = None,
+    ):
+        self._map_args = [block_udf, random_shuffle, random_seed]
 
-    # Randomize the distribution of records to blocks.
-    if random_shuffle:
-        seed_i = random_seed + idx if random_seed is not None else None
-        block = block.random_shuffle(seed_i)
+    @staticmethod
+    def map(
+        idx: int,
+        block: Block,
+        output_num_blocks: int,
+        block_udf: Optional[Callable[[Block], Iterable[Block]]],
+        random_shuffle: bool,
+        random_seed: Optional[int],
+    ) -> List[Union[BlockMetadata, Block]]:
+        """Returns list of [BlockMetadata, O1, O2, O3, ...output_num_blocks]."""
+        stats = BlockExecStats.builder()
+        if block_udf:
+            # TODO(ekl) note that this effectively disables block splitting.
+            blocks = list(block_udf(block))
+            if len(blocks) > 1:
+                builder = BlockAccessor.for_block(blocks[0]).builder()
+                for b in blocks:
+                    builder.add_block(b)
+                block = builder.build()
+            else:
+                block = blocks[0]
         block = BlockAccessor.for_block(block)
 
-    slice_sz = max(1, math.ceil(block.num_rows() / output_num_blocks))
-    slices = []
-    for i in range(output_num_blocks):
-        slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz, copy=True))
+        # Randomize the distribution of records to blocks.
+        if random_shuffle:
+            seed_i = random_seed + idx if random_seed is not None else None
+            block = block.random_shuffle(seed_i)
+            block = BlockAccessor.for_block(block)
 
-    # Randomize the distribution order of the blocks (this matters when
-    # some blocks are larger than others).
-    if random_shuffle:
-        random = np.random.RandomState(seed_i)
-        random.shuffle(slices)
+        slice_sz = max(1, math.ceil(block.num_rows() / output_num_blocks))
+        slices = []
+        for i in range(output_num_blocks):
+            slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz, copy=True))
 
-    num_rows = sum(BlockAccessor.for_block(s).num_rows() for s in slices)
-    assert num_rows == block.num_rows(), (num_rows, block.num_rows())
-    metadata = block.get_metadata(input_files=None, exec_stats=stats.build())
-    return [metadata] + slices
+        # Randomize the distribution order of the blocks (this matters when
+        # some blocks are larger than others).
+        if random_shuffle:
+            random = np.random.RandomState(seed_i)
+            random.shuffle(slices)
 
+        num_rows = sum(BlockAccessor.for_block(s).num_rows() for s in slices)
+        assert num_rows == block.num_rows(), (num_rows, block.num_rows())
+        metadata = block.get_metadata(input_files=None, exec_stats=stats.build())
+        return [metadata] + slices
 
-def _shuffle_partitions_reduce(*mapper_outputs: List[Block]) -> (Block, BlockMetadata):
-    stats = BlockExecStats.builder()
-    builder = DelegatingBlockBuilder()
-    for block in mapper_outputs:
-        builder.add_block(block)
-    new_block = builder.build()
-    accessor = BlockAccessor.for_block(new_block)
-    new_metadata = BlockMetadata(
-        num_rows=accessor.num_rows(),
-        size_bytes=accessor.size_bytes(),
-        schema=accessor.schema(),
-        input_files=None,
-        exec_stats=stats.build(),
-    )
-    return new_block, new_metadata
+    @staticmethod
+    def reduce(*mapper_outputs: List[Block]) -> (Block, BlockMetadata):
+        stats = BlockExecStats.builder()
+        builder = DelegatingBlockBuilder()
+        for block in mapper_outputs:
+            builder.add_block(block)
+        new_block = builder.build()
+        accessor = BlockAccessor.for_block(new_block)
+        new_metadata = BlockMetadata(
+            num_rows=accessor.num_rows(),
+            size_bytes=accessor.size_bytes(),
+            schema=accessor.schema(),
+            input_files=None,
+            exec_stats=stats.build(),
+        )
+        return new_block, new_metadata

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -101,8 +101,7 @@ class ShuffleOp:
         # the blocks' memory.
         del shuffle_map_out
         new_blocks, new_metadata = zip(*shuffle_reduce_out)
-        reduce_bar.block_until_complete(list(new_blocks))
-        new_metadata = ray.get(list(new_metadata))
+        new_metadata = reduce_bar.fetch_until_complete(list(new_metadata))
         reduce_bar.close()
 
         stats = {

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -65,7 +65,7 @@ class ShuffleOp:
         shuffle_map = cached_remote_fn(self.map)
         shuffle_reduce = cached_remote_fn(self.reduce)
 
-        map_bar = ProgressBar("Shuffle Map", position=0, total=input_num_blocks)
+        map_bar = ProgressBar("Shuffle Map", total=input_num_blocks)
 
         shuffle_map_out = [
             shuffle_map.options(

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -1,6 +1,8 @@
 import math
 from typing import TypeVar, List, Optional, Dict, Any, Tuple, Union, Callable, Iterable
 
+import numpy as np
+
 from ray.data.block import Block, BlockAccessor, BlockMetadata, BlockExecStats
 from ray.data.impl.progress_bar import ProgressBar
 from ray.data.impl.block_list import BlockList
@@ -162,9 +164,9 @@ class ShufflePartitionOp(ShuffleOp):
 
         # Randomize the distribution order of the blocks (this prevents empty
         # outputs when input blocks are very small).
-	if random_shuffle:
-	    random = np.random.RandomState(seed_i)
-	    random.shuffle(slices)
+        if random_shuffle:
+            random = np.random.RandomState(seed_i)
+            random.shuffle(slices)
 
         num_rows = sum(BlockAccessor.for_block(s).num_rows() for s in slices)
         assert num_rows == block.num_rows(), (num_rows, block.num_rows())

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -1,8 +1,6 @@
 import math
 from typing import TypeVar, List, Optional, Dict, Any, Tuple, Union, Callable, Iterable
 
-import numpy as np
-
 import ray
 from ray.data.block import Block, BlockAccessor, BlockMetadata, BlockExecStats
 from ray.data.impl.progress_bar import ProgressBar
@@ -14,6 +12,12 @@ T = TypeVar("T")
 
 
 class ShuffleOp:
+    """
+    A generic shuffle operator. Callers should implement the `map` and `reduce`
+    static methods. Any custom arguments for map and reduce tasks should be
+    specified by setting `ShuffleOp._map_args` and `ShuffleOp._reduce_args`.
+    """
+
     def __init__(self, map_args: List[Any] = None, reduce_args: List[Any] = None):
         self._map_args = map_args or []
         self._reduce_args = reduce_args or []
@@ -24,10 +28,18 @@ class ShuffleOp:
     def map(
         idx: int, block: Block, output_num_blocks: int, *map_args: List[Any]
     ) -> List[Union[BlockMetadata, Block]]:
+        """
+        Map function to be run on each input block.
+
+        Returns list of [BlockMetadata, O1, O2, O3, ...output_num_blocks].
+        """
         raise NotImplementedError
 
     @staticmethod
     def reduce(*mapper_outputs: List[Block]) -> (Block, BlockMetadata):
+        """
+        Reduce function to be run for each output block.
+        """
         raise NotImplementedError
 
     def execute(
@@ -102,13 +114,20 @@ class ShuffleOp:
 
 
 class ShufflePartitionOp(ShuffleOp):
+    """
+    Operator used for `random_shuffle` and `repartition` transforms.
+    """
+
     def __init__(
         self,
         block_udf=None,
         random_shuffle: bool = False,
         random_seed: Optional[int] = None,
     ):
-        super().__init__(map_args=[block_udf, random_shuffle, random_seed])
+        super().__init__(
+            map_args=[block_udf, random_shuffle, random_seed],
+            reduce_args=[random_shuffle, random_seed],
+        )
 
     @staticmethod
     def map(
@@ -119,7 +138,6 @@ class ShufflePartitionOp(ShuffleOp):
         random_shuffle: bool,
         random_seed: Optional[int],
     ) -> List[Union[BlockMetadata, Block]]:
-        """Returns list of [BlockMetadata, O1, O2, O3, ...output_num_blocks]."""
         stats = BlockExecStats.builder()
         if block_udf:
             # TODO(ekl) note that this effectively disables block splitting.
@@ -144,25 +162,26 @@ class ShufflePartitionOp(ShuffleOp):
         for i in range(output_num_blocks):
             slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz, copy=True))
 
-        # Randomize the distribution order of the blocks (this matters when
-        # some blocks are larger than others).
-        if random_shuffle:
-            random = np.random.RandomState(seed_i)
-            random.shuffle(slices)
-
         num_rows = sum(BlockAccessor.for_block(s).num_rows() for s in slices)
         assert num_rows == block.num_rows(), (num_rows, block.num_rows())
         metadata = block.get_metadata(input_files=None, exec_stats=stats.build())
         return [metadata] + slices
 
     @staticmethod
-    def reduce(*mapper_outputs: List[Block]) -> (Block, BlockMetadata):
+    def reduce(
+        random_shuffle: bool, random_seed: Optional[int], *mapper_outputs: List[Block]
+    ) -> (Block, BlockMetadata):
         stats = BlockExecStats.builder()
         builder = DelegatingBlockBuilder()
         for block in mapper_outputs:
             builder.add_block(block)
         new_block = builder.build()
         accessor = BlockAccessor.for_block(new_block)
+        if random_shuffle:
+            new_block = accessor.random_shuffle(
+                random_seed if random_seed is not None else None
+            )
+            accessor = BlockAccessor.for_block(new_block)
         new_metadata = BlockMetadata(
             num_rows=accessor.num_rows(),
             size_bytes=accessor.size_bytes(),

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -160,6 +160,12 @@ class ShufflePartitionOp(ShuffleOp):
         for i in range(output_num_blocks):
             slices.append(block.slice(i * slice_sz, (i + 1) * slice_sz, copy=True))
 
+        # Randomize the distribution order of the blocks (this prevents empty
+        # outputs when input blocks are very small).
+	if random_shuffle:
+	    random = np.random.RandomState(seed_i)
+	    random.shuffle(slices)
+
         num_rows = sum(BlockAccessor.for_block(s).num_rows() for s in slices)
         assert num_rows == block.num_rows(), (num_rows, block.num_rows())
         metadata = block.get_metadata(input_files=None, exec_stats=stats.build())

--- a/python/ray/data/impl/shuffle.py
+++ b/python/ray/data/impl/shuffle.py
@@ -1,7 +1,6 @@
 import math
 from typing import TypeVar, List, Optional, Dict, Any, Tuple, Union, Callable, Iterable
 
-import ray
 from ray.data.block import Block, BlockAccessor, BlockMetadata, BlockExecStats
 from ray.data.impl.progress_bar import ProgressBar
 from ray.data.impl.block_list import BlockList

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3123,6 +3123,54 @@ def test_random_shuffle(shutdown_only, pipelined):
     assert r1.take() == ds.take()
 
 
+def test_random_shuffle_check_random(shutdown_only):
+    # Rows from the same input should not be contiguous in the final output.
+    num_files = 10
+    num_rows = 100
+    items = [i for i in range(num_files) for _ in range(num_rows)]
+    ds = ray.data.from_items(items, parallelism=num_files)
+    out = ds.random_shuffle().take(num_files * num_rows)
+    for i in range(num_files):
+        part = out[i * num_rows : (i + 1) * num_rows]
+        seen = set()
+        num_contiguous = 1
+        prev = -1
+        for x in part:
+            if prev != x:
+                prev = x
+                num_contiguous = 1
+            else:
+                num_contiguous += 1
+                assert num_contiguous < (
+                    num_rows / num_files
+                ), f"{part} contains too many contiguous rows from same input block"
+            seen.add(x)
+        assert (
+            set(range(num_files)) == seen
+        ), f"{part} does not contain elements from all input blocks"
+
+    # Rows from the same input should appear in a different order in the
+    # output.
+    num_files = 10
+    num_rows = 100
+    items = [j for i in range(num_files) for j in range(num_rows)]
+    ds = ray.data.from_items(items, parallelism=num_files)
+    out = ds.random_shuffle().take(num_files * num_rows)
+    for i in range(num_files):
+        part = out[i * num_rows : (i + 1) * num_rows]
+        num_increasing = 0
+        prev = -1
+        for x in part:
+            if x >= prev:
+                num_increasing += 1
+            else:
+                assert num_increasing < (
+                    num_rows / num_files
+                ), f"{part} contains non-shuffled rows from input blocks"
+                num_increasing = 0
+            prev = x
+
+
 def test_random_shuffle_spread(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -116,7 +116,7 @@ def test_dataset_stats_sort(ray_start_regular_shared):
     ds = ds.sort()
     stats = ds.stats()
     assert "sort_map" in stats, stats
-    assert "sort_merge" in stats, stats
+    assert "sort_reduce" in stats, stats
 
 
 def test_dataset_stats_from_items(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently Datasets primitives repartition, groupby, sort, and random_shuffle all use different internal shuffle implementations. This PR unifies them on a single internal `ShuffleOp` class. This class exposes static methods for `map` and `reduce` which must be implemented by the specific higher-level primitive. Then the `ShuffleOp.execute` method implements a simple pull-based shuffle by submitting one map task per input block and one reduce task per output block.

## Related issue number

Closes #23593.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
