### PR TITLE
Update ray version from 1.12.0rc1 to 1.12.0

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -7,7 +7,7 @@ set -x
 
 GPU=""
 BASE_IMAGE="ubuntu:focal"
-WHEEL_URL="https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.12.0rc1-cp37-cp37m-manylinux2014_x86_64.whl"
+WHEEL_URL="https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.12.0-cp37-cp37m-manylinux2014_x86_64.whl"
 PYTHON_VERSION="3.7.7"
 
 

--- a/java/api/pom_template.xml
+++ b/java/api/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.12.0rc1</version>
+    <version>1.12.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/performance_test/pom_template.xml
+++ b/java/performance_test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.12.0rc1</version>
+    <version>1.12.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.ray</groupId>
   <artifactId>ray-superpom</artifactId>
-  <version>1.12.0rc1</version>
+  <version>1.12.0</version>
   <packaging>pom</packaging>
   <name>Ray Project Parent POM</name>
   <description>An open source framework that provides a simple, universal API for building distributed applications.
@@ -63,7 +63,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.version>1.12.0rc1</project.version>
+    <project.version>1.12.0</project.version>
   </properties>
 
   <dependencyManagement>

--- a/java/runtime/pom_template.xml
+++ b/java/runtime/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.12.0rc1</version>
+    <version>1.12.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/serve/pom_template.xml
+++ b/java/serve/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.12.0rc1</version>
+    <version>1.12.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/test/pom_template.xml
+++ b/java/test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.12.0rc1</version>
+    <version>1.12.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -103,7 +103,7 @@ del _configure_system
 
 # Replaced with the current commit when building the wheels.
 __commit__ = "{{RAY_COMMIT_SHA}}"
-__version__ = "1.12.0rc1"
+__version__ = "1.12.0"
 
 import ray._raylet  # noqa: E402
 

--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -30,7 +30,7 @@ class WheelsFinderTest(unittest.TestCase):
 
         with patch("urllib.request.urlopen", lambda _: content):
             version = get_ray_version(DEFAULT_REPO, commit="fake")
-            self.assertEqual(version, "1.12.0rc1")
+            self.assertEqual(version, "1.12.0")
 
         with patch("urllib.request.urlopen", lambda _: []), self.assertRaises(
             RayWheelsNotFoundError

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -52,4 +52,4 @@ constexpr int kMessagePackOffset = 9;
 constexpr char kSetupWorkerFilename[] = "setup_worker.py";
 
 /// The version of Ray
-constexpr char kRayVersion[] = "1.12.0rc1";
+constexpr char kRayVersion[] = "1.12.0";


### PR DESCRIPTION
## Why are these changes needed?

Make 1.12.0rc1 as 1.12.0

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
