### PR TITLE
[Data] Make `BlockMetadata` a `dataclass`

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import time
 from typing import (
     TypeVar,
@@ -142,6 +143,7 @@ class _BlockExecStatsBuilder:
 
 
 @DeveloperAPI
+@dataclass
 class BlockMetadata:
     """Metadata about the block.
 
@@ -154,22 +156,15 @@ class BlockMetadata:
         exec_stats: Execution stats for this block.
     """
 
-    def __init__(
-        self,
-        *,
-        num_rows: Optional[int],
-        size_bytes: Optional[int],
-        schema: Union[type, "pyarrow.lib.Schema"],
-        input_files: List[str],
-        exec_stats: Optional[BlockExecStats]
-    ):
-        if input_files is None:
-            input_files = []
-        self.num_rows: Optional[int] = num_rows
-        self.size_bytes: Optional[int] = size_bytes
-        self.schema: Optional[Any] = schema
-        self.input_files: List[str] = input_files
-        self.exec_stats: Optional[BlockExecStats] = exec_stats
+    num_rows: Optional[int]
+    size_bytes: Optional[int]
+    schema: Optional[Union[type, "pyarrow.lib.Schema"]]
+    input_files: Optional[List[str]]
+    exec_stats: Optional[BlockExecStats]
+
+    def __post_init__(self):
+        if self.input_files is None:
+            self.input_files = []
 
 
 @DeveloperAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

By making `BlockMetadata` a `dataclass`, I've decreased the length of `BlockMetadata` from 16 lines to 9 lines. This should improve readability. 

The functionality of `BlockMetadata` is unchanged. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
