### PR TITLE
Fix the failure of sort_main in the case of  num_cpus > 1 and not an integer

### DIFF
--- a/python/ray/experimental/raysort/main.py
+++ b/python/ray/experimental/raysort/main.py
@@ -332,9 +332,14 @@ def sort_main(args: Args):
     assert len(parts) == args.num_mappers
     boundaries = sortlib.get_boundaries(args.num_reducers)
 
+    # The exception of 'ValueError("Resource quantities >1 must be whole numbers.")'
+    # will be raised if the `num_cpus` > 1 and not an integer.
+    num_cpus = os.cpu_count() / args.num_concurrent_rounds
+    if num_cpus > 1.0:
+        num_cpus = int(num_cpus)
     mapper_opt = {
         "num_returns": args.num_reducers,
-        "num_cpus": os.cpu_count() / args.num_concurrent_rounds,
+        "num_cpus": num_cpus,
     }  # Load balance across worker nodes by setting `num_cpus`.
     merge_results = np.empty((args.num_rounds, args.num_reducers), dtype=object)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The exception of 'ValueError("Resource quantities >1 must be whole numbers.")' will be raised if the `num_cpus` > 1 and not an integer.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
