### PR TITLE
[tune] Simplify experiment tag formatting, clean directory names

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -400,6 +400,14 @@ py_test(
     tags = ["team:ml", "exclusive", "tests_dir_T"],
 )
 
+py_test(
+    name = "test_utils",
+    size = "small",
+    srcs = ["tests/test_utils.py"],
+    deps = [":tune_lib"],
+    tags = ["team:ml", "exclusive", "tests_dir_U"],
+)
+
 py_test_module_list(
   files = [
       "tests/test_trial_executor_inheritance.py",

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -112,7 +112,9 @@ def format_vars(resolved_vars: Dict) -> str:
     for v in ["run", "env", "resources_per_trial"]:
         vars.pop(v, None)
 
-    return ",".join(f"{k[-1]}={_clean_value(v)}" for k, v in sorted(vars.items()))
+    return ",".join(
+        f"{_clean_value(k[-1])}={_clean_value(v)}" for k, v in sorted(vars.items())
+    )
 
 
 def flatten_resolved_vars(resolved_vars: Dict) -> Dict:

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -101,6 +101,10 @@ def format_vars(resolved_vars: Dict) -> str:
     separated string of the form ``last_key=value``, so in this example
     ``path=value``.
 
+    Note that this means that empty strings are possible return values. This
+    is ok, as this will be not a common case and still result in a valid
+    path.
+
     Args:
         resolved_vars: Dictionary mapping from config path tuples to a value.
 

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -101,9 +101,9 @@ def format_vars(resolved_vars: Dict) -> str:
     separated string of the form ``last_key=value``, so in this example
     ``path=value``.
 
-    Note that this means that empty strings are possible return values. This
-    is ok, as this will be not a common case and still result in a valid
-    path.
+    Note that the sanitizing implies that empty strings are possible return
+    values. This is expected and acceptable, as it is not a common case and
+    the resulting directory names will still be valid.
 
     Args:
         resolved_vars: Dictionary mapping from config path tuples to a value.

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import re
 from collections.abc import Mapping
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
@@ -90,22 +91,28 @@ def resolve_nested_dict(nested_dict: Dict) -> Dict[Tuple, Any]:
 
 
 def format_vars(resolved_vars: Dict) -> str:
-    """Formats the resolved variable dict into a single string."""
-    out = []
-    for path, value in sorted(resolved_vars.items()):
-        if path[0] in ["run", "env", "resources_per_trial"]:
-            continue  # TrialRunner already has these in the experiment_tag
-        pieces = []
-        last_string = True
-        for k in path[::-1]:
-            if isinstance(k, int):
-                pieces.append(str(k))
-            elif last_string:
-                last_string = False
-                pieces.append(k)
-        pieces.reverse()
-        out.append(_clean_value("_".join(pieces)) + "=" + _clean_value(value))
-    return ",".join(out)
+    """Format variables to be used as experiment tags.
+
+    Experiment tags are used in directory names, so this method makes sure
+    the resulting tags can be legally used in directory names on all systems.
+
+    The input to this function is a dict of the form
+    ``{("nested", "config", "path"): "value"}``. The output will be a comma
+    separated string of the form ``last_key=value``, so in this example
+    ``path=value``.
+
+    Args:
+        resolved_vars: Dictionary mapping from config path tuples to a value.
+
+    Returns:
+        Comma-separated key=value string.
+    """
+    vars = resolved_vars.copy()
+    # TrialRunner already has these in the experiment_tag
+    for v in ["run", "env", "resources_per_trial"]:
+        vars.pop(v, None)
+
+    return ",".join(f"{k[-1]}={_clean_value(v)}" for k, v in sorted(vars.items()))
 
 
 def flatten_resolved_vars(resolved_vars: Dict) -> Dict:
@@ -120,10 +127,14 @@ def flatten_resolved_vars(resolved_vars: Dict) -> Dict:
 
 
 def _clean_value(value: Any) -> str:
+    """Format floats and replace invalid string characters with ``_``."""
     if isinstance(value, float):
-        return "{:.5}".format(value)
+        return f"{value:.4f}"
     else:
-        return str(value).replace("/", "_")
+        # Define an invalid alphabet, which is the inverse of the
+        # stated regex characters
+        invalid_alphabet = r"[^a-zA-Z0-9_-]+"
+        return re.sub(invalid_alphabet, "_", str(value)).strip("_")
 
 
 def parse_spec_vars(

--- a/python/ray/tune/tests/test_utils.py
+++ b/python/ray/tune/tests/test_utils.py
@@ -1,0 +1,38 @@
+import unittest
+
+from ray.tune.suggest.variant_generator import format_vars
+
+
+class TuneUtilsTest(unittest.TestCase):
+    def testFormatVars(self):
+        # Format brackets correctly
+        self.assertTrue(
+            format_vars(
+                {
+                    ("a", "b", "c"): 8.1234567,
+                    ("a", "b", "d"): [7, 8],
+                    ("a", "b", "e"): [[[3, 4]]],
+                }
+            ),
+            "c=8.12345,d=7_8,e=3_4",
+        )
+        # Sorted by full keys, but only last key is reported
+        self.assertTrue(
+            format_vars(
+                {
+                    ("a", "c", "x"): [7, 8],
+                    ("a", "b", "x"): 8.1234567,
+                }
+            ),
+            "x=8.12345,x=7_8",
+        )
+        # Filter out invalid chars. It's ok to have empty keys or values.
+        self.assertTrue(
+            format_vars(
+                {
+                    ("a  c?x"): " <;%$ok ",
+                    ("some"): " ",
+                }
+            ),
+            "a_c_x=ok,some=",
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Experiment tags are not always rendered in a sane way for all operating systems. For instance,  a config of

```
            "a": tune.choice([(3, 4), (5, 6)]),
            "b": tune.choice([[7, 8], [6, 5]]),
```

will lead to an experiment dir like `lambda_53737_00000_0_a=_3, 4_,b=[7, 8]_2022-04-02_10-21-27/`. This can lead to problems with utilities such as gsutil (which misinterprets some characters as wildcards, see #23670), but also with e.g. MacOS which doesn't like `[` brackets in filenames. 

This PR adds an improvement to the `_clean_value` function used to sanitize values. We specify a valid alphabet which includes a limited set of characters that is broadly usable in most operating systems. We also simplify the `format_vars` function - even though it was previously a bit more sophisticated in handling list items, this was error-prone, and can be replaced in favor of a better readable and simpler implementation that yields the same results in almost all cases.

## Related issue number

Closes #23670

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
