### PR TITLE
[tune] Skip tmp checkpoints in analysis and read iteration from metadata

### DIFF
--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -263,6 +263,31 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         assert checkpoints_metrics[0][0] == expected_path
         assert checkpoints_metrics[0][1] == 1
 
+    def testGetTrialCheckpointsPathsWithTemporaryCheckpoints(self):
+        analysis = tune.run(
+            MyTrainableClass,
+            name="test_example",
+            local_dir=self.test_dir,
+            stop={"training_iteration": 2},
+            num_samples=1,
+            config={"test": tune.grid_search([[1, 2], [3, 4]])},
+            checkpoint_at_end=True,
+        )
+        logdir = analysis.get_best_logdir(self.metric, mode="max")
+
+        shutil.copytree(
+            os.path.join(logdir, "checkpoint_000002"),
+            os.path.join(logdir, "checkpoint_tmpxxx"),
+        )
+
+        checkpoints_metrics = analysis.get_trial_checkpoints_paths(logdir)
+        expected_path = os.path.join(logdir, "checkpoint_000002/", "checkpoint")
+
+        assert len(checkpoints_metrics) == 1
+
+        assert checkpoints_metrics[0][0] == expected_path
+        assert checkpoints_metrics[0][1] == 2
+
 
 class ExperimentAnalysisPropertySuite(unittest.TestCase):
     def testBestProperties(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What: Skips left-over `checkpoint_tmp*` directories when loading experiment analysis. Also loads iteration number from metadata file rather than parsing the checkpoint directory name.

Why: Sometimes temporary checkpoint directories are not deleted correctly when restoring (e.g. when interrupted). In these cases, they shouldn't be included in experiment analysis. Parsing their iteration number also failed, and should generally be done by reading the metadata file, not by inferring it from the directory name.

## Related issue number

Closes #20762

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
