### PR TITLE
[GCS] Use gRPC instead of socket for GCS client health check

### DIFF
--- a/src/ray/common/network_util.cc
+++ b/src/ray/common/network_util.cc
@@ -190,12 +190,6 @@ bool NameStartsWith(const std::string &name, const std::string &prefix) {
 }
 }  // namespace NetIf
 
-bool Ping(const std::string &ip, int port, int64_t timeout_ms) {
-  AsyncClient client;
-  bool is_timeout;
-  return client.Connect(ip, port, timeout_ms, &is_timeout);
-}
-
 bool CheckFree(int port) {
   instrumented_io_context io_service;
   tcp::socket socket(io_service);

--- a/src/ray/common/network_util.h
+++ b/src/ray/common/network_util.h
@@ -130,14 +130,6 @@ class AsyncClient {
 /// \return a valid local ip.
 std::string GetValidLocalIp(int port, int64_t timeout_ms);
 
-/// A helper function to test whether target rpc server is valid.
-///
-/// \param ip The ip that the target rpc server is listening on.
-/// \param port The port that the target rpc server is listening on.
-/// \param timeout_ms The maximum wait time in milliseconds.
-/// \return Whether target rpc server is valid.
-bool Ping(const std::string &ip, int port, int64_t timeout_ms);
-
 bool CheckFree(int port);
 
 /// \namespace NetIf

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -203,6 +203,7 @@ bool GcsClient::CheckHealth(const std::string &ip, int port, int64_t timeout_ms)
   return true;
 }
 
+// TODO(iycheng, mwtian): rework the reconnection logic for GCS HA.
 void GcsClient::PeriodicallyCheckGcsConnection() {
   if (disconnected_) {
     return;

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -170,6 +170,9 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<InternalKVAccessor> internal_kv_accessor_;
 
  private:
+  /// Checks whether GCS at the specified address is healthy.
+  bool CheckHealth(const std::string &ip, int port, int64_t timeout_ms);
+
   /// Fire a periodic timer to check if GCS sever address has changed.
   void PeriodicallyCheckGcsServerAddress();
 
@@ -198,6 +201,7 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::pair<std::string, int> current_gcs_server_address_;
   int64_t last_reconnect_timestamp_ms_;
   std::pair<std::string, int> last_reconnect_address_;
+  std::optional<rpc::GcsServiceFailureType> current_connection_failure_;
 
   /// Retry interval to reconnect to a GCS server.
   const int64_t kGCSReconnectionRetryIntervalMs = 1000;

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -173,8 +173,8 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   /// Checks whether GCS at the specified address is healthy.
   bool CheckHealth(const std::string &ip, int port, int64_t timeout_ms);
 
-  /// Fire a periodic timer to check if GCS sever address has changed.
-  void PeriodicallyCheckGcsServerAddress();
+  /// Fires a periodic timer to check if the connection to GCS is healthy.
+  void PeriodicallyCheckGcsConnection();
 
   /// This function is used to redo subscription and reconnect to GCS RPC server when gcs
   /// service failure is detected.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A user has reported a crash in GCS client where the client was unable to connect to the GCS server after retries, even when GCS server has always been running. I was not able to reproduce the exact issue, but noticed that the health check logic with socket has unexpected behavior sometimes, e.g. it is much slower to use socket for health check compared to using gRPC (~40s vs < 1s sometimes). The user issue could be related to this slowness, so this PR updates the logic to use gRPC health check.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
