### PR TITLE
[air/release] Improve file packing/unpacking

### DIFF
--- a/release/ray_release/file_manager/remote_task.py
+++ b/release/ray_release/file_manager/remote_task.py
@@ -51,9 +51,7 @@ def fetch_dir_from_node(
         )
         _unpack(packed, local_dir)
     except Exception as e:
-        print(
-            f"Warning: Could not fetch remote directory contents. Message: {str(e)}"
-        )
+        print(f"Warning: Could not fetch remote directory contents. Message: {str(e)}")
 
 
 def _get_head_ip():

--- a/release/ray_release/file_manager/remote_task.py
+++ b/release/ray_release/file_manager/remote_task.py
@@ -52,7 +52,7 @@ def fetch_dir_from_node(
         _unpack(packed, local_dir)
     except Exception as e:
         print(
-            f"Warning: Could not fetch remote directory contents. Message: " f"{str(e)}"
+            f"Warning: Could not fetch remote directory contents. Message: {str(e)}"
         )
 
 

--- a/release/ray_release/file_manager/remote_task.py
+++ b/release/ray_release/file_manager/remote_task.py
@@ -1,28 +1,20 @@
+import io
 import tarfile
-import tempfile
 from typing import Optional
 
 from ray_release.file_manager.file_manager import FileManager
 
 
 def _pack(source_dir: str) -> bytes:
-    tmpfile = tempfile.mktemp()
-    with tarfile.open(tmpfile, "w:gz") as tar:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
         tar.add(source_dir, arcname="")
 
-    with open(tmpfile, "rb") as f:
-        stream = f.read()
-
-    return stream
+    return stream.getvalue()
 
 
 def _unpack(stream: bytes, target_dir: str):
-    tmpfile = tempfile.mktemp()
-
-    with open(tmpfile, "wb") as f:
-        f.write(stream)
-
-    with tarfile.open(tmpfile) as tar:
+    with tarfile.open(fileobj=io.BytesIO(stream)) as tar:
         tar.extractall(target_dir)
 
 

--- a/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
+++ b/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
@@ -29,6 +29,7 @@ More details on the expected results can be found in the scenario descriptions.
 
 import argparse
 import csv
+import io
 import tarfile
 from dataclasses import dataclass
 import json
@@ -407,22 +408,16 @@ def fetch_remote_directory_content(
     local_dir: str,
 ):
     def _pack(dir: str):
-        _, tmpfile = tempfile.mkstemp()
-        with tarfile.open(tmpfile, "w:gz") as tar:
+        stream = io.BytesIO()
+        with tarfile.open(
+            fileobj=stream, mode="w:gz", format=tarfile.PAX_FORMAT
+        ) as tar:
             tar.add(dir, arcname="")
 
-        with open(tmpfile, "rb") as f:
-            stream = f.read()
-
-        return stream
+        return stream.getvalue()
 
     def _unpack(stream: str, dir: str):
-        _, tmpfile = tempfile.mkstemp()
-
-        with open(tmpfile, "wb") as f:
-            f.write(stream)
-
-        with tarfile.open(tmpfile) as tar:
+        with tarfile.open(fileobj=io.BytesIO(stream)) as tar:
             tar.extractall(dir)
 
     try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We use `tarfile` to pack/unpack directories in several locations. Instead of using temporary files, we can just use `io.BytesIO` to avoid unnecessary disk writes.

Note that this functionality is present in 3 different modules - in Ray (AIR), in the release test package, and in a specific release test. The implementations should live in the three modules independently, so we don't add a common utility for this (e.g. the ray_release package should be independent of the Ray package).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
