### PR TITLE
[Datasets] Pipeline task dependency prefetching with actor compute via customizable max tasks in flight per worker.

### DIFF
--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -104,6 +104,11 @@ class ActorPoolStrategy(ComputeStrategy):
     To autoscale from ``m`` to ``n`` actors, specify
     ``compute=ActorPoolStrategy(m, n)``.
     For a fixed-sized pool of size ``n``, specify ``compute=ActorPoolStrategy(n, n)``.
+
+    To increase opportunities for pipelining task dependency prefetching with
+    computation and avoiding actor startup delays, set max_tasks_in_flight_per_actor
+    to 2 or greater; to try to decrease the delay due to queueing of tasks on the worker
+    actors, set max_tasks_in_flight_per_actor to 1.
     """
 
     def __init__(

--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -1,3 +1,4 @@
+import collections
 from typing import TypeVar, Any, Union, Callable, List, Tuple, Optional
 
 import ray
@@ -105,13 +106,29 @@ class ActorPoolStrategy(ComputeStrategy):
     For a fixed-sized pool of size ``n``, specify ``compute=ActorPoolStrategy(n, n)``.
     """
 
-    def __init__(self, min_size: int = 1, max_size: Optional[int] = None):
+    def __init__(
+        self,
+        min_size: int = 1,
+        max_size: Optional[int] = None,
+        max_tasks_in_flight: Optional[int] = 2,
+    ):
+        """Construct ActorPoolStrategy for a Dataset transform.
+
+        Args:
+            min_size: The minimize size of the actor pool.
+            max_size: The maximum size of the actor pool.
+            max_tasks_in_flight: The maximum number of tasks to concurrently send to a
+                single actor worker. Increasing this will increase opportunities for
+                pipelining task dependency prefetching with computation and avoiding
+                actor startup delays, but will also increase queueing delay.
+        """
         if min_size < 1:
             raise ValueError("min_size must be > 1", min_size)
         if max_size is not None and min_size > max_size:
             raise ValueError("min_size must be <= max_size", min_size, max_size)
         self.min_size = min_size
         self.max_size = max_size or float("inf")
+        self.max_tasks_in_flight = max_tasks_in_flight
 
     def _apply(
         self,
@@ -155,13 +172,14 @@ class ActorPoolStrategy(ComputeStrategy):
 
         workers = [BlockWorker.remote() for _ in range(self.min_size)]
         tasks = {w.ready.remote(): w for w in workers}
+        tasks_in_flight = collections.defaultdict(int)
         metadata_mapping = {}
         block_indices = {}
         ready_workers = set()
 
         while len(results) < orig_num_blocks:
             ready, _ = ray.wait(
-                list(tasks), timeout=0.01, num_returns=1, fetch_local=False
+                list(tasks.keys()), timeout=0.01, num_returns=1, fetch_local=False
             )
             if not ready:
                 if (
@@ -179,12 +197,12 @@ class ActorPoolStrategy(ComputeStrategy):
                 continue
 
             [obj_id] = ready
-            worker = tasks[obj_id]
-            del tasks[obj_id]
+            worker = tasks.pop(obj_id)
 
             # Process task result.
             if worker in ready_workers:
                 results.append(obj_id)
+                tasks_in_flight[worker] -= 1
                 map_bar.update(1)
             else:
                 ready_workers.add(worker)
@@ -195,7 +213,7 @@ class ActorPoolStrategy(ComputeStrategy):
                 )
 
             # Schedule a new task.
-            if blocks_in:
+            while blocks_in and tasks_in_flight[worker] < self.max_tasks_in_flight:
                 block, meta = blocks_in.pop()
                 if context.block_splitting_enabled:
                     ref = worker.map_block_split.remote(block, meta.input_files)
@@ -206,6 +224,7 @@ class ActorPoolStrategy(ComputeStrategy):
                     metadata_mapping[ref] = meta_ref
                 tasks[ref] = worker
                 block_indices[ref] = len(blocks_in)
+                tasks_in_flight[worker] += 1
 
         map_bar.close()
         new_blocks, new_metadata = [], []

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -100,12 +100,15 @@ def test_basic_actors(shutdown_only, pipelined):
     # Test setting custom max inflight tasks.
     ds = ray.data.range(10, parallelism=5)
     ds = maybe_pipeline(ds, pipelined)
-    assert sorted(
-        ds.map(
-            lambda x: x + 1,
-            compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=3),
-        ).take()
-    ) == list(range(1, 11))
+    assert (
+        sorted(
+            ds.map(
+                lambda x: x + 1,
+                compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=3),
+            ).take()
+        )
+        == list(range(1, 11))
+    )
 
     # Test invalid max tasks inflight arg.
     with pytest.raises(ValueError):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -97,6 +97,16 @@ def test_basic_actors(shutdown_only, pipelined):
         ds.map(lambda x: x + 1, compute=ray.data.ActorPoolStrategy(4, 4)).take()
     ) == list(range(1, n + 1))
 
+    # Test setting custom max inflight tasks.
+    ds = ray.data.range(10, parallelism=5)
+    ds = maybe_pipeline(ds, pipelined)
+    assert sorted(
+        ds.map(
+            lambda x: x + 1, compute=ray.data.ActorPoolStrategy(max_tasks_in_flight=3)
+        ).take()
+    ) == list(range(1, 11))
+
+    # Test min no more than max check.
     with pytest.raises(ValueError):
         ray.data.range(10).map(lambda x: x, compute=ray.data.ActorPoolStrategy(8, 4))
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -102,9 +102,17 @@ def test_basic_actors(shutdown_only, pipelined):
     ds = maybe_pipeline(ds, pipelined)
     assert sorted(
         ds.map(
-            lambda x: x + 1, compute=ray.data.ActorPoolStrategy(max_tasks_in_flight=3)
+            lambda x: x + 1,
+            compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=3),
         ).take()
     ) == list(range(1, 11))
+
+    # Test invalid max tasks inflight arg.
+    with pytest.raises(ValueError):
+        ray.data.range(10).map(
+            lambda x: x,
+            compute=ray.data.ActorPoolStrategy(max_tasks_in_flight_per_actor=0),
+        )
 
     # Test min no more than max check.
     with pytest.raises(ValueError):


### PR DESCRIPTION
When using the actor compute model for batch mapping (e.g. in batch inference), map tasks are often blocked waiting for their dependencies to be fetched since we submit one actor task at a time. This PR changes the default behavior of the actor compute model to have up to two actor tasks in flight for each actor in order to better pipeline task dependency fetching with the actual compute. This "max tasks in flight per actor worker" is also made configurable, in case a particular use case warrants more aggressive pipelining (e.g. big blocks and/or fast maps) or more conservative pipelining (e.g. small data or slow maps).

## Related issue number

Closes https://github.com/ray-project/ray/issues/24189

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
