### PR TITLE
[tune] Beautify Optional typehints

### DIFF
--- a/python/ray/tune/examples/xgboost_dynamic_resources_example.py
+++ b/python/ray/tune/examples/xgboost_dynamic_resources_example.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, Optional
 import sklearn.datasets
 import sklearn.metrics
 import os
@@ -161,7 +161,7 @@ def tune_xgboost(use_class_trainable=True):
         trial: Trial,
         result: Dict[str, Any],
         scheduler: "ResourceChangingScheduler",
-    ) -> Union[None, PlacementGroupFactory, Resources]:
+    ) -> Optional[Union[PlacementGroupFactory, Resources]]:
         """This is a basic example of a resource allocating function.
 
         The function naively balances available CPUs over live trials.

--- a/python/ray/tune/integration/lightgbm.py
+++ b/python/ray/tune/integration/lightgbm.py
@@ -196,7 +196,7 @@ class TuneReportCheckpointCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         filename: str = "checkpoint",
         frequency: int = 5,
         results_postprocessing_fn: Optional[

--- a/python/ray/tune/integration/mxnet.py
+++ b/python/ray/tune/integration/mxnet.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 from ray import tune
 
@@ -46,7 +46,7 @@ class TuneReportCallback(TuneCallback):
 
     """
 
-    def __init__(self, metrics: Union[None, str, List[str], Dict[str, str]] = None):
+    def __init__(self, metrics: Optional[Union[str, List[str], Dict[str, str]]] = None):
         if isinstance(metrics, str):
             metrics = [metrics]
         self._metrics = metrics

--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -202,7 +202,7 @@ class TuneReportCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         on: Union[str, List[str]] = "validation_end",
     ):
         super(TuneReportCallback, self).__init__(on)
@@ -313,7 +313,7 @@ class TuneReportCheckpointCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         filename: str = "checkpoint",
         on: Union[str, List[str]] = "validation_end",
     ):

--- a/python/ray/tune/integration/xgboost.py
+++ b/python/ray/tune/integration/xgboost.py
@@ -70,7 +70,7 @@ class TuneReportCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         results_postprocessing_fn: Optional[
             Callable[[Dict[str, Union[float, List[float]]]], Dict[str, float]]
         ] = None,
