### PR TITLE
[Datasets] Add example of using `map_batches` to filter

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -247,11 +247,11 @@ class Dataset(Generic[T]):
             You can use ``map_batches`` to efficiently filter records.
 
             >>> import ray
-            >>> ds = ray.data.range(10000)
-            >>> ds.count()
+            >>> ds = ray.data.range(10000)  # doctest: +SKIP
+            >>> ds.count()  # doctest: +SKIP
             10000
-            >>> ds = ds.map_batches(lambda batch: [x for x in batch if x % 2 == 0])
-            >>> ds.count()
+            >>> ds = ds.map_batches(lambda batch: [x for x in batch if x % 2 == 0])  # doctest: +SKIP  # noqa: #501
+            >>> ds.count()  # doctest: +SKIP
             5000
 
         Time complexity: O(dataset size / parallelism)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -244,6 +244,16 @@ class Dataset(Generic[T]):
             ...     compute=ActorPoolStrategy(2, 8), # doctest: +SKIP
             ...     num_gpus=1) # doctest: +SKIP
 
+            You can use ``map_batches`` to efficiently filter records.
+
+            >>> import ray
+            >>> ds = ray.data.range(10000)
+            >>> ds.count()
+            10000
+            >>> ds = ds.map_batches(lambda batch: [x for x in batch if x % 2 == 0])
+            >>> ds.count()
+            5000
+
         Time complexity: O(dataset size / parallelism)
 
         Args:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The documentation says 

> Consider using .map_batches() for better performance (you can implement filter by dropping records).

but there aren't any examples of how to do so.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
