### PR TITLE
[ci/hotfix] Fix race condition in pytest reporting

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -709,7 +709,7 @@ def append_short_test_summary(rep):
         return
 
     if not os.path.exists(summary_dir):
-        os.makedirs(summary_dir)
+        os.makedirs(summary_dir, exist_ok=True)
 
     test_name = rep.nodeid.replace(os.sep, "::")
 
@@ -720,10 +720,6 @@ def append_short_test_summary(rep):
         # The test succeeded after failing, thus it is flaky.
         # We do not want to annotate flaky tests just now, so remove report.
         os.remove(summary_file)
-
-        # If there is only the header file left, remove directory
-        if len(os.listdir(summary_dir)) <= 1:
-            shutil.rmtree(summary_dir)
         return
 
     # Only consider failed tests from now on


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The AWS test seems to try to create the directory multiple times.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
