### PR TITLE
IMapIterator fix when using iterator inputs

### DIFF
--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -467,6 +467,7 @@ def callback_test_helper(args):
         raise Exception("intentional failure")
     return index
 
+
 @pytest.mark.parametrize("use_iter", [True, False])
 def test_imap(pool_4_processes, use_iter):
     def f(args):
@@ -482,9 +483,7 @@ def test_imap(pool_4_processes, use_iter):
         imap_iterable = iter([(index, error_indices) for index in range(100)])
     else:
         imap_iterable = [(index, error_indices) for index in range(100)]
-    result_iter = pool_4_processes.imap(
-        f, imap_iterable, chunksize=11
-    )
+    result_iter = pool_4_processes.imap(f, imap_iterable, chunksize=11)
     for i in range(100):
         result = result_iter.next()
         if i in error_indices:
@@ -513,9 +512,7 @@ def test_imap_unordered(pool_4_processes, use_iter):
         imap_iterable = iter([(index, error_indices) for index in range(100)])
     else:
         imap_iterable = [(index, error_indices) for index in range(100)]
-    result_iter = pool_4_processes.imap_unordered(
-        f, imap_iterable, chunksize=11
-    )
+    result_iter = pool_4_processes.imap_unordered(f, imap_iterable, chunksize=11)
     for i in range(100):
         result = result_iter.next()
         if isinstance(result, Exception):
@@ -549,9 +546,7 @@ def test_imap_timeout(pool_4_processes, use_iter):
         imap_iterable = iter([(index, wait_index, signal) for index in range(100)])
     else:
         imap_iterable = [(index, wait_index, signal) for index in range(100)]
-    result_iter = pool_4_processes.imap(
-        f, imap_iterable
-    )
+    result_iter = pool_4_processes.imap(f, imap_iterable)
     for i in range(100):
         if i == wait_index:
             with pytest.raises(TimeoutError):
@@ -570,9 +565,7 @@ def test_imap_timeout(pool_4_processes, use_iter):
         imap_iterable = iter([(index, wait_index, signal) for index in range(100)])
     else:
         imap_iterable = [(index, wait_index, signal) for index in range(100)]
-    result_iter = pool_4_processes.imap_unordered(
-        f, imap_iterable, chunksize=11
-    )
+    result_iter = pool_4_processes.imap_unordered(f, imap_iterable, chunksize=11)
     in_order = []
     for i in range(100):
         try:

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -656,6 +656,7 @@ def test_imap_timeout(pool_4_processes):
     with pytest.raises(StopIteration):
         result_iter.next()
 
+
 def test_maxtasksperchild(shutdown_only):
     def f(args):
         return os.getpid()

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -367,7 +367,7 @@ class IMapIterator:
             iterable = [iterable]
             self._iterator = iter(iterable)
         if isinstance(iterable, collections.Iterator):
-            # Got iterator (which has no len() function). 
+            # Got iterator (which has no len() function).
             # Make default chunksize 1 instead of using _calculate_chunksize().
             self._chunksize = chunksize or 1
             result_list_size = 0

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -201,6 +201,7 @@ class ResultThread(threading.Thread):
     def run(self):
         unready = copy.copy(self._object_refs)
         aggregated_batch_results = []
+        
         # Run for a specific number of objects if self._total_object_refs is finite.
         # Otherwise, process all objects received prior to the stop signal, given by
         # self.add_object(END_SENTINEL).
@@ -213,7 +214,7 @@ class ResultThread(threading.Thread):
                     new_object_ref = self._new_object_refs.get(block=block)
                     if new_object_ref is self.END_SENTINEL:
                         # Receiving the END_SENTINEL object is the signal to stop.
-                        # Store the total number of added objects.
+                        # Store the total number of objects.
                         self._total_object_refs = len(self._object_refs)
                     else:
                         self._add_object_ref(new_object_ref)
@@ -390,10 +391,10 @@ class IMapIterator:
         # This consumes the original iterator, so we convert to a list and back
         chunk_list = list(chunk_iterator)
         if len(chunk_list) < self._chunksize:
-            # we have reached the end of self._iterator
+            # Reached end of self._iterator
             self._finished_iterating = True
             if len(chunk_list) == 0:
-                # there is nothing to do, return.
+                # Nothing to do, return.
                 return
         chunk_iterator = iter(chunk_list)
 

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -258,7 +258,7 @@ class ResultThread(threading.Thread):
                 self._callback(aggregated_batch_results[0])
 
     def stop(self):
