### PR TITLE
[GCS][Storage unification 2/n] unify InternalKvInterface with StoreClient

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -52,7 +52,6 @@ class MockInternalKVInterface : public ray::gcs::InternalKVInterface {
                const std::string &prefix,
                std::function<void(std::vector<std::string>)> callback),
               (override));
-  MOCK_METHOD(instrumented_io_context &, GetEventLoop, (), (override));
 };
 
 }  // namespace gcs

--- a/src/mock/ray/gcs/store_client/store_client.h
+++ b/src/mock/ray/gcs/store_client/store_client.h
@@ -22,7 +22,8 @@ class MockStoreClient : public StoreClient {
               (const std::string &table_name,
                const std::string &key,
                const std::string &data,
-               const StatusCallback &callback),
+               bool overwrite,
+               std::function<void(bool)> callback),
               (override));
   MOCK_METHOD(Status,
               AsyncGet,
@@ -45,15 +46,28 @@ class MockStoreClient : public StoreClient {
               AsyncDelete,
               (const std::string &table_name,
                const std::string &key,
-               const StatusCallback &callback),
+               std::function<void(bool)> callback),
               (override));
   MOCK_METHOD(Status,
               AsyncBatchDelete,
               (const std::string &table_name,
                const std::vector<std::string> &keys,
-               const StatusCallback &callback),
+               std::function<void(int64_t)> callback),
               (override));
   MOCK_METHOD(int, GetNextJobID, (), (override));
