### PR TITLE
Revert "Add "issue severity" back to GitHub bug template  (#23793)"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -47,16 +47,3 @@ body:
         until the repro instruction is updated.
     validations:
       required: true
-
-  - type: dropdown
-    attributes:
-      label: Issue Severity
-        description: |
-          How does this issue affect your experience as a Ray user?
-        multiple: false
-        options:
-          - "Low: It annoys or frustrates me."
-          - "Medium: It is a significant difficulty towards completing my task but I can work around it and get it resolved."
-          - "High: It blocks me from completing my task."
-      validations:
-        required: false


### PR DESCRIPTION
This reverts commit 2b04e5bd7e631eae1e1724e9bc8ef04c5906b920.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I think this broke the bug report issue template.