### PR TITLE
[train] Copy resources_per_worker to avoid modifying user input

### DIFF
--- a/python/ray/train/tests/test_trainer.py
+++ b/python/ray/train/tests/test_trainer.py
@@ -1164,6 +1164,9 @@ def test_resources(ray_start_4_cpus_4_gpus_4_extra, resource, num_requested):
     trainer.shutdown()
     wait_for_condition(lambda: ray.available_resources().get(resource, 0) == original)
 
+    # Check that user input has not been modified
+    assert resources_per_worker == {resource: num_requested}
+
 
 def test_gpu_requests(ray_start_4_cpus_4_gpus_4_extra):
     class CudaTestBackend(TestBackend):

--- a/python/ray/train/trainer.py
+++ b/python/ray/train/trainer.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import datetime
 import logging
 import os
@@ -148,6 +149,10 @@ class Trainer:
                 "GPU training, make sure to set `use_gpu` to True "
                 "when instantiating your Trainer."
             )
+
+        if resources_per_worker is not None:
+            # Copy this parameter to avoid mutating the user input
+            resources_per_worker = copy.deepcopy(resources_per_worker)
 
         self._num_workers = num_workers
         self._use_gpu = use_gpu


### PR DESCRIPTION
## Why are these changes needed?

Avoid modifying user input to Trainer.

## Related issue number

Closes #24139

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
