### PR TITLE
[core] Fix internal storage S3 bugs

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1238,3 +1238,44 @@ def no_resource_leaks_excluding_node_resources():
             del available_resources[r]
 
     return cluster_resources == available_resources
+
+
+@contextmanager
+def simulate_storage(storage_type, root=None):
+    if storage_type == "fs":
+        if root is None:
+            with tempfile.TemporaryDirectory() as d:
+                yield "file://" + d
+        else:
+            yield "file://" + root
+    elif storage_type == "s3":
+        import uuid
+        from moto import mock_s3
+        from ray.tests.mock_s3_server import start_service, stop_process
+
+        @contextmanager
+        def aws_credentials():
+            old_env = os.environ
+            os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+            os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+            os.environ["AWS_SECURITY_TOKEN"] = "testing"
+            os.environ["AWS_SESSION_TOKEN"] = "testing"
+            yield
+            os.environ = old_env
+
+        @contextmanager
+        def moto_s3_server():
+            host = "localhost"
+            port = 5002
+            url = f"http://{host}:{port}"
+            process = start_service("s3", host, port)
+            yield url
+            stop_process(process)
+
+        if root is None:
+            root = uuid.uuid4().hex
+        with moto_s3_server() as s3_server, aws_credentials(), mock_s3():
+            url = f"s3://{root}?region=us-west-2&endpoint_override={s3_server}"
+            yield url
+    else:
+        raise ValueError(f"Unknown storage type: {storage_type}")

--- a/python/ray/internal/storage.py
+++ b/python/ray/internal/storage.py
@@ -298,7 +298,7 @@ class KVClient:
                 # TODO(suquark): There might be a corner case: the capped path exists
                 # locally and is a symlink. Then pathlib resolves it to the unwanted
                 # physical path. This could be a security attack.
-                # Here we has to make sure it does not exist locally.
+                # Here we must make sure it does not exist locally.
                 # This may add overhead and we may implement our resolving function
                 # later.
                 cap_str = f"/{uuid.uuid4().hex}/"

--- a/python/ray/internal/storage.py
+++ b/python/ray/internal/storage.py
@@ -359,7 +359,9 @@ def _init_filesystem(create_valid_file: bool = False, check_valid_file: bool = T
 
     import pyarrow.fs
 
-    parsed_uri = urllib.parse.urlparse(_storage_uri)
+    # TODO(suquark): This is a temporary patch for windows - the backslash
+    # could not be understood by pyarrow. We replace it with slash here.
+    parsed_uri = urllib.parse.urlparse(_storage_uri.replace("\\", "/"))
     if parsed_uri.scheme == "custom":
         fs_creator = _load_class(parsed_uri.netloc)
         _filesystem, _storage_prefix = fs_creator(parsed_uri.path)

--- a/python/ray/tests/mock_s3_server.py
+++ b/python/ray/tests/mock_s3_server.py
@@ -1,0 +1,88 @@
+# extracted from aioboto3
+#    https://github.com/terrycain/aioboto3/blob/16a1a1085191ebe6d40ee45d9588b2173738af0c/tests/mock_server.py
+import pytest
+import requests
+import shutil
+import signal
+import subprocess as sp
+import time
+
+_proxy_bypass = {
+    "http": None,
+    "https": None,
+}
+
+
+def start_service(service_name, host, port):
+    moto_svr_path = shutil.which("moto_server")
+    args = [moto_svr_path, service_name, "-H", host, "-p", str(port)]
+    process = sp.Popen(
+        args, stdin=sp.PIPE, stdout=sp.DEVNULL, stderr=sp.DEVNULL
+    )  # shell=True
+    url = "http://{host}:{port}".format(host=host, port=port)
+
+    for i in range(0, 30):
+        output = process.poll()
+        if output is not None:
+            print("moto_server exited status {0}".format(output))
+            stdout, stderr = process.communicate()
+            print("moto_server stdout: {0}".format(stdout))
+            print("moto_server stderr: {0}".format(stderr))
+            pytest.fail("Can not start service: {}".format(service_name))
+
+        try:
+            # we need to bypass the proxies due to monkeypatches
+            requests.get(url, timeout=5, proxies=_proxy_bypass)
+            break
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.5)
+    else:
+        stop_process(process)  # pytest.fail doesn't call stop_process
+        pytest.fail("Can not start service: {}".format(service_name))
+
+    return process
+
+
+def stop_process(process):
+    try:
+        process.send_signal(signal.SIGTERM)
+        process.communicate(timeout=20)
+    except sp.TimeoutExpired:
+        process.kill()
+        outs, errors = process.communicate(timeout=20)
+        exit_code = process.returncode
+        msg = "Child process finished {} not in clean way: {} {}".format(
+            exit_code, outs, errors
+        )
+        raise RuntimeError(msg)
+
+
+@pytest.fixture(scope="session")
+def dynamodb2_server():
+    host = "localhost"
+    port = 5001
+    url = "http://{host}:{port}".format(host=host, port=port)
+    process = start_service("dynamodb2", host, port)
+    yield url
+    stop_process(process)
+
+
+@pytest.fixture(scope="session")
+def s3_server():
+    host = "localhost"
+    port = 5002
+    url = "http://{host}:{port}".format(host=host, port=port)
+    process = start_service("s3", host, port)
+    yield url
+    stop_process(process)
+
+
+@pytest.fixture(scope="session")
+def kms_server():
+    host = "localhost"
+    port = 5003
+    url = "http://{host}:{port}".format(host=host, port=port)
+    process = start_service("kms", host, port)
+
+    yield url
+    stop_process(process)

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -7,6 +7,7 @@ import pytest
 import ray
 import ray.internal.storage as storage
 from ray.tests.conftest import *  # noqa
