### PR TITLE
[GCS][Storage unification 1/n] store index in memory instead of storage

### DIFF
--- a/src/mock/ray/gcs/store_client/store_client.h
+++ b/src/mock/ray/gcs/store_client/store_client.h
@@ -36,6 +36,12 @@ class MockStoreClient : public StoreClient {
                (const MapCallback<std::string, std::string> &callback)),
               (override));
   MOCK_METHOD(Status,
+              AsyncMultiGet,
+              (const std::string &table_name,
+               const std::vector<std::string> &key,
+               (const MapCallback<std::string, std::string> &callback)),
+              (override));
+  MOCK_METHOD(Status,
               AsyncDelete,
               (const std::string &table_name,
                const std::string &key,

--- a/src/mock/ray/gcs/store_client/store_client.h
+++ b/src/mock/ray/gcs/store_client/store_client.h
@@ -25,24 +25,10 @@ class MockStoreClient : public StoreClient {
                const StatusCallback &callback),
               (override));
   MOCK_METHOD(Status,
-              AsyncPutWithIndex,
-              (const std::string &table_name,
-               const std::string &key,
-               const std::string &index_key,
-               const std::string &data,
-               const StatusCallback &callback),
-              (override));
-  MOCK_METHOD(Status,
               AsyncGet,
               (const std::string &table_name,
                const std::string &key,
                const OptionalItemCallback<std::string> &callback),
-              (override));
-  MOCK_METHOD(Status,
-              AsyncGetByIndex,
-              (const std::string &table_name,
-               const std::string &index_key,
-               (const MapCallback<std::string, std::string> &callback)),
               (override));
   MOCK_METHOD(Status,
               AsyncGetAll,
@@ -56,29 +42,9 @@ class MockStoreClient : public StoreClient {
                const StatusCallback &callback),
               (override));
   MOCK_METHOD(Status,
-              AsyncDeleteWithIndex,
-              (const std::string &table_name,
-               const std::string &key,
-               const std::string &index_key,
-               const StatusCallback &callback),
-              (override));
-  MOCK_METHOD(Status,
               AsyncBatchDelete,
               (const std::string &table_name,
                const std::vector<std::string> &keys,
-               const StatusCallback &callback),
-              (override));
-  MOCK_METHOD(Status,
-              AsyncBatchDeleteWithIndex,
-              (const std::string &table_name,
-               const std::vector<std::string> &keys,
-               const std::vector<std::string> &index_keys,
-               const StatusCallback &callback),
-              (override));
-  MOCK_METHOD(Status,
-              AsyncDeleteByIndex,
-              (const std::string &table_name,
-               const std::string &index_key,
                const StatusCallback &callback),
               (override));
   MOCK_METHOD(int, GetNextJobID, (), (override));

--- a/src/ray/gcs/gcs_server/gcs_init_data.cc
+++ b/src/ray/gcs/gcs_server/gcs_init_data.cc
@@ -98,7 +98,8 @@ void GcsInitData::AsyncLoadActorTableData(const EmptyCallback &on_done) {
                       << actor_table_data_.size();
         on_done();
       };
-  RAY_CHECK_OK(gcs_table_storage_->ActorTable().GetAll(load_actor_table_data_callback));
+  RAY_CHECK_OK(gcs_table_storage_->ActorTable().AsyncRebuildIndexAndGetAll(
+      load_actor_table_data_callback));
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -80,16 +80,25 @@ template <typename Key, typename Data>
 Status GcsTableWithJobId<Key, Data>::Put(const Key &key,
                                          const Data &value,
                                          const StatusCallback &callback) {
-  return this->store_client_->AsyncPutWithIndex(this->table_name_,
-                                                key.Binary(),
-                                                GetJobIdFromKey(key).Binary(),
-                                                value.SerializeAsString(),
-                                                callback);
+  {
+    absl::MutexLock lock(&mutex_);
+    index_[GetJobIdFromKey(key)].insert(key);
+  }
+  return this->store_client_->AsyncPut(
+      this->table_name_, key.Binary(), value.SerializeAsString(), callback);
 }
 
 template <typename Key, typename Data>
 Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
                                                 const MapCallback<Key, Data> &callback) {
+  std::vector<std::string> keys;
+  {
+    absl::MutexLock lock(&mutex_);
+    auto &key_set = index_[job_id];
+    for (auto &key : key_set) {
+      keys.push_back(key.Binary());
+    }
+  }
   auto on_done = [callback](absl::flat_hash_map<std::string, std::string> &&result) {
     absl::flat_hash_map<Key, Data> values;
     for (auto &item : result) {
@@ -99,35 +108,65 @@ Status GcsTableWithJobId<Key, Data>::GetByJobId(const JobID &job_id,
     }
     callback(std::move(values));
   };
-  return this->store_client_->AsyncGetByIndex(
-      this->table_name_, job_id.Binary(), on_done);
+  return this->store_client_->AsyncMultiGet(this->table_name_, keys, on_done);
 }
 
 template <typename Key, typename Data>
 Status GcsTableWithJobId<Key, Data>::DeleteByJobId(const JobID &job_id,
                                                    const StatusCallback &callback) {
-  return this->store_client_->AsyncDeleteByIndex(
-      this->table_name_, job_id.Binary(), callback);
+  std::vector<Key> keys;
+  {
+    absl::MutexLock lock(&mutex_);
+    auto &key_set = index_[job_id];
+    for (auto &key : key_set) {
+      keys.push_back(key);
+    }
+  }
+  return BatchDelete(keys, callback);
 }
 
 template <typename Key, typename Data>
 Status GcsTableWithJobId<Key, Data>::Delete(const Key &key,
                                             const StatusCallback &callback) {
-  return this->store_client_->AsyncDeleteWithIndex(
-      this->table_name_, key.Binary(), GetJobIdFromKey(key).Binary(), callback);
+  return BatchDelete({key}, callback);
 }
 
 template <typename Key, typename Data>
 Status GcsTableWithJobId<Key, Data>::BatchDelete(const std::vector<Key> &keys,
                                                  const StatusCallback &callback) {
   std::vector<std::string> keys_to_delete;
-  std::vector<std::string> indexs_to_delete;
   for (auto key : keys) {
     keys_to_delete.push_back(key.Binary());
-    indexs_to_delete.push_back(GetJobIdFromKey(key).Binary());
   }
-  return this->store_client_->AsyncBatchDeleteWithIndex(
-      this->table_name_, keys_to_delete, indexs_to_delete, callback);
+  return this->store_client_->AsyncBatchDelete(
+      this->table_name_, keys_to_delete, [this, callback, keys](auto status) {
+        if (status.ok()) {
+          {
+            absl::MutexLock lock(&mutex_);
+            for (auto &key : keys) {
+              index_[GetJobIdFromKey(key)].erase(key);
+            }
+          }
+        }
+        callback(status);
+      });
+}
+
+template <typename Key, typename Data>
+void GcsTableWithJobId<Key, Data>::SyncRebuildIndex() {
+  auto rebuild_promise = std::make_shared<std::promise<void>>();
+  auto future = rebuild_promise->get_future();
+  RAY_CHECK_OK(this->GetAll(
+      [this, rebuild_promise](absl::flat_hash_map<Key, Data> &&result) mutable {
+        absl::MutexLock lock(&mutex_);
+        index_.clear();
+        for (auto &item : result) {
+          auto key = item.first;
+          index_[GetJobIdFromKey(key)].insert(key);
+        }
+        rebuild_promise->set_value();
+      }));
+  future.get();
 }
 
 template class GcsTable<JobID, JobTableData>;

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -104,9 +104,7 @@ template <typename Key, typename Data>
 class GcsTableWithJobId : public GcsTable<Key, Data> {
  public:
   explicit GcsTableWithJobId(std::shared_ptr<StoreClient> store_client)
-      : GcsTable<Key, Data>(std::move(store_client)) {
-    SyncRebuildIndex();
-  }
+      : GcsTable<Key, Data>(std::move(store_client)) {}
 
   /// Write data to the table asynchronously.
   ///
@@ -146,12 +144,11 @@ class GcsTableWithJobId : public GcsTable<Key, Data> {
   Status BatchDelete(const std::vector<Key> &keys,
                      const StatusCallback &callback) override;
 
+  /// Rebuild the index during startup.
+  Status AsyncRebuildIndexAndGetAll(const MapCallback<Key, Data> &callback);
+
  protected:
   virtual JobID GetJobIdFromKey(const Key &key) = 0;
-
- private:
-  /// Rebuild the index during startup.
-  void SyncRebuildIndex();
 
   absl::Mutex mutex_;
   absl::flat_hash_map<JobID, absl::flat_hash_set<Key>> index_ GUARDED_BY(mutex_);

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
@@ -118,8 +118,8 @@ TEST_F(GcsActorSchedulerTest, KillWorkerLeak2) {
 
   std::function<void(ray::Status)> async_put_with_index_cb;
   // Leasing successfully
-  EXPECT_CALL(*store_client, AsyncPutWithIndex(_, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<4>(&async_put_with_index_cb), Return(Status::OK())));
+  EXPECT_CALL(*store_client, AsyncPut(_, _, _, _))
+      .WillOnce(DoAll(SaveArg<3>(&async_put_with_index_cb), Return(Status::OK())));
   actor_scheduler->Schedule(actor);
   rpc::RequestWorkerLeaseReply reply;
   reply.mutable_worker_address()->set_raylet_id(node_id.Binary());

--- a/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
+++ b/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
@@ -58,7 +58,7 @@ class GcsTableStorageTestBase : public ::testing::Test {
   }
 
   void TestGcsTableWithJobIdApi() {
-    auto table = gcs_table_storage_->ActorTable();
+    auto &table = gcs_table_storage_->ActorTable();
     JobID job_id1 = JobID::FromInt(1);
     JobID job_id2 = JobID::FromInt(2);
     JobID job_id3 = JobID::FromInt(3);

--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -32,22 +32,6 @@ Status InMemoryStoreClient::AsyncPut(const std::string &table_name,
   return Status::OK();
 }
 
-Status InMemoryStoreClient::AsyncPutWithIndex(const std::string &table_name,
-                                              const std::string &key,
-                                              const std::string &index_key,
-                                              const std::string &data,
-                                              const StatusCallback &callback) {
-  auto table = GetOrCreateTable(table_name);
-  absl::MutexLock lock(&(table->mutex_));
-  table->records_[key] = data;
-  table->index_keys_[index_key].emplace_back(key);
-  if (callback != nullptr) {
-    main_io_service_.post([callback]() { callback(Status::OK()); },
-                          "GcsInMemoryStore.PutWithIndex");
-  }
-  return Status::OK();
-}
-
 Status InMemoryStoreClient::AsyncGet(const std::string &table_name,
                                      const std::string &key,
                                      const OptionalItemCallback<std::string> &callback) {
@@ -81,6 +65,27 @@ Status InMemoryStoreClient::AsyncGetAll(
   return Status::OK();
 }
 
+Status InMemoryStoreClient::AsyncMultiGet(
+    const std::string &table_name,
+    const std::vector<std::string> &keys,
+    const MapCallback<std::string, std::string> &callback) {
+  RAY_CHECK(callback);
+  auto table = GetOrCreateTable(table_name);
+  absl::MutexLock lock(&(table->mutex_));
+  auto result = absl::flat_hash_map<std::string, std::string>();
+  for (auto &key : keys) {
+    auto it = table->records_.find(key);
+    if (it == table->records_.end()) {
+      continue;
+    }
+    result[key] = it->second;
+  }
+  main_io_service_.post(
+      [result = std::move(result), callback]() mutable { callback(std::move(result)); },
+      "GcsInMemoryStore.GetAll");
+  return Status::OK();
+}
+
 Status InMemoryStoreClient::AsyncDelete(const std::string &table_name,
                                         const std::string &key,
                                         const StatusCallback &callback) {
@@ -90,33 +95,6 @@ Status InMemoryStoreClient::AsyncDelete(const std::string &table_name,
   if (callback != nullptr) {
     main_io_service_.post([callback]() { callback(Status::OK()); },
                           "GcsInMemoryStore.Delete");
-  }
-  return Status::OK();
-}
-
-Status InMemoryStoreClient::AsyncDeleteWithIndex(const std::string &table_name,
-                                                 const std::string &key,
-                                                 const std::string &index_key,
-                                                 const StatusCallback &callback) {
-  auto table = GetOrCreateTable(table_name);
-  absl::MutexLock lock(&(table->mutex_));
-  // Remove key-value data.
-  table->records_.erase(key);
-
-  // Remove index-key data.
-  auto iter = table->index_keys_.find(index_key);
-  if (iter != table->index_keys_.end()) {
-    auto it = std::find(iter->second.begin(), iter->second.end(), key);
-    if (it != iter->second.end()) {
-      iter->second.erase(it);
-      if (iter->second.size() == 0) {
-        table->index_keys_.erase(iter);
-      }
-    }
-  }
-  if (callback != nullptr) {
-    main_io_service_.post([callback]() { callback(Status::OK()); },
-                          "GcsInMemoryStore.DeleteWithIndex");
   }
   return Status::OK();
 }
@@ -132,84 +110,6 @@ Status InMemoryStoreClient::AsyncBatchDelete(const std::string &table_name,
   if (callback != nullptr) {
     main_io_service_.post([callback]() { callback(Status::OK()); },
                           "GcsInMemoryStore.BatchDelete");
-  }
-  return Status::OK();
-}
-
-Status InMemoryStoreClient::AsyncBatchDeleteWithIndex(
-    const std::string &table_name,
-    const std::vector<std::string> &keys,
-    const std::vector<std::string> &index_keys,
-    const StatusCallback &callback) {
-  RAY_CHECK(keys.size() == index_keys.size());
-
-  auto table = GetOrCreateTable(table_name);
-  absl::MutexLock lock(&(table->mutex_));
-
-  for (size_t i = 0; i < keys.size(); ++i) {
-    const std::string &key = keys[i];
-    const std::string &index_key = index_keys[i];
-    table->records_.erase(key);
-
-    auto iter = table->index_keys_.find(index_key);
-    if (iter != table->index_keys_.end()) {
-      auto it = std::find(iter->second.begin(), iter->second.end(), key);
-      if (it != iter->second.end()) {
-        iter->second.erase(it);
-        if (iter->second.size() == 0) {
-          table->index_keys_.erase(iter);
-        }
-      }
-    }
-  }
-
-  if (callback != nullptr) {
-    main_io_service_.post([callback]() { callback(Status::OK()); },
-                          "GcsInMemoryStore.BatchDeleteWithIndex");
-  }
-
-  return Status::OK();
-}
-
-Status InMemoryStoreClient::AsyncGetByIndex(
-    const std::string &table_name,
-    const std::string &index_key,
-    const MapCallback<std::string, std::string> &callback) {
-  RAY_CHECK(callback);
-  auto table = GetOrCreateTable(table_name);
-  absl::MutexLock lock(&(table->mutex_));
-  auto iter = table->index_keys_.find(index_key);
-  auto result = absl::flat_hash_map<std::string, std::string>();
-  if (iter != table->index_keys_.end()) {
-    for (auto &key : iter->second) {
-      auto kv_iter = table->records_.find(key);
-      if (kv_iter != table->records_.end()) {
-        result[kv_iter->first] = kv_iter->second;
-      }
-    }
-  }
-  main_io_service_.post(
-      [result = std::move(result), callback]() mutable { callback(std::move(result)); },
-      "GcsInMemoryStore.GetByIndex");
-
-  return Status::OK();
-}
-
-Status InMemoryStoreClient::AsyncDeleteByIndex(const std::string &table_name,
-                                               const std::string &index_key,
-                                               const StatusCallback &callback) {
-  auto table = GetOrCreateTable(table_name);
-  absl::MutexLock lock(&(table->mutex_));
-  auto iter = table->index_keys_.find(index_key);
-  if (iter != table->index_keys_.end()) {
-    for (auto &key : iter->second) {
-      table->records_.erase(key);
-    }
-    table->index_keys_.erase(iter);
-  }
-  if (callback != nullptr) {
-    main_io_service_.post([callback]() { callback(Status::OK()); },
-                          "GcsInMemoryStore.DeleteByIndex");
   }
   return Status::OK();
 }

--- a/src/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/ray/gcs/store_client/in_memory_store_client.h
@@ -37,44 +37,24 @@ class InMemoryStoreClient : public StoreClient {
                   const std::string &data,
                   const StatusCallback &callback) override;
 
-  Status AsyncPutWithIndex(const std::string &table_name,
-                           const std::string &key,
-                           const std::string &index_key,
-                           const std::string &data,
-                           const StatusCallback &callback) override;
-
   Status AsyncGet(const std::string &table_name,
                   const std::string &key,
                   const OptionalItemCallback<std::string> &callback) override;
 
-  Status AsyncGetByIndex(const std::string &table_name,
-                         const std::string &index_key,
-                         const MapCallback<std::string, std::string> &callback) override;
-
   Status AsyncGetAll(const std::string &table_name,
                      const MapCallback<std::string, std::string> &callback) override;
+
+  Status AsyncMultiGet(const std::string &table_name,
+                       const std::vector<std::string> &keys,
+                       const MapCallback<std::string, std::string> &callback) override;
 
   Status AsyncDelete(const std::string &table_name,
                      const std::string &key,
                      const StatusCallback &callback) override;
 
-  Status AsyncDeleteWithIndex(const std::string &table_name,
-                              const std::string &key,
-                              const std::string &index_key,
-                              const StatusCallback &callback) override;
-
   Status AsyncBatchDelete(const std::string &table_name,
                           const std::vector<std::string> &keys,
                           const StatusCallback &callback) override;
-
-  Status AsyncBatchDeleteWithIndex(const std::string &table_name,
-                                   const std::vector<std::string> &keys,
-                                   const std::vector<std::string> &index_keys,
-                                   const StatusCallback &callback) override;
-
-  Status AsyncDeleteByIndex(const std::string &table_name,
-                            const std::string &index_key,
-                            const StatusCallback &callback) override;
 
   int GetNextJobID() override;
 
@@ -84,9 +64,6 @@ class InMemoryStoreClient : public StoreClient {
     absl::Mutex mutex_;
     // Mapping from key to data.
     absl::flat_hash_map<std::string, std::string> records_ GUARDED_BY(mutex_);
-    // Mapping from index key to keys.
-    absl::flat_hash_map<std::string, std::vector<std::string>> index_keys_
-        GUARDED_BY(mutex_);
   };
 
   std::shared_ptr<InMemoryStoreClient::InMemoryTable> GetOrCreateTable(

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -34,44 +34,24 @@ class RedisStoreClient : public StoreClient {
                   const std::string &data,
                   const StatusCallback &callback) override;
 
-  Status AsyncPutWithIndex(const std::string &table_name,
-                           const std::string &key,
-                           const std::string &index_key,
-                           const std::string &data,
-                           const StatusCallback &callback) override;
-
   Status AsyncGet(const std::string &table_name,
                   const std::string &key,
                   const OptionalItemCallback<std::string> &callback) override;
 
-  Status AsyncGetByIndex(const std::string &table_name,
-                         const std::string &index_key,
-                         const MapCallback<std::string, std::string> &callback) override;
-
   Status AsyncGetAll(const std::string &table_name,
                      const MapCallback<std::string, std::string> &callback) override;
+
+  Status AsyncMultiGet(const std::string &table_name,
+                       const std::vector<std::string> &keys,
+                       const MapCallback<std::string, std::string> &callback) override;
 
   Status AsyncDelete(const std::string &table_name,
                      const std::string &key,
                      const StatusCallback &callback) override;
 
-  Status AsyncDeleteWithIndex(const std::string &table_name,
-                              const std::string &key,
-                              const std::string &index_key,
-                              const StatusCallback &callback) override;
-
   Status AsyncBatchDelete(const std::string &table_name,
                           const std::vector<std::string> &keys,
                           const StatusCallback &callback) override;
-
-  Status AsyncBatchDeleteWithIndex(const std::string &table_name,
-                                   const std::vector<std::string> &keys,
-                                   const std::vector<std::string> &index_keys,
-                                   const StatusCallback &callback) override;
-
-  Status AsyncDeleteByIndex(const std::string &table_name,
-                            const std::string &index_key,
-                            const StatusCallback &callback) override;
 
   int GetNextJobID() override;
 

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -46,20 +46,6 @@ class StoreClient {
                           const std::string &data,
                           const StatusCallback &callback) = 0;
 
-  /// Write data to the given table asynchronously.
-  ///
-  /// \param table_name The name of the table to be written.
-  /// \param key The key that will be written to the table.
-  /// \param index_key A secondary key that will be used for indexing the data.
-  /// \param data The value of the key that will be written to the table.
-  /// \param callback Callback that will be called after write finishes.
-  /// \return Status
-  virtual Status AsyncPutWithIndex(const std::string &table_name,
-                                   const std::string &key,
-                                   const std::string &index_key,
-                                   const std::string &data,
-                                   const StatusCallback &callback) = 0;
-
   /// Get data from the given table asynchronously.
   ///
   /// \param table_name The name of the table to be read.
@@ -70,17 +56,6 @@ class StoreClient {
                           const std::string &key,
                           const OptionalItemCallback<std::string> &callback) = 0;
 
-  /// Get data by index from the given table asynchronously.
-  ///
-  /// \param table_name The name of the table to be read.
-  /// \param index_key The secondary key that will be used to get the indexed data.
-  /// \param callback Callback that will be called after read finishes.
-  /// \return Status
-  virtual Status AsyncGetByIndex(
-      const std::string &table_name,
-      const std::string &index_key,
-      const MapCallback<std::string, std::string> &callback) = 0;
-
   /// Get all data from the given table asynchronously.
   ///
   /// \param table_name The name of the table to be read.
@@ -88,6 +63,15 @@ class StoreClient {
   /// \return Status
   virtual Status AsyncGetAll(const std::string &table_name,
                              const MapCallback<std::string, std::string> &callback) = 0;
+
+  /// Get all data from the given table asynchronously.
+  ///
+  /// \param table_name The name of the table to be read.
+  /// \param callback Callback that will be called after data has been received.
+  /// \return Status
+  virtual Status AsyncMultiGet(const std::string &table_name,
+                               const std::vector<std::string> &keys,
+                               const MapCallback<std::string, std::string> &callback) = 0;
 
   /// Delete data from the given table asynchronously.
   ///
@@ -99,19 +83,6 @@ class StoreClient {
                              const std::string &key,
                              const StatusCallback &callback) = 0;
 
-  /// Delete data from the given table asynchronously, this can delete
-  /// key--value and index--key.
-  ///
-  /// \param table_name The name of the table from which data is to be deleted.
-  /// \param key The key that will be deleted from the table.
-  /// \param index_key The index key of the given key.
-  /// \param callback Callback that will be called after delete finishes.
-  /// \return Status
-  virtual Status AsyncDeleteWithIndex(const std::string &table_name,
-                                      const std::string &key,
-                                      const std::string &index_key,
-                                      const StatusCallback &callback) = 0;
-
   /// Batch delete data from the given table asynchronously.
   ///
   /// \param table_name The name of the table from which data is to be deleted.
@@ -121,31 +92,6 @@ class StoreClient {
   virtual Status AsyncBatchDelete(const std::string &table_name,
                                   const std::vector<std::string> &keys,
                                   const StatusCallback &callback) = 0;
-
-  /// Batch delete data from the given table asynchronously, this can delete all
-  /// key--value data and index--key data.
-  ///
-  /// \param table_name The name of the table from which data is to be deleted.
-  /// \param keys The keys that will be deleted from the table.
-  /// \param index_keys The index keys of the given keys, they are in one-to-one
-  ///                   correspondence
-  /// \param callback Callback that will be called after delete finishes.
-  /// \return Status
-  virtual Status AsyncBatchDeleteWithIndex(const std::string &table_name,
-                                           const std::vector<std::string> &keys,
-                                           const std::vector<std::string> &index_keys,
-                                           const StatusCallback &callback) = 0;
-
-  /// Delete by index from the given table asynchronously.
-  ///
-  /// \param table_name The name of the table from which data is to be deleted.
-  /// \param index_key The secondary key that will be used to delete the indexed data.
-  /// from the table.
-  /// \param callback Callback that will be called after delete finishes.
-  /// \return Status
-  virtual Status AsyncDeleteByIndex(const std::string &table_name,
-                                    const std::string &index_key,
-                                    const StatusCallback &callback) = 0;
 
   /// Get next job id by `INCR` "JobCounter" key synchronously.
   ///

--- a/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
@@ -31,18 +31,8 @@ class InMemoryStoreClientTest : public StoreClientTestBase {
 
 TEST_F(InMemoryStoreClientTest, AsyncPutAndAsyncGetTest) { TestAsyncPutAndAsyncGet(); }
 
-TEST_F(InMemoryStoreClientTest, AsyncPutAndDeleteWithIndexTest) {
-  TestAsyncPutAndDeleteWithIndex();
-}
-
 TEST_F(InMemoryStoreClientTest, AsyncGetAllAndBatchDeleteTest) {
   TestAsyncGetAllAndBatchDelete();
-}
-
-TEST_F(InMemoryStoreClientTest, TestAsyncDeleteWithIndex) { TestAsyncDeleteWithIndex(); }
-
-TEST_F(InMemoryStoreClientTest, TestAsyncBatchDeleteWithIndex) {
-  TestAsyncBatchDeleteWithIndex();
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/store_client/test/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/redis_store_client_test.cc
@@ -51,18 +51,8 @@ class RedisStoreClientTest : public StoreClientTestBase {
 
 TEST_F(RedisStoreClientTest, AsyncPutAndAsyncGetTest) { TestAsyncPutAndAsyncGet(); }
 
-TEST_F(RedisStoreClientTest, AsyncPutAndDeleteWithIndexTest) {
-  TestAsyncPutAndDeleteWithIndex();
-}
-
 TEST_F(RedisStoreClientTest, AsyncGetAllAndBatchDeleteTest) {
   TestAsyncGetAllAndBatchDelete();
-}
-
-TEST_F(RedisStoreClientTest, TestAsyncDeleteWithIndex) { TestAsyncDeleteWithIndex(); }
-
-TEST_F(RedisStoreClientTest, TestAsyncBatchDeleteWithIndex) {
-  TestAsyncBatchDeleteWithIndex();
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -51,8 +51,6 @@ class StoreClientTestBase : public ::testing::Test {
     io_service_pool_->Stop();
 
     key_to_value_.clear();
-    key_to_index_.clear();
-    index_to_keys_.clear();
   }
 
   virtual void InitStoreClient() = 0;
@@ -126,58 +124,6 @@ class StoreClientTestBase : public ::testing::Test {
     WaitPendingDone();
   }
 
-  void PutWithIndex() {
-    auto put_calllback = [this](const Status &status) { --pending_count_; };
-    for (const auto &[key, value] : key_to_value_) {
-      ++pending_count_;
-      RAY_CHECK_OK(store_client_->AsyncPutWithIndex(table_name_,
-                                                    key.Binary(),
-                                                    key_to_index_[key].Hex(),
-                                                    value.SerializeAsString(),
-                                                    put_calllback));
-      // Make sure no-op callback is handled well
-      RAY_CHECK_OK(store_client_->AsyncPutWithIndex(table_name_,
-                                                    key.Binary(),
-                                                    key_to_index_[key].Hex(),
-                                                    value.SerializeAsString(),
-                                                    nullptr));
-    }
-    WaitPendingDone();
-  }
-
-  void GetByIndex() {
-    auto get_calllback =
-        [this](const absl::flat_hash_map<std::string, std::string> &result) {
-          if (!result.empty()) {
-            auto key = ActorID::FromBinary(result.begin()->first);
-            auto it = key_to_index_.find(key);
-            RAY_CHECK(it != key_to_index_.end());
-            RAY_CHECK(index_to_keys_[it->second].size() == result.size());
-          }
-          pending_count_ -= result.size();
-        };
-    auto iter = index_to_keys_.begin();
-    pending_count_ += iter->second.size();
-    RAY_CHECK_OK(
-        store_client_->AsyncGetByIndex(table_name_, iter->first.Hex(), get_calllback));
-    WaitPendingDone();
-  }
-
-  void DeleteByIndex() {
-    auto delete_calllback = [this](const Status &status) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
-    };
-    for (const auto &[key, _] : index_to_keys_) {
-      ++pending_count_;
-      RAY_CHECK_OK(
-          store_client_->AsyncDeleteByIndex(table_name_, key.Hex(), delete_calllback));
-      // Make sure no-op callback is handled well
-      RAY_CHECK_OK(store_client_->AsyncDeleteByIndex(table_name_, key.Hex(), nullptr));
-    }
-    WaitPendingDone();
-  }
-
   void GetAll() {
     auto get_all_callback =
         [this](const absl::flat_hash_map<std::string, std::string> &result) {
@@ -216,42 +162,6 @@ class StoreClientTestBase : public ::testing::Test {
     WaitPendingDone();
   }
 
-  void DeleteWithIndex() {
-    auto delete_calllback = [this](const Status &status) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
-    };
-    for (const auto &[key, _] : key_to_value_) {
-      ++pending_count_;
-      RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(
-          table_name_, key.Binary(), key_to_index_[key].Hex(), delete_calllback));
-      // Make sure no-op callback is handled well
-      RAY_CHECK_OK(store_client_->AsyncDeleteWithIndex(
-          table_name_, key.Binary(), key_to_index_[key].Hex(), nullptr));
-    }
-    WaitPendingDone();
-  }
-
-  void BatchDeleteWithIndex() {
-    auto delete_calllback = [this](const Status &status) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
-    };
-    ++pending_count_;
-    std::vector<std::string> keys;
-    std::vector<std::string> index_keys;
-    for (auto &[key, _] : key_to_value_) {
-      keys.push_back(key.Binary());
-      index_keys.push_back(key_to_index_[key].Hex());
-    }
-    RAY_CHECK_OK(store_client_->AsyncBatchDeleteWithIndex(
-        table_name_, keys, index_keys, delete_calllback));
-    // Make sure no-op callback is handled well
-    RAY_CHECK_OK(
-        store_client_->AsyncBatchDeleteWithIndex(table_name_, keys, index_keys, nullptr));
-    WaitPendingDone();
-  }
-
   void TestAsyncPutAndAsyncGet() {
     // AsyncPut without index.
     Put();
@@ -262,20 +172,6 @@ class StoreClientTestBase : public ::testing::Test {
     // AsyncDelete
     Delete();
 
-    GetEmpty();
-  }
-
-  void TestAsyncPutAndDeleteWithIndex() {
-    // AsyncPut with index
-    PutWithIndex();
-
-    // AsyncGet with index
-    GetByIndex();
-
-    // AsyncDelete by index
-    DeleteByIndex();
-
-    // AsyncGet
     GetEmpty();
   }
 
@@ -293,34 +189,6 @@ class StoreClientTestBase : public ::testing::Test {
     GetEmpty();
   }
 
-  void TestAsyncDeleteWithIndex() {
-    // AsyncPut with index
-    PutWithIndex();
-
-    // AsyncGet with index
-    GetByIndex();
-
-    // AsyncDelete key-value and index-key
-    DeleteWithIndex();
-
-    // AsyncGet
-    GetEmpty();
-  }
-
-  void TestAsyncBatchDeleteWithIndex() {
-    // AsyncPut with index
-    PutWithIndex();
-
-    // AsyncGetAll
-    GetByIndex();
-
-    // AsyncBatchDeleteWithIndex
-    BatchDeleteWithIndex();
-
-    // AsyncGet
-    GetEmpty();
-  }
-
   void GenTestData() {
     for (size_t i = 0; i < key_count_; i++) {
       rpc::ActorTableData actor;
@@ -333,17 +201,6 @@ class StoreClientTestBase : public ::testing::Test {
       actor.set_actor_id(actor_id.Binary());
 
       key_to_value_[actor_id] = actor;
-
-      key_to_index_[actor_id] = job_id;
-
-      auto it = index_to_keys_.find(job_id);
-      if (it != index_to_keys_.end()) {
-        it->second.emplace(actor_id);
-      } else {
-        std::unordered_set<ActorID> key_set;
-        key_set.emplace(actor_id);
-        index_to_keys_.emplace(job_id, std::move(key_set));
-      }
     }
   }
 
@@ -364,8 +221,6 @@ class StoreClientTestBase : public ::testing::Test {
   size_t key_count_{5000};
   size_t index_count_{100};
   absl::flat_hash_map<ActorID, rpc::ActorTableData> key_to_value_;
-  absl::flat_hash_map<ActorID, JobID> key_to_index_;
-  absl::flat_hash_map<JobID, std::unordered_set<ActorID>> index_to_keys_;
 
   std::atomic<int> pending_count_{0};
   std::chrono::milliseconds wait_pending_timeout_{5000};


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Today we have two storage interfaces in Gcs, one is InternalKvInterface which exposes key value interfaces, another is StoreClient which is kv interface with secondary index support.
To make GCS storage pluggable, we need to narrow down and unify the storage interface.  This is a try to only use kv store and build index purely in memory.

known limitations:

- we need to rebuild index during GCS startup
- there might be consistency issues when concurrent change (write/delete) to the same key; but the current redis based solution also suffer from the same issue.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
