### PR TITLE
[runtime_env] Add the ability to inject a setup hook for customization of runtime_env on init

### DIFF
--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -68,6 +68,10 @@ RAY_ADDRESS_ENVIRONMENT_VARIABLE = "RAY_ADDRESS"
 RAY_NAMESPACE_ENVIRONMENT_VARIABLE = "RAY_NAMESPACE"
 RAY_RUNTIME_ENV_ENVIRONMENT_VARIABLE = "RAY_RUNTIME_ENV"
 RAY_STORAGE_ENVIRONMENT_VARIABLE = "RAY_STORAGE"
+# Hook for running a user-specified runtime-env hook. This hook will be called
+# unconditionally given the runtime_env dict passed for ray.init. It must return
+# a rewritten runtime_env dict.
+RAY_RUNTIME_ENV_HOOK = "RAY_RUNTIME_ENV_HOOK"
 
 DEFAULT_DASHBOARD_IP = "127.0.0.1"
 DEFAULT_DASHBOARD_PORT = 8265

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -70,7 +70,7 @@ RAY_RUNTIME_ENV_ENVIRONMENT_VARIABLE = "RAY_RUNTIME_ENV"
 RAY_STORAGE_ENVIRONMENT_VARIABLE = "RAY_STORAGE"
 # Hook for running a user-specified runtime-env hook. This hook will be called
 # unconditionally given the runtime_env dict passed for ray.init. It must return
-# a rewritten runtime_env dict.
+# a rewritten runtime_env dict. Example: "your.module.runtime_env_hook".
 RAY_RUNTIME_ENV_HOOK = "RAY_RUNTIME_ENV_HOOK"
 
 DEFAULT_DASHBOARD_IP = "127.0.0.1"

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -40,7 +40,7 @@ for _ in range(10):
 
 
 def _hook(env):
-    return {"env_vars": {"TEST_BLAH": "HOOK OK"}}
+    return {"env_vars": {"HOOK_KEY": "HOOK_VALUE"}}
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
@@ -51,7 +51,7 @@ import os
 
 @ray.remote
 def f():
-    return os.environ.get("TEST_BLAH")
+    return os.environ.get("HOOK_KEY")
 
 print(ray.get(f.remote()))
 """
@@ -61,7 +61,7 @@ print(ray.get(f.remote()))
     )
     out_str = proc.stdout.read().decode("ascii") + proc.stderr.read().decode("ascii")
     print(out_str)
-    assert "HOOK OK" in out_str
+    assert "HOOK_VALUE" in out_str
 
 
 def test_autoscaler_infeasible():

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 import ray.cloudpickle as pickle
 import ray._private.memory_monitor as memory_monitor
 import ray.internal.storage as storage
+from ray.internal.storage import _load_class
 import ray.node
 import ray.job_config
 import ray._private.parameter
@@ -918,6 +919,10 @@ def init(
     except ImportError:
         logger.debug("Could not import resource module (on Windows)")
         pass
+
+    if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ:
+        runtime_env = _load_class(
+            os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(runtime_env)
 
     if RAY_JOB_CONFIG_JSON_ENV_VAR in os.environ:
         if runtime_env:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -921,8 +921,9 @@ def init(
         pass
 
     if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ:
-        runtime_env = _load_class(
-            os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(runtime_env)
+        runtime_env = _load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(
+            runtime_env
+        )
 
     if RAY_JOB_CONFIG_JSON_ENV_VAR in os.environ:
         if runtime_env:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds an environment variable hook which can be used to arbitrarily rewrite the runtime_env option programmatically. The user specifies a module path (e.g., `your.module.runtime_env_hook`) that receives the runtime_env option from ray.init() and can rewrite it as needed.