### PR TITLE
[RLlib] Add support for writing env 'info' dicts to output datasets for TFPolicies (for TorchPolicies, these are part of the view-requirements by default and thus written either way).

### DIFF
--- a/doc/source/rllib/rllib-offline.rst
+++ b/doc/source/rllib/rllib-offline.rst
@@ -178,6 +178,34 @@ To write sample data to JSON or Parquet files using Dataset, specify output and 
         }
     }
 
+Writing Environment Data
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To include environment data in the training sample datasets you can use the optional
+``store_infos_dict`` parameter that is part of the ``output_config`` dictionary. This parameter
+ensures that the ``infos_dict``, as returned by the RL environment, is included in the output files.
+
+Note 1: It is the responsibility of the user to ensure that the content of ``infos_dict`` can be serialized
+to file.
+Note 2: This setting is only relevant for the TensorFlow based agents, for PyTorch agents the ``infos_dict`` data is always stored.
+
+To write the ``infos_dict`` data to JSON or Parquet files using Dataset, specify output and output_config keys like the following:
+
+.. code-block:: python
+
+    config = {
+        "output": "dataset",
+        "output_config": {
+            "format": "json",  # json or parquet
+            # Directory to write data files.
+            "path": "/tmp/test_samples/",
+            # Write the infos dict data
+            "store_infos_dict" : True,
+        }
+    }
+
+
+
 Input Pipeline for Supervised Losses
 ------------------------------------
 

--- a/doc/source/rllib/rllib-offline.rst
+++ b/doc/source/rllib/rllib-offline.rst
@@ -182,14 +182,14 @@ Writing Environment Data
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 To include environment data in the training sample datasets you can use the optional
-``store_infos_dict`` parameter that is part of the ``output_config`` dictionary. This parameter
-ensures that the ``infos_dict``, as returned by the RL environment, is included in the output files.
+``store_infos`` parameter that is part of the ``output_config`` dictionary. This parameter
+ensures that the ``infos`` dictionary, as returned by the RL environment, is included in the output files.
 
-Note 1: It is the responsibility of the user to ensure that the content of ``infos_dict`` can be serialized
+Note 1: It is the responsibility of the user to ensure that the content of ``infos`` can be serialized
 to file.
-Note 2: This setting is only relevant for the TensorFlow based agents, for PyTorch agents the ``infos_dict`` data is always stored.
+Note 2: This setting is only relevant for the TensorFlow based agents, for PyTorch agents the ``infos`` data is always stored.
 
-To write the ``infos_dict`` data to JSON or Parquet files using Dataset, specify output and output_config keys like the following:
+To write the ``infos`` data to JSON or Parquet files using Dataset, specify output and output_config keys like the following:
 
 .. code-block:: python
 
@@ -200,7 +200,7 @@ To write the ``infos_dict`` data to JSON or Parquet files using Dataset, specify
             # Directory to write data files.
             "path": "/tmp/test_samples/",
             # Write the infos dict data
-            "store_infos_dict" : True,
+            "store_infos" : True,
         }
     }
 

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -202,6 +202,10 @@ class TFPolicy(Policy):
             self.view_requirements[SampleBatch.INFOS].used_for_training = False
             self.view_requirements[SampleBatch.INFOS].used_for_compute_actions = False
 
+        # Optionally add the info batch to sample batches for writing to file
+        if self.config["output_config"].get("store_infos_dict", False):
+            self.view_requirements[SampleBatch.INFOS].used_for_training = True
+
         assert model is None or isinstance(model, (ModelV2, tf.keras.Model)), (
             "Model classes for TFPolicy other than `ModelV2|tf.keras.Model` "
             "not allowed! You passed in {}.".format(model)

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -199,12 +199,11 @@ class TFPolicy(Policy):
 
         # Disable env-info placeholder.
         if SampleBatch.INFOS in self.view_requirements:
-            self.view_requirements[SampleBatch.INFOS].used_for_training = False
             self.view_requirements[SampleBatch.INFOS].used_for_compute_actions = False
-
-        # Optionally add the info batch to sample batches for writing to file
-        if self.config["output_config"].get("store_infos_dict", False):
-            self.view_requirements[SampleBatch.INFOS].used_for_training = True
+            self.view_requirements[SampleBatch.INFOS].used_for_training = False
+            # Optionally add `infos` to the output dataset
+            if self.config["output_config"].get("store_infos", False):
+                self.view_requirements[SampleBatch.INFOS].used_for_training = True
 
         assert model is None or isinstance(model, (ModelV2, tf.keras.Model)), (
             "Model classes for TFPolicy other than `ModelV2|tf.keras.Model` "

--- a/rllib/tests/test_io.py
+++ b/rllib/tests/test_io.py
@@ -51,13 +51,14 @@ class AgentIOTest(unittest.TestCase):
         shutil.rmtree(self.test_dir)
         ray.shutdown()
 
-    def write_outputs(self, output, fw):
+    def write_outputs(self, output, fw, output_config=None):
         agent = PGTrainer(
             env="CartPole-v0",
             config={
                 "output": output + (fw if output != "logdir" else ""),
                 "rollout_fragment_length": 250,
                 "framework": fw,
+                "output_config": output_config or {},
             },
         )
         agent.train()
@@ -75,6 +76,19 @@ class AgentIOTest(unittest.TestCase):
         for fw in framework_iterator():
             agent = self.write_outputs("logdir", fw)
             self.assertEqual(len(glob.glob(agent.logdir + "/output-*.json")), 1)
+
+    def test_agent_output_infos_dict(self):
+        """Verify that the infos_dict is written to the output files.
+
+        Note, with torch this is always the case.
+        """
+        output_config = {"store_infos_dict": True}
+        for fw in framework_iterator(frameworks=("torch", "tf")):
+            self.write_outputs(self.test_dir, fw, output_config=output_config)
+            self.assertEqual(len(os.listdir(self.test_dir + fw)), 1)
+            reader = JsonReader(self.test_dir + fw + "/*.json")
+            data = reader.next()
+            assert "infos" in data
 
     def test_agent_input_dir(self):
         for fw in framework_iterator(frameworks=("torch", "tf")):

--- a/rllib/tests/test_io.py
+++ b/rllib/tests/test_io.py
@@ -77,12 +77,12 @@ class AgentIOTest(unittest.TestCase):
             agent = self.write_outputs("logdir", fw)
             self.assertEqual(len(glob.glob(agent.logdir + "/output-*.json")), 1)
 
-    def test_agent_output_infos_dict(self):
-        """Verify that the infos_dict is written to the output files.
+    def test_agent_output_infos(self):
+        """Verify that the infos dictionary is written to the output files.
 
         Note, with torch this is always the case.
         """
-        output_config = {"store_infos_dict": True}
+        output_config = {"store_infos": True}
         for fw in framework_iterator(frameworks=("torch", "tf")):
             self.write_outputs(self.test_dir, fw, output_config=output_config)
             self.assertEqual(len(os.listdir(self.test_dir + fw)), 1)
@@ -93,6 +93,7 @@ class AgentIOTest(unittest.TestCase):
     def test_agent_input_dir(self):
         for fw in framework_iterator(frameworks=("torch", "tf")):
             self.write_outputs(self.test_dir, fw)
+            print("WROTE TO: ", self.test_dir)
             agent = PGTrainer(
                 env="CartPole-v0",
                 config={


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The TensorFlow policy currently does not have an option to log the `infos` dictionary that is returned from the RL environment. This adds a configuration setting that does enable this. Note that with the PyTorch policy the `infos` dictionary is always written.

## Related issue number

Closes #23826

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
