### PR TITLE
[Serve] Allow cloudpickle serializable objects as init args/kwargs

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -1,6 +1,5 @@
 import inspect
 import json
-import pickle
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -15,7 +14,7 @@ from pydantic import (
     validator,
 )
 
-from ray import cloudpickle as cloudpickle
+from ray import cloudpickle
 from ray.serve.constants import (
     DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S,
     DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S,
@@ -153,7 +152,7 @@ class DeploymentConfig(BaseModel):
     def to_proto(self):
         data = self.dict()
         if data.get("user_config"):
-            data["user_config"] = pickle.dumps(data["user_config"])
+            data["user_config"] = cloudpickle.dumps(data["user_config"])
         if data.get("autoscaling_config"):
             data["autoscaling_config"] = AutoscalingConfigProto(
                 **data["autoscaling_config"]
@@ -173,7 +172,7 @@ class DeploymentConfig(BaseModel):
         )
         if "user_config" in data:
             if data["user_config"] != "":
-                data["user_config"] = pickle.loads(proto.user_config)
+                data["user_config"] = cloudpickle.loads(proto.user_config)
             else:
                 data["user_config"] = None
         if "autoscaling_config" in data:
@@ -355,9 +354,11 @@ class ReplicaConfig:
                 # TODO use messagepack
                 deployment_def = cloudpickle.loads(proto.serialized_deployment_def)
 
-        init_args = pickle.loads(proto.init_args) if proto.init_args != b"" else None
+        init_args = (
+            cloudpickle.loads(proto.init_args) if proto.init_args != b"" else None
+        )
         init_kwargs = (
-            pickle.loads(proto.init_kwargs) if proto.init_kwargs != b"" else None
+            cloudpickle.loads(proto.init_kwargs) if proto.init_kwargs != b"" else None
         )
         ray_actor_options = (
             json.loads(proto.ray_actor_options)
@@ -379,9 +380,9 @@ class ReplicaConfig:
             "serialized_deployment_def": self.serialized_deployment_def,
         }
         if self.init_args:
-            data["init_args"] = pickle.dumps(self.init_args)
+            data["init_args"] = cloudpickle.dumps(self.init_args)
         if self.init_kwargs:
-            data["init_kwargs"] = pickle.dumps(self.init_kwargs)
+            data["init_kwargs"] = cloudpickle.dumps(self.init_kwargs)
         if self.ray_actor_options:
             data["ray_actor_options"] = json.dumps(
                 self.ray_actor_options, cls=ServeEncoder

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -791,6 +791,20 @@ def test_init_kwargs(serve_instance):
     check({"c": 10, "d": 11})
 
 
+def test_init_args_with_closure(serve_instance):
+    @serve.deployment
+    class Evaluator:
+        def __init__(self, func):
+            self.func = func
+
+        def __call__(self, inp):
+            return self.func(inp)
+
+    Evaluator.deploy(lambda a: a + 1)
+    handle = Evaluator.get_handle()
+    assert ray.get(handle.remote(41)) == 42
+
+
 def test_input_validation():
     name = "test"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Closes #23503 

We are fixing two issue here:
1. The unified controller API used pickle to pack the init args, we are changing it to cloudpickle for now. (this is something I missed during code review)
2. The checkpoint state functionality in controller uses pickle to prevent ray cluster specific state written to checkpoint and unable to recover in a fresh new cluster. However, this recover from new cluster is not good UX and we should prefer an end to end solution like resubmitting via REST API.


As a corollary, the deployment state manager should not care about deserializing replica config and init args. Rather, it should just pass the protobuf directly to replica. I can do that either here or as a follow up. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
