### PR TITLE
Pinning gym to 0.21 to fix test issues

### DIFF
--- a/python/ray/tune/requirements-dev.txt
+++ b/python/ray/tune/requirements-dev.txt
@@ -1,6 +1,6 @@
 flake8==3.9.1
 flake8-quotes
-gym
+gym==0.21
 scikit-image
 pandas
 requests

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -31,7 +31,7 @@ virtualenv
 ## setup.py extras
 dm_tree
 flask
-gym>=0.21.0,<0.22.0; python_version >= '3.7'
+gym==0.21.0; python_version >= '3.7'
 gym==0.19.0; python_version < '3.7'
 lz4
 scikit-image

--- a/python/requirements/ml/requirements_rllib.txt
+++ b/python/requirements/ml/requirements_rllib.txt
@@ -4,7 +4,7 @@
 # ---------------------
 # Atari
 autorom[accept-rom-license]
-gym[atari]>=0.21.0,<0.22.0; python_version >= '3.7'
+gym[atari]==0.21.0; python_version >= '3.7'
 gym[atari]==0.19.0; python_version < '3.7'
 # Kaggle envs.
 kaggle_environments==1.7.11

--- a/python/requirements/ml/requirements_tune.txt
+++ b/python/requirements/ml/requirements_tune.txt
@@ -11,7 +11,7 @@ freezegun==1.1.0
 gluoncv==0.10.1.post0
 gpy==1.10.0
 autorom[accept-rom-license]
-gym[atari]>=0.21.0,<0.22.0; python_version >= '3.7'
+gym[atari]==0.21.0; python_version >= '3.7'
 gym[atari]==0.19.0; python_version < '3.7'
 h5py==3.1.0
 hpbandster==0.7.4


### PR DESCRIPTION
see https://github.com/openai/gym/pull/2639

for more details

tldr; Theres some issue with RandomNumberGenerator pickling and the pr even mentions RLlib as being broken by gym 0.22

This breakage is also causing issues with the red tests on flakey tests ray io:
<img width="281" alt="image" src="https://user-images.githubusercontent.com/38871737/163916541-f88bafb1-519e-4377-8183-52dd36be7905.png">


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
