### PR TITLE
[RLlib] Reinstate flakey AlphaStar learning CI test (flakey due to 2 changed, bad config default values).

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -114,16 +114,15 @@ py_test(
 )
 
 # AlphaStar
-# Todo (rllib-team): Re-activate once flakiness fixed
-# py_test(
-#     name = "learning_tests_cartpole_alpha_star",
-#     main = "tests/run_regression_tests.py",
-#     tags = ["team:ml", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
-#     size = "large",
-#     srcs = ["tests/run_regression_tests.py"],
-#     data = ["tuned_examples/alpha_star/multi-agent-cartpole-alpha-star.yaml"],
-#     args = ["--yaml-dir=tuned_examples/alpha_star", "--num-cpus=20"]
-# )
+py_test(
+    name = "learning_tests_cartpole_alpha_star",
+    main = "tests/run_regression_tests.py",
+    tags = ["team:ml", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    size = "large",
+    srcs = ["tests/run_regression_tests.py"],
+    data = ["tuned_examples/alpha_star/multi-agent-cartpole-alpha-star.yaml"],
+    args = ["--yaml-dir=tuned_examples/alpha_star", "--num-cpus=10"]
+)
 
 # APEX-DQN
 py_test(

--- a/rllib/agents/alpha_star/alpha_star.py
+++ b/rllib/agents/alpha_star/alpha_star.py
@@ -61,12 +61,12 @@ DEFAULT_CONFIG = Trainer.merge_trainer_configs(
         # Timeout to use for `ray.wait()` when waiting for samplers to have placed
         # new data into the buffers. If no samples are ready within the timeout,
         # the buffers used for mixin-sampling will return only older samples.
-        "sample_wait_timeout": 0.0,
+        "sample_wait_timeout": 0.01,
         # Timeout to use for `ray.wait()` when waiting for the policy learner actors
         # to have performed an update and returned learning stats. If no learner
         # actors have produced any learning results in the meantime, their
         # learner-stats in the results will be empty for that iteration.
-        "learn_wait_timeout": 0.0,
+        "learn_wait_timeout": 0.1,
 
         # League-building parameters.
         # The LeagueBuilder class to be used for league building logic.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Reinstate flakey AlphaStar learning CI test (flakey due to 2 changed, bad config default values).
* Default values for sample_wait_timeout and learn_wait_timeout should be changed to their Ray1.12 values (0.01 and 0.1 respectively).
* Re-instate multi-agent CartPole learning test case in the CI.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
