### PR TITLE
[Datasets] [Out-of-Band Serialization: 2/3] Refactor `ExecutionPlan` to maintain complete lineage and eagerly unlink block references.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2547,22 +2547,22 @@ Dict[str, List[str]]]): The names of the columns
                 to repeat indefinitely.
         """
         from ray.data.dataset_pipeline import DatasetPipeline
+        from ray.data.impl.plan import _rewrite_read_stage
 
-        # If optimizations are enabled, rewrite the read stage into a OneToOneStage
-        # to enable fusion with downstream map stages.
         ctx = DatasetContext.get_current()
-        if self._plan._is_read_stage() and ctx.optimize_fuse_read_stages:
-            self._plan._in_blocks.clear()
-            blocks, read_stage = self._plan._rewrite_read_stage()
-            outer_stats = DatasetStats(stages={}, parent=None)
+        if self._plan.is_read_stage() and ctx.optimize_fuse_read_stages:
+            blocks, _ = self._plan._get_source_blocks()
+            blocks.clear()
+            blocks, outer_stats, read_stage = _rewrite_read_stage(blocks)
         else:
             blocks = self._plan.execute()
-            read_stage = None
             outer_stats = self._plan.stats()
+            read_stage = None
+        uuid = self._get_uuid()
+        outer_stats.dataset_uuid = uuid
 
         if times is not None and times < 1:
             raise ValueError("`times` must be >= 1, got {}".format(times))
-        uuid = self._get_uuid()
 
         class Iterator:
             def __init__(self, blocks):
@@ -2660,6 +2660,7 @@ Dict[str, List[str]]]): The names of the columns
                 exclusive with ``blocks_per_window``.
         """
         from ray.data.dataset_pipeline import DatasetPipeline
+        from ray.data.impl.plan import _rewrite_read_stage
 
         if blocks_per_window is not None and bytes_per_window is not None:
             raise ValueError("Only one windowing scheme can be specified.")
@@ -2667,17 +2668,15 @@ Dict[str, List[str]]]): The names of the columns
         if blocks_per_window is None:
             blocks_per_window = 10
 
-        # If optimizations are enabled, rewrite the read stage into a OneToOneStage
-        # to enable fusion with downstream map stages.
         ctx = DatasetContext.get_current()
-        if self._plan._is_read_stage() and ctx.optimize_fuse_read_stages:
-            self._plan._in_blocks.clear()
-            blocks, read_stage = self._plan._rewrite_read_stage()
-            outer_stats = DatasetStats(stages={}, parent=None)
+        if self._plan.is_read_stage() and ctx.optimize_fuse_read_stages:
+            blocks, _ = self._plan._get_source_blocks()
+            blocks.clear()
+            blocks, outer_stats, read_stage = _rewrite_read_stage(blocks)
         else:
             blocks = self._plan.execute()
-            read_stage = None
             outer_stats = self._plan.stats()
+            read_stage = None
 
         class Iterator:
             def __init__(self, splits, epoch):
@@ -2755,19 +2754,9 @@ Dict[str, List[str]]]): The names of the columns
         Returns:
             A Dataset with all blocks fully materialized in memory.
         """
-        blocks, metadata = [], []
-        for b, m in self._plan.execute().get_blocks_with_metadata():
-            blocks.append(b)
-            metadata.append(m)
-        ds = Dataset(
-            ExecutionPlan(
-                BlockList(blocks, metadata),
-                self._plan.stats(),
-                dataset_uuid=self._get_uuid(),
-            ),
-            self._epoch,
-            lazy=False,
-        )
+        plan = self._plan.deep_copy(preserve_uuid=True)
+        plan.execute(force_read=True)
+        ds = Dataset(plan, self._epoch, lazy=False)
         ds._set_uuid(self._get_uuid())
         return ds
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -126,7 +126,6 @@ class Dataset(Generic[T]):
         self._lazy = lazy
 
         if not lazy:
-            # TODO(ekl) we should clear inputs once we have full lineage recorded.
             self._plan.execute(clear_input_blocks=False)
 
     @staticmethod
@@ -2551,7 +2550,7 @@ Dict[str, List[str]]]): The names of the columns
 
         ctx = DatasetContext.get_current()
         if self._plan.is_read_stage() and ctx.optimize_fuse_read_stages:
-            blocks, _ = self._plan._get_source_blocks()
+            blocks, _, _ = self._plan._get_source_blocks_and_stages()
             blocks.clear()
             blocks, outer_stats, read_stage = _rewrite_read_stage(blocks)
         else:
@@ -2670,7 +2669,7 @@ Dict[str, List[str]]]): The names of the columns
 
         ctx = DatasetContext.get_current()
         if self._plan.is_read_stage() and ctx.optimize_fuse_read_stages:
-            blocks, _ = self._plan._get_source_blocks()
+            blocks, _, _ = self._plan._get_source_blocks_and_stages()
             blocks.clear()
             blocks, outer_stats, read_stage = _rewrite_read_stage(blocks)
         else:
@@ -2745,17 +2744,30 @@ Dict[str, List[str]]]): The names of the columns
             )
         return pipe
 
-    def fully_executed(self) -> "Dataset[T]":
+    def fully_executed(
+        self,
+        preserve_input_blocks: bool = True,
+    ) -> "Dataset[T]":
         """Force full evaluation of the blocks of this dataset.
 
         This can be used to read all blocks into memory. By default, Datasets
         doesn't read blocks from the datasource until the first transform.
 
+        Args:
+            preserve_input_blocks: Whether the input blocks of the dataset should not be
+                eagerly released. If this is False, the input blocks will be destroyed,
+                which means that reusing the base dataset ``ds`` in
+                ``ds.fully_executed()`` will recompute the input blocks if they're lazy,
+                and will fail if they're non-lazy.
+
         Returns:
             A Dataset with all blocks fully materialized in memory.
         """
         plan = self._plan.deep_copy(preserve_uuid=True)
-        plan.execute(force_read=True)
+        plan.execute(
+            force_read=True,
+            destroy_unrecoverable_input_blocks=not preserve_input_blocks,
+        )
         ds = Dataset(plan, self._epoch, lazy=False)
         ds._set_uuid(self._get_uuid())
         return ds

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -126,6 +126,7 @@ class Dataset(Generic[T]):
         self._lazy = lazy
 
         if not lazy:
+            # TODO(ekl) we should clear inputs once we have full lineage recorded.
             self._plan.execute(clear_input_blocks=False)
 
     @staticmethod
@@ -2550,7 +2551,7 @@ Dict[str, List[str]]]): The names of the columns
 
         ctx = DatasetContext.get_current()
         if self._plan.is_read_stage() and ctx.optimize_fuse_read_stages:
-            blocks, _, _ = self._plan._get_source_blocks_and_stages()
+            blocks, _ = self._plan._get_source_blocks()
             blocks.clear()
             blocks, outer_stats, read_stage = _rewrite_read_stage(blocks)
         else:
@@ -2669,7 +2670,7 @@ Dict[str, List[str]]]): The names of the columns
 
         ctx = DatasetContext.get_current()
         if self._plan.is_read_stage() and ctx.optimize_fuse_read_stages:
-            blocks, _, _ = self._plan._get_source_blocks_and_stages()
+            blocks, _ = self._plan._get_source_blocks()
             blocks.clear()
             blocks, outer_stats, read_stage = _rewrite_read_stage(blocks)
         else:
@@ -2744,30 +2745,17 @@ Dict[str, List[str]]]): The names of the columns
             )
         return pipe
 
-    def fully_executed(
-        self,
-        preserve_input_blocks: bool = True,
-    ) -> "Dataset[T]":
+    def fully_executed(self) -> "Dataset[T]":
         """Force full evaluation of the blocks of this dataset.
 
         This can be used to read all blocks into memory. By default, Datasets
         doesn't read blocks from the datasource until the first transform.
 