-        # Call this to interrupt the run function. 
+        # Call this to interrupt the run function.
         # The run() will terminate when all pending jobs have completed.
         self._stop_event.set()
         # Push a non-event to trigger to unblock the run function if it is waiting.
@@ -388,7 +388,7 @@ class IMapIterator:
         actor_index = len(self._submitted_chunks) % len(self._pool._actor_pool)
         chunk_iterator = itertools.islice(self._iterator, self._chunksize)
 
-        # Check whether we have run out of samples. 
+        # Check whether we have run out of samples.
         # This consumes the original iterator, so we convert to a list and back
         chunk_list = list(chunk_iterator)
         if len(chunk_list) < self._chunksize:

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -405,7 +405,7 @@ class IMapIterator:
         self._result_thread.add_object_ref(new_chunk_id)
         # If we submitted the final chunk, notify the result thread
         if self._finished_iterating:
-            self._result_thread.add_object_ref(self._result_thread.END_SENTINEL)
+            self._result_thread.add_object_ref(ResultThread.END_SENTINEL)
 
     def __iter__(self):
         return self

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -366,8 +366,9 @@ class IMapIterator:
             # for compatibility with prior releases, encapsulate non-iterable in a list
             iterable = [iterable]
             self._iterator = iter(iterable)
-        if self._iterator == iterable:
-            # we were passsed an iterator, so do not know the number of samples
+        if isinstance(iterable, collections.Iterator):
+            # Got iterator (which has no len() function). 
+            # Make default chunksize 1 instead of using _calculate_chunksize().
             self._chunksize = chunksize or 1
             result_list_size = 0
         else:

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -370,7 +370,9 @@ class IMapIterator:
         chunk_list = list(chunk_iterator)
         if len(chunk_list) < self._chunksize:
             self._finished_iterating = True
-            return
+            if len(chunk_list) == 0:
+                # there is nothing to do, return.
+                return
         chunk_iterator = iter(chunk_list)
 
         new_chunk_id = self._pool._submit_chunk(

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -157,6 +157,11 @@ class PoolTaskError(Exception):
 
 
 class ResultThread(threading.Thread):
+    # END_SENTINEL signals that there are no more new object_refs.
+    # When this thread gets the END_SENTINEL from
+    # self._new_object_refs, it winds down.
+    END_SENTINEL = None
+
     def __init__(
         self,
         object_refs,
@@ -166,7 +171,6 @@ class ResultThread(threading.Thread):
         total_object_refs=None,
     ):
         threading.Thread.__init__(self, daemon=True)
-        self.END_SENTINEL = None
         self._got_error = False
         self._object_refs = []
         self._num_ready = 0

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -366,7 +366,7 @@ class IMapIterator:
             # for compatibility with prior releases, encapsulate non-iterable in a list
             iterable = [iterable]
             self._iterator = iter(iterable)
-        if isinstance(iterable, collections.Iterator):
+        if isinstance(iterable, collections.abc.Iterator):
             # Got iterator (which has no len() function).
             # Make default chunksize 1 instead of using _calculate_chunksize().
             self._chunksize = chunksize or 1

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -369,7 +369,7 @@ class IMapIterator:
         if self._iterator == iterable:
             # we were passsed an iterator, so do not know the number of samples
             self._chunksize = chunksize or 1
-            result_list_size = 0  # len(self._pool._actor_pool)
+            result_list_size = 0
         else:
             self._chunksize = chunksize or pool._calculate_chunksize(iterable)
             result_list_size = div_round_up(len(iterable), chunksize)


### PR DESCRIPTION


## Why are these changes needed?

In the current code base, `multiprocessing.Pool.imap_unordered` fails when it is called with an iterator (for which the length is not known on the first call). For example, the following code would fail:
```
import ray.util.multiprocessing as raymp

# test function
def func(input):
    print('run func [{}]'.format(input))
    return input

with raymp.Pool() as pool:
    
    # this fails with a TypeError (could not serialize)
    print('use an iterator')
    for x in pool.imap_unordered(func, iter(range(5))):
        print('Finished [{}]'.format(x))
```

## Summary of changes

* I made changes to the `ResultThread` class that enable it to work with argument `total_object_refs=0`. This will let it run until a call to `stop()` is received.
* I have adapted the `IMapIterator` class to better check input arguments and distinguish between iterables and iterators.
* The super classes `OrderedIMapIterator` and `UnorderedIMapIterator` have been updated to stop appropriately when iterators are used, and explicitly stop the `_result_thread`.

## Related issue number

This is a first attempt to solve #24081 

## Checks

I have *not yet* run these checks. @edoakes can you please give me a hand? (I am new to some of these github aspects)

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
