### PR TITLE
[RLlib] Fix "tf variable is unhashable" Error.

### DIFF
--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -515,7 +515,7 @@ class ModelCatalog:
 
                 def track_var_creation(next_creator, **kw):
                     v = next_creator(**kw)
-                    created.add(v)
+                    created.add(v.ref())
                     return v
 
                 with tf.variable_creator_scope(track_var_creation):


### PR DESCRIPTION
Fixes `TypeError: Variable is unhashable. Instead, use variable.ref() as the key. (Variable: <tf.Variable 'default_policy/Variable:0' shape=() dtype=int64, numpy=0>)`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Starting with tf2, .ref() must be used when adding a Variable to a set. See the [tf documentation](https://www.tensorflow.org/api_docs/python/tf/Variable#ref) for details.

Here, `created` is a set and `v` is a tf.Variable.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