-        Args:
-            preserve_input_blocks: Whether the input blocks of the dataset should not be
-                eagerly released. If this is False, the input blocks will be destroyed,
-                which means that reusing the base dataset ``ds`` in
-                ``ds.fully_executed()`` will recompute the input blocks if they're lazy,
-                and will fail if they're non-lazy.
-
         Returns:
             A Dataset with all blocks fully materialized in memory.
         """
         plan = self._plan.deep_copy(preserve_uuid=True)
-        plan.execute(
-            force_read=True,
-            destroy_unrecoverable_input_blocks=not preserve_input_blocks,
-        )
+        plan.execute(force_read=True)
         ds = Dataset(plan, self._epoch, lazy=False)
         ds._set_uuid(self._get_uuid())
         return ds

--- a/python/ray/data/impl/lazy_block_list.py
+++ b/python/ray/data/impl/lazy_block_list.py
@@ -261,6 +261,11 @@ class LazyBlockList(BlockList):
         self._cached_metadata = metadata
         return block_refs, metadata
 
+    def compute_to_blocklist(self) -> BlockList:
+        """Launch all tasks and return a concrete BlockList."""
+        blocks, metadata = self._get_blocks_with_metadata()
+        return BlockList(blocks, metadata)
+
     def compute_first_block(self):
         """Kick off computation for the first block in the list.
 

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -19,9 +19,7 @@ def pipeline_stage(fn: Callable[[], Dataset[T]]) -> Dataset[T]:
     # Force eager evaluation of all blocks in the pipeline stage. This
     # prevents resource deadlocks due to overlapping stage execution (e.g.,
     # task -> actor stage).
-    # We allow non-lazy (unrecoverable) input blocks to be destroyed here since no
-    # fan-out is allowed in a pipeline.
-    return fn().fully_executed(preserve_input_blocks=True)
+    return fn().fully_executed()
 
 
 class PipelineExecutor:

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -19,7 +19,9 @@ def pipeline_stage(fn: Callable[[], Dataset[T]]) -> Dataset[T]:
     # Force eager evaluation of all blocks in the pipeline stage. This
     # prevents resource deadlocks due to overlapping stage execution (e.g.,
     # task -> actor stage).
-    return fn().fully_executed()
+    # We allow non-lazy (unrecoverable) input blocks to be destroyed here since no
+    # fan-out is allowed in a pipeline.
+    return fn().fully_executed(preserve_input_blocks=True)
 
 
 class PipelineExecutor:

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -420,6 +420,10 @@ class OneToOneStage(Stage):
         return True
 
     def fuse(self, prev: Stage):
+        if not self.can_fuse(prev):
+            raise ValueError(
+                f"Tried to fuse {prev} with {self}, but these are not fusable."
+            )
         name = prev.name + "->" + self.name
         fn1 = prev.block_fn
         fn2 = self.block_fn
@@ -476,6 +480,10 @@ class AllToAllStage(Stage):
         return True
 
     def fuse(self, prev: Stage):
