### PR TITLE
[Test] Fix test_log 

### DIFF
--- a/dashboard/modules/log/tests/test_log.py
+++ b/dashboard/modules/log/tests/test_log.py
@@ -40,6 +40,12 @@ def test_log(disable_aiohttp_cache, ray_start_with_dashboard):
 
     test_log_text = "test_log_text"
     ray.get(write_log.remote(test_log_text))
+
+    test_file = "test.log"
+    with open(
+        f"{ray.worker.global_worker.node.get_logs_dir_path()}/{test_file}", "w"
+    ) as f:
+        f.write(test_log_text)
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
@@ -81,10 +87,10 @@ def test_log(disable_aiohttp_cache, ray_start_with_dashboard):
 
             # Test range request.
             response = requests.get(
-                webui_url + "/logs/dashboard.log", headers={"Range": "bytes=44-52"}
+                webui_url + f"/logs/{test_file}", headers={"Range": "bytes=2-5"}
             )
             response.raise_for_status()
-            assert response.text == "Dashboard"
+            assert response.text == test_log_text[2:6]
 
             # Test logUrl in node info.
             response = requests.get(webui_url + f"/nodes/{node_id}")
@@ -118,16 +124,22 @@ def test_log_proxy(ray_start_with_dashboard):
     timeout_seconds = 5
     start_time = time.time()
     last_ex = None
+    test_log_text = "test_log_text"
+    test_file = "test.log"
+    with open(
+        f"{ray.worker.global_worker.node.get_logs_dir_path()}/{test_file}", "w"
+    ) as f:
+        f.write(test_log_text)
     while True:
         time.sleep(1)
         try:
             # Test range request.
             response = requests.get(
-                f"{webui_url}/log_proxy?url={webui_url}/logs/dashboard.log",
-                headers={"Range": "bytes=44-52"},
+                f"{webui_url}/log_proxy?url={webui_url}/logs/{test_file}",
+                headers={"Range": "bytes=2-5"},
             )
             response.raise_for_status()
-            assert response.text == "Dashboard"
+            assert response.text == test_log_text[2:6]
             # Test 404.
             response = requests.get(
                 f"{webui_url}/log_proxy?" f"url={webui_url}/logs/not_exist_file.log"

--- a/dashboard/modules/log/tests/test_log.py
+++ b/dashboard/modules/log/tests/test_log.py
@@ -81,10 +81,10 @@ def test_log(disable_aiohttp_cache, ray_start_with_dashboard):
 
             # Test range request.
             response = requests.get(
-                webui_url + "/logs/dashboard.log", headers={"Range": "bytes=40-55"}
+                webui_url + "/logs/dashboard.log", headers={"Range": "bytes=44-52"}
             )
             response.raise_for_status()
-            assert "Dashboard" in response.text
+            assert response.text == "Dashboard"
 
             # Test logUrl in node info.
             response = requests.get(webui_url + f"/nodes/{node_id}")
@@ -124,10 +124,10 @@ def test_log_proxy(ray_start_with_dashboard):
             # Test range request.
             response = requests.get(
                 f"{webui_url}/log_proxy?url={webui_url}/logs/dashboard.log",
-                headers={"Range": "bytes=40-55"},
+                headers={"Range": "bytes=44-52"},
             )
             response.raise_for_status()
-            assert "Dashboard" in response.text
+            assert response.text == "Dashboard"
             # Test 404.
             response = requests.get(
                 f"{webui_url}/log_proxy?" f"url={webui_url}/logs/not_exist_file.log"

--- a/dashboard/modules/log/tests/test_log.py
+++ b/dashboard/modules/log/tests/test_log.py
@@ -81,10 +81,10 @@ def test_log(disable_aiohttp_cache, ray_start_with_dashboard):
 
             # Test range request.
             response = requests.get(
-                webui_url + "/logs/dashboard.log", headers={"Range": "bytes=43-51"}
+                webui_url + "/logs/dashboard.log", headers={"Range": "bytes=40-55"}
             )
             response.raise_for_status()
-            assert response.text == "Dashboard"
+            assert "Dashboard" in response.text
 
             # Test logUrl in node info.
             response = requests.get(webui_url + f"/nodes/{node_id}")
@@ -124,10 +124,10 @@ def test_log_proxy(ray_start_with_dashboard):
             # Test range request.
             response = requests.get(
                 f"{webui_url}/log_proxy?url={webui_url}/logs/dashboard.log",
-                headers={"Range": "bytes=43-51"},
+                headers={"Range": "bytes=40-55"},
             )
             response.raise_for_status()
-            assert response.text == "Dashboard"
+            assert "Dashboard" in response.text
             # Test 404.
             response = requests.get(
                 f"{webui_url}/log_proxy?" f"url={webui_url}/logs/not_exist_file.log"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test verifies the first line 43~51 bytes are "dashboard"

But due to recent code addition to head.py, the line where logs are written became 2 digits -> 3 digits
```
Previously,
2022-04-18 23:23:56,946	INFO head.py:[less than 100] -- Dashboard head grpc address: 127.0.0.1:57208
 
Now
2022-04-18 23:23:56,946	INFO head.py:101 -- Dashboard head grpc address: 127.0.0.1:57208
```

So we should increase the bytes range.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
