### PR TITLE
Fix incorrect inputs into tf.random.categorical

### DIFF
--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -88,7 +88,7 @@ class Categorical(TFActionDistribution):
 
     @override(TFActionDistribution)
     def _build_sample_op(self) -> TensorType:
-        return tf.squeeze(tf.random.categorical(self.inputs, 1), axis=1)
+        return tf.squeeze(tf.random.categorical(tf.math.log(self.inputs), 1), axis=1)
 
     @staticmethod
     @override(ActionDistribution)

--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -88,7 +88,7 @@ class Categorical(TFActionDistribution):
 
     @override(TFActionDistribution)
     def _build_sample_op(self) -> TensorType:
-        return tf.squeeze(tf.random.categorical(tf.math.log(self.inputs), 1), axis=1)
+        return tf.squeeze(tf.random.categorical(tf.math.log(tf.nn.softmax(tf.where(self.inputs!=0, self.inputs, tf.float64.min))), 1), axis=1)
 
     @staticmethod
     @override(ActionDistribution)


### PR DESCRIPTION
change first input to log probabilities rather than logits

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The inputs for tf.random.categorical are incorrect. The name of the input is 'logits', but it actually represents the log probabilities according to [the documentation](https://www.tensorflow.org/api_docs/python/tf/random/categorical#args).

With the current inputs, tf.random.categorical is free to sample from masked actions, which should have zero probability.

## Related issue number

<!-- For example: "Closes #1234" -->
#24055 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
