### PR TITLE
[core] Add task function name to ray.timeline profiling events

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -615,7 +615,7 @@ cdef execute_task(
 
             return function(actor, *arguments, **kwarguments)
 
-    with core_worker.profile_event(b"task", extra_data=extra_data):
+    with core_worker.profile_event(b"task::" + name, extra_data=extra_data):
         try:
             task_exception = False
             if not (<int>task_type == <int>TASK_TYPE_ACTOR_TASK


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `ray.timeline` command currently only shows `task` for task events, which isn't very useful if your program has multiple types of tasks. This PR adds "::\<function name\>" to the string, similar to what we do for process names, to distinguish between different tasks.