### PR TITLE
[GH] Trim the github issue templates to make them more developer friendly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,3 +81,5 @@
 # CI scripts.
 #/.travis.yml @ray-project/ray-core
 #/ci/travis/ @ray-project/ray-core
+
+/.github/ISSUE_TEMPLATE/ @ericl @stephanie-wang

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-title: "[Bug] "
+title: "[<Ray Component Here>] "
 description: Problems and issues with code of Ray
 labels: [bug, triage]
 body:
@@ -8,52 +8,7 @@ body:
       value: |
         Thank you for reporting the problem!
         Please make sure what you are reporting is a bug with reproducible steps. To ask questions
-        or share ideas, pleae post on our [Discussion page](https://discuss.ray.io/) instead.
-
-  - type: checkboxes
-    attributes:
-      label: Search before asking
-      description: >
-        Please make sure to search in the [issues](https://github.com/ray-project/ray/issues) first to see
-        whether the same issue was reported already.
-      options:
-        - label: >
-            I searched the [issues](https://github.com/ray-project/ray/issues) and found no similar
-            issues.
-          required: true
-
-  - type: dropdown
-    attributes:
-      label: Ray Component
-      description: |
-        What component are you using? Ray has many subprojects, please make sure to choose the component that
-        you found the bug.
-      multiple: true
-      options:
-        - "Ray Core"
-        - "Ray Tune"
-        - "Ray Serve"
-        - "Ray Train"
-        - "RLlib"
-        - "Ray Clusters"
-        - "Monitoring & Debugging"
-        - "Dashboard"
-        - "Others"
-    validations:
-      required: true
-      
-  - type: dropdown
-    attributes:
-      label: Issue Severity
-      description: |
-        How severe does this issue affect your experience?
-      multiple: false
-      options:
-        - "Low: It annoys or frustrates me for a moment."
-        - "Medium: It contributes to significant difficulty to complete my task but I work arounds and get it resolved."
-        - "High: It blocks me to complete my task."
-    validations:
-      required: true
+        or share ideas, please post on our [Discussion page](https://discuss.ray.io/) instead.
 
   - type: textarea
     attributes:
@@ -92,24 +47,3 @@ body:
         until the repro instruction is updated.
     validations:
       required: true
-
-  - type: textarea
-    attributes:
-      label: Anything else
-      description: Anything else we need to know?
-      placeholder: >
-        How often does this problem occur? (Once? Every time? Only when certain conditions are met?)
-        Any relevant logs to include? Are there other relevant issues?
-
-  - type: checkboxes
-    attributes:
-      label: Are you willing to submit a PR?
-      description: >
-        This is absolutely not required, but we are happy to guide you in the contribution process
-        especially if you already have a good understanding of how to implement the fix.
-      options:
-        - label: Yes I am willing to submit a PR!
-
-  - type: markdown
-    attributes:
-      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-title: "[<Ray component: Core|RLlib|Serve|Tune|Java etc...>] "
+title: "[<Ray component: Core|RLlib|etc...>] "
 description: Problems and issues with code of Ray
 labels: [bug, triage]
 body:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-title: "[<Ray Component Here>] "
+title: "[<Ray component: Core|RLlib|Serve|Tune|Java etc...>] "
 description: Problems and issues with code of Ray
 labels: [bug, triage]
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Ray feature request
 description: Suggest an idea for Ray project
-title: "[<Ray Component Here>] "
+title: "[<Ray component: Core|RLlib|Serve|Tune|Java etc...>] "
 labels: [enhancement]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Ray feature request
 description: Suggest an idea for Ray project
-title: "[Feature] "
+title: "[<Ray Component Here>] "
 labels: [enhancement]
 body:
   - type: markdown
@@ -8,17 +8,7 @@ body:
       value: |
         Thank you for finding the time to propose a new feature!
         We really appreciate the community efforts to improve Ray.
-  - type: checkboxes
-    attributes:
-      label: Search before asking
-      description: >
-        Please make sure to search in the [issues](https://github.com/ray-project/ray/issues) first to see
-        whether the same feature was requested already.
-      options:
-        - label: >
-            I had searched in the [issues](https://github.com/ray-project/ray/issues) and found no similar
-            feature requirement.
-          required: true
+
   - type: textarea
     attributes:
       label: Description
@@ -33,20 +23,3 @@ body:
       placeholder: >
         Rather than telling us how you might implement this feature, try to take a
         step back and describe what you are trying to achieve.
-  - type: textarea
-    attributes:
-      label: Related issues
-      description: Is there currently another issue associated with this?
-
-  - type: checkboxes
-    attributes:
-      label: Are you willing to submit a PR?
-      description: >
-        This is absolutely not required, but we are happy to guide you in the contribution process
-        especially if you already have a good understanding of how to implement the feature.
-      options:
-        - label: Yes I am willing to submit a PR!
-
-  - type: markdown
-    attributes:
-      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Ray feature request
 description: Suggest an idea for Ray project
-title: "[<Ray component: Core|RLlib|Serve|Tune|Java etc...>] "
+title: "[<Ray component: Core|RLlib|etc...>] "
 labels: [enhancement]
 body:
   - type: markdown


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the github issue templates are quite verbose, and as a result few developers end up using them. Clean them up so that they can be the standard workflow for all Ray contributors.

I have inline comments on specific rationale for removal of items.