### PR TITLE
[tune] Make Timeout stopper work after restoring in the future

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -265,6 +265,14 @@ py_test(
 )
 
 py_test(
+    name = "test_stopper",
+    size = "small",
+    srcs = ["tests/test_stopper.py"],
+    deps = [":tune_lib"],
+    tags = ["team:ml", "exclusive", "tests_dir_S"],
+)
+
+py_test(
     name = "test_sync",
     size = "medium",
     srcs = ["tests/test_sync.py"],

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -368,9 +368,6 @@ class TimeoutStopper(Stopper):
 
         return False
 
-    def __getstate__(self):
-        return self.__dict__
-
     def __setstate__(self, state: dict):
         state["_last_check"] = None
         self.__dict__.update(state)

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -341,23 +341,36 @@ class TimeoutStopper(Stopper):
                 "`datetime.timedelta` object. Found: {}".format(type(timeout))
             )
 
-        # To account for setup overhead, set the start time only after
+        self._budget = self._timeout_seconds
+
+        # To account for setup overhead, set the last check time only after
         # the first call to `stop_all()`.
-        self._start = None
+        self._last_check = None
 
     def __call__(self, trial_id, result):
         return False
 
     def stop_all(self):
-        if not self._start:
-            self._start = time.time()
-            return False
-
         now = time.time()
-        if now - self._start >= self._timeout_seconds:
+
+        if self._last_check:
+            taken = now - self._last_check
+            self._budget -= taken
+
+        self._last_check = now
+
+        if self._budget <= 0:
             logger.info(
                 f"Reached timeout of {self._timeout_seconds} seconds. "
                 f"Stopping all trials."
             )
             return True
+
         return False
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state: dict):
+        state["_last_check"] = None
+        self.__dict__.update(state)

--- a/python/ray/tune/tests/test_stopper.py
+++ b/python/ray/tune/tests/test_stopper.py
@@ -1,0 +1,63 @@
+import pickle
+
+from freezegun import freeze_time
+
+from ray.tune.stopper import TimeoutStopper
+
+
+def test_timeout_stopper_timeout():
+    with freeze_time() as frozen:
+        stopper = TimeoutStopper(timeout=60)
+        assert not stopper.stop_all()
+        frozen.tick(40)
+        assert not stopper.stop_all()
+        frozen.tick(22)
+        assert stopper.stop_all()
+
+
+def test_timeout_stopper_recover_before_timeout():
+    """ "If checkpointed before timeout, should continue where we left."""
+    with freeze_time() as frozen:
+        stopper = TimeoutStopper(timeout=60)
+        assert not stopper.stop_all()
+        frozen.tick(40)
+        assert not stopper.stop_all()
+        checkpoint = pickle.dumps(stopper)
+
+        # Continue sometime in the future. This is after start_time + timeout
+        # but we should still continue training.
+        frozen.tick(200)
+
+        # Continue, so we shouldn't time out
+        stopper = pickle.loads(checkpoint)
+        assert not stopper.stop_all()
+        frozen.tick(10)
+        assert not stopper.stop_all()
+        frozen.tick(12)
+        assert stopper.stop_all()
+
+
+def test_timeout_stopper_recover_after_timeout():
+    """ "If checkpointed after timeout, should still stop after recover."""
+    with freeze_time() as frozen:
+        stopper = TimeoutStopper(timeout=60)
+        assert not stopper.stop_all()
+        frozen.tick(62)
+        assert stopper.stop_all()
+        checkpoint = pickle.dumps(stopper)
+
+        # Continue sometime in the future
+        frozen.tick(200)
+
+        # Continue, so we should still time out.
+        stopper = pickle.loads(checkpoint)
+        assert stopper.stop_all()
+        frozen.tick(10)
+        assert stopper.stop_all()
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__] + sys.argv[1:]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, the `TimeoutStopper` did not work after recovery from checkpoints in the future, as the start time + budget was exceeded. Instead, we're now tracking a timeout budget that gets decreased and properly saved in checkpoints, so that recovery in the future works.

## Related issue number

Closes #21038

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
