### PR TITLE
[Datasets] Add support for write task remote options.

### DIFF
--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -1,5 +1,5 @@
 import builtins
-from typing import Any, Generic, List, Callable, Union, Tuple, Iterable
+from typing import Any, Generic, List, Dict, Callable, Union, Tuple, Iterable
 
 import numpy as np
 
@@ -55,6 +55,7 @@ class Datasource(Generic[T]):
         self,
         blocks: List[ObjectRef[Block]],
         metadata: List[BlockMetadata],
+        ray_remote_args: Dict[str, Any],
         **write_args,
     ) -> List[ObjectRef[WriteResult]]:
         """Launch Ray tasks for writing blocks out to the datasource.
@@ -63,6 +64,7 @@ class Datasource(Generic[T]):
             blocks: List of data block references. It is recommended that one
                 write task be generated per block.
             metadata: List of block metadata.
+            ray_remote_args: Kwargs passed to ray.remote in the write tasks.
             write_args: Additional kwargs to pass to the datasource impl.
 
         Returns:
@@ -277,6 +279,7 @@ class DummyOutputDatasource(Datasource[Union[ArrowRow, int]]):
         self,
         blocks: List[ObjectRef[Block]],
         metadata: List[BlockMetadata],
+        ray_remote_args: Dict[str, Any],
         **write_args,
     ) -> List[ObjectRef[WriteResult]]:
         tasks = []

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from typing import Union, List, Dict, Any
 
 import numpy as np
 import pandas as pd
@@ -15,13 +16,17 @@ from functools import partial
 import ray
 
 from ray.tests.conftest import *  # noqa
+from ray.types import ObjectRef
+from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.datasource import (
+    Datasource,
     DummyOutputDatasource,
     PathPartitionFilter,
     PathPartitionEncoder,
     PartitionStyle,
+    WriteResult,
 )
-from ray.data.block import BlockAccessor
+from ray.data.impl.arrow_block import ArrowRow
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import PARALLELIZE_META_FETCH_THRESHOLD
 from ray.data.tests.conftest import *  # noqa
@@ -1927,7 +1932,7 @@ def test_csv_roundtrip(ray_start_regular_shared, fs, data_path):
     ],
 )
 def test_csv_write_block_path_provider(
-    ray_start_regular_shared,
+    shutdown_only,
     fs,
     data_path,
     endpoint_url,
@@ -1964,6 +1969,95 @@ def test_csv_write_block_path_provider(
         ]
     )
     assert df.equals(ds_df)
+
+
+class NodeLoggerOutputDatasource(Datasource[Union[ArrowRow, int]]):
+    """A writable datasource that logs node IDs of write tasks, for testing."""
+
+    def __init__(self):
+        @ray.remote
+        class DataSink:
+            def __init__(self):
+                self.rows_written = 0
+                self.enabled = True
+                self.node_ids = set()
+
+            def write(self, node_id: str, block: Block) -> str:
+                block = BlockAccessor.for_block(block)
+                if not self.enabled:
+                    raise ValueError("disabled")
+                self.rows_written += block.num_rows()
+                self.node_ids.add(node_id)
+                return "ok"
+
+            def get_rows_written(self):
+                return self.rows_written
+
+            def get_node_ids(self):
+                return self.node_ids
+
+            def set_enabled(self, enabled):
+                self.enabled = enabled
+
+        self.data_sink = DataSink.remote()
+        self.num_ok = 0
+        self.num_failed = 0
+
+    def do_write(
+        self,
+        blocks: List[ObjectRef[Block]],
+        metadata: List[BlockMetadata],
+        ray_remote_args: Dict[str, Any],
+        **write_args,
+    ) -> List[ObjectRef[WriteResult]]:
+        data_sink = self.data_sink
+
+        @ray.remote
+        def write(b):
+            node_id = ray.get_runtime_context().node_id.hex()
+            return ray.get(data_sink.write.remote(node_id, b))
+
+        tasks = []
+        for b in blocks:
+            tasks.append(write.options(**ray_remote_args).remote(b))
+        return tasks
+
+    def on_write_complete(self, write_results: List[WriteResult]) -> None:
+        assert all(w == "ok" for w in write_results), write_results
+        self.num_ok += 1
+
+    def on_write_failed(
+        self, write_results: List[ObjectRef[WriteResult]], error: Exception
+    ) -> None:
+        self.num_failed += 1
+
+
+def test_write_datasource_ray_remote_args(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(
+        resources={"foo": 100},
+        num_cpus=1,
+    )
+    cluster.add_node(resources={"bar": 100}, num_cpus=1)
+
+    ray.init(cluster.address)
+
+    @ray.remote
+    def get_node_id():
+        return ray.get_runtime_context().node_id.hex()
+
+    bar_node_id = ray.get(get_node_id.options(resources={"bar": 1}).remote())
+
+    output = NodeLoggerOutputDatasource()
+    ds = ray.data.range(100, parallelism=10)
+    # Pin write tasks to
+    ds.write_datasource(output, ray_remote_args={"resources": {"bar": 1}})
+    assert output.num_ok == 1
+    assert output.num_failed == 0
+    assert ray.get(output.data_sink.get_rows_written.remote()) == 100
+
+    node_ids = ray.get(output.data_sink.get_node_ids.remote())
+    assert node_ids == {bar_node_id}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Users may want to provide Ray task option overrides for write tasks, e.g. having write tasks retried on application-level exceptions (`retry_exceptions=True`) or change the default number of retries (`max_retries=8`). This PR adds support for providing such task options for write tasks.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #22130 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
