### PR TITLE
[ci/release] Parse PR github repos correctly

### DIFF
--- a/release/ray_release/buildkite/settings.py
+++ b/release/ray_release/buildkite/settings.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict, Tuple
 
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.logger import logger
-from ray_release.wheels import DEFAULT_BRANCH
+from ray_release.wheels import DEFAULT_BRANCH, get_buildkite_repo_branch
 
 
 class Frequency(enum.Enum):
@@ -141,25 +141,7 @@ def update_settings_from_environment(settings: Dict) -> Dict:
         settings["ray_test_repo"] = os.environ["RAY_TEST_REPO"]
         settings["ray_test_branch"] = os.environ.get("RAY_TEST_BRANCH", DEFAULT_BRANCH)
     elif "BUILDKITE_BRANCH" in os.environ:
-        branch_str = os.environ["BUILDKITE_BRANCH"]
-
-        if "BUILDKITE_PULL_REQUEST_REPO" in os.environ:
-            repo_url = os.environ["BUILDKITE_PULL_REQUEST_REPO"]
-        else:
-            repo_url = os.environ["BUILDKITE_REPO"]
-
-        if ":" in branch_str:
-            # If the branch is user:branch, we split into user, branch
-            owner, branch = branch_str.split(":", maxsplit=1)
-
-            # If this is a PR, the repo_url is already set via env variable.
-            # We only construct our own repo url if this is a branch build.
-            if not os.environ.get("BUILDKITE_PULL_REQUEST_REPO"):
-                repo_url = f"https://github.com/{owner}/ray.git"
-        else:
-            branch = branch_str
-
-        repo_url = repo_url.replace("git://", "https://")
+        repo_url, branch = get_buildkite_repo_branch()
 
         settings["ray_test_repo"] = repo_url
         settings["ray_test_branch"] = branch

--- a/release/ray_release/buildkite/settings.py
+++ b/release/ray_release/buildkite/settings.py
@@ -159,6 +159,8 @@ def update_settings_from_environment(settings: Dict) -> Dict:
         else:
             branch = branch_str
 
+        repo_url = repo_url.replace("git://", "https://")
+
         settings["ray_test_repo"] = repo_url
         settings["ray_test_branch"] = branch
 

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -167,6 +167,67 @@ class BuildkiteSettingsTest(unittest.TestCase):
             },
         )
 
+        ###
+        # Buildkite PR build settings
+
+        # Default PR
+        os.environ.clear()
+        os.environ.update(environ)
+        os.environ["BUILDKITE_REPO"] = "https://github.com/ray-project/ray.git"
+        os.environ[
+            "BUILDKITE_PULL_REQUEST_REPO"
+        ] = "https://github.com/user/ray-fork.git"
+        os.environ["BUILDKITE_BRANCH"] = "user:some_branch"
+        updated_settings = settings.copy()
+        update_settings_from_environment(updated_settings)
+
+        self.assertEqual(
+            updated_settings["ray_test_repo"], "https://github.com/user/ray-fork.git"
+        )
+        self.assertEqual(updated_settings["ray_test_branch"], "some_branch")
+
+        # PR without prefix
+        os.environ.clear()
+        os.environ.update(environ)
+        os.environ["BUILDKITE_REPO"] = "https://github.com/ray-project/ray.git"
+        os.environ[
+            "BUILDKITE_PULL_REQUEST_REPO"
+        ] = "https://github.com/user/ray-fork.git"
+        os.environ["BUILDKITE_BRANCH"] = "some_branch"
+        updated_settings = settings.copy()
+        update_settings_from_environment(updated_settings)
+
+        self.assertEqual(
+            updated_settings["ray_test_repo"], "https://github.com/user/ray-fork.git"
+        )
+        self.assertEqual(updated_settings["ray_test_branch"], "some_branch")
+
+        # Branch build but pointing to fork
+        os.environ.clear()
+        os.environ.update(environ)
+        os.environ["BUILDKITE_REPO"] = "https://github.com/ray-project/ray.git"
+        os.environ["BUILDKITE_BRANCH"] = "user:some_branch"
+        updated_settings = settings.copy()
+        update_settings_from_environment(updated_settings)
+
+        self.assertEqual(
+            updated_settings["ray_test_repo"], "https://github.com/user/ray.git"
+        )
+        self.assertEqual(updated_settings["ray_test_branch"], "some_branch")
+
+        # Branch build but pointing to main repo branch
+        os.environ.clear()
+        os.environ.update(environ)
+        os.environ["BUILDKITE_REPO"] = "https://github.com/ray-project/ray.git"
+        os.environ["BUILDKITE_BRANCH"] = "some_branch"
+        updated_settings = settings.copy()
+        update_settings_from_environment(updated_settings)
+
+        self.assertEqual(
+            updated_settings["ray_test_repo"], "https://github.com/ray-project/ray.git"
+        )
+        self.assertEqual(updated_settings["ray_test_branch"], "some_branch")
+
     def testSettingsOverrideBuildkite(self):
         settings = get_default_settings()
 

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -190,9 +190,7 @@ class BuildkiteSettingsTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(environ)
         os.environ["BUILDKITE_REPO"] = "https://github.com/ray-project/ray.git"
