### PR TITLE
[gcs] Change old syncer to gcs_syncer namespace

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -52,7 +52,7 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
     GcsResourceManager &gcs_resource_manager,
     ClusterResourceScheduler &cluster_resource_scheduler,
     std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
-    syncer::RaySyncer &ray_syncer)
+    gcs_syncer::RaySyncer &ray_syncer)
     : return_timer_(io_context),
       gcs_table_storage_(std::move(gcs_table_storage)),
       gcs_node_manager_(gcs_node_manager),

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -406,7 +406,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       GcsResourceManager &gcs_resource_manager,
       ClusterResourceScheduler &cluster_resource_scheduler,
       std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
-      syncer::RaySyncer &ray_syncer);
+      gcs_syncer::RaySyncer &ray_syncer);
 
   virtual ~GcsPlacementGroupScheduler() = default;
 
@@ -582,7 +582,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
 
   /// The syncer of resource. This is used to report placement group updates.
   /// TODO (iycheng): Remove this one from pg once we finish the refactor
-  syncer::RaySyncer &ray_syncer_;
+  gcs_syncer::RaySyncer &ray_syncer_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -429,7 +429,7 @@ void GcsServer::InitRaySyncer(const GcsInitData &gcs_init_data) {
         raylet -> syncer::poller --> syncer::update -> gcs_resource_manager
         gcs_placement_scheduler --/
   */
-  ray_syncer_ = std::make_unique<syncer::RaySyncer>(
+  ray_syncer_ = std::make_unique<gcs_syncer::RaySyncer>(
       main_service_, raylet_client_pool_, *gcs_resource_manager_);
   ray_syncer_->Initialize(gcs_init_data);
   ray_syncer_->Start();

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -211,7 +211,7 @@ class GcsServer {
   std::unique_ptr<rpc::StatsHandler> stats_handler_;
   std::unique_ptr<rpc::StatsGrpcService> stats_service_;
   // Synchronization service for ray.
-  std::unique_ptr<syncer::RaySyncer> ray_syncer_;
+  std::unique_ptr<gcs_syncer::RaySyncer> ray_syncer_;
   /// The gcs worker manager.
   std::unique_ptr<GcsWorkerManager> gcs_worker_manager_;
   /// Worker info service.

--- a/src/ray/gcs/gcs_server/ray_syncer.h
+++ b/src/ray/gcs/gcs_server/ray_syncer.h
@@ -23,7 +23,7 @@
 
 namespace ray {
 class GcsPlacementGroupSchedulerTest;
-namespace syncer {
+namespace gcs_syncer {
 
 // RaySyncer is a service to sync components in the cluster.
 // It's supposed to be used to synchronize resource usage and scheduling information
@@ -185,5 +185,5 @@ class RaySyncer {
   friend class ray::GcsPlacementGroupSchedulerTest;
 };
 
-}  // namespace syncer
+}  // namespace gcs_syncer
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -46,7 +46,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     cluster_resource_scheduler_ = std::make_shared<ClusterResourceScheduler>();
     gcs_resource_manager_ = std::make_shared<gcs::GcsResourceManager>(
         gcs_table_storage_, cluster_resource_scheduler_->GetClusterResourceManager());
-    ray_syncer_ = std::make_shared<ray::syncer::RaySyncer>(
+    ray_syncer_ = std::make_shared<ray::gcs_syncer::RaySyncer>(
         io_service_, nullptr, *gcs_resource_manager_);
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>(io_service_);
     raylet_client_pool_ = std::make_shared<rpc::NodeManagerClientPool>(
@@ -275,7 +275,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<gcs::RedisClient> redis_client_;
   std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool_;
-  std::shared_ptr<ray::syncer::RaySyncer> ray_syncer_;
+  std::shared_ptr<ray::gcs_syncer::RaySyncer> ray_syncer_;
 };
 
 TEST_F(GcsPlacementGroupSchedulerTest, TestSpreadScheduleFailedWithZeroNode) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before integration of the newly introduced ray_syncer, there is a conflict in naming. This PR move the old ray syncer to another namespace.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
