### PR TITLE
[Datasets] Clean up lineage serialization support for fan-in operations.

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -983,6 +983,9 @@ class Dataset(Generic[T]):
         The order of the blocks in the datasets is preserved, as is the
         relative ordering between the datasets passed in the argument list.
 
+        NOTE: Unioned datasets are not lineage-serializable, i.e. they can not be used
+        as a tunable hyperparameter in Ray Tune.
+
         Args:
             other: List of datasets to combine with this one. The datasets
                 must have the same schema as this dataset, otherwise the
@@ -993,29 +996,37 @@ class Dataset(Generic[T]):
         """
 
         start_time = time.perf_counter()
-        context = DatasetContext.get_current()
-        tasks: List[ReadTask] = []
-        block_partition_refs: List[ObjectRef[BlockPartition]] = []
-        block_partition_meta_refs: List[ObjectRef[BlockPartitionMetadata]] = []
 
         datasets = [self] + list(other)
+        bls = []
+        has_nonlazy = False
         for ds in datasets:
             bl = ds._plan.execute()
-            if isinstance(bl, LazyBlockList):
+            if not isinstance(bl, LazyBlockList):
+                has_nonlazy = True
+            bls.append(bl)
+        if has_nonlazy:
+            blocks = []
+            metadata = []
+            for bl in bls:
+                if isinstance(bl, LazyBlockList):
+                    bs, ms = bl._get_blocks_with_metadata()
+                else:
+                    bs, ms = bl._blocks, bl._metadata
+                blocks.extend(bs)
+                metadata.extend(ms)
+            blocklist = BlockList(blocks, metadata)
+        else:
+            tasks: List[ReadTask] = []
+            block_partition_refs: List[ObjectRef[BlockPartition]] = []
+            block_partition_meta_refs: List[ObjectRef[BlockPartitionMetadata]] = []
+            for bl in bls:
                 tasks.extend(bl._tasks)
                 block_partition_refs.extend(bl._block_partition_refs)
                 block_partition_meta_refs.extend(bl._block_partition_meta_refs)
-            else:
-                tasks.extend([ReadTask(lambda: None, meta) for meta in bl._metadata])
-                if context.block_splitting_enabled:
-                    block_partition_refs.extend(
-                        [ray.put([(b, m)]) for b, m in bl.get_blocks_with_metadata()]
-                    )
-                else:
-                    block_partition_refs.extend(bl.get_blocks())
-                block_partition_meta_refs.extend(
-                    [ray.put(meta) for meta in bl._metadata]
-                )
+            blocklist = LazyBlockList(
+                tasks, block_partition_refs, block_partition_meta_refs
+            )
 
         epochs = [ds._get_epoch() for ds in datasets]
         max_epoch = max(*epochs)
@@ -1035,10 +1046,7 @@ class Dataset(Generic[T]):
         )
         dataset_stats.time_total_s = time.perf_counter() - start_time
         return Dataset(
-            ExecutionPlan(
-                LazyBlockList(tasks, block_partition_refs, block_partition_meta_refs),
-                dataset_stats,
-            ),
+            ExecutionPlan(blocklist, dataset_stats),
             max_epoch,
             self._lazy,
         )
@@ -1477,6 +1485,9 @@ class Dataset(Generic[T]):
         (e.g., one was produced from a ``.map()`` of another). For Arrow
         blocks, the schema will be concatenated, and any duplicate column
         names disambiguated with _1, _2, etc. suffixes.
+
+        NOTE: Zipped datasets are not lineage-serializable, i.e. they can not be used
+        as a tunable hyperparameter in Ray Tune.
 
         Time complexity: O(dataset size / parallelism)
 
@@ -2895,19 +2906,25 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
         Use :py:meth:`Dataset.deserialize_lineage` to deserialize the serialized bytes
         returned from this method into a Dataset.
 
+        NOTE: Unioned and zipped datasets, produced by :py:meth`Dataset.union` and
+        :py:meth:`Dataset.zip`, are not lineage-serializable.
+
         Returns:
             Serialized bytes containing the lineage of this dataset.
         """
         if not self.has_serializable_lineage():
             raise ValueError(
-                "Lineage-based serialization is only supported for Datasets created "
-                "from data that we know will still exist at deserialization "
-                "time, e.g. external data in persistent cloud object stores or "
-                "in-memory data from long-lived clusters. Concretely, all "
-                "ray.data.read_*() APIs should support lineage-based serialization, "
-                "while all of the ray.data.from_*() APIs do not. To allow this "
-                "Dataset to be serialized to storage, write the data to an external "
-                "store (such as AWS S3, GCS, or Azure Blob Storage) using the "
+                "Lineage-based serialization is not supported for this dataset, which "
+                "means that it cannot be used as a tunable hyperparameter. "
+                "Lineage-based serialization is explicitly NOT supported for unioned "
+                "or zipped datasets (see docstrings for those methods), and is only "
+                "supported for Datasets created from data that we know will still "
+                "exist at deserialization time, e.g. external data in persistent cloud "
+                "object stores or in-memory data from long-lived clusters. Concretely, "
+                "all ray.data.read_*() APIs should support lineage-based "
+                "serialization, while all of the ray.data.from_*() APIs do not. To "
+                "allow this Dataset to be serialized to storage, write the data to an "
+                "external store (such as AWS S3, GCS, or Azure Blob Storage) using the "
                 "Dataset.write_*() APIs, and serialize a new dataset reading from the "
                 "external store using the ray.data.read_*() APIs."
             )

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -231,8 +231,9 @@ def test_dataset_lineage_serialization(shutdown_only, lazy):
 
 
 @pytest.mark.parametrize("lazy", [False, True])
