### PR TITLE
Missing `f` prefix on f-strings fix

### DIFF
--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -394,7 +394,7 @@ class Trial:
             self.custom_dirname = trial_dirname_creator(self)
             if os.path.sep in self.custom_dirname:
                 raise ValueError(
-                    "Trial dirname must not contain '/'. Got {self.custom_dirname}"
+                    f"Trial dirname must not contain '/'. Got {self.custom_dirname}"
                 )
 
         self._state_json = None


### PR DESCRIPTION
Fix [#24143](https://github.com/ray-project/ray/issues/24143)
