### PR TITLE
[Docs] Fix actor fault tolerance link.

### DIFF
--- a/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
+++ b/doc/source/ray-core/actors/patterns/fault-tolerance-actor-checkpointing.rst
@@ -1,7 +1,7 @@
 Pattern: Fault Tolerance with Actor Checkpointing
 =================================================
 
-Ray offers support for task and actor `fault tolerance <https://docs.ray.io/en/latest/fault-tolerance.html>`__. Specifically for actors, you can specify max_restarts to automatically enable restart for Ray actors. This means when your actor or the node hosting that actor crashed, the actor will be automatically reconstructed. However, this doesn’t provide ways for you to restore application level states in your actor. You checkpoint your actor periodically and read from the checkpoint if possible.
+Ray offers support for task and actor `fault tolerance <https://docs.ray.io/en/latest/ray-core/actors/fault-tolerance.html>`__. Specifically for actors, you can specify max_restarts to automatically enable restart for Ray actors. This means when your actor or the node hosting that actor crashed, the actor will be automatically reconstructed. However, this doesn’t provide ways for you to restore application level states in your actor. You checkpoint your actor periodically and read from the checkpoint if possible.
 
 There are several ways to checkpoint:
 


### PR DESCRIPTION
This PR fixes a link to the actor fault tolerance page. This is currently breaking LinkCheck in our CI.