### PR TITLE
[Core] pin prometheus_client version

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -18,7 +18,7 @@ scikit-image
 openpyxl
 pandas==0.24.2
 Pillow
-prometheus_client
+prometheus_client >= 0.7.1, <= 0.13.1
 py-spy
 pygments
 pytest==5.4.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,7 @@ jsonschema
 msgpack >= 1.0.0, < 2.0.0
 numpy >= 1.16
 opencensus
-prometheus_client >= 0.7.1
+prometheus_client >= 0.7.1, <= 0.13.1
 protobuf >= 3.8.0
 py-spy >= 0.2.0
 pydantic >= 1.8

--- a/python/requirements/requirements_default.txt
+++ b/python/requirements/requirements_default.txt
@@ -3,5 +3,5 @@ aiosignal
 aiohttp_cors
 colorful
 opencensus
-prometheus_client>=0.7.1
+prometheus_client >= 0.7.1, <= 0.13.1
 smart_open


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Seems latest version of prmetheus breaks a bunch of tests. See if pin it to an earlier version solve the issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
