### PR TITLE
[Core] cleanup pickle5 version check

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -14,7 +14,7 @@ def _configure_system():
     # Sanity check pickle5 if it has been installed.
     if "pickle5" in sys.modules:
         if sys.version_info >= (3, 8):
-            raise ImportError(
+            logger.warning(
                 "Package pickle5 becomes unnecessary in Python 3.8 and above. "
                 "Its presence may confuse libraries including Ray. "
                 "Please uninstall the package."
@@ -26,10 +26,9 @@ def _configure_system():
             version_info = pkg_resources.require("pickle5")
             version = tuple(int(n) for n in version_info[0].version.split("."))
             if version < (0, 0, 10):
-                raise ImportError(
-                    "You are using an old version of pickle5 "
-                    "that leaks memory, please run "
-                    "'pip install pickle5 -U' to upgrade."
+                logger.warning(
+                    "Although not used by Ray, a version of pickle5 that leaks memory "
+                    "is found in the environment. Please run 'pip install pickle5 -U' to upgrade."
                 )
         except pkg_resources.DistributionNotFound:
             logger.warning(

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -11,29 +11,6 @@ def _configure_system():
 
     """Wraps system configuration to avoid 'leaking' variables into ray."""
 
-    # MUST add pickle5 to the import path because it will be imported by some
-    # raylet modules.
-    if "pickle5" in sys.modules:
-        import pkg_resources
-
-        try:
-            version_info = pkg_resources.require("pickle5")
-            version = tuple(int(n) for n in version_info[0].version.split("."))
-            if version < (0, 0, 10):
-                raise ImportError(
-                    "You are using an old version of pickle5 "
-                    "that leaks memory, please run "
-                    "'pip install pickle5 -U' to upgrade"
-                )
-        except pkg_resources.DistributionNotFound:
-            logger.warning(
-                "You are using the 'pickle5' module, but "
-                "the exact version is unknown (possibly carried as "
-                "an internal component by another module). Please "
-                "make sure you are using pickle5 >= 0.0.10 because "
-                "previous versions may leak memory."
-            )
-
     # Check that grpc can actually be imported on Apple Silicon. Some package
     # managers (such as `pip`) can't properly install the grpcio library yet,
     # so provide a proactive error message if that's the case.

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -28,7 +28,8 @@ def _configure_system():
             if version < (0, 0, 10):
                 logger.warning(
                     "Although not used by Ray, a version of pickle5 that leaks memory "
-                    "is found in the environment. Please run 'pip install pickle5 -U' to upgrade."
+                    "is found in the environment. Please run 'pip install pickle5 -U' "
+                    "to upgrade."
                 )
         except pkg_resources.DistributionNotFound:
             logger.warning(

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -11,6 +11,48 @@ def _configure_system():
 
     """Wraps system configuration to avoid 'leaking' variables into ray."""
 
+    # Sanity check pickle5 if it has been installed.
+    if "pickle5" in sys.modules:
+        if sys.version_info >= (3, 8):
+            raise ImportError(
+                "Package pickle5 becomes unnecessary in Python 3.8 and above. "
+                "Its presence may confuse libraries including Ray. "
+                "Please uninstall the package."
+            )
+
+        import pkg_resources
+
+        try:
+            version_info = pkg_resources.require("pickle5")
+            version = tuple(int(n) for n in version_info[0].version.split("."))
+            if version < (0, 0, 10):
+                raise ImportError(
+                    "You are using an old version of pickle5 "
+                    "that leaks memory, please run "
+                    "'pip install pickle5 -U' to upgrade."
+                )
+        except pkg_resources.DistributionNotFound:
+            logger.warning(
+                "You are using the 'pickle5' module, but "
+                "the exact version is unknown (possibly carried as "
+                "an internal component by another module). Please "
+                "make sure you are using pickle5 >= 0.0.10 because "
+                "previous versions may leak memory."
+            )
+
+    # MUST add pickle5 to the import path because it will be imported by some
+    # raylet modules.
+    #
+    # When running Python version < 3.8, Ray needs to use pickle5 instead of
+    # Python's built-in pickle. Add the directory containing pickle5 to the
+    # Python path so that we find the pickle5 version packaged with Ray and
+    # not a pre-existing pickle5.
+    if sys.version_info < (3, 8):
+        pickle5_path = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), "pickle5_files"
+        )
+        sys.path.insert(0, pickle5_path)
+
     # Check that grpc can actually be imported on Apple Silicon. Some package
     # managers (such as `pip`) can't properly install the grpcio library yet,
     # so provide a proactive error message if that's the case.
@@ -33,16 +75,6 @@ def _configure_system():
             "override this by explicitly setting OMP_NUM_THREADS."
         )
         os.environ["OMP_NUM_THREADS"] = "1"
-
-    # When running Python version < 3.8, Ray needs to use pickle5 instead of
-    # Python's built-in pickle. Add the directory containing pickle5 to the
-    # Python path so that we find the pickle5 version packaged with Ray and
-    # not a pre-existing pickle5.
-    if sys.version_info < (3, 8):
-        pickle5_path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), "pickle5_files"
-        )
-        sys.path.insert(0, pickle5_path)
 
     # Importing psutil & setproctitle. Must be before ray._raylet is
     # initialized.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray is supposed to only use own vendored `pickle5` or `pickle` from Python >= 3.8. Checking `pickle5` version in the current environment is unnecessary and may confuse users.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
