### PR TITLE
[RLlib] Add missing callbacks to MultiCallbacks.

### DIFF
--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -381,6 +381,26 @@ class MultiCallbacks(DefaultCallbacks):
 
         return self
 
+    def on_trainer_init(self, *, trainer: "Trainer", **kwargs) -> None:
+        for callback in self._callback_list:
+            callback.on_trainer_init(trainer=trainer, **kwargs)
+
+    def on_sub_environment_created(
+        self,
+        *,
+        worker: "RolloutWorker",
+        sub_environment: EnvType,
+        env_context: EnvContext,
+        **kwargs,
+    ) -> None:
+        for callback in self._callback_list:
+            callback.on_sub_environment_created(
+                worker=worker,
+                sub_environment=sub_environment,
+                env_context=env_context,
+                **kwargs,
+            )
+
     def on_episode_start(
         self,
         *,


### PR DESCRIPTION
## Why are these changes needed?
`rllib.agents.callbacks.MultiCallbacks` currently neglects to execute `on_trainer_init` and `on_sub_environment_created` callbacks.

## Related issue number
N/A

## Checks
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