@@ -195,7 +195,7 @@ class TuneReportCheckpointCallback(TuneCallback):
 
     def __init__(
         self,
-        metrics: Union[None, str, List[str], Dict[str, str]] = None,
+        metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
         filename: str = "checkpoint",
         frequency: int = 5,
         results_postprocessing_fn: Optional[

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -150,8 +150,8 @@ class TuneReporterBase(ProgressReporter):
 
     def __init__(
         self,
-        metric_columns: Union[None, List[str], Dict[str, str]] = None,
-        parameter_columns: Union[None, List[str], Dict[str, str]] = None,
+        metric_columns: Optional[Union[List[str], Dict[str, str]]] = None,
+        parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         total_samples: Optional[int] = None,
         max_progress_rows: int = 20,
         max_error_rows: int = 20,
@@ -423,8 +423,8 @@ class JupyterNotebookReporter(TuneReporterBase):
     def __init__(
         self,
         overwrite: bool,
-        metric_columns: Union[None, List[str], Dict[str, str]] = None,
-        parameter_columns: Union[None, List[str], Dict[str, str]] = None,
+        metric_columns: Optional[Union[List[str], Dict[str, str]]] = None,
+        parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         total_samples: Optional[int] = None,
         max_progress_rows: int = 20,
         max_error_rows: int = 20,
@@ -528,8 +528,8 @@ class CLIReporter(TuneReporterBase):
 
     def __init__(
         self,
-        metric_columns: Union[None, List[str], Dict[str, str]] = None,
-        parameter_columns: Union[None, List[str], Dict[str, str]] = None,
+        metric_columns: Optional[Union[List[str], Dict[str, str]]] = None,
+        parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         total_samples: Optional[int] = None,
         max_progress_rows: int = 20,
         max_error_rows: int = 20,
@@ -623,7 +623,7 @@ def _get_trials_by_state(trials: List[Trial]):
 def trial_progress_str(
     trials: List[Trial],
     metric_columns: Union[List[str], Dict[str, str]],
-    parameter_columns: Union[None, List[str], Dict[str, str]] = None,
+    parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
     total_samples: int = 0,
     force_table: bool = False,
     fmt: str = "psql",
@@ -708,7 +708,7 @@ def trial_progress_str(
 def trial_progress_table(
     trials: List[Trial],
     metric_columns: Union[List[str], Dict[str, str]],
-    parameter_columns: Union[None, List[str], Dict[str, str]] = None,
+    parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
     fmt: str = "psql",
     max_rows: Optional[int] = None,
     metric: Optional[str] = None,
@@ -849,7 +849,7 @@ def trial_errors_str(
 def best_trial_str(
     trial: Trial,
     metric: str,
-    parameter_columns: Union[None, List[str], Dict[str, str]] = None,
+    parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
 ):
     """Returns a readable message stating the current best trial."""
     val = trial.last_result[metric]

--- a/python/ray/tune/schedulers/async_hyperband.py
+++ b/python/ray/tune/schedulers/async_hyperband.py
@@ -196,7 +196,7 @@ class _Bracket:
             (min_t * self.rf ** (k + s), {}) for k in reversed(range(MAX_RUNGS))
         ]
 
-    def cutoff(self, recorded) -> Union[None, int, float, complex, np.ndarray]:
+    def cutoff(self, recorded) -> Optional[Union[int, float, complex, np.ndarray]]:
         if not recorded:
             return None
         return np.nanpercentile(list(recorded.values()), (1 - 1 / self.rf) * 100)

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -385,7 +385,7 @@ class DistributeResources:
         trial: Trial,
         result: Dict[str, Any],
         scheduler: "ResourceChangingScheduler",
-    ) -> Union[None, PlacementGroupFactory]:
+    ) -> Optional[PlacementGroupFactory]:
         """Run resource allocation logic.
 
         Returns a new ``PlacementGroupFactory`` with updated
@@ -589,7 +589,7 @@ def evenly_distribute_cpus_gpus(
     trial: Trial,
     result: Dict[str, Any],
     scheduler: "ResourceChangingScheduler",
-) -> Union[None, PlacementGroupFactory]:
+) -> Optional[PlacementGroupFactory]:
     """This is a basic uniform resource allocating function.
 
     This function is used by default in ``ResourceChangingScheduler``.
@@ -639,7 +639,7 @@ def evenly_distribute_cpus_gpus_distributed(
     trial: Trial,
     result: Dict[str, Any],
     scheduler: "ResourceChangingScheduler",
-) -> Union[None, PlacementGroupFactory]:
+) -> Optional[PlacementGroupFactory]:
     """This is a basic uniform resource allocating function.
 
     The function naively balances free resources (CPUs and GPUs) between
@@ -746,7 +746,7 @@ class ResourceChangingScheduler(TrialScheduler):
                 trial: Trial,
                 result: Dict[str, Any],
                 scheduler: "ResourceChangingScheduler"
-            ) -> Union[None, PlacementGroupFactory, Resource]:
+            ) -> Optional[Union[PlacementGroupFactory, Resource]]:
                 # logic here
                 # usage of PlacementGroupFactory is strongly preferred
                 return PlacementGroupFactory(...)
@@ -770,7 +770,7 @@ class ResourceChangingScheduler(TrialScheduler):
                     Dict[str, Any],
                     "ResourceChangingScheduler",
                 ],
-                Union[None, PlacementGroupFactory, Resources],
+                Optional[Union[PlacementGroupFactory, Resources]],
             ]
         ] = _DistributeResourcesDefault,
     ) -> None:
@@ -787,7 +787,7 @@ class ResourceChangingScheduler(TrialScheduler):
             Union[Resources, PlacementGroupFactory]
         ] = None
         self._trials_to_reallocate: Dict[
-            Trial, Union[None, dict, PlacementGroupFactory]
+            Trial, Optional[Union[dict, PlacementGroupFactory]]
         ] = {}
         self._reallocated_trial_ids: Set[str] = set()
         self._metric = None
@@ -951,7 +951,7 @@ class ResourceChangingScheduler(TrialScheduler):
 
     def reallocate_trial_resources_if_needed(
         self, trial_runner: "trial_runner.TrialRunner", trial: Trial, result: Dict
-    ) -> Union[None, dict, PlacementGroupFactory]:
+    ) -> Optional[Union[dict, PlacementGroupFactory]]:
         """Calls user defined resources_allocation_function. If the returned
         resources are not none and not the same as currently present, returns
         them. Otherwise, returns None."""

--- a/python/ray/tune/suggest/nevergrad.py
+++ b/python/ray/tune/suggest/nevergrad.py
@@ -113,7 +113,9 @@ class NevergradSearch(Searcher):
 
     def __init__(
         self,
-        optimizer: Union[None, Optimizer, Type[Optimizer], ConfiguredOptimizer] = None,
+        optimizer: Optional[
+            Union[Optimizer, Type[Optimizer], ConfiguredOptimizer]
+        ] = None,
         space: Optional[Union[Dict, Parameter]] = None,
         metric: Optional[str] = None,
         mode: Optional[str] = None,

--- a/python/ray/tune/suggest/sigopt.py
+++ b/python/ray/tune/suggest/sigopt.py
@@ -135,8 +135,8 @@ class SigOptSearch(Searcher):
         experiment_id: Optional[str] = None,
         observation_budget: Optional[int] = None,
         project: Optional[str] = None,
-        metric: Union[None, str, List[str]] = "episode_reward_mean",
-        mode: Union[None, str, List[str]] = "max",
+        metric: Optional[Union[str, List[str]]] = "episode_reward_mean",
+        mode: Optional[Union[str, List[str]]] = "max",
         points_to_evaluate: Optional[List[Dict]] = None,
         **kwargs,
     ):

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -165,7 +165,7 @@ class SyncConfig:
     """
 
     upload_dir: Optional[str] = None
-    syncer: Union[None, str] = "auto"
+    syncer: Optional[str] = "auto"
 
     sync_on_checkpoint: bool = True
     sync_period: int = 300
@@ -466,7 +466,7 @@ def get_node_syncer(
 
 
 class SyncerCallback(Callback):
-    def __init__(self, sync_function: Union[None, bool, Callable]):
+    def __init__(self, sync_function: Optional[Union[bool, Callable]]):
         self._sync_function = sync_function
         self._syncers: Dict["Trial", NodeSyncer] = {}
 

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 from unittest.mock import MagicMock, patch
 
-from typing import Callable, Union
+from typing import Callable, Union, Optional
 
 import ray
 from ray import tune
@@ -59,7 +59,9 @@ def _start_new_cluster():
 
 
 class _PerTrialSyncerCallback(SyncerCallback):
-    def __init__(self, get_sync_fn: Callable[["Trial"], Union[None, bool, Callable]]):
+    def __init__(
+        self, get_sync_fn: Callable[["Trial"], Optional[Union[bool, Callable]]]
+    ):
         self._get_sync_fn = get_sync_fn
         super(_PerTrialSyncerCallback, self).__init__(None)
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -92,8 +92,8 @@ def run(
     name: Optional[str] = None,
     metric: Optional[str] = None,
     mode: Optional[str] = None,
-    stop: Union[None, Mapping, Stopper, Callable[[str, Mapping], bool]] = None,
-    time_budget_s: Union[None, int, float, datetime.timedelta] = None,
+    stop: Optional[Union[Mapping, Stopper, Callable[[str, Mapping], bool]]] = None,
+    time_budget_s: Optional[Union[int, float, datetime.timedelta]] = None,
     config: Optional[Dict[str, Any]] = None,
     resources_per_trial: Union[
         None, Mapping[str, Union[float, int, Mapping]], PlacementGroupFactory


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What: Changes `Union[None, type1, ..., typeN]` type hints to `Optional[type1, ..., typeN]`
Why: Better readability, consistency across library, consistency with code style guides.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
