### PR TITLE
[RLlib] Ensure `MultiCallbacks` always implements all callback methods

### DIFF
--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -17,6 +17,7 @@ from ray.rllib.utils.exploration.random_encoder import (
     update_beta,
 )
 from ray.rllib.utils.typing import AgentID, EnvType, PolicyID
+from ray.tune.callback import CallbackMeta
 
 # Import psutil after ray so the packaged version is used.
 import psutil
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 
 
 @PublicAPI
-class DefaultCallbacks:
+class DefaultCallbacks(metaclass=CallbackMeta):
     """Abstract base class for RLlib callbacks (similar to Keras callbacks).
 
     These callbacks can be used for custom metrics and custom postprocessing.
@@ -367,6 +368,8 @@ class MultiCallbacks(DefaultCallbacks):
                 ....
             ])
     """
+
+    IS_CALLBACK_CONTAINER = True
 
     def __init__(self, callback_class_list):
         super().__init__()

--- a/rllib/agents/tests/test_callbacks.py
+++ b/rllib/agents/tests/test_callbacks.py
@@ -1,7 +1,7 @@
 import unittest
 
 import ray
-from ray.rllib.agents.callbacks import DefaultCallbacks
+from ray.rllib.agents.callbacks import DefaultCallbacks, MultiCallbacks
 import ray.rllib.agents.dqn as dqn
 from ray.rllib.utils.test_utils import framework_iterator
 
@@ -32,36 +32,41 @@ class TestCallbacks(unittest.TestCase):
         ray.shutdown()
 
     def test_on_sub_environment_created(self):
-        config = {
+        base_config = {
             "env": "CartPole-v1",
             # Create 4 sub-environments per remote worker.
             "num_envs_per_worker": 4,
             # Create 2 remote workers.
             "num_workers": 2,
-            "callbacks": OnSubEnvironmentCreatedCallback,
         }
 
-        for _ in framework_iterator(config, frameworks=("tf", "torch")):
-            trainer = dqn.DQNTrainer(config=config)
-            # Fake the counter on the local worker (doesn't have an env) and
-            # set it to -1 so the below `foreach_worker()` won't fail.
-            trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+        for callbacks in (
+            OnSubEnvironmentCreatedCallback,
+            MultiCallbacks([OnSubEnvironmentCreatedCallback]),
+        ):
+            config = dict(base_config, callbacks=callbacks)
 
-            # Get sub-env vector index sums from the 2 remote workers:
-            sum_sub_env_vector_indices = trainer.workers.foreach_worker(
-                lambda w: w.sum_sub_env_vector_indices
-            )
-            # Local worker has no environments -> Expect the -1 special
-            # value returned by the above lambda.
-            self.assertTrue(sum_sub_env_vector_indices[0] == -1)
-            # Both remote workers (index 1 and 2) have a vector index counter
-            # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
-            self.assertTrue(sum_sub_env_vector_indices[1] == 6)
-            self.assertTrue(sum_sub_env_vector_indices[2] == 6)
-            trainer.stop()
+            for _ in framework_iterator(config, frameworks=("tf", "torch")):
+                trainer = dqn.DQNTrainer(config=config)
+                # Fake the counter on the local worker (doesn't have an env) and
+                # set it to -1 so the below `foreach_worker()` won't fail.
+                trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+
+                # Get sub-env vector index sums from the 2 remote workers:
+                sum_sub_env_vector_indices = trainer.workers.foreach_worker(
+                    lambda w: w.sum_sub_env_vector_indices
+                )
+                # Local worker has no environments -> Expect the -1 special
+                # value returned by the above lambda.
+                self.assertTrue(sum_sub_env_vector_indices[0] == -1)
+                # Both remote workers (index 1 and 2) have a vector index counter
+                # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
+                self.assertTrue(sum_sub_env_vector_indices[1] == 6)
+                self.assertTrue(sum_sub_env_vector_indices[2] == 6)
+                trainer.stop()
 
     def test_on_sub_environment_created_with_remote_envs(self):
-        config = {
+        base_config = {
             "env": "CartPole-v1",
             # Make each sub-environment a ray actor.
             "remote_worker_envs": True,
@@ -70,27 +75,32 @@ class TestCallbacks(unittest.TestCase):
             "num_envs_per_worker": 4,
             # Create 2 remote workers.
             "num_workers": 2,
-            "callbacks": OnSubEnvironmentCreatedCallback,
         }
 
-        for _ in framework_iterator(config, frameworks=("tf", "torch")):
-            trainer = dqn.DQNTrainer(config=config)
-            # Fake the counter on the local worker (doesn't have an env) and
-            # set it to -1 so the below `foreach_worker()` won't fail.
-            trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+        for callbacks in (
+            OnSubEnvironmentCreatedCallback,
+            MultiCallbacks([OnSubEnvironmentCreatedCallback]),
+        ):
+            config = dict(base_config, callbacks=callbacks)
 
-            # Get sub-env vector index sums from the 2 remote workers:
-            sum_sub_env_vector_indices = trainer.workers.foreach_worker(
-                lambda w: w.sum_sub_env_vector_indices
-            )
-            # Local worker has no environments -> Expect the -1 special
-            # value returned by the above lambda.
-            self.assertTrue(sum_sub_env_vector_indices[0] == -1)
-            # Both remote workers (index 1 and 2) have a vector index counter
-            # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
-            self.assertTrue(sum_sub_env_vector_indices[1] == 6)
-            self.assertTrue(sum_sub_env_vector_indices[2] == 6)
-            trainer.stop()
+            for _ in framework_iterator(config, frameworks=("tf", "torch")):
+                trainer = dqn.DQNTrainer(config=config)
+                # Fake the counter on the local worker (doesn't have an env) and
+                # set it to -1 so the below `foreach_worker()` won't fail.
+                trainer.workers.local_worker().sum_sub_env_vector_indices = -1
+
+                # Get sub-env vector index sums from the 2 remote workers:
+                sum_sub_env_vector_indices = trainer.workers.foreach_worker(
+                    lambda w: w.sum_sub_env_vector_indices
+                )
+                # Local worker has no environments -> Expect the -1 special
+                # value returned by the above lambda.
+                self.assertTrue(sum_sub_env_vector_indices[0] == -1)
+                # Both remote workers (index 1 and 2) have a vector index counter
+                # of 6 (sum of vector indices: 0 + 1 + 2 + 3).
+                self.assertTrue(sum_sub_env_vector_indices[1] == 6)
+                self.assertTrue(sum_sub_env_vector_indices[2] == 6)
+                trainer.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Follows by closed PR #24011. Ensure `ray.rllib.agents.callbacks.MultiCallbacks` and `ray.tune.callback.CallbackList` always have implemented all the callback methods `on_*`.

cc @sven1977 @gjoliver 

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
