### PR TITLE
[Core] trim size of Reference struct

### DIFF
--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -20,10 +20,10 @@
                  << " local_ref_count: " << it->second.local_ref_count             \
                  << " submitted_count: " << it->second.submitted_task_ref_count    \
                  << " contained_in_owned: "                                        \
-                 << it->second.containing().contained_in_owned.size()              \
+                 << it->second.nested().contained_in_owned.size()                  \
                  << " contained_in_borrowed: "                                     \
-                 << (it)->second.containing().contained_in_borrowed_ids.size()     \
-                 << " contains: " << it->second.containing().contains.size()       \
+                 << (it)->second.nested().contained_in_borrowed_ids.size()         \
+                 << " contains: " << it->second.nested().contains.size()           \
                  << " stored_in: " << it->second.borrow().stored_in_objects.size() \
                  << " lineage_ref_count: " << it->second.lineage_ref_count;
 
@@ -112,8 +112,8 @@ bool ReferenceCounter::AddBorrowedObjectInternal(const ObjectID &object_id,
     if (outer_it != object_id_refs_.end() && !outer_it->second.owned_by_us) {
       RAY_LOG(DEBUG) << "Setting borrowed inner ID " << object_id
                      << " contained_in_borrowed: " << outer_id;
-      it->second.mutable_containing()->contained_in_borrowed_ids.insert(outer_id);
-      outer_it->second.mutable_containing()->contains.insert(object_id);
+      it->second.mutable_nested()->contained_in_borrowed_ids.insert(outer_id);
+      outer_it->second.mutable_nested()->contains.insert(object_id);
       // The inner object ref is in use. We must report our ref to the object's
       // owner.
       if (it->second.RefCount() > 0) {
@@ -150,7 +150,7 @@ void ReferenceCounter::AddObjectRefStats(
         ref_proto->set_call_site(it->second.second);
       }
     }
-    for (const auto &obj_id : ref.second.containing().contained_in_owned) {
+    for (const auto &obj_id : ref.second.nested().contained_in_owned) {
       ref_proto->add_contained_in_owned(obj_id.Binary());
     }
 
@@ -248,7 +248,7 @@ void ReferenceCounter::AddLocalReference(const ObjectID &object_id,
 
 void ReferenceCounter::SetNestedRefInUseRecursive(ReferenceTable::iterator inner_ref_it) {
   for (const auto &contained_in_borrowed_id :
-       inner_ref_it->second.containing().contained_in_borrowed_ids) {
+       inner_ref_it->second.nested().contained_in_borrowed_ids) {
     auto contained_in_it = object_id_refs_.find(contained_in_borrowed_id);
     RAY_CHECK(contained_in_it != object_id_refs_.end());
     if (!contained_in_it->second.has_nested_refs_to_report) {
@@ -532,7 +532,7 @@ void ReferenceCounter::DeleteReferenceInternal(ReferenceTable::iterator it,
 
   // Whether it is safe to unpin the value.
   if (it->second.OutOfScope(lineage_pinning_enabled_)) {
-    for (const auto &inner_id : it->second.containing().contains) {
+    for (const auto &inner_id : it->second.nested().contains) {
       auto inner_it = object_id_refs_.find(inner_id);
       if (inner_it != object_id_refs_.end()) {
         RAY_LOG(DEBUG) << "Try to delete inner object " << inner_id;
@@ -540,13 +540,13 @@ void ReferenceCounter::DeleteReferenceInternal(ReferenceTable::iterator it,
           // If this object ID was nested in an owned object, make sure that
           // the outer object counted towards the ref count for the inner
           // object.
-          RAY_CHECK(inner_it->second.mutable_containing()->contained_in_owned.erase(id));
+          RAY_CHECK(inner_it->second.mutable_nested()->contained_in_owned.erase(id));
         } else {
           RAY_CHECK(
-              inner_it->second.mutable_containing()->contained_in_borrowed_ids.erase(id));
+              inner_it->second.mutable_nested()->contained_in_borrowed_ids.erase(id));
         }
-        // NOTE: a ContainingReferences struct is created after the first
-        // mutable_containing() call, but the struct will not be deleted until the
+        // NOTE: a NestedReferenceCount struct is created after the first
+        // mutable_nested() call, but the struct will not be deleted until the
         // enclosing Reference struct is deleted.
         DeleteReferenceInternal(inner_it, deleted);
       }
@@ -833,7 +833,7 @@ bool ReferenceCounter::GetAndClearLocalBorrowersInternal(
     }
   }
   // Attempt to pop children.
-  for (const auto &contained_id : it->second.containing().contains) {
+  for (const auto &contained_id : it->second.nested().contains) {
     GetAndClearLocalBorrowersInternal(
         contained_id, for_ref_removed, /*deduct_local_ref=*/false, borrowed_refs);
   }
@@ -857,7 +857,7 @@ void ReferenceCounter::MergeRemoteBorrowers(const ObjectID &object_id,
                  << ", local: " << borrower_ref.local_ref_count
                  << ", submitted: " << borrower_ref.submitted_task_ref_count
                  << ", contained_in_owned: "
-                 << borrower_ref.containing().contained_in_owned.size()
+                 << borrower_ref.nested().contained_in_owned.size()
                  << ", stored_in_objects: "
                  << borrower_ref.borrow().stored_in_objects.size();
 
@@ -891,7 +891,7 @@ void ReferenceCounter::MergeRemoteBorrowers(const ObjectID &object_id,
   // This ref was nested inside another object. Copy this information to our
   // local table.
   for (const auto &contained_in_borrowed_id :
-       borrower_it->second.containing().contained_in_borrowed_ids) {
+       borrower_it->second.nested().contained_in_borrowed_ids) {
     RAY_CHECK(borrower_ref.owner_address);
     AddBorrowedObjectInternal(object_id,
                               contained_in_borrowed_id,
@@ -920,7 +920,7 @@ void ReferenceCounter::MergeRemoteBorrowers(const ObjectID &object_id,
 
   // Recursively merge any references that were contained in this object, to
   // handle any borrowers of nested objects.
-  for (const auto &inner_id : borrower_ref.containing().contains) {
+  for (const auto &inner_id : borrower_ref.nested().contains) {
     MergeRemoteBorrowers(inner_id, worker_addr, borrowed_refs);
   }
   PRINT_REF_COUNT(it);
@@ -1017,7 +1017,7 @@ void ReferenceCounter::AddNestedObjectIdsInternal(
       // contained in the outer object ID so we do not GC the inner objects
       // until the outer object goes out of scope.
       for (const auto &inner_id : inner_ids) {
-        it->second.mutable_containing()->contains.insert(inner_id);
+        it->second.mutable_nested()->contains.insert(inner_id);
         RAY_LOG(DEBUG) << "Setting inner ID " << inner_id
                        << " contained_in_owned: " << object_id;
       }
@@ -1026,7 +1026,7 @@ void ReferenceCounter::AddNestedObjectIdsInternal(
       for (const auto &inner_id : inner_ids) {
         auto inner_it = object_id_refs_.emplace(inner_id, Reference()).first;
         bool was_in_use = inner_it->second.RefCount() > 0;
-        inner_it->second.mutable_containing()->contained_in_owned.insert(object_id);
+        inner_it->second.mutable_nested()->contained_in_owned.insert(object_id);
         if (!was_in_use && inner_it->second.RefCount() > 0) {
           SetNestedRefInUseRecursive(inner_it);
         }
@@ -1461,11 +1461,11 @@ ReferenceCounter::Reference ReferenceCounter::Reference::FromProto(
         object_id, rpc::WorkerAddress(object.owner_address()));
   }
   for (const auto &id : ref_count.contains()) {
-    ref.mutable_containing()->contains.insert(ObjectID::FromBinary(id));
+    ref.mutable_nested()->contains.insert(ObjectID::FromBinary(id));
   }
   const auto contained_in_borrowed_ids =
       IdVectorFromProtobuf<ObjectID>(ref_count.contained_in_borrowed_ids());
-  ref.mutable_containing()->contained_in_borrowed_ids.insert(
+  ref.mutable_nested()->contained_in_borrowed_ids.insert(
       contained_in_borrowed_ids.begin(), contained_in_borrowed_ids.end());
   return ref;
 }
@@ -1484,10 +1484,10 @@ void ReferenceCounter::Reference::ToProto(rpc::ObjectReferenceCount *ref,
     ref_object->set_object_id(object.first.Binary());
     ref_object->mutable_owner_address()->CopyFrom(object.second.ToProto());
   }
-  for (const auto &contained_in_borrowed_id : containing().contained_in_borrowed_ids) {
+  for (const auto &contained_in_borrowed_id : nested().contained_in_borrowed_ids) {
     ref->add_contained_in_borrowed_ids(contained_in_borrowed_id.Binary());
   }
-  for (const auto &contains_id : containing().contains) {
+  for (const auto &contains_id : nested().contains) {
     ref->add_contains(contains_id.Binary());
   }
 }

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1465,19 +1465,10 @@ ReferenceCounter::Reference ReferenceCounter::Reference::FromProto(
 
 void ReferenceCounter::Reference::ToProto(rpc::ObjectReferenceCount *ref,
                                           int deduct_ref_count) const {
-  RAY_LOG(INFO) << "dbg Reference size=" << sizeof(Reference);
-  RAY_LOG(INFO) << "dbg ContainingReferences size=" << sizeof(ContainingReferences);
   if (owner_address) {
     ref->mutable_reference()->mutable_owner_address()->CopyFrom(*owner_address);
   }
   ref->set_has_local_ref(RefCount() > deduct_ref_count);
-  RAY_LOG(INFO) << "dbg "
-                << absl::StrCat("RefCount()=",
-                                RefCount(),
-                                " local_ref_count=",
-                                local_ref_count,
-                                " ref->has_local_ref()=",
-                                ref->has_local_ref());
   for (const auto &borrower : borrow().borrowers) {
     ref->add_borrowers()->CopyFrom(borrower.ToProto());
   }
@@ -1492,7 +1483,6 @@ void ReferenceCounter::Reference::ToProto(rpc::ObjectReferenceCount *ref,
   for (const auto &contains_id : containing().contains) {
     ref->add_contains(contains_id.Binary());
   }
-  RAY_LOG(INFO) << "dbg ReferenceCounter::Reference::ToProto()\n" << ref->DebugString();
 }
 
 }  // namespace core

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -187,6 +187,8 @@ void ReferenceCounter::AddOwnedObject(const ObjectID &object_id,
   // in the frontend language, incrementing the reference count.
   // TODO(swang): Objects that are not reconstructable should not increment
   // their arguments' lineage ref counts.
+  RAY_LOG(ERROR) << "dbg Reference size=" << sizeof(Reference);
+  RAY_LOG(ERROR) << "dbg NestedInfo size=" << sizeof(NestedInfo);
   auto it = object_id_refs_
                 .emplace(object_id,
                          Reference(owner_address,
@@ -730,8 +732,8 @@ std::unordered_set<ObjectID> ReferenceCounter::GetAllInScopeObjectIDs() const {
   absl::MutexLock lock(&mutex_);
   std::unordered_set<ObjectID> in_scope_object_ids;
   in_scope_object_ids.reserve(object_id_refs_.size());
-  for (auto it : object_id_refs_) {
-    in_scope_object_ids.insert(it.first);
+  for (const auto &[id, ref] : object_id_refs_) {
+    in_scope_object_ids.insert(id);
   }
   return in_scope_object_ids;
 }
@@ -741,10 +743,10 @@ ReferenceCounter::GetAllReferenceCounts() const {
   absl::MutexLock lock(&mutex_);
   std::unordered_map<ObjectID, std::pair<size_t, size_t>> all_ref_counts;
   all_ref_counts.reserve(object_id_refs_.size());
-  for (auto it : object_id_refs_) {
-    all_ref_counts.emplace(it.first,
-                           std::pair<size_t, size_t>(it.second.local_ref_count,
-                                                     it.second.submitted_task_ref_count));
+  for (const auto &[id, ref] : object_id_refs_) {
+    all_ref_counts.emplace(id,
+                           std::pair<size_t, size_t>(ref.local_ref_count,
+                                                     ref.submitted_task_ref_count));
   }
   return all_ref_counts;
 }

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -545,9 +545,9 @@ void ReferenceCounter::DeleteReferenceInternal(ReferenceTable::iterator it,
           RAY_CHECK(
               inner_it->second.mutable_containing()->contained_in_borrowed_ids.erase(id));
         }
-        // NOTE: a ContainingReferences struct is created after the first mutable_containing()
-        // call, but the struct will not be deleted until the enclosing Reference struct is
-        // deleted.
+        // NOTE: a ContainingReferences struct is created after the first
+        // mutable_containing() call, but the struct will not be deleted until the
+        // enclosing Reference struct is deleted.
         DeleteReferenceInternal(inner_it, deleted);
       }
     }
@@ -761,8 +761,8 @@ void ReferenceCounter::PopAndClearLocalBorrowers(
   absl::MutexLock lock(&mutex_);
   ReferenceProtoTable borrowed_refs;
   for (const auto &borrowed_id : borrowed_ids) {
-    // Setting `deduct_local_ref` to true to decrease the ref count for each of the 
-    // borrowed IDs. This is because we artificially increment each borrowed ID to 
+    // Setting `deduct_local_ref` to true to decrease the ref count for each of the
+    // borrowed IDs. This is because we artificially increment each borrowed ID to
     // keep it pinned during task execution. However, this should not count towards
     // the final ref count / existence of local ref returned to the task's caller.
     RAY_CHECK(GetAndClearLocalBorrowersInternal(borrowed_id,

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -23,7 +23,7 @@
                  << it->second.containing().contained_in_owned.size()              \
                  << " contained_in_borrowed: "                                     \
                  << (it)->second.containing().contained_in_borrowed_ids.size()     \
-                 << " contains: " << it->second.containing().contains.size()                    \
+                 << " contains: " << it->second.containing().contains.size()       \
                  << " stored_in: " << it->second.borrow().stored_in_objects.size() \
                  << " lineage_ref_count: " << it->second.lineage_ref_count;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
During large scale shuffle (number of partitions used >= 1000), driver uses significant amount of memory for storing ObjectRefs. On Intel MacOS, each `Reference` struct currently takes up 592 bytes. We can reduce per-`Reference` memory footprint:
- During shuffle, no ObjectRef borrowing or nesting happens. And in this case fields related to borrowing or nesting should not take up memory. This reduces `sizeof(Reference)` from 592 to 400.
- Fields in the `Reference` struct can be reordered to enhance packing. This reduces `sizeof(Reference)` from 400 to 368.

On Intel MacOS running the shuffle benchmark with 1000 partitions and 10MB partition size, RSS at the end of shuffle drops from ~5GB to ~4.5GB.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#23604

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
