### PR TITLE
[air] Refactor `most_frequent` `SimpleImputer`

### DIFF
--- a/python/ray/ml/preprocessors/imputer.py
+++ b/python/ray/ml/preprocessors/imputer.py
@@ -1,10 +1,11 @@
 from typing import List, Union, Optional, Dict
 from numbers import Number
+from collections import Counter
 
 import pandas as pd
 
 from ray.data import Dataset
-from ray.data.aggregate import Mean, Max
+from ray.data.aggregate import Mean
 from ray.ml.preprocessor import Preprocessor
 
 
@@ -79,26 +80,19 @@ class SimpleImputer(Preprocessor):
 def _get_most_frequent_values(
     dataset: Dataset, *columns: str
 ) -> Dict[str, Union[str, Number]]:
-    # TODO(matt): Optimize this.
-    results = {}
-    for column in columns:
-        # Remove nulls.
-        nonnull_dataset = dataset.map_batches(
-            lambda df: df.dropna(subset=[column]), batch_format="pandas"
-        )
-        # Count values.
-        counts = nonnull_dataset.groupby(column).count()
-        # Find max count.
-        max_aggregate = counts.aggregate(Max("count()"))
-        max_count = max_aggregate["max(count())"]
-        # Find values with max_count.
-        most_frequent_values = counts.map_batches(
-            lambda df: df.drop(df[df["count()"] < max_count].index),
-            batch_format="pandas",
-        )
-        # Take first (sorted) value.
-        most_frequent_value_count = most_frequent_values.take(1)[0]
-        most_frequent_value = most_frequent_value_count[column]
-        results[f"most_frequent({column})"] = most_frequent_value
+    columns = list(columns)
 
-    return results
+    def get_pd_value_counts(df: pd.DataFrame) -> pd.DataFrame:
+        df = [Counter(df[col].value_counts().to_dict()) for col in columns]
+        return df
+
+    value_counts = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
+    final_counters = [Counter() for _ in columns]
+    for batch in value_counts.iter_batches():
+        for i, col_value_counts in enumerate(batch):
+            final_counters[i] += col_value_counts
+
+    return {
+        f"most_frequent({column})": final_counters[i].most_common(1)[0][0]
+        for i, column in enumerate(columns)
+    }

--- a/python/ray/ml/preprocessors/imputer.py
+++ b/python/ray/ml/preprocessors/imputer.py
@@ -82,9 +82,8 @@ def _get_most_frequent_values(
 ) -> Dict[str, Union[str, Number]]:
     columns = list(columns)
 
-    def get_pd_value_counts(df: pd.DataFrame) -> pd.DataFrame:
-        df = [Counter(df[col].value_counts().to_dict()) for col in columns]
-        return df
+    def get_pd_value_counts(df: pd.DataFrame) -> List[Counter]:
+        return [Counter(df[col].value_counts().to_dict()) for col in columns]
 
     value_counts = dataset.map_batches(get_pd_value_counts, batch_format="pandas")
     final_counters = [Counter() for _ in columns]

--- a/python/ray/ml/tests/test_preprocessors.py
+++ b/python/ray/ml/tests/test_preprocessors.py
@@ -452,20 +452,20 @@ def test_simple_imputer():
     most_frequent_df = pd.DataFrame.from_dict(
         {"A": most_frequent_col_a, "B": most_frequent_col_b}
     )
-    most_frequent_ds = ray.data.from_pandas(most_frequent_df)
+    most_frequent_ds = ray.data.from_pandas(most_frequent_df).repartition(3)
 
     most_frequent_imputer = SimpleImputer(["A", "B"], strategy="most_frequent")
     most_frequent_imputer.fit(most_frequent_ds)
     assert most_frequent_imputer.stats_ == {
         "most_frequent(A)": 2.0,
-        "most_frequent(B)": "b",
+        "most_frequent(B)": "c",
     }
 
     most_frequent_transformed = most_frequent_imputer.transform(most_frequent_ds)
     most_frequent_out_df = most_frequent_transformed.to_pandas()
 
     most_frequent_processed_col_a = [1.0, 2.0, 2.0, 2.0, 2.0, 2.0]
-    most_frequent_processed_col_b = ["b", "c", "c", "b", "b", "a"]
+    most_frequent_processed_col_b = ["c", "c", "c", "b", "b", "a"]
     most_frequent_expected_df = pd.DataFrame.from_dict(
         {"A": most_frequent_processed_col_a, "B": most_frequent_processed_col_b}
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Takes care of the TODO left for `SimpleImputer` with `most_frequent` strategy by refactoring and optimising the logic for computing the most frequent value.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
