### PR TITLE
validate autoscaler.sdk.request_resources input

### DIFF
--- a/python/ray/autoscaler/sdk/sdk.py
+++ b/python/ray/autoscaler/sdk/sdk.py
@@ -234,6 +234,12 @@ def request_resources(
         >>> request_resources( # doctest: +SKIP
         ...     bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}])
     """
+    if not isinstance(bundles, List):
+        raise TypeError('bundles input must be in form List[Dict[str,int]]')
+    else:
+        for bundle in bundles:
+            if not isinstance(bundle, Dict):
+                raise TypeError('bundles input must be in form List[Dict[str,int]]')
     return commands.request_resources(num_cpus, bundles)
 
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -3447,6 +3447,15 @@ MemAvailable:   33000000 kB
         assert head_node_config["min_workers"] == 0
         assert head_node_config["max_workers"] == 0
 
+    def testInitializeSDKArguments(self):
+        # https://github.com/ray-project/ray/issues/23166
+        from ray.autoscaler.sdk import request_resources
+        ray.init()
+        # dict[str, int] is invalid
+        self.assertRaises(TypeError, request_resources(bundles={"GPU": 1}))
+        # list[str, str] is invalid
+        self.assertRaises(TypeError, request_resources(bundles=["GPU", "CPU"]))
+
 
 def test_import():
     """This test ensures that all the autoscaler imports work as expected to


### PR DESCRIPTION
## Why are these changes needed?
This change verifies the input to autoscaler.sdk.request_resources is in the format List[Dict], which prevents junk in the autoscaler logs in the case in which data is not properly formatted. I've included a regression test that ensures the TypeError is thrown when data format is incorrect. 

## Related issue number
Closes #23166

## Checks
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
