### PR TITLE
[Pubsub] reduce memory usage for channels that do not require total memory cap

### DIFF
--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -102,7 +102,8 @@ using SubscriptionFailureCallbackMap =
 // static maps are used to simulate distirubted environment.
 static SubscriptionCallbackMap subscription_callback_map;
 static SubscriptionFailureCallbackMap subscription_failure_callback_map;
-static pubsub::pub_internal::SubscriptionIndex directory;
+static pubsub::pub_internal::SubscriptionIndex directory(
+    rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL);
 
 static std::string GenerateID(UniqueID publisher_id, UniqueID subscriber_id) {
   return publisher_id.Binary() + subscriber_id.Binary();

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -33,7 +33,7 @@ bool BasicEntityState::Publish(const rpc::PubMessage &pub_message) {
   return true;
 }
 
-bool StreamEntityState::Publish(const rpc::PubMessage &pub_message) {
+bool CappedEntityState::Publish(const rpc::PubMessage &pub_message) {
   if (subscribers_.empty()) {
     return false;
   }
@@ -233,11 +233,14 @@ bool SubscriptionIndex::CheckNoLeaks() const {
 }
 
 std::unique_ptr<EntityState> SubscriptionIndex::CreateEntityState() {
-  if (channel_type_ == rpc::ChannelType::RAY_ERROR_INFO_CHANNEL ||
-      channel_type_ == rpc::ChannelType::RAY_LOG_CHANNEL) {
-    return std::make_unique<StreamEntityState>();
+  switch (channel_type_) {
+  case rpc::ChannelType::RAY_ERROR_INFO_CHANNEL:
+  case rpc::ChannelType::RAY_LOG_CHANNEL: {
+    return std::make_unique<CappedEntityState>();
   }
-  return std::make_unique<BasicEntityState>();
+  default:
+    return std::make_unique<BasicEntityState>();
+  }
 }
 
 void SubscriberState::ConnectToSubscriber(const rpc::PubsubLongPollingRequest &request,

--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -22,7 +22,18 @@ namespace pubsub {
 
 namespace pub_internal {
 
-bool EntityState::Publish(const rpc::PubMessage &pub_message) {
+bool BasicEntityState::Publish(const rpc::PubMessage &pub_message) {
+  if (subscribers_.empty()) {
+    return false;
+  }
+  const auto msg = std::make_shared<rpc::PubMessage>(pub_message);
+  for (auto &[id, subscriber] : subscribers_) {
+    subscriber->QueueMessage(msg);
+  }
+  return true;
+}
+
+bool StreamEntityState::Publish(const rpc::PubMessage &pub_message) {
   if (subscribers_.empty()) {
     return false;
   }
@@ -90,24 +101,32 @@ const absl::flat_hash_map<SubscriberID, SubscriberState *> &EntityState::Subscri
   return subscribers_;
 }
 
+SubscriptionIndex::SubscriptionIndex(rpc::ChannelType channel_type)
+    : channel_type_(channel_type), subscribers_to_all_(CreateEntityState()) {}
+
 bool SubscriptionIndex::Publish(const rpc::PubMessage &pub_message) {
-  const bool publish_to_all = subscribers_to_all_.Publish(pub_message);
+  const bool publish_to_all = subscribers_to_all_->Publish(pub_message);
   bool publish_to_entity = false;
   auto it = entities_.find(pub_message.key_id());
   if (it != entities_.end()) {
-    publish_to_entity = it->second.Publish(pub_message);
+    publish_to_entity = it->second->Publish(pub_message);
   }
   return publish_to_all || publish_to_entity;
 }
 
 bool SubscriptionIndex::AddEntry(const std::string &key_id, SubscriberState *subscriber) {
   if (key_id.empty()) {
-    return subscribers_to_all_.AddSubscriber(subscriber);
+    return subscribers_to_all_->AddSubscriber(subscriber);
   }
 
   auto &subscribing_key_ids = subscribers_to_key_id_[subscriber->id()];
   const bool key_added = subscribing_key_ids.emplace(key_id).second;
-  const bool subscriber_added = entities_[key_id].AddSubscriber(subscriber);
+
+  auto sub_it = entities_.find(key_id);
+  if (sub_it == entities_.end()) {
+    sub_it = entities_.emplace(key_id, CreateEntityState()).first;
+  }
+  const bool subscriber_added = sub_it->second->AddSubscriber(subscriber);
 
   RAY_CHECK(key_added == subscriber_added);
   return key_added;
@@ -116,14 +135,14 @@ bool SubscriptionIndex::AddEntry(const std::string &key_id, SubscriberState *sub
 std::vector<SubscriberID> SubscriptionIndex::GetSubscriberIdsByKeyId(
     const std::string &key_id) const {
   std::vector<SubscriberID> subscribers;
-  if (!subscribers_to_all_.Subscribers().empty()) {
-    for (const auto &[sub_id, sub] : subscribers_to_all_.Subscribers()) {
+  if (!subscribers_to_all_->Subscribers().empty()) {
+    for (const auto &[sub_id, sub] : subscribers_to_all_->Subscribers()) {
       subscribers.push_back(sub_id);
     }
   }
   auto it = entities_.find(key_id);
   if (it != entities_.end()) {
-    for (const auto &[sub_id, sub] : it->second.Subscribers()) {
+    for (const auto &[sub_id, sub] : it->second->Subscribers()) {
       subscribers.push_back(sub_id);
     }
   }
@@ -132,7 +151,7 @@ std::vector<SubscriberID> SubscriptionIndex::GetSubscriberIdsByKeyId(
 
 bool SubscriptionIndex::EraseSubscriber(const SubscriberID &subscriber_id) {
   // Erase subscriber of all keys.
-  if (subscribers_to_all_.RemoveSubscriber(subscriber_id)) {
+  if (subscribers_to_all_->RemoveSubscriber(subscriber_id)) {
     return true;
   }
 
@@ -149,7 +168,7 @@ bool SubscriptionIndex::EraseSubscriber(const SubscriberID &subscriber_id) {
     if (entity_it == entities_.end()) {
       continue;
     }
-    auto &entity = entity_it->second;
+    auto &entity = *entity_it->second;
     entity.RemoveSubscriber(subscriber_id);
     if (entity.Subscribers().empty()) {
       entities_.erase(entity_it);
@@ -163,7 +182,7 @@ bool SubscriptionIndex::EraseEntry(const std::string &key_id,
                                    const SubscriberID &subscriber_id) {
   // Erase the subscriber of all keys.
   if (key_id.empty()) {
-    return subscribers_to_all_.RemoveSubscriber(subscriber_id);
+    return subscribers_to_all_->RemoveSubscriber(subscriber_id);
   }
 
   // Erase keys from the subscriber of individual keys.
@@ -176,7 +195,7 @@ bool SubscriptionIndex::EraseEntry(const std::string &key_id,
   if (object_it == objects.end()) {
     auto it = entities_.find(key_id);
     if (it != entities_.end()) {
-      RAY_CHECK(!it->second.Subscribers().contains(subscriber_id));
+      RAY_CHECK(!it->second->Subscribers().contains(subscriber_id));
     }
     return false;
   }
@@ -189,7 +208,7 @@ bool SubscriptionIndex::EraseEntry(const std::string &key_id,
   auto entity_it = entities_.find(key_id);
   // If code reaches this line, that means the object id was in the index.
   RAY_CHECK(entity_it != entities_.end());
-  auto &entity = entity_it->second;
+  auto &entity = *entity_it->second;
   // If code reaches this line, that means the subscriber id was in the index.
   RAY_CHECK(entity.RemoveSubscriber(subscriber_id));
   if (entity.Subscribers().empty()) {
@@ -203,7 +222,7 @@ bool SubscriptionIndex::HasKeyId(const std::string &key_id) const {
 }
 
 bool SubscriptionIndex::HasSubscriber(const SubscriberID &subscriber_id) const {
-  if (subscribers_to_all_.Subscribers().contains(subscriber_id)) {
+  if (subscribers_to_all_->Subscribers().contains(subscriber_id)) {
     return true;
   }
   return subscribers_to_key_id_.contains(subscriber_id);
@@ -211,6 +230,14 @@ bool SubscriptionIndex::HasSubscriber(const SubscriberID &subscriber_id) const {
 
 bool SubscriptionIndex::CheckNoLeaks() const {
   return entities_.empty() && subscribers_to_key_id_.empty();
+}
+
+std::unique_ptr<EntityState> SubscriptionIndex::CreateEntityState() {
+  if (channel_type_ == rpc::ChannelType::RAY_ERROR_INFO_CHANNEL ||
+      channel_type_ == rpc::ChannelType::RAY_LOG_CHANNEL) {
+    return std::make_unique<StreamEntityState>();
+  }
+  return std::make_unique<BasicEntityState>();
 }
 
 void SubscriberState::ConnectToSubscriber(const rpc::PubsubLongPollingRequest &request,

--- a/src/ray/pubsub/test/publisher_test.cc
+++ b/src/ray/pubsub/test/publisher_test.cc
@@ -115,7 +115,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexSingeNodeSingleObject) {
   /// Test single node id & object id
   ///
   /// oid1 -> [nid1]
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
   subscription_index.AddEntry(oid.Binary(), subscriber);
   const auto &subscribers_from_index =
       subscription_index.GetSubscriberIdsByKeyId(oid.Binary());
@@ -127,7 +127,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexMultiNodeSingleObject) {
   /// Test single object id & multi nodes
   ///
   /// oid1 -> [nid1~nid5]
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
   const auto oid = ObjectID::FromRandom();
   absl::flat_hash_set<NodeID> empty_set;
   subscribers_map_.emplace(oid, empty_set);
@@ -177,7 +177,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexErase) {
   ///
   /// oid1 -> [nid1~nid5]
   /// oid2 -> [nid1~nid5]
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
   int total_entries = 6;
   int entries_to_delete_at_each_time = 3;
   auto oid = ObjectID::FromRandom();
@@ -226,7 +226,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexEraseMultiSubscribers) {
   ///
   /// Test erase the duplicated entries with multi subscribers.
   ///
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
   auto oid = ObjectID::FromRandom();
   auto oid2 = ObjectID::FromRandom();
   absl::flat_hash_set<NodeID> empty_set;
@@ -250,7 +250,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexEraseSubscriber) {
   ///
   /// Test erase subscriber.
   ///
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
   auto oid = ObjectID::FromRandom();
   auto &subscribers = subscribers_map_[oid];
   std::vector<SubscriberID> subscriber_ids;
@@ -282,7 +282,7 @@ TEST_F(PublisherTest, TestSubscriptionIndexIdempotency) {
   auto *subscriber = CreateSubscriber();
   auto subscriber_id = subscriber->id();
   auto oid = ObjectID::FromRandom();
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
 
   // Add the same entry many times.
   for (int i = 0; i < 5; i++) {
@@ -1040,7 +1040,7 @@ class ScopedEntityBufferMaxBytes {
 TEST_F(PublisherTest, TestMaxBufferSizePerEntity) {
   ScopedEntityBufferMaxBytes max_bytes(10000);
 
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
   auto job_id = JobID::FromInt(1234);
   auto *subscriber = CreateSubscriber();
   // Subscribe to job_id.
@@ -1082,7 +1082,7 @@ TEST_F(PublisherTest, TestMaxBufferSizePerEntity) {
 TEST_F(PublisherTest, TestMaxBufferSizeAllEntities) {
   ScopedEntityBufferMaxBytes max_bytes(10000);
 
-  SubscriptionIndex subscription_index;
+  SubscriptionIndex subscription_index(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
   auto *subscriber = CreateSubscriber();
   // Subscribe to all entities.
   subscription_index.AddEntry("", subscriber);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In https://github.com/ray-project/ray/commit/a1e06f64aecd2bd17d3c995211a2aaeffd03925a, memory bound was added for each subscribed entity in the publisher. It adds two extra `std::deque` per subscribed entity, which turns out to cost a lot more memory when there are a large number of `ObjectRef`s: https://github.com/ray-project/ray/pull/23853#issuecomment-1098382286

This PR avoids the extra memory usage for entities in channels unlikely to grow too large, i.e. all channels except those for logs and error info. Subscribed entity memory usage no longer shows up in the memory profile when there are 1M object refs:
<img width="1651" alt="image" src="https://user-images.githubusercontent.com/81660174/163888671-3f288940-172c-4db2-b518-c41743a96d08.png">
Raw data: [profile006.pb.gz](https://github.com/ray-project/ray/files/8508547/profile006.pb.gz)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#23604
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
