### PR TITLE
[serve] Deflake `test_replica_startup_status_transitions ` by `await`ing signal actor in constructor

### DIFF
--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -130,8 +130,8 @@ def test_replica_startup_status_transitions(ray_cluster):
 
     @serve.deployment(version="1", ray_actor_options={"num_cpus": 2})
     class E:
-        def __init__(self):
-            ray.get(signal.wait.remote())
+        async def __init__(self):
+            await signal.wait.remote()
 
     E.deploy(_blocking=False)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_cluster: test_replica_startup_status_transitions` is periodically flaky with the replica hanging in `PENDING_ALLOCATION`. This could be because there is no ordering guarantee on async actor calls, so the `reconfigure` method might execute first and block the asyncio loop (due to `ray.get`), not allowing the `is_allocated` call to run.

This is a bit of a long shot, because if this was the case I'd expect it to be failing much more often than it is.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
