### PR TITLE
[flaky] deflaky ray syncer test

### DIFF
--- a/src/ray/common/test/ray_syncer_test.cc
+++ b/src/ray/common/test/ray_syncer_test.cc
@@ -229,8 +229,6 @@ struct SyncerServerTest {
           msg.set_component_id(static_cast<RayComponentId>(cid));
           msg.set_version(local_versions[cid]);
           msg.set_node_id(syncer->GetLocalNodeID());
-          std::string dbg_message;
-          google::protobuf::util::MessageToJsonString(msg, &dbg_message);
           snapshot_taken++;
           return std::make_optional(std::move(msg));
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I'm not sure about the underline reasons, but TSAN test reports:
```




WARNING: ThreadSanitizer: data race (pid=509)
  | Read of size 8 at 0x7f3caa4efe10 by thread T10:
  | #0 google::protobuf::util::converter::ProtoStreamObjectSource::FindTypeRenderer(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc:720:22 (libexternal_Scom_Ugoogle_Uprotobuf_Slibprotobuf.so+0x29afd1)
  | #1 google::protobuf::util::converter::ProtoStreamObjectSource::WriteMessage(google::protobuf::Type const&, google::protobuf::stringpiece_internal::StringPiece, unsigned int, bool, google::protobuf::util::converter::ObjectWriter*) const /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc:173:39 (libexternal_Scom_Ugoogle_Uprotobuf_Slibprotobuf.so+0x29afd1)
  | #2 google::protobuf::util::converter::ProtoStreamObjectSource::NamedWriteTo(google::protobuf::stringpiece_internal::StringPiece, google::protobuf::util::converter::ObjectWriter*) const /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc:145:10 (libexternal_Scom_Ugoogle_Uprotobuf_Slibprotobuf.so+0x29ae1b)
  | #3 google::protobuf::util::converter::ObjectSource::WriteTo(google::protobuf::util::converter::ObjectWriter*) const /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/internal/object_source.h:61:12 (libexternal_Scom_Ugoogle_Uprotobuf_Slibprotobuf.so+0x2b4eff)
  | #4 google::protobuf::util::BinaryToJsonStream(google::protobuf::util::TypeResolver*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, google::protobuf::io::ZeroCopyInputStream*, google::protobuf::io::ZeroCopyOutputStream*, google::protobuf::util::JsonPrintOptions const&) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/json_util.cc:113:25 (libexternal_Scom_Ugoogle_Uprotobuf_Slibprotobuf.so+0x2b4eff)
  | #5 google::protobuf::util::BinaryToJsonString(google::protobuf::util::TypeResolver*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, google::protobuf::util::JsonPrintOptions const&) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/json_util.cc:124:10 (libexternal_Scom_Ugoogle_Uprotobuf_Slibprotobuf.so+0x2b5979)
  | #6 google::protobuf::util::MessageToJsonString(google::protobuf::Message const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, google::protobuf::util::JsonPrintOptions const&) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/json_util.cc:252:7 (libexternal_Scom_Ugoogle_Uprotobuf_Slibprotobuf.so+0x2b5979)
  | #7 google::protobuf::util::MessageToJsonString(google::protobuf::Message const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/json_util.h:102:10 (ray_syncer_test+0x143f25)
  | #8 ray::syncer::SyncerServerTest::SyncerServerTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool)::'lambda'(long)::operator()(long) /proc/self/cwd/src/ray/common/test/ray_syncer_test.cc:233:11 (ray_syncer_test+0x143f25)
  | #9 decltype(std::__1::forward<ray::syncer::SyncerServerTest::SyncerServerTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool)::'lambda'(long)&>(fp)(std::__1::forward<long>(fp0))) std::__1::__invoke<ray::syncer::SyncerServerTest::SyncerServerTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool)::'lambda'(long)&, long>(ray::syncer::SyncerServerTest::SyncerServerTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool)::'lambda'(long)&, long&&) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (ray_syncer_test+0x143d85)

```

I removed the lines and run local tests for 20 times and all passed. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
