### PR TITLE
[Core] do not add Ray's pickle5 path to `sys.path` when running Python >= 3.8 

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -57,12 +57,15 @@ def _configure_system():
         )
         os.environ["OMP_NUM_THREADS"] = "1"
 
-    # Add the directory containing pickle5 to the Python path so that we find
-    # the pickle5 version packaged with ray and not a pre-existing pickle5.
-    pickle5_path = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), "pickle5_files"
-    )
-    sys.path.insert(0, pickle5_path)
+    # When running Python version < 3.8, Ray needs to use pickle5 instead of
+    # Python's built-in pickle. Add the directory containing pickle5 to the
+    # Python path so that we find the pickle5 version packaged with Ray and
+    # not a pre-existing pickle5.
+    if sys.version_info < (3, 8):
+        pickle5_path = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), "pickle5_files"
+        )
+        sys.path.insert(0, pickle5_path)
 
     # Importing psutil & setproctitle. Must be before ray._raylet is
     # initialized.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When running Python >= 3.8, Ray uses Python's built-in pickle module instead of own pickle5 module. Adding Ray's pickle5 module path to the search path confuses other programs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
