### PR TITLE
[Tune] Logging of bad results dict keys

### DIFF
--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -176,8 +176,10 @@ class CheckpointManager:
         except KeyError:
             logger.error(
                 "Result dict has no key: {}. "
-                "checkpoint_score_attr must be set to a key in the "
-                "result dict.".format(self._checkpoint_score_attr)
+                "checkpoint_score_attr must be set to a key of the "
+                "result dict. Valid keys are {}".format(
+                    self._checkpoint_score_attr, list(
+                        checkpoint.result.keys()))
             )
             return
 

--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -178,8 +178,8 @@ class CheckpointManager:
                 "Result dict has no key: {}. "
                 "checkpoint_score_attr must be set to a key of the "
                 "result dict. Valid keys are {}".format(
-                    self._checkpoint_score_attr, list(
-                        checkpoint.result.keys()))
+                    self._checkpoint_score_attr, list(checkpoint.result.keys())
+                )
             )
             return
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -619,9 +619,8 @@ class Trial:
         for criteria, stop_value in self.stopping_criterion.items():
             if criteria not in result:
                 raise TuneError(
-                    "Stopping criteria {} not provided in result {}.".format(
-                        criteria, result
-                    )
+                    "Stopping criteria {} not provided in result dict. Keys "
+                    "are {}.".format(criteria, list(result.keys()))
                 )
             elif isinstance(criteria, dict):
                 raise ValueError(


### PR DESCRIPTION
## Why are these changes needed?

[User complains](https://discuss.ray.io/t/which-attributes-can-be-used-in-checkpoint-score-attr-when-using-tune-run/5826) about logging on failure of locating `checkpoint_score_attr ` in results dict not being informative.
I propose that we log the actual results dict keys and extended stopping criteria, which imho should not log the whole result dict as this might contain tensors.

Maybe there are other similar cases in tune library, in which I don't know my way around that good.


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
