### PR TITLE
[ci] Remove existing artifacts pre-command with docker

### DIFF
--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -16,7 +16,7 @@ if [ -d "/tmp/artifacts" ]; then
     if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
-      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/{,.[!.],..?}*' || true
     else
       echo "Directory already empty, no need to clean up."
     fi

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -13,9 +13,13 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    # Need sudo because artifacts were created by root
-    # within the docker container
-    rm -rf /tmp/artifacts/{,.[!.],..?}* || true
+    if [ "$(ls -A /tmp/testpath)" ]; then
+      echo "Directory not empty, cleaning up..."
+      # Need to run in docker to avoid permission issues
+      docker run --rm --pull missing -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
+    else
+      echo "Directory already empty, no need to clean up."
+    fi
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -16,7 +16,7 @@ if [ -d "/tmp/artifacts" ]; then
     if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
-      docker run --rm --pull missing -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
     else
       echo "Directory already empty, no need to clean up."
     fi

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -16,7 +16,7 @@ if [ -d "/tmp/artifacts" ]; then
     if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
-      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/{,.[!.],..?}*' || true
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
     else
       echo "Directory already empty, no need to clean up."
     fi

--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -13,7 +13,7 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    if [ "$(ls -A /tmp/testpath)" ]; then
+    if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
       docker run --rm --pull missing -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -16,7 +16,7 @@ if [ -d "/tmp/artifacts" ]; then
     if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
-      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/{,.[!.],..?}*' || true
     else
       echo "Directory already empty, no need to clean up."
     fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -13,9 +13,13 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    # Need sudo because artifacts were created by root
-    # within the docker container
-    rm -rf /tmp/artifacts/{,.[!.],..?}* || true
+    if [ "$(ls -A /tmp/testpath)" ]; then
+      echo "Directory not empty, cleaning up..."
+      # Need to run in docker to avoid permission issues
+      docker run --rm --pull missing -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
+    else
+      echo "Directory already empty, no need to clean up."
+    fi
 
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -16,7 +16,7 @@ if [ -d "/tmp/artifacts" ]; then
     if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
-      docker run --rm --pull missing -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true
     else
       echo "Directory already empty, no need to clean up."
     fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -16,7 +16,7 @@ if [ -d "/tmp/artifacts" ]; then
     if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
-      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/{,.[!.],..?}*' || true
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
     else
       echo "Directory already empty, no need to clean up."
     fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -13,7 +13,7 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents before cleanup:"
     find /tmp/artifacts -print || true
 
-    if [ "$(ls -A /tmp/testpath)" ]; then
+    if [ "$(ls -A /tmp/artifacts)" ]; then
       echo "Directory not empty, cleaning up..."
       # Need to run in docker to avoid permission issues
       docker run --rm --pull missing -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*' || true


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, pre-existing artifacts were not deleted pre-command because of permission issues. This can be fixed by running the remove command in another docker container.

Seems to work well here: https://buildkite.com/ray-project/ray-builders-pr/builds/28683#322c7a9d-cba7-4c23-8b00-7ebc6144a777

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