-def test_dataset_lineage_serialization_in_memory(shutdown_only, lazy):
+def test_dataset_lineage_serialization_unsupported(shutdown_only, lazy):
     ray.init()
+    # In-memory data sources not supported.
     ds = ray.data.from_items(list(range(10)))
     ds = maybe_lazy(ds, lazy)
     ds = ds.map(lambda x: x + 1)
@@ -240,6 +241,43 @@ def test_dataset_lineage_serialization_in_memory(shutdown_only, lazy):
 
     with pytest.raises(ValueError):
         ds.serialize_lineage()
+
+    # In-memory data source unions not supported.
+    ds = ray.data.from_items(list(range(10)))
+    ds = maybe_lazy(ds, lazy)
+    ds1 = ray.data.from_items(list(range(10, 20)))
+    ds2 = ds.union(ds1)
+
+    with pytest.raises(ValueError):
+        ds2.serialize_lineage()
+
+    # Post-lazy-read unions not supported.
+    ds = ray.data.range(10).map(lambda x: x + 1)
+    ds = maybe_lazy(ds, lazy)
+    ds1 = ray.data.range(20).map(lambda x: 2 * x)
+    ds2 = ds.union(ds1)
+
+    with pytest.raises(ValueError):
+        ds2.serialize_lineage()
+
+    # Lazy read unions supported.
+    ds = ray.data.range(10)
+    ds = maybe_lazy(ds, lazy)
+    ds1 = ray.data.range(20)
+    ds2 = ds.union(ds1)
+
+    serialized_ds = ds2.serialize_lineage()
+    ds3 = Dataset.deserialize_lineage(serialized_ds)
+    assert ds3.take(30) == list(range(10)) + list(range(20))
+
+    # Zips not supported.
+    ds = ray.data.from_items(list(range(10)))
+    ds = maybe_lazy(ds, lazy)
+    ds1 = ray.data.from_items(list(range(10, 20)))
+    ds2 = ds.zip(ds1)
+
+    with pytest.raises(ValueError):
+        ds2.serialize_lineage()
 
 
 @pytest.mark.parametrize("pipelined", [False, True])


### PR DESCRIPTION
Lineage-based serialization isn't supported for fan-in operations such as unions and zips. This PR adds documentation indicating as much, and ensures that a good error message is raised.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
