### PR TITLE
debug call_ray_start failure

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -275,9 +275,13 @@ def call_ray_start(request):
         "--max-worker-port=0 --port 0",
     )
     command_args = parameter.split(" ")
-    out = ray._private.utils.decode(
-        subprocess.check_output(command_args, stderr=subprocess.STDOUT)
-    )
+    try:
+        out = ray._private.utils.decode(
+            subprocess.check_output(command_args, stderr=subprocess.STDOUT)
+        )
+    except Exception as e:
+        print(type(e), e)
+        raise
     # Get the redis address from the output.
     redis_substring_prefix = "--address='"
     address_location = out.find(redis_substring_prefix) + len(redis_substring_prefix)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Exploring #24251. The call to the `call_ray_start` fixture seems to be timing out in `test_ray_init`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
