### PR TITLE
[Datasets] Preserve block order when transforming using the actor compute model.

### DIFF
--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -156,6 +156,7 @@ class ActorPoolStrategy(ComputeStrategy):
         workers = [BlockWorker.remote() for _ in range(self.min_size)]
         tasks = {w.ready.remote(): w for w in workers}
         metadata_mapping = {}
+        block_indices = {}
         ready_workers = set()
 
         while len(results) < orig_num_blocks:
@@ -204,9 +205,12 @@ class ActorPoolStrategy(ComputeStrategy):
                     )
                     metadata_mapping[ref] = meta_ref
                 tasks[ref] = worker
+                block_indices[ref] = len(blocks_in)
 
         map_bar.close()
         new_blocks, new_metadata = [], []
+        # Put blocks in input order.
+        results.sort(key=block_indices.get)
         if context.block_splitting_enabled:
             for result in ray.get(results):
                 for block, metadata in result:

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1476,6 +1476,12 @@ def test_map_batch(ray_start_regular_shared, tmp_path):
         ).take()
 
 
+def test_map_batch_actors_preserves_order(ray_start_regular_shared):
+    # Test that actor compute model preserves block order.
+    ds = ray.data.range(10, parallelism=5)
+    assert ds.map_batches(lambda x: x, compute="actors").take() == list(range(10))
+
+
 def test_union(ray_start_regular_shared):
     ds = ray.data.range(20, parallelism=10)
 


### PR DESCRIPTION
This PR preserves block order when transforming under the actor compute model. Before this PR, we were submitting block transformations in reverse order and creating the output block list in completion order.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #23833 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
