### PR TITLE
[serve] Include full traceback in deployment update error message

### DIFF
--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -7,6 +7,7 @@ import os
 import pickle
 import random
 import time
+import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import ray
@@ -1504,10 +1505,11 @@ class DeploymentState:
                 self._notify_running_replicas_changed()
 
             deleted = self._check_curr_status()
-        except Exception as e:
+        except Exception:
             self._curr_status_info = DeploymentStatusInfo(
                 status=DeploymentStatus.UNHEALTHY,
-                message=f"Failed to update deployment:\n{e}.",
+                message="Failed to update deployment:"
+                        f"\n{traceback.format_exception()}",
             )
             deleted = False
 

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -1393,6 +1393,7 @@ class DeploymentState:
 
         Returns if any running replicas transitioned to another state.
         """
+
         running_replicas_changed = False
         for replica in self._replicas.pop(states=[ReplicaState.RUNNING]):
             if replica.check_health():
@@ -1508,8 +1509,7 @@ class DeploymentState:
         except Exception:
             self._curr_status_info = DeploymentStatusInfo(
                 status=DeploymentStatus.UNHEALTHY,
-                message="Failed to update deployment:"
-                        f"\n{traceback.format_exception()}",
+                message="Failed to update deployment:" f"\n{traceback.format_exc()}",
             )
             deleted = False
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When deployments fail to update, [Serve sets their status to UNHEALTHY and logs the error message](https://github.com/ray-project/ray/blob/46465abd6d866c3903b17c601e84e81b46c67190/python/ray/serve/deployment_state.py#L1507-L1511). However, the message lacks a traceback, making it impossible to find what caused it. [For example](https://console.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_SfGPJq8WWJUhAvmHHsDgJWUe?command-history-section=command_history):

```
File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/api.py", line 328, in _wait_for_deployment_healthy
    raise RuntimeError(f"Deployment {name} is UNHEALTHY: {status.message}")
RuntimeError: Deployment echo is UNHEALTHY: Failed to update deployment:
'>' not supported between instances of 'NoneType' and 'int'.
```

It's not clear where `'>' not supported between instances of 'NoneType' and 'int'.` is being triggered.

The change includes the full traceback for this type of update failure. The new status message is easier to debug:

```
File "/Users/shrekris/Desktop/ray/python/ray/serve/api.py", line 328, in _wait_for_deployment_healthy
    raise RuntimeError(f"Deployment {name} is UNHEALTHY: {status.message}")
RuntimeError: Deployment A is UNHEALTHY: Failed to update deployment:
Traceback (most recent call last):
  File "/Users/shrekris/Desktop/ray/python/ray/serve/deployment_state.py", line 1503, in update
    running_replicas_changed |= self._check_and_update_replicas()
  File "/Users/shrekris/Desktop/ray/python/ray/serve/deployment_state.py", line 1396, in _check_and_update_replicas
    a = 1/0
ZeroDivisionError: division by zero
```

(I forced a divide-by-zero error to get this traceback).

## Related issue number

<!-- For example: "Closes #1234" -->

Addresses the vague error from #23747.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - N/A
