### PR TITLE
[workflow] Deprecate "workflow.step" [Part 2 - most nested workflows] 

### DIFF
--- a/python/ray/workflow/examples/comparisons/airflow/etl_workflow.py
+++ b/python/ray/workflow/examples/comparisons/airflow/etl_workflow.py
@@ -4,14 +4,14 @@ import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def extract() -> dict:
     data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
     order_data_dict = json.loads(data_string)
     return order_data_dict
 
 
-@workflow.step
+@ray.remote
 def transform(order_data_dict: dict) -> dict:
     total_order_value = 0
     for value in order_data_dict.values():
@@ -19,7 +19,7 @@ def transform(order_data_dict: dict) -> dict:
     return {"total_order_value": ray.put(total_order_value)}
 
 
-@workflow.step
+@ray.remote
 def load(data_dict: dict) -> str:
     total_order_value = ray.get(data_dict["total_order_value"])
     return f"Total order value is: {total_order_value:.2f}"
@@ -27,7 +27,7 @@ def load(data_dict: dict) -> str:
 
 if __name__ == "__main__":
     workflow.init()
-    order_data = extract.step()
-    order_summary = transform.step(order_data)
-    etl = load.step(order_summary)
-    print(etl.run())
+    order_data = extract.bind()
+    order_summary = transform.bind(order_data)
+    etl = load.bind(order_summary)
+    print(workflow.create(etl).run())

--- a/python/ray/workflow/examples/comparisons/argo/conditionals_workflow.py
+++ b/python/ray/workflow/examples/comparisons/argo/conditionals_workflow.py
@@ -1,30 +1,28 @@
+import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def handle_heads() -> str:
     return "It was heads"
 
 
-@workflow.step
+@ray.remote
 def handle_tails() -> str:
     return "It was tails"
 
 
-@workflow.step
+@ray.remote
 def flip_coin() -> str:
     import random
 
-    @workflow.step
+    @ray.remote
     def decide(heads: bool) -> str:
-        if heads:
-            return handle_heads.step()
-        else:
-            return handle_tails.step()
+        return handle_heads.bind() if heads else handle_tails.bind()
 
-    return decide.step(random.random() > 0.5)
+    return workflow.continuation(decide.bind(random.random() > 0.5))
 
 
 if __name__ == "__main__":
     workflow.init()
-    print(flip_coin.step().run())
+    print(workflow.create(flip_coin.bind()).run())

--- a/python/ray/workflow/examples/comparisons/argo/conditionals_workflow.py
+++ b/python/ray/workflow/examples/comparisons/argo/conditionals_workflow.py
@@ -18,7 +18,9 @@ def flip_coin() -> str:
 
     @ray.remote
     def decide(heads: bool) -> str:
-        return handle_heads.bind() if heads else handle_tails.bind()
+        return workflow.continuation(
+            handle_heads.bind() if heads else handle_tails.bind()
+        )
 
     return workflow.continuation(decide.bind(random.random() > 0.5))
 

--- a/python/ray/workflow/examples/comparisons/argo/hello_world_workflow.py
+++ b/python/ray/workflow/examples/comparisons/argo/hello_world_workflow.py
@@ -1,12 +1,13 @@
+import ray
 from ray import workflow
 
 
 # TODO(ekl) should support something like runtime_env={"pip": ["whalesay"]}
-@workflow.step
+@ray.remote
 def hello(msg: str) -> None:
     print(msg)
 
 
 if __name__ == "__main__":
     workflow.init()
-    hello.step("hello world").run()
+    workflow.create(hello.bind("hello world")).run()

--- a/python/ray/workflow/examples/comparisons/argo/loops_workflow.py
+++ b/python/ray/workflow/examples/comparisons/argo/loops_workflow.py
@@ -1,12 +1,13 @@
+import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def hello(msg: str) -> None:
     print(msg)
 
 
-@workflow.step
+@ray.remote
 def wait_all(*args) -> None:
     pass
 
@@ -15,5 +16,5 @@ if __name__ == "__main__":
     workflow.init()
     children = []
     for msg in ["hello world", "goodbye world"]:
-        children.append(hello.step(msg))
-    wait_all.step(*children).run()
+        children.append(hello.bind(msg))
+    workflow.create(wait_all.bind(*children)).run()

