### PR TITLE
[Release] Fix XGBoost Golden Notebook Tests

### DIFF
--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -21,4 +21,4 @@ post_build_cmds:
   - echo {{ env["TIMESTAMP"] }}
   - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
   - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.
-  - pip3 install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
+  - pip install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray

--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -17,3 +17,8 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
+  - # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
+  - echo {{ env["TIMESTAMP"] }}
+  - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
+  - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.
+  - pip3 install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray

--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -17,7 +17,7 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
+  # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
   - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
   - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -22,5 +22,5 @@ post_build_cmds:
   - echo {{ env["TIMESTAMP"] }}
   - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
   - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.
-  - pip3 install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
+  - pip install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
 

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -18,3 +18,9 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
+  - # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
+  - echo {{ env["TIMESTAMP"] }}
+  - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
+  - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.
+  - pip3 install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
+

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -18,7 +18,7 @@ post_build_cmds:
   - pip uninstall -y ray || true
   - pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
+  # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
   - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
   - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Xgboost released a new version a few days ago. Due to caching of the Anyscale cluster env, this resulted in the server having an outdated xgboost version while the client has the most recent version causing the test to fail.

Instead, we reinstall xgboost-ray and xgboost in the post build commands so that these dependencies are not being cached in the cluster env.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
