### PR TITLE
[rllib] Fix some missing f-strings

### DIFF
--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1522,7 +1522,7 @@ class RolloutWorker(ParallelIteratorWorker):
                         f"PolicyID '{pid}' was probably added on-the-fly (not"
                         " part of the static `multagent.policies` config) and"
                         " no PolicySpec objects found in the pickled policy "
-                        "state. Will not add `{pid}`, but ignore it for now."
+                        f"state. Will not add `{pid}`, but ignore it for now."
                     )
                 else:
                     self.add_policy(

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -745,7 +745,7 @@ def _env_runner(
                     simple_image_viewer.imshow(rendered)
             elif rendered not in [True, False, None]:
                 raise ValueError(
-                    "The env's ({base_env}) `try_render()` method returned an"
+                    f"The env's ({base_env}) `try_render()` method returned an"
                     " unsupported value! Make sure you either return a "
                     "uint8/w x h x 3 (RGB) image or handle rendering in a "
                     "window and then return `True`."

--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -516,8 +516,8 @@ def build_eager_tf_policy(
                 _is_training=tf.constant(False),
             )
             if state_batches is not None:
-                for s in enumerate(state_batches):
-                    input_dict["state_in_{i}"] = s
+                for i, s in enumerate(state_batches):
+                    input_dict[f"state_in_{i}"] = s
             if prev_action_batch is not None:
                 input_dict[SampleBatch.PREV_ACTIONS] = prev_action_batch
             if prev_reward_batch is not None:

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -260,7 +260,7 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
     if not env.action_space_contains(sampled_action):
         error = (
             _not_contained_error("action_space_sample", "action")
-            + "\n\n sampled_action {sampled_action}\n\n"
+            + f"\n\n sampled_action {sampled_action}\n\n"
         )
         raise ValueError(error)
 
@@ -277,7 +277,7 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
     if not env.observation_space_contains(next_obs):
         error = (
             _not_contained_error("env.step(sampled_action)", "observation")
-            + ":\n\n next_obs: {next_obs} \n\n sampled_obs: {sampled_obs}"
+            + f":\n\n next_obs: {next_obs} \n\n sampled_obs: {sampled_obs}"
         )
         raise ValueError(error)
 


### PR DESCRIPTION
Noticed some strings should've been f-strings; this fixes them, and
fixes a minor bug that was present, as a result.

Note that I only did this in the `rllib` folder; I didn't want to go through everything, because my regex generated a lot of false positives; but someone better with regexes could probably improve it:

```
rg '(?<!f)"[^"]*?{.{1,}}.*?"' --pcre2 -t py | grep -v format
```

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It's a bug.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