--- a/python/ray/workflow/examples/comparisons/cadence/sub_workflow_workflow.py
+++ b/python/ray/workflow/examples/comparisons/cadence/sub_workflow_workflow.py
@@ -1,17 +1,18 @@
+import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def compose_greeting(greeting: str, name: str) -> str:
     return greeting + ": " + name
 
 
-@workflow.step
+@ray.remote
 def main_workflow(name: str) -> str:
-    return compose_greeting.step("Hello", name)
+    return workflow.continuation(compose_greeting.bind("Hello", name))
 
 
 if __name__ == "__main__":
     workflow.init()
-    wf = main_workflow.step("Alice")
+    wf = workflow.create(main_workflow.bind("Alice"))
     print(wf.run())

--- a/python/ray/workflow/examples/comparisons/google_cloud_workflows/concat_array_workflow.py
+++ b/python/ray/workflow/examples/comparisons/google_cloud_workflows/concat_array_workflow.py
@@ -13,4 +13,4 @@ def iterate(array: List[str], result: str, i: int) -> str:
 
 if __name__ == "__main__":
     workflow.init()
-    print(iterate.step(["foo", "ba", "r"], "", 0).run())
+    print(workflow.create(iterate.bind(["foo", "ba", "r"], "", 0)).run())

--- a/python/ray/workflow/examples/comparisons/google_cloud_workflows/concat_array_workflow.py
+++ b/python/ray/workflow/examples/comparisons/google_cloud_workflows/concat_array_workflow.py
@@ -1,13 +1,14 @@
 from typing import List
 
+import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def iterate(array: List[str], result: str, i: int) -> str:
     if i >= len(array):
         return result
-    return iterate.step(array, result + array[i], i + 1)
+    return workflow.continuation(iterate.bind(array, result + array[i], i + 1))
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/examples/comparisons/google_cloud_workflows/sub_workflows_workflow.py
+++ b/python/ray/workflow/examples/comparisons/google_cloud_workflows/sub_workflows_workflow.py
@@ -1,23 +1,24 @@
+import ray
 from ray import workflow
 
 
-@workflow.step
+@ray.remote
 def hello(name: str) -> str:
-    return format_name.step(name)
+    return workflow.continuation(format_name.bind(name))
 
 
-@workflow.step
+@ray.remote
 def format_name(name: str) -> str:
-    return "hello, {}".format(name)
+    return f"hello, {name}"
 
 
-@workflow.step
+@ray.remote
 def report(msg: str) -> None:
     print(msg)
 
 
 if __name__ == "__main__":
     workflow.init()
-    r1 = hello.step("Kristof")
-    r2 = report.step(r1)
-    r2.run()
+    r1 = hello.bind("Kristof")
+    r2 = report.bind(r1)
+    workflow.create(r2).run()

--- a/python/ray/workflow/examples/comparisons/prefect/compute_fib_workflow.py
+++ b/python/ray/workflow/examples/comparisons/prefect/compute_fib_workflow.py
@@ -1,8 +1,9 @@
+import ray
 from ray import workflow
 import requests
 
 
