### PR TITLE
[ci] Non-verbose llvm download in Buildkite

### DIFF
--- a/ci/travis/install-llvm-binaries.sh
+++ b/ci/travis/install-llvm-binaries.sh
@@ -60,7 +60,15 @@ install_llvm() {
   case "${osversion}" in
     linux-gnu-ubuntu*)
       printInfo "Downloading LLVM from ${url}"
-      wget -c $url -O llvm.tar.xz
+
+      WGET_OPTIONS=""
+      if [ -n "${BUILDKITE-}" ]; then
+        # Non-verbose output in BUILDKITE
+        WGET_OPTIONS="-nv"
+      fi
+
+      wget ${WGET_OPTIONS} -c $url -O llvm.tar.xz
+
       printInfo "Installing LLVM to ${targetdir}"
       mkdir -p "${targetdir}"
       tar -xf ./llvm.tar.xz -C "${targetdir}" --strip-components=1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What: Use `wget -nv` in Buildkite environments
Why: The llvm download currently clutters the log output as it's not rendered correctly, thus we should silence it.

Result: Logs are finally readable again in Buildkite without download: https://buildkite.com/ray-project/ray-builders-pr/builds/28916#25e8965a-d18b-49a1-8e29-200365b13c53

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
