### PR TITLE
[Core] Add metadata to ray.remote keywords

### DIFF
--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -69,7 +69,6 @@ def _resource_option(name: str, default_value: Any = None):
 _common_options = {
     "accelerator_type": Option((str, type(None))),
     "memory": _resource_option("memory"),
-    "metadata": Option((dict, type(None))),
     "name": Option((str, type(None))),
     "num_cpus": _resource_option("num_cpus"),
     "num_gpus": _resource_option("num_gpus"),
@@ -97,6 +96,7 @@ _common_options = {
             NodeAffinitySchedulingStrategy,
         )
     ),
+    "_metadata": Option((dict, type(None))),
 }
 
 

--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -69,6 +69,7 @@ def _resource_option(name: str, default_value: Any = None):
 _common_options = {
     "accelerator_type": Option((str, type(None))),
     "memory": _resource_option("memory"),
+    "metadata": Option((dict, type(None))),
     "name": Option((str, type(None))),
     "num_cpus": _resource_option("num_cpus"),
     "num_gpus": _resource_option("num_gpus"),

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -228,10 +228,10 @@ def test_invalid_arguments():
         + f"must be {(dict, type(None))}, but received type {float}"
     )
     with pytest.raises(TypeError, match=re.escape(metadata_type_err)):
-        ray.remote(metadata=3.14)(A)
+        ray.remote(_metadata=3.14)(A)
 
-    ray.remote(metadata={"data": 1})(f)
-    ray.remote(metadata={"data": 1})(A)
+    ray.remote(_metadata={"data": 1})(f)
+    ray.remote(_metadata={"data": 1})(A)
 
 
 def test_options():

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -224,7 +224,7 @@ def test_invalid_arguments():
             ray.remote(**{keyword: np.random.randint(-100, -2)})(A)
 
     metadata_type_err = (
-        "The type of keyword 'metadata' "
+        "The type of keyword '_metadata' "
         + f"must be {(dict, type(None))}, but received type {float}"
     )
     with pytest.raises(TypeError, match=re.escape(metadata_type_err)):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -177,10 +177,8 @@ def test_submit_api(shutdown_only):
     assert ray.get([id1, id2, id3, id4]) == [0, 1, "test", 2]
 
 
-def test_invalid_arguments(shutdown_only):
+def test_invalid_arguments():
     import re
-
-    ray.init(num_cpus=2)
 
     def f():
         return 1
@@ -224,6 +222,16 @@ def test_invalid_arguments(shutdown_only):
     for keyword in ("max_restarts", "max_task_retries"):
         with pytest.raises(ValueError, match=template2.format(keyword)):
             ray.remote(**{keyword: np.random.randint(-100, -2)})(A)
+
+    metadata_type_err = (
+        "The type of keyword 'metadata' "
+        + f"must be {(dict, type(None))}, but received type {float}"
+    )
+    with pytest.raises(TypeError, match=re.escape(metadata_type_err)):
+        ray.remote(metadata=3.14)(A)
+
+    ray.remote(metadata={"data": 1})(f)
+    ray.remote(metadata={"data": 1})(A)
 
 
 def test_options():

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2246,6 +2246,8 @@ def remote(*args, **kwargs):
             "SPREAD": best effort spread scheduling;
             `PlacementGroupSchedulingStrategy`:
             placement group based scheduling.
+        metadata (Dict[str, Any]): Extended options for Ray libraries. For example,
+            metadata={"workflows.io/options": <workflow options>} for Ray workflows.
     """
     # "callable" returns true for both function and class.
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2246,8 +2246,8 @@ def remote(*args, **kwargs):
             "SPREAD": best effort spread scheduling;
             `PlacementGroupSchedulingStrategy`:
             placement group based scheduling.
-        metadata (Dict[str, Any]): Extended options for Ray libraries. For example,
-            metadata={"workflows.io/options": <workflow options>} for Ray workflows.
+        _metadata: Extended options for Ray libraries. For example,
+            _metadata={"workflows.io/options": <workflow options>} for Ray workflows.
     """
     # "callable" returns true for both function and class.
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We need `metadata` keyword for both Ray Workflow and Ray Serve. This is because after unification, Ray workflow and Ray serve are using remote function/remote actor API, we need to put extra options for them.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