+        if not self.can_fuse(prev):
+            raise ValueError(
+                f"Tried to fuse {prev} with {self}, but these are not fusable."
+            )
         assert self.supports_block_udf
         name = prev.name + "->" + self.name
         return AllToAllStage(

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -1,4 +1,14 @@
-from typing import Callable, Tuple, Optional, Union, Iterable, Iterator, TYPE_CHECKING
+import copy
+from typing import (
+    Callable,
+    List,
+    Tuple,
+    Optional,
+    Union,
+    Iterator,
+    Iterable,
+    TYPE_CHECKING,
+)
 import uuid
 
 if TYPE_CHECKING:
@@ -14,217 +24,6 @@ from ray.data.impl.lazy_block_list import LazyBlockList
 
 # Scheduling strategy can be inherited from prev stage if not specified.
 INHERITABLE_REMOTE_ARGS = ["scheduling_strategy"]
-
-
-class ExecutionPlan:
-    """A lazy execution plan for a Dataset."""
-
-    def __init__(self, in_blocks: BlockList, stats: DatasetStats, dataset_uuid=None):
-        """Create a plan with no transformation stages.
-
-        Args:
-            in_blocks: Base list of blocks.
-            stats: Stats for the base blocks.
-        """
-        self._in_blocks = in_blocks
-        self._out_blocks = None
-        self._in_stats = stats
-        self._out_stats = None
-        self._stages = []
-        self._dataset_uuid = dataset_uuid or uuid.uuid4().hex
-        if not stats.dataset_uuid:
-            stats.dataset_uuid = self._dataset_uuid
-
-    def with_stage(self, stage: "Stage") -> "ExecutionPlan":
-        """Return a copy of this plan with the given stage appended.
-
-        Args:
-            stage: The stage to append.
-
-        Returns:
-            A new ExecutionPlan with this stage appended.
-        """
-        if self._out_blocks:
-            copy = ExecutionPlan(self._out_blocks, self._out_stats)
-            copy._stages = [stage]
-        else:
-            copy = ExecutionPlan(self._in_blocks, self._in_stats)
-            copy._stages = self._stages.copy()
-            copy._stages.append(stage)
-        return copy
-
-    def initial_num_blocks(self) -> int:
-        """Get the estimated number of blocks after applying all plan stages."""
-        if self._out_blocks:
-            return self._out_blocks.initial_num_blocks()
-        for stage in self._stages[::-1]:
-            if stage.num_blocks is not None:
-                return stage.num_blocks
-        return self._in_blocks.initial_num_blocks()
-
-    def schema(
-        self, fetch_if_missing: bool = False
-    ) -> Union[type, "pyarrow.lib.Schema"]:
-        """Get the schema after applying all plan stages.
-
-        Args:
-            fetch_if_missing: Whether to execute the plan to fetch the schema.
-
-        Returns:
-            The schema of the output dataset.
-        """
-        if self._stages:
-            if fetch_if_missing:
-                self.execute()
-            blocks = self._out_blocks
-        else:
-            blocks = self._in_blocks
-        if blocks:
-            # Don't force fetching in case it's a lazy block list, in which case we
-            # don't want to trigger full execution for a schema read. If we want to
-            # trigger execution to get schema, we'll trigger read tasks progressively
-            # until a viable schema is available, below.
-            metadata = blocks.get_metadata(fetch_if_missing=False)
-        else:
-            metadata = []
-        # Some blocks could be empty, in which case we cannot get their schema.
-        # TODO(ekl) validate schema is the same across different blocks.
-        for m in metadata:
-            if m.schema is not None and (m.num_rows is None or m.num_rows > 0):
-                return m.schema
-        if not fetch_if_missing:
-            return None
-        # Synchronously fetch the schema.
-        # For lazy block lists, this launches read tasks and fetches block metadata
-        # until we find valid block schema.
-        for _, m in blocks.iter_blocks_with_metadata():
-            if m.schema is not None and (m.num_rows is None or m.num_rows > 0):
-                return m.schema
-        return None
-
-    def meta_count(self) -> Optional[int]:
-        """Get the number of rows after applying all plan stages if possible.
-
-        This method will never trigger any computation.
-
-        Returns:
-            The number of records of the result Dataset, or None.
-        """
-        if self._stages:
-            blocks = self._out_blocks
-        else:
-            blocks = self._in_blocks
-        metadata = blocks.get_metadata() if blocks else None
-        if metadata and all(m.num_rows is not None for m in metadata):
-            return sum(m.num_rows for m in metadata)
-        else:
-            return None
-
-    def execute(self, clear_input_blocks: bool = True) -> BlockList:
-        """Execute this plan.
-
-        Args:
-            clear_input_blocks: Whether to assume ownership of the input blocks,
-                allowing them to be dropped from memory during execution.
-
-        Returns:
-            The blocks of the output dataset.
-        """
-        if self._out_blocks is None:
-            self._optimize()
-            blocks = self._in_blocks
-            stats = self._in_stats
-            for stage in self._stages:
-                stats_builder = stats.child_builder(stage.name)
-                blocks, stage_info = stage(blocks, clear_input_blocks)
-                if stage_info:
-                    stats = stats_builder.build_multistage(stage_info)
-                else:
-                    stats = stats_builder.build(blocks)
-                stats.dataset_uuid = uuid.uuid4().hex
-            self._out_blocks = blocks
-            self._out_stats = stats
-            self._out_stats.dataset_uuid = self._dataset_uuid
-        return self._out_blocks
-
-    def clear(self) -> None:
-        """Clear all cached block references of this plan, including input blocks.
-
-        This will render the plan un-executable unless the root is a LazyBlockList."""
-        self._in_blocks.clear()
-        self._out_blocks = None
-        self._out_stats = None
-
-    def stats(self) -> DatasetStats:
-        """Return stats for this plan, forcing execution if needed."""
-        self.execute()
-        return self._out_stats
-
-    def _optimize(self) -> None:
-        """Apply stage fusion optimizations, updating this plan."""
-        context = DatasetContext.get_current()
-        if context.optimize_fuse_stages:
-            if context.optimize_fuse_read_stages:
-                self._rewrite_read_stages()
-            self._fuse_one_to_one_stages()
-
-    def _rewrite_read_stages(self) -> None:
-        """Rewrites read stages into one-to-one stages."""
-        if self._stages and self._has_read_stage():
-            block_list, stage = self._rewrite_read_stage()
-            self._in_blocks = block_list
-            self._in_stats = DatasetStats(stages={}, parent=None)
-            self._stages.insert(0, stage)
-
-    def _has_read_stage(self) -> bool:
-        """Whether this plan has a read stage for its input."""
-        return isinstance(self._in_blocks, LazyBlockList)
-
-    def _is_read_stage(self) -> bool:
-        """Whether this plan is a bare read stage."""
-        return self._has_read_stage() and not self._stages
-
-    def _rewrite_read_stage(self) -> Tuple[BlockList, "Stage"]:
-        """Rewrite the read stage to a OneToOne stage over read tasks as input.
-
-        For example, suppose the plan was [Read -> MapBatches(Fn)]. These stages cannot
-        be fused, since read stages are handled specially.
-
-        After rewriting to [GetReadTasks -> MapBatches(DoRead) -> MapBatches(Fn)],
-        now we can fuse the latter two MapBatches stages into a single OneToOne stage:
-        [GetReadTasks -> MapBatches(DoRead -> Fn)].
-        """
-        # Generate the "GetReadTasks" stage blocks.
-        remote_args = self._in_blocks._remote_args
-        blocks = []
-        metadata = []
-        for read_task in self._in_blocks._tasks:
-            blocks.append(ray.put(read_task._read_fn))
-            metadata.append(read_task.get_metadata())
-        block_list = BlockList(blocks, metadata)
-
-        def block_fn(read_fn: Callable[[], Iterator[Block]]) -> Iterator[Block]:
-            for block in read_fn():
-                yield block
-
-        return block_list, OneToOneStage("read", block_fn, "tasks", remote_args)
-
-    def _fuse_one_to_one_stages(self) -> None:
-        """Fuses compatible one-to-one stages."""
-        optimized_stages = []
-        prev_stage = None
-        for stage in self._stages:
-            if prev_stage is None:
-                prev_stage = stage
-            elif stage.can_fuse(prev_stage):
-                prev_stage = stage.fuse(prev_stage)
-            else:
-                optimized_stages.append(prev_stage)
-                prev_stage = stage
-        if prev_stage:
-            optimized_stages.append(prev_stage)
-            prev_stage = None
-        self._stages = optimized_stages
 
 
 class Stage:
@@ -249,6 +48,299 @@ class Stage:
         raise NotImplementedError
 
 
+class ExecutionPlan:
+    """A lazy execution plan for a Dataset."""
+
+    # Implementation Notes:
+    #
+    # This lazy execution plan takes in an input block list and builds up a chain of
+    # BlockList --> BlockList stages. When execution is triggered, it tries to fuse
+    # together stages in order to reduce Ray task overhead and data copies.
+    #
+    # Internally, the execution plan holds two block lists:
+    #   * _in_blocks: The (possibly lazy) input block list.
+    #   * _snapshot_blocks: A snapshot of a computed block list, where this snapshot
+    #     is the cached output of executing some prefix in the stage chain.
+    #
+    # The stages in this execution plan are partitioned into two subchains: before the
+    # snapshot and after the snapshot. When the snapshot exists from a previous
+    # execution, any future executions will only have to execute the "after the
+    # snapshot" subchain, using the snapshot as the input to that subchain.
+
+    def __init__(self, in_blocks: BlockList, stats: DatasetStats, dataset_uuid=None):
+        """Create a plan with no transformation stages.
+
+        Args:
+            in_blocks: Base list of blocks.
+            stats: Stats for the base blocks.
+            dataset_uuid: Dataset's UUID.
+        """
+        self._in_blocks = in_blocks
+        self._in_stats = stats
+        # A computed snapshot of some prefix of stages.
+        self._snapshot_blocks = None
+        self._snapshot_stats = None
+        # Chains of stages.
+        self._stages_before_snapshot = []
+        self._stages_after_snapshot = []
+        # Cache of optimized stages.
+        self._last_optimized_stages = None
+
+        self._dataset_uuid = dataset_uuid or uuid.uuid4().hex
+        if not stats.dataset_uuid:
+            stats.dataset_uuid = self._dataset_uuid
+
+    def with_stage(self, stage: "Stage") -> "ExecutionPlan":
+        """Return a copy of this plan with the given stage appended.
+
+        Args:
+            stage: The stage to append.
+
+        Returns:
+            A new ExecutionPlan with this stage appended.
+        """
+        copy = self.copy()
+        copy._stages_after_snapshot.append(stage)
+        return copy
+
+    def copy(self) -> "ExecutionPlan":
+        """Create a shallow copy of this execution plan.
+
+        This copy can be executed without mutating the original, but clearing the copy
+        will also clear the original.
+
+        Returns:
+            A shallow copy of this execution plan.
+        """
+        plan_copy = ExecutionPlan(self._in_blocks, self._in_stats)
+        if self._snapshot_blocks is not None:
+            # Copy over the existing snapshot.
+            plan_copy._snapshot_blocks = self._snapshot_blocks
+            plan_copy._snapshot_stats = self._snapshot_stats
+        plan_copy._stages_before_snapshot = self._stages_before_snapshot.copy()
+        plan_copy._stages_after_snapshot = self._stages_after_snapshot.copy()
+        return plan_copy
+
+    def deep_copy(self, preserve_uuid: bool = False) -> "ExecutionPlan":
+        """Create a deep copy of this execution plan.
+
+        This copy can be executed AND cleared without mutating the original.
+
+        Args:
+            preserve_uuid: Whether to preserve the original UUID in the copy.
+
+        Returns:
+            A deep copy of this execution plan.
+        """
+        dataset_uuid = None
+        if preserve_uuid:
+            dataset_uuid = self._dataset_uuid
+        in_blocks = self._in_blocks
+        if isinstance(in_blocks, BlockList):
+            in_blocks = in_blocks.copy()
+        plan_copy = ExecutionPlan(
+            in_blocks, copy.copy(self._in_stats), dataset_uuid=dataset_uuid
+        )
+        if self._snapshot_blocks:
+            # Copy over the existing snapshot.
+            snapshot_blocks = self._snapshot_blocks
+            if isinstance(snapshot_blocks, BlockList):
+                snapshot_blocks = snapshot_blocks.copy()
+            plan_copy._snapshot_blocks = snapshot_blocks
+            plan_copy._snapshot_stats = copy.copy(self._snapshot_stats)
+        plan_copy._stages_before_snapshot = self._stages_before_snapshot.copy()
+        plan_copy._stages_after_snapshot = self._stages_after_snapshot.copy()
+        return plan_copy
+
+    def initial_num_blocks(self) -> int:
+        """Get the estimated number of blocks after applying all plan stages."""
+        if self.has_computed_output():
+            return self._snapshot_blocks.initial_num_blocks()
+        for stage in self._stages_after_snapshot[::-1]:
+            if stage.num_blocks is not None:
+                return stage.num_blocks
+        if self._snapshot_blocks is not None:
+            return self._snapshot_blocks.initial_num_blocks()
+        for stage in self._stages_before_snapshot[::-1]:
+            if stage.num_blocks is not None:
+                return stage.num_blocks
+        if self._in_blocks is not None:
+            return self._in_blocks.initial_num_blocks()
+        return None
+
+    def schema(
+        self, fetch_if_missing: bool = False
+    ) -> Union[type, "pyarrow.lib.Schema"]:
+        """Get the schema after applying all plan stages.
+
+        Args:
+            fetch_if_missing: Whether to execute the plan to fetch the schema.
+
+        Returns:
+            The schema of the output dataset.
+        """
+        if self._stages_after_snapshot:
+            if fetch_if_missing:
+                self.execute()
+            else:
+                return None
+        # Snapshot is now guaranteed to be the output of the final stage or None.
+        blocks = self._snapshot_blocks
+        if not blocks:
+            return None
+        # Don't force fetching in case it's a lazy block list, in which case we
+        # don't want to trigger full execution for a schema read. If we want to
+        # trigger execution to get schema, we'll trigger read tasks progressively
+        # until a viable schema is available, below.
+        metadata = blocks.get_metadata(fetch_if_missing=False)
+        # Some blocks could be empty, in which case we cannot get their schema.
+        # TODO(ekl) validate schema is the same across different blocks.
+        for m in metadata:
+            if m.schema is not None and (m.num_rows is None or m.num_rows > 0):
+                return m.schema
+        if not fetch_if_missing:
+            return None
+        # Synchronously fetch the schema.
+        # For lazy block lists, this launches read tasks and fetches block metadata
+        # until we find valid block schema.
+        for _, m in blocks.iter_blocks_with_metadata():
+            if m.schema is not None and (m.num_rows is None or m.num_rows > 0):
+                return m.schema
+        return None
+
+    def meta_count(self) -> Optional[int]:
+        """Get the number of rows after applying all plan stages if possible.
+
+        This method will never trigger any computation.
+
+        Returns:
+            The number of records of the result Dataset, or None.
+        """
+        if self._stages_after_snapshot:
+            return None
+        # Snapshot is now guaranteed to be the output of the final stage or None.
+        blocks = self._snapshot_blocks
+        metadata = blocks.get_metadata() if blocks else None
+        if metadata and all(m.num_rows is not None for m in metadata):
+            return sum(m.num_rows for m in metadata)
+        else:
+            return None
+
+    def execute(
+        self, clear_input_blocks: bool = True, force_read: bool = False
+    ) -> BlockList:
+        """Execute this plan.
+
+        Args:
+            clear_input_blocks: Whether to assume ownership of the input blocks,
+                allowing them to be dropped from memory during execution.
+            force_read: Whether to force the read stage to fully execute.
+
+        Returns:
+            The blocks of the output dataset.
+        """
+        if not self.has_computed_output():
+            blocks, stats, stages = self._optimize()
+            for stage in stages:
+                stats_builder = stats.child_builder(stage.name)
+                blocks, stage_info = stage(blocks, clear_input_blocks)
+                if stage_info:
+                    stats = stats_builder.build_multistage(stage_info)
+                else:
+                    stats = stats_builder.build(blocks)
+                stats.dataset_uuid = uuid.uuid4().hex
+            # Set the snapshot to the output of the final stage.
+            self._snapshot_blocks = blocks
+            self._snapshot_stats = stats
+            self._snapshot_stats.dataset_uuid = self._dataset_uuid
+            self._stages_before_snapshot += self._stages_after_snapshot
+            self._stages_after_snapshot = []
+        if _is_lazy(self._snapshot_blocks) and force_read:
+            self._snapshot_blocks = self._snapshot_blocks.compute_to_blocklist()
+        return self._snapshot_blocks
+
+    def clear(self) -> None:
+        """Clear all cached block references of this plan, including input blocks.
+
+        This will render the plan un-executable unless the root is a LazyBlockList."""
+        self._in_blocks.clear()
+        self._snapshot_blocks = None
+        self._snapshot_stats = None
+        # We're erasing the snapshot, so put all stages into the "after snapshot"
+        # bucket.
+        self._stages_after_snapshot = (
+            self._stages_before_snapshot + self._stages_after_snapshot
+        )
+        self._stages_before_snapshot = []
+
+    def stats(self) -> DatasetStats:
+        """Return stats for this plan, forcing execution if needed."""
+        self.execute()
+        return self._snapshot_stats
+
+    def _optimize(self) -> Tuple[BlockList, DatasetStats, List[Stage]]:
+        """Apply stage fusion optimizations, returning an updated source block list and
+        associated stats, and a set of optimized stages.
+        """
+        context = DatasetContext.get_current()
+        blocks, stats = self._get_source_blocks()
+        stages = self._stages_after_snapshot.copy()
+        if context.optimize_fuse_stages:
+            if context.optimize_fuse_read_stages:
+                # If using a lazy datasource, rewrite read stage into one-to-one stage
+                # so it can be fused into downstream stages.
+                blocks, stats, stages = _rewrite_read_stages(
+                    blocks, stats, stages, self._dataset_uuid
+                )
+            stages = _fuse_one_to_one_stages(stages)
+            self._last_optimized_stages = stages
+        return blocks, stats, stages
+
+    def _get_source_blocks(self) -> Tuple[BlockList, DatasetStats]:
+        """Get the source blocks (and corresponding stats) for plan execution.
+
+        If a computed snapshot exists, return the snapshot blocks and stats; otherwise,
+        return the input blocks and stats that the plan was created with.
+        """
+        if self._snapshot_blocks is not None:
+            # If snapshot exists, we only have to execute the plan from the
+            # snapshot.
+            blocks = self._snapshot_blocks
+            stats = self._snapshot_stats
+            # Unlink the snapshot blocks from the plan so we can eagerly reclaim the
+            # snapshot block memory after the first stage is done executing.
+            self._snapshot_blocks = None
+        else:
+            # If no snapshot exists, we have to execute the full plan from the
+            # beginning.
+            blocks = self._in_blocks
+            stats = self._in_stats
+            if not self.has_lazy_input():
+                # If not a lazy datasource, unlink the input blocks from the plan so we
+                # can eagerly reclaim the input block memory after the first stage is
+                # done executing.
+                self._in_blocks = None
+        return blocks, stats
+
+    def has_lazy_input(self) -> bool:
+        """Return whether this plan has lazy input blocks."""
+        return _is_lazy(self._in_blocks)
+
+    def is_read_stage(self) -> bool:
+        """Return whether this plan only consists of a read stage."""
+        return (
+            self.has_lazy_input()
+            and not self._stages_before_snapshot
+            and not self._stages_after_snapshot
+        )
+
+    def has_computed_output(self) -> bool:
+        """Whether this plan has a computed snapshot for the final stage, i.e. for the
+        output of this plan.
+        """
+        return self._snapshot_blocks is not None and not self._stages_after_snapshot
+
+
 class OneToOneStage(Stage):
     """A stage that transforms blocks independently (e.g., map or filter)."""
 
@@ -269,11 +361,7 @@ class OneToOneStage(Stage):
             return False
         if prev.compute != self.compute:
             return False
-        for key in INHERITABLE_REMOTE_ARGS:
-            remote_args = self.ray_remote_args.copy()
-            if key in prev.ray_remote_args:
-                remote_args[key] = prev.ray_remote_args[key]
-        if prev.ray_remote_args != remote_args:
+        if not _are_remote_args_compatible(prev.ray_remote_args, self.ray_remote_args):
             return False
         return True
 
@@ -348,3 +436,95 @@ class AllToAllStage(Stage):
         )
         assert isinstance(blocks, BlockList), blocks
         return blocks, stage_info
