### PR TITLE
Expose A100 in accelerators module

### DIFF
--- a/python/ray/util/accelerators/__init__.py
+++ b/python/ray/util/accelerators/__init__.py
@@ -4,6 +4,7 @@ from ray.util.accelerators.accelerators import (
     NVIDIA_TESLA_T4,
     NVIDIA_TESLA_P4,
     NVIDIA_TESLA_K80,
+    NVIDIA_TESLA_A100,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "NVIDIA_TESLA_T4",
     "NVIDIA_TESLA_P4",
     "NVIDIA_TESLA_K80",
+    "NVIDIA_TESLA_A100",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
`NVIDIA_TESLA_A100` is added [here](https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py) but it's not exposed in `accelerators` module's `__init__` file.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
