### PR TITLE
[RLlib] Ensure `MultiCallbacks` always implements all callback methods

### DIFF
--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -381,6 +381,31 @@ class MultiCallbacks(DefaultCallbacks):
 
         return self
 
+    def on_sub_environment_created(
+        self,
+        *,
+        worker: "RolloutWorker",
+        sub_environment: EnvType,
+        env_context: EnvContext,
+        **kwargs,
+    ) -> None:
+        for callback in self._callback_list:
+            callback.on_sub_environment_created(
+                worker=worker,
+                sub_environment=sub_environment,
+                env_context=env_context,
+                **kwargs
+            )
+
+    def on_trainer_init(
+        self,
+        *,
+        trainer: "Trainer",
+        **kwargs,
+    ) -> None:
+        for callback in self._callback_list:
+            callback.on_trainer_init(trainer=trainer, **kwargs)
+
     def on_episode_start(
         self,
         *,

--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -394,7 +394,7 @@ class MultiCallbacks(DefaultCallbacks):
                 worker=worker,
                 sub_environment=sub_environment,
                 env_context=env_context,
-                **kwargs
+                **kwargs,
             )
 
     def on_trainer_init(

--- a/rllib/agents/tests/test_callbacks.py
+++ b/rllib/agents/tests/test_callbacks.py
@@ -1,7 +1,7 @@
 import unittest
 
 import ray
-from ray.rllib.agents.callbacks import DefaultCallbacks
+from ray.rllib.agents.callbacks import DefaultCallbacks, MultiCallbacks
 import ray.rllib.agents.dqn as dqn
 from ray.rllib.utils.test_utils import framework_iterator
 
@@ -32,36 +32,41 @@ class TestCallbacks(unittest.TestCase):
         ray.shutdown()
 
     def test_on_sub_environment_created(self):
-        config = {
+        base_config = {
             "env": "CartPole-v1",
             # Create 4 sub-environments per remote worker.
             "num_envs_per_worker": 4,
             # Create 2 remote workers.
             "num_workers": 2,
-            "callbacks": OnSubEnvironmentCreatedCallback,
         }
 
-        for _ in framework_iterator(config, frameworks=("tf", "torch")):
-            trainer = dqn.DQNTrainer(config=config)
-            # Fake the counter on the local worker (doesn't have an env) and
-            # set it to -1 so the below `foreach_worker()` won't fail.
-            trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+        for callbacks in (
+            OnSubEnvironmentCreatedCallback,
+            MultiCallbacks([OnSubEnvironmentCreatedCallback])
+        ):
+            config = dict(base_config, callbacks=callbacks)
 
-            # Get sub-env vector index sums from the 2 remote workers:
-            sum_sub_env_vector_indices = trainer.workers.foreach_worker(
-                lambda w: w.sum_sub_env_vector_indices
-            )
-            # Local worker has no environments -> Expect the -1 special
-            # value returned by the above lambda.
-            self.assertTrue(sum_sub_env_vector_indices[0] == -1)
-            # Both remote workers (index 1 and 2) have a vector index counter
-            # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
-            self.assertTrue(sum_sub_env_vector_indices[1] == 6)
-            self.assertTrue(sum_sub_env_vector_indices[2] == 6)
-            trainer.stop()
+            for _ in framework_iterator(config, frameworks=("tf", "torch")):
+                trainer = dqn.DQNTrainer(config=config)
+                # Fake the counter on the local worker (doesn't have an env) and
+                # set it to -1 so the below `foreach_worker()` won't fail.
+                trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+
+                # Get sub-env vector index sums from the 2 remote workers:
+                sum_sub_env_vector_indices = trainer.workers.foreach_worker(
+                    lambda w: w.sum_sub_env_vector_indices
+                )
+                # Local worker has no environments -> Expect the -1 special
+                # value returned by the above lambda.
+                self.assertTrue(sum_sub_env_vector_indices[0] == -1)
+                # Both remote workers (index 1 and 2) have a vector index counter
+                # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
+                self.assertTrue(sum_sub_env_vector_indices[1] == 6)
+                self.assertTrue(sum_sub_env_vector_indices[2] == 6)
+                trainer.stop()
 
     def test_on_sub_environment_created_with_remote_envs(self):
-        config = {
+        base_config = {
             "env": "CartPole-v1",
             # Make each sub-environment a ray actor.
             "remote_worker_envs": True,
@@ -70,27 +75,32 @@ class TestCallbacks(unittest.TestCase):
             "num_envs_per_worker": 4,
             # Create 2 remote workers.
             "num_workers": 2,
-            "callbacks": OnSubEnvironmentCreatedCallback,
         }
 
-        for _ in framework_iterator(config, frameworks=("tf", "torch")):
-            trainer = dqn.DQNTrainer(config=config)
-            # Fake the counter on the local worker (doesn't have an env) and
-            # set it to -1 so the below `foreach_worker()` won't fail.
-            trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+        for callbacks in (
+            OnSubEnvironmentCreatedCallback,
+            MultiCallbacks([OnSubEnvironmentCreatedCallback])
+        ):
+            config = dict(base_config, callbacks=callbacks)
 
-            # Get sub-env vector index sums from the 2 remote workers:
-            sum_sub_env_vector_indices = trainer.workers.foreach_worker(
-                lambda w: w.sum_sub_env_vector_indices
-            )
-            # Local worker has no environments -> Expect the -1 special
-            # value returned by the above lambda.
-            self.assertTrue(sum_sub_env_vector_indices[0] == -1)
-            # Both remote workers (index 1 and 2) have a vector index counter
-            # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
-            self.assertTrue(sum_sub_env_vector_indices[1] == 6)
-            self.assertTrue(sum_sub_env_vector_indices[2] == 6)
-            trainer.stop()
+            for _ in framework_iterator(config, frameworks=("tf", "torch")):
+                trainer = dqn.DQNTrainer(config=config)
+                # Fake the counter on the local worker (doesn't have an env) and
+                # set it to -1 so the below `foreach_worker()` won't fail.
+                trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+
+                # Get sub-env vector index sums from the 2 remote workers:
+                sum_sub_env_vector_indices = trainer.workers.foreach_worker(
+                    lambda w: w.sum_sub_env_vector_indices
+                )
+                # Local worker has no environments -> Expect the -1 special
+                # value returned by the above lambda.
+                self.assertTrue(sum_sub_env_vector_indices[0] == -1)
+                # Both remote workers (index 1 and 2) have a vector index counter
+                # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
+                self.assertTrue(sum_sub_env_vector_indices[1] == 6)
+                self.assertTrue(sum_sub_env_vector_indices[2] == 6)
+                trainer.stop()
 
 
 if __name__ == "__main__":

--- a/rllib/agents/tests/test_callbacks.py
+++ b/rllib/agents/tests/test_callbacks.py
@@ -42,7 +42,7 @@ class TestCallbacks(unittest.TestCase):
 
         for callbacks in (
             OnSubEnvironmentCreatedCallback,
-            MultiCallbacks([OnSubEnvironmentCreatedCallback])
+            MultiCallbacks([OnSubEnvironmentCreatedCallback]),
         ):
             config = dict(base_config, callbacks=callbacks)
 
@@ -79,7 +79,7 @@ class TestCallbacks(unittest.TestCase):
 
         for callbacks in (
             OnSubEnvironmentCreatedCallback,
-            MultiCallbacks([OnSubEnvironmentCreatedCallback])
+            MultiCallbacks([OnSubEnvironmentCreatedCallback]),
         ):
             config = dict(base_config, callbacks=callbacks)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Add the following missing methods to `rllib.agent.callbacks.MultiCallbacks`:

- `on_trainer_init` (added in #22493)
- `on_sub_environment_created` (added in #21893)

cc @gjoliver, @sven1977 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
