### PR TITLE
[Core][nightly-test] fix shuffle 5000 partition OOM

### DIFF
--- a/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
@@ -9,12 +9,12 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type:  m5.4xlarge
+    instance_type:  m5.8xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.4xlarge
+      instance_type: m5.8xlarge
       min_workers: 19
       max_workers: 19
       use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

closes #23992
https://github.com/ray-project/ray/pull/23781 changed the machine type where the memory capacity dropped from 128GB to 64GB and thus shuffle_1tb_5000_partitions starts OOMing.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
