### PR TITLE
[workflow] skip flaky tests

### DIFF
--- a/python/ray/workflow/tests/test_virtual_actor_2.py
+++ b/python/ray/workflow/tests/test_virtual_actor_2.py
@@ -278,6 +278,8 @@ def test_wf_in_actor_seq_2(workflow_start_regular, tmp_path):
     ],
     indirect=True,
 )
+@pytest.mark.skip(reason="The test become flaky on CI recently, but we could not "
+                         "reproduce it locally. Skip it temporarily.")
 def test_wf_in_actor_seq_3(workflow_start_regular, tmp_path):
     @workflow.virtual_actor
     class Counter:

--- a/python/ray/workflow/tests/test_virtual_actor_2.py
+++ b/python/ray/workflow/tests/test_virtual_actor_2.py
@@ -278,8 +278,10 @@ def test_wf_in_actor_seq_2(workflow_start_regular, tmp_path):
     ],
     indirect=True,
 )
-@pytest.mark.skip(reason="The test become flaky on CI recently, but we could not "
-                         "reproduce it locally. Skip it temporarily.")
+@pytest.mark.skip(
+    reason="The test become flaky on CI recently, but we could not "
+    "reproduce it locally. Skip it temporarily."
+)
 def test_wf_in_actor_seq_3(workflow_start_regular, tmp_path):
     @workflow.virtual_actor
     class Counter:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A workflow test became flaky on CI recently, but we could not reproduce it locally. Skip it temporarily.

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