+
+
+def _rewrite_read_stages(
+    blocks: BlockList,
+    stats: DatasetStats,
+    stages: List[Stage],
+    dataset_uuid: str,
+) -> Tuple[BlockList, DatasetStats, List[Stage]]:
+    """Rewrites read stages into one-to-one stages, if needed."""
+    if _is_lazy(blocks) and stages:
+        blocks, stats, stage = _rewrite_read_stage(blocks)
+        stats.dataset_uuid = dataset_uuid
+        stages.insert(0, stage)
+    return blocks, stats, stages
+
+
+def _rewrite_read_stage(
+    in_blocks: LazyBlockList,
+) -> Tuple[BlockList, DatasetStats, Stage]:
+    """Rewrite the read stage to a OneToOne stage over read tasks as input.
+
+    For example, suppose the plan was [Read -> MapBatches(Fn)]. These stages cannot
+    be fused, since read stages are handled specially.
+    After rewriting to [GetReadTasks -> MapBatches(DoRead) -> MapBatches(Fn)],
+    now we can fuse the latter two MapBatches stages into a single OneToOne stage:
+    [GetReadTasks -> MapBatches(DoRead -> Fn)].
+
+    Args:
+        blocks: Lazy block list representing read stage.
+
+    Returns:
+        Non-lazy block list containing read tasks for not-yet-read block partitions,
+        new stats for the block list, and the new one-to-one read stage.
+    """
+    # Generate the "GetReadTasks" stage blocks.
+    remote_args = in_blocks._remote_args
+    blocks, metadata = [], []
+    for read_task in in_blocks._tasks:
+        blocks.append(ray.put(read_task._read_fn))
+        metadata.append(read_task.get_metadata())
+    block_list = BlockList(blocks, metadata)
+
+    def block_fn(read_fn: Callable[[], Iterator[Block]]) -> Iterator[Block]:
+        for block in read_fn():
+            yield block
+
+    stage = OneToOneStage("read", block_fn, "tasks", remote_args)
+    stats = DatasetStats(stages={}, parent=None)
+    return block_list, stats, stage
+
+
+def _fuse_one_to_one_stages(stages: List[Stage]) -> List[Stage]:
+    """Fuses compatible one-to-one stages.
+
+    Args:
+        stages: Stages to try to fuse.
+
+    Returns:
+        Optimized, fused stages.
+    """
+    optimized_stages = []
+    prev_stage = None
+    # We do not fuse stages across the snapshot, since we want to reuse the
+    # snapshot.
+    for idx, stage in enumerate(stages):
+        if prev_stage is None:
+            prev_stage = stage
+        elif stage.can_fuse(prev_stage):
+            prev_stage = stage.fuse(prev_stage)
+        else:
+            optimized_stages.append(prev_stage)
+            prev_stage = stage
+    if prev_stage:
+        optimized_stages.append(prev_stage)
+        prev_stage = None
+    return optimized_stages
+
+
+def _are_remote_args_compatible(prev_args, next_args):
+    """Check if Ray remote arguments are compatible for merging."""
+    remote_args = next_args.copy()
+    for key in INHERITABLE_REMOTE_ARGS:
+        if key in prev_args:
+            remote_args[key] = prev_args[key]
+    if prev_args != remote_args:
+        return False
+    return True
+
+
+def _is_lazy(blocks: BlockList) -> bool:
+    """Whether the provided block list is lazy."""
+    return isinstance(blocks, LazyBlockList)

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -227,17 +227,13 @@ class ExecutionPlan:
             return None
 
     def execute(
-        self,
-        clear_input_blocks: bool = True,
-        destroy_unrecoverable_input_blocks: bool = False,
-        force_read: bool = False,
+        self, clear_input_blocks: bool = True, force_read: bool = False
     ) -> BlockList:
         """Execute this plan.
 
         Args:
-            destroy_unrecoverable_input_blocks: Whether to clear the non-lazy input
-                blocks for this plan. This will destroy the blocks, meaning that this
-                dataset will not be executable after this run.
+            clear_input_blocks: Whether to assume ownership of the input blocks,
+                allowing them to be dropped from memory during execution.
             force_read: Whether to force the read stage to fully execute.
 
         Returns:
@@ -245,15 +241,9 @@ class ExecutionPlan:
         """
         if not self.has_computed_output():
             blocks, stats, stages = self._optimize()