-@workflow.step
+@ray.remote
 def compute_large_fib(M: int, n: int = 1, fib: int = 1):
     next_fib = requests.post(
         "https://nemo.api.stdlib.com/fibonacci@0.0.1/", data={"nth": n}
@@ -10,9 +11,9 @@ def compute_large_fib(M: int, n: int = 1, fib: int = 1):
     if next_fib > M:
         return fib
     else:
-        return compute_large_fib.step(M, n + 1, next_fib)
+        return workflow.continuation(compute_large_fib.bind(M, n + 1, next_fib))
 
 
 if __name__ == "__main__":
     workflow.init()
-    assert compute_large_fib.step(100).run() == 89
+    assert workflow.create(compute_large_fib.bind(100)).run() == 89

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -269,13 +269,13 @@ def test_step_failure_decorator(workflow_start_regular_shared, tmp_path):
 
 
 def test_nested_catch_exception(workflow_start_regular_shared, tmp_path):
-    @workflow.step
+    @ray.remote
     def f2():
         return 10
 
     @workflow.step
     def f1():
-        return f2.step()
+        return workflow.continuation(f2.bind())
 
     assert (10, None) == f1.options(catch_exceptions=True).step().run()
 

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -64,16 +64,16 @@ def test_basic_workflows(workflow_start_regular_shared):
         z = append2.bind(x)
         return workflow.continuation(join.bind(y, z))
 
-    @workflow.step
+    @ray.remote
     def mul(a, b):
         return a * b
 
-    @workflow.step
+    @ray.remote
     def factorial(n):
         if n == 1:
             return 1
         else:
-            return mul.step(n, factorial.step(n - 1))
+            return workflow.continuation(mul.bind(n, factorial.bind(n - 1)))
 
     # This test also shows different "style" of running workflows.
     assert (
@@ -92,7 +92,7 @@ def test_basic_workflows(workflow_start_regular_shared):
     wf = fork_join.bind()
     assert workflow.create(wf).run() == "join([source1][append1], [source1][append2])"
 
-    assert factorial.step(10).run() == 3628800
+    assert workflow.create(factorial.bind(10)).run() == 3628800
 
 
 def test_async_execution(workflow_start_regular_shared):

--- a/python/ray/workflow/tests/test_basic_workflows_2.py
+++ b/python/ray/workflow/tests/test_basic_workflows_2.py
@@ -210,15 +210,15 @@ def test_get_named_step_output_error(workflow_start_regular, tmp_path):
 
 
 def test_get_named_step_default(workflow_start_regular, tmp_path):
-    @workflow.step
+    @ray.remote
     def factorial(n, r=1):
         if n == 1:
             return r
-        return factorial.step(n - 1, r * n)
+        return workflow.continuation(factorial.bind(n - 1, r * n))
 
     import math
 
-    assert math.factorial(5) == factorial.step(5).run("factorial")
+    assert math.factorial(5) == workflow.create(factorial.bind(5)).run("factorial")
     for i in range(5):
         step_name = (
             "test_basic_workflows_2.test_get_named_step_default.locals.factorial"

--- a/python/ray/workflow/tests/test_large_intermediate.py
+++ b/python/ray/workflow/tests/test_large_intermediate.py
@@ -3,6 +3,7 @@ import pytest
 from ray.tests.conftest import *  # noqa
 
 import numpy as np
+import ray
 from ray import workflow
 
 

--- a/python/ray/workflow/tests/test_large_intermediate.py
+++ b/python/ray/workflow/tests/test_large_intermediate.py
@@ -7,26 +7,26 @@ from ray import workflow
 
 
 def test_simple_large_intermediate(workflow_start_regular_shared):
-    @workflow.step
+    @ray.remote
     def large_input():
         return np.arange(2 ** 24)
 
-    @workflow.step
+    @ray.remote
     def identity(x):
         return x
 
-    @workflow.step
+    @ray.remote
     def average(x):
         return np.mean(x)
 
-    @workflow.step
+    @ray.remote
     def simple_large_intermediate():
-        x = large_input.step()
-        y = identity.step(x)
-        return average.step(y)
+        x = large_input.bind()
+        y = identity.bind(x)
+        return workflow.continuation(average.bind(y))
 
     start = time.time()
-    outputs = simple_large_intermediate.step().run()
+    outputs = workflow.create(simple_large_intermediate.bind()).run()
     print(f"duration = {time.time() - start}")
     assert np.isclose(outputs, 8388607.5)
 

--- a/python/ray/workflow/tests/test_object_deref.py
+++ b/python/ray/workflow/tests/test_object_deref.py
@@ -31,12 +31,14 @@ def test_objectref_inputs(workflow_start_regular_shared):
         except Exception as e:
             return False, str(e)
 
-    output, s = workflow.create(deref_check.bind(
-        ray.put(42),
-        nested_workflow.step(10),
-        [nested_workflow.step(9)],
-        [{"output": nested_workflow.step(7)}],
-    )).run()
+    output, s = workflow.create(
+        deref_check.bind(
+            ray.put(42),
+            nested_workflow.step(10),
+            [nested_workflow.step(9)],
+            [{"output": nested_workflow.step(7)}],
+        )
+    ).run()
     assert output is True, s
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A followup of #23456. The remaining workflows cannot be transformed due to other issues (e.g. lack of support of workflow options in ray.remote)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
