### PR TITLE
[tune] Fix checkpoint sorting with nan values

### DIFF
--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -204,7 +204,11 @@ class CheckpointManager:
         priority = result[self._checkpoint_score_attr]
         if self._checkpoint_score_desc:
             priority = -priority
-        return (not is_nan(priority), priority, checkpoint.order)
+        return (
+            not is_nan(priority),
+            priority if not is_nan(priority) else 0,
+            checkpoint.order,
+        )
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/python/ray/tune/tests/test_checkpoint_manager.py
+++ b/python/ray/tune/tests/test_checkpoint_manager.py
@@ -130,6 +130,28 @@ class CheckpointManagerTest(unittest.TestCase):
         self.assertEqual(best_checkpoints[0].value, None)
         self.assertEqual(best_checkpoints[1].value, 3)
 
+    def testBestCheckpointsOnlyNan(self):
+        """
+        Tests that checkpoints with only nan priority are handled correctly.
+        """
+        keep_checkpoints_num = 2
+        checkpoint_manager = self.checkpoint_manager(keep_checkpoints_num)
+        checkpoints = [
+            _TuneCheckpoint(
+                _TuneCheckpoint.PERSISTENT, i, self.mock_result(float("nan"), i)
+            )
+            for i in range(4)
+        ]
+
+        for checkpoint in checkpoints:
+            checkpoint_manager.on_checkpoint(checkpoint)
+
+        best_checkpoints = checkpoint_manager.best_checkpoints()
+        # best_checkpoints is sorted from worst to best
+        self.assertEqual(len(best_checkpoints), keep_checkpoints_num)
+        self.assertEqual(best_checkpoints[0].value, 2)
+        self.assertEqual(best_checkpoints[1].value, 3)
+
     def testOnCheckpointUnavailableAttribute(self):
         """
         Tests that an error is logged when the associated result of the


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Following #23862, there was an uncaught bug when comparing `nan`-priority checkpoints. This is because `float("nan") <= float("nan")` is always `False` (unlike e.g. `np.nan <= np.nan`, which is `True`).

This PR fixes this bug and adds a new test to ensure correct behavior.

cc @XuehaiPan

## Related issue number

Follow-up from #23862

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
