### PR TITLE
[RLlib] Issue 23907: SampleBatch.shuffle does not flush intercepted_values dict (which it should).

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -414,7 +414,9 @@ class SampleBatch(dict):
         self_as_dict = {k: v for k, v in self.items()}
         shuffled = tree.map_structure(lambda v: v[permutation], self_as_dict)
         self.update(shuffled)
-
+        # Flush cache such that intercepted values are recalculated after the
+        # shuffling.
+        self.intercepted_values = {}
         return self
 
     @PublicAPI

--- a/rllib/policy/tests/test_sample_batch.py
+++ b/rllib/policy/tests/test_sample_batch.py
@@ -296,6 +296,22 @@ class TestSampleBatch(unittest.TestCase):
         self.assertEqual(s[SampleBatch.SEQ_LENS][1], s_copy[SampleBatch.SEQ_LENS][1])
         self.assertEqual(s["state_in_0"][0], s_copy["state_in_0"][0])
 
+    def test_shuffle_with_interceptor(self):
+        """Tests, whether `shuffle()` clears the `intercepted_values` cache."""
+        s = SampleBatch(
+            {
+                "a": np.array([1, 2, 3, 2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7]),
+            }
+        )
+        # Set a summy get-interceptor (returning all values, but plus 1).
+        s.set_get_interceptor(lambda v: v + 1)
+        # Make sure, interceptor works.
+        check(s["a"], [2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7, 6, 7, 8])
+        s.shuffle()
+        # Make sure, intercepted values are NOT the original ones (before the shuffle),
+        # but have also been shuffled.
+        check(s["a"], [2, 3, 4, 3, 4, 5, 4, 5, 6, 5, 6, 7, 6, 7, 8], false=True)
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 23907: SampleBatch.shuffle does not flush intercepted_values dict (which it should).

Otherwise, intercepted values are still un-shuffled.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Issue #23907 
<!-- For example: "Closes #1234" -->
Closes #23907 
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
