### PR TITLE
[RLlib] Fix type hints for `original_batches` in callbacks.

### DIFF
--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os
 import tracemalloc
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 from ray.rllib.env.base_env import BaseEnv
 from ray.rllib.env.env_context import EnvContext
@@ -196,7 +196,7 @@ class DefaultCallbacks:
         policy_id: PolicyID,
         policies: Dict[PolicyID, Policy],
         postprocessed_batch: SampleBatch,
-        original_batches: Dict[AgentID, SampleBatch],
+        original_batches: Dict[AgentID, Tuple[Policy, SampleBatch]],
         **kwargs,
     ) -> None:
         """Called immediately after a policy's postprocess_fn is called.
@@ -470,7 +470,7 @@ class MultiCallbacks(DefaultCallbacks):
         policy_id: PolicyID,
         policies: Dict[PolicyID, Policy],
         postprocessed_batch: SampleBatch,
-        original_batches: Dict[AgentID, SampleBatch],
+        original_batches: Dict[AgentID, Tuple[Policy, SampleBatch]],
         **kwargs,
     ) -> None:
         for callback in self._callback_list:

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -4,7 +4,7 @@ Here we use callbacks to track the average CartPole pole angle magnitude as a
 custom metric.
 """
 
-from typing import Dict
+from typing import Dict, Tuple
 import argparse
 import numpy as np
 import os
@@ -129,7 +129,7 @@ class MyCallbacks(DefaultCallbacks):
         policy_id: str,
         policies: Dict[str, Policy],
         postprocessed_batch: SampleBatch,
-        original_batches: Dict[str, SampleBatch],
+        original_batches: Dict[str, Tuple[Policy, SampleBatch]],
         **kwargs
     ):
         print("postprocessed {} steps".format(postprocessed_batch.count))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fix type hints for `original_batches` in `on_postprocess_trajectory`.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