-        os.environ[
-            "BUILDKITE_PULL_REQUEST_REPO"
-        ] = "https://github.com/user/ray-fork.git"
+        os.environ["BUILDKITE_PULL_REQUEST_REPO"] = "git://github.com/user/ray-fork.git"
         os.environ["BUILDKITE_BRANCH"] = "some_branch"
         updated_settings = settings.copy()
         update_settings_from_environment(updated_settings)

--- a/release/ray_release/wheels.py
+++ b/release/ray_release/wheels.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import time
 import urllib.request
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 from ray_release.config import set_test_env_var
 from ray_release.exception import (
@@ -150,6 +150,32 @@ def find_and_wait_for_ray_wheels_url(
     return wait_for_url(ray_wheels_url, timeout=timeout)
 
 
+def get_buildkite_repo_branch() -> Tuple[str, str]:
+    if "BUILDKITE_BRANCH" not in os.environ:
+        return DEFAULT_REPO, DEFAULT_BRANCH
+
+    branch_str = os.environ["BUILDKITE_BRANCH"]
+
+    if "BUILDKITE_PULL_REQUEST_REPO" in os.environ:
+        repo_url = os.environ["BUILDKITE_PULL_REQUEST_REPO"]
+    else:
+        repo_url = os.environ["BUILDKITE_REPO"]
+
+    if ":" in branch_str:
+        # If the branch is user:branch, we split into user, branch
+        owner, branch = branch_str.split(":", maxsplit=1)
+
+        # If this is a PR, the repo_url is already set via env variable.
+        # We only construct our own repo url if this is a branch build.
+        if not os.environ.get("BUILDKITE_PULL_REQUEST_REPO"):
+            repo_url = f"https://github.com/{owner}/ray.git"
+    else:
+        branch = branch_str
+
+    repo_url = repo_url.replace("git://", "https://")
+    return repo_url, branch
+
+
 def find_ray_wheels_url(ray_wheels: Optional[str] = None) -> str:
     if not ray_wheels:
         # If no wheels are specified, default to BUILDKITE_COMMIT
@@ -162,8 +188,7 @@ def find_ray_wheels_url(ray_wheels: Optional[str] = None) -> str:
                 "the latest available master wheels."
             )
 
-        branch = os.environ.get("BUILDKITE_BRANCH", DEFAULT_BRANCH)
-        repo_url = os.environ.get("BUILDKITE_REPO", DEFAULT_REPO)
+        repo_url, branch = get_buildkite_repo_branch()
 
         if not re.match(r"\b([a-f0-9]{40})\b", commit):
             # commit is symbolic, like HEAD

--- a/release/ray_release/wheels.py
+++ b/release/ray_release/wheels.py
@@ -159,7 +159,7 @@ def get_buildkite_repo_branch() -> Tuple[str, str]:
     if "BUILDKITE_PULL_REQUEST_REPO" in os.environ:
         repo_url = os.environ["BUILDKITE_PULL_REQUEST_REPO"]
     else:
-        repo_url = os.environ["BUILDKITE_REPO"]
+        repo_url = os.environ.get("BUILDKITE_REPO", DEFAULT_REPO)
 
     if ":" in branch_str:
         # If the branch is user:branch, we split into user, branch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What: Correctly infer github repo from PRs iin Buildkite environments
Why: For PRs, we need to checkout the correct github repo and branch so we can kick off release tests directly from PRs.

Test run (from this PR!): https://buildkite.com/ray-project/release-tests-pr/builds/20#7f5a6526-0040-4896-b23a-f4896c75973d

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
