### PR TITLE
[CoreWorker API] collect mobius used core worker api to internal

### DIFF
--- a/src/ray/internal/internal.cc
+++ b/src/ray/internal/internal.cc
@@ -53,8 +53,20 @@ std::vector<rpc::ObjectReference> SendInternal(const ActorID &peer_actor_id,
   }
   return result.value();
 }
+
 const ray::stats::TagKeyType TagRegister(const std::string tag_name) {
   return ray::stats::TagKeyType::Register(tag_name);
 }
+
+const ActorID &GetCurrentActorID() {
+  return CoreWorkerProcess::GetCoreWorker().GetWorkerContext().GetCurrentActorID();
+}
+
+bool IsInitialized() { return CoreWorkerProcess::IsInitialized(); }
+
+void SetCurrentThreadWorker(const WorkerID &worker_id) {
+  CoreWorkerProcess::SetCurrentThreadWorkerId(worker_id);
+}
+
 }  // namespace internal
 }  // namespace ray

--- a/src/ray/internal/internal.h
+++ b/src/ray/internal/internal.h
@@ -36,5 +36,17 @@ std::vector<rpc::ObjectReference> SendInternal(const ActorID &peer_actor_id,
                                                int return_num);
 
 const stats::TagKeyType TagRegister(const std::string tag_name);
+
+/// Get current actor id via internal.
+const ActorID &GetCurrentActorID();
+
+/// Set the core worker associated with the current thread by worker ID.
+/// Currently used by Java worker only.
+///
+/// \param worker_id The worker ID of the core worker instance.
+void SetCurrentThreadWorker(const WorkerID &worker_id);
+
+/// Get core worker initialization flag via internal.
+bool IsInitialized();
 }  // namespace internal
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
To remove symbols conflict effect on core worker linked different ray versions. This PR extracts an united core worker api (not all) and collect them into a internal library, so native devs can use them anywhere no matter the core worker implementation changes.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/23960
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
