### PR TITLE
[air] Use custom fsspec handler for GS

### DIFF
--- a/python/ray/ml/utils/remote_storage.py
+++ b/python/ray/ml/utils/remote_storage.py
@@ -11,19 +11,22 @@ try:
     import pyarrow
     import pyarrow.fs
 
-    class _CustomFSSpecHandler(pyarrow.fs.FSSpecHandler):
-        """Custom FSSpecHandler that avoids bugs in some fsspec implementations."""
+    # Todo(krfricke): Remove this once gcsfs > 2022.3.0 is released
+    # (and make sure to pin)
+    class _CustomGCSHandler(pyarrow.fs.FSSpecHandler):
+        """Custom FSSpecHandler that avoids a bug in gcsfs <= 2022.3.0."""
 
         def create_dir(self, path, recursive):
             try:
-                # No `create_parents` argument
+                # GCSFS doesn't expose `create_parents` argument,
+                # so it is omitted here
                 self.fs.mkdir(path)
             except FileExistsError:
                 pass
 
 except (ImportError, ModuleNotFoundError):
     pyarrow = None
-    _CustomFSSpecHandler = None
+    _CustomGCSHandler = None
 
 from ray import logger
 
@@ -116,7 +119,7 @@ def get_fs_and_path(
     fsspec_handler = pyarrow.fs.FSSpecHandler
     if parsed.scheme in ["gs", "gcs"]:
         # GS doesn't support `create_parents` arg in `create_dir()`
-        fsspec_handler = _CustomFSSpecHandler
+        fsspec_handler = _CustomGCSHandler
 
     fs = pyarrow.fs.PyFileSystem(fsspec_handler(fsspec_fs))
     _cached_fs[cache_key] = fs

--- a/python/ray/ml/utils/remote_storage.py
+++ b/python/ray/ml/utils/remote_storage.py
@@ -112,7 +112,7 @@ def get_fs_and_path(
         return None, None
 
     fsspec_handler = pyarrow.fs.FSSpecHandler
-    if parsed.scheme == "gs":
+    if parsed.scheme in ["gs", "gcs"]:
         # GS doesn't support `create_parents` arg in `create_dir()`
         fsspec_handler = _CustomFSSpecHandler
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`gcsfs` complains about an invalid `create_parents` argument when using google cloud storage with cloud checkpoints. Thus we should use an alternative fs spec handler that omits this argument for gs.

The root issue will be fixed here: https://github.com/fsspec/gcsfs/pull/471

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
