### PR TITLE
[tune] Fix empty CSV headers on trial restart

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -136,7 +136,9 @@ class CSVLogger(Logger):
         """CSV outputted with Headers as first set of results."""
         if not self._initialized:
             progress_file = os.path.join(self.logdir, EXPR_PROGRESS_FILE)
-            self._continuing = os.path.exists(progress_file)
+            self._continuing = (
+                os.path.exists(progress_file) and os.path.getsize(progress_file) > 0
+            )
             self._file = open(progress_file, "a")
             self._csv_out = None
             self._initialized = True
@@ -570,7 +572,9 @@ class CSVLoggerCallback(LoggerCallback):
         # Make sure logdir exists
         trial.init_logdir()
         local_file = os.path.join(trial.logdir, EXPR_PROGRESS_FILE)
-        self._trial_continue[trial] = os.path.exists(local_file)
+        self._trial_continue[trial] = (
+            os.path.exists(local_file) and os.path.getsize(local_file) > 0
+        )
         self._trial_files[trial] = open(local_file, "at")
         self._trial_csv[trial] = None
 

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -160,11 +160,12 @@ class CSVLogger(Logger):
         self._file.flush()
 
     def flush(self):
-        if not self._file.closed:
+        if self._initialized and not self._file.closed:
             self._file.flush()
 
     def close(self):
-        self._file.close()
+        if self._initialized:
+            self._file.close()
 
 
 class TBXLogger(Logger):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What: Only open (create) CSV files when actually reporting results.
Why: When trials crash before they report first (e.g. on init), they will have created an empty CSV file. When results are subsequently written, the CSV header is then missing.

## Related issue number

Closes #15106
Closes #18892

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
