### PR TITLE
[Serve] Fix torch_tune_serve_test client test

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -749,14 +749,6 @@ def start(
     if not ray.is_initialized():
         ray.init(namespace="serve")
 
-    if ray.util.client.ray.get_context().is_connected():
-        logger.warning(
-            "It seems like you are connecting to Serve via Ray Client. "
-            "This codepath will be deprecated soon. We recommend `ray job submit` "
-            "as an alternative. "
-            "See https://docs.ray.io/en/latest/cluster/job-submission.html"
-        )
-
     controller_namespace = _get_controller_namespace(
         detached, _override_controller_namespace=_override_controller_namespace
     )

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -749,6 +749,14 @@ def start(
     if not ray.is_initialized():
         ray.init(namespace="serve")
 
+    if ray.util.client.ray.get_context().is_connected():
+        logger.warning(
+            "It seems like you are connecting to Serve via Ray Client. "
+            "This codepath will be deprecated soon. We recommend `ray job submit` "
+            "as an alternative. "
+            "See https://docs.ray.io/en/latest/cluster/job-submission.html"
+        )
+
     controller_namespace = _get_controller_namespace(
         detached, _override_controller_namespace=_override_controller_namespace
     )

--- a/release/BUILD
+++ b/release/BUILD
@@ -93,6 +93,24 @@ py_test(
 )
 
 py_test(
+    name = "tune_serve_golden_notebook_client_smoke_test",
+    size = "medium",
+    srcs = test_srcs,
+    env = {
+        "IS_SMOKE_TEST": "1",
+    },
+    main = "golden_notebook_tests/workloads/torch_tune_serve_test.py",
+    tags = [
+        "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        "//:ray_lib",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
+py_test(
     name = "test_alerts",
     tags = ["team:ci", "release_unit"],
     size = "small",

--- a/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
+++ b/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
@@ -104,17 +104,16 @@ def get_model(model_checkpoint_path):
     model = ResNet18(None)
     model.conv1 = nn.Conv2d(1, 64, kernel_size=7, stride=1, padding=3, bias=False)
     model.load_state_dict(model_state["models"][0])
-    model_id = ray.put(model)
 
-    return model_id
+    return model
 
 
 @serve.deployment(name="mnist", route_prefix="/mnist")
 class MnistDeployment:
-    def __init__(self, model_id):
+    def __init__(self, model):
         use_cuda = torch.cuda.is_available()
         self.device = torch.device("cuda" if use_cuda else "cpu")
-        model = ray.get(model_id).to(self.device)
+        model = model.to(self.device)
         self.model = model
 
     async def __call__(self, request):
@@ -132,13 +131,13 @@ class MnistDeployment:
         return predictions
 
 
-def setup_serve(model_id):
+def setup_serve(model, use_gpu: bool = False):
     serve.start(
         http_options={"location": "EveryNode"}
     )  # Start on every node so `predict` can hit localhost.
-    MnistDeployment.options(num_replicas=2, ray_actor_options={"num_gpus": 1}).deploy(
-        model_id
-    )
+    MnistDeployment.options(
+        num_replicas=2, ray_actor_options={"num_gpus": bool(use_gpu)}
+    ).deploy(model)
 
 
 @ray.remote
@@ -212,17 +211,17 @@ if __name__ == "__main__":
         client = ray.init(address="auto")
 
     num_workers = 2
-    use_gpu = True
+    use_gpu = not args.smoke_test
 
     print("Training model.")
     analysis = train_mnist(args.smoke_test, num_workers, use_gpu)
 
     print("Retrieving best model.")
     best_checkpoint = analysis.best_checkpoint.local_path
-    model_id = get_remote_model(best_checkpoint)
+    model = get_remote_model(best_checkpoint)
 
     print("Setting up Serve.")
-    setup_serve(model_id)
+    setup_serve(model, use_gpu)
 
     print("Testing Prediction Service.")
     accuracy = test_predictions(args.smoke_test)

--- a/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
+++ b/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
@@ -1,7 +1,9 @@
 import argparse
+import atexit
 import json
 import os
 import time
+import subprocess
 
 import ray
 import requests
@@ -200,6 +202,17 @@ if __name__ == "__main__":
         help="Finish quickly for testing.",
     )
     args = parser.parse_args()
+
+    if os.environ.get("IS_SMOKE_TEST"):
+        args.smoke_test = True
+        proc = subprocess.Popen(["ray", "start", "--head"])
+        proc.wait()
+        os.environ["RAY_ADDRESS"] = "ray://localhost:10001"
+
+        def stop_ray():
+            subprocess.Popen(["ray", "stop", "--force"]).wait()
+
+        atexit.register(stop_ray)
 
     start = time.time()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Closes #24018 

The root cause of the issue was that the test depends on using ObjectRef as part of deployment's init arguments. As part of unified controller API refactor, we dumped the init args using pickle and pack it with protobuf, so putting ObjectRef as part of init args is no longer supported.

To make it worse, the test was using Ray Client. Client's ObjectRef serde stack is entirely custom made. It has a dedicated serializer to use in client side to catch ObjectRef in client side and a separate deserializer in the server side. There is no way to adopt these serializer for our init_args serde into protobuf. 

Therefore this PR does two things:
1. Changed to test to not to pass ObjectRef around and directly pass models.
2. ~Warn if users are calling `serve.start` from within Ray Client, and recommend `ray job submit`.~ (moved to future work)

I also contemplated another fix by introduce PyObjScanner and give more informative error if users give us ObjectRef and ClientObjectRef as part of init arguments. But 
- it might be render useless if we require args to be JSON serializable
- it might introduce blockers for users already depend on this.
- it requires another PR to peel out the PyObjScanner in ray dag code. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests: added smoke test
   - [ ] Release tests
   - [ ] This PR is not tested :(
