### PR TITLE
Add "issue severity" back to GitHub bug template #23793

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,4 +88,4 @@
 #/.travis.yml @ray-project/ray-core
 #/ci/travis/ @ray-project/ray-core
 
-/.github/ISSUE_TEMPLATE/ @ericl @stephanie-wang
+/.github/ISSUE_TEMPLATE/ @ericl @stephanie-wang @scv119 @pcmoritz

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -47,3 +47,16 @@ body:
         until the repro instruction is updated.
     validations:
       required: true
+
+  - type: dropdown
+    attributes:
+      label: Issue Severity
+        description: |
+          How does this issue affect your experience as a Ray user?
+        multiple: false
+        options:
+          - "Low: It annoys or frustrates me."
+          - "Medium: It is a significant difficulty but I can work around it."
+          - "High: It blocks me from completing my task."
+      validations:
+        required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,12 +51,12 @@ body:
   - type: dropdown
     attributes:
       label: Issue Severity
-        description: |
-          How does this issue affect your experience as a Ray user?
-        multiple: false
-        options:
+      description: |
+        How does this issue affect your experience as a Ray user?
+      multiple: false
+      options:
           - "Low: It annoys or frustrates me."
           - "Medium: It is a significant difficulty but I can work around it."
           - "High: It blocks me from completing my task."
-      validations:
+    validations:
         required: false


### PR DESCRIPTION
Adds back the "Issue severity" dropdown to the bug template so that Ray users can have a way of reporting UX problems. Made some changes to try to streamline issue reporting:

- made this field optional
- moved the field to be last
- slightly changed some of the wording

Also adding more codeowners for the issue templates.