-            for stage_idx, stage in enumerate(stages):
-                should_clear_input_blocks = self._should_clear_input_blocks(
-                    blocks,
-                    stage_idx,
-                    clear_input_blocks,
-                    destroy_unrecoverable_input_blocks,
-                )
+            for stage in stages:
                 stats_builder = stats.child_builder(stage.name)
-                blocks, stage_info = stage(blocks, should_clear_input_blocks)
+                blocks, stage_info = stage(blocks, clear_input_blocks)
                 if stage_info:
                     stats = stats_builder.build_multistage(stage_info)
                 else:
@@ -288,45 +278,13 @@ class ExecutionPlan:
         self.execute()
         return self._snapshot_stats
 
-    def _should_clear_input_blocks(
-        self,
-        blocks: BlockList,
-        stage_idx: int,
-        clear_input_blocks: bool,
-        destroy_unrecoverable_input_blocks: bool,
-    ):
-        """Whether the provided blocks should be cleared when passed into the stage.
-
-        Args:
-            blocks: The blocks that we may want to clear.
-            stage_idx: The position of the stage in the optimized after-snapshot chain.
-            clear_input_blocks: Whether we want to clear input blocks at all. If this is
-                False, this function returns False.
-            destroy_unrecoverable_input_blocks: Whether we want to clear unrecoverable
-                (non-lazy) input blocks.
-        """
-        if not clear_input_blocks:
-            return False
-        if stage_idx != 0 or self._stages_before_snapshot:
-            # Not the first stage, always clear stage input blocks.
-            return True
-        elif isinstance(blocks, LazyBlockList):
-            # Always clear lazy input blocks since they can be recomputed.
-            return True
-        elif destroy_unrecoverable_input_blocks:
-            # Only clear non-lazy input blocks if directed.
-            return True
-        else:
-            # Otherwise, we have non-lazy input blocks that's the source of this
-            # execution plan, and we've indicated that we don't want to clear these.
-            return False
-
     def _optimize(self) -> Tuple[BlockList, DatasetStats, List[Stage]]:
         """Apply stage fusion optimizations, returning an updated source block list and
         associated stats, and a set of optimized stages.
         """
         context = DatasetContext.get_current()