+from ray._private.test_utils import simulate_storage
 
 
 def _custom_fs(uri):
@@ -15,6 +16,10 @@ def _custom_fs(uri):
 
 
 def path_eq(a, b):
+    # NOTE: ".resolve()" does not work properly for paths other than
+    # local filesystem paths. For example, for S3, it turns "<s3_bucket>/foo"
+    # into "<workdir>/<s3_bucket>/foo". But for the purpose of this function,
+    # it works fine as well as both paths are resolved in the same way.
     return Path(a).resolve() == Path(b).resolve()
 
 
@@ -36,15 +41,12 @@ def test_get_custom_filesystem(shutdown_only, tmp_path):
 
 
 def test_get_filesystem_s3(shutdown_only):
-    # TODO(ekl) we could use moto to test the API directly against S3 APIs. For now,
-    # hook a little into the internals to test the S3 path.
-    ray.init(storage=None)
-    storage._init_storage("s3://bucket/foo/bar", False)
-    fs, prefix = storage._init_filesystem(
-        create_valid_file=False, check_valid_file=False
-    )
-    assert path_eq(prefix, "bucket/foo/bar"), prefix
-    assert isinstance(fs, pyarrow.fs.S3FileSystem), fs
+    root = "bucket/foo/bar"
+    with simulate_storage("s3", root) as s3_uri:
+        ray.init(storage=s3_uri)
+        fs, prefix = storage.get_filesystem()
+        assert path_eq(prefix, root), prefix
+        assert isinstance(fs, pyarrow.fs.S3FileSystem), fs
 
 
 def test_get_filesystem_invalid(shutdown_only, tmp_path):
@@ -73,59 +75,79 @@ def test_get_filesystem_remote_workers(shutdown_only, tmp_path):
         ray.get(check.remote())
 
 
-def test_put_get(shutdown_only, tmp_path):
-    path = str(tmp_path)
-    ray.init(storage=path, num_gpus=1)
-    client = storage.get_client("ns")
-    client2 = storage.get_client("ns2")
-    client.put("foo/bar", b"hello")
-    client.put("baz", b"goodbye")
-    client2.put("baz", b"goodbye!")
-    assert client.get("foo/bar") == b"hello"
-    assert client.get("baz") == b"goodbye"
-    assert client2.get("baz") == b"goodbye!"
+@pytest.mark.parametrize("storage_type", ["s3", "fs"])
+def test_put_get(shutdown_only, tmp_path, storage_type):
+    with simulate_storage(storage_type) as storage_uri:
+        ray.init(storage=storage_uri, num_gpus=1)
+        client = storage.get_client("ns")
+        client2 = storage.get_client("ns2")
+        assert client.get("foo/bar") is None
+        client.put("foo/bar", b"hello")
+        client.put("baz", b"goodbye")
+        client2.put("baz", b"goodbye!")
+        assert client.get("foo/bar") == b"hello"
+        assert client.get("baz") == b"goodbye"
+        assert client2.get("baz") == b"goodbye!"
 
-    client.delete("baz")
-    assert client.get("baz") is None
+        # delete file
+        assert client.delete("baz")
+        assert client.get("baz") is None
+        assert not client.delete("non_existing")
 
