### PR TITLE
[nightly tests] Mark Datasets shuffle tests stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3412,13 +3412,13 @@
     file_manager: sdk
 
 - name: dataset_shuffle_random_shuffle_1tb
-  group: core-multi-test
+  group: core-dataset-tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_random_shuffle_1tb
     test_suite: dataset_test
 
-  stable: false
+  stable: true
 
   frequency: nightly
   team: core
@@ -3438,13 +3438,13 @@
     file_manager: sdk
 
 - name: dataset_shuffle_sort_1tb
-  group: core-multi-test
+  group: core-dataset-tests
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_sort_1tb
     test_suite: dataset_test
 
-  stable: false
+  stable: true
 
   frequency: nightly
   team: core


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

dataset_shuffle_random_shuffle_1tb was previously failing due to OOM but has now passed on the last 4 runs due to changing the node type. These tests should be stable now, although we will want to look into the OOM issue later.