### PR TITLE
[WIP][ray collective] Use Ray internal kv for gloo group.

### DIFF
--- a/python/ray/util/collective/collective.py
+++ b/python/ray/util/collective/collective.py
@@ -60,7 +60,7 @@ class GroupManager(object):
         elif backend == types.Backend.GLOO:
             logger.debug("Creating GLOO group: '{}'...".format(group_name))
             g = GLOOGroup(
-                world_size, rank, group_name, store_type="redis", device_type="tcp"
+                world_size, rank, group_name, store_type="ray_internal_kv", device_type="tcp"
             )
             self._name_group_map[group_name] = g
             self._group_name_map[g] = group_name


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray use gcs in memory store by default instead of Redis, which cause gloo group doesn't work by default.
In this PR, we use Ray internal kv for the store of gloo group to replace the RedisStore by default, to make gloo group work well.

This PR depends on another PR in pygloo https://github.com/ray-project/pygloo/pull/10

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