-        blocks, stats, stages = self._get_source_blocks_and_stages()
+        blocks, stats = self._get_source_blocks()
+        stages = self._stages_after_snapshot.copy()
         if context.optimize_fuse_stages:
             if context.optimize_fuse_read_stages:
                 # If using a lazy datasource, rewrite read stage into one-to-one stage
@@ -338,32 +296,20 @@ class ExecutionPlan:
             self._last_optimized_stages = stages
         return blocks, stats, stages
 
-    def _get_source_blocks_and_stages(
-        self,
-    ) -> Tuple[BlockList, DatasetStats, List[Stage]]:
-        """Get the source blocks, corresponding stats, and the stages for plan
-        execution.
+    def _get_source_blocks(self) -> Tuple[BlockList, DatasetStats]:
+        """Get the source blocks (and corresponding stats) for plan execution.
 
-        If a computed snapshot exists and has not been cleared, return the snapshot
-        blocks and stats; otherwise, return the input blocks and stats that the plan was
-        created with.
+        If a computed snapshot exists, return the snapshot blocks and stats; otherwise,
+        return the input blocks and stats that the plan was created with.
         """
-        stages = self._stages_after_snapshot
         if self._snapshot_blocks is not None:
-            if not self._snapshot_blocks._check_if_cleared():
-                # If snapshot exists, we only have to execute the plan from the
-                # snapshot.
-                blocks = self._snapshot_blocks
-                stats = self._snapshot_stats
-                # Unlink the snapshot blocks from the plan so we can eagerly reclaim the
-                # snapshot block memory after the first stage is done executing.
-                self._snapshot_blocks = None
-            else:
-                # Snapshot exists but has been cleared, so we need to recompute from the
-                # source (input blocks).
-                blocks = self._in_blocks
-                stats = self._in_stats
-                stages = self._stages_before_snapshot + self._stages_after_snapshot
+            # If snapshot exists, we only have to execute the plan from the
+            # snapshot.
+            blocks = self._snapshot_blocks
+            stats = self._snapshot_stats
+            # Unlink the snapshot blocks from the plan so we can eagerly reclaim the
+            # snapshot block memory after the first stage is done executing.
+            self._snapshot_blocks = None
         else:
             # If no snapshot exists, we have to execute the full plan from the
             # beginning.
@@ -374,7 +320,7 @@ class ExecutionPlan:
                 # can eagerly reclaim the input block memory after the first stage is
                 # done executing.
                 self._in_blocks = None
-        return blocks, stats, stages
+        return blocks, stats
 
     def has_lazy_input(self) -> bool:
         """Return whether this plan has lazy input blocks."""

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -143,10 +143,7 @@ class ExecutionPlan:
         )
         if self._snapshot_blocks:
             # Copy over the existing snapshot.
-            snapshot_blocks = self._snapshot_blocks
-            if isinstance(snapshot_blocks, BlockList):
-                snapshot_blocks = snapshot_blocks.copy()
-            plan_copy._snapshot_blocks = snapshot_blocks
+            plan_copy._snapshot_blocks = self._snapshot_blocks.copy()
             plan_copy._snapshot_stats = copy.copy(self._snapshot_stats)
         plan_copy._stages_before_snapshot = self._stages_before_snapshot.copy()
         plan_copy._stages_after_snapshot = self._stages_after_snapshot.copy()
@@ -502,24 +499,22 @@ def _fuse_one_to_one_stages(stages: List[Stage]) -> List[Stage]:
         stages: Stages to try to fuse.
 
     Returns:
-        Optimized, fused stages.
+        Fused stages.
     """
-    optimized_stages = []
+    fused_stages = []
     prev_stage = None
-    # We do not fuse stages across the snapshot, since we want to reuse the
-    # snapshot.
     for idx, stage in enumerate(stages):
         if prev_stage is None:
             prev_stage = stage
         elif stage.can_fuse(prev_stage):
             prev_stage = stage.fuse(prev_stage)
         else:
-            optimized_stages.append(prev_stage)
+            fused_stages.append(prev_stage)
             prev_stage = stage
     if prev_stage:
-        optimized_stages.append(prev_stage)
+        fused_stages.append(prev_stage)
         prev_stage = None
-    return optimized_stages
+    return fused_stages
 
 
 def _are_remote_args_compatible(prev_args, next_args):

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -227,13 +227,17 @@ class ExecutionPlan:
             return None
 
     def execute(
-        self, clear_input_blocks: bool = True, force_read: bool = False
+        self,
+        clear_input_blocks: bool = True,
+        destroy_unrecoverable_input_blocks: bool = False,
+        force_read: bool = False,
     ) -> BlockList:
         """Execute this plan.
 
         Args:
-            clear_input_blocks: Whether to assume ownership of the input blocks,
-                allowing them to be dropped from memory during execution.
+            destroy_unrecoverable_input_blocks: Whether to clear the non-lazy input
+                blocks for this plan. This will destroy the blocks, meaning that this
+                dataset will not be executable after this run.
             force_read: Whether to force the read stage to fully execute.
 
         Returns:
@@ -241,9 +245,15 @@ class ExecutionPlan:
         """
         if not self.has_computed_output():
             blocks, stats, stages = self._optimize()
-            for stage in stages:
+            for stage_idx, stage in enumerate(stages):
+                should_clear_input_blocks = self._should_clear_input_blocks(
+                    blocks,
+                    stage_idx,
+                    clear_input_blocks,
+                    destroy_unrecoverable_input_blocks,
+                )
                 stats_builder = stats.child_builder(stage.name)
-                blocks, stage_info = stage(blocks, clear_input_blocks)
+                blocks, stage_info = stage(blocks, should_clear_input_blocks)
                 if stage_info:
                     stats = stats_builder.build_multistage(stage_info)
                 else:
@@ -278,13 +288,45 @@ class ExecutionPlan:
         self.execute()
         return self._snapshot_stats
 
