### PR TITLE
[air] Tuner should use `run_config` from Trainer per default

### DIFF
--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -43,7 +43,8 @@ class TunerInternal:
         tune_config: Tuning algorithm specific configs.
             Refer to ray.tune.tune_config.TuneConfig for more info.
         run_config: Runtime configuration that is specific to individual trials.
-            Refer to ray.ml.config.RunConfig for more info.
+            If passed, this will overwrite the run config passed to the Trainer,
+            if applicable. Refer to ray.ml.config.RunConfig for more info.
     """
 
     def __init__(

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -82,6 +82,11 @@ class TunerInternal:
         if not trainable:
             raise TuneError("You need to provide a trainable to tune.")
 
+        # If no run config was passed to Tuner directly, use the one from the Trainer,
+        # if available
+        if not run_config and isinstance(trainable, Trainer):
+            run_config = trainable.run_config
+
         self._is_restored = False
         self._trainable = trainable
         self._tune_config = tune_config or TuneConfig()

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -21,6 +21,20 @@ from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
 
 
+class DummyTrainer(Trainer):
+    _scaling_config_allowed_keys = [
+        "num_workers",
+        "num_cpus_per_worker",
+        "num_gpus_per_worker",
+        "additional_resources_per_worker",
+        "use_gpu",
+        "trainer_resources",
+    ]
+
+    def training_loop(self) -> None:
+        raise RuntimeError("There is an error in trainer!")
+
+
 class TestDatasource(Datasource):
     def __init__(self, do_shuffle: bool):
         self._shuffle = do_shuffle
@@ -174,19 +188,6 @@ class TunerTest(unittest.TestCase):
         assert len(results) == 2
 
     def test_tuner_trainer_fail(self):
-        class DummyTrainer(Trainer):
-            _scaling_config_allowed_keys = [
-                "num_workers",
-                "num_cpus_per_worker",
-                "num_gpus_per_worker",
-                "additional_resources_per_worker",
-                "use_gpu",
-                "trainer_resources",
-            ]
-
-            def training_loop(self) -> None:
-                raise RuntimeError("There is an error in trainer!")
-
         trainer = DummyTrainer()
         param_space = {
             "scaling_config": {
@@ -244,6 +245,12 @@ class TunerTest(unittest.TestCase):
         )
         results = tuner.fit()
         assert len(results) == 8
+
+    def test_tuner_run_config_override(self):
+        trainer = DummyTrainer(run_config=RunConfig(stop={"metric": 4}))
+        tuner = Tuner(trainer)
+
+        assert tuner._local_tuner._run_config.stop == {"metric": 4}
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -35,7 +35,8 @@ class Tuner:
         tune_config: Tuning algorithm specific configs.
             Refer to ray.tune.tune_config.TuneConfig for more info.
         run_config: Runtime configuration that is specific to individual trials.
-            Refer to ray.ml.config.RunConfig for more info.
+            If passed, this will overwrite the run config passed to the Trainer,
+            if applicable. Refer to ray.ml.config.RunConfig for more info.
 
     Usage pattern:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a `Trainer` is initialized with a run config and then passed into a `Tuner`, it is currently silently discarded and a default RunConfig is used. Instead we should use the run config in trainer if not overridden.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
