### PR TITLE
[Datasets] Print hierarchical stats for multi-stage operations.

### DIFF
--- a/python/ray/data/impl/stats.py
+++ b/python/ray/data/impl/stats.py
@@ -63,6 +63,7 @@ class _DatasetStatsBuilder:
         stats = DatasetStats(
             stages=stage_infos,
             parent=self.parent,
+            base_name=self.stage_name,
         )
         stats.time_total_s = time.perf_counter() - self.start_time
         return stats
@@ -144,8 +145,9 @@ class DatasetStats:
         *,
         stages: Dict[str, List[BlockMetadata]],
         parent: Union[Optional["DatasetStats"], List["DatasetStats"]],
-        needs_stats_actor=False,
-        stats_uuid=None
+        needs_stats_actor: bool = False,
+        stats_uuid: str = None,
+        base_name: str = None,
     ):
         """Create dataset stats.
 
@@ -159,6 +161,7 @@ class DatasetStats:
                 datasource (i.e. a LazyBlockList).
             stats_uuid: The uuid for the stats, used to fetch the right stats
                 from the stats actor.
+            base_name: The name of the base operation for a multi-stage operation.
         """
 
         self.stages: Dict[str, List[BlockMetadata]] = stages
@@ -171,6 +174,7 @@ class DatasetStats:
         self.number: int = (
             0 if not self.parents else max(p.number for p in self.parents) + 1
         )
+        self.base_name = base_name
         self.dataset_uuid: str = None
         self.time_total_s: float = 0
         self.needs_stats_actor = needs_stats_actor
@@ -219,19 +223,32 @@ class DatasetStats:
                 if parent_sum:
                     out += parent_sum
                     out += "\n"
-        first = True
-        for stage_name, metadata in self.stages.items():
+        if len(self.stages) == 1:
+            stage_name, metadata = next(iter(self.stages.items()))
             stage_uuid = self.dataset_uuid + stage_name
-            if first:
-                first = False
-            else:
-                out += "\n"
             out += "Stage {} {}: ".format(self.number, stage_name)
             if stage_uuid in already_printed:
                 out += "[execution cached]"
             else:
                 already_printed.add(stage_uuid)
-                out += self._summarize_blocks(metadata)
+                out += self._summarize_blocks(metadata, is_substage=False)
+        elif len(self.stages) > 1:
+            rounded_total = round(self.time_total_s, 2)
+            if rounded_total <= 0:
+                # Handle -0.0 case.
+                rounded_total = 0
+            out += "Stage {} {}: executed in {}s\n".format(
+                self.number, self.base_name, rounded_total
+            )
+            for n, (stage_name, metadata) in enumerate(self.stages.items()):
+                stage_uuid = self.dataset_uuid + stage_name
+                out += "\n"
+                out += "\tSubstage {} {}: ".format(n, stage_name)
+                if stage_uuid in already_printed:
+                    out += "\t[execution cached]"
+                else:
+                    already_printed.add(stage_uuid)
+                    out += self._summarize_blocks(metadata, is_substage=True)
         out += self._summarize_iter()
         return out
 
@@ -253,17 +270,22 @@ class DatasetStats:
             out += "* Total time: {}\n".format(fmt(self.iter_total_s.get()))
         return out
 
-    def _summarize_blocks(self, blocks: List[BlockMetadata]) -> str:
+    def _summarize_blocks(self, blocks: List[BlockMetadata], is_substage: bool) -> str:
         exec_stats = [m.exec_stats for m in blocks if m.exec_stats is not None]
-        rounded_total = round(self.time_total_s, 2)
-        if rounded_total <= 0:
-            # Handle -0.0 case.
-            rounded_total = 0
-        out = "{}/{} blocks executed in {}s\n".format(
-            len(exec_stats), len(blocks), rounded_total
-        )
+        indent = "\t" if is_substage else ""
+        if is_substage:
+            out = "{}/{} blocks executed\n".format(len(exec_stats), len(blocks))
+        else:
+            rounded_total = round(self.time_total_s, 2)
+            if rounded_total <= 0:
+                # Handle -0.0 case.
+                rounded_total = 0
+            out = "{}/{} blocks executed in {}s\n".format(
+                len(exec_stats), len(blocks), rounded_total
+            )
 
         if exec_stats:
