### PR TITLE
improve exponential backoff when connecting to the redis

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -861,13 +861,8 @@ def wait_for_redis_to_start(redis_ip_address, redis_port, password=None):
                 ) from connEx
             # Wait a little bit.
             time.sleep(delay)
-            # When deploying a Ray cluster based on k8s, if the shape of the
-            # head node is large, the delivery time of the redis inside the
-            # head pod will be long as well. If exponential backoff is used on
-            # the work node, it may occur that the redis started at 33s, the
-            # work node did not connect the redis until 64s, which in turn
-            # affected the delivery time of the Ray cluster. Therefore, we make
-            # a fixed retry interval (1s) when backoff times >= 10.
+            # Make sure the retry interval doesn't increase too large, which will
+            # affect the delivery time of the Ray cluster.
             delay = 1000 if i >= 10 else delay * 2
         else:
             break

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -181,7 +181,7 @@ REPORTER_UPDATE_INTERVAL_MS = env_integer("REPORTER_UPDATE_INTERVAL_MS", 2500)
 # Number of attempts to ping the Redis server. See
 # `services.py::wait_for_redis_to_start()` and
 # `services.py::create_redis_client()`
-START_REDIS_WAIT_RETRIES = env_integer("RAY_START_REDIS_WAIT_RETRIES", 16)
+START_REDIS_WAIT_RETRIES = env_integer("RAY_START_REDIS_WAIT_RETRIES", 60)
 
 LOGGER_FORMAT = "%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message)s"
 LOGGER_FORMAT_HELP = f"The logging format. default='{LOGGER_FORMAT}'"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When deploying a Ray cluster based on k8s, if the shape of the head node is large, the delivery time of the redis inside the head pod will be long as well. If exponential backoff is used on the work node, it may occur that the redis started at 33s, the work node did not connect the redis until 64s, which in turn affected the delivery time of the Ray cluster. Therefore, we make a fixed retry interval (1s) when backoff times >= 10.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
