### PR TITLE
[ci/serve] Fix Serve minimal install silent failure

### DIFF
--- a/python/ray/tests/test_serve_ray_minimal.py
+++ b/python/ray/tests/test_serve_ray_minimal.py
@@ -5,6 +5,7 @@ it needs not to have dependencies on serve's conftest.py.
 """
 
 import os
+import sys
 
 import pytest
 
@@ -14,11 +15,11 @@ import pytest
     reason="This test is only run in CI with a minimal Ray installation.",
 )
 def test_error_msg():
-    with pytest.raises(ModuleNotFoundError, match="install 'ray\[serve\]'"):
+    with pytest.raises(ModuleNotFoundError, match='install "ray[serve]"'):
         from ray import serve
 
         serve.start()
 
 
 if __name__ == "__main__":
-    pytest.main(["-v", "-s", __file__])
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/tests/test_serve_ray_minimal.py
+++ b/python/ray/tests/test_serve_ray_minimal.py
@@ -15,7 +15,7 @@ import pytest
     reason="This test is only run in CI with a minimal Ray installation.",
 )
 def test_error_msg():
-    with pytest.raises(ModuleNotFoundError, match='install "ray[serve]"'):
+    with pytest.raises(ModuleNotFoundError, match=r'.*install "ray\[serve\]".*'):
         from ray import serve
 
         serve.start()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously `sys.exit()` wasn't called, so bazel wouldn't fail because of the faulty match pattern.

Uncovered here: https://buildkite.com/ray-project/ray-builders-pr/builds/30291#_

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
