### PR TITLE
[AIR] Add `config` to `Result`, extend `ResultGrid.get_best_config`

### DIFF
--- a/python/ray/ml/result.py
+++ b/python/ray/ml/result.py
@@ -1,12 +1,14 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional
+from dataclasses import dataclass
 
 from ray.ml.checkpoint import Checkpoint
 
 
+@dataclass
 class Result:
     """The final result of a ML training run or a Tune trial.
 
-    This is the class produced by Trainer.fit() or Tuner.fit() (through ResultGrid).
+    This is the class produced by Trainer.fit().
     It contains a checkpoint, which can be used for resuming training and for
     creating a Predictor object. It also contains a metrics object describing
     training metrics. `error` is included so that non successful runs
@@ -16,22 +18,17 @@ class Result:
 
     Args:
         metrics: The final metrics as reported by an Trainable.
-        checkpoint: The final checkpoint of the Trainable
+        checkpoint: The final checkpoint of the Trainable.
         error: The execution error of the Trainable run, if the trial finishes in error.
     """
 
-    def __init__(
-        self,
-        metrics: Any,
-        checkpoint: Optional[Checkpoint],
-        error: Optional[Exception] = None,
-    ):
-        self.metrics = metrics
-        self.checkpoint = checkpoint
-        self.error = error
+    metrics: Optional[Dict[str, Any]]
+    checkpoint: Optional[Checkpoint]
+    error: Optional[Exception]
 
-    def __getstate__(self) -> dict:
-        return self.__dict__
-
-    def __setstate__(self, state: dict) -> None:
-        self.__dict__.update(state)
+    @property
+    def config(self) -> Optional[Dict[str, Any]]:
+        """The config associated with the result."""
+        if not self.metrics:
+            return None
+        return self.metrics.get("config", None)

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -75,7 +75,7 @@ class ResultGrid:
             checkpoint=Checkpoint.from_directory(trial.checkpoint.value)
             if trial.checkpoint.value
             else None,
-            metrics=trial.last_result,
+            metrics=trial.last_result.copy(),
             error=self._populate_exception(trial),
         )
         return result

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -42,15 +42,42 @@ class ResultGrid:
     def __init__(self, experiment_analysis: ExperimentAnalysis):
         self._experiment_analysis = experiment_analysis
 
-    def get_best_result(self) -> Result:
+    def get_best_result(
+        self,
+        metric: Optional[str] = None,
+        mode: Optional[str] = None,
+        scope: str = "last",
+        filter_nan_and_inf: bool = True,
+    ) -> Result:
         """Get the best result from all the trials run.
 
-        Note, "best" here is determined by "metric" and "mode" specified in your Tuner's
-        TuneConfig.
-
-        Trials are compared using their "last" results. In a similar notion, the last
-        checkpoint of the best trial is returned as part of the result."""
-        return self._trial_to_result(self._experiment_analysis.best_trial)
+        Args:
+            metric: Key for trial info to order on. Defaults to
+                the metric specified in your Tuner's ``TuneConfig``.
+            mode: One of [min, max]. Defaults to the mode specified
+                in your Tuner's ``TuneConfig``.
+            scope: One of [all, last, avg, last-5-avg, last-10-avg].
+                If `scope=last`, only look at each trial's final step for
+                `metric`, and compare across trials based on `mode=[min,max]`.
+                If `scope=avg`, consider the simple average over all steps
+                for `metric` and compare across trials based on
+                `mode=[min,max]`. If `scope=last-5-avg` or `scope=last-10-avg`,
+                consider the simple average over the last 5 or 10 steps for
+                `metric` and compare across trials based on `mode=[min,max]`.
+                If `scope=all`, find each trial's min/max score for `metric`
+                based on `mode`, and compare trials based on `mode=[min,max]`.
+            filter_nan_and_inf: If True (default), NaN or infinite
+                values are disregarded and these trials are never selected as
+                the best trial.
+        """
+        return self._trial_to_result(
+            self._experiment_analysis.get_best_trial(
+                metric=metric,
+                mode=mode,
+                scope=scope,
+                filter_nan_and_inf=filter_nan_and_inf,
+            )
+        )
 
     def __len__(self) -> int:
         return len(self._experiment_analysis.trials)

--- a/python/ray/tune/tests/test_result_grid.py
+++ b/python/ray/tune/tests/test_result_grid.py
@@ -14,11 +14,15 @@ def test_result_grid():
             with open(path, "w") as f:
                 f.write(json.dumps({"step": 0}))
 
-    analysis = tune.run(f)
+    analysis = tune.run(f, config={"a": 1})
     analysis._legacy_checkpoint = False
     result_grid = ResultGrid(analysis)
     result = result_grid[0]
     assert isinstance(result.checkpoint, Checkpoint)
+    assert isinstance(result.metrics, dict)
+    assert isinstance(result.config, dict)
+    assert result.config == {"a": 1}
+    assert result.metrics == result.config
 
 
 def test_result_grid_no_checkpoint():

--- a/python/ray/tune/tests/test_result_grid.py
+++ b/python/ray/tune/tests/test_result_grid.py
@@ -22,7 +22,7 @@ def test_result_grid():
     assert isinstance(result.metrics, dict)
     assert isinstance(result.config, dict)
     assert result.config == {"a": 1}
-    assert result.metrics == result.config
+    assert result.metrics["config"] == result.config
 
 
 def test_result_grid_no_checkpoint():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a dynamic property to easily obtain `config` dict from `Result`, extends the `ResultGrid.get_best_config` method for parity with `ExperimentAnalysis.get_best_trial` (allows for using of mode and metric different to the one set in the Tuner).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
