### PR TITLE
[Datasets] Expose `DatasetPipeline` in `ray.data` module

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -23,6 +23,7 @@ from ray.data.read_api import (
 )
 from ray.data.datasource import Datasource, ReadTask
 from ray.data.dataset import Dataset
+from ray.data.dataset_pipeline import DatasetPipeline
 from ray.data.impl.progress_bar import set_progress_bars
 from ray.data.impl.compute import ActorPoolStrategy
 
@@ -34,6 +35,7 @@ _cached_cls = None
 __all__ = [
     "ActorPoolStrategy",
     "Dataset",
+    "DatasetPipeline",
     "Datasource",
     "ReadTask",
     "from_dask",


### PR DESCRIPTION
Referencing the `DatasetPipeline` class currently requires `ray.data.dataset_pipeline.DatasetPipeline`; we should expose it directly in the `ray.data` module, as we do for `Dataset`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
