### PR TITLE
[Serve] Update the test_pipeline_ingress_deployment size to small

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -373,7 +373,7 @@ py_test(
 
 py_test(
     name = "test_pipeline_ingress_deployment",
-    size = "medium",
+    size = "small",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The test_pipeline_ingress_deployment test is finished in 13s, which meet the criteria for "small" size tests, helps to retry the tests as quickly as possible.

https://buildkite.com/ray-project/ray-builders-branch/builds/7195#66c5e6fe-6daf-449b-bd50-abb4c3b9d056/236-3392 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
