### PR TITLE
[serve] Create `application.py`

### DIFF
--- a/dashboard/modules/serve/serve_head.py
+++ b/dashboard/modules/serve/serve_head.py
@@ -18,7 +18,8 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @routes.get("/api/serve/deployments/")
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def get_all_deployments(self, req: Request) -> Response:
-        from ray.serve.api import Application, list_deployments
+        from ray.serve.api import list_deployments
+        from ray.serve.application import Application
 
         app = Application(list(list_deployments().values()))
         return Response(
@@ -54,10 +55,8 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def put_all_deployments(self, req: Request) -> Response:
         from ray import serve
-        from ray.serve.api import (
-            Application,
-            internal_get_global_client,
-        )
+        from ray.serve.api import internal_get_global_client
+        from ray.serve.application import Application
 
         app = Application.from_dict(await req.json())
         serve.run(app, _blocking=False)

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -6,7 +6,6 @@ import logging
 import random
 import re
 import time
-import yaml
 from dataclasses import dataclass
 from functools import wraps
 from typing import (
@@ -14,7 +13,6 @@ from typing import (
     Callable,
     Dict,
     Optional,
-    TextIO,
     Tuple,
     Type,
     Union,
@@ -84,6 +82,7 @@ from ray.serve.schema import (
     ServeApplicationStatusSchema,
 )
 from ray.serve.deployment_graph import DeploymentNode, DeploymentFunctionNode
+from ray.serve.application import Application
 
 
 _INTERNAL_REPLICA_CONTEXT = None
@@ -1265,156 +1264,9 @@ def get_deployment_statuses() -> Dict[str, DeploymentStatusInfo]:
     return internal_get_global_client().get_deployment_statuses()
 
 
-class ImmutableDeploymentDict(dict):
-    def __init__(self, deployments: Dict[str, Deployment]):
-        super().__init__()
-        self.update(deployments)
-
-    def __setitem__(self, *args):
-        """Not allowed. Modify deployment options using set_options instead."""
-        raise RuntimeError(
-            "Setting deployments in a built app is not allowed. Modify the "
-            'options using app.deployments["deployment"].set_options instead.'
-        )
-
-
-class Application:
-    """A static, pre-built Serve application.
-
-    An application consists of a number of Serve deployments that can send
-    requests to each other. One of the deployments acts as the "ingress,"
-    meaning that it receives external traffic and is the entrypoint to the
-    application.
-
-    The ingress deployment can be accessed via app.ingress and a dictionary of
-    all deployments can be accessed via app.deployments.
-
-    The config options of each deployment can be modified using set_options:
-    app.deployments["name"].set_options(...).
-
-    This application object can be written to a config file and later deployed
-    to production using the Serve CLI or REST API.
-    """
-
-    def __init__(self, deployments: List[Deployment]):
-        deployment_dict = {}
-        for d in deployments:
-            if not isinstance(d, Deployment):
-                raise TypeError(f"Got {type(d)}. Expected deployment.")
-            elif d.name in deployment_dict:
-                raise ValueError(f"App got multiple deployments named '{d.name}'.")
-
-            deployment_dict[d.name] = d
-
-        self._deployments = ImmutableDeploymentDict(deployment_dict)
-
-    @property
-    def deployments(self) -> ImmutableDeploymentDict:
-        return self._deployments
-
-    @property
-    def ingress(self) -> Optional[Deployment]:
-        """Gets the app's ingress, if one exists.
-
-        The ingress is the single deployment with a non-None route prefix. If more
-        or less than one deployment has a route prefix, no single ingress exists,
-        so returns None.
-        """
-
-        ingress = None
-
-        for deployment in self._deployments.values():
-            if deployment.route_prefix is not None:
-                if ingress is None:
-                    ingress = deployment
-                else:
-                    return None
-
-        return ingress
-
-    def to_dict(self) -> Dict:
-        """Returns this Application's deployments as a dictionary.
-
-        This dictionary adheres to the Serve REST API schema. It can be deployed
-        via the Serve REST API.
-
-        Returns:
-            Dict: The Application's deployments formatted in a dictionary.
-        """
-        return serve_application_to_schema(self._deployments.values()).dict()
-
-    @classmethod
-    def from_dict(cls, d: Dict) -> "Application":
-        """Converts a dictionary of deployment data to an application.
-
-        Takes in a dictionary matching the Serve REST API schema and converts
-        it to an application containing those deployments.
-
-        Args:
-            d (Dict): A dictionary containing the deployments' data that matches
-                the Serve REST API schema.
-
-        Returns:
-            Application: a new application object containing the deployments.
-        """
-
-        return cls(schema_to_serve_application(ServeApplicationSchema.parse_obj(d)))
-
-    def to_yaml(self, f: Optional[TextIO] = None) -> Optional[str]:
-        """Returns this application's deployments as a YAML string.
-
-        Optionally writes the YAML string to a file as well. To write to a
-        file, use this pattern:
-
-        with open("file_name.txt", "w") as f:
-            app.to_yaml(f=f)
-
-        This file is formatted as a Serve YAML config file. It can be deployed
-        via the Serve CLI.
-
-        Args:
-            f (Optional[TextIO]): A pointer to the file where the YAML should
-                be written.
-
-        Returns:
-            Optional[String]: The deployments' YAML string. The output is from
-                yaml.safe_dump(). Returned only if no file pointer is passed in.
-        """
-
-        return yaml.safe_dump(
-            self.to_dict(), stream=f, default_flow_style=False, sort_keys=False
-        )
-
-    @classmethod
-    def from_yaml(cls, str_or_file: Union[str, TextIO]) -> "Application":
-        """Converts YAML data to deployments for an application.
-
-        Takes in a string or a file pointer to a file containing deployment
-        definitions in YAML. These definitions are converted to a new
-        application object containing the deployments.
-
-        To read from a file, use the following pattern:
-
-        with open("file_name.txt", "w") as f:
-            app = app.from_yaml(str_or_file)
-
-        Args:
-            str_or_file (Union[String, TextIO]): Either a string containing
-                YAML deployment definitions or a pointer to a file containing
-                YAML deployment definitions. The YAML format must adhere to the
-                ServeApplicationSchema JSON Schema defined in
-                ray.serve.schema. This function works with
-                Serve YAML config files.
-
-        Returns:
-            Application: a new Application object containing the deployments.
-        """
-        return cls.from_dict(yaml.safe_load(str_or_file))
-
-
 @PublicAPI(stability="alpha")
 def run(
-    target: Union[DeploymentNode, DeploymentFunctionNode, Application],
+    target: Union[DeploymentNode, DeploymentFunctionNode],
     _blocking: bool = True,
     *,
     host: str = DEFAULT_HTTP_HOST,

--- a/python/ray/serve/application.py
+++ b/python/ray/serve/application.py
@@ -95,6 +95,7 @@ class Application:
         """
 
         from ray.serve.api import serve_application_to_schema
+
         return serve_application_to_schema(self._deployments.values()).dict()
 
     @classmethod
@@ -113,6 +114,7 @@ class Application:
         """
 
         from ray.serve.api import schema_to_serve_application
+
         return cls(schema_to_serve_application(ServeApplicationSchema.parse_obj(d)))
 
     def to_yaml(self, f: Optional[TextIO] = None) -> Optional[str]:

--- a/python/ray/serve/application.py
+++ b/python/ray/serve/application.py
@@ -1,0 +1,167 @@
+import yaml
+from typing import (
+    Dict,
+    Optional,
+    TextIO,
+    Union,
+    List,
+)
+
+from ray.serve.deployment import Deployment
+from ray.serve.schema import (
+    ServeApplicationSchema,
+)
+
+# TODO (shrekris-anyscale): remove following dependencies on api.py:
+# - serve_application_to_schema
+# - schema_to_serve_application
+
+
+class ImmutableDeploymentDict(dict):
+    def __init__(self, deployments: Dict[str, Deployment]):
+        super().__init__()
+        self.update(deployments)
+
+    def __setitem__(self, *args):
+        """Not allowed. Modify deployment options using set_options instead."""
+        raise RuntimeError(
+            "Setting deployments in a built app is not allowed. Modify the "
+            'options using app.deployments["deployment"].set_options instead.'
+        )
+
+
+class Application:
+    """A static, pre-built Serve application.
+
+    An application consists of a number of Serve deployments that can send
+    requests to each other. One of the deployments acts as the "ingress,"
+    meaning that it receives external traffic and is the entrypoint to the
+    application.
+
+    The ingress deployment can be accessed via app.ingress and a dictionary of
+    all deployments can be accessed via app.deployments.
+
+    The config options of each deployment can be modified using set_options:
+    app.deployments["name"].set_options(...).
+
+    This application object can be written to a config file and later deployed
+    to production using the Serve CLI or REST API.
+    """
+
+    def __init__(self, deployments: List[Deployment]):
+        deployment_dict = {}
+        for d in deployments:
+            if not isinstance(d, Deployment):
+                raise TypeError(f"Got {type(d)}. Expected deployment.")
+            elif d.name in deployment_dict:
+                raise ValueError(f"App got multiple deployments named '{d.name}'.")
+
+            deployment_dict[d.name] = d
+
+        self._deployments = ImmutableDeploymentDict(deployment_dict)
+
+    @property
+    def deployments(self) -> ImmutableDeploymentDict:
+        return self._deployments
+
+    @property
+    def ingress(self) -> Optional[Deployment]:
+        """Gets the app's ingress, if one exists.
+
+        The ingress is the single deployment with a non-None route prefix. If more
+        or less than one deployment has a route prefix, no single ingress exists,
+        so returns None.
+        """
+
+        ingress = None
+
+        for deployment in self._deployments.values():
+            if deployment.route_prefix is not None:
+                if ingress is None:
+                    ingress = deployment
+                else:
+                    return None
+
+        return ingress
+
+    def to_dict(self) -> Dict:
+        """Returns this Application's deployments as a dictionary.
+
+        This dictionary adheres to the Serve REST API schema. It can be deployed
+        via the Serve REST API.
+
+        Returns:
+            Dict: The Application's deployments formatted in a dictionary.
+        """
+
+        from ray.serve.api import serve_application_to_schema
+        return serve_application_to_schema(self._deployments.values()).dict()
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "Application":
+        """Converts a dictionary of deployment data to an application.
+
+        Takes in a dictionary matching the Serve REST API schema and converts
+        it to an application containing those deployments.
+
+        Args:
+            d (Dict): A dictionary containing the deployments' data that matches
+                the Serve REST API schema.
+
+        Returns:
+            Application: a new application object containing the deployments.
+        """
+
+        from ray.serve.api import schema_to_serve_application
+        return cls(schema_to_serve_application(ServeApplicationSchema.parse_obj(d)))
+
+    def to_yaml(self, f: Optional[TextIO] = None) -> Optional[str]:
+        """Returns this application's deployments as a YAML string.
+
+        Optionally writes the YAML string to a file as well. To write to a
+        file, use this pattern:
+
+        with open("file_name.txt", "w") as f:
+            app.to_yaml(f=f)
+
+        This file is formatted as a Serve YAML config file. It can be deployed
+        via the Serve CLI.
+
+        Args:
+            f (Optional[TextIO]): A pointer to the file where the YAML should
+                be written.
+
+        Returns:
+            Optional[String]: The deployments' YAML string. The output is from
+                yaml.safe_dump(). Returned only if no file pointer is passed in.
+        """
+
+        return yaml.safe_dump(
+            self.to_dict(), stream=f, default_flow_style=False, sort_keys=False
+        )
+
+    @classmethod
+    def from_yaml(cls, str_or_file: Union[str, TextIO]) -> "Application":
+        """Converts YAML data to deployments for an application.
+
+        Takes in a string or a file pointer to a file containing deployment
+        definitions in YAML. These definitions are converted to a new
+        application object containing the deployments.
+
+        To read from a file, use the following pattern:
+
+        with open("file_name.txt", "w") as f:
+            app = app.from_yaml(str_or_file)
+
+        Args:
+            str_or_file (Union[String, TextIO]): Either a string containing
+                YAML deployment definitions or a pointer to a file containing
+                YAML deployment definitions. The YAML format must adhere to the
+                ServeApplicationSchema JSON Schema defined in
+                ray.serve.schema. This function works with
+                Serve YAML config files.
+
+        Returns:
+            Application: a new Application object containing the deployments.
+        """
+        return cls.from_dict(yaml.safe_load(str_or_file))

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -8,7 +8,7 @@ import starlette.responses
 import ray
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
-from ray.serve.api import Application
+from ray.serve.application import Application
 
 
 def test_e2e(serve_instance):

--- a/python/ray/serve/tests/test_application.py
+++ b/python/ray/serve/tests/test_application.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import ray
 from ray import serve
-from ray.serve.api import Application
+from ray.serve.application import Application
 from ray.serve.api import build as build_app
 from ray._private.test_utils import wait_for_condition
 

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -12,7 +12,7 @@ import ray
 from ray import serve
 from ray.tests.conftest import tmp_working_dir  # noqa: F401, E501
 from ray._private.test_utils import wait_for_condition
-from ray.serve.api import Application
+from ray.serve.application import Application
 from ray.serve.deployment_graph import RayServeDAGHandle
 
 

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -9,7 +9,7 @@ import requests
 import ray
 from ray import serve
 from ray.experimental.dag.input_node import InputNode
-from ray.serve.api import Application
+from ray.serve.application import Application
 from ray.serve.api import build as build_app
 from ray.serve.deployment_graph import DeploymentNode, RayServeDAGHandle
 from ray.serve.pipeline.api import build as pipeline_build


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `Application` class is stored in `api.py`. The object is relatively standalone and is used as a dependency in other classes, so this change moves `Application` (and `ImmutableDeploymentDict`) to a new file, `application.py`.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests only.
