### PR TITLE
[ci] Pin prometheus_client to fix current test outages

### DIFF
--- a/ci/asan_tests/ray-project/requirements.txt
+++ b/ci/asan_tests/ray-project/requirements.txt
@@ -18,7 +18,7 @@ scikit-image
 openpyxl
 pandas==0.24.2
 Pillow
-prometheus_client
+prometheus_client<0.14.0
 py-spy
 pygments
 pytest==5.4.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,7 @@ jsonschema
 msgpack >= 1.0.0, < 2.0.0
 numpy >= 1.16
 opencensus
-prometheus_client >= 0.7.1
+prometheus_client >= 0.7.1, < 0.14.0
 protobuf >= 3.8.0
 py-spy >= 0.2.0
 pydantic >= 1.8

--- a/python/requirements/requirements_default.txt
+++ b/python/requirements/requirements_default.txt
@@ -1,7 +1,7 @@
-aiohttp>=3.7
+aiohttp >= 3.7
 aiosignal
 aiohttp_cors
 colorful
 opencensus
-prometheus_client>=0.7.1
+prometheus_client >= 0.7.1, < 0.14.0
 smart_open

--- a/python/setup.py
+++ b/python/setup.py
@@ -213,7 +213,7 @@ if setup_spec.type == SetupType.RAY:
             "requests",
             "gpustat >= 1.0.0b1",  # for windows
             "opencensus",
-            "prometheus_client >= 0.7.1",
+            "prometheus_client >= 0.7.1, < 0.14.0",
             "smart_open",
         ],
         "serve": ["uvicorn==0.16.0", "requests", "starlette", "fastapi", "aiorwlock"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What: Pins prometheus_client to < 0.14.0, hopefully fixing today's CI outages
Why: New version of the python client (https://github.com/prometheus/client_python/releases) breaks our CI

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
