### PR TITLE
Revert "[core] Use cheaper AWS m5 instances for shuffle tests (#23781)"

### DIFF
--- a/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
+++ b/release/nightly_tests/shuffle/shuffle_compute_large_scale.yaml
@@ -9,12 +9,12 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type:  m5.8xlarge
+    instance_type:  i3.8xlarge
     resources: {"object_store_memory": 21474836480}
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.8xlarge
+      instance_type: i3.8xlarge
       min_workers: 19
       max_workers: 19
       use_spot: false


### PR DESCRIPTION
This reverts commit 717e60cb4d109967ff59e69189d8c1d107fefe72 and 4aa854aa2327ccca6f4e41e600f5db5f9ca11c02

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests https://console.anyscale.com/o/anyscale-internal/projects/prj_SVFGM5yBqK6DHCfLtRMryXHM/clusters/ses_dgWAyrTMh4fefYdcnsjUzQht
   - [ ] This PR is not tested :(
