### PR TITLE
Set type hints for dist_class arguments to corresponding types.

### DIFF
--- a/rllib/agents/a3c/a3c_tf_policy.py
+++ b/rllib/agents/a3c/a3c_tf_policy.py
@@ -1,5 +1,5 @@
 """Note: Keep in sync with changes to VTraceTFPolicy."""
-from typing import Optional, Dict
+from typing import Optional, Dict, Type
 import gym
 
 import ray
@@ -85,7 +85,7 @@ class A3CLoss:
 def actor_critic_loss(
     policy: Policy,
     model: ModelV2,
-    dist_class: ActionDistribution,
+    dist_class: Type[ActionDistribution],
     train_batch: SampleBatch,
 ) -> TensorType:
     model_out, _ = model(train_batch)

--- a/rllib/agents/a3c/a3c_torch_policy.py
+++ b/rllib/agents/a3c/a3c_torch_policy.py
@@ -1,5 +1,5 @@
 import gym
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 
 import ray
 from ray.rllib.evaluation.episode import Episode
@@ -47,7 +47,7 @@ def add_advantages(
 def actor_critic_loss(
     policy: Policy,
     model: ModelV2,
-    dist_class: ActionDistribution,
+    dist_class: Type[ActionDistribution],
     train_batch: SampleBatch,
 ) -> TensorType:
     logits, _ = model(train_batch)

--- a/rllib/agents/marwil/marwil_tf_policy.py
+++ b/rllib/agents/marwil/marwil_tf_policy.py
@@ -1,6 +1,6 @@
 import logging
 import gym
-from typing import Optional, Dict
+from typing import Optional, Dict, Type
 
 import ray
 from ray.rllib.agents.ppo.ppo_tf_policy import compute_and_clip_gradients
@@ -177,7 +177,7 @@ class MARWILLoss:
 def marwil_loss(
     policy: Policy,
     model: ModelV2,
-    dist_class: ActionDistribution,
+    dist_class: Type[ActionDistribution],
     train_batch: SampleBatch,
 ) -> TensorType:
     model_out, _ = model(train_batch)

--- a/rllib/agents/marwil/marwil_torch_policy.py
+++ b/rllib/agents/marwil/marwil_torch_policy.py
@@ -1,5 +1,5 @@
 import gym
-from typing import Dict
+from typing import Dict, Type
 
 import ray
 from ray.rllib.agents.a3c.a3c_torch_policy import ValueNetworkMixin
@@ -20,7 +20,7 @@ torch, _ = try_import_torch()
 def marwil_loss(
     policy: Policy,
     model: ModelV2,
-    dist_class: ActionDistribution,
+    dist_class: Type[ActionDistribution],
     train_batch: SampleBatch,
 ) -> TensorType:
     model_out, _ = model(train_batch)

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -847,7 +847,7 @@ class ModelCatalog:
     @staticmethod
     @PublicAPI
     def register_custom_action_dist(
-        action_dist_name: str, action_dist_class: type
+        action_dist_name: str, action_dist_class: Type[ActionDistribution]
     ) -> None:
         """Register a custom action distribution class by name.
 

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -153,7 +153,7 @@ class Policy(metaclass=ABCMeta):
 
         # The action distribution class to use for action sampling, if any.
         # Child classes may set this.
-        self.dist_class: Optional[Type] = None
+        self.dist_class: Optional[Type[ActionDistribution]] = None
 
         # Maximal view requirements dict for `learn_on_batch()` and
         # `compute_actions` calls.
@@ -448,7 +448,7 @@ class Policy(metaclass=ABCMeta):
     @ExperimentalAPI
     @OverrideToImplementCustomLogic
     def loss(
-        self, model: ModelV2, dist_class: ActionDistribution, train_batch: SampleBatch
+        self, model: ModelV2, dist_class: Type[ActionDistribution], train_batch: SampleBatch
     ) -> Union[TensorType, List[TensorType]]:
         """Loss function for this Policy.
 

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 import os
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING, Type
 
 import ray
 import ray.experimental.tf_utils
@@ -13,6 +13,7 @@ from ray.util.debug import log_once
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.rnn_sequencing import pad_batch_to_sequences_of_same_size
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.models import ActionDistribution
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.utils import force_list
 from ray.rllib.utils.annotations import DeveloperAPI, override
@@ -83,7 +84,7 @@ class TFPolicy(Policy):
         action_input: Optional[TensorType] = None,
         log_likelihood: Optional[TensorType] = None,
         dist_inputs: Optional[TensorType] = None,
-        dist_class: Optional[type] = None,
+        dist_class: Optional[Type[ActionDistribution]] = None,
         state_inputs: Optional[List[TensorType]] = None,
         state_outputs: Optional[List[TensorType]] = None,
         prev_action_input: Optional[TensorType] = None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`dist_class` parameters require a distribution **class**, but the type hints suggest that they are `ActionDistribution` objects.

## Related issue number

Closes #21973.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/ (There are only changes to docs which are autogenerated)
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested: I am not sure if you have tests for type hints.
