### PR TITLE
[serve] Move schema helpers out of `api.py`

### DIFF
--- a/dashboard/modules/serve/serve_head.py
+++ b/dashboard/modules/serve/serve_head.py
@@ -11,6 +11,9 @@ logger.setLevel(logging.INFO)
 routes = optional_utils.ClassMethodRouteTable
 
 
+# NOTE (shrekris-anyscale): This class uses delayed imports for all
+# Ray Serve-related modules. That way, users can use the Ray dashboard for
+# non-Serve purposes without downloading Serve dependencies.
 class ServeHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, dashboard_head):
         super().__init__(dashboard_head)
@@ -30,10 +33,8 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @routes.get("/api/serve/deployments/status")
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def get_all_deployment_statuses(self, req: Request) -> Response:
-        from ray.serve.api import (
-            serve_application_status_to_schema,
-            get_deployment_statuses,
-        )
+        from ray.serve.api import get_deployment_statuses
+        from ray.serve.schema import serve_application_status_to_schema
 
         serve_application_status_schema = serve_application_status_to_schema(
             get_deployment_statuses()

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1140,11 +1140,11 @@ def deployment(
         num_replicas=num_replicas,
         user_config=user_config,
         max_concurrent_queries=max_concurrent_queries,
-        _autoscaling_config=_autoscaling_config,
-        _graceful_shutdown_wait_loop_s=_graceful_shutdown_wait_loop_s,
-        _graceful_shutdown_timeout_s=_graceful_shutdown_timeout_s,
-        _health_check_period_s=_health_check_period_s,
-        _health_check_timeout_s=_health_check_timeout_s,
+        autoscaling_config=_autoscaling_config,
+        graceful_shutdown_wait_loop_s=_graceful_shutdown_wait_loop_s,
+        graceful_shutdown_timeout_s=_graceful_shutdown_timeout_s,
+        health_check_period_s=_health_check_period_s,
+        health_check_timeout_s=_health_check_timeout_s,
     )
 
     def decorator(_func_or_class):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1133,31 +1133,18 @@ def deployment(
             "Manually setting num_replicas is not allowed when "
             "_autoscaling_config is provided."
         )
-
-    config = DeploymentConfig()
-    if num_replicas is not None:
-        config.num_replicas = num_replicas
-
-    if user_config is not None:
-        config.user_config = user_config
-
-    if max_concurrent_queries is not None:
-        config.max_concurrent_queries = max_concurrent_queries
-
-    if _autoscaling_config is not None:
-        config.autoscaling_config = _autoscaling_config
-
-    if _graceful_shutdown_wait_loop_s is not None:
-        config.graceful_shutdown_wait_loop_s = _graceful_shutdown_wait_loop_s
-
-    if _graceful_shutdown_timeout_s is not None:
-        config.graceful_shutdown_timeout_s = _graceful_shutdown_timeout_s
-
-    if _health_check_period_s is not None:
-        config.health_check_period_s = _health_check_period_s
-
-    if _health_check_timeout_s is not None:
-        config.health_check_timeout_s = _health_check_timeout_s
+    
+    config = DeploymentConfig.from_default(
+        ignore_none=True,
+        num_replicas=num_replicas,
+        user_config=user_config,
+        max_concurrent_queries=max_concurrent_queries,
+        _autoscaling_config=_autoscaling_config,
+        _graceful_shutdown_wait_loop_s=_graceful_shutdown_wait_loop_s,
+        _graceful_shutdown_timeout_s=_graceful_shutdown_timeout_s,
+        _health_check_period_s=_health_check_period_s,
+        _health_check_timeout_s=_health_check_timeout_s,
+    )
 
     def decorator(_func_or_class):
         return Deployment(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -50,11 +50,7 @@ from ray.serve.constants import (
     DEFAULT_HTTP_PORT,
 )
 from ray.serve.controller import ServeController
-from ray.serve.deployment import (
-    Deployment,
-    deployment_to_schema,
-    schema_to_deployment,
-)
+from ray.serve.deployment import Deployment
 from ray.serve.exceptions import RayServeException
 from ray.serve.generated.serve_pb2 import (
     DeploymentRoute,
@@ -76,11 +72,6 @@ from ray.serve.utils import (
 from ray.util.annotations import PublicAPI
 import ray
 from ray import cloudpickle
-from ray.serve.schema import (
-    DeploymentStatusSchema,
-    ServeApplicationSchema,
-    ServeApplicationStatusSchema,
-)
 from ray.serve.deployment_graph import DeploymentNode, DeploymentFunctionNode
 from ray.serve.application import Application
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1414,21 +1414,28 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
     else:
         ray_actor_options = s.ray_actor_options.dict(exclude_unset=True)
 
-    return deployment(
-        name=s.name,
-        init_args=convert_from_json_safe_obj(s.init_args, err_key="init_args"),
-        init_kwargs=convert_from_json_safe_obj(s.init_kwargs, err_key="init_kwargs"),
+    config = DeploymentConfig.from_default(
+        ignore_none=True,
         num_replicas=s.num_replicas,
-        route_prefix=s.route_prefix,
-        max_concurrent_queries=s.max_concurrent_queries,
         user_config=s.user_config,
+        max_concurrent_queries=s.max_concurrent_queries,
         _autoscaling_config=s.autoscaling_config,
         _graceful_shutdown_wait_loop_s=s.graceful_shutdown_wait_loop_s,
         _graceful_shutdown_timeout_s=s.graceful_shutdown_timeout_s,
         _health_check_period_s=s.health_check_period_s,
         _health_check_timeout_s=s.health_check_timeout_s,
+    )
+    
+    return Deployment(
+        func_or_class=s.import_path,
+        name=s.name,
+        config=config,
+        init_args=convert_from_json_safe_obj(s.init_args, err_key="init_args"),
+        init_kwargs=convert_from_json_safe_obj(s.init_kwargs, err_key="init_kwargs"),
+        route_prefix=s.route_prefix,
         ray_actor_options=ray_actor_options,
-    )(s.import_path)
+        _internal=True,
+    )
 
 
 def serve_application_to_schema(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -50,7 +50,11 @@ from ray.serve.constants import (
     DEFAULT_HTTP_PORT,
 )
 from ray.serve.controller import ServeController
-from ray.serve.deployment import Deployment
+from ray.serve.deployment import (
+    Deployment,
+    deployment_to_schema,
+    schema_to_deployment,
+)
 from ray.serve.exceptions import RayServeException
 from ray.serve.generated.serve_pb2 import (
     DeploymentRoute,
@@ -66,7 +70,6 @@ from ray.serve.utils import (
     format_actor_name,
     get_current_node_resource_key,
     get_random_letters,
-    get_deployment_import_path,
     in_interactive_shell,
     DEFAULT,
 )
@@ -74,8 +77,6 @@ from ray.util.annotations import PublicAPI
 import ray
 from ray import cloudpickle
 from ray.serve.schema import (
-    RayActorOptionsSchema,
-    DeploymentSchema,
     DeploymentStatusSchema,
     ServeApplicationSchema,
     ServeApplicationStatusSchema,
@@ -1368,74 +1369,6 @@ def build(target: Union[DeploymentNode, DeploymentFunctionNode]) -> Application:
     # TODO(edoakes): this should accept host and port, but we don't
     # currently support them in the REST API.
     return Application(pipeline_build(target))
-
-
-def deployment_to_schema(d: Deployment) -> DeploymentSchema:
-    """Converts a live deployment object to a corresponding structured schema.
-
-    If the deployment has a class or function, it will be attemptetd to be
-    converted to a valid corresponding import path.
-
-    init_args and init_kwargs must also be JSON-serializable or this call will
-    fail.
-    """
-    from ray.serve.pipeline.json_serde import convert_to_json_safe_obj
-
-    if d.ray_actor_options is not None:
-        ray_actor_options_schema = RayActorOptionsSchema.parse_obj(d.ray_actor_options)
-    else:
-        ray_actor_options_schema = None
-
-    return DeploymentSchema(
-        name=d.name,
-        import_path=get_deployment_import_path(
-            d, enforce_importable=True, replace_main=True
-        ),
-        init_args=convert_to_json_safe_obj(d.init_args, err_key="init_args"),
-        init_kwargs=convert_to_json_safe_obj(d.init_kwargs, err_key="init_kwargs"),
-        num_replicas=d.num_replicas,
-        route_prefix=d.route_prefix,
-        max_concurrent_queries=d.max_concurrent_queries,
-        user_config=d.user_config,
-        autoscaling_config=d._config.autoscaling_config,
-        graceful_shutdown_wait_loop_s=d._config.graceful_shutdown_wait_loop_s,
-        graceful_shutdown_timeout_s=d._config.graceful_shutdown_timeout_s,
-        health_check_period_s=d._config.health_check_period_s,
-        health_check_timeout_s=d._config.health_check_timeout_s,
-        ray_actor_options=ray_actor_options_schema,
-    )
-
-
-def schema_to_deployment(s: DeploymentSchema) -> Deployment:
-    from ray.serve.pipeline.json_serde import convert_from_json_safe_obj
-
-    if s.ray_actor_options is None:
-        ray_actor_options = None
-    else:
-        ray_actor_options = s.ray_actor_options.dict(exclude_unset=True)
-
-    config = DeploymentConfig.from_default(
-        ignore_none=True,
-        num_replicas=s.num_replicas,
-        user_config=s.user_config,
-        max_concurrent_queries=s.max_concurrent_queries,
-        _autoscaling_config=s.autoscaling_config,
-        _graceful_shutdown_wait_loop_s=s.graceful_shutdown_wait_loop_s,
-        _graceful_shutdown_timeout_s=s.graceful_shutdown_timeout_s,
-        _health_check_period_s=s.health_check_period_s,
-        _health_check_timeout_s=s.health_check_timeout_s,
-    )
-    
-    return Deployment(
-        func_or_class=s.import_path,
-        name=s.name,
-        config=config,
-        init_args=convert_from_json_safe_obj(s.init_args, err_key="init_args"),
-        init_kwargs=convert_from_json_safe_obj(s.init_kwargs, err_key="init_kwargs"),
-        route_prefix=s.route_prefix,
-        ray_actor_options=ray_actor_options,
-        _internal=True,
-    )
 
 
 def serve_application_to_schema(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1369,34 +1369,3 @@ def build(target: Union[DeploymentNode, DeploymentFunctionNode]) -> Application:
     # TODO(edoakes): this should accept host and port, but we don't
     # currently support them in the REST API.
     return Application(pipeline_build(target))
-
-
-def status_info_to_schema(
-    deployment_name: str, status_info: Union[DeploymentStatusInfo, Dict]
-) -> DeploymentStatusSchema:
-    if isinstance(status_info, DeploymentStatusInfo):
-        return DeploymentStatusSchema(
-            name=deployment_name, status=status_info.status, message=status_info.message
-        )
-    elif isinstance(status_info, dict):
-        return DeploymentStatusSchema(
-            name=deployment_name,
-            status=status_info["status"],
-            message=status_info["message"],
-        )
-    else:
-        raise TypeError(
-            f"Got {type(status_info)} as status_info's "
-            "type. Expected status_info to be either a "
-            "DeploymentStatusInfo or a dictionary."
-        )
-
-
-def serve_application_status_to_schema(
-    status_infos: Dict[str, Union[DeploymentStatusInfo, Dict]]
-) -> ServeApplicationStatusSchema:
-    schemas = [
-        status_info_to_schema(deployment_name, status_info)
-        for deployment_name, status_info in status_infos.items()
-    ]
-    return ServeApplicationStatusSchema(statuses=schemas)

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1371,18 +1371,6 @@ def build(target: Union[DeploymentNode, DeploymentFunctionNode]) -> Application:
     return Application(pipeline_build(target))
 
 
-def serve_application_to_schema(
-    deployments: List[Deployment],
-) -> ServeApplicationSchema:
-    return ServeApplicationSchema(
-        deployments=[deployment_to_schema(d) for d in deployments]
-    )
-
-
-def schema_to_serve_application(schema: ServeApplicationSchema) -> List[Deployment]:
-    return [schema_to_deployment(s) for s in schema.deployments]
-
-
 def status_info_to_schema(
     deployment_name: str, status_info: Union[DeploymentStatusInfo, Dict]
 ) -> DeploymentStatusSchema:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1125,7 +1125,7 @@ def deployment(
             "Manually setting num_replicas is not allowed when "
             "_autoscaling_config is provided."
         )
-    
+
     config = DeploymentConfig.from_default(
         ignore_none=True,
         num_replicas=num_replicas,

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -191,6 +191,44 @@ class DeploymentConfig(BaseModel):
         proto = DeploymentConfigProto.FromString(proto_bytes)
         return cls.from_proto(proto)
 
+    @classmethod
+    def from_default(cls, ignore_none: bool = False, **kwargs):
+        """Creates a default DeploymentConfig and overrides it with kwargs.
+
+        Only accepts the same keywords as the class. Passing in any other
+        keyword raises a ValueError.
+
+        Args:
+            ignore_none (bool): When True, any valid keywords with value None
+                are ignored, and their values stay default. Invalid keywords
+                still raise a TypeError.
+
+        Raises:
+            TypeError: when a keyword that's not an argument to the class is
+                passed in.
+        """
+
+        config = cls()
+        valid_config_options = set(config.dict().keys())
+
+        # Friendly error if a non-DeploymentConfig kwarg was passed in
+        for key, val in kwargs.items():
+            if key not in valid_config_options:
+                raise TypeError(
+                    f'Got invalid Deployment config option "{key}" '
+                    f"(with value {val}) as keyword argument. All Deployment "
+                    "config options must come from this list: "
+                    f"{list(valid_config_options)}."
+                )
+
+        if ignore_none:
+            kwargs = {key: val for key, val in kwargs.items() if val is not None}
+
+        for key, val in kwargs:
+            config.__setattr__(key, val)
+
+        return config
+
 
 class ReplicaConfig:
     def __init__(

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -224,7 +224,7 @@ class DeploymentConfig(BaseModel):
         if ignore_none:
             kwargs = {key: val for key, val in kwargs.items() if val is not None}
 
-        for key, val in kwargs:
+        for key, val in kwargs.items():
             config.__setattr__(key, val)
 
         return config

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -504,7 +504,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         health_check_period_s=s.health_check_period_s,
         health_check_timeout_s=s.health_check_timeout_s,
     )
-    
+
     return Deployment(
         func_or_class=s.import_path,
         name=s.name,

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -193,7 +193,6 @@ class Deployment:
         The returned bound deployment can be deployed or bound to other
         deployments to create a deployment graph.
         """
-        # from ray.serve.api import deployment_to_schema
 
         copied_self = copy(self)
         copied_self._init_args = []

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -25,7 +25,6 @@ from ray.serve.schema import (
 
 # TODO (shrekris-anyscale): remove following dependencies on api.py:
 # - internal_get_global_client
-# - deployment_to_schema
 
 
 @PublicAPI

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -500,11 +500,11 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         num_replicas=s.num_replicas,
         user_config=s.user_config,
         max_concurrent_queries=s.max_concurrent_queries,
-        _autoscaling_config=s.autoscaling_config,
-        _graceful_shutdown_wait_loop_s=s.graceful_shutdown_wait_loop_s,
-        _graceful_shutdown_timeout_s=s.graceful_shutdown_timeout_s,
-        _health_check_period_s=s.health_check_period_s,
-        _health_check_timeout_s=s.health_check_timeout_s,
+        autoscaling_config=s.autoscaling_config,
+        graceful_shutdown_wait_loop_s=s.graceful_shutdown_wait_loop_s,
+        graceful_shutdown_timeout_s=s.graceful_shutdown_timeout_s,
+        health_check_period_s=s.health_check_period_s,
+        health_check_timeout_s=s.health_check_timeout_s,
     )
     
     return Deployment(

--- a/python/ray/serve/pipeline/deployment_function_node.py
+++ b/python/ray/serve/pipeline/deployment_function_node.py
@@ -5,8 +5,7 @@ from ray import ObjectRef
 from ray.experimental.dag.dag_node import DAGNode
 from ray.experimental.dag.format_utils import get_dag_node_str
 from ray.experimental.dag.constants import DAGNODE_TYPE_KEY
-from ray.serve.api import schema_to_deployment
-from ray.serve.deployment import Deployment
+from ray.serve.deployment import Deployment, schema_to_deployment
 from ray.serve.config import DeploymentConfig
 from ray.serve.schema import DeploymentSchema
 from ray.serve.handle import RayServeLazySyncHandle

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -9,8 +9,7 @@ from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
 from ray.serve.pipeline.constants import USE_SYNC_HANDLE_KEY
 from ray.experimental.dag.constants import DAGNODE_TYPE_KEY
 from ray.experimental.dag.format_utils import get_dag_node_str
-from ray.serve.api import schema_to_deployment
-from ray.serve.deployment import Deployment
+from ray.serve.deployment import Deployment, schema_to_deployment
 from ray.serve.deployment_graph import RayServeDAGHandle
 from ray.serve.config import DeploymentConfig
 from ray.serve.utils import get_deployment_import_path

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -33,36 +33,84 @@ def test_autoscaling_config_validation():
     AutoscalingConfig()
 
 
-def test_deployment_config_validation():
-    # Test unknown key.
-    with pytest.raises(ValidationError):
-        DeploymentConfig(unknown_key=-1)
+class TestDeploymentConfig:
+    def test_deployment_config_validation(self):
+        # Test unknown key.
+        with pytest.raises(ValidationError):
+            DeploymentConfig(unknown_key=-1)
 
-    # Test num_replicas validation.
-    DeploymentConfig(num_replicas=1)
-    with pytest.raises(ValidationError, match="type_error"):
-        DeploymentConfig(num_replicas="hello")
-    with pytest.raises(ValidationError, match="value_error"):
-        DeploymentConfig(num_replicas=-1)
+        # Test num_replicas validation.
+        DeploymentConfig(num_replicas=1)
+        with pytest.raises(ValidationError, match="type_error"):
+            DeploymentConfig(num_replicas="hello")
+        with pytest.raises(ValidationError, match="value_error"):
+            DeploymentConfig(num_replicas=-1)
 
-    # Test dynamic default for max_concurrent_queries.
-    assert DeploymentConfig().max_concurrent_queries == 100
+        # Test dynamic default for max_concurrent_queries.
+        assert DeploymentConfig().max_concurrent_queries == 100
 
+    def test_deployment_config_update(self):
+        b = DeploymentConfig(num_replicas=1, max_concurrent_queries=1)
 
-def test_deployment_config_update():
-    b = DeploymentConfig(num_replicas=1, max_concurrent_queries=1)
+        # Test updating a key works.
+        b.num_replicas = 2
+        assert b.num_replicas == 2
+        # Check that not specifying a key doesn't update it.
+        assert b.max_concurrent_queries == 1
 
-    # Test updating a key works.
-    b.num_replicas = 2
-    assert b.num_replicas == 2
-    # Check that not specifying a key doesn't update it.
-    assert b.max_concurrent_queries == 1
+        # Check that input is validated.
+        with pytest.raises(ValidationError):
+            b.num_replicas = "Hello"
+        with pytest.raises(ValidationError):
+            b.num_replicas = -1
 
-    # Check that input is validated.
-    with pytest.raises(ValidationError):
-        b.num_replicas = "Hello"
-    with pytest.raises(ValidationError):
-        b.num_replicas = -1
+    @pytest.mark.parametrize("ignore_none", [True, False])
+    def test_from_default(self, ignore_none):
+        """Check from_default() method behavior."""
+
+        # Valid parameters
+        dc = DeploymentConfig.from_default(
+            ignore_none=ignore_none, num_replicas=5, is_cross_language=True
+        )
+        assert dc.num_replicas == 5
+        assert dc.is_cross_language is True
+
+        # Invalid parameters should raise TypeError
+        with pytest.raises(TypeError):
+            DeploymentConfig.from_default(
+                ignore_none=ignore_none, num_replicas=5, is_xlang=True
+            )
+
+        # Validation should still be performed
+        with pytest.raises(ValidationError):
+            DeploymentConfig.from_default(
+                ignore_none=ignore_none, num_replicas="hello world"
+            )
+
+    def test_from_default_ignore_none(self):
+        """Check from_default()'s ignore_none parameter"""
+
+        default = DeploymentConfig()
+
+        # Valid parameter with None passed in should be ignored
+        dc = DeploymentConfig.from_default(ignore_none=True, num_replicas=None)
+
+        # Invalid parameter should raise TypeError no matter what
+        with pytest.raises(TypeError):
+            DeploymentConfig.from_default(ignore_none=True, fake=5)
+        with pytest.raises(TypeError):
+            DeploymentConfig.from_default(ignore_none=False, fake=5)
+
+        # Validators should run no matter what
+        dc = DeploymentConfig.from_default(
+            ignore_none=True, max_concurrent_queries=None
+        )
+        assert dc.max_concurrent_queries == default.max_concurrent_queries
+        dc = DeploymentConfig.from_default(
+            ignore_none=False, max_concurrent_queries=None
+        )
+        assert dc.max_concurrent_queries is not None
+        assert dc.max_concurrent_queries == default.max_concurrent_queries
 
 
 def test_replica_config_validation():

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -19,12 +19,14 @@ from ray.serve.config import AutoscalingConfig
 from ray.serve.common import DeploymentStatus, DeploymentStatusInfo
 from ray.serve.api import (
     get_deployment_statuses,
-    deployment_to_schema,
-    schema_to_deployment,
     serve_application_to_schema,
     schema_to_serve_application,
     status_info_to_schema,
     serve_application_status_to_schema,
+)
+from ray.serve.deployment import (
+    deployment_to_schema,
+    schema_to_deployment,
 )
 from ray import serve
 

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -19,8 +19,6 @@ from ray.serve.config import AutoscalingConfig
 from ray.serve.common import DeploymentStatus, DeploymentStatusInfo
 from ray.serve.api import (
     get_deployment_statuses,
-    serve_application_to_schema,
-    schema_to_serve_application,
     status_info_to_schema,
     serve_application_status_to_schema,
 )
@@ -574,7 +572,7 @@ def test_unset_fields_schema_to_deployment_ray_actor_options():
     assert len(deployment.ray_actor_options) == 0
 
 
-def test_serve_application_to_schema_to_serve_application():
+def test_status_schema_helpers():
     @serve.deployment(
         num_replicas=1,
         route_prefix="/hello",
@@ -594,21 +592,10 @@ def test_serve_application_to_schema_to_serve_application():
     f1._func_or_class = "ray.serve.tests.test_schema.global_f"
     f2._func_or_class = "ray.serve.tests.test_schema.global_f"
 
-    deployments = schema_to_serve_application(serve_application_to_schema([f1, f2]))
-
-    assert deployments[0].num_replicas == 1
-    assert deployments[0].route_prefix == "/hello"
-    assert deployments[1].num_replicas == 2
-    assert deployments[1].route_prefix == "/hi"
-
     serve.start()
 
-    deployments[0].deploy()
-    deployments[1].deploy()
-    assert ray.get(deployments[0].get_handle().remote()) == "Hello world!"
-    assert requests.get("http://localhost:8000/hello").text == "Hello world!"
-    assert ray.get(deployments[1].get_handle().remote()) == "Hello world!"
-    assert requests.get("http://localhost:8000/hi").text == "Hello world!"
+    f1.deploy()
+    f2.deploy()
 
     # Check statuses
     statuses = serve_application_status_to_schema(get_deployment_statuses()).statuses

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -13,15 +13,13 @@ from ray.serve.schema import (
     DeploymentStatusSchema,
     ServeApplicationSchema,
     ServeApplicationStatusSchema,
+    status_info_to_schema,
+    serve_application_status_to_schema,
 )
 from ray.util.accelerators.accelerators import NVIDIA_TESLA_V100, NVIDIA_TESLA_P4
 from ray.serve.config import AutoscalingConfig
 from ray.serve.common import DeploymentStatus, DeploymentStatusInfo
-from ray.serve.api import (
-    get_deployment_statuses,
-    status_info_to_schema,
-    serve_application_status_to_schema,
-)
+from ray.serve.api import get_deployment_statuses
 from ray.serve.deployment import (
     deployment_to_schema,
     schema_to_deployment,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`api.py` contains helper functions used internally to convert common data structures like `Deployment` to a schema and back. This causes cyclic dependencies and delayed import. This change moves (and in some cases removes) these helper functions to reduce delayed imports.

Functions moved:

* `deployment_to_schema` (to `deployment.py`)
* `schema_to_deployment` (to `deployment.py`)
* `status_info_to_schema` (to `schema.py`)
* `serve_application_status_to_schema` (to `schema.py`)

Functions removed:

* `serve_application_to_schema`
* `schema_to_serve_application`

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests only.
