### PR TITLE
[ci/release] Fix concurrency group calculation for smoke tests

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -3,7 +3,7 @@ import os
 from typing import Optional, Dict, Any
 
 from ray_release.buildkite.concurrency import CONCURRENY_GROUPS, get_concurrency_group
-from ray_release.config import Test, get_test_env_var
+from ray_release.config import Test, get_test_env_var, as_smoke_test
 from ray_release.exception import ReleaseTestConfigError
 
 DEFAULT_ARTIFACTS_DIR_HOST = "/tmp/ray_release_test_artifacts"
@@ -76,7 +76,11 @@ def get_step(
             )
         concurrency_limit = CONCURRENY_GROUPS[concurrency_group]
     else:
-        concurrency_group, concurrency_limit = get_concurrency_group(test)
+        if smoke_test:
+            concurrency_test = as_smoke_test(test)
+        else:
+            concurrency_test = test
+        concurrency_group, concurrency_limit = get_concurrency_group(concurrency_test)
 
     step["concurrency_group"] = concurrency_group
     step["concurrency"] = concurrency_limit

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -1,8 +1,11 @@
 import os
 import sys
+import tempfile
 import unittest
 from typing import Dict
 from unittest.mock import patch
+
+import yaml
 
 from ray_release.buildkite.concurrency import (
     get_test_resources_from_cluster_compute,
@@ -578,6 +581,55 @@ class BuildkiteSettingsTest(unittest.TestCase):
         test_concurrency(1, 0, "tiny")
         test_concurrency(32, 0, "tiny")
         test_concurrency(33, 0, "small")
+
+    def testConcurrencyGroupSmokeTest(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster_config_full = {
+                "head_node_type": {
+                    "instance_type": "n1-standard-16"  # 16 CPUs, 0 GPUs
+                },
+                "worker_node_types": [
+                    {
+                        "instance_type": "random-str-xxx-32",  # 32 CPUS, 0 GPUs
+                        "max_workers": 10,
+                    },
+                ],
+            }
+
+            cluster_config_smoke = {
+                "head_node_type": {
+                    "instance_type": "n1-standard-16"  # 16 CPUs, 0 GPUs
+                },
+                "worker_node_types": [
+                    {
+                        "instance_type": "random-str-xxx-32",  # 32 CPUS, 0 GPUs
+                        "max_workers": 1,
+                    },
+                ],
+            }
+
+            cluster_config_full_path = os.path.join(tmpdir, "full.yaml")
+            with open(cluster_config_full_path, "w") as fp:
+                yaml.safe_dump(cluster_config_full, fp)
+
+            cluster_config_smoke_path = os.path.join(tmpdir, "smoke.yaml")
+            with open(cluster_config_smoke_path, "w") as fp:
+                yaml.safe_dump(cluster_config_smoke, fp)
+
+            test = Test(
+                {
+                    "name": "test_1",
+                    "cluster": {"cluster_compute": cluster_config_full_path},
+                    "smoke_test": {
+                        "cluster": {"cluster_compute": cluster_config_smoke_path},
+                    },
+                }
+            )
+            step = get_step(test, smoke_test=False)
+            self.assertEquals(step["concurrency_group"], "medium")
+
+            step = get_step(test, smoke_test=True)
+            self.assertEquals(step["concurrency_group"], "small")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently concurrency groups are always calculated based on the full test cluster compute. Instead, smoke tests should use the smoke test cluster compute.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
