### PR TITLE
improve redis connection backoff

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -578,7 +578,7 @@ def create_redis_client(redis_address, password=None):
             # Wait a little bit.
             time.sleep(delay)
             # Make sure the retry interval doesn't increase too large.
-            delay = 1 if i >= 10 else delay * 2
+            delay = min(1, delay * 2)
 
     raise RuntimeError(f"Unable to connect to Redis at {redis_address}")
 
@@ -870,7 +870,7 @@ def wait_for_redis_to_start(redis_ip_address, redis_port, password=None):
             time.sleep(delay)
             # Make sure the retry interval doesn't increase too large, which will
             # affect the delivery time of the Ray cluster.
-            delay = 1 if i >= 10 else delay * 2
+            delay = min(1, delay * 2)
         else:
             break
     else:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -573,6 +573,8 @@ def create_redis_client(redis_address, password=None):
             return cli
         except Exception:
             create_redis_client.instances.pop(redis_address)
+            if i >= num_retries - 1:
+                break
             # Wait a little bit.
             time.sleep(delay)
             # Make sure the retry interval doesn't increase too large.

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -393,14 +393,14 @@ def test_redis_connect_backoff():
             ray._private.services.wait_for_redis_to_start(redis_ip, redis_port)
         end = time.time()
         duration = end - start
-        assert duration > 2 and duration < 4
+        assert duration > 2
 
         start = time.time()
         with pytest.raises(RuntimeError):
             ray._private.services.create_redis_client(redis_address=unreachable_address)
         end = time.time()
         duration = end - start
-        assert duration > 2 and duration < 4
+        assert duration > 2
     finally:
         ray_constants.START_REDIS_WAIT_RETRIES = wait_retries
 

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -382,6 +382,7 @@ def test_ray_init_using_hostname(ray_start_cluster):
 def test_redis_connect_backoff():
     from ray import ray_constants
     import time
+
     unreachable_address = "127.0.2.2:6377"
     redis_ip, redis_port = unreachable_address.split(":")
     wait_retries = ray_constants.START_REDIS_WAIT_RETRIES
@@ -396,8 +397,7 @@ def test_redis_connect_backoff():
 
         start = time.time()
         with pytest.raises(RuntimeError):
-            ray._private.services.create_redis_client(
-                redis_address=unreachable_address)
+            ray._private.services.create_redis_client(redis_address=unreachable_address)
         end = time.time()
         duration = end - start
         assert duration > 2 and duration < 4

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -379,6 +379,32 @@ def test_ray_init_using_hostname(ray_start_cluster):
     assert node_table[0].get("NodeManagerHostname", "") == hostname
 
 
+def test_redis_connect_backoff():
+    from ray import ray_constants
+    import time
+    unreachable_address = "127.0.2.2:6377"
+    redis_ip, redis_port = unreachable_address.split(":")
+    wait_retries = ray_constants.START_REDIS_WAIT_RETRIES
+    ray_constants.START_REDIS_WAIT_RETRIES = 12
+    try:
+        start = time.time()
+        with pytest.raises(RuntimeError):
+            ray._private.services.wait_for_redis_to_start(redis_ip, redis_port)
+        end = time.time()
+        duration = end - start
+        assert duration > 2 and duration < 4
+
+        start = time.time()
+        with pytest.raises(RuntimeError):
+            ray._private.services.create_redis_client(
+                redis_address=unreachable_address)
+        end = time.time()
+        duration = end - start
+        assert duration > 2 and duration < 4
+    finally:
+        ray_constants.START_REDIS_WAIT_RETRIES = wait_retries
+
+
 if __name__ == "__main__":
     import pytest
     import sys

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -383,14 +383,14 @@ def test_redis_connect_backoff():
     from ray import ray_constants
     import time
 
-    unreachable_address = "127.0.2.2:6377"
+    unreachable_address = "127.0.0.1:65535"
     redis_ip, redis_port = unreachable_address.split(":")
     wait_retries = ray_constants.START_REDIS_WAIT_RETRIES
     ray_constants.START_REDIS_WAIT_RETRIES = 12
     try:
         start = time.time()
         with pytest.raises(RuntimeError):
-            ray._private.services.wait_for_redis_to_start(redis_ip, redis_port)
+            ray._private.services.wait_for_redis_to_start(redis_ip, int(redis_port))
         end = time.time()
         duration = end - start
         assert duration > 2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- The delay interval should be 1 rather than 1000 when retry times >= 10, because the unit of sleep is seconds.
- `create_redis_client` is also rely on `START_REDIS_WAIT_RETRIES`, so make it the same as `wait_for_redis_to_start`. see (https://github.com/ray-project/ray/pull/24150#issuecomment-1108254424)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
