### PR TITLE
[Serve] Fix surprious `__call__` invocation in Deployment DAG's exec_impl

### DIFF
--- a/python/ray/serve/deployment_graph.py
+++ b/python/ray/serve/deployment_graph.py
@@ -15,9 +15,6 @@ class RayServeDAGHandle:
     """
 
     def __init__(self, dag_node_json: str) -> None:
-        from ray.serve.pipeline.json_serde import dagnode_from_json
-
-        self.dagnode_from_json = dagnode_from_json
         self.dag_node_json = dag_node_json
 
         # NOTE(simon): Making this lazy to avoid deserialization in controller for now
@@ -35,7 +32,9 @@ class RayServeDAGHandle:
 
     def remote(self, *args, **kwargs):
         if self.dag_node is None:
+            from ray.serve.pipeline.json_serde import dagnode_from_json
+
             self.dag_node = json.loads(
-                self.dag_node_json, object_hook=self.dagnode_from_json
+                self.dag_node_json, object_hook=dagnode_from_json
             )
         return self.dag_node.execute(*args, **kwargs)

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -56,40 +56,6 @@ class DeploymentMethodNode(DAGNode):
             **self._bound_kwargs,
         )
 
-    def _get_serve_deployment_handle(
-        self,
-        deployment: Deployment,
-        bound_other_args_to_resolve: Dict[str, Any],
-    ) -> Union[RayServeHandle, RayServeSyncHandle]:
-        """
-        Return a sync or async handle of the encapsulated Deployment based on
-        config.
-
-        Args:
-            deployment (Deployment): Deployment instance wrapped in the DAGNode.
-            bound_other_args_to_resolve (Dict[str, Any]): Contains args used
-                to configure DeploymentNode.
-
-        Returns:
-            RayServeHandle: Default and catch-all is to return sync handle.
-                return async handle only if user explicitly set
-                USE_SYNC_HANDLE_KEY with value of False.
-        """
-        # TODO (jiaodong): Support configurable async handle
-        if USE_SYNC_HANDLE_KEY not in bound_other_args_to_resolve:
-            # Return sync RayServeLazySyncHandle
-            return RayServeLazySyncHandle(deployment.name)
-        elif bound_other_args_to_resolve.get(USE_SYNC_HANDLE_KEY) is True:
-            # Return sync RayServeSyncHandle
-            return deployment.get_handle(sync=True)
-        elif bound_other_args_to_resolve.get(USE_SYNC_HANDLE_KEY) is False:
-            # Return async RayServeHandle
-            return deployment.get_handle(sync=False)
-        else:
-            raise ValueError(
-                f"{USE_SYNC_HANDLE_KEY} should only be set with a boolean value."
-            )
-
     def __str__(self) -> str:
         return get_dag_node_str(
             self,

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -4,7 +4,7 @@ from ray.experimental.dag import DAGNode
 from ray.experimental.dag.format_utils import get_dag_node_str
 from ray.serve.handle import RayServeLazySyncHandle, RayServeSyncHandle, RayServeHandle
 from ray.serve.pipeline.constants import USE_SYNC_HANDLE_KEY
-from ray.experimental.dag.constants import DAGNODE_TYPE_KEY
+from ray.experimental.dag.constants import DAGNODE_TYPE_KEY, PARENT_CLASS_NODE_KEY
 from ray.serve.deployment import Deployment
 from ray.serve.config import DeploymentConfig
 
@@ -23,15 +23,13 @@ class DeploymentMethodNode(DAGNode):
     ):
         self._deployment = deployment
         self._deployment_method_name: str = deployment_method_name
+        self._deployment_node = other_args_to_resolve[PARENT_CLASS_NODE_KEY]
         super().__init__(
             method_args,
             method_kwargs,
             method_options,
             other_args_to_resolve=other_args_to_resolve,
         )
-        self._deployment_handle: Union[
-            RayServeLazySyncHandle, RayServeHandle, RayServeSyncHandle
-        ] = self._get_serve_deployment_handle(deployment, other_args_to_resolve)
 
     def _copy_impl(
         self,
@@ -52,7 +50,7 @@ class DeploymentMethodNode(DAGNode):
     def _execute_impl(self, *args, **kwargs):
         """Executor of DeploymentMethodNode by ray.remote()"""
         # Execute with bound args.
-        method_body = getattr(self._deployment_handle, self._deployment_method_name)
+        method_body = getattr(self._deployment_node, self._deployment_method_name)
         return method_body.remote(
             *self._bound_args,
             **self._bound_kwargs,

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -1,9 +1,7 @@
-from typing import Any, Dict, Optional, Tuple, List, Union
+from typing import Any, Dict, Optional, Tuple, List
 
 from ray.experimental.dag import DAGNode
 from ray.experimental.dag.format_utils import get_dag_node_str
-from ray.serve.handle import RayServeLazySyncHandle, RayServeSyncHandle, RayServeHandle
-from ray.serve.pipeline.constants import USE_SYNC_HANDLE_KEY
 from ray.experimental.dag.constants import DAGNODE_TYPE_KEY, PARENT_CLASS_NODE_KEY
 from ray.serve.deployment import Deployment
 from ray.serve.config import DeploymentConfig

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -7,7 +7,7 @@ from ray.serve.handle import RayServeLazySyncHandle, RayServeSyncHandle, RayServ
 from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
 from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
 from ray.serve.pipeline.constants import USE_SYNC_HANDLE_KEY
-from ray.experimental.dag.constants import DAGNODE_TYPE_KEY
+from ray.experimental.dag.constants import DAGNODE_TYPE_KEY, PARENT_CLASS_NODE_KEY
 from ray.experimental.dag.format_utils import get_dag_node_str
 from ray.serve.deployment import Deployment, schema_to_deployment
 from ray.serve.deployment_graph import RayServeDAGHandle
@@ -199,7 +199,10 @@ class DeploymentNode(DAGNode):
             (),
             {},
             {},
-            other_args_to_resolve=self._bound_other_args_to_resolve,
+            other_args_to_resolve={
+                **self._bound_other_args_to_resolve,
+                PARENT_CLASS_NODE_KEY: self,
+            },
         )
         return call_node
 

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -138,8 +138,12 @@ class DeploymentNode(DAGNode):
         )
 
     def _execute_impl(self, *args, **kwargs):
-        """Executor of DeploymentNode by ray.remote()"""
-        # TODO fix comment
+        """Executor of DeploymentNode getting called each time on dag.execute.
+
+        The execute implementation is recursive, that is, the method nodes will receive
+        whatever this method returns. We return a handle here so method node can
+        directly call upon.
+        """
         return self._deployment_handle
 
     def _get_serve_deployment_handle(

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -139,7 +139,8 @@ class DeploymentNode(DAGNode):
 
     def _execute_impl(self, *args, **kwargs):
         """Executor of DeploymentNode by ray.remote()"""
-        return self._deployment_handle.remote(*self._bound_args, **self._bound_kwargs)
+        # TODO fix comment
+        return self._deployment_handle
 
     def _get_serve_deployment_handle(
         self,

--- a/python/ray/serve/pipeline/tests/test_deployment_node.py
+++ b/python/ray/serve/pipeline/tests/test_deployment_node.py
@@ -2,6 +2,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray.experimental.dag.constants import PARENT_CLASS_NODE_KEY
 from ray.experimental.dag.input_node import InputNode
 from ray.serve.deployment import Deployment
 from ray.serve.config import DeploymentConfig
@@ -153,20 +154,7 @@ def test_invalid_use_sync_handle():
             {},
             other_args_to_resolve={USE_SYNC_HANDLE_KEY: {"options_a": "hii"}},
         )
-    with pytest.raises(
-        ValueError,
-        match=f"{USE_SYNC_HANDLE_KEY} should only be set with a boolean value",
-    ):
-        _ = DeploymentMethodNode(
-            deployment,
-            "method",
-            [],
-            {},
-            {},
-            other_args_to_resolve={
-                USE_SYNC_HANDLE_KEY: None,
-            },
-        )
+
 
 
 def test_mix_sync_async_handle(serve_instance):

--- a/python/ray/serve/pipeline/tests/test_deployment_node.py
+++ b/python/ray/serve/pipeline/tests/test_deployment_node.py
@@ -2,13 +2,9 @@ import pytest
 
 import ray
 from ray import serve
-from ray.experimental.dag.constants import PARENT_CLASS_NODE_KEY
 from ray.experimental.dag.input_node import InputNode
-from ray.serve.deployment import Deployment
-from ray.serve.config import DeploymentConfig
 from ray.serve.pipeline.deployment_node import (
     DeploymentNode,
-    DeploymentMethodNode,
 )
 from ray.serve.pipeline.constants import USE_SYNC_HANDLE_KEY
 
@@ -136,12 +132,6 @@ def test_no_input_node_as_init_args():
 
 
 def test_invalid_use_sync_handle():
-    deployment = Deployment(
-        Actor,
-        "test",
-        DeploymentConfig(),
-        _internal=True,
-    )
     with pytest.raises(
         ValueError,
         match=f"{USE_SYNC_HANDLE_KEY} should only be set with a boolean value",
@@ -154,7 +144,6 @@ def test_invalid_use_sync_handle():
             {},
             other_args_to_resolve={USE_SYNC_HANDLE_KEY: {"options_a": "hii"}},
         )
-
 
 
 def test_mix_sync_async_handle(serve_instance):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It turns out whenever you call `dag.execute` on a deployment graph, the nodes are executed recursively. When a node is executed, whatever in its `_exec_impl` will be called and its return value is put in `parent_node` of all its child node's `_exec_impl`. So this PR make sure the DeploymentNode's exec just return the handle to be used by DeploymentMethodNode's exec. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24116
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
