### PR TITLE
[ci/release] Fix pipeline build for empty PR repo

### DIFF
--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -226,6 +226,20 @@ class BuildkiteSettingsTest(unittest.TestCase):
         )
         self.assertEqual(updated_settings["ray_test_branch"], "some_branch")
 
+        # Empty BUILDKITE_PULL_REQUEST_REPO
+        os.environ.clear()
+        os.environ.update(environ)
+        os.environ["BUILDKITE_REPO"] = "https://github.com/ray-project/ray.git"
+        os.environ["BUILDKITE_BRANCH"] = "some_branch"
+        os.environ["BUILDKITE_PULL_REQUEST_REPO"] = ""
+        updated_settings = settings.copy()
+        update_settings_from_environment(updated_settings)
+
+        self.assertEqual(
+            updated_settings["ray_test_repo"], "https://github.com/ray-project/ray.git"
+        )
+        self.assertEqual(updated_settings["ray_test_branch"], "some_branch")
+
     def testSettingsOverrideBuildkite(self):
         settings = get_default_settings()
 

--- a/release/ray_release/wheels.py
+++ b/release/ray_release/wheels.py
@@ -156,10 +156,10 @@ def get_buildkite_repo_branch() -> Tuple[str, str]:
 
     branch_str = os.environ["BUILDKITE_BRANCH"]
 
-    if "BUILDKITE_PULL_REQUEST_REPO" in os.environ:
-        repo_url = os.environ["BUILDKITE_PULL_REQUEST_REPO"]
-    else:
-        repo_url = os.environ.get("BUILDKITE_REPO", DEFAULT_REPO)
+    # BUILDKITE_PULL_REQUEST_REPO can be empty string, use `or` to catch this
+    repo_url = os.environ.get("BUILDKITE_PULL_REQUEST_REPO", None) or os.environ.get(
+        "BUILDKITE_REPO", DEFAULT_REPO
+    )
 
     if ":" in branch_str:
         # If the branch is user:branch, we split into user, branch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What: If `BUILDKITE_PULL_REQUEST_REPO` is empty string, default to `DEFAULT_REPO`
Why: BUILDKITE_PULL_REQUEST_REPO is set to an empty string per default, thus we're currently not detecting the buildkite repo correctly in branched builds.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
