### PR TITLE
[Ray Collective] Fix the incorrect Redis password issue.

### DIFF
--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -69,6 +69,9 @@ class Rendezvous:
                 self._redis_ip_address, int(self._redis_port)
             )
             redis_password = ray_constants.REDIS_DEFAULT_PASSWORD
+            # redis_password = ray.worker._global_node.redis_password
+            # if redis_password is None or len(redis_password) == 0:
+            #     redis_password = ray_constants.REDIS_DEFAULT_PASSWORD
             redisStore.authorize(redis_password)
             self._store = redisStore
         elif store_type == "file":

--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -68,10 +68,9 @@ class Rendezvous:
             redisStore = pygloo.rendezvous.RedisStore(
                 self._redis_ip_address, int(self._redis_port)
             )
-            redis_password = ray_constants.REDIS_DEFAULT_PASSWORD
-            # redis_password = ray.worker._global_node.redis_password
-            # if redis_password is None or len(redis_password) == 0:
-            #     redis_password = ray_constants.REDIS_DEFAULT_PASSWORD
+            redis_password = ray.worker._global_node.redis_password
+            if redis_password is None or len(redis_password) == 0:
+                redis_password = ray_constants.REDIS_DEFAULT_PASSWORD
             redisStore.authorize(redis_password)
             self._store = redisStore
         elif store_type == "file":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes the issue that we are not able to use GLOO as collective lib for the Ray cluster which is set Redis password.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Close #24108
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
