### PR TITLE
fix: ensure flat and discrete models are added to parent torch module

### DIFF
--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -115,6 +115,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                     name="one_hot_{}".format(i),
                 )
                 concat_size += self.one_hot[i].num_outputs
+                self.add_module("discrete_{}".format(i), self.cnns[i])
             # Everything else (1D Box).
             else:
                 size = int(np.product(component.shape))
@@ -133,6 +134,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 )
                 self.flatten_dims[i] = size
                 concat_size += self.flatten[i].num_outputs
+                self.add_module("flat_{}".format(i), self.cnns[i])
 
         # Optional post-concat FC-stack.
         post_fc_stack_config = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, MLP encoders were not being trained, nor tracked by the
parent model class. This harms model performance, and prevented the
networks from being moved to the appropriate device.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/23967

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
