### PR TITLE
WINDOWS: increase timeouts on flaky tests

### DIFF
--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -96,8 +96,17 @@ def test_wait_mixup(init):
 
         return asyncio.ensure_future(_g(n))
 
-    tasks = [f.remote(0.1).as_future(), g(7), f.remote(5).as_future(), g(2)]
-    ready, _ = loop.run_until_complete(asyncio.wait(tasks, timeout=4))
+    if sys.platform == "win32":
+        factor = 2
+    else:
+        factor = 1
+    tasks = [
+        f.remote(0.1 * factor).as_future(),
+        g(7 * factor),
+        f.remote(5 * factor).as_future(),
+        g(2 * factor),
+    ]
+    ready, _ = loop.run_until_complete(asyncio.wait(tasks, timeout=4 * factor))
     assert set(ready) == {tasks[0], tasks[-1]}
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The test_async and test_metrics tests are quite high on https://flaky-tests.ray.io. Running them locally I could see that the timeouts are not long enough.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
