### PR TITLE
[RLlib] Remove Unnecessary List Conversion of Complex Observations in SAC Model

### DIFF
--- a/rllib/agents/sac/tests/test_sac.py
+++ b/rllib/agents/sac/tests/test_sac.py
@@ -492,17 +492,22 @@ class TestSAC(unittest.TestCase):
             trainer.stop()
 
     def test_sac_dict_obs_order(self):
-        dict_space = Dict({"img": Box(low=0, high=1, shape=(42, 42, 3)),
-                           "cont": Box(low=0, high=100, shape=(3,))})
+        dict_space = Dict(
+            {
+                "img": Box(low=0, high=1, shape=(42, 42, 3)),
+                "cont": Box(low=0, high=100, shape=(3,)),
+            }
+        )
 
         # Dict space .sample() returns an ordered dict.
         # Make sure the keys in samples are ordered differently.
-        dict_samples = [{k: v for k, v in reversed(dict_space.sample().items())} for _ in range(10)]
-
+        dict_samples = [
+            {k: v for k, v in reversed(dict_space.sample().items())} for _ in range(10)
+        ]
 
         class NestedDictEnv(Env):
             def __init__(self):
-                self.action_space = Box(low=42, high=56, shape=(2,))
+                self.action_space = Box(low=-1.0, high=1.0, shape=(2,))
                 self.observation_space = dict_space
                 self._spec = EnvSpec("NestedDictEnv-v0")
                 self.steps = 0
@@ -514,7 +519,6 @@ class TestSAC(unittest.TestCase):
             def step(self, action):
                 self.steps += 1
                 return dict_samples[self.steps], 1, self.steps >= 5, {}
-
 
         tune.register_env("nested", lambda _: NestedDictEnv())
 
@@ -535,7 +539,7 @@ class TestSAC(unittest.TestCase):
                 check_train_results(results)
                 print(results)
             check_compute_single_action(trainer)
-    
+
     def _get_batch_helper(self, obs_size, actions, batch_size):
         return SampleBatch(
             {

--- a/rllib/agents/sac/tests/test_sac.py
+++ b/rllib/agents/sac/tests/test_sac.py
@@ -1,5 +1,6 @@
 from gym import Env
 from gym.spaces import Box, Dict, Discrete, Tuple
+from gym.envs.registration import EnvSpec
 import numpy as np
 import re
 import unittest
@@ -490,6 +491,51 @@ class TestSAC(unittest.TestCase):
                             check(tf_var, torch_var, atol=0.003)
             trainer.stop()
 
+    def test_sac_dict_obs_order(self):
+        dict_space = Dict({"img": Box(low=0, high=1, shape=(42, 42, 3)),
+                           "cont": Box(low=0, high=100, shape=(3,))})
+
+        # Dict space .sample() returns an ordered dict.
+        # Make sure the keys in samples are ordered differently.
+        dict_samples = [{k: v for k, v in reversed(dict_space.sample().items())} for _ in range(10)]
+
+
+        class NestedDictEnv(Env):
+            def __init__(self):
+                self.action_space = Box(low=42, high=56, shape=(2,))
+                self.observation_space = dict_space
+                self._spec = EnvSpec("NestedDictEnv-v0")
+                self.steps = 0
+
+            def reset(self):
+                self.steps = 0
+                return dict_samples[0]
+
+            def step(self, action):
+                self.steps += 1
+                return dict_samples[self.steps], 1, self.steps >= 5, {}
+
+
+        tune.register_env("nested", lambda _: NestedDictEnv())
+
+        config = sac.DEFAULT_CONFIG.copy()
+        config["num_workers"] = 0  # Run locally.
+        config["learning_starts"] = 0
+        config["rollout_fragment_length"] = 5
+        config["train_batch_size"] = 5
+        config["replay_buffer_config"]["capacity"] = 10
+        # Disable preprocessors.
+        config["_disable_preprocessor_api"] = True
+        num_iterations = 1
+
+        for _ in framework_iterator(config, with_eager_tracing=True):
+            trainer = sac.SACTrainer(env="nested", config=config)
+            for _ in range(num_iterations):
+                results = trainer.train()
+                check_train_results(results)
+                print(results)
+            check_compute_single_action(trainer)
+    
     def _get_batch_helper(self, obs_size, actions, batch_size):
         return SampleBatch(
             {

--- a/rllib/models/modelv2.py
+++ b/rllib/models/modelv2.py
@@ -428,6 +428,12 @@ def _unpack_obs(obs: TensorType, space: Space, tensorlib: Any = tf) -> TensorStr
     """
 
     if isinstance(space, (gym.spaces.Dict, gym.spaces.Tuple, Repeated)):
+        # Already unpacked?
+        if (isinstance(space, gym.spaces.Tuple) and isinstance(obs, (list, tuple))) or (
+            isinstance(space, gym.spaces.Dict) and isinstance(obs, dict)
+        ):
+            return obs
+        # Unpack using preprocessor
         if id(space) in _cache:
             prep = _cache[id(space)]
         else:
@@ -435,12 +441,7 @@ def _unpack_obs(obs: TensorType, space: Space, tensorlib: Any = tf) -> TensorStr
             # Make an attempt to cache the result, if enough space left.
             if len(_cache) < 999:
                 _cache[id(space)] = prep
-        # Already unpacked?
-        if (isinstance(space, gym.spaces.Tuple) and isinstance(obs, (list, tuple))) or (
-            isinstance(space, gym.spaces.Dict) and isinstance(obs, dict)
-        ):
-            return obs
-        elif len(obs.shape) < 2 or obs.shape[-1] != prep.shape[0]:
+        if len(obs.shape) < 2 or obs.shape[-1] != prep.shape[0]:
             raise ValueError(
                 "Expected flattened obs shape of [..., {}], got {}".format(
                     prep.shape[0], obs.shape


### PR DESCRIPTION
## Why are these changes needed?

SAC models pack the values of complex observations into a list before passing them to the Q-Networks. This step may cause a bug for `dict` observations where the order of the keys is mixed up.
Moreover, this list conversion is not necessary. In case of continuous actions which need to be added to the input of the Q-Networks, we can also add another hierarchical layer on top of the complex observations to attach the action.

## Related issue number

Fixes #24105

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
