### PR TITLE
[RLlib] Don't add elements to _agent_ids during env pre-checks.

### DIFF
--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -1,4 +1,5 @@
 """Common pre-checks for all RLlib experiments."""
+from copy import copy
 import logging
 import gym
 import numpy as np
@@ -488,7 +489,7 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
                 f" {type(element)}"
             )
         raise ValueError(error)
-    agent_ids: Set = env.get_agent_ids()
+    agent_ids: Set = copy(env.get_agent_ids())
     agent_ids.add("__all__")
 
     if not all(k in agent_ids for k in element):


### PR DESCRIPTION
Because `get_agent_ids` returns the actual set, when we add to it, this
modifies it.

This isn't preferred; a check shouldn't be modifying something!

So, we defensively copy in the test.

It's perhaps better for the `.get_agent_ids()` function to return a copy
instead, but I thought this was less controversial.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If you have loops over your `self._agent_ids` in your step function, say, they crash, because of this addition by the checking.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
