### PR TITLE
[Core / SDK] remove inefficient  `ray.state.nodes()` implementation

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -189,11 +189,7 @@ class GlobalState:
                 "NodeName": item.node_name,
             }
             node_info["alive"] = node_info["Alive"]
-            node_info["Resources"] = (
-                self.node_resource_table(node_info["NodeID"])
-                if node_info["Alive"]
-                else {}
-            )
+            node_info["Resources"] = item.resources_total
             results.append(node_info)
         return results
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previous implementation of state API makes blocking GCS call per node to derive `node_table` and thus `nodes()` API.

<!-- Please give a short summary of the change and the problem this solves. -->
Use the information already available in NodeInfoTable derived from a single GCS rpc call.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
