### PR TITLE
[Dashboard] Specify `@types/react` resolution

### DIFF
--- a/dashboard/client/package.json
+++ b/dashboard/client/package.json
@@ -33,12 +33,16 @@
     "react-window": "^1.8.5",
     "typeface-roboto": "0.0.75",
     "typescript": "3.8.3",
-    "use-debounce": "^3.4.3"
+    "use-debounce": "^3.4.3",
+    "yarn": "^1.22.18"
   },
   "devDependencies": {
     "eslint-plugin-import": "2.20.1",
     "eslint-plugin-prefer-arrow": "1.1.7",
     "prettier": "2.3.0"
+  },
+  "resolutions": {
+    "@types/react": "16.9.26"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/dashboard/client/package.json
+++ b/dashboard/client/package.json
@@ -33,8 +33,7 @@
     "react-window": "^1.8.5",
     "typeface-roboto": "0.0.75",
     "typescript": "3.8.3",
-    "use-debounce": "^3.4.3",
-    "yarn": "^1.22.18"
+    "use-debounce": "^3.4.3"
   },
   "devDependencies": {
     "eslint-plugin-import": "2.20.1",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
A new @types/react release has broken the dashboard build. Make sure to specify the older version under package resolutions.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
