### PR TITLE
[RLlib] [Docs] Fix RLLib example link.

### DIFF
--- a/doc/source/rllib/rllib-examples.rst
+++ b/doc/source/rllib/rllib-examples.rst
@@ -49,7 +49,7 @@ Environments and Adapters
    Coin Game Env Example (provided by the "Center on Long Term Risk").
 - `DMLab Watermaze example <https://github.com/ray-project/ray/blob/master/rllib/examples/dmlab_watermaze.py>`__:
    Example for how to use a DMLab environment (Watermaze).
-- `RecSym environment example (for recommender systems) using the SlateQ algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/recsim_with_slateq.py>`__:
+- `RecSym environment example (for recommender systems) using the SlateQ algorithm <https://github.com/ray-project/ray/blob/master/rllib/examples/recommender_system_with_recsim_and_slateq.py>`__:
    Script showing how to train a SlateQTrainer on a RecSym environment.
 - `SUMO (Simulation of Urban MObility) environment example <https://github.com/ray-project/ray/blob/master/rllib/examples/sumo_env_local.py>`__:
    Example demonstrating how to use the SUMO simulator in connection with RLlib.


### PR DESCRIPTION
This old example was deleted in [this commit](https://github.com/ray-project/ray/commit/c38a29573fa7e1b749666230924ae5d7196027fe#diff-a9306793e50066431972a0fe8ffc788c98fe4fa247a880d274f30ca1bb42aabc), breaking our LinkCheck stage in CI. This updates the link to the new example location: https://github.com/ray-project/ray/blob/master/rllib/examples/recommender_system_with_recsim_and_slateq.py