### PR TITLE
[Ray client] return `None` from internal KV for non-existent keys

### DIFF
--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -583,7 +583,7 @@ def test_internal_kv(ray_start_regular_shared):
         assert ray._internal_kv_get("apple") == b"asdf"
         assert ray._internal_kv_list("a") == [b"apple"]
         ray._internal_kv_del("apple")
-        assert ray._internal_kv_get("apple") == b""
+        assert ray._internal_kv_get("apple") is None
 
 
 def test_startup_retry(ray_start_regular_shared):

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -711,7 +711,10 @@ class Worker:
     def internal_kv_get(self, key: bytes) -> bytes:
         req = ray_client_pb2.KVGetRequest(key=key)
         resp = self._call_stub("KVGet", req, metadata=self.metadata)
-        return resp.value
+        if resp.HasField("value"):
+            return resp.value
+        # Value is None when the key does not exist in the KV.
+        return None
 
     def internal_kv_exists(self, key: bytes) -> bytes:
         req = ray_client_pb2.KVGetRequest(key=key)

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -243,7 +243,8 @@ message KVGetRequest {
 }
 
 message KVGetResponse {
-  bytes value = 1;
+  // Not set when key does not exist.
+  optional bytes value = 1;
 }
 
 message KVPutRequest {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This fixes the behavior diff between client and non-client internal KV.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #21734
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