-
-def test_directory_traversal_attack(shutdown_only, tmp_path):
-    path = str(tmp_path)
-    ray.init(storage=path, num_gpus=1)
-    client = storage.get_client("foo")
-    client.put("data", b"hello")
-    client2 = storage.get_client("foo/bar")
-    # Should not be able to access '../data'.
-    with pytest.raises(ValueError):
-        client2.get("../data")
-
-
-def test_list_basic(shutdown_only, tmp_path):
-    path = str(tmp_path)
-    ray.init(storage=path, num_gpus=1)
-    client = storage.get_client("ns")
-    client.put("foo/bar1", b"hello")
-    client.put("foo/bar2", b"hello")
-    client.put("baz/baz1", b"goodbye!")
-    d1 = client.list("")
-    assert sorted([f.base_name for f in d1]) == ["baz", "foo"], d1
-    d2 = client.list("foo")
-    assert sorted([f.base_name for f in d2]) == ["bar1", "bar2"], d2
-    with pytest.raises(FileNotFoundError):
-        client.list("invalid")
-    with pytest.raises(NotADirectoryError):
-        client.list("foo/bar1")
+        # delete dir
+        n_files = 3
+        for i in range(n_files):
+            assert client2.get(f"foo/bar{i}") is None
+        for i in range(n_files):
+            client2.put(f"foo/bar{i}", f"hello{i}".encode())
+        for i in range(n_files):
+            assert client2.get(f"foo/bar{i}") == f"hello{i}".encode()
+        assert client2.delete_dir("foo")
+        for i in range(n_files):
+            assert client2.get(f"foo/bar{i}") is None
+        assert not client2.delete_dir("non_existing")
 
 
-def test_get_info_basic(shutdown_only, tmp_path):
-    path = str(tmp_path)
-    ray.init(storage=path, num_gpus=1)
-    client = storage.get_client("ns")
-    client.put("foo/bar1", b"hello")
-    assert client.get_info("foo/bar1").base_name == "bar1"
-    assert client.get_info("foo/bar2") is None
-    assert client.get_info("foo").base_name == "foo"
-    assert client.get_info("").base_name == "ns"
+@pytest.mark.parametrize("storage_type", ["s3", "fs"])
+def test_directory_traversal_attack(shutdown_only, storage_type):
+    with simulate_storage(storage_type) as storage_uri:
+        ray.init(storage=storage_uri, num_gpus=1)
+        client = storage.get_client("foo")
+        client.put("data", b"hello")
+        client2 = storage.get_client("foo/bar")
+        # Should not be able to access '../data'.
+        with pytest.raises(ValueError):
+            client2.get("../data")
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "fs"])
+def test_list_basic(shutdown_only, storage_type):
+    with simulate_storage(storage_type) as storage_uri:
+        ray.init(storage=storage_uri, num_gpus=1)
+        client = storage.get_client("ns")
+        client.put("foo/bar1", b"hello")
+        client.put("foo/bar2", b"hello")
+        client.put("baz/baz1", b"goodbye!")
+        d1 = client.list("")
+        assert sorted([f.base_name for f in d1]) == ["baz", "foo"], d1
+        d2 = client.list("foo")
+        assert sorted([f.base_name for f in d2]) == ["bar1", "bar2"], d2
+        with pytest.raises(FileNotFoundError):
+            client.list("invalid")
+        with pytest.raises(NotADirectoryError):
+            client.list("foo/bar1")
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "fs"])
+def test_get_info_basic(shutdown_only, storage_type):
+    with simulate_storage(storage_type) as storage_uri:
+        ray.init(storage=storage_uri, num_gpus=1)
+        client = storage.get_client("ns")
+        client.put("foo/bar1", b"hello")
+        assert client.get_info("foo/bar1").base_name == "bar1"
+        assert client.get_info("foo/bar2") is None
+        assert client.get_info("foo").base_name == "foo"
+        assert client.get_info("").base_name == "ns"
 
 
 if __name__ == "__main__":

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -62,7 +62,7 @@ google-cloud-storage
 gym-minigrid
 kubernetes
 lxml
-moto
+moto[s3,server]
 mypy
 networkx
 numba


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are several S3 bugs in the internal storage. This PR fixes them. S3 tests are enabled in the unittest to ensure S3 is working properly with the fix.

1. `/bucket/foo` is an invalid S3 path, pyarrow would raise `E pyarrow.lib.ArrowInvalid: Missing bucket name in S3 URI` with any S3 path starts with `/`. However, if you does not start with `/`, the path will be resolved to `<local_workdir>/<s3 path>`, which is also wrong.
2. Miss `storage.delete_dir`. It become very hard to remove directories recursively.
3. When `storage.get/delete/delete_dir` is a missing S3 key/dir, it raises `OSError` instead of `FileNotFoundError` (`FileNotFoundError` is raised when using pyarrow.fs.LocalFilesystem). `FileNotFoundError` in `storage.get/delete/delete_dir` returns `None`, but `OSError` is unhandled.
4. When `storage.list` a S3 key, it does not raise `NotADirectoryError`
5. When under windows, "/" becomes "\\" and S3 does not support it.


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
