### PR TITLE
[Serve] ensure replica reconfigure runs after allocation check

### DIFF
--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -336,7 +336,10 @@ class ActorReplicaWrapper:
 
         self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
         self._ready_obj_ref = self._actor_handle.reconfigure.remote(
-            deployment_info.deployment_config.user_config
+            deployment_info.deployment_config.user_config,
+            # ensure that `reconfigure` will only be called after a response
+            # has been received from `is_allocated`.
+            _after=self._allocated_obj_ref,
         )
 
     def update_user_config(self, user_config: Any):

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -337,8 +337,10 @@ class ActorReplicaWrapper:
         self._allocated_obj_ref = self._actor_handle.is_allocated.remote()
         self._ready_obj_ref = self._actor_handle.reconfigure.remote(
             deployment_info.deployment_config.user_config,
-            # ensure that `reconfigure` will only be called after a response
-            # has been received from `is_allocated`.
+            # Ensure that `is_allocated` will execute before `reconfigure`,
+            # because `reconfigure` runs user code that could block the replica
+            # asyncio loop. If that happens before `is_allocated` is executed,
+            # the `is_allocated` call won't be able to run.
             _after=self._allocated_obj_ref,
         )
 

--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -341,7 +341,7 @@ class ActorReplicaWrapper:
             # because `reconfigure` runs user code that could block the replica
             # asyncio loop. If that happens before `is_allocated` is executed,
             # the `is_allocated` call won't be able to run.
-            _after=self._allocated_obj_ref,
+            self._allocated_obj_ref,
         )
 
     def update_user_config(self, user_config: Any):

--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -201,8 +201,10 @@ def create_replica_wrapper(
             return ray.get_runtime_context().node_id
 
         async def reconfigure(
-            self, user_config: Optional[Any] = None
+            self, user_config: Optional[Any] = None, _after: Optional[Any] = None
         ) -> Tuple[DeploymentConfig, DeploymentVersion]:
+            # unused `_after` argument is for scheduling: passing an ObjectRef
+            # allows delaying reconfiguration until after the object is ready.
             if self.replica is None:
                 await self._initialize_replica()
             if user_config is not None:

--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -203,8 +203,8 @@ def create_replica_wrapper(
         async def reconfigure(
             self, user_config: Optional[Any] = None, _after: Optional[Any] = None
         ) -> Tuple[DeploymentConfig, DeploymentVersion]:
-            # unused `_after` argument is for scheduling: passing an ObjectRef
-            # allows delaying reconfiguration until after the object is ready.
+            # Unused `_after` argument is for scheduling: passing an ObjectRef
+            # allows delaying reconfiguration until after this call has returned.
             if self.replica is None:
                 await self._initialize_replica()
             if user_config is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Since remote calls provide no ordering guarantees, it could happen that `reconfigure` gets called before `is_allocated` Since `reconfigure` then runs the user initialization code, the replica actor could get blocked and never provide its allocation check.
This PR ensures that the allocation proof has been received before we run the replica initialization.

I believe this approach is better than handling the ordering in the calling code (in deployment_state), since that would require the controller to poll the replica in order to make progress on the initialization.

Would we want a test for this? What would that look like?
## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/pull/24044

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
