### PR TITLE
[rllib] Deactivate flaky alpha star learning test

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -114,15 +114,16 @@ py_test(
 )
 
 # AlphaStar
-py_test(
-    name = "learning_tests_cartpole_alpha_star",
-    main = "tests/run_regression_tests.py",
-    tags = ["team:ml", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
-    size = "large",
-    srcs = ["tests/run_regression_tests.py"],
-    data = ["tuned_examples/alpha_star/multi-agent-cartpole-alpha-star.yaml"],
-    args = ["--yaml-dir=tuned_examples/alpha_star", "--num-cpus=20"]
-)
+# Todo (rllib-team): Re-activate once flakiness fixed
+# py_test(
+#     name = "learning_tests_cartpole_alpha_star",
+#     main = "tests/run_regression_tests.py",
+#     tags = ["team:ml", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+#     size = "large",
+#     srcs = ["tests/run_regression_tests.py"],
+#     data = ["tuned_examples/alpha_star/multi-agent-cartpole-alpha-star.yaml"],
+#     args = ["--yaml-dir=tuned_examples/alpha_star", "--num-cpus=20"]
+# )
 
 # APEX-DQN
 py_test(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test is at a 86% flakiness rate and failed in most of the most recent commits: https://flakey-tests.ray.io/

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
