### PR TITLE
[Test] Use spot instances for chaos tests.

### DIFF
--- a/release/nightly_tests/chaos_test/compute_template.yaml
+++ b/release/nightly_tests/chaos_test/compute_template.yaml
@@ -15,7 +15,7 @@ worker_node_types:
      instance_type: m5.4xlarge
      min_workers: 9
      max_workers: 9
-     use_spot: false
+     use_spot: true
      resources:
       custom_resources:
         worker: 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Use spot instances for chaos tests.

We can also experiment with other tests that don't suppose to have dead nodes, but let's do it once the nightly infra is stabilized

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
