### PR TITLE
Fix incorrect sequence length for rnn

### DIFF
--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -317,9 +317,9 @@ class TorchPolicy(Policy):
             # Calculate RNN sequence lengths.
             seq_lens = (
                 torch.tensor(
-                    [1] * len(input_dict["obs"]),
+                    [1] * len(state_batches[0]),
                     dtype=torch.long,
-                    device=input_dict["obs"].device,
+                    device=state_batches[0].device,
                 )
                 if state_batches
                 else None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Update the torch policy to find the seq_lens using state_batches instead of input_dict. This helps handle the complex inputs to the model when the inbuilt preprocessing API is disabled.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #23202 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
