### PR TITLE
[serve][minor] Remove "statuses" key from `serve status` output

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -355,7 +355,7 @@ def config(address: str):
 def status(address: str):
     app_status = ServeSubmissionClient(address).get_status()
     if app_status is not None:
-        print(json.dumps(app_status, indent=4))
+        print(json.dumps(app_status["statuses"], indent=4))
 
 
 @cli.command(

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -208,7 +208,7 @@ def test_status(ray_start_stop):
 
     subprocess.check_output(["serve", "deploy", config_file_name])
     status_response = subprocess.check_output(["serve", "status"])
-    statuses = json.loads(status_response)["statuses"]
+    statuses = json.loads(status_response)
 
     expected_deployments = {"shallow", "deep", "one"}
     for status in statuses:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before:
```
(ray) eoakes@Edwards-MBP ray % time serve status
{
    "statuses": [
        {
            "name": "A",
            "status": "HEALTHY",
            "message": ""
        }
    ]
}
```

After:
```
(ray) eoakes@Edwards-MBP ray % time serve status
[
    {
        "name": "A",
        "status": "HEALTHY",
        "message": ""
    }
]
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
