### PR TITLE
[Datasets] [Out-of-Band Serialization: 3/3] Add out-of-band serialization.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2891,8 +2891,8 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
                 "Dataset.write_*() APIs, and serialize a new dataset reading from the "
                 "external store using the ray.data.read_*() APIs."
             )
-        # Copy Dataset and clear the execution plan so the Dataset is out-of-band
-        # serializable.
+        # Copy Dataset and clear the blocks from the execution plan so only the
+        # Dataset's lineage is serialized.
         plan_copy = self._plan.deep_copy(preserve_uuid=True)
         ds = Dataset(plan_copy, self._get_epoch(), self._lazy)
         ds._plan.clear_block_refs()

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -256,7 +256,7 @@ class ExecutionPlan:
             self._snapshot_blocks = self._snapshot_blocks.compute_to_blocklist()
         return self._snapshot_blocks
 
-    def clear(self) -> None:
+    def clear_block_refs(self) -> None:
         """Clear all cached block references of this plan, including input blocks.
 
         This will render the plan un-executable unless the root is a LazyBlockList."""

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -210,9 +210,10 @@ def test_dataset_lineage_serialization(shutdown_only, lazy):
     in_blocks = ds._plan._in_blocks
     # Should not raise.
     in_blocks._check_if_cleared()
-    if lazy and isinstance(in_blocks, LazyBlockList):
+    assert isinstance(in_blocks, LazyBlockList)
+    if lazy:
         assert in_blocks._block_partition_refs[0] is not None
-    if not lazy:
+    else:
         assert ds._plan._snapshot_blocks is not None
 
     ray.shutdown()

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -13,12 +13,13 @@ import pytest
 import ray
 
 from ray.tests.conftest import *  # noqa
-from ray.data.dataset import _sliding_window
+from ray.data.dataset import Dataset, _sliding_window
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockAccessor
 from ray.data.row import TableRow
 from ray.data.impl.arrow_block import ArrowRow
 from ray.data.impl.block_builder import BlockBuilder
+from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.pandas_block import PandasRow
 from ray.data.aggregate import AggregateFn, Count, Sum, Min, Max, Mean, Std
 from ray.data.extensions.tensor_extension import (
@@ -34,6 +35,13 @@ from ray.data.tests.conftest import *  # noqa
 def maybe_pipeline(ds, enabled):
     if enabled:
         return ds.window(blocks_per_window=1)
+    else:
+        return ds
+
+
+def maybe_lazy(ds, enabled):
+    if enabled:
+        return ds._experimental_lazy()
     else:
         return ds
 
@@ -182,6 +190,55 @@ def test_transform_failure(shutdown_only):
 
     with pytest.raises(ray.exceptions.RayTaskError):
         ds.map(mapper)
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_dataset_out_of_band_serialization(shutdown_only, lazy):
+    ray.init()
+    ds = ray.data.range(10)
+    ds = maybe_lazy(ds, lazy)
+    ds = ds.map(lambda x: x + 1)
+    ds = ds.map(lambda x: x + 1)
+    ds = ds.random_shuffle()
+    epoch = ds._get_epoch()
+    uuid = ds._get_uuid()
+    plan_uuid = ds._plan._dataset_uuid
+    lazy = ds._lazy
+
+    serialized_ds = ds.serialize_out_of_band()
+    # Confirm that the original Dataset was properly copied before clearing/mutating.
+    in_blocks = ds._plan._in_blocks
+    # Should not raise.
+    in_blocks._check_if_cleared()
+    if lazy and isinstance(in_blocks, LazyBlockList):
+        assert in_blocks._block_partition_refs[0] is not None
+    if not lazy:
+        assert ds._plan._snapshot_blocks is not None
+
+    ray.shutdown()
+    ray.init()
+
+    ds = Dataset.deserialize_out_of_band(serialized_ds)
+    # Check Dataset state.
+    assert ds._get_epoch() == epoch
+    assert ds._get_uuid() == uuid
+    assert ds._plan._dataset_uuid == plan_uuid
+    assert ds._lazy == lazy
+    # Check Dataset content.
+    assert ds.count() == 10
+    assert sorted(ds.take()) == list(range(2, 12))
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_dataset_out_of_band_serialization_in_memory(shutdown_only, lazy):
+    ray.init()
+    ds = ray.data.from_items(list(range(10)))
+    ds = maybe_lazy(ds, lazy)
+    ds = ds.map(lambda x: x + 1)
+    ds = ds.map(lambda x: x + 1)
+
+    with pytest.raises(ValueError):
+        ds.serialize_out_of_band()
 
 
 @pytest.mark.parametrize("pipelined", [False, True])

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -193,7 +193,7 @@ def test_transform_failure(shutdown_only):
 
 
 @pytest.mark.parametrize("lazy", [False, True])
-def test_dataset_out_of_band_serialization(shutdown_only, lazy):
+def test_dataset_lineage_serialization(shutdown_only, lazy):
     ray.init()
     ds = ray.data.range(10)
     ds = maybe_lazy(ds, lazy)
@@ -205,7 +205,7 @@ def test_dataset_out_of_band_serialization(shutdown_only, lazy):
     plan_uuid = ds._plan._dataset_uuid
     lazy = ds._lazy
 
-    serialized_ds = ds.serialize_out_of_band()
+    serialized_ds = ds.serialize_lineage()
     # Confirm that the original Dataset was properly copied before clearing/mutating.
     in_blocks = ds._plan._in_blocks
     # Should not raise.
@@ -218,7 +218,7 @@ def test_dataset_out_of_band_serialization(shutdown_only, lazy):
     ray.shutdown()
     ray.init()
 
-    ds = Dataset.deserialize_out_of_band(serialized_ds)
+    ds = Dataset.deserialize_lineage(serialized_ds)
     # Check Dataset state.
     assert ds._get_epoch() == epoch
     assert ds._get_uuid() == uuid
@@ -230,7 +230,7 @@ def test_dataset_out_of_band_serialization(shutdown_only, lazy):
 
 
 @pytest.mark.parametrize("lazy", [False, True])
-def test_dataset_out_of_band_serialization_in_memory(shutdown_only, lazy):
+def test_dataset_lineage_serialization_in_memory(shutdown_only, lazy):
     ray.init()
     ds = ray.data.from_items(list(range(10)))
     ds = maybe_lazy(ds, lazy)
@@ -238,7 +238,7 @@ def test_dataset_out_of_band_serialization_in_memory(shutdown_only, lazy):
     ds = ds.map(lambda x: x + 1)
 
     with pytest.raises(ValueError):
-        ds.serialize_out_of_band()
+        ds.serialize_lineage()
 
 
 @pytest.mark.parametrize("pipelined", [False, True])


### PR DESCRIPTION
This PR adds support for out-of-band serialization of datasets, i.e. for serializing and deserializing datasets across Ray clusters. This PR is the final PR in a set to add such support (3/3). See the [mono PR](https://github.com/ray-project/ray/pull/22616) for more context.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
