### PR TITLE
[rllib] Clarify how MultiDiscrete is encoded

### DIFF
--- a/doc/source/rllib/rllib-models.rst
+++ b/doc/source/rllib/rllib-models.rst
@@ -29,8 +29,11 @@ observation space. Thereby, the following simple rules apply:
 
 - Discrete observations are one-hot encoded, e.g. ``Discrete(3) and value=1 -> [0, 1, 0]``.
 
-- MultiDiscrete observations are "multi" one-hot encoded,
-  e.g. ``MultiDiscrete([3, 4]) and value=[1, 0] -> [0 1 0 1 0 0 0]``.
+- MultiDiscrete observations are encoded by one-hot encoding each discrete element
+  and then concatenating the respective one-hot encoded vectors. 
+  e.g. ``MultiDiscrete([3, 4]) and value=[1, 3] -> [0 1 0 0 0 0 1]`` because
+  the first ``1`` is encoded as ``[0 1 0]`` and the second ``3`` is encoded as
+  ``[0 0 0 1]``; these two vectors are then concatenated to ``[0 1 0 0 0 0 1]``.
 
 - Tuple and Dict observations are flattened, thereby, Discrete and MultiDiscrete
   sub-spaces are handled as described above.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The previous documentation referred to "multi" one-hot encoding which could be confusing and may also mean something different than the intended meaning (see [here](https://stats.stackexchange.com/questions/467633/what-exactly-is-multi-hot-encoding-and-how-is-it-different-from-one-hot)). The new version clarifies more precisely how `MultiDiscrete` spaces are encoded in RLlib.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(  👉 As this is only a textual change to the docs, I did not test but I did run `make_html` per the instructions [here](https://docs.ray.io/en/master/ray-contribute/docs.html).
