### PR TITLE
[AIR] Interface for `HuggingFaceTorchTrainer`

### DIFF
--- a/python/ray/ml/constants.py
+++ b/python/ray/ml/constants.py
@@ -7,3 +7,8 @@ MODEL_KEY = "model"
 # Key to denote which dataset is the training dataset.
 # This is the dataset that the preprocessor is fit on.
 TRAIN_DATASET_KEY = "train"
+
+# Key to denote which dataset is the validation dataset.
+# Only used in trainers which do not support multiple
+# validation datasets.
+VALIDATION_DATASET_KEY = "validation"

--- a/python/ray/ml/constants.py
+++ b/python/ray/ml/constants.py
@@ -8,7 +8,7 @@ MODEL_KEY = "model"
 # This is the dataset that the preprocessor is fit on.
 TRAIN_DATASET_KEY = "train"
 
-# Key to denote which dataset is the validation dataset.
+# Key to denote which dataset is the evaluation dataset.
 # Only used in trainers which do not support multiple
-# validation datasets.
-VALIDATION_DATASET_KEY = "validation"
+# evaluation datasets.
+EVALUATION_DATASET_KEY = "evaluation"

--- a/python/ray/ml/train/data_parallel_trainer.py
+++ b/python/ray/ml/train/data_parallel_trainer.py
@@ -226,6 +226,12 @@ class DataParallelTrainer(Trainer):
                 f"integer. Received {self.scaling_config['num_workers']}"
             )
 
+        self._validate_train_loop_per_worker()
+
+        backend_config = backend_config if backend_config else BackendConfig()
+        self.backend_config = backend_config
+
+    def _validate_train_loop_per_worker(self):
         num_params = len(inspect.signature(self.train_loop_per_worker).parameters)
         if num_params > 1:
             raise ValueError(
@@ -233,8 +239,25 @@ class DataParallelTrainer(Trainer):
                 f"but it accepts {num_params} arguments instead."
             )
 
-        backend_config = backend_config if backend_config else BackendConfig()
-        self.backend_config = backend_config
+    @property
+    def train_loop_per_worker(
+        self,
+    ) -> Union[Callable[[], None], Callable[[Dict], None]]:
+        return self._train_loop_per_worker
+
+    @train_loop_per_worker.setter
+    def train_loop_per_worker(
+        self, val: Union[Callable[[], None], Callable[[Dict], None]]
+    ):
+        self._train_loop_per_worker = val
+
+    @property
+    def train_loop_config(self) -> Optional[Dict]:
+        return self._train_loop_config
+
+    @train_loop_config.setter
+    def train_loop_config(self, val: Optional[Dict]):
+        self._train_loop_config = val
 
     def training_loop(self) -> None:
         scaling_config_dataclass = ScalingConfigDataClass(**self.scaling_config)

--- a/python/ray/ml/train/data_parallel_trainer.py
+++ b/python/ray/ml/train/data_parallel_trainer.py
@@ -226,38 +226,22 @@ class DataParallelTrainer(Trainer):
                 f"integer. Received {self.scaling_config['num_workers']}"
             )
 
-        self._validate_train_loop_per_worker()
+        self._validate_train_loop_per_worker(
+            self.train_loop_per_worker, "train_loop_per_worker"
+        )
 
         backend_config = backend_config if backend_config else BackendConfig()
         self.backend_config = backend_config
 
-    def _validate_train_loop_per_worker(self):
-        num_params = len(inspect.signature(self.train_loop_per_worker).parameters)
+    def _validate_train_loop_per_worker(
+        self, train_loop_per_worker: Callable, fn_name: str
+    ) -> None:
+        num_params = len(inspect.signature(train_loop_per_worker).parameters)
         if num_params > 1:
             raise ValueError(
-                f"train_loop_per_worker should take in 0 or 1 arguments, "
+                f"{fn_name} should take in 0 or 1 arguments, "
                 f"but it accepts {num_params} arguments instead."
             )