+  MOCK_METHOD(Status,
+              AsyncGetKeys,
+              (const std::string &table_name,
+               const std::string &prefix,
+               std::function<void(std::vector<std::string>)> callback),
+              (override));
+
+  MOCK_METHOD(Status,
+              AsyncExists,
+              (const std::string &table_name,
+               const std::string &key,
+               std::function<void(bool)> callback),
+              (override));
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -34,7 +34,7 @@ class InternalKVInterface {
   ///
   /// \param ns The namespace of the key.
   /// \param key The key to fetch.
-  /// \param callback Callback function.
+  /// \param callback Returns the value or null if the key doesn't exist.
   virtual void Get(const std::string &ns,
                    const std::string &key,
                    std::function<void(std::optional<std::string>)> callback) = 0;
@@ -46,8 +46,7 @@ class InternalKVInterface {
   /// \param value The value for the pair.
   /// \param overwrite Whether to overwrite existing values. Otherwise, the update
   ///   will be ignored.
-  /// \param callback Callback function.
-  /// WARNING: it returns true if and only if A NEW ENTRY is added.
+  /// \param callback WARNING: it returns true if and only if A NEW ENTRY is added.
   /// Overwritten return false.
   virtual void Put(const std::string &ns,
                    const std::string &key,
@@ -61,7 +60,7 @@ class InternalKVInterface {
   /// \param key The key to be deleted.
   /// \param del_by_prefix Whether to treat the key as prefix. If true, it'll
   ///     delete all keys with `key` as the prefix.
-  /// \param callback Callback function.
+  /// \param callback returns the number of entries deleted.
   virtual void Del(const std::string &ns,
                    const std::string &key,
                    bool del_by_prefix,
@@ -80,7 +79,7 @@ class InternalKVInterface {
   ///
   /// \param ns The namespace of the prefix.
   /// \param prefix The prefix to be scaned.
-  /// \param callback Callback function.
+  /// \param callback return all the keys matching the prefix.
   virtual void Keys(const std::string &ns,
                     const std::string &prefix,
                     std::function<void(std::vector<std::string>)> callback) = 0;

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -25,8 +25,11 @@ template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Put(const Key &key,
                                 const Data &value,
                                 const StatusCallback &callback) {
-  return store_client_->AsyncPut(
-      table_name_, key.Binary(), value.SerializeAsString(), callback);
+  return store_client_->AsyncPut(table_name_,
+                                 key.Binary(),
+                                 value.SerializeAsString(),
+                                 /*overwrite*/ true,
+                                 [callback](auto) { callback(Status::OK()); });
 }
 
 template <typename Key, typename Data>
@@ -61,7 +64,11 @@ Status GcsTable<Key, Data>::GetAll(const MapCallback<Key, Data> &callback) {
 
 template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Delete(const Key &key, const StatusCallback &callback) {
-  return store_client_->AsyncDelete(table_name_, key.Binary(), callback);
+  return store_client_->AsyncDelete(table_name_, key.Binary(), [callback](auto) {
+    if (callback) {
+      callback(Status::OK());
+    }
+  });
 }
 
 template <typename Key, typename Data>
@@ -73,7 +80,11 @@ Status GcsTable<Key, Data>::BatchDelete(const std::vector<Key> &keys,
     keys_to_delete.emplace_back(std::move(key.Binary()));
   }
   return this->store_client_->AsyncBatchDelete(
-      this->table_name_, keys_to_delete, callback);
+      this->table_name_, keys_to_delete, [callback](auto) {
+        if (callback) {
+          callback(Status::OK());
+        }
+      });
 }
 
 template <typename Key, typename Data>
@@ -84,8 +95,11 @@ Status GcsTableWithJobId<Key, Data>::Put(const Key &key,
     absl::MutexLock lock(&mutex_);
     index_[GetJobIdFromKey(key)].insert(key);
   }
-  return this->store_client_->AsyncPut(
-      this->table_name_, key.Binary(), value.SerializeAsString(), callback);
+  return this->store_client_->AsyncPut(this->table_name_,
+                                       key.Binary(),
+                                       value.SerializeAsString(),
+                                       /*overwrite*/ true,
+                                       [callback](auto) { callback(Status::OK()); });
 }
 
 template <typename Key, typename Data>
@@ -139,17 +153,15 @@ Status GcsTableWithJobId<Key, Data>::BatchDelete(const std::vector<Key> &keys,
     keys_to_delete.push_back(key.Binary());
   }
   return this->store_client_->AsyncBatchDelete(
-      this->table_name_, keys_to_delete, [this, callback, keys](auto status) {
-        if (status.ok()) {
-          {
-            absl::MutexLock lock(&mutex_);
-            for (auto &key : keys) {
-              index_[GetJobIdFromKey(key)].erase(key);
-            }
+      this->table_name_, keys_to_delete, [this, callback, keys](auto) {
+        {
+          absl::MutexLock lock(&mutex_);
+          for (auto &key : keys) {
+            index_[GetJobIdFromKey(key)].erase(key);
           }
         }
         if (callback) {
-          callback(status);
+          callback(Status::OK());
         }
       });
 }

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -101,6 +101,9 @@ class GcsTable {
 /// specific jobs. This class is not meant to be used directly. All gcs table classes with
 /// job id should derive from this class and override the table_name_ member with a unique
 /// value for that table.
+///
+/// GcsTableWithJobId build index in memory. There is a known race condition
+/// that index could be stale if multiple writer change the same index at the same time.
 template <typename Key, typename Data>
 class GcsTableWithJobId : public GcsTable<Key, Data> {
  public:

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -59,7 +59,7 @@ void StoreClientInternalKV::Del(const std::string &table_name,
           callback(0);
           return;
         }
-        RAY_CHECK_OK(delegate_->AsyncBatchDelete(table_name, keys, callback));
+        RAY_CHECK_OK(delegate_->AsyncBatchDelete(table_name, keys, std::move(callback)));
       }));
 }
 

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -1,0 +1,85 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_server/store_client_kv.h"
+
+#include <memory>
+
+namespace ray {
+namespace gcs {
+
+StoreClientInternalKV::StoreClientInternalKV(std::unique_ptr<StoreClient> store_client)
+    : delegate_(std::move(store_client)) {}
+
+void StoreClientInternalKV::Get(
+    const std::string &ns,
+    const std::string &key,
+    std::function<void(std::optional<std::string>)> callback) {
+  RAY_CHECK_OK(delegate_->AsyncGet(
+      ns, key, [callback = std::move(callback)](auto status, auto result) {
+        callback(result.has_value() ? std::optional<std::string>(result.value())
+                                    : std::optional<std::string>());
+      }));
+}
+
+void StoreClientInternalKV::Put(const std::string &ns,
+                                const std::string &key,
+                                const std::string &value,
+                                bool overwrite,
+                                std::function<void(bool)> callback) {
+  RAY_CHECK_OK(delegate_->AsyncPut(
+      ns, key, value, overwrite, [callback = std::move(callback)](bool result) {
+        callback(result);
+      }));
+}
+
+void StoreClientInternalKV::Del(const std::string &ns,
+                                const std::string &key,
+                                bool del_by_prefix,
+                                std::function<void(int64_t)> callback) {
+  if (!del_by_prefix) {
+    RAY_CHECK_OK(
+        delegate_->AsyncDelete(ns, key, [callback = std::move(callback)](bool deleted) {
+          callback(deleted ? 1 : 0);
+        }));
+    return;
+  }
+
+  RAY_CHECK_OK(delegate_->AsyncGetKeys(
+      ns, key, [this, ns, callback = std::move(callback)](auto keys) {
+        if (keys.empty()) {
+          callback(0);
+          return;
+        }
+        RAY_CHECK_OK(delegate_->AsyncBatchDelete(
+            ns, keys, [callback = std::move(callback)](auto num_deleted) {
+              callback(num_deleted);
+            }));
+      }));
+}
+
+void StoreClientInternalKV::Exists(const std::string &ns,
+                                   const std::string &key,
+                                   std::function<void(bool)> callback) {
+  RAY_CHECK_OK(delegate_->AsyncExists(ns, key, callback));
+}
+
+void StoreClientInternalKV::Keys(const std::string &ns,
+                                 const std::string &prefix,
+                                 std::function<void(std::vector<std::string>)> callback) {
+  RAY_CHECK_OK(delegate_->AsyncGetKeys(ns, prefix, callback));
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/store_client_kv.h
+++ b/src/ray/gcs/gcs_server/store_client_kv.h
@@ -1,0 +1,57 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <memory>
+
+#include "ray/gcs/gcs_server/gcs_kv_manager.h"
+#include "ray/gcs/store_client/store_client.h"
+
+namespace ray {
+namespace gcs {
+
+/// InternalKVInterface implementation that wraps around
+/// StoreClient.
+class StoreClientInternalKV : public InternalKVInterface {
+ public:
+  explicit StoreClientInternalKV(std::unique_ptr<StoreClient> store_client);
+
+  void Get(const std::string &ns,
+           const std::string &key,
+           std::function<void(std::optional<std::string>)> callback) override;
+
+  void Put(const std::string &ns,
+           const std::string &key,
+           const std::string &value,
+           bool overwrite,
+           std::function<void(bool)> callback) override;
+
+  void Del(const std::string &ns,
+           const std::string &key,
+           bool del_by_prefix,
+           std::function<void(int64_t)> callback) override;
+
+  void Exists(const std::string &ns,
+              const std::string &key,
+              std::function<void(bool)> callback) override;
+
+  void Keys(const std::string &ns,
+            const std::string &prefix,
+            std::function<void(std::vector<std::string>)> callback) override;
+
+ private:
+  std::unique_ptr<StoreClient> delegate_;
+};
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/store_client_kv.h
+++ b/src/ray/gcs/gcs_server/store_client_kv.h
@@ -23,30 +23,32 @@ namespace gcs {
 
 /// InternalKVInterface implementation that wraps around
 /// StoreClient.
+/// Please refer to InternalKVInterface for semantics
+/// of public APIs.
 class StoreClientInternalKV : public InternalKVInterface {
  public:
   explicit StoreClientInternalKV(std::unique_ptr<StoreClient> store_client);
 
-  void Get(const std::string &ns,
+  void Get(const std::string &table_name,
            const std::string &key,
            std::function<void(std::optional<std::string>)> callback) override;
 
-  void Put(const std::string &ns,
+  void Put(const std::string &table_name,
            const std::string &key,
            const std::string &value,
            bool overwrite,
            std::function<void(bool)> callback) override;
 
-  void Del(const std::string &ns,
+  void Del(const std::string &table_name,
            const std::string &key,
            bool del_by_prefix,
            std::function<void(int64_t)> callback) override;
 
-  void Exists(const std::string &ns,
+  void Exists(const std::string &table_name,
               const std::string &key,
               std::function<void(bool)> callback) override;
 
-  void Keys(const std::string &ns,
+  void Keys(const std::string &table_name,
             const std::string &prefix,
             std::function<void(std::vector<std::string>)> callback) override;
 

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
@@ -116,10 +116,10 @@ TEST_F(GcsActorSchedulerTest, KillWorkerLeak2) {
   EXPECT_CALL(*raylet_client, RequestWorkerLease(An<const rpc::TaskSpec &>(), _, _, _, _))
       .WillOnce(testing::SaveArg<2>(&request_worker_lease_cb));
 
-  std::function<void(ray::Status)> async_put_with_index_cb;
+  std::function<void(bool)> async_put_with_index_cb;
   // Leasing successfully
-  EXPECT_CALL(*store_client, AsyncPut(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&async_put_with_index_cb), Return(Status::OK())));
+  EXPECT_CALL(*store_client, AsyncPut(_, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<4>(&async_put_with_index_cb), Return(Status::OK())));
   actor_scheduler->Schedule(actor);
   rpc::RequestWorkerLeaseReply reply;
   reply.mutable_worker_address()->set_raylet_id(node_id.Binary());
@@ -130,7 +130,7 @@ TEST_F(GcsActorSchedulerTest, KillWorkerLeak2) {
   // Worker start to run task
   EXPECT_CALL(*core_worker_client, PushNormalTask(_, _))
       .WillOnce(testing::SaveArg<1>(&push_normal_task_cb));
-  async_put_with_index_cb(Status::OK());
+  async_put_with_index_cb(true);
   actor->GetMutableActorTableData()->set_state(rpc::ActorTableData::DEAD);
   actor_scheduler->CancelOnWorker(node_id, worker_id);
   push_normal_task_cb(Status::OK(), rpc::PushTaskReply());

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -37,8 +37,9 @@ class MockInMemoryStoreClient : public gcs::InMemoryStoreClient {
   Status AsyncPut(const std::string &table_name,
                   const std::string &key,
                   const std::string &data,
-                  const gcs::StatusCallback &callback) override {
-    callback(Status::OK());
+                  bool overwrite,
+                  std::function<void(bool)> callback) override {
+    callback(true);
     return Status::OK();
   }
 };

--- a/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
@@ -18,6 +18,9 @@
 
 #include "gtest/gtest.h"
 #include "ray/common/test_util.h"
+#include "ray/gcs/gcs_server/store_client_kv.h"
+#include "ray/gcs/store_client/in_memory_store_client.h"
+#include "ray/gcs/store_client/redis_store_client.h"
 
 class GcsKVManagerTest : public ::testing::TestWithParam<std::string> {
  public:
@@ -28,13 +31,20 @@ class GcsKVManagerTest : public ::testing::TestWithParam<std::string> {
       boost::asio::io_service::work work(io_service);
       io_service.run();
     });
-    ASSERT_TRUE(GetParam() == "redis" || GetParam() == "memory");
     ray::gcs::RedisClientOptions redis_client_options(
         "127.0.0.1", ray::TEST_REDIS_SERVER_PORTS.front(), "", false);
     if (GetParam() == "redis") {
       kv_instance = std::make_unique<ray::gcs::RedisInternalKV>(redis_client_options);
     } else if (GetParam() == "memory") {
       kv_instance = std::make_unique<ray::gcs::MemoryInternalKV>(io_service);
+    } else if (GetParam() == "redis_client") {
+      auto client = std::make_shared<ray::gcs::RedisClient>(redis_client_options);
+      RAY_CHECK_OK(client->Connect(io_service));
+      kv_instance = std::make_unique<ray::gcs::StoreClientInternalKV>(
+          std::make_unique<ray::gcs::RedisStoreClient>(client));
+    } else if (GetParam() == "memory_client") {
+      kv_instance = std::make_unique<ray::gcs::StoreClientInternalKV>(
+          std::make_unique<ray::gcs::InMemoryStoreClient>(io_service));
     }
   }
 
@@ -97,9 +107,10 @@ TEST_P(GcsKVManagerTest, TestInternalKV) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(GcsKVManagerTestFixture,
-                         GcsKVManagerTest,
-                         ::testing::Values("redis", "memory"));
+INSTANTIATE_TEST_SUITE_P(
+    GcsKVManagerTestFixture,
+    GcsKVManagerTest,
+    ::testing::Values("redis", "memory", "redis_client", "memory_client"));
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
@@ -66,9 +66,9 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityReschedule) {
   auto cb = [](Status s) {};
   PGSchedulingFailureCallback failure_callback;
   PGSchedulingSuccessfulCallback success_callback;
-  StatusCallback put_cb;
-  EXPECT_CALL(*store_client_, AsyncPut(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&put_cb), Return(Status::OK())));
+  std::function<void(bool)> put_cb;
+  EXPECT_CALL(*store_client_, AsyncPut(_, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<4>(&put_cb), Return(Status::OK())));
   EXPECT_CALL(*gcs_placement_group_scheduler_, ScheduleUnplacedBundles(_, _, _))
       .WillOnce(DoAll(SaveArg<1>(&failure_callback), SaveArg<2>(&success_callback)));
   auto now = absl::GetCurrentTimeNanos();
@@ -77,7 +77,7 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityReschedule) {
   ASSERT_EQ(1, pending_queue.size());
   ASSERT_LE(now, pending_queue.begin()->first);
   ASSERT_GE(absl::GetCurrentTimeNanos(), pending_queue.begin()->first);
-  put_cb(Status::OK());
+  put_cb(true);
   pg->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
   failure_callback(pg, true);
   ASSERT_EQ(1, pending_queue.size());
@@ -93,9 +93,9 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityFailed) {
   auto cb = [](Status s) {};
   PGSchedulingFailureCallback failure_callback;
   PGSchedulingSuccessfulCallback success_callback;
-  StatusCallback put_cb;
-  EXPECT_CALL(*store_client_, AsyncPut(_, _, _, _))
-      .WillOnce(DoAll(SaveArg<3>(&put_cb), Return(Status::OK())));
+  std::function<void(bool)> put_cb;
+  EXPECT_CALL(*store_client_, AsyncPut(_, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<4>(&put_cb), Return(Status::OK())));
   EXPECT_CALL(*gcs_placement_group_scheduler_, ScheduleUnplacedBundles(_, _, _))
       .Times(2)
       .WillRepeatedly(
@@ -106,7 +106,7 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityFailed) {
   ASSERT_EQ(1, pending_queue.size());
   ASSERT_LE(now, pending_queue.begin()->first);
   ASSERT_GE(absl::GetCurrentTimeNanos(), pending_queue.begin()->first);
-  put_cb(Status::OK());
+  put_cb(true);
   pg->UpdateState(rpc::PlacementGroupTableData::PENDING);
   now = absl::GetCurrentTimeNanos();
   failure_callback(pg, true);
@@ -151,10 +151,10 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityOrder) {
   auto cb = [](Status s) {};
   PGSchedulingFailureCallback failure_callback;
   PGSchedulingSuccessfulCallback success_callback;
-  StatusCallback put_cb;
-  EXPECT_CALL(*store_client_, AsyncPut(_, _, _, _))
+  std::function<void(bool)> put_cb;
+  EXPECT_CALL(*store_client_, AsyncPut(_, _, _, _, _))
       .Times(2)
-      .WillRepeatedly(DoAll(SaveArg<3>(&put_cb), Return(Status::OK())));
+      .WillRepeatedly(DoAll(SaveArg<4>(&put_cb), Return(Status::OK())));
   EXPECT_CALL(*gcs_placement_group_scheduler_, ScheduleUnplacedBundles(_, _, _))
       .Times(2)
       .WillRepeatedly(
@@ -163,7 +163,7 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityOrder) {
   gcs_placement_group_manager_->RegisterPlacementGroup(pg2, cb);
   auto &pending_queue = gcs_placement_group_manager_->pending_placement_groups_;
   ASSERT_EQ(2, pending_queue.size());
-  put_cb(Status::OK());
+  put_cb(true);
   ASSERT_EQ(1, pending_queue.size());
   // PG1 is scheduled first, so PG2 is in pending queue
   ASSERT_EQ(pg2, pending_queue.begin()->second.second);

--- a/src/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/ray/gcs/store_client/in_memory_store_client.h
@@ -25,6 +25,7 @@ namespace ray {
 namespace gcs {
 
 /// \class InMemoryStoreClient
+/// Please refer to StoreClient for API semantics.
 ///
 /// This class is thread safe.
 class InMemoryStoreClient : public StoreClient {

--- a/src/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/ray/gcs/store_client/in_memory_store_client.h
@@ -35,7 +35,8 @@ class InMemoryStoreClient : public StoreClient {
   Status AsyncPut(const std::string &table_name,
                   const std::string &key,
                   const std::string &data,
-                  const StatusCallback &callback) override;
+                  bool overwrite,
+                  std::function<void(bool)> callback) override;
 
   Status AsyncGet(const std::string &table_name,
                   const std::string &key,
@@ -50,13 +51,21 @@ class InMemoryStoreClient : public StoreClient {
 
   Status AsyncDelete(const std::string &table_name,
                      const std::string &key,
-                     const StatusCallback &callback) override;
+                     std::function<void(bool)> callback) override;
 
   Status AsyncBatchDelete(const std::string &table_name,
                           const std::vector<std::string> &keys,
-                          const StatusCallback &callback) override;
+                          std::function<void(int64_t)> callback) override;
 
   int GetNextJobID() override;
+
+  Status AsyncGetKeys(const std::string &table_name,
+                      const std::string &prefix,
+                      std::function<void(std::vector<std::string>)> callback) override;
+
+  Status AsyncExists(const std::string &table_name,
+                     const std::string &key,
+                     std::function<void(bool)> callback) override;
 
  private:
   struct InMemoryTable {

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -30,8 +30,9 @@ std::string RedisStoreClient::index_table_separator_ = "&";
 Status RedisStoreClient::AsyncPut(const std::string &table_name,
                                   const std::string &key,
                                   const std::string &data,
-                                  const StatusCallback &callback) {
-  return DoPut(GenRedisKey(table_name, key), data, callback);
+                                  bool overwrite,
+                                  std::function<void(bool)> callback) {
+  return DoPut(GenRedisKey(table_name, key), data, overwrite, callback);
 }
 
 Status RedisStoreClient::AsyncGet(const std::string &table_name,
@@ -61,7 +62,7 @@ Status RedisStoreClient::AsyncGetAll(
     const std::string &table_name,
     const MapCallback<std::string, std::string> &callback) {
   RAY_CHECK(callback);
-  std::string match_pattern = GenRedisMatchPattern(table_name);
+  std::string match_pattern = GenKeyRedisMatchPattern(table_name);
   auto scanner = std::make_shared<RedisScanner>(redis_client_, table_name);
   auto on_done = [callback,
                   scanner](absl::flat_hash_map<std::string, std::string> &&result) {
@@ -72,11 +73,11 @@ Status RedisStoreClient::AsyncGetAll(
 
 Status RedisStoreClient::AsyncDelete(const std::string &table_name,
                                      const std::string &key,
-                                     const StatusCallback &callback) {
+                                     std::function<void(bool)> callback) {
   RedisCallback delete_callback = nullptr;
   if (callback) {
     delete_callback = [callback](const std::shared_ptr<CallbackReply> &reply) {
-      callback(Status::OK());
+      callback(reply->ReadAsInteger() == 1);
     };
   }
 
@@ -90,7 +91,7 @@ Status RedisStoreClient::AsyncDelete(const std::string &table_name,
 
 Status RedisStoreClient::AsyncBatchDelete(const std::string &table_name,
                                           const std::vector<std::string> &keys,
-                                          const StatusCallback &callback) {
+                                          std::function<void(int64_t)> callback) {
   std::vector<std::string> redis_keys;
   redis_keys.reserve(keys.size());
   for (auto &key : keys) {
@@ -117,13 +118,19 @@ Status RedisStoreClient::AsyncMultiGet(
 
 Status RedisStoreClient::DoPut(const std::string &key,
                                const std::string &data,
-                               const StatusCallback &callback) {
-  std::vector<std::string> args = {"SET", key, data};
+                               bool overwrite,
+                               std::function<void(bool)> callback) {
+  std::vector<std::string> args = {overwrite ? "GETSET" : "SETNX", key, data};
   RedisCallback write_callback = nullptr;
   if (callback) {
-    write_callback = [callback](const std::shared_ptr<CallbackReply> &reply) {
-      auto status = reply->ReadAsStatus();
-      callback(status);
+    write_callback = [callback = std::move(callback),
+                      overwrite](const std::shared_ptr<CallbackReply> &reply) {
+      if (overwrite) {
+        callback(reply->IsNil());
+      } else {
+        auto added_num = reply->ReadAsInteger();
+        callback(added_num != 0);
+      }
     };
   }
 
@@ -132,7 +139,7 @@ Status RedisStoreClient::DoPut(const std::string &key,
 }
 
 Status RedisStoreClient::DeleteByKeys(const std::vector<std::string> &keys,
-                                      const StatusCallback &callback) {
+                                      std::function<void(int64_t)> callback) {
   // Delete for each shard.
   // We always replace `DEL` with `UNLINK`.
   int total_count = 0;
@@ -140,15 +147,17 @@ Status RedisStoreClient::DeleteByKeys(const std::vector<std::string> &keys,
       GenCommandsByShards(redis_client_, "UNLINK", keys, &total_count);
 
   auto finished_count = std::make_shared<int>(0);
+  auto num_deleted = std::make_shared<int64_t>(0);
 
   for (auto &command_list : del_commands_by_shards) {
     for (auto &command : command_list.second) {
-      auto delete_callback = [finished_count, total_count, callback](
+      auto delete_callback = [num_deleted, finished_count, total_count, callback](
                                  const std::shared_ptr<CallbackReply> &reply) {
+        (*num_deleted) += reply->ReadAsInteger();
         ++(*finished_count);
         if (*finished_count == total_count) {
           if (callback) {
-            callback(Status::OK());
+            callback(*num_deleted);
           }
         }
       };
@@ -204,14 +213,21 @@ std::string RedisStoreClient::GenRedisKey(const std::string &table_name,
   return ss.str();
 }
 
-std::string RedisStoreClient::GenRedisMatchPattern(const std::string &table_name) {
+std::string RedisStoreClient::GenKeyRedisMatchPattern(const std::string &table_name) {
   std::stringstream ss;
   ss << table_name << table_separator_ << "*";
   return ss.str();
 }
 
-std::string RedisStoreClient::GenRedisMatchPattern(const std::string &table_name,
-                                                   const std::string &index_key) {
+std::string RedisStoreClient::GenKeyRedisMatchPattern(const std::string &table_name,
+                                                      const std::string &key) {
+  std::stringstream ss;
+  ss << table_name << table_separator_ << key << "*";
+  return ss.str();
+}
+
+std::string RedisStoreClient::GenIndexRedisMatchPattern(const std::string &table_name,
+                                                        const std::string &index_key) {
   std::stringstream ss;
   ss << table_name << index_table_separator_ << index_key << index_table_separator_
      << "*";
@@ -373,6 +389,39 @@ void RedisStoreClient::RedisScanner::OnScanCallback(
 }
 
 int RedisStoreClient::GetNextJobID() { return redis_client_->GetNextJobID(); }
+
+Status RedisStoreClient::AsyncGetKeys(
+    const std::string &table_name,
+    const std::string &prefix,
+    std::function<void(std::vector<std::string>)> callback) {
+  std::string match_pattern = GenKeyRedisMatchPattern(table_name, prefix);
+  auto scanner = std::make_shared<RedisScanner>(redis_client_, table_name);
+  auto on_done = [table_name, callback, scanner](auto /* status*/, auto keys) {
+    std::vector<std::string> result;
+    result.reserve(keys.size());
+    for (auto &key : keys) {
+      result.push_back(GetKeyFromRedisKey(std::move(key), table_name));
+    }
+    callback(std::move(result));
+  };
+  return scanner->ScanKeys(match_pattern, on_done);
+}
+
+Status RedisStoreClient::AsyncExists(const std::string &table_name,
+                                     const std::string &key,
+                                     std::function<void(bool)> callback) {
+  std::string redis_key = GenRedisKey(table_name, key);
+  std::vector<std::string> args = {"EXISTS", redis_key};
+
+  auto shard_context = redis_client_->GetShardContext(redis_key);
+  RAY_CHECK_OK(shard_context->RunArgvAsync(
+      args,
+      [callback = std::move(callback)](const std::shared_ptr<CallbackReply> &reply) {
+        bool exists = reply->ReadAsInteger() > 0;
+        callback(exists);
+      }));
+  return Status::OK();
+}
 
 }  // namespace gcs
 

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -32,7 +32,8 @@ class RedisStoreClient : public StoreClient {
   Status AsyncPut(const std::string &table_name,
                   const std::string &key,
                   const std::string &data,
-                  const StatusCallback &callback) override;
+                  bool overwrite,
+                  std::function<void(bool)> callback) override;
 
   Status AsyncGet(const std::string &table_name,
                   const std::string &key,
@@ -47,13 +48,21 @@ class RedisStoreClient : public StoreClient {
 
   Status AsyncDelete(const std::string &table_name,
                      const std::string &key,
-                     const StatusCallback &callback) override;
+                     std::function<void(bool)> callback) override;
 
   Status AsyncBatchDelete(const std::string &table_name,
                           const std::vector<std::string> &keys,
-                          const StatusCallback &callback) override;
+                          std::function<void(int64_t)> callback) override;
 
   int GetNextJobID() override;
+
+  Status AsyncGetKeys(const std::string &table_name,
+                      const std::string &prefix,
+                      std::function<void(std::vector<std::string>)> callback) override;
+
+  Status AsyncExists(const std::string &table_name,
+                     const std::string &key,
+                     std::function<void(bool)> callback) override;
 
  private:
   /// \class RedisScanner
@@ -100,10 +109,11 @@ class RedisStoreClient : public StoreClient {
 
   Status DoPut(const std::string &key,
                const std::string &data,
-               const StatusCallback &callback);
+               bool overwrite,
+               std::function<void(bool)> callback);
 
   Status DeleteByKeys(const std::vector<std::string> &keys,
-                      const StatusCallback &callback);
+                      std::function<void(int64_t)> callback);
 
   /// The return value is a map, whose key is the shard and the value is a list of batch
   /// operations.
@@ -123,10 +133,13 @@ class RedisStoreClient : public StoreClient {
                                  const std::string &key,
                                  const std::string &index_key);
 
-  static std::string GenRedisMatchPattern(const std::string &table_name);
+  static std::string GenKeyRedisMatchPattern(const std::string &table_name);
 
-  static std::string GenRedisMatchPattern(const std::string &table_name,
-                                          const std::string &index_key);
+  static std::string GenKeyRedisMatchPattern(const std::string &table_name,
+                                             const std::string &key);
+
+  static std::string GenIndexRedisMatchPattern(const std::string &table_name,
+                                               const std::string &index_key);
 
   static std::string GetKeyFromRedisKey(const std::string &redis_key,
                                         const std::string &table_name);

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -41,8 +41,7 @@ class StoreClient {
   /// \param data The value of the key that will be written to the table.
   /// \param overwrite Whether to overwrite existing values. Otherwise, the update
   ///   will be ignored.
-  /// \param callback Callback that will be called after write finishes.
-  /// WARNING: it returns true if and only if A NEW ENTRY is added.
+  /// \param callback WARNING: it returns true if and only if A NEW ENTRY is added.
   /// Overwritten return false.
   /// \return Status
   virtual Status AsyncPut(const std::string &table_name,
@@ -55,7 +54,7 @@ class StoreClient {
   ///
   /// \param table_name The name of the table to be read.
   /// \param key The key to lookup from the table.
-  /// \param callback Callback that will be called after read finishes.
+  /// \param callback returns the value or null.
   /// \return Status
   virtual Status AsyncGet(const std::string &table_name,
                           const std::string &key,
@@ -64,7 +63,7 @@ class StoreClient {
   /// Get all data from the given table asynchronously.
   ///
   /// \param table_name The name of the table to be read.
-  /// \param callback Callback that will be called after data has been received.
+  /// \param callback returns the key value pairs in a map.
   /// \return Status
   virtual Status AsyncGetAll(const std::string &table_name,
                              const MapCallback<std::string, std::string> &callback) = 0;
@@ -72,7 +71,7 @@ class StoreClient {
   /// Get all data from the given table asynchronously.
   ///
   /// \param table_name The name of the table to be read.
-  /// \param callback Callback that will be called after data has been received.
+  /// \param callback returns the key value pairs in a map.
   /// \return Status
   virtual Status AsyncMultiGet(const std::string &table_name,
                                const std::vector<std::string> &keys,
@@ -82,7 +81,7 @@ class StoreClient {
   ///
   /// \param table_name The name of the table from which data is to be deleted.
   /// \param key The key that will be deleted from the table.
-  /// \param callback Callback that will be called after delete finishes.
+  /// \param callback returns true if an entry with matching key is deleted.
   /// \return Status
   virtual Status AsyncDelete(const std::string &table_name,
                              const std::string &key,
@@ -92,7 +91,7 @@ class StoreClient {
   ///
   /// \param table_name The name of the table from which data is to be deleted.
   /// \param keys The keys that will be deleted from the table.
-  /// \param callback Callback that will be called after delete finishes.
+  /// \param callback returns the number of deleted entries.
   /// \return Status
   virtual Status AsyncBatchDelete(const std::string &table_name,
                                   const std::vector<std::string> &keys,
@@ -107,7 +106,7 @@ class StoreClient {
   ///
   /// \param table_name The name of the table to be read.
   /// \param prefix The prefix to be scaned.
-  /// \param callback Callback that will be called after data has been received.
+  /// \param callback returns all matching keys in a vector.
   /// \return Status
   virtual Status AsyncGetKeys(const std::string &table_name,
                               const std::string &prefix,
@@ -117,7 +116,7 @@ class StoreClient {
   ///
   /// \param table_name The name of the table to be read.
   /// \param key The key to be checked.
-  /// \param callback Callback function.
+  /// \param callback Returns true if such key exists.
   virtual Status AsyncExists(const std::string &table_name,
                              const std::string &key,
                              std::function<void(bool)> callback) = 0;

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -39,12 +39,17 @@ class StoreClient {
   /// \param table_name The name of the table to be written.
   /// \param key The key that will be written to the table.
   /// \param data The value of the key that will be written to the table.
+  /// \param overwrite Whether to overwrite existing values. Otherwise, the update
+  ///   will be ignored.
   /// \param callback Callback that will be called after write finishes.
+  /// WARNING: it returns true if and only if A NEW ENTRY is added.
+  /// Overwritten return false.
   /// \return Status
   virtual Status AsyncPut(const std::string &table_name,
                           const std::string &key,
                           const std::string &data,
-                          const StatusCallback &callback) = 0;
+                          bool overwrite,
+                          std::function<void(bool)> callback) = 0;
 
   /// Get data from the given table asynchronously.
   ///
@@ -81,7 +86,7 @@ class StoreClient {
   /// \return Status
   virtual Status AsyncDelete(const std::string &table_name,
                              const std::string &key,
-                             const StatusCallback &callback) = 0;
+                             std::function<void(bool)> callback) = 0;
 
   /// Batch delete data from the given table asynchronously.
   ///
@@ -91,12 +96,31 @@ class StoreClient {
   /// \return Status
   virtual Status AsyncBatchDelete(const std::string &table_name,
                                   const std::vector<std::string> &keys,
-                                  const StatusCallback &callback) = 0;
+                                  std::function<void(int64_t)> callback) = 0;
 
   /// Get next job id by `INCR` "JobCounter" key synchronously.
   ///
   /// \return Next job id in integer representation.
   virtual int GetNextJobID() = 0;
+
+  /// Get all the keys match the prefix from the given table asynchronously.
+  ///
+  /// \param table_name The name of the table to be read.
+  /// \param prefix The prefix to be scaned.
+  /// \param callback Callback that will be called after data has been received.
+  /// \return Status
+  virtual Status AsyncGetKeys(const std::string &table_name,
+                              const std::string &prefix,
+                              std::function<void(std::vector<std::string>)> callback) = 0;
+
+  /// Check whether the key exists in the table.
+  ///
+  /// \param table_name The name of the table to be read.
+  /// \param key The key to be checked.
+  /// \param callback Callback function.
+  virtual Status AsyncExists(const std::string &table_name,
+                             const std::string &key,
+                             std::function<void(bool)> callback) = 0;
 
  protected:
   StoreClient() = default;

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -64,10 +64,10 @@ class StoreClientTestBase : public ::testing::Test {
     for (const auto &[key, value] : key_to_value_) {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncPut(
-          table_name_, key.Hex(), value.SerializeAsString(), true, put_calllback));
+          table_name_, key.Binary(), value.SerializeAsString(), true, put_calllback));
       // Make sure no-op callback is handled well
       RAY_CHECK_OK(store_client_->AsyncPut(
-          table_name_, key.Hex(), value.SerializeAsString(), true, nullptr));
+          table_name_, key.Binary(), value.SerializeAsString(), true, nullptr));
     }
     WaitPendingDone();
   }
@@ -76,9 +76,10 @@ class StoreClientTestBase : public ::testing::Test {
     auto delete_calllback = [this](auto) { --pending_count_; };
     for (const auto &[key, _] : key_to_value_) {
       ++pending_count_;
-      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, key.Hex(), delete_calllback));
+      RAY_CHECK_OK(
+          store_client_->AsyncDelete(table_name_, key.Binary(), delete_calllback));
       // Make sure no-op callback is handled well
-      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, key.Hex(), nullptr));
+      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, key.Binary(), nullptr));
     }
     WaitPendingDone();
   }
@@ -97,14 +98,14 @@ class StoreClientTestBase : public ::testing::Test {
     };
     for (const auto &[key, _] : key_to_value_) {
       ++pending_count_;
-      RAY_CHECK_OK(store_client_->AsyncGet(table_name_, key.Hex(), get_callback));
+      RAY_CHECK_OK(store_client_->AsyncGet(table_name_, key.Binary(), get_callback));
     }
     WaitPendingDone();
   }
 
   void GetEmpty() {
     for (const auto &[k, _] : key_to_value_) {
-      auto key = k.Hex();
+      auto key = k.Binary();
       auto get_callback = [this, key](const Status &status,
                                       const boost::optional<std::string> &result) {
         RAY_CHECK_OK(status);
@@ -123,7 +124,7 @@ class StoreClientTestBase : public ::testing::Test {
         [this](const absl::flat_hash_map<std::string, std::string> &result) {
           static std::unordered_set<ActorID> received_keys;
           for (const auto &item : result) {
-            const ActorID &actor_id = ActorID::FromHex(item.first);
+            const ActorID &actor_id = ActorID::FromBinary(item.first);
             auto it = received_keys.find(actor_id);
             RAY_CHECK(it == received_keys.end());
             received_keys.emplace(actor_id);
@@ -142,13 +143,13 @@ class StoreClientTestBase : public ::testing::Test {
 
   void GetKeys() {
     for (int i = 0; i < 30; i++) {
-      auto key = keys_.at(std::rand() % keys_.size()).Hex();
+      auto key = keys_.at(std::rand() % keys_.size()).Binary();
       auto prefix = key.substr(0, std::rand() % key.size());
       RAY_LOG(INFO) << "key is: " << key << ", prefix is: " << prefix;
       std::unordered_set<std::string> result_set;
       for (const auto &item1 : key_to_value_) {
-        if (item1.first.Hex().find(prefix) == 0) {
-          result_set.insert(item1.first.Hex());
+        if (item1.first.Binary().find(prefix) == 0) {
+          result_set.insert(item1.first.Binary());
         }
       }
       ASSERT_FALSE(result_set.empty());
@@ -176,7 +177,7 @@ class StoreClientTestBase : public ::testing::Test {
     pending_count_ += key_to_value_.size();
     for (const auto &item : key_to_value_) {
       RAY_CHECK_OK(
-          store_client_->AsyncExists(table_name_, item.first.Hex(), exists_callback));
+          store_client_->AsyncExists(table_name_, item.first.Binary(), exists_callback));
     }
     WaitPendingDone();
   }
@@ -186,7 +187,7 @@ class StoreClientTestBase : public ::testing::Test {
     ++pending_count_;
     std::vector<std::string> keys;
     for (auto &[key, _] : key_to_value_) {
-      keys.push_back(key.Hex());
+      keys.push_back(key.Binary());
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, delete_calllback));
     // Make sure no-op callback is handled well

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -142,7 +142,7 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void GetKeys() {
-    for (int i = 0; i < 30; i++) {
+    for (int i = 0; i < 100; i++) {
       auto key = keys_.at(std::rand() % keys_.size()).Binary();
       auto prefix = key.substr(0, std::rand() % key.size());
       RAY_LOG(INFO) << "key is: " << key << ", prefix is: " << prefix;

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -59,32 +60,25 @@ class StoreClientTestBase : public ::testing::Test {
 
  protected:
   void Put() {
-    auto put_calllback = [this](const Status &status) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
-    };
+    auto put_calllback = [this](auto) { --pending_count_; };
     for (const auto &[key, value] : key_to_value_) {
       ++pending_count_;
       RAY_CHECK_OK(store_client_->AsyncPut(
-          table_name_, key.Binary(), value.SerializeAsString(), put_calllback));
+          table_name_, key.Hex(), value.SerializeAsString(), true, put_calllback));
       // Make sure no-op callback is handled well
       RAY_CHECK_OK(store_client_->AsyncPut(
-          table_name_, key.Binary(), value.SerializeAsString(), nullptr));
+          table_name_, key.Hex(), value.SerializeAsString(), true, nullptr));
     }
     WaitPendingDone();
   }
 
   void Delete() {
-    auto delete_calllback = [this](const Status &status) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
-    };
+    auto delete_calllback = [this](auto) { --pending_count_; };
     for (const auto &[key, _] : key_to_value_) {
       ++pending_count_;
-      RAY_CHECK_OK(
-          store_client_->AsyncDelete(table_name_, key.Binary(), delete_calllback));
+      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, key.Hex(), delete_calllback));
       // Make sure no-op callback is handled well
-      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, key.Binary(), nullptr));
+      RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, key.Hex(), nullptr));
     }
     WaitPendingDone();
   }
@@ -103,14 +97,14 @@ class StoreClientTestBase : public ::testing::Test {
     };
     for (const auto &[key, _] : key_to_value_) {
       ++pending_count_;
-      RAY_CHECK_OK(store_client_->AsyncGet(table_name_, key.Binary(), get_callback));
+      RAY_CHECK_OK(store_client_->AsyncGet(table_name_, key.Hex(), get_callback));
     }
     WaitPendingDone();
   }
 
   void GetEmpty() {
     for (const auto &[k, _] : key_to_value_) {
-      auto key = k.Binary();
+      auto key = k.Hex();
       auto get_callback = [this, key](const Status &status,
                                       const boost::optional<std::string> &result) {
         RAY_CHECK_OK(status);
@@ -129,7 +123,7 @@ class StoreClientTestBase : public ::testing::Test {
         [this](const absl::flat_hash_map<std::string, std::string> &result) {
           static std::unordered_set<ActorID> received_keys;
           for (const auto &item : result) {
-            const ActorID &actor_id = ActorID::FromBinary(item.first);
+            const ActorID &actor_id = ActorID::FromHex(item.first);
             auto it = received_keys.find(actor_id);
             RAY_CHECK(it == received_keys.end());
             received_keys.emplace(actor_id);
@@ -146,15 +140,53 @@ class StoreClientTestBase : public ::testing::Test {
     WaitPendingDone();
   }
 
-  void BatchDelete() {
-    auto delete_calllback = [this](const Status &status) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
+  void GetKeys() {
+    for (int i = 0; i < 30; i++) {
+      auto key = keys_.at(std::rand() % keys_.size()).Hex();
+      auto prefix = key.substr(0, std::rand() % key.size());
+      RAY_LOG(INFO) << "key is: " << key << ", prefix is: " << prefix;
+      std::unordered_set<std::string> result_set;
+      for (const auto &item1 : key_to_value_) {
+        if (item1.first.Hex().find(prefix) == 0) {
+          result_set.insert(item1.first.Hex());
+        }
+      }
+      ASSERT_FALSE(result_set.empty());
+
+      auto get_keys_callback = [this,
+                                &result_set](const std::vector<std::string> result) {
+        std::unordered_set<std::string> received_keys(result.begin(), result.end());
+        ASSERT_EQ(received_keys, result_set);
+        pending_count_ -= result.size();
+      };
+
+      pending_count_ += result_set.size();
+
+      RAY_CHECK_OK(store_client_->AsyncGetKeys(table_name_, prefix, get_keys_callback));
+      WaitPendingDone();
+    }
+  }
+
+  void Exists(bool exists) {
+    auto exists_callback = [this, exists](bool result) {
+      ASSERT_TRUE(result == exists);
+      pending_count_--;
     };
+
+    pending_count_ += key_to_value_.size();
+    for (const auto &item : key_to_value_) {
+      RAY_CHECK_OK(
+          store_client_->AsyncExists(table_name_, item.first.Hex(), exists_callback));
+    }
+    WaitPendingDone();
+  }
+
+  void BatchDelete() {
+    auto delete_calllback = [this](auto) { --pending_count_; };
     ++pending_count_;
     std::vector<std::string> keys;
     for (auto &[key, _] : key_to_value_) {
-      keys.push_back(key.Binary());
+      keys.push_back(key.Hex());
     }
     RAY_CHECK_OK(store_client_->AsyncBatchDelete(table_name_, keys, delete_calllback));
     // Make sure no-op callback is handled well
@@ -176,15 +208,20 @@ class StoreClientTestBase : public ::testing::Test {
   }
 
   void TestAsyncGetAllAndBatchDelete() {
+    Exists(false);
     // AsyncPut
     Put();
 
     // AsyncGetAll
     GetAll();
 
+    GetKeys();
+    Exists(true);
+
     // AsyncBatchDelete
     BatchDelete();
 
+    Exists(false);
     // AsyncGet
     GetEmpty();
   }
@@ -201,6 +238,7 @@ class StoreClientTestBase : public ::testing::Test {
       actor.set_actor_id(actor_id.Binary());
 
       key_to_value_[actor_id] = actor;
+      keys_.push_back(actor_id);
     }
   }
 
@@ -221,6 +259,7 @@ class StoreClientTestBase : public ::testing::Test {
   size_t key_count_{5000};
   size_t index_count_{100};
   absl::flat_hash_map<ActorID, rpc::ActorTableData> key_to_value_;
+  std::vector<ActorID> keys_;
 
   std::atomic<int> pending_count_{0};
   std::chrono::milliseconds wait_pending_timeout_{5000};


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR depends on #23754.

#23754 removes the need for index in the StoreClient interface. 

This PR unifies InternalKVInterface and StoreClient. Specifically, we implement an InternalKVInterface which wraps around StoreClient.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests. TODO: more tests could be added.
   - [ ] Release tests
   - [ ] This PR is not tested :(
