### PR TITLE
[Core] remove Windows compatibility for Redis

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -83,11 +83,6 @@ def _configure_system():
     )
     sys.path.insert(0, thirdparty_files)
 
-    if sys.platform == "win32":
-        import ray._private.compat  # noqa: E402
-
-        ray._private.compat.patch_redis_empty_recv()
-
     if (
         platform.system() == "Linux"
         and "Microsoft".lower() in platform.release().lower()

--- a/python/ray/_private/compat.py
+++ b/python/ray/_private/compat.py
@@ -1,8 +1,5 @@
-import errno
 import io
 import platform
-import socket
-import sys
 
 
 def patch_psutil():

--- a/python/ray/_private/compat.py
+++ b/python/ray/_private/compat.py
@@ -5,26 +5,6 @@ import socket
 import sys
 
 
-def patch_redis_empty_recv():
-    """On Windows, socket disconnect result in errors rather than empty reads.
-    redis-py does not handle these errors correctly.
-    This patch translates connection resets to empty reads as in POSIX.
-    """
-    assert sys.platform == "win32"
-    import redis
-
-    def redis_recv(sock, *args, **kwargs):
-        result = b""
-        try:
-            result = redis._compat.recv(sock, *args, **kwargs)
-        except socket.error as ex:
-            if ex.errno not in [errno.ECONNRESET, errno.ECONNREFUSED]:
-                raise
-        return result
-
-    redis.connection.recv = redis_recv
-
-
 def patch_psutil():
     """WSL's /proc/meminfo has an inconsistency where it
     nondeterministically omits a space after colons (after "SwapFree:"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,6 @@
 #
 # setup.py install_requires
 aiohttp>=3.7
-aioredis < 2
 aiosignal
 click >= 7.0, <= 8.0.4
 cloudpickle
@@ -23,7 +22,6 @@ protobuf >= 3.8.0
 py-spy >= 0.2.0
 pydantic >= 1.8
 pyyaml
-redis >= 3.5.0, < 4.0.0
 requests
 smart_open
 virtualenv
@@ -83,6 +81,7 @@ pytest-sugar
 pytest-lazy-fixture
 pytest-timeout
 pytest-virtualenv
+redis >= 3.5.0, < 4.0.0
 scikit-learn==0.22.2
 testfixtures
 werkzeug


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There should be no reference to Redis in Python anymore except parts of bootstrap code path.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
closes #23982
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
