### PR TITLE
[Datasets] Add basic stats instrumentation of `split_at_indices()`.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2865,6 +2865,7 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
     def _split(
         self, index: int, return_right_half: bool
     ) -> ("Dataset[T]", "Dataset[T]"):
+        start_time = time.perf_counter()
         get_num_rows = cached_remote_fn(_get_num_rows)
         split_block = cached_remote_fn(_split_block, num_returns=4)
 
@@ -2900,19 +2901,50 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
                 right_metadata.append(ray.get(m1))
             count += num_rows
 
+        split_duration = time.perf_counter() - start_time
+        left_meta_for_stats = [
+            BlockMetadata(
+                num_rows=m.num_rows,
+                size_bytes=m.size_bytes,
+                schema=m.schema,
+                input_files=m.input_files,
+                exec_stats=None,
+            )
+            for m in left_metadata
+        ]
+        left_dataset_stats = DatasetStats(
+            stages={"split": left_meta_for_stats},
+            parent=self._plan.stats(),
+        )
+        left_dataset_stats.time_total_s = split_duration
         left = Dataset(
             ExecutionPlan(
                 BlockList(left_blocks, left_metadata),
-                self._plan.stats().child_TODO("split"),
+                left_dataset_stats,
             ),
             self._epoch,
             self._lazy,
         )
         if return_right_half:
+            right_meta_for_stats = [
+                BlockMetadata(
+                    num_rows=m.num_rows,
+                    size_bytes=m.size_bytes,
+                    schema=m.schema,
+                    input_files=m.input_files,
+                    exec_stats=None,
+                )
+                for m in right_metadata
+            ]
+            right_dataset_stats = DatasetStats(
+                stages={"split": right_meta_for_stats},
+                parent=self._plan.stats(),
+            )
+            right_dataset_stats.time_total_s = split_duration
             right = Dataset(
                 ExecutionPlan(
                     BlockList(right_blocks, right_metadata),
-                    self._plan.stats().child_TODO("split"),
+                    right_dataset_stats,
                 ),
                 self._epoch,
                 self._lazy,

--- a/python/ray/data/impl/stats.py
+++ b/python/ray/data/impl/stats.py
@@ -165,12 +165,9 @@ class DatasetStats:
         """
 
         self.stages: Dict[str, List[BlockMetadata]] = stages
-        self.parents: List["DatasetStats"] = []
-        if parent:
-            if isinstance(parent, list):
-                self.parents.extend(parent)
-            else:
-                self.parents.append(parent)
+        if parent is not None and not isinstance(parent, list):
+            parent = [parent]
+        self.parents: List["DatasetStats"] = parent
         self.number: int = (
             0 if not self.parents else max(p.number for p in self.parents) + 1
         )
@@ -280,9 +277,22 @@ class DatasetStats:
             if rounded_total <= 0:
                 # Handle -0.0 case.
                 rounded_total = 0
-            out = "{}/{} blocks executed in {}s\n".format(
-                len(exec_stats), len(blocks), rounded_total
-            )
+            if exec_stats:
+                out = "{}/{} blocks executed in {}s".format(
+                    len(exec_stats), len(blocks), rounded_total
+                )
+            else:
+                out = ""
+            if len(exec_stats) < len(blocks):
+                if exec_stats:
+                    out += ", "
+                num_inherited = len(blocks) - len(exec_stats)
+                out += "{}/{} blocks split from parent".format(
+                    num_inherited, len(blocks)
+                )
+                if not exec_stats:
+                    out += " in {}s".format(rounded_total)
+            out += "\n"
 
         if exec_stats:
             out += indent


### PR DESCRIPTION
This PR adds basic stats instrumentation of `split_at_indices()`, the first stage in fully instrumenting split operations (see [issue](https://github.com/ray-project/ray/issues/24178)).

```
In [1]: import ray; ray.init()
In [2]: ds = ray.data.range(100).map(lambda x: x + 1)                                                                                                                                                                                 
In [3]: dses = ds.split_at_indices([50])
In [4]: dses2 = [ds.map(lambda x: x + 1) for ds in dses]
In [5]: for ds_ in dses2:
   ...:     print(ds_.stats())

Stage 1 read->map: 100/100 blocks executed in 1.15s
* Remote wall time: 185.94us min, 1.04s max, 62.98ms mean, 6.3s total
* Remote cpu time: 184.63us min, 807.57ms max, 51.29ms mean, 5.13s total
* Output num rows: 1 min, 1 max, 1 mean, 100 total
* Output size bytes: 104 min, 104 max, 104 mean, 10400 total
* Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used

Stage 2 split: 50/50 blocks inherited from parent in 0s
* Output num rows: 1 min, 1 max, 1 mean, 50 total
* Output size bytes: 104 min, 104 max, 104 mean, 5200 total

Stage 3 map: 50/50 blocks executed in 0.11s
* Remote wall time: 142.4us min, 6.71ms max, 556.74us mean, 27.84ms total
* Remote cpu time: 141.57us min, 1.69ms max, 327.92us mean, 16.4ms total
* Output num rows: 1 min, 1 max, 1 mean, 50 total
* Output size bytes: 104 min, 104 max, 104 mean, 5200 total
* Tasks per node: 50 min, 50 max, 50 mean; 1 nodes used

Stage 1 read->map: 100/100 blocks executed in 1.15s
* Remote wall time: 185.94us min, 1.04s max, 62.98ms mean, 6.3s total
* Remote cpu time: 184.63us min, 807.57ms max, 51.29ms mean, 5.13s total
* Output num rows: 1 min, 1 max, 1 mean, 100 total
* Output size bytes: 104 min, 104 max, 104 mean, 10400 total
* Tasks per node: 100 min, 100 max, 100 mean; 1 nodes used

Stage 2 split: 50/50 blocks inherited from parent in 0s
* Output num rows: 1 min, 1 max, 1 mean, 50 total
* Output size bytes: 104 min, 104 max, 104 mean, 5200 total

Stage 3 map: 50/50 blocks executed in 0.11s
* Remote wall time: 176.76us min, 3.76ms max, 385.42us mean, 19.27ms total
* Remote cpu time: 176.05us min, 1.22ms max, 297.95us mean, 14.9ms total
* Output num rows: 1 min, 1 max, 1 mean, 50 total
* Output size bytes: 104 min, 104 max, 104 mean, 5200 total
* Tasks per node: 50 min, 50 max, 50 mean; 1 nodes used
```

## Related issue number

<!-- For example: "Closes #1234" -->

Towards https://github.com/ray-project/ray/issues/24178

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
