### PR TITLE
[Test] Don't send usage data to server for unit tests

### DIFF
--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -204,6 +204,7 @@ def test_usage_stats_heads_up_message():
 def test_usage_lib_cluster_metadata_generation(monkeypatch, shutdown_only):
     with monkeypatch.context() as m:
         m.setenv("RAY_USAGE_STATS_ENABLED", "1")
+        m.setenv("RAY_USAGE_STATS_REPORT_URL", "http://127.0.0.1:8000")
         ray.init(num_cpus=0)
         """
         Test metadata stored is equivalent to `_generate_cluster_metadata`.
@@ -374,6 +375,7 @@ available_node_types:
 def test_usage_lib_report_data(monkeypatch, shutdown_only, tmp_path):
     with monkeypatch.context() as m:
         m.setenv("RAY_USAGE_STATS_ENABLED", "1")
+        m.setenv("RAY_USAGE_STATS_REPORT_URL", "http://127.0.0.1:8000")
         # Runtime env is required to run this test in minimal installation test.
         ray.init(num_cpus=0, runtime_env={"pip": ["ray[serve]"]})
         """
@@ -648,4 +650,5 @@ def test_usage_file_error_message(monkeypatch, shutdown_only):
 
 
 if __name__ == "__main__":
+    os.environ["RAY_USAGE_STATS_REPORT_URL"] = "http://127.0.0.1:8000"
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are two tests that are accidentally sending usage data to the server. This pr fixes that.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