+    def _should_clear_input_blocks(
+        self,
+        blocks: BlockList,
+        stage_idx: int,
+        clear_input_blocks: bool,
+        destroy_unrecoverable_input_blocks: bool,
+    ):
+        """Whether the provided blocks should be cleared when passed into the stage.
+
+        Args:
+            blocks: The blocks that we may want to clear.
+            stage_idx: The position of the stage in the optimized after-snapshot chain.
+            clear_input_blocks: Whether we want to clear input blocks at all. If this is
+                False, this function returns False.
+            destroy_unrecoverable_input_blocks: Whether we want to clear unrecoverable
+                (non-lazy) input blocks.
+        """
+        if not clear_input_blocks:
+            return False
+        if stage_idx != 0 or self._stages_before_snapshot:
+            # Not the first stage, always clear stage input blocks.
+            return True
+        elif isinstance(blocks, LazyBlockList):
+            # Always clear lazy input blocks since they can be recomputed.
+            return True
+        elif destroy_unrecoverable_input_blocks:
+            # Only clear non-lazy input blocks if directed.
+            return True
+        else:
+            # Otherwise, we have non-lazy input blocks that's the source of this
+            # execution plan, and we've indicated that we don't want to clear these.
+            return False
+
     def _optimize(self) -> Tuple[BlockList, DatasetStats, List[Stage]]:
         """Apply stage fusion optimizations, returning an updated source block list and
         associated stats, and a set of optimized stages.
         """
         context = DatasetContext.get_current()
-        blocks, stats = self._get_source_blocks()
-        stages = self._stages_after_snapshot.copy()
+        blocks, stats, stages = self._get_source_blocks_and_stages()
         if context.optimize_fuse_stages:
             if context.optimize_fuse_read_stages:
                 # If using a lazy datasource, rewrite read stage into one-to-one stage
@@ -296,20 +338,32 @@ class ExecutionPlan:
             self._last_optimized_stages = stages
         return blocks, stats, stages
 
-    def _get_source_blocks(self) -> Tuple[BlockList, DatasetStats]:
-        """Get the source blocks (and corresponding stats) for plan execution.
+    def _get_source_blocks_and_stages(
+        self,
+    ) -> Tuple[BlockList, DatasetStats, List[Stage]]:
+        """Get the source blocks, corresponding stats, and the stages for plan
+        execution.
 
