### PR TITLE
[workflow] Fix workflow continuation resolving

### DIFF
--- a/python/ray/workflow/BUILD
+++ b/python/ray/workflow/BUILD
@@ -13,7 +13,7 @@ SRCS = [] + select({
     "//conditions:default": [],
 })
 
-LARGE_TESTS = ["tests/test_recovery.py", "tests/test_basic_workflows_2.py"]
+LARGE_TESTS = ["tests/test_recovery.py", "tests/test_basic_workflows_2.py", "tests/test_metadata.py"]
 
 py_test_module_list(
   files = glob(["tests/test_*.py", "examples/**/*.py"], exclude=LARGE_TESTS),

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -121,6 +121,15 @@ class WorkflowStaticRef:
     # included in the arguments of another workflow.
     _resolve_like_object_ref_in_args: bool = False
 
+    @classmethod
+    def from_output(cls, step_id: str, output: Any):
+        """Create static ref from given output."""
+        if not isinstance(output, cls):
+            if not isinstance(output, ray.ObjectRef):
+                output = ray.put(output)
+            output = cls(step_id=step_id, ref=output)
+        return output
+
     def __hash__(self):
         return hash(self.step_id + self.ref.hex())
 
@@ -312,12 +321,9 @@ class WorkflowExecutionResult:
     """Dataclass for holding workflow execution result."""
 
     # Part of result to persist in a storage and pass to the next step.
-    persisted_output: "ObjectRef"
+    persisted_output: "WorkflowStaticRef"
     # Part of result to return to the user but does not require persistence.
-    volatile_output: "ObjectRef"
-
-    def __reduce__(self):
-        return WorkflowExecutionResult, (self.persisted_output, self.volatile_output)
+    volatile_output: "WorkflowStaticRef"
 
 
 @dataclass

--- a/python/ray/workflow/recovery.py
+++ b/python/ray/workflow/recovery.py
@@ -226,6 +226,8 @@ def resume_workflow_step(
     persisted_output, volatile_output = _resume_workflow_step_executor.remote(
         workflow_id, step_id, store_url, current_output
     )
+    persisted_output = WorkflowStaticRef.from_output(step_id, persisted_output)
+    volatile_output = WorkflowStaticRef.from_output(step_id, volatile_output)
     return WorkflowExecutionResult(persisted_output, volatile_output)
 
 

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -193,6 +193,9 @@ def _execute_workflow(workflow: "Workflow") -> "WorkflowExecutionResult":
         workflow_data.step_options,
     )
 
+    persisted_output = WorkflowStaticRef.from_output(workflow.step_id, persisted_output)
+    volatile_output = WorkflowStaticRef.from_output(workflow.step_id, volatile_output)
+
     # Stage 4: post processing outputs
     if step_options.step_type != StepType.READONLY_ACTOR_METHOD:
         if not step_options.allow_inplace:
@@ -530,6 +533,7 @@ def _workflow_step_executor(
         volatile_output = volatile_output.run_async(
             workflow_context.get_current_workflow_id()
         )
+        volatile_output = WorkflowStaticRef.from_output(step_id, volatile_output)
     return persisted_output, volatile_output
 
 

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -21,7 +21,6 @@ from ray.workflow.workflow_access import (
 from ray.workflow.common import (
     Workflow,
     WorkflowStatus,
-    WorkflowOutputType,
     WorkflowExecutionResult,
     StepType,
     StepID,
@@ -43,21 +42,11 @@ WaitResult = Tuple[List[Any], List[Workflow]]
 logger = logging.getLogger(__name__)
 
 
-def _resolve_object_ref(ref: ObjectRef) -> Tuple[Any, ObjectRef]:
-    """
-    Resolves the ObjectRef into the object instance.
-
-    Returns:
-        The object instance and the direct ObjectRef to the instance.
-    """
-    last_ref = ref
-    while True:
-        if isinstance(ref, ObjectRef):
-            last_ref = ref
-        else:
-            break
-        ref = ray.get(last_ref)
-    return ref, last_ref
+def _resolve_static_workflow_ref(workflow_ref: WorkflowStaticRef):
+    """Get the output of a workflow step with the step ID and ObjectRef."""
+    while isinstance(workflow_ref, WorkflowStaticRef):
+        workflow_ref = ray.get(workflow_ref.ref)
+    return workflow_ref
 
 
 def _resolve_dynamic_workflow_refs(workflow_refs: "List[WorkflowRef]"):
@@ -84,7 +73,7 @@ def _resolve_dynamic_workflow_refs(workflow_refs: "List[WorkflowRef]"):
         get_cached_step = False
         if step_ref is not None:
             try:
-                output, _ = _resolve_object_ref(step_ref)
+                output = _resolve_static_workflow_ref(step_ref)
                 get_cached_step = True
             except Exception:
                 get_cached_step = False
@@ -102,7 +91,7 @@ def _resolve_dynamic_workflow_refs(workflow_refs: "List[WorkflowRef]"):
                 step_ref = recovery.resume_workflow_step(
                     workflow_id, workflow_ref.step_id, storage_url, None
                 ).persisted_output
-                output, _ = _resolve_object_ref(step_ref)
+                output = _resolve_static_workflow_ref(step_ref)
         workflow_ref_mapping.append(output)
     return workflow_ref_mapping
 
@@ -152,13 +141,9 @@ def _execute_workflow(workflow: "Workflow") -> "WorkflowExecutionResult":
                 extra_options = w.data.step_options.ray_options
                 # The input workflow is not a reference to an executed
                 # workflow.
-                output = execute_workflow(w).persisted_output
-                static_ref = WorkflowStaticRef(
-                    step_id=w.step_id,
-                    ref=output,
-                    _resolve_like_object_ref_in_args=extra_options.get(
-                        "_resolve_like_object_ref_in_args", False
-                    ),
+                static_ref = execute_workflow(w).persisted_output
+                static_ref._resolve_like_object_ref_in_args = extra_options.get(
+                    "_resolve_like_object_ref_in_args", False
                 )
             workflow_outputs.append(static_ref)
 
@@ -255,11 +240,13 @@ def execute_workflow(workflow: Workflow) -> "WorkflowExecutionResult":
         workflow = result.persisted_output.workflow
         context = result.persisted_output.context
 
-    # Convert the outputs into ObjectRefs.
-    if not isinstance(result.persisted_output, WorkflowOutputType):
-        result.persisted_output = ray.put(result.persisted_output)
-    if not isinstance(result.persisted_output, WorkflowOutputType):
-        result.volatile_output = ray.put(result.volatile_output)
+    # Convert the outputs into WorkflowStaticRef.
+    result.persisted_output = WorkflowStaticRef.from_output(
+        workflow.step_id, result.persisted_output
+    )
+    result.volatile_output = WorkflowStaticRef.from_output(
+        workflow.step_id, result.volatile_output
+    )
     return result
 
 
@@ -582,10 +569,7 @@ def _workflow_wait_executor(
 
     # Part 2: Resolve any ready workflows.
     ready_workflows, remaining_workflows = baked_inputs.wait(**wait_options)
-    ready_objects = []
-    for w in ready_workflows:
-        obj, _ = _resolve_object_ref(w.ref.ref)
-        ready_objects.append(obj)
+    ready_objects = [_resolve_static_workflow_ref(w.ref) for w in ready_workflows]
     persisted_output = (ready_objects, remaining_workflows)
 
     # Part 3: Save the outputs.
@@ -617,6 +601,16 @@ def _workflow_wait_executor_remote(
     )
 
 
+class _SelfDereference:
+    """A object that dereferences static object ref during deserialization."""
+
+    def __init__(self, x):
+        self.x = x
+
+    def __reduce__(self):
+        return _resolve_static_workflow_ref, (self.x,)
+
+
 @dataclass
 class _BakedWorkflowInputs:
     """This class stores pre-processed inputs for workflow step execution.
@@ -645,11 +639,13 @@ class _BakedWorkflowInputs:
             Instances of arguments.
         """
         objects_mapping = []
-        for obj_ref in self.workflow_outputs:
-            if obj_ref._resolve_like_object_ref_in_args:
-                obj = obj_ref.ref
+        for static_workflow_ref in self.workflow_outputs:
+            if static_workflow_ref._resolve_like_object_ref_in_args:
+                # Keep it unresolved as an ObjectRef. Then we resolve it
+                # later in the arguments, like how Ray does with ObjectRefs.
+                obj = ray.put(_SelfDereference(static_workflow_ref))
             else:
-                obj, ref = _resolve_object_ref(obj_ref.ref)
+                obj = _resolve_static_workflow_ref(static_workflow_ref)
             objects_mapping.append(obj)
 
         workflow_ref_mapping = _resolve_dynamic_workflow_refs(self.workflow_refs)

--- a/python/ray/workflow/step_executor.py
+++ b/python/ray/workflow/step_executor.py
@@ -193,15 +193,17 @@ def _execute_workflow(workflow: "Workflow") -> "WorkflowExecutionResult":
         workflow_data.step_options,
     )
 
-    persisted_output = WorkflowStaticRef.from_output(workflow.step_id, persisted_output)
-    volatile_output = WorkflowStaticRef.from_output(workflow.step_id, volatile_output)
-
     # Stage 4: post processing outputs
     if step_options.step_type != StepType.READONLY_ACTOR_METHOD:
         if not step_options.allow_inplace:
             # TODO: [Possible flaky bug] Here the RUNNING state may
             # be recorded earlier than SUCCESSFUL. This caused some
             # confusion during development.
+
+            # convert into workflow static ref for step status record.
+            volatile_output = WorkflowStaticRef.from_output(
+                workflow.step_id, volatile_output
+            )
             _record_step_status(
                 workflow.step_id, WorkflowStatus.RUNNING, [volatile_output]
             )

--- a/python/ray/workflow/tests/test_dag_to_workflow.py
+++ b/python/ray/workflow/tests/test_dag_to_workflow.py
@@ -141,13 +141,23 @@ def test_dereference_dags(workflow_start_regular_shared):
     """Ensure that DAGs are dereferenced like ObjectRefs in ray tasks."""
 
     @ray.remote
-    def g(x, y, z, w):
-        assert x == 314
-        assert isinstance(y[0], ray.ObjectRef)
-        assert ray.get(y) == [2022]
-        assert isinstance(z, ray.ObjectRef)
-        assert ray.get(z) == 271828
-        assert w == 46692
+    def g(x0, y0, z0, x1, y1, z1):
+        assert x0 == 314
+        assert isinstance(x1[0], ray.ObjectRef)
+        assert ray.get(x1) == [314]
+
+        assert isinstance(y0, ray.ObjectRef)
+        assert ray.get(y0) == 271828
+        (y10,) = y1
+        assert isinstance(y10, ray.ObjectRef)
+        assert isinstance(ray.get(y10), ray.ObjectRef)
+        assert ray.get(ray.get(y10)) == 271828
+
+        assert z0 == 46692
+        assert isinstance(z1[0], ray.ObjectRef)
+        assert ray.get(z1) == [46692]
+
+        return "ok"
 
     @ray.remote
     def h(x):
@@ -162,15 +172,17 @@ def test_dereference_dags(workflow_start_regular_shared):
         return workflow.continuation(h.bind(x))
 
     dag = g.bind(
-        x=h.bind(314),
-        y=[h.bind(2022)],
-        z=nested.bind(271828),
-        w=nested_continuation.bind(46692),
+        x0=h.bind(314),
+        y0=nested.bind(271828),
+        z0=nested_continuation.bind(46692),
+        x1=[h.bind(314)],
+        y1=[nested.bind(271828)],
+        z1=[nested_continuation.bind(46692)],
     )
 
     # Run with workflow and normal Ray engine.
-    workflow.create(dag).run()
-    ray.get(dag.execute())
+    assert workflow.create(dag).run() == "ok"
+    assert ray.get(dag.execute()) == "ok"
 
 
 def test_workflow_continuation(workflow_start_regular_shared):

--- a/python/ray/workflow/tests/test_object_deref.py
+++ b/python/ray/workflow/tests/test_object_deref.py
@@ -54,7 +54,7 @@ def test_objectref_outputs(workflow_start_regular_shared):
         return [ray.put(x) for x in range(5)]
 
     single = nested_ref_workflow.step().run()
-    assert single == 42
+    assert ray.get(ray.get(single)) == 42
 
     multi = return_objectrefs.step().run()
     assert ray.get(multi) == list(range(5))

--- a/python/ray/workflow/tests/test_object_deref.py
+++ b/python/ray/workflow/tests/test_object_deref.py
@@ -11,76 +11,26 @@ from ray import ObjectRef
 from ray import workflow
 
 
-@ray.remote
-def nested_ref():
-    return ray.put(42)
-
-
-@workflow.step
-def return_objectrefs() -> List[ObjectRef]:
-    return [ray.put(x) for x in range(5)]
-
-
-@workflow.step
-def nested_ref_workflow():
-    return nested_ref.remote()
-
-
-@workflow.step
-def nested_workflow(n: int):
-    if n <= 0:
-        return "nested"
-    else:
-        return nested_workflow.step(n - 1)
-
-
-@workflow.step
-def deref_check(u: int, x: str, y: List[str], z: List[Dict[str, str]]):
-    try:
-        return (
-            u == 42
-            and x == "nested"
-            and y[0] == "nested"
-            and z[0]["output"] == "nested"
-        ), f"{u}, {x}, {y}, {z}"
-    except Exception as e:
-        return False, str(e)
-
-
-@workflow.step
-def deref_shared(x, y):
-    # x and y should share the same variable.
-    x.append(2)
-    return y == [1, 2]
-
-
-@workflow.step
-def empty_list():
-    return [1]
-
-
-@ray.remote
-def receive_workflow(workflow):
-    pass
-
-
-@ray.remote
-def return_workflow():
-    return empty_list.step()
-
-
-@workflow.step
-def return_data() -> ray.ObjectRef:
-    obj = ray.put(np.ones(4096))
-    return obj
-
-
-@workflow.step
-def receive_data(data: np.ndarray):
-    return data
-
-
 def test_objectref_inputs(workflow_start_regular_shared):
+    @workflow.step
+    def nested_workflow(n: int):
+        if n <= 0:
+            return "nested"
+        else:
+            return nested_workflow.step(n - 1)
+
+    @workflow.step
+    def deref_check(u: int, x: str, y: List[str], z: List[Dict[str, str]]):
+        try:
+            return (
+                u == 42
+                and x == "nested"
+                and y[0] == "nested"
+                and z[0]["output"] == "nested"
+            ), f"{u}, {x}, {y}, {z}"
+        except Exception as e:
+            return False, str(e)
+
     output, s = deref_check.step(
         ray.put(42),
         nested_workflow.step(10),
@@ -91,6 +41,18 @@ def test_objectref_inputs(workflow_start_regular_shared):
 
 
 def test_objectref_outputs(workflow_start_regular_shared):
+    @ray.remote
+    def nested_ref():
+        return ray.put(42)
+
+    @workflow.step
+    def nested_ref_workflow():
+        return nested_ref.remote()
+
+    @workflow.step
+    def return_objectrefs() -> List[ObjectRef]:
+        return [ray.put(x) for x in range(5)]
+
     single = nested_ref_workflow.step().run()
     assert single == 42
 
@@ -99,6 +61,33 @@ def test_objectref_outputs(workflow_start_regular_shared):
 
 
 def test_object_deref(workflow_start_regular_shared):
+    @workflow.step
+    def deref_shared(x, y):
+        # x and y should share the same variable.
+        x.append(2)
+        return y == [1, 2]
+
+    @workflow.step
+    def empty_list():
+        return [1]
+
+    @ray.remote
+    def receive_workflow(workflow):
+        pass
+
+    @ray.remote
+    def return_workflow():
+        return empty_list.step()
+
+    @workflow.step
+    def return_data() -> ray.ObjectRef:
+        obj = ray.put(np.ones(4096))
+        return obj
+
+    @workflow.step
+    def receive_data(data: np.ndarray):
+        return data
+
     x = empty_list.step()
     assert deref_shared.step(x, x).run()
 

--- a/python/ray/workflow/virtual_actor_class.py
+++ b/python/ray/workflow/virtual_actor_class.py
@@ -557,7 +557,7 @@ class VirtualActor:
         ):
             wf = method_helper.step(*args, **kwargs)
             if method_helper.readonly:
-                return execute_workflow(wf).volatile_output
+                return execute_workflow(wf).volatile_output.ref
             else:
                 return wf.run_async(self._actor_id)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With workflow continuation, the behavior should be as shown in this example. Currently it is not, because the workflow cannot distinguish return of a workflow or a objectref. We enforce the using of `WorkflowStaticRef` as the output of a workflow step, this helps distinguish two difference scenarios.

```python
    @ray.remote
    def g(y0, z0, y1, z1):
        assert isinstance(y0, ray.ObjectRef)
        assert ray.get(y0) == 271828
        (y10,) = y1
        assert isinstance(y10, ray.ObjectRef)
        assert isinstance(ray.get(y10), ray.ObjectRef)
        assert ray.get(ray.get(y10)) == 271828

        assert z0 == 46692
        assert isinstance(z1[0], ray.ObjectRef)
        assert ray.get(z1) == [46692]

        return "ok"

    @ray.remote
    def nested(x):
        return h.bind(x).execute()

    @ray.remote
    def nested_continuation(x):
        return workflow.continuation(h.bind(x))

    dag = g.bind(
        y0=nested.bind(271828),
        z0=nested_continuation.bind(46692),
        y1=[nested.bind(271828)],
        z1=[nested_continuation.bind(46692)],
    )

    # Run with workflow and normal Ray engine.
    workflow.create(dag).run()
    ray.get(dag.execute())
    assert workflow.create(dag).run() == "ok"
    assert ray.get(dag.execute()) == "ok"
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
