### PR TITLE
[Datasets] Add test for reading CSV files without reading the first line as the header.

### DIFF
--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -1932,7 +1932,7 @@ def test_csv_roundtrip(ray_start_regular_shared, fs, data_path):
     ],
 )
 def test_csv_write_block_path_provider(
-    shutdown_only,
+    ray_start_regular_shared,
     fs,
     data_path,
     endpoint_url,
@@ -1969,6 +1969,24 @@ def test_csv_write_block_path_provider(
         ]
     )
     assert df.equals(ds_df)
+
+
+# NOTE: The last test using the shared ray_start_regular_shared cluster must use the
+# shutdown_only fixture so the shared cluster is shut down, otherwise the below
+# test_write_datasource_ray_remote_args test, which uses a cluster_utils cluster, will
+# fail with a double-init.
+def test_csv_read_no_header(shutdown_only, tmp_path):
+    from pyarrow import csv
+
+    file_path = os.path.join(tmp_path, "test.csv")
+    df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    df.to_csv(file_path, index=False, header=False)
+    ds = ray.data.read_csv(
+        file_path,
+        read_options=csv.ReadOptions(column_names=["one", "two"]),
+    )
+    out_df = ds.to_pandas()
+    assert df.equals(out_df)
 
 
 class NodeLoggerOutputDatasource(Datasource[Union[ArrowRow, int]]):


### PR DESCRIPTION
This PR adds a test confirming that the user can manually supply column names as an alternative to reading a header line.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #18117 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