+            out += indent
             out += "* Remote wall time: {} min, {} max, {} mean, {} total\n".format(
                 fmt(min([e.wall_time_s for e in exec_stats])),
                 fmt(max([e.wall_time_s for e in exec_stats])),
@@ -271,6 +293,7 @@ class DatasetStats:
                 fmt(sum([e.wall_time_s for e in exec_stats])),
             )
 
+            out += indent
             out += "* Remote cpu time: {} min, {} max, {} mean, {} total\n".format(
                 fmt(min([e.cpu_time_s for e in exec_stats])),
                 fmt(max([e.cpu_time_s for e in exec_stats])),
@@ -280,6 +303,7 @@ class DatasetStats:
 
         output_num_rows = [m.num_rows for m in blocks if m.num_rows is not None]
         if output_num_rows:
+            out += indent
             out += "* Output num rows: {} min, {} max, {} mean, {} total\n".format(
                 min(output_num_rows),
                 max(output_num_rows),
@@ -289,6 +313,7 @@ class DatasetStats:
 
         output_size_bytes = [m.size_bytes for m in blocks if m.size_bytes is not None]
         if output_size_bytes:
+            out += indent
             out += "* Output size bytes: {} min, {} max, {} mean, {} total\n".format(
                 min(output_size_bytes),
                 max(output_size_bytes),
@@ -300,6 +325,7 @@ class DatasetStats:
             node_counts = collections.defaultdict(int)
             for s in exec_stats:
                 node_counts[s.node_id] += 1
+            out += indent
             out += "* Tasks per node: {} min, {} max, {} mean; {} nodes used\n".format(
                 min(node_counts.values()),
                 max(node_counts.values()),

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -13,7 +13,9 @@ def canonicalize(stats: str) -> str:
     s2 = re.sub(" [0]+(\.[0]+)?", " Z", s1)
     # Other numerics.
     s3 = re.sub("[0-9]+(\.[0-9]+)?", "N", s2)
-    return s3
+    # Replace tabs with spaces.
+    s4 = re.sub("\t", "    ", s3)
+    return s4
 
 
 def test_dataset_stats_basic(ray_start_regular_shared):
@@ -59,33 +61,37 @@ def test_dataset_stats_shuffle(ray_start_regular_shared):
     stats = canonicalize(ds.stats())
     assert (
         stats
-        == """Stage N read->random_shuffle_map: N/N blocks executed in T
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
-* Tasks per node: N min, N max, N mean; N nodes used
+        == """Stage N read->random_shuffle: executed in T
 
-Stage N random_shuffle_reduce: N/N blocks executed in T
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
-* Tasks per node: N min, N max, N mean; N nodes used
+    Substage Z read->random_shuffle_map: N/N blocks executed
+    * Remote wall time: T min, T max, T mean, T total
+    * Remote cpu time: T min, T max, T mean, T total
+    * Output num rows: N min, N max, N mean, N total
+    * Output size bytes: N min, N max, N mean, N total
+    * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N repartition_map: N/N blocks executed in T
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
-* Tasks per node: N min, N max, N mean; N nodes used
+    Substage N random_shuffle_reduce: N/N blocks executed
+    * Remote wall time: T min, T max, T mean, T total
+    * Remote cpu time: T min, T max, T mean, T total
+    * Output num rows: N min, N max, N mean, N total
+    * Output size bytes: N min, N max, N mean, N total
+    * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N repartition_reduce: N/N blocks executed in T
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
-* Tasks per node: N min, N max, N mean; N nodes used
+Stage N repartition: executed in T
+
+    Substage Z repartition_map: N/N blocks executed
+    * Remote wall time: T min, T max, T mean, T total
+    * Remote cpu time: T min, T max, T mean, T total
+    * Output num rows: N min, N max, N mean, N total
+    * Output size bytes: N min, N max, N mean, N total
+    * Tasks per node: N min, N max, N mean; N nodes used
+
+    Substage N repartition_reduce: N/N blocks executed
+    * Remote wall time: T min, T max, T mean, T total
+    * Remote cpu time: T min, T max, T mean, T total
+    * Output num rows: N min, N max, N mean, N total
+    * Output size bytes: N min, N max, N mean, N total
+    * Tasks per node: N min, N max, N mean; N nodes used
 """
     )
 


### PR DESCRIPTION
The total execution time for multi-stage operations being logged twice in the dataset stats is [confusing to users](https://github.com/ray-project/ray/issues/23915), making it seem like each stage in the operation took the same amount of time. This PR modifies the stats output for multi-stage operations, such that the total execution time is printed out once as a top-level op stats line, with the stats for each of the (sub)stages indented and devoid of the total execution time repeat.

This also opens the door for other op-level stats (e.g. peak memory utilization) and per-substage stats (e.g. total substage execution time).

### Before
```
Stage 1 read->map: 100/100 blocks executed in 1.02s
* Remote wall time: 156.91us min, 922.5ms max, 61.74ms mean, 6.17s total
* Remote cpu time: 156.62us min, 835.88ms max, 52.83ms mean, 5.28s total
* Output num rows: 1 min, 1 max, 1 mean, 100 total
* Output size bytes: 104 min, 104 max, 104 mean, 10400 total
* Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used

Stage 2 random_shuffle_map: 100/100 blocks executed in 0.31s
* Remote wall time: 727.34us min, 6.23ms max, 1.4ms mean, 140.28ms total
* Remote cpu time: 722.51us min, 1.47ms max, 1.18ms mean, 118.45ms total
* Output num rows: 1 min, 1 max, 1 mean, 100 total
* Output size bytes: 80 min, 80 max, 80 mean, 8000 total
* Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used

Stage 2 random_shuffle_reduce: 100/100 blocks executed in 0.31s
* Remote wall time: 573.85us min, 1.79ms max, 924.7us mean, 92.47ms total
* Remote cpu time: 573.64us min, 1.18ms max, 873.97us mean, 87.4ms total
* Output num rows: 0 min, 5 max, 1 mean, 100 total
* Output size bytes: 72 min, 112 max, 80 mean, 8000 total
* Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used
```

### After
```
In [1]: ds = ray.data.range(100).map(lambda x: x + 1).random_shuffle()

In [2]: print(ds.stats())
Stage 1 read->map: 100/100 blocks executed in 1.13s
* Remote wall time: 185.63us min, 958.86ms max, 56.78ms mean, 5.68s total
* Remote cpu time: 184.8us min, 688.89ms max, 47.7ms mean, 4.77s total
* Output num rows: 1 min, 1 max, 1 mean, 100 total
* Output size bytes: 104 min, 104 max, 104 mean, 10400 total
* Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used

Stage 2 random_shuffle: executed in 1.47s

        Substage 0 random_shuffle_map: 100/100 blocks executed
        * Remote wall time: 778.47us min, 2.39ms max, 1.03ms mean, 103.42ms total
        * Remote cpu time: 777.55us min, 1.74ms max, 1.02ms mean, 101.9ms total
        * Output num rows: 1 min, 1 max, 1 mean, 100 total
        * Output size bytes: 80 min, 80 max, 80 mean, 8000 total
        * Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used

        Substage 1 random_shuffle_reduce: 100/100 blocks executed
        * Remote wall time: 621.11us min, 7.41ms max, 987.92us mean, 98.79ms total
        * Remote cpu time: 620.93us min, 1.34ms max, 896.22us mean, 89.62ms total
        * Output num rows: 0 min, 5 max, 1 mean, 100 total
        * Output size bytes: 72 min, 112 max, 80 mean, 8000 total
        * Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/23915

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