-
-    @property
-    def train_loop_per_worker(
-        self,
-    ) -> Union[Callable[[], None], Callable[[Dict], None]]:
-        return self._train_loop_per_worker
-
-    @train_loop_per_worker.setter
-    def train_loop_per_worker(
-        self, val: Union[Callable[[], None], Callable[[Dict], None]]
-    ):
-        self._train_loop_per_worker = val
-
-    @property
-    def train_loop_config(self) -> Optional[Dict]:
-        return self._train_loop_config
-
-    @train_loop_config.setter
-    def train_loop_config(self, val: Optional[Dict]):
-        self._train_loop_config = val
 
     def training_loop(self) -> None:
         scaling_config_dataclass = ScalingConfigDataClass(**self.scaling_config)

--- a/python/ray/ml/train/integrations/huggingface/__init__.py
+++ b/python/ray/ml/train/integrations/huggingface/__init__.py
@@ -1,5 +1,5 @@
-from ray.ml.train.integrations.huggingface.huggingface_torch_trainer import (
-    HuggingFaceTorchTrainer,
+from ray.ml.train.integrations.huggingface.huggingface_trainer import (
+    HuggingFaceTrainer,
 )
 
-__all__ = ["HuggingFaceTorchTrainer"]
+__all__ = ["HuggingFaceTrainer"]

--- a/python/ray/ml/train/integrations/huggingface/__init__.py
+++ b/python/ray/ml/train/integrations/huggingface/__init__.py
@@ -1,0 +1,5 @@
+from ray.ml.train.integrations.huggingface.huggingface_torch_trainer import (
+    HuggingFaceTorchTrainer,
+)
+
+__all__ = ["HuggingFaceTorchTrainer"]

--- a/python/ray/ml/train/integrations/huggingface/huggingface_torch_trainer.py
+++ b/python/ray/ml/train/integrations/huggingface/huggingface_torch_trainer.py
@@ -1,0 +1,217 @@
+from typing import Any, Callable, Optional, Dict, Union, Type
+
+from transformers.trainer import Trainer
+
+from ray.train.torch import TorchConfig
+from ray.ml.trainer import GenDataset
+from ray.ml.train.integrations.torch import TorchTrainer
+from ray.ml.config import ScalingConfig, RunConfig
+from ray.ml.preprocessor import Preprocessor
+from ray.ml.checkpoint import Checkpoint
+from ray.util import PublicAPI
+
+
+def _huggingface_train_loop_per_worker(config: Dict[str, Any]):
+    config
+    return
+
+
+@PublicAPI(stability="alpha")
+class HuggingFaceTorchTrainer(TorchTrainer):
+    """A Trainer for data parallel HuggingFace Transformers on PyTorch training.
+
+    This Trainer runs the ``transformers.Trainer.train()`` method on multiple
+    Ray Actors. The training is carried out in a distributed fashion through PyTorch
+    DDP. These actors already have the necessary torch process group already
+    configured for distributed pytorch training.
+
+    The training function ran on every Actor will first initialize a
+    ``transformers.TrainingArguments`` object using the ``args`` dict,
+    and then use it alongside ``trainer_kwargs`` to initialize an
+    object with a ``trainer_class`` class (by default, this is
+    ``transformers.Trainer``) and run ``train()``, using the
+    provided datasets.
+
+    It is important to ensure that all contents of ``args`` and
+    ``trainer_kwargs`` are serializable by Ray. In case you have
+    arguments that are not serializable, you can specify a
+    ``pre_init_function`` taking in the ``args`` and
+    ``trainer_kwargs`` dicts to modify them in-place on every
+    Actor separately. This can be used to eg. obtain a Transformers
+    model from hub.
+
+    If the ``datasets`` dict contains a training dataset (denoted by
+    the "train" key), then it will be split into multiple dataset
+    shards, with each Actor training on a single shard.
+    All the other datasets will not be split.
+
+    Example:
+        .. code-block:: python
+            # Based on
+            # huggingface/notebooks/examples/language_modeling_from_scratch.ipynb
+
+            # Hugging Face imports
+            from datasets import load_dataset
+            from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+            import ray
+            from ray.ml.train.integrations.huggingface import HuggingFaceTorchTrainer
+
+            model_checkpoint = "gpt2"
+            tokenizer_checkpoint = "sgugger/gpt2-like-tokenizer"
+            block_size = 128
+
+            datasets = load_dataset("wikitext", "wikitext-2-raw-v1")
+            tokenizer = AutoTokenizer.from_pretrained(tokenizer_checkpoint)
+
+            def tokenize_function(examples):
+                return tokenizer(examples["text"])
+
+            tokenized_datasets = datasets.map(
+                tokenize_function, batched=True, num_proc=1, remove_columns=["text"]
+            )
+
+            def group_texts(examples):
+                # Concatenate all texts.
+                concatenated_examples = {
+                    k: sum(examples[k], []) for k in examples.keys()
+                }
+                total_length = len(concatenated_examples[list(examples.keys())[0]])
+                # We drop the small remainder, we could add padding if the model
+                # supported it.
+                # instead of this drop, you can customize this part to your needs.
+                total_length = (total_length // block_size) * block_size
+                # Split by chunks of max_len.
+                result = {
+                    k: [
+                        t[i : i + block_size]
+                        for i in range(0, total_length, block_size)
+                    ]
+                    for k, t in concatenated_examples.items()
+                }
+                result["labels"] = result["input_ids"].copy()
+                return result
+
+            lm_datasets = tokenized_datasets.map(
+                group_texts,
+                batched=True,
+                batch_size=1000,
+                num_proc=1,
+            )
+            ray_train_ds = ray.data.from_arrow(lm_datasets["train"]._data.table)
+            ray_validation_ds = ray.data.from_arrow(
+                lm_datasets["validation"]._data.table
+            )
+
+            def pre_init_function(args, trainer_kwargs):
+                model_config = AutoConfig.from_pretrained(model_checkpoint)
+                model = AutoModelForCausalLM.from_config(model_config)
+                trainer_kwargs["model"] = model
+
+            scaling_config = {"num_workers": 3}
+            # If using GPUs, use the below scaling config instead.
+            # scaling_config = {"num_workers": 3, "use_gpu": True}
+            trainer = HuggingFaceTorchTrainer(
+                args={
+                    "output_dir": f"{model_checkpoint}-wikitext2",
+                    "evaluation_strategy": "epoch",
+                    "learning_rate": 2e-5,
+                    "weight_decay": 0.01,
+                },
+                pre_init_function=pre_init_function,
+                scaling_config=scaling_config,
+                datasets={"train": ray_train_ds, "validation": ray_validation_ds},
+            )
+            result = trainer.fit()
+
+    Args:
+        trainer_class: A subclass of ``transformers.Trainer`` to use.
+            Defaults to ``transformers.Trainer``.
+        args: Keyword arguments passed to ``transformers.TrainingArguments``
+            during initialization on every Actor.
+        pre_init_function: A function taking in the ``args`` and ``trainer_kwargs``
+            dicts to modify them in-place on every Actor before ``trainer_class``
+            object is initialized.
+        torch_config: Configuration for setting up the PyTorch backend. If set to
+            None, use the default configuration. This replaces the ``backend_config``
+            arg of ``DataParallelTrainer``. Same as in ``TorchTrainer``.
+        scaling_config: Configuration for how to scale data parallel training.
+        run_config: Configuration for the execution of the training run.
+        datasets: Any Ray Datasets to use for training. Use
+            the key "train" to denote which dataset is the training
+            dataset. Can only contain a training dataset
+            and up to one extra dataset to be used for validation.
+            If a ``preprocessor`` is provided and has not already been fit,
+            it will be fit on the training dataset. All datasets will be
+            transformed by the ``preprocessor`` if one is provided.
+        preprocessor: A ray.ml.preprocessor.Preprocessor to preprocess the
+            provided datasets.
+        resume_from_checkpoint: A checkpoint to resume training from.
+        **trainer_kwargs: Additional kwargs to pass to ``trainer_class``
+            object during initailization on every Actor.
+    """
+
+    def __init__(
+        self,
+        trainer_class: Type[Trainer] = Trainer,
+        args: Optional[Dict[str, Any]] = None,
+        pre_init_function: Optional[
+            Callable[[Dict[str, Any], Dict[str, Any]], None]
+        ] = None,
+        torch_config: Optional[TorchConfig] = None,
+        scaling_config: Optional[ScalingConfig] = None,
+        run_config: Optional[RunConfig] = None,
+        datasets: Optional[Dict[str, GenDataset]] = None,
+        preprocessor: Optional[Preprocessor] = None,
+        resume_from_checkpoint: Optional[Checkpoint] = None,
+        **trainer_kwargs
+    ):
+        # Will improve during implementation
+        assert "local_rank" not in args
+        assert "no_cuda" not in args
+        assert "train_dataset" not in trainer_kwargs
+        assert "eval_dataset" not in trainer_kwargs
+
+        self.trainer_class = trainer_class
+        self.args = args
+        self.trainer_kwargs = trainer_kwargs
+        self.pre_init_function = pre_init_function
+
+        super().__init__(
+            None,
+            None,
+            torch_config,
+            scaling_config,
+            run_config,
+            datasets,
+            preprocessor,
+            resume_from_checkpoint,
+        )
+
+    def _validate_train_loop_per_worker(self):
+        return
+
+    @property
+    def train_loop_per_worker(
+        self,
+    ) -> Union[Callable[[], None], Callable[[Dict], None]]:
+        return _huggingface_train_loop_per_worker
+
+    @train_loop_per_worker.setter
+    def train_loop_per_worker(
+        self, val: Union[Callable[[], None], Callable[[Dict], None]]
+    ):
+        pass
+
+    @property
+    def train_loop_config(self) -> Optional[Dict]:
+        return {
+            "trainer_class": self.trainer_class,
+            "args": self.args,
+            "trainer_kwargs": self.trainer_kwargs,
+            "pre_init_function": self.pre_init_function,
+        }
+
+    @train_loop_config.setter
+    def train_loop_config(self, val: Optional[Dict]):
+        pass

--- a/python/ray/ml/train/integrations/huggingface/huggingface_trainer.py
+++ b/python/ray/ml/train/integrations/huggingface/huggingface_trainer.py
@@ -127,7 +127,7 @@ class HuggingFaceTrainer(TorchTrainer):
     Args:
         trainer_init_per_worker: The function that returns an instantiated
             ``transformers.Trainer`` object and takes in the following arguments:
-            train datset, optional evaluation datset, and config as kwargs.
+            train dataset, optional evaluation dataset, and config as kwargs.
         trainer_init_config: Configurations to pass into
             ``trainer_init_per_worker`` as kwargs.
         torch_config: Configuration for setting up the PyTorch backend. If set to

--- a/python/ray/ml/train/integrations/huggingface/huggingface_trainer.py
+++ b/python/ray/ml/train/integrations/huggingface/huggingface_trainer.py
@@ -182,6 +182,8 @@ class HuggingFaceTrainer(TorchTrainer):
 
     def _create_train_func(self, trainer_init_per_worker):
         def train_loop_per_worker(config):
+            # Set to None just to make CI pass & show
+            # the intended usage with trainer_init_per_worker
             train_dataset = None
             eval_dataset = None
             trainer = trainer_init_per_worker(train_dataset, eval_dataset, **config)

--- a/python/ray/ml/train/integrations/torch/torch_trainer.py
+++ b/python/ray/ml/train/integrations/torch/torch_trainer.py
@@ -15,7 +15,7 @@ class TorchTrainer(DataParallelTrainer):
 
     This Trainer runs the function ``train_loop_per_worker`` on multiple Ray
     Actors. These actors already have the necessary torch process group already
-    configured for distributed pytorch training.
+    configured for distributed PyTorch training.
 
     The ``train_loop_per_worker`` function is expected to take in either 0 or 1
     arguments:
@@ -139,7 +139,7 @@ class TorchTrainer(DataParallelTrainer):
             # scaling_config = {"num_workers": 3, "use_gpu": True}
             trainer = TorchTrainer(
                 train_loop_per_worker=train_loop_per_worker,
-                scaling_config={"num_workers": 3},
+                scaling_config=scaling_config,
                 datasets={"train": train_dataset})
             result = trainer.fit()
 
@@ -158,7 +158,7 @@ class TorchTrainer(DataParallelTrainer):
             dataset. If a ``preprocessor`` is provided and has not already been fit,
             it will be fit on the training dataset. All datasets will be transformed
             by the ``preprocessor`` if one is provided.
-        preprocessor: A ray.ml.preprocessor.Preprocessor to preprocess the
+        preprocessor: A ``ray.ml.preprocessor.Preprocessor`` to preprocess the
             provided datasets.
         resume_from_checkpoint: A checkpoint to resume training from.
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Initial draft of the interface for `HuggingFaceTorchTrainer`.

One alternative for limiting the number of datasets in `datasets` dict would be to have the user pass `train_dataset` and `validation_dataset` as separate arguments, though that would be inconsistent with `TorchTrainer`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
