### PR TITLE
[core] Use cheaper AWS m5 instances for shuffle tests

### DIFF
--- a/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
@@ -10,7 +10,7 @@ aws:
 head_node_type:
     name: head_node
     instance_type:  m5.4xlarge
-    resources: {"object_store_memory": 21474836480, "cpu": 0}
+    resources: {"object_store_memory": 21474836480}
 
 worker_node_types:
     - name: worker_node

--- a/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
@@ -9,12 +9,12 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type:  i3.8xlarge
-    resources: {"object_store_memory": 21474836480}
+    instance_type:  m5.4xlarge
+    resources: {"object_store_memory": 21474836480, "cpu": 0}
 
 worker_node_types:
     - name: worker_node
-      instance_type: i3.4xlarge
+      instance_type: m5.4xlarge
       min_workers: 19
       max_workers: 19
       use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current config uses i3 instances but it requires additional configuration to mount the NVMe volumes that we're not doing. This PR switches the config to m5 instances since they're cheaper and the tests are already just using EBS anyway.