### PR TITLE
[Core] [Tests] Skip memory limit determination test for Windows.

### DIFF
--- a/python/ray/tests/test_advanced_8.py
+++ b/python/ray/tests/test_advanced_8.py
@@ -274,6 +274,7 @@ def test_accelerator_type_api(shutdown_only):
     wait_for_condition(lambda: ray.available_resources()[resource_name] < quantity)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="not relevant for windows")
 def test_get_system_memory():
     # cgroups v1, set
     with tempfile.NamedTemporaryFile("w") as memory_limit_file:


### PR DESCRIPTION
Memory limit determination test is not relevant for Windows; we already skip the CPU limit determination tests for Windows, so we skip for the memory limit determination as well.