### PR TITLE
[Datasets] Add Path Partitioning Support for All Content Types

### DIFF
--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -26,8 +26,9 @@ from ray.data.datasource.file_based_datasource import (
 from ray.data.datasource.file_meta_provider import FileMetadataProvider
 from ray.data.datasource.partitioning import (
     PartitionStyle,
-    PathPartitionGenerator,
+    PathPartitionEncoder,
     PathPartitionParser,
+    PathPartitionFilter,
 )
 
 __all__ = [
@@ -53,5 +54,6 @@ __all__ = [
     "DefaultParquetMetadataProvider",
     "PartitionStyle",
     "PathPartitionParser",
-    "PathPartitionGenerator",
+    "PathPartitionEncoder",
+    "PathPartitionFilter",
 ]

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -26,6 +26,7 @@ from ray.data.datasource.file_based_datasource import (
 from ray.data.datasource.file_meta_provider import FileMetadataProvider
 from ray.data.datasource.partitioning import (
     PartitionStyle,
+    PathPartitionGenerator,
     PathPartitionParser,
 )
 
@@ -52,4 +53,5 @@ __all__ = [
     "DefaultParquetMetadataProvider",
     "PartitionStyle",
     "PathPartitionParser",
+    "PathPartitionGenerator",
 ]

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -24,6 +24,10 @@ from ray.data.datasource.file_based_datasource import (
     DefaultFileMetadataProvider,
 )
 from ray.data.datasource.file_meta_provider import FileMetadataProvider
+from ray.data.datasource.partitioning import (
+    PartitionStyle,
+    PathPartitionParser,
+)
 
 __all__ = [
     "JSONDatasource",
@@ -46,4 +50,6 @@ __all__ = [
     "DefaultFileMetadataProvider",
     "ParquetMetadataProvider",
     "DefaultParquetMetadataProvider",
+    "PartitionStyle",
+    "PathPartitionParser",
 ]

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -14,7 +14,7 @@ from typing import (
 )
 import urllib.parse
 
-from ray.data.datasource.partitioning import PathPartitionParser
+from ray.data.datasource.partitioning import PathPartitionFilter
 
 if TYPE_CHECKING:
     import pyarrow
@@ -257,7 +257,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
         schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None,
         open_stream_args: Optional[Dict[str, Any]] = None,
         meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
-        partitioning: PathPartitionParser = None,
+        partition_filter: PathPartitionFilter = None,
         # TODO(ekl) deprecate this once read fusion is available.
         _block_udf: Optional[Callable[[Block], Block]] = None,
         **reader_args,
@@ -268,8 +268,8 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
 
         paths, filesystem = _resolve_paths_and_filesystem(paths, filesystem)
         paths, file_sizes = meta_provider.expand_paths(paths, filesystem)
-        if partitioning is not None:
-            paths = partitioning.filter_paths(paths, filesystem)
+        if partition_filter is not None:
+            paths = partition_filter(paths)
 
         read_stream = self._read_stream
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -114,7 +114,7 @@ class DefaultBlockWritePathProvider(BlockWritePathProvider):
         file_format: Optional[str] = None,
     ) -> str:
         suffix = f"{dataset_uuid}_{block_index:06}.{file_format}"
-        # Use forward slashes for cross-filesystem compatibility, since PyArrow
+        # Uses POSIX path for cross-filesystem compatibility, since PyArrow
         # FileSystem paths are always forward slash separated, see:
         # https://arrow.apache.org/docs/python/filesystems.html
         return posixpath.join(base_path, suffix)

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -595,7 +595,7 @@ def _unwrap_protocol(path):
     Slice off any protocol prefixes on path.
     """
     parsed = urllib.parse.urlparse(path, allow_fragments=False)  # support '#' in path
-    query = parsed.query or ""  # support '?' in path
+    query = "?" + parsed.query if parsed.query else ""  # support '?' in path
     return parsed.netloc + parsed.path + query
 
 

--- a/python/ray/data/datasource/partitioning.py
+++ b/python/ray/data/datasource/partitioning.py
@@ -33,33 +33,41 @@ class PartitionStyle(str, Enum):
 
 
 @DeveloperAPI
-class PathPartitionBase:
-    """Path-based partition formats embed all partition keys and values directly in
-    their dataset file paths.
+class PathPartitionScheme:
+    """Partition scheme used to describe path-based partitions.
 
-    Base class for path-based partition formats.
+    Path-based partition formats embed all partition keys and values directly in
+    their dataset file paths.
     """
 
     def __init__(
         self,
         style: PartitionStyle,
-        base_dir: Optional[str],
-        field_names: Optional[List[str]],
+        base_dir: Optional[str] = None,
+        field_names: Optional[List[str]] = None,
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     ):
         """Creates a new path-based dataset partition scheme.
 
         Args:
             style: The partition style - may be either HIVE or DIRECTORY.
             base_dir: "/"-delimited base directory that all partitioned paths should
-                exist under (exclusive).
+                exist under (exclusive). File paths either outside of, or at the first
+                level of, this directory will be considered unpartitioned. Specify
+                `None` or an empty string to search for partitions in all file path
+                directories.
             field_names: The partition key field names (i.e. column names for tabular
-                datasets). Required when parsing DIRECTORY partitioned paths or
-                generating HIVE partitioned paths.
+                datasets). When non-empty, the order and length of partition key
+                field names must match the order and length of partition values.
+                Required when parsing DIRECTORY partitioned paths or generating
+                HIVE partitioned paths.
+            filesystem: Filesystem that will be used for partition path file I/O.
         """
         self._style = style
         self._base_dir = base_dir or ""
-        self._normalized_base_dir = None
         self._field_names = field_names
+        self._filesystem = filesystem
+        self._normalize_base_dir()
 
     @property
     def style(self) -> PartitionStyle:
@@ -68,16 +76,12 @@ class PathPartitionBase:
 
     @property
     def base_dir(self) -> str:
-        """Gets the base directory."""
+        """Gets the original base directory supplied during object construction."""
         return self._base_dir
 
     @property
-    def normalized_base_dir(self) -> Optional[str]:
-        """Returns the base directory normalized for compatibility with a filesystem.
-
-        The normalized base directory is undefined by default, then lazily resolved
-        or updated by any operation that takes a filesystem as input.
-        """
+    def normalized_base_dir(self) -> str:
+        """Returns the base directory normalized for compatibility with a filesystem."""
         return self._normalized_base_dir
 
     @property
@@ -85,7 +89,17 @@ class PathPartitionBase:
         """Gets the partition key field names."""
         return self._field_names
 
-    def _normalize_base_dir(self, filesystem: "pyarrow.fs.FileSystem"):
+    @property
+    def filesystem(self) -> Optional["pyarrow.fs.FileSystem"]:
+        """Gets the original filesystem supplied during object construction."""
+        return self._filesystem
+
+    @property
+    def resolved_filesystem(self) -> "pyarrow.fs.FileSystem":
+        """Returns the filesystem resolved for compatibility with a base directory."""
+        return self._resolved_filesystem
+
+    def _normalize_base_dir(self):
         """Normalizes the partition base directory for compatibility with the
         given filesystem.
 
@@ -97,9 +111,9 @@ class PathPartitionBase:
             _resolve_paths_and_filesystem,
         )
 
-        paths, _ = _resolve_paths_and_filesystem(
+        paths, self._resolved_filesystem = _resolve_paths_and_filesystem(
             self._base_dir,
-            filesystem,
+            self._filesystem,
         )
         assert (
             len(paths) == 1
@@ -111,8 +125,8 @@ class PathPartitionBase:
 
 
 @DeveloperAPI
-class PathPartitionGenerator(PathPartitionBase):
-    """Callable that generates directory paths for path-based partition formats.
+class PathPartitionEncoder:
+    """Callable that generates directory path strings for path-based partition formats.
 
     Path-based partition formats embed all partition keys and values directly in
     their dataset file paths.
@@ -129,14 +143,44 @@ class PathPartitionGenerator(PathPartitionBase):
     values using a "{value1}/{value2}" naming convention under the base directory.
     """
 
-    def __init__(
-        self,
+    def __init__(self, path_partition_scheme: PathPartitionScheme):
+        """Creates a new partition path encoder.
+
+        Args:
+            path_partition_scheme: The path-based partition scheme. All partition paths
+                will be generated under this scheme's base directory. Field names are
+                required for HIVE partition paths, optional for DIRECTORY partition
+                paths. When non-empty, the order and length of partition key field
+                names must match the order and length of partition values.
+        """
+        style = path_partition_scheme.style
+        field_names = path_partition_scheme.field_names
+        if style == PartitionStyle.HIVE and not field_names:
+            raise ValueError(
+                "Hive partition path generation requires a corresponding list of "
+                "partition key field names. Please retry your request with one "
+                "or more field names specified."
+            )
+        generators = {
+            PartitionStyle.HIVE: self._as_hive_partition_dirs,
+            PartitionStyle.DIRECTORY: self._as_directory_partition_dirs,
+        }
+        self._encoder_fn: Callable[[List[str]], List[str]] = generators.get(style)
+        if self._encoder_fn is None:
+            raise ValueError(
+                f"Unsupported partition style: {style}. "
+                f"Supported styles: {generators.keys()}"
+            )
+        self._scheme = path_partition_scheme
+
+    @staticmethod
+    def of(
         style: PartitionStyle = PartitionStyle.HIVE,
         base_dir: Optional[str] = None,
         field_names: Optional[List[str]] = None,
-    ):
-        """Creates a new partition path generator.
-
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> "PathPartitionEncoder":
+        """Creates a new partition path encoder.
         Args:
             style: The partition style - may be either HIVE or DIRECTORY.
             base_dir: "/"-delimited base directory that all partition paths will be
@@ -146,46 +190,34 @@ class PathPartitionGenerator(PathPartitionBase):
                 partition paths. When non-empty, the order and length of partition key
                 field names must match the order and length of partition values.
         """
-        super(PathPartitionGenerator, self).__init__(style, base_dir, field_names)
-        if self.style == PartitionStyle.HIVE and not self.field_names:
-            raise ValueError(
-                "Hive partition path generation requires a corresponding list of "
-                "partition key field names. Please retry your request with one "
-                "or more field names specified."
-            )
-        generators = {
-            PartitionStyle.HIVE: self._generate_hive_partition_dirs,
-            PartitionStyle.DIRECTORY: self._generate_directory_partition_dirs,
-        }
-        self._generator_fn: Callable[[List[str]], List[str]] = generators.get(style)
-        if self._generator_fn is None:
-            raise ValueError(
-                f"Unsupported partition style: {style}. "
-                f"Supported styles: {generators.keys()}"
-            )
+        scheme = PathPartitionScheme(style, base_dir, field_names, filesystem)
+        return PathPartitionEncoder(scheme)
 
-    def _generate_hive_partition_dirs(self, values: List[str]) -> List[str]:
-        """Generates Hive directory names for the given values."""
-        return [f"{self._field_names[i]}={val}" for i, val in enumerate(values)]
+    @property
+    def scheme(self) -> PathPartitionScheme:
+        """Returns the path partition scheme for this encoder."""
+        return self._scheme
 
-    def _generate_directory_partition_dirs(self, values: List[str]) -> List[str]:
-        """Generates Directory partition directory names for the given values."""
+    def _as_hive_partition_dirs(self, values: List[str]) -> List[str]:
+        """Creates HIVE directory names for the given values."""
+        field_names = self._scheme.field_names
+        return [f"{field_names[i]}={val}" for i, val in enumerate(values)]
+
+    def _as_directory_partition_dirs(self, values: List[str]) -> List[str]:
+        """Creates DIRECTORY partition directory names for the given values."""
         return values
 
-    def _generate_partition_dirs(self, values: List[str]) -> List[str]:
-        """Generates a list of partition directory names for the given values."""
-        if self._field_names:
-            assert len(values) == len(self._field_names), (
-                f"Expected {len(self._field_names)} partition value(s) but found "
+    def _as_partition_dirs(self, values: List[str]) -> List[str]:
+        """Creates a list of partition directory names for the given values."""
+        field_names = self._scheme.field_names
+        if field_names:
+            assert len(values) == len(field_names), (
+                f"Expected {len(field_names)} partition value(s) but found "
                 f"{len(values)}: {values}."
             )
-        return self._generator_fn(values)
+        return self._encoder_fn(values)
 
-    def __call__(
-        self,
-        partition_values: List[str],
-        filesystem: "pyarrow.fs.FileSystem",
-    ) -> str:
+    def __call__(self, partition_values: List[str]) -> str:
         """Returns the partition directory path for the given partition value strings.
 
         All files for this partition should be written to this directory. If a base
@@ -196,19 +228,17 @@ class PathPartitionGenerator(PathPartitionBase):
             partition_values: The partition value strings to include in the partition
                 path. For HIVE partition paths, the order and length of partition
                 values must match the order and length of partition key field names.
-            filesystem: Filesystem that will be used for partition path file I/O.
 
         Returns:
             Partition directory path for the given partition values.
         """
-        self._normalize_base_dir(filesystem)
-        partition_dirs = self._generate_partition_dirs(partition_values)
-        return posixpath.join(self._normalized_base_dir, *partition_dirs)
+        partition_dirs = self._as_partition_dirs(partition_values)
+        return posixpath.join(self._scheme.normalized_base_dir, *partition_dirs)
 
 
 @DeveloperAPI
-class PathPartitionParser(PathPartitionBase):
-    """Partition parser and associated utilities for path-based partition formats.
+class PathPartitionParser:
+    """Partition parser for path-based partition formats.
 
     Path-based partition formats embed all partition keys and values directly in
     their dataset file paths.
@@ -237,41 +267,21 @@ class PathPartitionParser(PathPartitionBase):
     "foo/bar/baz.csv" would be associated with partition ("foo", "bar").
     """
 
-    def __init__(
-        self,
-        style: PartitionStyle = PartitionStyle.HIVE,
-        base_dir: Optional[str] = None,
-        field_names: Optional[List[str]] = None,
-        filter_fn: Optional[Callable[[Dict[str, str]], bool]] = None,
-    ):
-        """Creates a new path-based dataset partition parser.
+    def __init__(self, path_partition_scheme: PathPartitionScheme):
+        """Creates a path-based partition parser.
 
         Args:
-            style: The partition style - may be either HIVE or DIRECTORY.
-            base_dir: "/"-delimited base directory to start searching for partitions
-                (exclusive). File paths outside of this directory will be considered
-                unpartitioned. Specify `None` or an empty string to search for
-                partitions in all file path directories.
-            field_names: The partition key names. Required for DIRECTORY partitioning.
-                Optional for HIVE partitioning. When non-empty, the order and length of
-                partition key field names must match the order and length of partition
-                directories discovered. Partition key field names are not required to
-                exist in the dataset schema.
-            filter_fn: Callback used to filter partitions. Takes a dictionary mapping
-                partition keys to values as input. Unpartitioned files are denoted with
-                an empty input dictionary. Returns `True` to read a file for that
-                partition or `False` to skip it. Partition keys and values are always
-                strings read from the filesystem path. For example, this removes all
-                unpartitioned files:
-                ``lambda d: True if d else False``
-                This raises an assertion error for any unpartitioned file found:
-                ``def do_assert(val, msg):
-                    assert val, msg
-                  lambda d: do_assert(d, "Expected all files to be partitioned!")``
-                And this only reads files from January, 2022 partitions:
-                ``lambda d: d["month"] == "January" and d["year"] == "2022"``
+            path_partition_scheme: The path-based partition scheme. The parser starts
+                searching for partitions from this scheme's base directory. File paths
+                outside the base directory will be considered unpartitioned. If the
+                base directory is `None` or an empty string then this will search for
+                partitions in all file path directories. Field names are required for
+                DIRECTORY partitioning, and optional for HIVE partitioning. When
+                non-empty, the order and length of partition key field names must match
+                the order and length of partition directories discovered.
         """
-        super(PathPartitionParser, self).__init__(style, base_dir, field_names)
+        style = path_partition_scheme.style
+        field_names = path_partition_scheme.field_names
         if style == PartitionStyle.DIRECTORY and not field_names:
             raise ValueError(
                 "Directory partitioning requires a corresponding list of "
@@ -288,13 +298,180 @@ class PathPartitionParser(PathPartitionBase):
                 f"Unsupported partition style: {style}. "
                 f"Supported styles: {parsers.keys()}"
             )
+        self._scheme = path_partition_scheme
+
+    @staticmethod
+    def of(
+        style: PartitionStyle = PartitionStyle.HIVE,
+        base_dir: Optional[str] = None,
+        field_names: Optional[List[str]] = None,
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> "PathPartitionParser":
+        """Creates a path-based partition parser using a flattened argument list.
+
+        Args:
+            style: The partition style - may be either HIVE or DIRECTORY.
+            base_dir: "/"-delimited base directory to start searching for partitions
+                (exclusive). File paths outside of this directory will be considered
+                unpartitioned. Specify `None` or an empty string to search for
+                partitions in all file path directories.
+            field_names: The partition key names. Required for DIRECTORY partitioning.
+                Optional for HIVE partitioning. When non-empty, the order and length of
+                partition key field names must match the order and length of partition
+                directories discovered. Partition key field names are not required to
+                exist in the dataset schema.
+        """
+        scheme = PathPartitionScheme(style, base_dir, field_names, filesystem)
+        return PathPartitionParser(scheme)
+
+    @property
+    def scheme(self) -> PathPartitionScheme:
+        """Returns the path partition scheme for this parser."""
+        return self._scheme
+
+    def _dir_path_trim_base(self, path: str) -> Optional[str]:
+        """Trims the normalized base directory and returns the directory path.
+
+        Returns None if the path does not start with the normalized base directory.
+        Simply returns the directory path if the base directory is undefined.
+        """
+        if not path.startswith(self._scheme.normalized_base_dir):
+            return None
+        path = path[len(self._scheme.normalized_base_dir) :]
+        return posixpath.dirname(path)
+
+    def _parse_hive_path(self, dir_path: str) -> Dict[str, str]:
+        """Hive partition path parser.
+
+        Returns a dictionary mapping partition keys to values given a hive-style
+        partition path of the form "{key1}={value1}/{key2}={value2}/..." or an empty
+        dictionary for unpartitioned files.
+        """
+        dirs = [d for d in dir_path.split("/") if d and (d.count("=") == 1)]
+        kv_pairs = [d.split("=") for d in dirs] if dirs else []
+        field_names = self._scheme.field_names
+        if field_names and kv_pairs:
+            assert len(kv_pairs) == len(field_names), (
+                f"Expected {len(field_names)} partition value(s) but found "
+                f"{len(kv_pairs)}: {kv_pairs}."
+            )
+            for i, field_name in enumerate(field_names):
+                assert (
+                    kv_pairs[i][0] == field_name
+                ), f"Expected partition key {field_name} but found {kv_pairs[i][0]}"
+        return dict(kv_pairs)
+
+    def _parse_dir_path(self, dir_path: str) -> Dict[str, str]:
+        """Directory partition path parser.
+
+        Returns a dictionary mapping directory partition keys to values from a
+        partition path of the form "{value1}/{value2}/..." or an empty dictionary for
+        unpartitioned files.
+
+        Requires a corresponding ordered list of partition key field names to map the
+        correct key to each value.
+        """
+        dirs = [d for d in dir_path.split("/") if d]
+        field_names = self._scheme.field_names
+        assert not dirs or len(dirs) == len(field_names), (
+            f"Expected {len(field_names)} partition value(s) but found "
+            f"{len(dirs)}: {dirs}."
+        )
+        return {field_names[i]: d for i, d in enumerate(dirs)} if dirs else {}
+
+    def __call__(self, path: str) -> Dict[str, str]:
+        """Parses partition keys and values from a single file path.
+
+        Args:
+            path: Input file path to parse.
+        Returns:
+            Dictionary mapping directory partition keys to values from the input file
+            path. Returns an empty dictionary for unpartitioned files.
+        """
+        dir_path = self._dir_path_trim_base(path)
+        if dir_path is None:
+            return {}
+        return self._parser_fn(dir_path)
+
+
+class PathPartitionFilter:
+    """Partition filter for path-based partition formats.
+
+    Used to explicitly keep or reject files based on a custom filter function that
+    takes partition keys and values parsed from the file's path as input.
+    """
+
+    def __init__(
+        self,
+        path_partition_parser: PathPartitionParser,
+        filter_fn: Callable[[Dict[str, str]], bool],
+    ):
+        """Creates a new path-based partition filter based on a parser.
+
+        Args:
+            path_partition_parser: The path-based partition parser.
+            filter_fn: Callback used to filter partitions. Takes a dictionary mapping
+                partition keys to values as input. Unpartitioned files are denoted with
+                an empty input dictionary. Returns `True` to read a file for that
+                partition or `False` to skip it. Partition keys and values are always
+                strings read from the filesystem path. For example, this removes all
+                unpartitioned files:
+                ``lambda d: True if d else False``
+                This raises an assertion error for any unpartitioned file found:
+                ``def do_assert(val, msg):
+                    assert val, msg
+                  lambda d: do_assert(d, "Expected all files to be partitioned!")``
+                And this only reads files from January, 2022 partitions:
+                ``lambda d: d["month"] == "January" and d["year"] == "2022"``
+        """
+        self._parser = path_partition_parser
         self._filter_fn = filter_fn
 
-    def filter_paths(
-        self,
-        paths: List[str],
-        filesystem: "pyarrow.fs.FileSystem",
-    ) -> List[str]:
+    @property
+    def parser(self) -> PathPartitionParser:
+        """Returns the path partition parser for this filter."""
+        return self._parser
+
+    @staticmethod
+    def of(
+        filter_fn: Callable[[Dict[str, str]], bool],
+        style: PartitionStyle = PartitionStyle.HIVE,
+        base_dir: Optional[str] = None,
+        field_names: Optional[List[str]] = None,
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> "PathPartitionFilter":
+        """Creates a path-based partition filter using a flattened argument list.
+
+        Args:
+            filter_fn: Callback used to filter partitions. Takes a dictionary mapping
+                partition keys to values as input. Unpartitioned files are denoted with
+                an empty input dictionary. Returns `True` to read a file for that
+                partition or `False` to skip it. Partition keys and values are always
+                strings read from the filesystem path. For example, this removes all
+                unpartitioned files:
+                ``lambda d: True if d else False``
+                This raises an assertion error for any unpartitioned file found:
+                ``def do_assert(val, msg):
+                    assert val, msg
+                  lambda d: do_assert(d, "Expected all files to be partitioned!")``
+                And this only reads files from January, 2022 partitions:
+                ``lambda d: d["month"] == "January" and d["year"] == "2022"``
+            style: The partition style - may be either HIVE or DIRECTORY.
+            base_dir: "/"-delimited base directory to start searching for partitions
+                (exclusive). File paths outside of this directory will be considered
+                unpartitioned. Specify `None` or an empty string to search for
+                partitions in all file path directories.
+            field_names: The partition key names. Required for DIRECTORY partitioning.
+                Optional for HIVE partitioning. When non-empty, the order and length of
+                partition key field names must match the order and length of partition
+                directories discovered. Partition key field names are not required to
+                exist in the dataset schema.
+        """
+        scheme = PathPartitionScheme(style, base_dir, field_names, filesystem)
+        path_partition_parser = PathPartitionParser(scheme)
+        return PathPartitionFilter(path_partition_parser, filter_fn)
+
+    def __call__(self, paths: List[str]) -> List[str]:
         """Returns all paths that pass this partition scheme's partition filter.
 
         If no partition filter is set, then returns all input paths. If a base
@@ -307,7 +484,6 @@ class PathPartitionParser(PathPartitionBase):
         given filesystem before applying the filter.
 
         Args:
-            filesystem: Filesystem that will be used to read all file paths.
             paths: Paths to pass through the partition filter function. All
                 paths should be normalized for compatibility with the given
                 filesystem.
@@ -317,62 +493,7 @@ class PathPartitionParser(PathPartitionBase):
         """
         filtered_paths = paths
         if self._filter_fn is not None:
-            self._normalize_base_dir(filesystem)
             filtered_paths = [
-                path for path in paths if self._filter_fn(self._parser_fn(path))
+                path for path in paths if self._filter_fn(self._parser(path))
             ]
         return filtered_paths
-
-    def _dir_path_trim_base(self, path: str) -> Optional[str]:
-        """Trims the normalized base directory and returns the directory path.
-
-        Returns None if the path does not start with the normalized base directory.
-        Simply returns the directory path if the base directory is undefined.
-        """
-        if not path.startswith(self._normalized_base_dir):
-            return None
-        path = path[len(self._normalized_base_dir) :]
-        return posixpath.dirname(path)
-
-    def _parse_hive_path(self, path: str) -> Dict[str, str]:
-        """Hive partition path parser.
-
-        Returns a dictionary mapping partition keys to values given a hive-style
-        partition path of the form "{key1}={value1}/{key2}={value2}/..." or an empty
-        dictionary for unpartitioned files.
-        """
-        dir_path = self._dir_path_trim_base(path)
-        if dir_path is None:
-            return {}
-        dirs = [d for d in dir_path.split("/") if d and (d.count("=") == 1)]
-        kv_pairs = [d.split("=") for d in dirs] if dirs else []
-        if self._field_names and kv_pairs:
-            assert len(kv_pairs) == len(self._field_names), (
-                f"Expected {len(self._field_names)} partition value(s) but found "
-                f"{len(kv_pairs)}: {kv_pairs}."
-            )
-            for i, field_name in enumerate(self._field_names):
-                assert (
-                    kv_pairs[i][0] == field_name
-                ), f"Expected partition key {field_name} but found {kv_pairs[i][0]}"
-        return dict(kv_pairs)
-
-    def _parse_dir_path(self, path: str) -> Dict[str, str]:
-        """Directory partition path parser.
-
-        Returns a dictionary mapping directory partition keys to values from a
-        partition path of the form "{value1}/{value2}/..." or an empty dictionary for
-        unpartitioned files.
-
-        Requires a corresponding ordered list of partition key field names to map the
-        correct key to each value.
-        """
-        dir_path = self._dir_path_trim_base(path)
-        if dir_path is None:
-            return {}
-        dirs = [d for d in dir_path.split("/") if d]
-        assert not dirs or len(dirs) == len(self._field_names), (
-            f"Expected {len(self._field_names)} partition value(s) but found "
-            f"{len(dirs)}: {dirs}."
-        )
-        return {self._field_names[i]: d for i, d in enumerate(dirs)} if dirs else {}

--- a/python/ray/data/datasource/partitioning.py
+++ b/python/ray/data/datasource/partitioning.py
@@ -346,8 +346,11 @@ class PathPartitionParser(PathPartitionBase):
             return {}
         dirs = [d for d in dir_path.split("/") if d and (d.count("=") == 1)]
         kv_pairs = [d.split("=") for d in dirs] if dirs else []
-        if self._field_names:
-            assert len(kv_pairs) == len(self._field_names)
+        if self._field_names and kv_pairs:
+            assert len(kv_pairs) == len(self._field_names), (
+                f"Expected {len(self._field_names)} partition value(s) but found "
+                f"{len(kv_pairs)}: {kv_pairs}."
+            )
             for i, field_name in enumerate(self._field_names):
                 assert (
                     kv_pairs[i][0] == field_name

--- a/python/ray/data/datasource/partitioning.py
+++ b/python/ray/data/datasource/partitioning.py
@@ -1,0 +1,228 @@
+import posixpath
+from enum import Enum
+from typing import (
+    Optional,
+    List,
+    Callable,
+    Dict,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    import pyarrow
+
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class PartitionStyle(str, Enum):
+    """Supported dataset partition styles.
+
+    Inherits from `str` to simplify plain text serialization/deserialization.
+
+    Examples:
+        >>> # Serialize to JSON text.
+        >>> json.dumps(PartitionStyle.HIVE)  # "hive"
+
+        >>> # Deserialize from JSON text.
+        >>> PartitionStyle(json.loads('"hive"'))  # PartitionStyle.HIVE
+    """
+
+    HIVE = "hive"
+    DIRECTORY = "dir"
+
+
+@DeveloperAPI
+class PathPartitionParser:
+    """Partition parser and utilities for path-based partition formats.
+
+    Path-based partition formats embed all partition keys and values directly in
+    their dataset file paths.
+
+    Two path partition formats are currently supported - HIVE and DIRECTORY.
+
+    For HIVE Partitioning, all partition directories under the base directory
+    will be discovered based on "{key1}={value1}/{key2}={value2}" naming
+    conventions. Key/value pairs do not need to be presented in the same
+    order across all paths. Directory names nested under the base directory that
+    don't follow this naming condition will be considered unpartitioned. If a
+    partition filter is defined, then it will be called with an empty input
+    dictionary for each unpartitioned file.
+
+    For DIRECTORY Partitioning, all directories under the base directory will
+    be interpreted as partition values of the form "{value1}/{value2}". An
+    accompanying ordered list of partition field names must also be provided,
+    where the order and length of all partition values must match the order and
+    length of field names. Files stored directly in the base directory will
+    be considered unpartitioned. If a partition filter is defined, then it will
+    be called with an empty input dictionary for each unpartitioned file. For
+    example, if the base directory is "foo" then "foo.csv" and "foo/bar.csv" would be
+    considered unpartitioned files but "foo/bar/baz.csv" would be associated with
+    partition "bar". If the base directory is undefined, then "foo.csv" would be
+    unpartitioned, "foo/bar.csv" would be associated with partition "foo", and
+    "foo/bar/baz.csv" would be associated with partition ("foo", "bar").
+    """
+
+    def __init__(
+        self,
+        style: PartitionStyle = PartitionStyle.HIVE,
+        base_dir: Optional[str] = None,
+        field_names: Optional[List[str]] = None,
+        filter_fn: Optional[Callable[[Dict[str, str]], bool]] = None,
+    ):
+        """Creates a new path-based dataset partition scheme.
+
+        Args:
+            style: The partition style - may be either HIVE or DIRECTORY.
+            base_dir: "/"-delimited base directory to start searching for partitions
+                (exclusive). File paths outside of this directory will be considered
+                unpartitioned. Specify `None` or an empty string to search for
+                partitions in all file path directories.
+            field_names: The partition key names. Required for DIRECTORY partitioning.
+                Optional for HIVE partitioning. When non-empty, the order and length of
+                of partition key field names must match the order and length of
+                partition directories discovered. Partition key field names are not
+                required to exist in the dataset schema.
+            filter_fn: Callback used to filter partitions. Takes a dictionary mapping
+                partition keys to values as input. Unpartitioned files are denoted with
+                an empty input dictionary. Returns `True` to read a partition or `False`
+                to skip it. Partition keys and values are always strings read from the
+                filesystem path. For example, this removes all unpartitioned files:
+                ``lambda d: True if d else False``
+                This raises an assertion error for any unpartitioned file found:
+                ``def do_assert(val, msg):
+                    assert val, msg
+                  lambda d: do_assert(d, "Expected all files to be partitioned!")``
+                And this only reads files from January, 2022 partitions:
+                ``lambda d: d["month"] == "January" and d["year"] == "2022"``
+        """
+        self._style = style
+        self._base_dir = base_dir or ""
+        if style == PartitionStyle.DIRECTORY and not field_names:
+            raise ValueError(
+                "Directory partitioning requires a corresponding list of "
+                "partition key field names. Please retry your request with one "
+                "or more field names specified."
+            )
+        self._field_names = field_names
+        self._filter_fn = filter_fn
+        kv_parser_map = {
+            PartitionStyle.HIVE: self._parse_hive_path,
+            PartitionStyle.DIRECTORY: self._parse_dir_path,
+        }
+        self._parser_fn: Callable[[str], Dict[str, str]] = kv_parser_map.get(style)
+        if self._parser_fn is None:
+            raise ValueError(
+                f"Unsupported partition style: {style}. "
+                f"Supported styles: {kv_parser_map.keys()}"
+            )
+
+    @property
+    def style(self) -> PartitionStyle:
+        return self._style
+
+    @property
+    def base_dir(self) -> Optional[str]:
+        return self._base_dir
+
+    @property
+    def field_names(self) -> Optional[List[str]]:
+        return self._field_names
+
+    def filter_paths(
+        self,
+        paths: List[str],
+        filesystem: "pyarrow.fs.FileSystem",
+    ) -> List[str]:
+        """Removes all paths that don't pass this partition scheme's partition
+        filter. If no partition filter is set, then returns all input paths. If
+        a base directory is set, then only paths under this base directory will
+        be parsed for partitions. All paths outside of this base directory will
+        automatically be considered unpartitioned, and passed into the filter
+        function as empty dictionaries.
+
+        Also normalizes the partition base directory for compatibility with the
+        given filesystem before applying the filter.
+
+        Args:
+            filesystem: Filesystem that will be used to read all file paths.
+            paths: Paths to pass through the partition filter function. All
+                paths should be normalized for compatibility with the given
+                filesystem.
+        Returns:
+            List of paths that pass the partition filter, or all paths if no
+            partition filter is defined.
+        """
+        filtered_paths = paths
+        if self._filter_fn is not None:
+            self._normalize_base_dir(filesystem)
+            filtered_paths = [
+                path for path in paths if self._filter_fn(self._parser_fn(path))
+            ]
+        return filtered_paths
+
+    def _normalize_base_dir(self, filesystem: "pyarrow.fs.FileSystem"):
+        """Normalizes the partition base directory for compatibility with the
+        given filesystem.
+
+        This should be called once a filesystem has been resolved for reading all
+        dataset file paths to ensure that this base directory is correctly discovered
+        at the root of all partitioned file paths.
+        """
+        from ray.data.datasource.file_based_datasource import (
+            _resolve_paths_and_filesystem,
+        )
+
+        paths, _ = _resolve_paths_and_filesystem(
+            self._base_dir,
+            filesystem,
+        )
+        assert (
+            len(paths) == 1
+        ), f"Expected 1 normalized base directory, but found {len(paths)}"
+        new_base_dir = paths[0]
+        if len(new_base_dir) and not new_base_dir.endswith("/"):
+            new_base_dir += "/"
+        self._base_dir = new_base_dir
+
+    def _parse_hive_path(self, path: str) -> Dict[str, str]:
+        """Hive partition path parser.
+
+        Returns a dictionary mapping partition keys to values given a hive-style
+        partition path of the form "{key1}={value1}/{key2}={value2}/..." or an empty
+        dictionary for unpartitioned files.
+        """
+        if not path.startswith(self._base_dir):
+            return {}
+        path = path[len(self._base_dir) :]
+        dir_path = posixpath.dirname(path)
+        dirs = [d for d in dir_path.split("/") if d and (d.count("=") == 1)]
+        kv_pairs = [d.split("=") for d in dirs] if dirs else []
+        if self._field_names:
+            assert len(kv_pairs) == len(self._field_names)
+            for i, field_name in enumerate(self._field_names):
+                assert (
+                    kv_pairs[i][0] == field_name
+                ), f"Expected partition key {field_name} but found {kv_pairs[i][0]}"
+        return dict(kv_pairs)
+
+    def _parse_dir_path(self, path: str) -> Dict[str, str]:
+        """Directory partition path parser.
+
+        Returns a dictionary mapping directory partition keys to values from a
+        partition path of the form "{value1}/{value2}/..." or an empty dictionary for
+        unpartitioned files.
+
+        Requires a corresponding ordered list of partition key field names to map the
+        correct key to each value.
+        """
+        if not path.startswith(self._base_dir):
+            return {}
+        path = path[len(self._base_dir) :]
+        dir_path = posixpath.dirname(path)
+        dirs = [d for d in dir_path.split("/") if d]
+        assert not dirs or len(dirs) == len(self._field_names), (
+            f"Expected {len(self._field_names)} partition value(s) but found "
+            f"{len(dirs)}: {dirs}."
+        )
+        return {self._field_names[i]: d for i, d in enumerate(dirs)} if dirs else {}

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -45,7 +45,7 @@ from ray.data.datasource import (
     DefaultFileMetadataProvider,
     ParquetMetadataProvider,
     DefaultParquetMetadataProvider,
-    PathPartitionParser,
+    PathPartitionFilter,
 )
 from ray.data.datasource.file_based_datasource import (
     _wrap_arrow_serialization_workaround,
@@ -356,7 +356,7 @@ def read_json(
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
-    partitioning: PathPartitionParser = None,
+    partition_filter: PathPartitionFilter = None,
     **arrow_json_args,
 ) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from json files.
@@ -384,7 +384,7 @@ def read_json(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
-        partitioning: Path-based partitioning style, if any. Can be used
+        partition_filter: Path-based partition filter, if any. Can be used
             with a custom callback to read only selected partitions of a dataset.
         arrow_json_args: Other json read options to pass to pyarrow.
 
@@ -399,7 +399,7 @@ def read_json(
         ray_remote_args=ray_remote_args,
         open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
-        partitioning=partitioning,
+        partition_filter=partition_filter,
         **arrow_json_args,
     )
 
@@ -413,7 +413,7 @@ def read_csv(
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
-    partitioning: PathPartitionParser = None,
+    partition_filter: PathPartitionFilter = None,
     **arrow_csv_args,
 ) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from csv files.
@@ -441,7 +441,7 @@ def read_csv(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
-        partitioning: Path-based partitioning style, if any. Can be used
+        partition_filter: Path-based partition filter, if any. Can be used
             with a custom callback to read only selected partitions of a dataset.
         arrow_csv_args: Other csv read options to pass to pyarrow.
 
@@ -456,7 +456,7 @@ def read_csv(
         ray_remote_args=ray_remote_args,
         open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
-        partitioning=partitioning,
+        partition_filter=partition_filter,
         **arrow_csv_args,
     )
 
@@ -472,7 +472,7 @@ def read_text(
     parallelism: int = 200,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
-    partitioning: PathPartitionParser = None,
+    partition_filter: PathPartitionFilter = None,
 ) -> Dataset[str]:
     """Create a dataset from lines stored in text files.
 
@@ -496,7 +496,7 @@ def read_text(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
-        partitioning: Path-based partitioning style, if any. Can be used
+        partition_filter: Path-based partition filter, if any. Can be used
             with a custom callback to read only selected partitions of a dataset.
 
     Returns:
@@ -515,7 +515,7 @@ def read_text(
         parallelism=parallelism,
         arrow_open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
-        partitioning=partitioning,
+        partition_filter=partition_filter,
     ).flat_map(to_text)
 
 
@@ -527,7 +527,7 @@ def read_numpy(
     parallelism: int = 200,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
-    partitioning: PathPartitionParser = None,
+    partition_filter: PathPartitionFilter = None,
     **numpy_load_args,
 ) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from numpy files.
@@ -555,7 +555,7 @@ def read_numpy(
         numpy_load_args: Other options to pass to np.load.
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
-        partitioning: Path-based partitioning style, if any. Can be used
+        partition_filter: Path-based partition filter, if any. Can be used
             with a custom callback to read only selected partitions of a dataset.
     Returns:
         Dataset holding Tensor records read from the specified paths.
@@ -567,7 +567,7 @@ def read_numpy(
         filesystem=filesystem,
         open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
-        partitioning=partitioning,
+        partition_filter=partition_filter,
         **numpy_load_args,
     )
 
@@ -582,7 +582,7 @@ def read_binary_files(
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
-    partitioning: PathPartitionParser = None,
+    partition_filter: PathPartitionFilter = None,
 ) -> Dataset[Union[Tuple[str, bytes], bytes]]:
     """Create a dataset from binary files of arbitrary contents.
 
@@ -608,7 +608,7 @@ def read_binary_files(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
-        partitioning: Path-based partitioning style, if any. Can be used
+        partition_filter: Path-based partition filter, if any. Can be used
             with a custom callback to read only selected partitions of a dataset.
 
     Returns:
@@ -624,7 +624,7 @@ def read_binary_files(
         open_stream_args=arrow_open_stream_args,
         schema=bytes,
         meta_provider=meta_provider,
-        partitioning=partitioning,
+        partition_filter=partition_filter,
     )
 
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -45,6 +45,7 @@ from ray.data.datasource import (
     DefaultFileMetadataProvider,
     ParquetMetadataProvider,
     DefaultParquetMetadataProvider,
+    PathPartitionParser,
 )
 from ray.data.datasource.file_based_datasource import (
     _wrap_arrow_serialization_workaround,
@@ -334,7 +335,6 @@ def read_parquet(
             return block
 
         arrow_parquet_args["_block_udf"] = _block_udf
-
     return read_datasource(
         ParquetDatasource(),
         parallelism=parallelism,
@@ -356,6 +356,7 @@ def read_json(
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
+    partitioning: PathPartitionParser = None,
     **arrow_json_args,
 ) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from json files.
@@ -383,6 +384,8 @@ def read_json(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
+        partitioning: Path-based partitioning style, if any. Can be used
+            with a custom callback to read only selected partitions of a dataset.
         arrow_json_args: Other json read options to pass to pyarrow.
 
     Returns:
@@ -396,6 +399,7 @@ def read_json(
         ray_remote_args=ray_remote_args,
         open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
+        partitioning=partitioning,
         **arrow_json_args,
     )
 
@@ -409,6 +413,7 @@ def read_csv(
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
+    partitioning: PathPartitionParser = None,
     **arrow_csv_args,
 ) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from csv files.
@@ -436,6 +441,8 @@ def read_csv(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
+        partitioning: Path-based partitioning style, if any. Can be used
+            with a custom callback to read only selected partitions of a dataset.
         arrow_csv_args: Other csv read options to pass to pyarrow.
 
     Returns:
@@ -449,6 +456,7 @@ def read_csv(
         ray_remote_args=ray_remote_args,
         open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
+        partitioning=partitioning,
         **arrow_csv_args,
     )
 
@@ -464,6 +472,7 @@ def read_text(
     parallelism: int = 200,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
+    partitioning: PathPartitionParser = None,
 ) -> Dataset[str]:
     """Create a dataset from lines stored in text files.
 
@@ -487,6 +496,8 @@ def read_text(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
+        partitioning: Path-based partitioning style, if any. Can be used
+            with a custom callback to read only selected partitions of a dataset.
 
     Returns:
         Dataset holding lines of text read from the specified paths.
@@ -504,6 +515,7 @@ def read_text(
         parallelism=parallelism,
         arrow_open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
+        partitioning=partitioning,
     ).flat_map(to_text)
 
 
@@ -515,6 +527,7 @@ def read_numpy(
     parallelism: int = 200,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
+    partitioning: PathPartitionParser = None,
     **numpy_load_args,
 ) -> Dataset[ArrowRow]:
     """Create an Arrow dataset from numpy files.
@@ -542,6 +555,8 @@ def read_numpy(
         numpy_load_args: Other options to pass to np.load.
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
+        partitioning: Path-based partitioning style, if any. Can be used
+            with a custom callback to read only selected partitions of a dataset.
     Returns:
         Dataset holding Tensor records read from the specified paths.
     """
@@ -552,6 +567,7 @@ def read_numpy(
         filesystem=filesystem,
         open_stream_args=arrow_open_stream_args,
         meta_provider=meta_provider,
+        partitioning=partitioning,
         **numpy_load_args,
     )
 
@@ -566,6 +582,7 @@ def read_binary_files(
     ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: BaseFileMetadataProvider = DefaultFileMetadataProvider(),
+    partitioning: PathPartitionParser = None,
 ) -> Dataset[Union[Tuple[str, bytes], bytes]]:
     """Create a dataset from binary files of arbitrary contents.
 
@@ -591,6 +608,8 @@ def read_binary_files(
             pyarrow.fs.FileSystem.open_input_stream
         meta_provider: File metadata provider. Custom metadata providers may
             be able to resolve file metadata more quickly and/or accurately.
+        partitioning: Path-based partitioning style, if any. Can be used
+            with a custom callback to read only selected partitions of a dataset.
 
     Returns:
         Dataset holding Arrow records read from the specified paths.
@@ -605,6 +624,7 @@ def read_binary_files(
         open_stream_args=arrow_open_stream_args,
         schema=bytes,
         meta_provider=meta_provider,
+        partitioning=partitioning,
     )
 
 

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -182,7 +182,7 @@ def assert_base_partitioned_ds():
         ds,
         count=6,
         num_input_files=2,
-        num_rows=None,
+        num_rows=6,
         schema="{one: int64, two: string}",
         num_computed=2,
         sorted_values=None,

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -118,7 +118,7 @@ def test_block_write_path_provider():
             suffix = (
                 f"{block_index:06}_{num_rows:02}_{dataset_uuid}" f".test.{file_format}"
             )
-            return f"{base_path}/{suffix}"
+            return posixpath.join(base_path, suffix)
 
     yield TestBlockWritePathProvider()
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -978,7 +978,6 @@ def test_read_text_partitioned_with_filter(
         ds = ray.data.read_text(base_dir, partition_filter=partition_path_filter)
         assert_base_partitioned_ds(
             ds,
-            num_rows=6,
             schema="<class 'str'>",
             num_computed=None,
             sorted_values=["1 a", "1 b", "1 c", "3 e", "3 f", "3 g"],

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -1543,9 +1543,10 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
     else:
         fs.delete_dir(_unwrap_protocol(path))
 
-    # Two directories, three files.
-    path1 = os.path.join(data_path, "test_csv_dir1")
-    path2 = os.path.join(data_path, "test_csv_dir2")
+    # Two directories, three files
+    # URL fragment, query, and trailing forward-slash chars in directory names.
+    path1 = os.path.join(data_path, "test_csv_dir1#fragment?query=0/")
+    path2 = os.path.join(data_path, "test_csv_dir2#fragment?query/")
     if fs is None:
         os.mkdir(path1)
         os.mkdir(path2)
@@ -1825,10 +1826,11 @@ def test_csv_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     file_path = os.path.join(data_path, "data_000000.csv")
     assert df1.equals(pd.read_csv(file_path, storage_options=storage_options))
 
-    # Two blocks.
+    # Two blocks with URL fragment, query, and trailing forward-slash in write path.
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     ds = ray.data.from_pandas([df1, df2])
     ds._set_uuid("data")
+    data_path += "#fragment?query=test/"
     ds.write_csv(data_path, filesystem=fs)
     file_path2 = os.path.join(data_path, "data_000001.csv")
     df = pd.concat([df1, df2])

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -10,11 +10,17 @@ import snappy
 from fsspec.implementations.local import LocalFileSystem
 from pytest_lazyfixture import lazy_fixture
 from io import BytesIO
+from functools import partial
 
 import ray
 
 from ray.tests.conftest import *  # noqa
-from ray.data.datasource import DummyOutputDatasource
+from ray.data.datasource import (
+    DummyOutputDatasource,
+    PathPartitionParser,
+    PathPartitionGenerator,
+    PartitionStyle,
+)
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import PARALLELIZE_META_FETCH_THRESHOLD
@@ -26,6 +32,25 @@ def maybe_pipeline(ds, enabled):
         return ds.window(blocks_per_window=1)
     else:
         return ds
+
+
+@ray.remote
+class Counter:
+    def __init__(self):
+        self.count = 0
+
+    def increment(self):
+        self.count += 1
+
+    def get(self):
+        return self.count
+
+    def reset(self):
+        self.count = 0
+
+
+def df_to_csv(dataframe, path, **kwargs):
+    dataframe.to_csv(path, **kwargs)
 
 
 @pytest.mark.parametrize("enable_pandas_block", [False, True])
@@ -769,6 +794,64 @@ def test_numpy_read(ray_start_regular_shared, tmp_path):
     assert str(ds.take(2)) == "[{'value': array([0])}, {'value': array([1])}]"
 
 
+def test_numpy_read_partitioned_with_filter(
+    ray_start_regular_shared,
+    tmp_path,
+    write_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    def df_to_np(dataframe, path, **kwargs):
+        np.save(path, dataframe.to_numpy(dtype=np.dtype(np.int8)), **kwargs)
+
+    df = pd.DataFrame({"one": [1, 1, 1, 3, 3, 3], "two": [0, 1, 2, 3, 4, 5]})
+    partition_keys = ["one"]
+    kept_file_counter = Counter.remote()
+    skipped_file_counter = Counter.remote()
+
+    def skip_unpartitioned(kv_dict):
+        keep = bool(kv_dict)
+        counter = kept_file_counter if keep else skipped_file_counter
+        ray.get(counter.increment.remote())
+        return keep
+
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        base_dir = os.path.join(tmp_path, style.value)
+        partition_path_generator = PathPartitionGenerator(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_partitioned_df(
+            df,
+            partition_keys,
+            partition_path_generator,
+            None,
+            df_to_np,
+        )
+        df_to_np(df, os.path.join(base_dir, "test.npy"))
+        partition_path_parser = PathPartitionParser(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+            filter_fn=skip_unpartitioned,
+        )
+        ds = ray.data.read_numpy(base_dir, partitioning=partition_path_parser)
+
+        vals = [[1, 0], [1, 1], [1, 2], [3, 3], [3, 4], [3, 5]]
+        val_str = "".join([f"{{'value': array({v}, dtype=int8)}}, " for v in vals])[:-2]
+        assert_base_partitioned_ds(
+            ds,
+            schema="{value: <ArrowTensorType: shape=(2,), dtype=int8>}",
+            sorted_values=f"[[{val_str}]]",
+            ds_take_transform_fn=lambda taken: [taken],
+            sorted_values_transform_fn=lambda sorted_values: str(sorted_values),
+        )
+        assert ray.get(kept_file_counter.get.remote()) == 2
+        assert ray.get(skipped_file_counter.get.remote()) == 1
+        ray.get(kept_file_counter.reset.remote())
+        ray.get(skipped_file_counter.reset.remote())
+
+
 @pytest.mark.parametrize(
     "fs,data_path,endpoint_url",
     [
@@ -855,6 +938,60 @@ def test_read_text(ray_start_regular_shared, tmp_path):
     assert ds.count() == 5
 
 
+def test_read_text_partitioned_with_filter(
+    ray_start_regular_shared,
+    tmp_path,
+    write_base_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    def df_to_text(dataframe, path, **kwargs):
+        dataframe.to_string(path, index=False, header=False, **kwargs)
+
+    partition_keys = ["one"]
+    kept_file_counter = Counter.remote()
+    skipped_file_counter = Counter.remote()
+
+    def skip_unpartitioned(kv_dict):
+        keep = bool(kv_dict)
+        counter = kept_file_counter if keep else skipped_file_counter
+        ray.get(counter.increment.remote())
+        return keep
+
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        base_dir = os.path.join(tmp_path, style.value)
+        partition_path_generator = PathPartitionGenerator(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_base_partitioned_df(
+            partition_keys,
+            partition_path_generator,
+            None,
+            df_to_text,
+        )
+        df_to_text(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.txt"))
+        partition_path_parser = PathPartitionParser(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+            filter_fn=skip_unpartitioned,
+        )
+        ds = ray.data.read_text(base_dir, partitioning=partition_path_parser)
+        assert_base_partitioned_ds(
+            ds,
+            num_rows=6,
+            schema="<class 'str'>",
+            num_computed=None,
+            sorted_values=["1 a", "1 b", "1 c", "3 e", "3 f", "3 g"],
+            ds_take_transform_fn=lambda t: t,
+        )
+        assert ray.get(kept_file_counter.get.remote()) == 2
+        assert ray.get(skipped_file_counter.get.remote()) == 1
+        ray.get(kept_file_counter.reset.remote())
+        ray.get(skipped_file_counter.reset.remote())
+
+
 def test_read_binary_snappy(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "test_binary_snappy")
     os.mkdir(path)
@@ -878,6 +1015,69 @@ def test_read_binary_snappy_inferred(ray_start_regular_shared, tmp_path):
         snappy.stream_compress(bytes, f)
     ds = ray.data.read_binary_files(path)
     assert sorted(ds.take()) == [byte_str]
+
+
+def test_read_binary_snappy_partitioned_with_filter(
+    ray_start_regular_shared,
+    tmp_path,
+    write_base_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    def df_to_binary(dataframe, path, **kwargs):
+        with open(path, "wb") as f:
+            df_string = dataframe.to_string(index=False, header=False, **kwargs)
+            byte_str = df_string.encode()
+            bytes = BytesIO(byte_str)
+            snappy.stream_compress(bytes, f)
+
+    partition_keys = ["one"]
+    kept_file_counter = Counter.remote()
+    skipped_file_counter = Counter.remote()
+
+    def skip_unpartitioned(kv_dict):
+        keep = bool(kv_dict)
+        counter = kept_file_counter if keep else skipped_file_counter
+        ray.get(counter.increment.remote())
+        return keep
+
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        base_dir = os.path.join(tmp_path, style.value)
+        partition_path_generator = PathPartitionGenerator(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_base_partitioned_df(
+            partition_keys,
+            partition_path_generator,
+            None,
+            df_to_binary,
+        )
+        df_to_binary(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.snappy"))
+        partition_path_parser = PathPartitionParser(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+            filter_fn=skip_unpartitioned,
+        )
+        ds = ray.data.read_binary_files(
+            base_dir,
+            partitioning=partition_path_parser,
+            arrow_open_stream_args=dict(compression="snappy"),
+        )
+        assert_base_partitioned_ds(
+            ds,
+            count=2,
+            num_rows=2,
+            schema="<class 'bytes'>",
+            num_computed=None,
+            sorted_values=[b"1 a\n1 b\n1 c", b"3 e\n3 f\n3 g"],
+            ds_take_transform_fn=lambda t: t,
+        )
+        assert ray.get(kept_file_counter.get.remote()) == 2
+        assert ray.get(skipped_file_counter.get.remote()) == 1
+        ray.get(kept_file_counter.reset.remote())
+        ray.get(skipped_file_counter.reset.remote())
 
 
 @pytest.mark.parametrize("pipelined", [False, True])
@@ -1065,6 +1265,63 @@ def test_zipped_json_read(ray_start_regular_shared, tmp_path):
     dsdf = ds.to_pandas()
     assert df.equals(dsdf)
     shutil.rmtree(dir_path)
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_json_read_partitioned_with_filter(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+    write_base_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    def df_to_json(dataframe, path, **kwargs):
+        dataframe.to_json(path, orient="records", lines=True, **kwargs)
+
+    partition_keys = ["one"]
+    kept_file_counter = Counter.remote()
+    skipped_file_counter = Counter.remote()
+
+    def skip_unpartitioned(kv_dict):
+        keep = bool(kv_dict)
+        counter = kept_file_counter if keep else skipped_file_counter
+        ray.get(counter.increment.remote())
+        return keep
+
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        base_dir = os.path.join(data_path, style.value)
+        partition_path_generator = PathPartitionGenerator(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_base_partitioned_df(
+            partition_keys,
+            partition_path_generator,
+            None,
+            df_to_json,
+        )
+        df_to_json(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.json"))
+        partition_path_parser = PathPartitionParser(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+            filter_fn=skip_unpartitioned,
+        )
+        ds = ray.data.read_json(base_dir, partitioning=partition_path_parser)
+        assert_base_partitioned_ds(ds)
+        assert ray.get(kept_file_counter.get.remote()) == 2
+        assert ray.get(skipped_file_counter.get.remote()) == 1
+        ray.get(kept_file_counter.reset.remote())
+        ray.get(skipped_file_counter.reset.remote())
 
 
 @pytest.mark.parametrize(
@@ -1335,6 +1592,216 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
         shutil.rmtree(dir_path)
     else:
         fs.delete_dir(_unwrap_protocol(dir_path))
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_csv_read_partitioned_hive_implicit(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+    write_base_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    storage_options = (
+        {}
+        if endpoint_url is None
+        else dict(client_kwargs=dict(endpoint_url=endpoint_url))
+    )
+    partition_keys = ["one"]
+    partition_path_generator = PathPartitionGenerator(
+        base_dir=data_path,
+        field_names=partition_keys,
+    )
+    write_base_partitioned_df(
+        partition_keys,
+        partition_path_generator,
+        fs,
+        partial(df_to_csv, storage_options=storage_options, index=False),
+    )
+    ds = ray.data.read_csv(data_path, partitioning=PathPartitionParser())
+    assert_base_partitioned_ds(ds)
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_csv_read_partitioned_styles_explicit(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+    write_base_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    storage_options = (
+        {}
+        if endpoint_url is None
+        else dict(client_kwargs=dict(endpoint_url=endpoint_url))
+    )
+    partition_keys = ["one"]
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        base_dir = os.path.join(data_path, style.value)
+        partition_path_generator = PathPartitionGenerator(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_base_partitioned_df(
+            partition_keys,
+            partition_path_generator,
+            fs,
+            partial(df_to_csv, storage_options=storage_options, index=False),
+        )
+        partition_path_parser = PathPartitionParser(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        ds = ray.data.read_csv(base_dir, partitioning=partition_path_parser)
+        assert_base_partitioned_ds(ds)
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_csv_read_partitioned_with_filter(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+    write_base_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    storage_options = (
+        {}
+        if endpoint_url is None
+        else dict(client_kwargs=dict(endpoint_url=endpoint_url))
+    )
+    partition_keys = ["one"]
+    file_writer_fn = partial(df_to_csv, storage_options=storage_options, index=False)
+    kept_file_counter = Counter.remote()
+    skipped_file_counter = Counter.remote()
+
+    def skip_unpartitioned(kv_dict):
+        keep = bool(kv_dict)
+        counter = kept_file_counter if keep else skipped_file_counter
+        ray.get(counter.increment.remote())
+        return keep
+
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        base_dir = os.path.join(data_path, style.value)
+        partition_path_generator = PathPartitionGenerator(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_base_partitioned_df(
+            partition_keys,
+            partition_path_generator,
+            fs,
+            file_writer_fn,
+        )
+        file_writer_fn(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.csv"))
+        partition_path_parser = PathPartitionParser(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+            filter_fn=skip_unpartitioned,
+        )
+        ds = ray.data.read_csv(base_dir, partitioning=partition_path_parser)
+        assert_base_partitioned_ds(ds)
+        assert ray.get(kept_file_counter.get.remote()) == 2
+        assert ray.get(skipped_file_counter.get.remote()) == 1
+        ray.get(kept_file_counter.reset.remote())
+        ray.get(skipped_file_counter.reset.remote())
+
+
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_csv_read_partitioned_with_filter_multikey(
+    ray_start_regular_shared,
+    fs,
+    data_path,
+    endpoint_url,
+    write_base_partitioned_df,
+    assert_base_partitioned_ds,
+):
+    storage_options = (
+        {}
+        if endpoint_url is None
+        else dict(client_kwargs=dict(endpoint_url=endpoint_url))
+    )
+    partition_keys = ["one", "two"]
+    file_writer_fn = partial(df_to_csv, storage_options=storage_options, index=False)
+    kept_file_counter = Counter.remote()
+    skipped_file_counter = Counter.remote()
+
+    def keep_expected_partitions(kv_dict):
+        keep = bool(kv_dict) and (
+            (kv_dict["one"] == "1" and kv_dict["two"] in {"a", "b", "c"})
+            or (kv_dict["one"] == "3" and kv_dict["two"] in {"e", "f", "g"})
+        )
+        counter = kept_file_counter if keep else skipped_file_counter
+        ray.get(counter.increment.remote())
+        return keep
+
+    for i, style in enumerate([PartitionStyle.HIVE, PartitionStyle.DIRECTORY]):
+        base_dir = os.path.join(data_path, style.value)
+        partition_path_generator = PathPartitionGenerator(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_base_partitioned_df(
+            partition_keys,
+            partition_path_generator,
+            fs,
+            file_writer_fn,
+        )
+        df = pd.DataFrame({"1": [1]})
+        file_writer_fn(df, os.path.join(data_path, f"test{i}.csv"))
+        partition_path_parser = PathPartitionParser(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+            filter_fn=keep_expected_partitions,
+        )
+        ds = ray.data.read_csv(data_path, partitioning=partition_path_parser)
+        assert_base_partitioned_ds(ds, input_files=6, num_computed=6)
+        assert ray.get(kept_file_counter.get.remote()) == 6
+        if i == 0:
+            # expect to skip 1 unpartitioned files in the parent of the base directory
+            assert ray.get(skipped_file_counter.get.remote()) == 1
+        else:
+            # expect to skip 2 unpartitioned files in the parent of the base directory
+            # plus 6 unpartitioned files in the base directory's sibling directories
+            assert ray.get(skipped_file_counter.get.remote()) == 8
+        ray.get(kept_file_counter.reset.remote())
+        ray.get(skipped_file_counter.reset.remote())
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -1284,8 +1284,19 @@ def test_json_read_partitioned_with_filter(
     assert_base_partitioned_ds,
 ):
     def df_to_json(dataframe, path, **kwargs):
-        dataframe.to_json(path, orient="records", lines=True, **kwargs)
+        dataframe.to_json(path, **kwargs)
 
+    storage_options = (
+        {}
+        if endpoint_url is None
+        else dict(client_kwargs=dict(endpoint_url=endpoint_url))
+    )
+    file_writer_fn = partial(
+        df_to_json,
+        orient="records",
+        lines=True,
+        storage_options=storage_options,
+    )
     partition_keys = ["one"]
     kept_file_counter = Counter.remote()
     skipped_file_counter = Counter.remote()
@@ -1306,17 +1317,21 @@ def test_json_read_partitioned_with_filter(
         write_base_partitioned_df(
             partition_keys,
             partition_path_generator,
-            None,
-            df_to_json,
+            fs,
+            file_writer_fn,
         )
-        df_to_json(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.json"))
+        file_writer_fn(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.json"))
         partition_path_parser = PathPartitionParser(
             style=style,
             base_dir=base_dir,
             field_names=partition_keys,
             filter_fn=skip_unpartitioned,
         )
-        ds = ray.data.read_json(base_dir, partitioning=partition_path_parser)
+        ds = ray.data.read_json(
+            base_dir,
+            partitioning=partition_path_parser,
+            filesystem=fs,
+        )
         assert_base_partitioned_ds(ds)
         assert ray.get(kept_file_counter.get.remote()) == 2
         assert ray.get(skipped_file_counter.get.remote()) == 1
@@ -1482,6 +1497,11 @@ def test_json_write_block_path_provider(
             lazy_fixture("s3_path_with_space"),
             lazy_fixture("s3_server"),
         ),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+            lazy_fixture("s3_server"),
+        ),
     ],
 )
 def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
@@ -1543,10 +1563,9 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
     else:
         fs.delete_dir(_unwrap_protocol(path))
 
-    # Two directories, three files
-    # URL fragment, query, and trailing forward-slash chars in directory names.
-    path1 = os.path.join(data_path, "test_csv_dir1#fragment?query=0/")
-    path2 = os.path.join(data_path, "test_csv_dir2#fragment?query/")
+    # Two directories, three files.
+    path1 = os.path.join(data_path, "test_csv_dir1")
+    path2 = os.path.join(data_path, "test_csv_dir2")
     if fs is None:
         os.mkdir(path1)
         os.mkdir(path2)
@@ -1627,7 +1646,11 @@ def test_csv_read_partitioned_hive_implicit(
         fs,
         partial(df_to_csv, storage_options=storage_options, index=False),
     )
-    ds = ray.data.read_csv(data_path, partitioning=PathPartitionParser())
+    ds = ray.data.read_csv(
+        data_path,
+        partitioning=PathPartitionParser(),
+        filesystem=fs,
+    )
     assert_base_partitioned_ds(ds)
 
 
@@ -1671,7 +1694,11 @@ def test_csv_read_partitioned_styles_explicit(
             base_dir=base_dir,
             field_names=partition_keys,
         )
-        ds = ray.data.read_csv(base_dir, partitioning=partition_path_parser)
+        ds = ray.data.read_csv(
+            base_dir,
+            partitioning=partition_path_parser,
+            filesystem=fs,
+        )
         assert_base_partitioned_ds(ds)
 
 
@@ -1727,7 +1754,11 @@ def test_csv_read_partitioned_with_filter(
             field_names=partition_keys,
             filter_fn=skip_unpartitioned,
         )
-        ds = ray.data.read_csv(base_dir, partitioning=partition_path_parser)
+        ds = ray.data.read_csv(
+            base_dir,
+            partitioning=partition_path_parser,
+            filesystem=fs,
+        )
         assert_base_partitioned_ds(ds)
         assert ray.get(kept_file_counter.get.remote()) == 2
         assert ray.get(skipped_file_counter.get.remote()) == 1
@@ -1791,7 +1822,11 @@ def test_csv_read_partitioned_with_filter_multikey(
             field_names=partition_keys,
             filter_fn=keep_expected_partitions,
         )
-        ds = ray.data.read_csv(data_path, partitioning=partition_path_parser)
+        ds = ray.data.read_csv(
+            data_path,
+            partitioning=partition_path_parser,
+            filesystem=fs,
+        )
         assert_base_partitioned_ds(ds, input_files=6, num_computed=6)
         assert ray.get(kept_file_counter.get.remote()) == 6
         if i == 0:
@@ -1811,6 +1846,11 @@ def test_csv_read_partitioned_with_filter_multikey(
         (None, lazy_fixture("local_path"), None),
         (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
         (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+            lazy_fixture("s3_server"),
+        ),
     ],
 )
 def test_csv_write(ray_start_regular_shared, fs, data_path, endpoint_url):
@@ -1826,11 +1866,10 @@ def test_csv_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     file_path = os.path.join(data_path, "data_000000.csv")
     assert df1.equals(pd.read_csv(file_path, storage_options=storage_options))
 
-    # Two blocks with URL fragment, query, and trailing forward-slash in write path.
+    # Two blocks.
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     ds = ray.data.from_pandas([df1, df2])
     ds._set_uuid("data")
-    data_path += "#fragment?query=test/"
     ds.write_csv(data_path, filesystem=fs)
     file_path2 = os.path.join(data_path, "data_000001.csv")
     df = pd.concat([df1, df2])

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -164,8 +164,6 @@ def test_path_partition_filter_errors():
         filter_fn=lambda d: d and d["foo"] == 1,
     )
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths([""], None)
-    with pytest.raises(AssertionError):
         path_partition_parser.filter_paths(["foo=1/"], None)
     with pytest.raises(AssertionError):
         path_partition_parser.filter_paths(["bar=1/foo=2/"], None)

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -161,7 +161,7 @@ def test_path_partition_encoder_directory(fs, base_dir):
     )
 
 
-def test_path_partition_filter_errors():
+def test_path_partition_parser_errors():
     # no field names for DIRECTORY path partitioning
     with pytest.raises(ValueError):
         PathPartitionParser.of(style=PartitionStyle.DIRECTORY)

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -6,15 +6,28 @@ from pyarrow.fs import FileType
 from pytest_lazyfixture import lazy_fixture
 from ray.data.datasource.file_based_datasource import _resolve_paths_and_filesystem
 
-from ray.data.datasource.partitioning import PathPartitionBase
+from ray.data.datasource.partitioning import PathPartitionScheme, PathPartitionFilter
 
 from ray.tests.conftest import *  # noqa
 from ray.data.datasource import (
     PathPartitionParser,
-    PathPartitionGenerator,
+    PathPartitionEncoder,
     PartitionStyle,
 )
 from ray.data.tests.conftest import *  # noqa
+
+
+def _verify_resolved_paths_and_filesystem(scheme: PathPartitionScheme):
+    assert scheme.base_dir is not None
+    assert scheme.normalized_base_dir is not None
+    paths, expected_fs = _resolve_paths_and_filesystem(
+        scheme.base_dir,
+        scheme.filesystem,
+    )
+    path = paths[0]
+    expected_path = f"{path}/" if path and not path.endswith("/") else path
+    assert scheme.normalized_base_dir == expected_path
+    assert isinstance(scheme.resolved_filesystem, type(expected_fs))
 
 
 def test_partition_style_serde_round_trip():
@@ -28,43 +41,43 @@ def test_path_partition_base_properties():
     style = PartitionStyle.DIRECTORY
     base_dir = "/foo/bar"
     field_names = ["baz", "qux"]
-    path_partition_base = PathPartitionBase(style, base_dir, field_names)
-    assert path_partition_base.style == style
-    assert path_partition_base.base_dir == base_dir
-    assert path_partition_base.normalized_base_dir is None
-    assert path_partition_base.field_names == field_names
+    scheme = PathPartitionScheme(style, base_dir, field_names, None)
+    assert scheme.style == style
+    assert scheme.base_dir == base_dir
+    assert scheme.field_names == field_names
+    _verify_resolved_paths_and_filesystem(scheme)
 
-    path_partition_base = PathPartitionBase(style, None, field_names)
-    assert path_partition_base.style == style
-    assert path_partition_base.base_dir == ""
-    assert path_partition_base.normalized_base_dir is None
-    assert path_partition_base.field_names == field_names
+    scheme = PathPartitionScheme(style, None, field_names, None)
+    assert scheme.style == style
+    assert scheme.base_dir == ""
+    assert scheme.field_names == field_names
+    _verify_resolved_paths_and_filesystem(scheme)
 
 
-def test_path_partition_generator_errors():
+def test_path_partition_encoder_errors():
     # no field names for default HIVE path partitioning
     with pytest.raises(ValueError):
-        PathPartitionGenerator()
+        PathPartitionEncoder.of()
     # explicit no field names for HIVE path partitioning
     with pytest.raises(ValueError):
-        PathPartitionGenerator(style=PartitionStyle.HIVE, field_names=[])
+        PathPartitionEncoder.of(style=PartitionStyle.HIVE, field_names=[])
     # invalid path partitioning style
     with pytest.raises(ValueError):
-        PathPartitionGenerator(style=None)
+        PathPartitionEncoder.of(style=None)
     # partition field name and field value length mismatch
     for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
-        path_partition_generator = PathPartitionGenerator(
+        path_partition_encoder = PathPartitionEncoder.of(
             style,
             field_names=["foo", "bar"],
         )
         with pytest.raises(TypeError):
-            path_partition_generator(None, None)
+            path_partition_encoder(None)
         with pytest.raises(AssertionError):
-            path_partition_generator([], None)
+            path_partition_encoder([])
         with pytest.raises(AssertionError):
-            path_partition_generator(["1"], None)
+            path_partition_encoder(["1"])
         with pytest.raises(AssertionError):
-            path_partition_generator(["1", "2", "3"], None)
+            path_partition_encoder(["1", "2", "3"])
 
 
 @pytest.mark.parametrize(
@@ -79,18 +92,18 @@ def test_path_partition_generator_errors():
         ),
     ],
 )
-def test_path_partition_generator_hive(fs, base_dir):
+def test_path_partition_encoder_hive(fs, base_dir):
     field_names = ["foo", "bar"]
-    path_partition_generator = PathPartitionGenerator(
+    path_partition_encoder = PathPartitionEncoder.of(
         field_names=field_names,
         base_dir=base_dir,
+        filesystem=fs,
     )
-    assert path_partition_generator.normalized_base_dir is None
+    _verify_resolved_paths_and_filesystem(path_partition_encoder.scheme)
     partition_values = ["1", "2"]
-    partition_path = path_partition_generator(partition_values, fs)
-    assert path_partition_generator.normalized_base_dir is not None
+    partition_path = path_partition_encoder(partition_values)
     assert partition_path == posixpath.join(
-        path_partition_generator.normalized_base_dir,
+        path_partition_encoder.scheme.normalized_base_dir,
         "foo=1",
         "bar=2",
     )
@@ -114,18 +127,18 @@ def test_path_partition_generator_hive(fs, base_dir):
         ),
     ],
 )
-def test_path_partition_generator_directory(fs, base_dir):
-    path_partition_generator = PathPartitionGenerator(
+def test_path_partition_encoder_directory(fs, base_dir):
+    path_partition_encoder = PathPartitionEncoder.of(
         style=PartitionStyle.DIRECTORY,
         field_names=["foo", "bar"],
         base_dir=base_dir,
+        filesystem=fs,
     )
-    assert path_partition_generator.normalized_base_dir is None
+    _verify_resolved_paths_and_filesystem(path_partition_encoder.scheme)
     partition_values = ["1", "2"]
-    partition_path = path_partition_generator(partition_values, fs)
-    assert path_partition_generator.normalized_base_dir is not None
+    partition_path = path_partition_encoder(partition_values)
     assert partition_path == posixpath.join(
-        path_partition_generator.normalized_base_dir,
+        path_partition_encoder.scheme.normalized_base_dir,
         *partition_values,
     )
     if fs is not None:
@@ -134,15 +147,16 @@ def test_path_partition_generator_directory(fs, base_dir):
         fs.create_dir(partition_path)
         file_info = fs.get_file_info(partition_path)
         assert file_info.type == FileType.Directory
-    path_partition_generator = PathPartitionGenerator(
+    path_partition_encoder = PathPartitionEncoder.of(
         style=PartitionStyle.DIRECTORY,
         base_dir=base_dir,
+        filesystem=fs,
     )
-    partition_path = path_partition_generator([], fs)
-    assert partition_path == path_partition_generator.normalized_base_dir
-    partition_path = path_partition_generator(partition_values, fs)
+    partition_path = path_partition_encoder([])
+    assert partition_path == path_partition_encoder.scheme.normalized_base_dir
+    partition_path = path_partition_encoder(partition_values)
     assert partition_path == posixpath.join(
-        path_partition_generator.normalized_base_dir,
+        path_partition_encoder.scheme.normalized_base_dir,
         *partition_values,
     )
 
@@ -150,53 +164,163 @@ def test_path_partition_generator_directory(fs, base_dir):
 def test_path_partition_filter_errors():
     # no field names for DIRECTORY path partitioning
     with pytest.raises(ValueError):
-        PathPartitionParser(style=PartitionStyle.DIRECTORY)
+        PathPartitionParser.of(style=PartitionStyle.DIRECTORY)
     # explicit no field names for DIRECTORY path partitioning
     with pytest.raises(ValueError):
-        PathPartitionParser(style=PartitionStyle.DIRECTORY, field_names=[])
+        PathPartitionParser.of(style=PartitionStyle.DIRECTORY, field_names=[])
     # invalid path partitioning style
     with pytest.raises(ValueError):
-        PathPartitionParser(style=None)
+        PathPartitionParser.of(style=None)
     # HIVE partition field name and field value length or order mismatch
-    path_partition_parser = PathPartitionParser(
-        PartitionStyle.HIVE,
+    path_partition_parser = PathPartitionParser.of(
+        style=PartitionStyle.HIVE,
         field_names=["foo", "bar"],
-        filter_fn=lambda d: d and d["foo"] == 1,
     )
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths(["foo=1/"], None)
+        path_partition_parser("foo=1/")
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths(["bar=1/foo=2/"], None)
+        path_partition_parser("bar=1/foo=2/")
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths(["foo=1/bar=2/qux=3/"], None)
+        path_partition_parser("foo=1/bar=2/qux=3/")
     # ensure HIVE partition base directory is not considered a partition
-    path_partition_parser = PathPartitionParser(
-        PartitionStyle.HIVE,
+    path_partition_parser = PathPartitionParser.of(
+        style=PartitionStyle.HIVE,
         base_dir="foo=1",
         field_names=["foo", "bar"],
-        filter_fn=lambda d: d and d["foo"] == 1,
     )
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths(["foo=1/bar=2/"], None)
+        path_partition_parser("foo=1/bar=2/")
     # DIRECTORY partition field name and field value length mismatch
-    path_partition_parser = PathPartitionParser(
-        PartitionStyle.DIRECTORY,
+    path_partition_parser = PathPartitionParser.of(
+        style=PartitionStyle.DIRECTORY,
         field_names=["foo", "bar"],
-        filter_fn=lambda d: d and d["foo"] == 1,
     )
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths(["1/"], None)
+        path_partition_parser("1/")
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths(["1/2/3/"], None)
+        path_partition_parser("1/2/3/")
     # ensure DIRECTORY partition base directory is not considered a partition
-    path_partition_parser = PathPartitionParser(
-        PartitionStyle.DIRECTORY,
+    path_partition_parser = PathPartitionParser.of(
+        style=PartitionStyle.DIRECTORY,
         base_dir="1",
         field_names=["foo", "bar"],
-        filter_fn=lambda d: d and d["foo"] == 1,
     )
     with pytest.raises(AssertionError):
-        path_partition_parser.filter_paths(["1/2/"], None)
+        path_partition_parser("1/2/")
+
+
+@pytest.mark.parametrize(
+    "fs,base_dir",
+    [
+        (None, None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+        ),
+    ],
+)
+def test_path_partition_parser_hive(fs, base_dir):
+    partition_parser = PathPartitionParser.of(base_dir=base_dir, filesystem=fs)
+    _verify_resolved_paths_and_filesystem(partition_parser.scheme)
+    base_dir = partition_parser.scheme.normalized_base_dir
+
+    # parse unpartitioned paths...
+    partition_kvs = partition_parser("")
+    assert partition_kvs == {}
+    unpartitioned_paths = [
+        "",
+        "foo/1",
+        "bar/2",
+        "baz/3",
+        posixpath.join(base_dir, "test.txt"),
+        posixpath.join(base_dir, "foo/test.txt"),
+        posixpath.join(base_dir, "foo/bar/qux=3"),
+        posixpath.join(base_dir, "test=1.txt"),
+    ]
+    for path in unpartitioned_paths:
+        assert partition_parser(path) == {}
+
+    partitioned_path = posixpath.join(base_dir, "foo=1/test.txt")
+    assert partition_parser(partitioned_path) == {"foo": "1"}
+    partitioned_path = posixpath.join(base_dir, " foo = 1  /test.txt")
+    assert partition_parser(partitioned_path) == {" foo ": " 1  "}
+    partitioned_path = posixpath.join(base_dir, "foo/bar=2/test.txt")
+    assert partition_parser(partitioned_path) == {"bar": "2"}
+    partitioned_path = posixpath.join(base_dir, "bar=2/foo=1/test")
+    assert partition_parser(partitioned_path) == {"foo": "1", "bar": "2"}
+    partitioned_path = posixpath.join(base_dir, "foo/bar/qux=3/")
+    assert partition_parser(partitioned_path) == {"qux": "3"}
+
+    partition_parser = PathPartitionParser.of(
+        base_dir=base_dir,
+        field_names=["foo", "bar"],
+        filesystem=fs,
+    )
+    partitioned_path = posixpath.join(base_dir, "foo=1/bar=2/test")
+    assert partition_parser(partitioned_path) == {"foo": "1", "bar": "2"}
+    partitioned_path = posixpath.join(base_dir, "prefix/foo=1/padding/bar=2/test")
+    assert partition_parser(partitioned_path) == {"foo": "1", "bar": "2"}
+
+
+@pytest.mark.parametrize(
+    "fs,base_dir",
+    [
+        (None, None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+        ),
+    ],
+)
+def test_path_partition_parser_dir(fs, base_dir):
+    partition_parser = PathPartitionParser.of(
+        PartitionStyle.DIRECTORY,
+        base_dir=base_dir,
+        field_names=["foo", "bar"],
+        filesystem=fs,
+    )
+    _verify_resolved_paths_and_filesystem(partition_parser.scheme)
+    base_dir = partition_parser.scheme.normalized_base_dir
+
+    # parse unpartitioned paths...
+    partition_kvs = partition_parser("")
+    assert partition_kvs == {}
+    if base_dir:
+        unpartitioned_paths = [
+            "",
+            "foo/1",
+            "bar/2",
+            "baz/3",
+            posixpath.join(base_dir, "test.txt"),
+        ]
+        for path in unpartitioned_paths:
+            assert partition_parser(path) == {}
+
+    partitioned_path = posixpath.join(base_dir, "1/2/test.txt")
+    assert partition_parser(partitioned_path) == {"foo": "1", "bar": "2"}
+    partitioned_path = posixpath.join(base_dir, " 1  / t w o /test.txt")
+    assert partition_parser(partitioned_path) == {"foo": " 1  ", "bar": " t w o "}
+    partitioned_path = posixpath.join(base_dir, "2/1/test.txt")
+    assert partition_parser(partitioned_path) == {"foo": "2", "bar": "1"}
+    partitioned_path = posixpath.join(base_dir, "1/2/")
+    assert partition_parser(partitioned_path) == {"foo": "1", "bar": "2"}
+    partitioned_path = posixpath.join(base_dir, "1/2/3")
+    assert partition_parser(partitioned_path) == {"foo": "1", "bar": "2"}
+
+    partition_parser = PathPartitionParser.of(
+        PartitionStyle.DIRECTORY,
+        base_dir=base_dir,
+        field_names=["bar", "foo"],
+        filesystem=fs,
+    )
+    partitioned_path = posixpath.join(base_dir, "1/2/test")
+    assert partition_parser(partitioned_path) == {"bar": "1", "foo": "2"}
+    partitioned_path = posixpath.join(base_dir, "2/1/test")
+    assert partition_parser(partitioned_path) == {"bar": "2", "foo": "1"}
 
 
 @pytest.mark.parametrize(
@@ -212,19 +336,20 @@ def test_path_partition_filter_errors():
     ],
 )
 def test_path_partition_filter_hive(fs, base_dir):
-    pass_through = PathPartitionParser(base_dir=base_dir)
-    paths = pass_through.filter_paths([], fs)
+    pass_through = PathPartitionFilter.of(None, base_dir=base_dir, filesystem=fs)
+    _verify_resolved_paths_and_filesystem(pass_through.parser.scheme)
+    paths = pass_through([])
     assert paths == []
-    paths = pass_through.filter_paths(["foo/1", "bar/2", "baz/3"], fs)
+    paths = pass_through(["foo/1", "bar/2", "baz/3"])
     assert paths == ["foo/1", "bar/2", "baz/3"]
 
-    filter_unpartitioned = PathPartitionParser(
+    filter_unpartitioned = PathPartitionFilter.of(
         base_dir=base_dir,
+        filesystem=fs,
         filter_fn=lambda d: bool(d),
     )
-    base_dir = base_dir or ""
-    dirs, _ = _resolve_paths_and_filesystem(base_dir, fs)
-    base_dir = dirs[0]
+    _verify_resolved_paths_and_filesystem(filter_unpartitioned.parser.scheme)
+    base_dir = filter_unpartitioned.parser.scheme.normalized_base_dir
     test_paths = [
         posixpath.join(base_dir, "test.txt"),
         posixpath.join(base_dir, "foo/test.txt"),
@@ -237,9 +362,7 @@ def test_path_partition_filter_hive(fs, base_dir):
     ]
     if base_dir:
         test_paths.extend(["test.txt", "foo=1/test.txt"])
-    assert filter_unpartitioned.normalized_base_dir is None
-    paths = filter_unpartitioned.filter_paths(test_paths, fs)
-    assert filter_unpartitioned.normalized_base_dir is not None
+    paths = filter_unpartitioned(test_paths)
     assert paths == [
         posixpath.join(base_dir, "foo=1/test.txt"),
         posixpath.join(base_dir, "foo/bar=2/test.txt"),
@@ -247,27 +370,30 @@ def test_path_partition_filter_hive(fs, base_dir):
         posixpath.join(base_dir, "foo/bar/qux=3/"),
     ]
 
-    filter_values = PathPartitionParser(
+    filter_values = PathPartitionFilter.of(
         base_dir=base_dir,
+        filesystem=fs,
         filter_fn=lambda d: d
         and (d.get("qux") == "3" or (d.get("foo") == "1" and d.get("bar") == "2")),
     )
-    paths = filter_values.filter_paths(test_paths, fs)
+    _verify_resolved_paths_and_filesystem(filter_values.parser.scheme)
+    paths = filter_values(test_paths)
     assert paths == [
         posixpath.join(base_dir, "foo=1/bar=2/test"),
         posixpath.join(base_dir, "foo/bar/qux=3/"),
     ]
 
-    filter_field_name_values = PathPartitionParser(
+    filter_field_name_values = PathPartitionFilter.of(
         base_dir=base_dir,
         field_names=["foo", "bar"],
+        filesystem=fs,
         filter_fn=lambda d: d and d.get("foo") == "1" and d.get("bar") == "2",
     )
     test_paths = [
         posixpath.join(base_dir, "foo=1/bar=2/test"),
         posixpath.join(base_dir, "prefix/foo=1/padding/bar=2/test"),
     ]
-    paths = filter_field_name_values.filter_paths(test_paths, fs)
+    paths = filter_field_name_values(test_paths)
     assert paths == test_paths
 
 
@@ -284,25 +410,27 @@ def test_path_partition_filter_hive(fs, base_dir):
     ],
 )
 def test_path_partition_filter_directory(fs, base_dir):
-    pass_through = PathPartitionParser(
+    pass_through = PathPartitionFilter.of(
+        None,
         style=PartitionStyle.DIRECTORY,
         base_dir=base_dir,
         field_names=["foo", "bar"],
+        filesystem=fs,
     )
-    paths = pass_through.filter_paths([], fs)
+    paths = pass_through([])
     assert paths == []
-    paths = pass_through.filter_paths(["foo/1", "bar/2", "baz/3"], fs)
+    paths = pass_through(["foo/1", "bar/2", "baz/3"])
     assert paths == ["foo/1", "bar/2", "baz/3"]
 
-    filter_unpartitioned = PathPartitionParser(
+    filter_unpartitioned = PathPartitionFilter.of(
         style=PartitionStyle.DIRECTORY,
         base_dir=base_dir,
         field_names=["foo", "bar"],
+        filesystem=fs,
         filter_fn=lambda d: bool(d),
     )
-    base_dir = base_dir or ""
-    dirs, _ = _resolve_paths_and_filesystem(base_dir, fs)
-    base_dir = dirs[0]
+    _verify_resolved_paths_and_filesystem(filter_unpartitioned.parser.scheme)
+    base_dir = filter_unpartitioned.parser.scheme.normalized_base_dir
     test_paths = [
         posixpath.join(base_dir, "test.txt"),
         posixpath.join(base_dir, "1/2/test.txt"),
@@ -313,9 +441,7 @@ def test_path_partition_filter_directory(fs, base_dir):
     if base_dir:
         # files outside of the base directory are implicitly unpartitioned
         test_paths.extend(["test.txt", "1/2/test.txt"])
-    assert filter_unpartitioned.normalized_base_dir is None
-    paths = filter_unpartitioned.filter_paths(test_paths, fs)
-    assert filter_unpartitioned.normalized_base_dir is not None
+    paths = filter_unpartitioned(test_paths)
     assert paths == [
         posixpath.join(base_dir, "1/2/test.txt"),
         posixpath.join(base_dir, "1/2/"),
@@ -323,13 +449,15 @@ def test_path_partition_filter_directory(fs, base_dir):
         posixpath.join(base_dir, "1/2/3"),
     ]
 
-    filter_values = PathPartitionParser(
+    filter_values = PathPartitionFilter.of(
         style=PartitionStyle.DIRECTORY,
         base_dir=base_dir,
         field_names=["foo", "bar"],
+        filesystem=fs,
         filter_fn=lambda d: d and d["foo"] == "1" and d["bar"] == "2",
     )
-    paths = filter_values.filter_paths(test_paths, fs)
+    _verify_resolved_paths_and_filesystem(filter_values.parser.scheme)
+    paths = filter_values(test_paths)
     assert paths == [
         posixpath.join(base_dir, "1/2/test.txt"),
         posixpath.join(base_dir, "1/2/"),

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -1,0 +1,345 @@
+import json
+import pytest
+import posixpath
+
+from pyarrow.fs import FileType
+from pytest_lazyfixture import lazy_fixture
+from ray.data.datasource.file_based_datasource import _resolve_paths_and_filesystem
+
+from ray.data.datasource.partitioning import PathPartitionBase
+
+from ray.tests.conftest import *  # noqa
+from ray.data.datasource import (
+    PathPartitionParser,
+    PathPartitionGenerator,
+    PartitionStyle,
+)
+from ray.data.tests.conftest import *  # noqa
+
+
+def test_partition_style_serde_round_trip():
+    for style in PartitionStyle:
+        serialized = json.dumps(style)
+        deserialized = PartitionStyle(json.loads(serialized))
+        assert deserialized == style
+
+
+def test_path_partition_base_properties():
+    style = PartitionStyle.DIRECTORY
+    base_dir = "/foo/bar"
+    field_names = ["baz", "qux"]
+    path_partition_base = PathPartitionBase(style, base_dir, field_names)
+    assert path_partition_base.style == style
+    assert path_partition_base.base_dir == base_dir
+    assert path_partition_base.normalized_base_dir is None
+    assert path_partition_base.field_names == field_names
+
+    path_partition_base = PathPartitionBase(style, None, field_names)
+    assert path_partition_base.style == style
+    assert path_partition_base.base_dir == ""
+    assert path_partition_base.normalized_base_dir is None
+    assert path_partition_base.field_names == field_names
+
+
+def test_path_partition_generator_errors():
+    # no field names for default HIVE path partitioning
+    with pytest.raises(ValueError):
+        PathPartitionGenerator()
+    # explicit no field names for HIVE path partitioning
+    with pytest.raises(ValueError):
+        PathPartitionGenerator(style=PartitionStyle.HIVE, field_names=[])
+    # invalid path partitioning style
+    with pytest.raises(ValueError):
+        PathPartitionGenerator(style=None)
+    # partition field name and field value length mismatch
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        path_partition_generator = PathPartitionGenerator(
+            style,
+            field_names=["foo", "bar"],
+        )
+        with pytest.raises(TypeError):
+            path_partition_generator(None, None)
+        with pytest.raises(AssertionError):
+            path_partition_generator([], None)
+        with pytest.raises(AssertionError):
+            path_partition_generator(["1"], None)
+        with pytest.raises(AssertionError):
+            path_partition_generator(["1", "2", "3"], None)
+
+
+@pytest.mark.parametrize(
+    "fs,base_dir",
+    [
+        (None, None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+        ),
+    ],
+)
+def test_path_partition_generator_hive(fs, base_dir):
+    field_names = ["foo", "bar"]
+    path_partition_generator = PathPartitionGenerator(
+        field_names=field_names,
+        base_dir=base_dir,
+    )
+    assert path_partition_generator.normalized_base_dir is None
+    partition_values = ["1", "2"]
+    partition_path = path_partition_generator(partition_values, fs)
+    assert path_partition_generator.normalized_base_dir is not None
+    assert partition_path == posixpath.join(
+        path_partition_generator.normalized_base_dir,
+        "foo=1",
+        "bar=2",
+    )
+    if fs is not None:
+        file_info = fs.get_file_info(partition_path)
+        assert file_info.type == FileType.NotFound
+        fs.create_dir(partition_path)
+        file_info = fs.get_file_info(partition_path)
+        assert file_info.type == FileType.Directory
+
+
+@pytest.mark.parametrize(
+    "fs,base_dir",
+    [
+        (None, None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+        ),
+    ],
+)
+def test_path_partition_generator_directory(fs, base_dir):
+    path_partition_generator = PathPartitionGenerator(
+        style=PartitionStyle.DIRECTORY,
+        field_names=["foo", "bar"],
+        base_dir=base_dir,
+    )
+    assert path_partition_generator.normalized_base_dir is None
+    partition_values = ["1", "2"]
+    partition_path = path_partition_generator(partition_values, fs)
+    assert path_partition_generator.normalized_base_dir is not None
+    assert partition_path == posixpath.join(
+        path_partition_generator.normalized_base_dir,
+        *partition_values,
+    )
+    if fs is not None:
+        file_info = fs.get_file_info(partition_path)
+        assert file_info.type == FileType.NotFound
+        fs.create_dir(partition_path)
+        file_info = fs.get_file_info(partition_path)
+        assert file_info.type == FileType.Directory
+    path_partition_generator = PathPartitionGenerator(
+        style=PartitionStyle.DIRECTORY,
+        base_dir=base_dir,
+    )
+    partition_path = path_partition_generator([], fs)
+    assert partition_path == path_partition_generator.normalized_base_dir
+    partition_path = path_partition_generator(partition_values, fs)
+    assert partition_path == posixpath.join(
+        path_partition_generator.normalized_base_dir,
+        *partition_values,
+    )
+
+
+def test_path_partition_filter_errors():
+    # no field names for DIRECTORY path partitioning
+    with pytest.raises(ValueError):
+        PathPartitionParser(style=PartitionStyle.DIRECTORY)
+    # explicit no field names for DIRECTORY path partitioning
+    with pytest.raises(ValueError):
+        PathPartitionParser(style=PartitionStyle.DIRECTORY, field_names=[])
+    # invalid path partitioning style
+    with pytest.raises(ValueError):
+        PathPartitionParser(style=None)
+    # HIVE partition field name and field value length or order mismatch
+    path_partition_parser = PathPartitionParser(
+        PartitionStyle.HIVE,
+        field_names=["foo", "bar"],
+        filter_fn=lambda d: d and d["foo"] == 1,
+    )
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths([""], None)
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths(["foo=1/"], None)
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths(["bar=1/foo=2/"], None)
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths(["foo=1/bar=2/qux=3/"], None)
+    # ensure HIVE partition base directory is not considered a partition
+    path_partition_parser = PathPartitionParser(
+        PartitionStyle.HIVE,
+        base_dir="foo=1",
+        field_names=["foo", "bar"],
+        filter_fn=lambda d: d and d["foo"] == 1,
+    )
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths(["foo=1/bar=2/"], None)
+    # DIRECTORY partition field name and field value length mismatch
+    path_partition_parser = PathPartitionParser(
+        PartitionStyle.DIRECTORY,
+        field_names=["foo", "bar"],
+        filter_fn=lambda d: d and d["foo"] == 1,
+    )
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths(["1/"], None)
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths(["1/2/3/"], None)
+    # ensure DIRECTORY partition base directory is not considered a partition
+    path_partition_parser = PathPartitionParser(
+        PartitionStyle.DIRECTORY,
+        base_dir="1",
+        field_names=["foo", "bar"],
+        filter_fn=lambda d: d and d["foo"] == 1,
+    )
+    with pytest.raises(AssertionError):
+        path_partition_parser.filter_paths(["1/2/"], None)
+
+
+@pytest.mark.parametrize(
+    "fs,base_dir",
+    [
+        (None, None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+        ),
+    ],
+)
+def test_path_partition_filter_hive(fs, base_dir):
+    pass_through = PathPartitionParser(base_dir=base_dir)
+    paths = pass_through.filter_paths([], fs)
+    assert paths == []
+    paths = pass_through.filter_paths(["foo/1", "bar/2", "baz/3"], fs)
+    assert paths == ["foo/1", "bar/2", "baz/3"]
+
+    filter_unpartitioned = PathPartitionParser(
+        base_dir=base_dir,
+        filter_fn=lambda d: bool(d),
+    )
+    base_dir = base_dir or ""
+    dirs, _ = _resolve_paths_and_filesystem(base_dir, fs)
+    base_dir = dirs[0]
+    test_paths = [
+        posixpath.join(base_dir, "test.txt"),
+        posixpath.join(base_dir, "foo/test.txt"),
+        posixpath.join(base_dir, "foo=1/test.txt"),
+        posixpath.join(base_dir, "foo/bar=2/test.txt"),
+        posixpath.join(base_dir, "foo=1/bar=2/test"),
+        posixpath.join(base_dir, "foo/bar/qux=3/"),
+        posixpath.join(base_dir, "foo/bar/qux=3"),
+        posixpath.join(base_dir, "test=1.txt"),
+    ]
+    if base_dir:
+        test_paths.extend(["test.txt", "foo=1/test.txt"])
+    assert filter_unpartitioned.normalized_base_dir is None
+    paths = filter_unpartitioned.filter_paths(test_paths, fs)
+    assert filter_unpartitioned.normalized_base_dir is not None
+    assert paths == [
+        posixpath.join(base_dir, "foo=1/test.txt"),
+        posixpath.join(base_dir, "foo/bar=2/test.txt"),
+        posixpath.join(base_dir, "foo=1/bar=2/test"),
+        posixpath.join(base_dir, "foo/bar/qux=3/"),
+    ]
+
+    filter_values = PathPartitionParser(
+        base_dir=base_dir,
+        filter_fn=lambda d: d
+        and (d.get("qux") == "3" or (d.get("foo") == "1" and d.get("bar") == "2")),
+    )
+    paths = filter_values.filter_paths(test_paths, fs)
+    assert paths == [
+        posixpath.join(base_dir, "foo=1/bar=2/test"),
+        posixpath.join(base_dir, "foo/bar/qux=3/"),
+    ]
+
+    filter_field_name_values = PathPartitionParser(
+        base_dir=base_dir,
+        field_names=["foo", "bar"],
+        filter_fn=lambda d: d and d.get("foo") == "1" and d.get("bar") == "2",
+    )
+    test_paths = [
+        posixpath.join(base_dir, "foo=1/bar=2/test"),
+        posixpath.join(base_dir, "prefix/foo=1/padding/bar=2/test"),
+    ]
+    paths = filter_field_name_values.filter_paths(test_paths, fs)
+    assert paths == test_paths
+
+
+@pytest.mark.parametrize(
+    "fs,base_dir",
+    [
+        (None, None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+        (
+            lazy_fixture("s3_fs_with_special_chars"),
+            lazy_fixture("s3_path_with_special_chars"),
+        ),
+    ],
+)
+def test_path_partition_filter_directory(fs, base_dir):
+    pass_through = PathPartitionParser(
+        style=PartitionStyle.DIRECTORY,
+        base_dir=base_dir,
+        field_names=["foo", "bar"],
+    )
+    paths = pass_through.filter_paths([], fs)
+    assert paths == []
+    paths = pass_through.filter_paths(["foo/1", "bar/2", "baz/3"], fs)
+    assert paths == ["foo/1", "bar/2", "baz/3"]
+
+    filter_unpartitioned = PathPartitionParser(
+        style=PartitionStyle.DIRECTORY,
+        base_dir=base_dir,
+        field_names=["foo", "bar"],
+        filter_fn=lambda d: bool(d),
+    )
+    base_dir = base_dir or ""
+    dirs, _ = _resolve_paths_and_filesystem(base_dir, fs)
+    base_dir = dirs[0]
+    test_paths = [
+        posixpath.join(base_dir, "test.txt"),
+        posixpath.join(base_dir, "1/2/test.txt"),
+        posixpath.join(base_dir, "1/2/"),
+        posixpath.join(base_dir, "2/1/"),
+        posixpath.join(base_dir, "1/2/3"),
+    ]
+    if base_dir:
+        # files outside of the base directory are implicitly unpartitioned
+        test_paths.extend(["test.txt", "1/2/test.txt"])
+    assert filter_unpartitioned.normalized_base_dir is None
+    paths = filter_unpartitioned.filter_paths(test_paths, fs)
+    assert filter_unpartitioned.normalized_base_dir is not None
+    assert paths == [
+        posixpath.join(base_dir, "1/2/test.txt"),
+        posixpath.join(base_dir, "1/2/"),
+        posixpath.join(base_dir, "2/1/"),
+        posixpath.join(base_dir, "1/2/3"),
+    ]
+
+    filter_values = PathPartitionParser(
+        style=PartitionStyle.DIRECTORY,
+        base_dir=base_dir,
+        field_names=["foo", "bar"],
+        filter_fn=lambda d: d and d["foo"] == "1" and d["bar"] == "2",
+    )
+    paths = filter_values.filter_paths(test_paths, fs)
+    assert paths == [
+        posixpath.join(base_dir, "1/2/test.txt"),
+        posixpath.join(base_dir, "1/2/"),
+        posixpath.join(base_dir, "1/2/3"),
+    ]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds a content-type-agnostic partition parser with support for filtering files. Also adds some corner-case bug fixes and usability improvements for supporting more robust input path types. This is the first PR of a series originally proposed in https://github.com/ray-project/ray/pull/23179.

The primary difference from https://github.com/ray-project/ray/pull/23179 is that this PR (1) only includes changes related to path-based partitioning and extended input path type support, (2) includes unit tests for path-based partitioning and corner-case path type support, and (3) refactors the single `PathPartitioning` class into `PathPartitionBase`, `PathPartitionGenerator`, and `PathPartitionParser`.

## Related issue number
Partially resolves https://github.com/ray-project/ray/issues/22910.


## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
