### PR TITLE
Change node_id in runtime_context to hex string

### DIFF
--- a/dashboard/modules/job/job_manager.py
+++ b/dashboard/modules/job/job_manager.py
@@ -365,7 +365,7 @@ class JobManager:
 
         It can be used for actor placement.
         """
-        current_node_id = ray.get_runtime_context().node_id.hex()
+        current_node_id = ray.get_runtime_context().node_id
         for node in ray.nodes():
             if node["NodeID"] == current_node_id:
                 # Found the node.

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -107,7 +107,7 @@ class BlockExecStats:
     def __init__(self):
         self.wall_time_s: Optional[float] = None
         self.cpu_time_s: Optional[float] = None
-        self.node_id = ray.runtime_context.get_runtime_context().node_id.hex()
+        self.node_id = ray.runtime_context.get_runtime_context().node_id
 
     @staticmethod
     def builder() -> "_BlockExecStatsBuilder":

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -215,7 +215,7 @@ class _RandomAccessWorker:
         return result
 
     def ping(self):
-        return ray.get_runtime_context().node_id.hex()
+        return ray.get_runtime_context().node_id
 
     def stats(self) -> dict:
         return {

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3133,7 +3133,7 @@ def test_random_shuffle_spread(ray_start_cluster):
 
     @ray.remote
     def get_node_id():
-        return ray.get_runtime_context().node_id.hex()
+        return ray.get_runtime_context().node_id
 
     node1_id = ray.get(get_node_id.options(resources={"bar:1": 1}).remote())
     node2_id = ray.get(get_node_id.options(resources={"bar:2": 1}).remote())
@@ -3162,7 +3162,7 @@ def test_parquet_read_spread(ray_start_cluster, tmp_path):
 
     @ray.remote
     def get_node_id():
-        return ray.get_runtime_context().node_id.hex()
+        return ray.get_runtime_context().node_id
 
     node1_id = ray.get(get_node_id.options(resources={"bar:1": 1}).remote())
     node2_id = ray.get(get_node_id.options(resources={"bar:2": 1}).remote())

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -59,7 +59,7 @@ class RuntimeContext(object):
         """
         node_id = self.worker.current_node_id
         assert not node_id.is_nil()
-        return node_id
+        return node_id.hex()
 
     @property
     def task_id(self):

--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -189,7 +189,7 @@ def create_replica_wrapper(
             At this time, the replica can transition from PENDING_ALLOCATION
             to PENDING_INITIALIZATION startup state.
 
-            Return the NodeID of this replica
+            Return the node id of this replica
             """
             return ray.get_runtime_context().node_id
 

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -219,7 +219,7 @@ def get_current_node_resource_key() -> str:
 
     It can be used for actor placement.
     """
-    current_node_id = ray.get_runtime_context().node_id.hex()
+    current_node_id = ray.get_runtime_context().node_id
     for node in ray.nodes():
         if node["NodeID"] == current_node_id:
             # Found the node.

--- a/python/ray/tests/test_client_metadata.py
+++ b/python/ray/tests/test_client_metadata.py
@@ -1,7 +1,6 @@
 import pytest
 
 from ray.util.client.ray_client_helpers import ray_start_client_server
-from ray._raylet import NodeID
 
 from ray.runtime_context import RuntimeContext
 
@@ -33,8 +32,8 @@ def test_get_runtime_context(ray_start_regular_shared):
     with ray_start_client_server() as ray:
         rtc = ray.get_runtime_context()
         assert isinstance(rtc, RuntimeContext)
-        assert isinstance(rtc.node_id, NodeID)
-        assert len(rtc.node_id.hex()) == 56
+        assert isinstance(rtc.node_id, str)
+        assert len(rtc.node_id) == 56
         assert isinstance(rtc.namespace, str)
 
         # Ensure this doesn't throw

--- a/python/ray/train/worker_group.py
+++ b/python/ray/train/worker_group.py
@@ -74,7 +74,7 @@ def construct_metadata() -> WorkerMetadata:
 
     This function is expected to be run on the actor.
     """
-    node_id = ray.get_runtime_context().node_id.hex()
+    node_id = ray.get_runtime_context().node_id
     node_ip = ray.util.get_node_ip_address()
     hostname = socket.gethostname()
     gpu_ids = ray.get_gpu_ids()

--- a/python/ray/util/client/runtime_context.py
+++ b/python/ray/util/client/runtime_context.py
@@ -43,7 +43,7 @@ class ClientWorkerPropertyAPI:
     def current_node_id(self) -> "NodeID":
         from ray import NodeID
 
-        return NodeID(self._fetch_runtime_context().node_id)
+        return NodeID.from_hex(self._fetch_runtime_context().node_id)
 
     @property
     def namespace(self) -> str:

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -232,7 +232,7 @@ class RayletServicer(ray_client_pb2_grpc.RayletDriverServicer):
             with disable_client_hook():
                 rtc = ray.get_runtime_context()
                 ctx.job_id = rtc.job_id.binary()
-                ctx.node_id = rtc.node_id.binary()
+                ctx.node_id = rtc.node_id
                 ctx.namespace = rtc.namespace
                 ctx.capture_client_tasks = (
                     rtc.should_capture_child_tasks_in_placement_group

--- a/python/ray/util/ml_utils/node.py
+++ b/python/ray/util/ml_utils/node.py
@@ -11,7 +11,7 @@ def get_current_node_resource_key() -> str:
     Returns:
         (str) A string of the format node:<CURRENT-NODE-IP-ADDRESS>
     """
-    current_node_id = ray.get_runtime_context().node_id.hex()
+    current_node_id = ray.get_runtime_context().node_id
     for node in ray.nodes():
         if node["NodeID"] == current_node_id:
             # Found the node.

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -244,7 +244,7 @@ def _actor_hydrate_span_args(class_: _nameable, method: _nameable):
         "ray.function": f"{class_}.{method}",
         "ray.pid": str(os.getpid()),
         "ray.job_id": runtime_context["job_id"].hex(),
-        "ray.node_id": runtime_context["node_id"].hex(),
+        "ray.node_id": runtime_context["node_id"],
     }
 
     # We only get actor ID for workers

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -193,7 +193,7 @@ def _function_hydrate_span_args(func: Callable[..., Any]):
         "ray.function": func,
         "ray.pid": str(os.getpid()),
         "ray.job_id": runtime_context["job_id"].hex(),
-        "ray.node_id": runtime_context["node_id"].hex(),
+        "ray.node_id": runtime_context["node_id"],
     }
 
     # We only get task ID for workers

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -194,7 +194,7 @@ message ClusterInfoResponse {
 
   message RuntimeContext {
     bytes job_id = 1;
-    bytes node_id = 2;
+    string node_id = 2;
     string namespace = 3;
     string runtime_env = 4;
     bool capture_client_tasks = 5;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Instead of exposing the cython NodeID object, we want to standardize on the hex string for public node id.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