-        If a computed snapshot exists, return the snapshot blocks and stats; otherwise,
-        return the input blocks and stats that the plan was created with.
+        If a computed snapshot exists and has not been cleared, return the snapshot
+        blocks and stats; otherwise, return the input blocks and stats that the plan was
+        created with.
         """
+        stages = self._stages_after_snapshot
         if self._snapshot_blocks is not None:
-            # If snapshot exists, we only have to execute the plan from the
-            # snapshot.
-            blocks = self._snapshot_blocks
-            stats = self._snapshot_stats
-            # Unlink the snapshot blocks from the plan so we can eagerly reclaim the
-            # snapshot block memory after the first stage is done executing.
-            self._snapshot_blocks = None
+            if not self._snapshot_blocks._check_if_cleared():
+                # If snapshot exists, we only have to execute the plan from the
+                # snapshot.
+                blocks = self._snapshot_blocks
+                stats = self._snapshot_stats
+                # Unlink the snapshot blocks from the plan so we can eagerly reclaim the
+                # snapshot block memory after the first stage is done executing.
+                self._snapshot_blocks = None
+            else:
+                # Snapshot exists but has been cleared, so we need to recompute from the
+                # source (input blocks).
+                blocks = self._in_blocks
+                stats = self._in_stats
+                stages = self._stages_before_snapshot + self._stages_after_snapshot
         else:
             # If no snapshot exists, we have to execute the full plan from the
             # beginning.
@@ -320,7 +374,7 @@ class ExecutionPlan:
                 # can eagerly reclaim the input block memory after the first stage is
                 # done executing.
                 self._in_blocks = None
-        return blocks, stats
+        return blocks, stats, stages
 
     def has_lazy_input(self) -> bool:
         """Return whether this plan has lazy input blocks."""

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -11,6 +11,33 @@ from ray.internal.internal_api import memory_summary
 from ray.tests.conftest import *  # noqa
 
 
+@ray.remote
+class Counter:
+    def __init__(self):
+        self.value = 0
+
+    def increment(self):
+        self.value += 1
+        return self.value
+
+    def get(self):
+        return self.value
+
+    def reset(self):
+        self.value = 0
+
+
+class MySource(CSVDatasource):
+    def __init__(self, counter):
+        self.counter = counter
+
+    def _read_stream(self, f, path: str, **reader_args):
+        count = self.counter.increment.remote()
+        ray.get(count)
+        for block in super()._read_stream(f, path, **reader_args):
+            yield block
+
+
 def expect_stages(pipe, num_stages_expected, stage_names):
     stats = pipe.stats()
     for name in stage_names:
@@ -27,22 +54,6 @@ def test_memory_sanity(shutdown_only):
 
     # Sanity check spilling is happening as expected.
     assert "Spilled" in meminfo, meminfo
-
-
-def test_memory_release_eager(shutdown_only):
-    info = ray.init(num_cpus=1, object_store_memory=1500e6)
-    ds = ray.data.range(10)
-
-    # Round 1.
-    ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
-    meminfo = memory_summary(info.address_info["address"], stats_only=True)
-    assert "Spilled" not in meminfo, meminfo
-
-    # Round 2.
-    ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
-    meminfo = memory_summary(info["address"], stats_only=True)
-    # TODO(ekl) we can add this back once we clear inputs on eager exec as well.
-    # assert "Spilled" not in meminfo, meminfo
 
 
 def test_memory_release_lazy(shutdown_only):
@@ -81,6 +92,67 @@ def test_memory_release_lazy_shuffle(shutdown_only):
         finally:
             ray.shutdown()
     raise error
+
+
+def test_lazy_fanout(shutdown_only, local_path):
+    ray.init(num_cpus=1)
+    map_counter = Counter.remote()
+
+    def inc(row):
+        map_counter.increment.remote()
+        row = row.as_pydict()
+        row["one"] += 1
+        return row
+
+    df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path = os.path.join(local_path, "test.csv")
+    df.to_csv(path, index=False, storage_options={})
+    read_counter = Counter.remote()
+    source = MySource(read_counter)
+
+    # Test that fan-out of a lazy dataset results in re-execution up to the datasource,
+    # due to block move semantics.
+    ds = ray.data.read_datasource(source, parallelism=1, paths=path)
+    ds = ds._experimental_lazy()
+    ds1 = ds.map(inc)
+    ds2 = ds1.map(inc)
+    ds3 = ds1.map(inc)
+    # Test content.
+    assert ds2.fully_executed().take() == [
+        {"one": 3, "two": "a"},
+        {"one": 4, "two": "b"},
+        {"one": 5, "two": "c"},
+    ]
+    assert ds3.fully_executed().take() == [
+        {"one": 3, "two": "a"},
+        {"one": 4, "two": "b"},
+        {"one": 5, "two": "c"},
+    ]
+    # Test that data is read twice (+ 1 extra for ramp-up read before converting to a
+    # lazy dataset).
+    assert ray.get(read_counter.get.remote()) == 3
+    # Test that first map is executed twice.
+    assert ray.get(map_counter.get.remote()) == 2 * 3 + 3 + 3
+
+    # Test that fan-out of a lazy dataset with a non-lazy datasource results in
+    # re-execution up to the datasource, due to block move semantics.
+    ray.get(map_counter.reset.remote())
+
+    def inc(x):
+        map_counter.increment.remote()
+        return x + 1
+
+    # The source data shouldn't be cleared since it's non-lazy.
+    ds = ray.data.from_items(list(range(10)))
+    ds = ds._experimental_lazy()
+    ds1 = ds.map(inc)
+    ds2 = ds1.map(inc)
+    ds3 = ds1.map(inc)
+    # Test content.
+    assert ds2.fully_executed().take() == list(range(2, 12))
+    assert ds3.fully_executed().take() == list(range(2, 12))
+    # Test that first map is executed twice.
+    assert ray.get(map_counter.get.remote()) == 2 * 10 + 10 + 10
 
 
 def test_spread_hint_inherit(ray_start_regular_shared):
@@ -197,33 +269,6 @@ def test_optimize_incompatible_stages(ray_start_regular_shared):
             "random_shuffle_reduce",
         ],
     )
-
-
-@ray.remote
-class Counter:
-    def __init__(self):
-        self.value = 0
-
-    def increment(self):
-        self.value += 1
-        return self.value
-
-    def get(self):
-        return self.value
-
-    def reset(self):
-        self.value = 0
-
-
-class MySource(CSVDatasource):
-    def __init__(self, counter):
-        self.counter = counter
-
-    def _read_stream(self, f, path: str, **reader_args):
-        count = self.counter.increment.remote()
-        ray.get(count)
-        for block in super()._read_stream(f, path, **reader_args):
-            yield block
 
 
 def test_optimize_reread_base_data(ray_start_regular_shared, local_path):

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -11,33 +11,6 @@ from ray.internal.internal_api import memory_summary
 from ray.tests.conftest import *  # noqa
 
 
-@ray.remote
-class Counter:
-    def __init__(self):
-        self.value = 0
-
-    def increment(self):
-        self.value += 1
-        return self.value
-
-    def get(self):
-        return self.value
-
-    def reset(self):
-        self.value = 0
-
-
-class MySource(CSVDatasource):
-    def __init__(self, counter):
-        self.counter = counter
-
-    def _read_stream(self, f, path: str, **reader_args):
-        count = self.counter.increment.remote()
-        ray.get(count)
-        for block in super()._read_stream(f, path, **reader_args):
-            yield block
-
-
 def expect_stages(pipe, num_stages_expected, stage_names):
     stats = pipe.stats()
     for name in stage_names:
@@ -54,6 +27,22 @@ def test_memory_sanity(shutdown_only):
 
     # Sanity check spilling is happening as expected.
     assert "Spilled" in meminfo, meminfo
+
+
+def test_memory_release_eager(shutdown_only):
+    info = ray.init(num_cpus=1, object_store_memory=1500e6)
+    ds = ray.data.range(10)
+
+    # Round 1.
+    ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
+    meminfo = memory_summary(info.address_info["address"], stats_only=True)
+    assert "Spilled" not in meminfo, meminfo
+
+    # Round 2.
+    ds = ds.map(lambda x: np.ones(100 * 1024 * 1024, dtype=np.uint8))
+    meminfo = memory_summary(info["address"], stats_only=True)
+    # TODO(ekl) we can add this back once we clear inputs on eager exec as well.
+    # assert "Spilled" not in meminfo, meminfo
 
 
 def test_memory_release_lazy(shutdown_only):
@@ -92,67 +81,6 @@ def test_memory_release_lazy_shuffle(shutdown_only):
         finally:
             ray.shutdown()
     raise error
-
-
-def test_lazy_fanout(shutdown_only, local_path):
-    ray.init(num_cpus=1)
-    map_counter = Counter.remote()
-
-    def inc(row):
-        map_counter.increment.remote()
-        row = row.as_pydict()
-        row["one"] += 1
-        return row
-
-    df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
-    path = os.path.join(local_path, "test.csv")
-    df.to_csv(path, index=False, storage_options={})
-    read_counter = Counter.remote()
-    source = MySource(read_counter)
-
-    # Test that fan-out of a lazy dataset results in re-execution up to the datasource,
-    # due to block move semantics.
-    ds = ray.data.read_datasource(source, parallelism=1, paths=path)
-    ds = ds._experimental_lazy()
-    ds1 = ds.map(inc)
-    ds2 = ds1.map(inc)
-    ds3 = ds1.map(inc)
-    # Test content.
-    assert ds2.fully_executed().take() == [
-        {"one": 3, "two": "a"},
-        {"one": 4, "two": "b"},
-        {"one": 5, "two": "c"},
-    ]
-    assert ds3.fully_executed().take() == [
-        {"one": 3, "two": "a"},
-        {"one": 4, "two": "b"},
-        {"one": 5, "two": "c"},
-    ]
-    # Test that data is read twice (+ 1 extra for ramp-up read before converting to a
-    # lazy dataset).
-    assert ray.get(read_counter.get.remote()) == 3
-    # Test that first map is executed twice.
-    assert ray.get(map_counter.get.remote()) == 2 * 3 + 3 + 3
-
-    # Test that fan-out of a lazy dataset with a non-lazy datasource results in
-    # re-execution up to the datasource, due to block move semantics.
-    ray.get(map_counter.reset.remote())
-
-    def inc(x):
-        map_counter.increment.remote()
-        return x + 1
-
-    # The source data shouldn't be cleared since it's non-lazy.
-    ds = ray.data.from_items(list(range(10)))
-    ds = ds._experimental_lazy()
-    ds1 = ds.map(inc)
-    ds2 = ds1.map(inc)
-    ds3 = ds1.map(inc)
-    # Test content.
-    assert ds2.fully_executed().take() == list(range(2, 12))
-    assert ds3.fully_executed().take() == list(range(2, 12))
-    # Test that first map is executed twice.
-    assert ray.get(map_counter.get.remote()) == 2 * 10 + 10 + 10
 
 
 def test_spread_hint_inherit(ray_start_regular_shared):
@@ -269,6 +197,33 @@ def test_optimize_incompatible_stages(ray_start_regular_shared):
             "random_shuffle_reduce",
         ],
     )
+
+
+@ray.remote
+class Counter:
+    def __init__(self):
+        self.value = 0
+
+    def increment(self):
+        self.value += 1
+        return self.value
+
+    def get(self):
+        return self.value
+
+    def reset(self):
+        self.value = 0
+
+
+class MySource(CSVDatasource):
+    def __init__(self, counter):
+        self.counter = counter
+
+    def _read_stream(self, f, path: str, **reader_args):
+        count = self.counter.increment.remote()
+        ray.get(count)
+        for block in super()._read_stream(f, path, **reader_args):
+            yield block
 
 
 def test_optimize_reread_base_data(ray_start_regular_shared, local_path):


### PR DESCRIPTION
This PR refactors `ExecutionPlan` to maintain complete stage lineage, even for eagerly computed datasets, while ensuring that block references are unlinked as early as possible in order to more eagerly release block memory. This PR is the final precursor to adding the actual out-of-band serialization APIs (PR 3/3).

The fully lineage has to be maintained, even for eagerly computed datasets, since the lineage is needed for out-of-band serialization of datasets. See the [mono-PR](https://github.com/ray-project/ray/pull/22616) for more context.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
