### PR TITLE
[Tune] Don't include nan metrics for best checkpoint

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -433,6 +433,8 @@ class ExperimentAnalysis:
     ) -> Optional[Checkpoint]:
         """Gets best persistent checkpoint path of provided trial.
 
+        Any checkpoints with an associated metric value of ``nan`` will be filtered out.
+
         Args:
             trial: The log directory of a trial, or a trial instance.
             metric: key of trial info to return, e.g. "mean_accuracy".
@@ -448,14 +450,14 @@ class ExperimentAnalysis:
 
         checkpoint_paths = self.get_trial_checkpoints_paths(trial, metric)
 
-        if not checkpoint_paths:
-            logger.error(f"No checkpoints have been found for trial {trial}.")
-            return None
-
         # Filter out nan. Sorting nan values leads to undefined behavior.
         checkpoint_paths = [
             (path, metric) for path, metric in checkpoint_paths if not is_nan(metric)
         ]
+
+        if not checkpoint_paths:
+            logger.error(f"No checkpoints have been found for trial {trial}.")
+            return None
 
         a = -1 if mode == "max" else 1
         best_path_metrics = sorted(checkpoint_paths, key=lambda x: a * x[1])

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -12,6 +12,7 @@ from ray import tune
 from ray.tune import ExperimentAnalysis
 import ray.tune.registry
 from ray.tune.utils.mock_trainable import MyTrainableClass
+from ray.tune.utils.util import is_nan
 
 
 class ExperimentAnalysisSuite(unittest.TestCase):
@@ -152,12 +153,43 @@ class ExperimentAnalysisSuite(unittest.TestCase):
 
     def testGetBestCheckpoint(self):
         best_trial = self.ea.get_best_trial(self.metric, mode="max")
-        checkpoints_metrics = self.ea.get_trial_checkpoints_paths(best_trial)
+        checkpoints_metrics = self.ea.get_trial_checkpoints_paths(
+            best_trial, metric=self.metric
+        )
         expected_path = max(checkpoints_metrics, key=lambda x: x[1])[0]
         best_checkpoint = self.ea.get_best_checkpoint(
             best_trial, self.metric, mode="max"
         )
         assert expected_path == best_checkpoint
+
+    def testGetBestCheckpointNan(self):
+        """Tests if nan values are excluded from best checkpoint."""
+        metric = "loss"
+
+        def train(config):
+            for i in range(config["steps"]):
+                if i == 0:
+                    value = float("nan")
+                else:
+                    value = i
+                result = {metric: value}
+                with tune.checkpoint_dir(step=i):
+                    pass
+                tune.report(**result)
+
+        ea = tune.run(train, local_dir=self.test_dir, config={"steps": 3})
+        best_trial = ea.get_best_trial(metric, mode="min")
+        best_checkpoint = ea.get_best_checkpoint(best_trial, metric, mode="min")
+        checkpoints_metrics = ea.get_trial_checkpoints_paths(best_trial, metric=metric)
+        expected_checkpoint_no_nan = min(
+            [
+                checkpoint_metric
+                for checkpoint_metric in checkpoints_metrics
+                if not is_nan(checkpoint_metric[1])
+            ],
+            key=lambda x: x[1],
+        )[0]
+        assert best_checkpoint == expected_checkpoint_no_nan
 
     def testGetLastCheckpoint(self):
         # one more experiment with 2 iterations

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -277,8 +277,12 @@ def date_str():
     return datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
 
 
+def is_nan(value):
+    return np.isnan(value)
+
+
 def is_nan_or_inf(value):
-    return np.isnan(value) or np.isinf(value)
+    return is_nan(value) or np.isinf(value)
 
 
 def _to_pinnable(obj):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Nan values do not have a well defined ordering. When sorting metrics to determine the best checkpoint, we should always filter out checkpoints that are associated with nan values.

Closes #23812 

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
