### PR TITLE
[Datasets] Add Polars backend for tabular aggregations

### DIFF
--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -321,7 +321,8 @@ def test_tensor_array_reductions():
     df = pd.DataFrame({"one": list(range(outer_dim)), "two": TensorArray(arr)})
 
     # Reduction tests, using NumPy as the groundtruth.
-    for name, reducer in TensorArray.SUPPORTED_REDUCERS.items():
+    for name, reducers in TensorArray.SUPPORTED_REDUCERS.items():
+        reducer, nan_reducer = reducers
         np_kwargs = {}
         if name in ("std", "var"):
             # Pandas uses a ddof default of 1 while NumPy uses 0.
@@ -329,6 +330,9 @@ def test_tensor_array_reductions():
             # standard deviation calculations.
             np_kwargs["ddof"] = 1
         np.testing.assert_equal(df["two"].agg(name), reducer(arr, axis=0, **np_kwargs))
+        np.testing.assert_equal(
+            df["two"].agg(name), nan_reducer(arr, axis=0, **np_kwargs)
+        )
 
 
 @pytest.mark.parametrize("chunked", [False, True])

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -135,6 +135,8 @@ class ArrowTensorArray(pa.ExtensionArray):
               containing ``len(arr)`` tensors of variable shape.
             - If scalar elements, a ``pyarrow.Array``.
         """
+        # TODO(Clark): Support null elements, e.g. a list or object-dtyped ndarray
+        # containing ndarrays + Nones, via mapping this to an Arrow validity bitmap.
         if isinstance(arr, (list, tuple)) and arr and isinstance(arr[0], np.ndarray):
             # Stack ndarrays and pass through to ndarray handling logic below.
             try:

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -696,16 +696,16 @@ class TensorArray(
     """
 
     SUPPORTED_REDUCERS = {
-        "sum": np.sum,
-        "all": np.all,
-        "any": np.any,
-        "min": np.min,
-        "max": np.max,
-        "mean": np.mean,
-        "median": np.median,
-        "prod": np.prod,
-        "std": np.std,
-        "var": np.var,
+        "sum": (np.sum, np.nansum),
+        "all": (np.all, np.all),
+        "any": (np.any, np.any),
+        "min": (np.min, np.nanmin),
+        "max": (np.max, np.nanmax),
+        "mean": (np.mean, np.nanmean),
+        "median": (np.median, np.nanmedian),
+        "prod": (np.prod, np.nanprod),
+        "std": (np.std, np.nanstd),
+        "var": (np.var, np.nanvar),
     }
 
     # See https://github.com/pandas-dev/pandas/blob/master/pandas/core/arrays/base.py
@@ -740,6 +740,8 @@ class TensorArray(
 
         if isinstance(values, np.ndarray):
             if values.dtype.type is np.object_:
+                # TODO(Clark): Support null elements, e.g. an object-dtyped ndarray
+                # containing ndarrays and Nones.
                 if len(values) == 0:
                     # Tensor is empty, pass through to create empty TensorArray.
                     pass
@@ -1190,7 +1192,9 @@ class TensorArray(
                 pass
         try:
             return TensorArrayElement(
-                self.SUPPORTED_REDUCERS[name](self._tensor, axis=0, **reducer_kwargs)
+                self.SUPPORTED_REDUCERS[name][skipna](
+                    self._tensor, axis=0, **reducer_kwargs
+                )
             )
         except KeyError:
             raise NotImplementedError(f"'{name}' aggregate not implemented.") from None

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -1,15 +1,21 @@
-from typing import TYPE_CHECKING, List, Union
+import collections
+from typing import TYPE_CHECKING, List, Union, Optional
+
+import numpy as np
 
 try:
-    import pyarrow
+    import pyarrow as pa
+
+    # This import is necessary to load the tensor extension type.
+    from ray.data.extensions.tensor_extension import ArrowTensorType  # noqa
 except ImportError:
-    pyarrow = None
+    pa = None
 
 if TYPE_CHECKING:
     from ray.data._internal.sort import SortKeyT
 
 
-def sort(table: "pyarrow.Table", key: "SortKeyT", descending: bool) -> "pyarrow.Table":
+def sort(table: "pa.Table", key: "SortKeyT", descending: bool) -> "pa.Table":
     import pyarrow.compute as pac
 
     indices = pac.sort_indices(table, sort_keys=key)
@@ -17,12 +23,12 @@ def sort(table: "pyarrow.Table", key: "SortKeyT", descending: bool) -> "pyarrow.
 
 
 def take_table(
-    table: "pyarrow.Table",
-    indices: Union[List[int], "pyarrow.Array", "pyarrow.ChunkedArray"],
-) -> "pyarrow.Table":
+    table: "pa.Table",
+    indices: Union[List[int], "pa.Array", "pa.ChunkedArray"],
+) -> "pa.Table":
     """Select rows from the table.
 
-    This method is an alternative to pyarrow.Table.take(), which breaks for
+    This method is an alternative to pa.Table.take(), which breaks for
     extension arrays. This is exposed as a static method for easier use on
     intermediate tables, not underlying an ArrowBlockAccessor.
     """
@@ -39,13 +45,13 @@ def take_table(
                 # extension arrays.
                 col = _concatenate_extension_column(col)
             new_cols.append(col.take(indices))
-        table = pyarrow.Table.from_arrays(new_cols, schema=table.schema)
+        table = pa.Table.from_arrays(new_cols, schema=table.schema)
     else:
         table = table.take(indices)
     return table
 
 
-def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.ChunkedArray":
+def _concatenate_chunked_arrays(arrs: "pa.ChunkedArray") -> "pa.ChunkedArray":
     """
     Concatenate provided chunked arrays into a single chunked array.
     """
@@ -70,12 +76,15 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
         # Add chunks for this chunked array to flat chunk list.
         chunks.extend(arr.chunks)
     # Construct chunked array on flat list of chunks.
-    return pyarrow.chunked_array(chunks, type=type_)
+    return pa.chunked_array(chunks, type=type_)
 
 
-def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
+def concat(blocks: List["pa.Table"]) -> "pa.Table":
     """Concatenate provided Arrow Tables into a single Arrow Table. This has special
-    handling for extension types that pyarrow.concat_tables does not yet support.
+    handling for:
+     - extension types that pa.concat_tables does not yet support,
+     - upcasting non-extension type column types,
+     - promoting nulls.
     """
     from ray.data.extensions import (
         ArrowTensorArray,
@@ -91,8 +100,10 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
         return blocks[0]
 
     schema = blocks[0].schema
-    if any(isinstance(type_, pyarrow.ExtensionType) for type_ in schema.types):
+    if any(isinstance(type_, pa.ExtensionType) for type_ in schema.types):
         # Custom handling for extension array columns.
+        # TODO(Clark): Add upcasting for extension type path once extension type support
+        # is added to Polars (and therefore our Polars integration).
         cols = []
         schema_tensor_field_overrides = {}
         for col_name in schema.names:
@@ -132,20 +143,148 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
                     schema = schema.set(idx, field)
             schemas.append(schema)
         # Let Arrow unify the schema of non-tensor extension type columns.
-        schema = pyarrow.unify_schemas(schemas)
+        schema = pa.unify_schemas(schemas)
         # Build the concatenated table.
-        table = pyarrow.Table.from_arrays(cols, schema=schema)
+        table = pa.Table.from_arrays(cols, schema=schema)
         # Validate table schema (this is a cheap check by default).
         table.validate()
     else:
-        # No extension array columns, so use built-in pyarrow.concat_tables.
-        table = pyarrow.concat_tables(blocks, promote=True)
+        # No extension array columns, so use built-in pa.concat_tables.
+        # TODO(Clark): Remove this upcasting once Arrow's concatenate supports implicit
+        # upcasting.
+        # NOTE(Clark): We only use Polars for workloads that don't have extension types,
+        # so we only need to upcast if there are no extension types.
+        blocks = _upcast_tables(blocks)
+        table = pa.concat_tables(blocks, promote=True)
     return table
 
 
 def concat_and_sort(
-    blocks: List["pyarrow.Table"], key: "SortKeyT", descending: bool
-) -> "pyarrow.Table":
+    blocks: List["pa.Table"], key: "SortKeyT", descending: bool
+) -> "pa.Table":
     ret = concat(blocks)
-    indices = pyarrow.compute.sort_indices(ret, sort_keys=key)
+    indices = pa.compute.sort_indices(ret, sort_keys=key)
     return take_table(ret, indices)
+
+
+def _upcast_tables(tables: List["pa.Table"]) -> List["pa.Table"]:
+    """Upcast columns across tables to their minimally sufficient dtype to ensure that
+    the tables can be properly concatenated.
+
+    This is required for Polars workloads because Polars will aggressively downcast
+    columns.
+    """
+    field_dtypes = collections.defaultdict(list)
+    field_meta = collections.defaultdict(dict)
+    field_nullable = collections.defaultdict(bool)
+    schema_meta = {}
+    for table in tables:
+        if table.schema.metadata is not None:
+            schema_meta.update(table.schema.metadata)
+        for field in table.schema:
+            if not pa.types.is_null(field.type):
+                # All Arrow types are nullable, so drop any null-type columns from
+                # the common dtype search.
+                field_dtypes[field.name].append(field.type)
+            if field.metadata is not None:
+                field_meta[field.name].update(field.metadata)
+            field_nullable[field.name] = field.nullable
+    common_dtypes = {}
+    for name in field_nullable.keys():
+        dtypes = field_dtypes[name]
+        if dtypes:
+            # Find the common Arrow type among all dtypes.
+            common_dtypes[name] = _common_arrow_type(dtypes)
+        else:
+            # All table's dtypes for this column are null, just use the first
+            # table's dtype for this column.
+            common_dtypes[name] = tables[0].schema.field(name).type
+    fields = [
+        pa.field(name, common_dtypes[name], field_nullable[name], field_meta[name])
+        for name in field_nullable.keys()
+    ]
+    schema = pa.schema(fields, schema_meta)
+    return [table.cast(schema) for table in tables]
+
+
+def _common_arrow_type(dtypes: List["pa.DataType"]) -> "pa.DataType":
+    """Get common Arrow type for the provided Arrow types, such that casting to the
+    returned type will not result in any loss of precision or other errors.
+    """
+    import pandas as pd
+
+    # Delegate to NumPy to find the minimally sufficient type for this column
+    # across all tables.
+    np_dtypes = [dtype.to_pandas_dtype() for dtype in dtypes]
+    if all(
+        np_dtype is not np.object_
+        and not pd.api.types.is_extension_array_dtype(np_dtype)
+        for np_dtype in np_dtypes
+    ):
+        # Use NumPy to find common dtype if all dtypes are known to NumPy.
+        try:
+            common_np_dtype = np.find_common_type(np_dtypes, [])
+            return pa.from_numpy_dtype(common_np_dtype)
+        except (TypeError, ValueError, pa.ArrowNotImplementedError):
+            # Fall back to manual Arrow type analysis.
+            pass
+    dtype = _common_arrow_binary_type(dtypes)
+    if dtype is not None:
+        return dtype
+    dtype = _common_arrow_tensor_extension_type(dtypes)
+    if dtype is not None:
+        return dtype
+    # Fall back to dtype of first table.
+    return dtypes[0]
+
+
+def _common_arrow_binary_type(
+    dtypes: List["pa.DataType"],
+) -> Optional["pa.DataType"]:
+    """Get common binary Arrow type for the provided Arrow types. Returns None if any
+    are non-binary.
+    """
+    all_utf8, all_offset32 = True, True
+    for dtype in dtypes:
+        if pa.types.is_string(dtype):
+            pass
+        elif pa.types.is_binary(dtype):
+            all_utf8 = False
+        elif pa.types.is_fixed_size_binary(dtype):
+            all_utf8 = False
+        elif pa.types.is_large_string(dtype):
+            all_offset32 = False
+        elif pa.types.is_large_binary(dtype):
+            all_offset32 = False
+            all_utf8 = False
+        else:
+            return None
+    if all_utf8:
+        # Strings.
+        return pa.string() if all_offset32 else pa.large_string()
+    # Binary.
+    return pa.binary() if all_offset32 else pa.large_binary()
+
+
+def _common_arrow_tensor_extension_type(
+    dtypes: List["pa.DataType"],
+) -> Optional["pa.DataType"]:
+    """Get common tensor extension Arrow type for the provided Arrow types. Returns
+    None if any are non-tensor-extension.
+    """
+    shape = None
+    value_dtypes = []
+    for dtype in dtypes:
+        if isinstance(dtype, ArrowTensorType):
+            if shape is None:
+                shape = dtype.shape
+            else:
+                if dtype.shape != shape:
+                    return None
+                value_dtypes.append(dtype.storage_type.value_type)
+        else:
+            return None
+    value_dtype = _common_arrow_type(value_dtypes)
+    if value_dtype is not None:
+        return ArrowTensorType(shape, value_dtype)
+    return None

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -450,8 +450,7 @@ def _map_block_split(
 ) -> BlockPartition:
     stats = BlockExecStats.builder()
     blocks, fn_args = blocks_and_fn_args[:num_blocks], blocks_and_fn_args[num_blocks:]
-    if fn is not None:
-        fn_args = (fn,) + fn_args
+    fn_args = (fn,) + fn_args
     new_metas = []
     for new_block in block_fn(blocks, *fn_args, **fn_kwargs):
         accessor = BlockAccessor.for_block(new_block)
@@ -479,8 +478,7 @@ def _map_block_nosplit(
     stats = BlockExecStats.builder()
     builder = DelegatingBlockBuilder()
     blocks, fn_args = blocks_and_fn_args[:num_blocks], blocks_and_fn_args[num_blocks:]
-    if fn is not None:
-        fn_args = (fn,) + fn_args
+    fn_args = (fn,) + fn_args
     for new_block in block_fn(blocks, *fn_args, **fn_kwargs):
         builder.add_block(new_block)
     new_block = builder.build()

--- a/python/ray/data/_internal/fast_repartition.py
+++ b/python/ray/data/_internal/fast_repartition.py
@@ -1,6 +1,7 @@
 import ray
 
 from ray.data.block import BlockAccessor
+from ray.data.context import DatasetContext
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.progress_bar import ProgressBar
@@ -38,10 +39,11 @@ def fast_repartition(blocks, num_blocks):
     # consider combining the split and coalesce tasks as an optimization.
 
     # Coalesce each split into a single block.
+    ctx = DatasetContext.get_current()
     reduce_task = cached_remote_fn(_ShufflePartitionOp.reduce).options(num_returns=2)
     reduce_bar = ProgressBar("Repartition", position=0, total=len(splits))
     reduce_out = [
-        reduce_task.remote(False, None, *s.get_internal_block_refs())
+        reduce_task.remote(ctx, False, None, *s.get_internal_block_refs())
         for s in splits
         if s.num_blocks() > 0
     ]

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -7,6 +7,7 @@ from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
 from ray.data._internal.shuffle import ShuffleOp, SimpleShufflePlan
 from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
+from ray.data.context import DatasetContext
 
 
 class _ShufflePartitionOp(ShuffleOp):
@@ -27,6 +28,7 @@ class _ShufflePartitionOp(ShuffleOp):
 
     @staticmethod
     def map(
+        ctx: DatasetContext,
         idx: int,
         block: Block,
         output_num_blocks: int,
@@ -71,6 +73,7 @@ class _ShufflePartitionOp(ShuffleOp):
 
     @staticmethod
     def reduce(
+        ctx: DatasetContext,
         random_shuffle: bool,
         random_seed: Optional[int],
         *mapper_outputs: List[Block],

--- a/python/ray/data/_internal/simple_block.py
+++ b/python/ray/data/_internal/simple_block.py
@@ -22,6 +22,7 @@ from ray.data.block import (
     BlockExecStats,
     KeyFn,
 )
+from ray.data.context import DatasetContext
 from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.size_estimator import SizeEstimator
 
@@ -282,7 +283,10 @@ class SimpleBlockAccessor(BlockAccessor):
         return ret
 
     def combine(
-        self, key: KeyFn, aggs: Tuple[AggregateFn]
+        self,
+        key: KeyFn,
+        aggs: Tuple[AggregateFn],
+        ctx: DatasetContext,
     ) -> Block[Tuple[KeyType, AggType]]:
         """Combine rows with the same key into an accumulator.
 
@@ -369,6 +373,7 @@ class SimpleBlockAccessor(BlockAccessor):
         key: KeyFn,
         aggs: Tuple[AggregateFn],
         finalize: bool,
+        ctx: DatasetContext,
     ) -> Tuple[Block[Tuple[KeyType, Union[U, AggType]]], BlockMetadata]:
         """Aggregate sorted, partially combined blocks with the same key range.
 

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -41,6 +41,7 @@ SortKeyT = Union[None, List[Tuple[str, str]], Callable[[T], Any]]
 class _SortOp(ShuffleOp):
     @staticmethod
     def map(
+        ctx: DatasetContext,
         idx: int,
         block: Block,
         output_num_blocks: int,
@@ -59,6 +60,7 @@ class _SortOp(ShuffleOp):
 
     @staticmethod
     def reduce(
+        ctx: DatasetContext,
         key: SortKeyT,
         descending: bool,
         *mapper_outputs: List[Block],

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1,3 +1,4 @@
+import functools
 import math
 from typing import Callable, Optional, List, TYPE_CHECKING
 
@@ -21,6 +22,7 @@ from ray.data._internal.null_aggregate import (
 )
 
 if TYPE_CHECKING:
+    import polars
     from ray.data import Dataset
 
 
@@ -86,7 +88,28 @@ class AggregateFn(object):
         pass
 
 
-class _AggregateOnKeyBase(AggregateFn):
+@PublicAPI(stability="alpha")
+class PolarsAggregation:
+    """A Polars aggregation, expressed via mapper and reducer Polars expressions."""
+
+    def __init__(
+        self,
+        map_expression: "polars.Expr",
+        reduce_expression: "polars.Expr",
+    ):
+        self.map_expression = map_expression
+        self.reduce_expression = reduce_expression
+
+
+@PublicAPI(stability="alpha")
+class WithPolars:
+    """An aggregation that can also be used as a Polars aggregation."""
+
+    def as_polars(self) -> PolarsAggregation:
+        raise NotImplementedError
+
+
+class _AggregateOnKeyBase(AggregateFn, WithPolars):
     def _set_key_fn(self, on: KeyFn):
         self._key_fn = on
 
@@ -95,7 +118,7 @@ class _AggregateOnKeyBase(AggregateFn):
 
 
 @PublicAPI
-class Count(AggregateFn):
+class Count(AggregateFn, WithPolars):
     """Defines count aggregation."""
 
     def __init__(self):
@@ -107,6 +130,11 @@ class Count(AggregateFn):
             merge=lambda a1, a2: a1 + a2,
             name="count()",
         )
+
+    def as_polars(self) -> PolarsAggregation:
+        import polars as pl
+
+        return PolarsAggregation(pl.count(), pl.sum("count").suffix("()"))
 
 
 @PublicAPI
@@ -130,6 +158,28 @@ class Sum(_AggregateOnKeyBase):
             name=(f"sum({str(on)})"),
         )
 
+        self.on = on
+        self.ignore_nulls = ignore_nulls
+
+    def as_polars(self) -> PolarsAggregation:
+        import polars as pl
+
+        sum_col = f"sum({self.on})"
+
+        map_expr = (
+            pl.when(self.ignore_nulls or pl.col(self.on).null_count() == 0)
+            .then(pl.sum(self.on))
+            .otherwise(None)
+            .alias(sum_col)
+        )
+        reduce_expr = (
+            pl.when(self.ignore_nulls or pl.col(sum_col).null_count() == 0)
+            .then(pl.sum(sum_col))
+            .otherwise(None)
+            .alias(sum_col)
+        )
+        return PolarsAggregation(map_expr, reduce_expr)
+
 
 @PublicAPI
 class Min(_AggregateOnKeyBase):
@@ -152,6 +202,28 @@ class Min(_AggregateOnKeyBase):
             name=(f"min({str(on)})"),
         )
 
+        self.on = on
+        self.ignore_nulls = ignore_nulls
+
+    def as_polars(self) -> PolarsAggregation:
+        import polars as pl
+
+        temp_col = f"__{self.on}_MIN__"
+
+        map_expr = (
+            pl.when(self.ignore_nulls or pl.col(self.on).null_count() == 0)
+            .then(pl.min(self.on))
+            .otherwise(None)
+            .alias(temp_col)
+        )
+        reduce_expr = (
+            pl.when(self.ignore_nulls or pl.col(temp_col).null_count() == 0)
+            .then(pl.min(temp_col))
+            .otherwise(None)
+            .alias(f"min({str(self.on)})")
+        )
+        return PolarsAggregation(map_expr, reduce_expr)
+
 
 @PublicAPI
 class Max(_AggregateOnKeyBase):
@@ -173,6 +245,28 @@ class Max(_AggregateOnKeyBase):
             finalize=_null_wrap_finalize(lambda a: a),
             name=(f"max({str(on)})"),
         )
+
+        self.on = on
+        self.ignore_nulls = ignore_nulls
+
+    def as_polars(self) -> PolarsAggregation:
+        import polars as pl
+
+        temp_col = f"__{self.on}_MAX__"
+
+        map_expr = (
+            pl.when(self.ignore_nulls or pl.col(self.on).null_count() == 0)
+            .then(pl.max(self.on))
+            .otherwise(None)
+            .alias(temp_col)
+        )
+        reduce_expr = (
+            pl.when(self.ignore_nulls or pl.col(temp_col).null_count() == 0)
+            .then(pl.max(temp_col))
+            .otherwise(None)
+            .alias(f"max({str(self.on)})")
+        )
+        return PolarsAggregation(map_expr, reduce_expr)
 
 
 @PublicAPI
@@ -209,6 +303,38 @@ class Mean(_AggregateOnKeyBase):
             finalize=_null_wrap_finalize(lambda a: a[0] / a[1]),
             name=(f"mean({str(on)})"),
         )
+
+        self.on = on
+        self.ignore_nulls = ignore_nulls
+
+    def as_polars(self) -> PolarsAggregation:
+        import polars as pl
+
+        temp_col = f"__{self.on}_MEAN__"
+
+        map_expr = (
+            pl.when(self.ignore_nulls or pl.col(self.on).null_count() == 0)
+            .then(
+                pl.struct(
+                    [
+                        pl.sum(self.on).alias("sum"),
+                        (pl.count() - pl.col(self.on).null_count()).alias("count"),
+                    ]
+                ),
+            )
+            .otherwise(None)
+            .alias(temp_col)
+        )
+        reduce_expr = (
+            pl.when(self.ignore_nulls or pl.col(temp_col).null_count() == 0)
+            .then(
+                pl.col(temp_col).struct.field("sum").sum()
+                / pl.col(temp_col).struct.field("count").sum()
+            )
+            .otherwise(None)
+            .alias(f"mean({str(self.on)})")
+        )
+        return PolarsAggregation(map_expr, reduce_expr)
 
 
 @PublicAPI
@@ -284,6 +410,81 @@ class Std(_AggregateOnKeyBase):
             finalize=_null_wrap_finalize(finalize),
             name=(f"std({str(on)})"),
         )
+
+        self.on = on
+        self.ignore_nulls = ignore_nulls
+        self.ddof = ddof
+
+    def as_polars(self) -> PolarsAggregation:
+        import polars as pl
+        import numpy as np
+
+        temp_col = f"__{self.on}_STD__"
+
+        map_expr = (
+            pl.when(self.ignore_nulls or pl.col(self.on).null_count() == 0)
+            .then(
+                pl.struct(
+                    [
+                        ((pl.col(self.on) - pl.mean(self.on)) ** 2).sum().alias("M2"),
+                        pl.mean(self.on).alias("mean"),
+                        (pl.count() - pl.col(self.on).null_count()).alias("count"),
+                    ]
+                )
+            )
+            .otherwise(None)
+            .alias(temp_col)
+        )
+
+        # TODO(Clark): Generalize Chan's method for merging Welford accumulations to be
+        # vectorized over N accumulations, rather than using binary fold/accumulation
+        # implementation.
+        def fold(acc, x):
+            if x is None:
+                return acc
+            # Merges two accumulations into one.
+            # See
+            # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+            M2_acc, mean_acc, count_acc = acc["M2"], acc["mean"], acc["count"]
+            M2_x, mean_x, count_x = x["M2"], x["mean"], x["count"]
+            if count_x is None or count_x == 0:
+                return acc
+            delta = mean_x - mean_acc
+            count = count_acc + count_x
+            # NOTE: We use this mean calculation since it's more numerically
+            # stable than mean_acc + delta * count_x / count, which actually
+            # deviates from Pandas in the ~15th decimal place and causes our
+            # exact comparison tests to fail.
+            mean = (mean_acc * count_acc + mean_x * count_x) / count
+            # Update the sum of squared differences.
+            M2 = M2_acc + M2_x + (delta**2) * count_acc * count_x / count
+            return {"M2": M2, "mean": mean, "count": count}
+
+        def finalize(a: dict):
+            # Compute the final standard deviation from the accumulated
+            # sum of squared differences from current mean and the count.
+            if a is None:
+                return np.nan
+            M2, _, count = a["M2"], a["mean"], a["count"]
+            if count is None or M2 is None:
+                return np.nan
+            if count < 2:
+                return 0.0
+            return math.sqrt(M2 / (count - self.ddof))
+
+        reduce_expr = (
+            pl.when(self.ignore_nulls or pl.col(temp_col).null_count() == 0)
+            .then(
+                pl.apply(
+                    pl.col(temp_col),
+                    lambda s: finalize(functools.reduce(fold, s[0])),
+                    return_dtype=pl.datatypes.Float64(),
+                )
+            )
+            .otherwise(None)
+            .alias(f"std({self.on})")
+        )
+        return PolarsAggregation(map_expr, reduce_expr)
 
 
 @PublicAPI

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -35,6 +35,7 @@ from ray.util.annotations import PublicAPI
 class _GroupbyOp(ShuffleOp):
     @staticmethod
     def map(
+        ctx: DatasetContext,
         idx: int,
         block: Block,
         output_num_blocks: int,
@@ -55,7 +56,7 @@ class _GroupbyOp(ShuffleOp):
                 [(key, "ascending")] if isinstance(key, str) else key,
                 descending=False,
             )
-        parts = [BlockAccessor.for_block(p).combine(key, aggs) for p in partitions]
+        parts = [BlockAccessor.for_block(p).combine(key, aggs, ctx) for p in partitions]
         meta = BlockAccessor.for_block(block).get_metadata(
             input_files=None, exec_stats=stats.build()
         )
@@ -63,6 +64,7 @@ class _GroupbyOp(ShuffleOp):
 
     @staticmethod
     def reduce(
+        ctx: DatasetContext,
         key: KeyFn,
         aggs: Tuple[AggregateFn],
         *mapper_outputs: List[Block],
@@ -70,7 +72,7 @@ class _GroupbyOp(ShuffleOp):
     ) -> (Block, BlockMetadata):
         """Aggregate sorted and partially combined blocks."""
         return BlockAccessor.for_block(mapper_outputs[0]).aggregate_combined_blocks(
-            list(mapper_outputs), key, aggs, finalize=not partial_reduce
+            list(mapper_outputs), key, aggs, not partial_reduce, ctx
         )
 
     @staticmethod

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -7,6 +7,7 @@ import time
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -15,6 +16,7 @@ import ray
 from ray._private.test_utils import wait_for_condition
 from ray.data._internal.stats import _StatsActor
 from ray.data._internal.arrow_block import ArrowRow
+from ray.data._internal.arrow_ops.transform_pyarrow import concat
 from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data._internal.pandas_block import PandasRow
@@ -493,6 +495,27 @@ def test_arrow_block_slice_copy_empty():
     assert table2.equals(expected_slice)
     assert table2.schema == table.schema
     assert table2.num_rows == 0
+
+
+def test_arrow_table_concat_tables():
+    # Check upcasting ints.
+    t1 = pa.table({"a": [1, 2, 3]}, schema=pa.schema([("a", pa.int8())]))
+    t2 = pa.table({"a": [4, 5, 6]}, schema=pa.schema([("a", pa.int64())]))
+    t = concat([t1, t2])
+    assert pa.types.is_int64(t.schema.field("a").type)
+
+    # Check upcasting floats.
+    t1 = pa.table({"a": [1.0, 2.5, 3.1]}, schema=pa.schema([("a", pa.float32())]))
+    t2 = pa.table({"a": [4.2, 5.4, 6.9]}, schema=pa.schema([("a", pa.float64())]))
+    t = concat([t1, t2])
+    assert pa.types.is_float64(t.schema.field("a").type)
+
+    # Check upcasting with nulls.
+    t1 = pa.table({"a": [1, 2, None]}, schema=pa.schema([("a", pa.int8())]))
+    t2 = pa.table({"a": [4, 5, 6]}, schema=pa.schema([("a", pa.int64())]))
+    t3 = pa.table({"a": [None, None, None]})
+    t = concat([t1, t2, t3])
+    assert pa.types.is_int64(t.schema.field("a").type)
 
 
 def test_range_table(ray_start_regular_shared):
@@ -2702,6 +2725,12 @@ def test_map_with_mismatched_columns(ray_start_regular_shared):
     assert ds_map.take() == [{"a": "hello1", "b": "hello2"} for _ in range(10)]
 
 
+def test_select_polars(ray_start_regular_shared):
+    ds = ray.data.range_table(1000, parallelism=10)
+    ds2 = ds.select_polars([2 * pl.col("value") + 1])
+    assert ds2.take(limit=10000) == [{"value": 2 * i + 1} for i in range(1000)]
+
+
 def test_union(ray_start_regular_shared):
     ds = ray.data.range(20, parallelism=10)
 
@@ -3179,10 +3208,17 @@ def test_groupby_agg_name_conflict(ray_start_regular_shared, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+@pytest.mark.parametrize("use_polars", [True, False])
 def test_groupby_tabular_count(
-    ray_start_regular_shared, ds_format, num_parts, use_push_based_shuffle
+    ray_start_regular_shared,
+    use_push_based_shuffle,
+    use_polars,
+    ds_format,
+    num_parts,
 ):
     # Test built-in count aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_count with: {seed}")
     random.seed(seed)
@@ -3208,10 +3244,13 @@ def test_groupby_tabular_count(
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+@pytest.mark.parametrize("use_polars", [True, False])
 def test_groupby_tabular_sum(
-    ray_start_regular_shared, ds_format, num_parts, use_push_based_shuffle
+    ray_start_regular_shared, use_push_based_shuffle, use_polars, ds_format, num_parts
 ):
     # Test built-in sum aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_sum with: {seed}")
     random.seed(seed)
@@ -3278,12 +3317,135 @@ def test_groupby_tabular_sum(
                 "sum(B)": [None, None, None],
             }
         ),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.skip(
+    reason=("Waiting for Arrow compute kernels and Polars to support extension types.")
+)
+@pytest.mark.parametrize("num_parts", [1, 30])
+@pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_groupby_tabular_sum_tensor_extension(
+    ray_start_regular_shared, use_polars, ds_format, num_parts
+):
+    # Test built-in sum aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
+    seed = int(time.time())
+    print(f"Seeding RNG for test_groupby_tabular_sum_tensor_extension with: {seed}")
+    random.seed(seed)
+    num_rows = 100
+    shape = (2, 2)
+    xs = list(range(num_rows * np.prod(shape)))
+    random.shuffle(xs)
+    xs = np.array(xs).reshape((num_rows,) + shape)
+    keys = [x % 3 for x in range(num_rows)]
+
+    def _to_pandas(ds):
+        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
+
+    t = pa.table({"A": keys, "B": ArrowTensorArray.from_numpy(xs)})
+    ds = ray.data.from_arrow(t).repartition(num_parts)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+
+    agg_ds = ds.groupby("A").sum("B")
+    assert agg_ds.count() == 3
+    assert [row.as_pydict() for row in agg_ds.sort("A").iter_rows()] == [
+        {"A": 0, "sum(B)": 1683},
+        {"A": 1, "sum(B)": 1617},
+        {"A": 2, "sum(B)": 1650},
+    ]
+
+    # Test built-in sum aggregation with nans
+    ds = ray.data.from_items(
+        [{"A": (x % 3), "B": x} for x in xs] + [{"A": 0, "B": None}]
+    ).repartition(num_parts)
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    nan_grouped_ds = ds.groupby("A")
+    nan_agg_ds = nan_grouped_ds.sum("B")
+    assert nan_agg_ds.count() == 3
+    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
+        {"A": 0, "sum(B)": 1683},
+        {"A": 1, "sum(B)": 1617},
+        {"A": 2, "sum(B)": 1650},
+    ]
+    # Test ignore_nulls=False
+    nan_agg_ds = nan_grouped_ds.sum("B", ignore_nulls=False)
+    assert nan_agg_ds.count() == 3
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "sum(B)": [None, 1617, 1650],
+            }
+        ),
+        check_dtype=False,
+    )
+    # Test all nans
+    ds = ray.data.from_items([{"A": (x % 3), "B": None} for x in xs]).repartition(
+        num_parts
+    )
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
+    nan_agg_ds = ds.groupby("A").sum("B")
+    assert nan_agg_ds.count() == 3
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "sum(B)": [None, None, None],
+            }
+        ),
+        check_dtype=False,
     )
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
+def test_groupby_tabular_sum_tensor_extension_pandas(
+    ray_start_regular_shared, num_parts
+):
+    # Test built-in sum aggregation
+    num_rows = 10
+    shape = (2, 2)
+    xs = list(np.arange(num_rows * np.prod(shape)).reshape((num_rows,) + shape))
+    xs = np.array(xs)
+    keys = [x % 3 for x in range(num_rows)]
+
+    t = pa.table({"A": keys, "B": ArrowTensorArray.from_numpy(xs)})
+    ds = ray.data.from_arrow(t).repartition(num_parts)
+    ds = ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
+
+    agg_ds = ds.groupby("A").sum("B")
+    assert agg_ds.count() == 3
+    df = agg_ds.sort("A").to_pandas()
+    assert list(df["A"]) == [0, 1, 2]
+    np.testing.assert_equal(
+        np.array(list(df["sum(B)"].to_numpy())),
+        np.array(
+            [
+                [[72, 76], [80, 84]],
+                [[48, 51], [54, 57]],
+                [[60, 63], [66, 69]],
+            ]
+        ),
+    )
+
+    # TODO(Clark): Add null coverage once tensor extension supports null elements.
+
+
+@pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_global_tabular_sum(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_global_tabular_sum(ray_start_regular_shared, use_polars, ds_format, num_parts):
+    # Test built-in sum aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_global_arrow_sum with: {seed}")
     random.seed(seed)
@@ -3324,8 +3486,16 @@ def test_global_tabular_sum(ray_start_regular_shared, ds_format, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_min(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_groupby_tabular_min(
+    ray_start_regular_shared,
+    use_polars,
+    ds_format,
+    num_parts,
+):
     # Test built-in min aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_min with: {seed}")
     random.seed(seed)
@@ -3398,7 +3568,11 @@ def test_groupby_tabular_min(ray_start_regular_shared, ds_format, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_global_tabular_min(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_global_tabular_min(ray_start_regular_shared, use_polars, ds_format, num_parts):
+    # Test built-in min aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_global_arrow_min with: {seed}")
     random.seed(seed)
@@ -3439,8 +3613,16 @@ def test_global_tabular_min(ray_start_regular_shared, ds_format, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_max(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_groupby_tabular_max(
+    ray_start_regular_shared,
+    use_polars,
+    ds_format,
+    num_parts,
+):
     # Test built-in max aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_max with: {seed}")
     random.seed(seed)
@@ -3464,7 +3646,7 @@ def test_groupby_tabular_max(ray_start_regular_shared, ds_format, num_parts):
         {"A": 2, "max(B)": 98},
     ]
 
-    # Test built-in min aggregation with nans
+    # Test built-in max aggregation with nans
     ds = ray.data.from_items(
         [{"A": (x % 3), "B": x} for x in xs] + [{"A": 0, "B": None}]
     ).repartition(num_parts)
@@ -3513,7 +3695,11 @@ def test_groupby_tabular_max(ray_start_regular_shared, ds_format, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_global_tabular_max(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_global_tabular_max(ray_start_regular_shared, use_polars, ds_format, num_parts):
+    # Test built-in max aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_global_arrow_max with: {seed}")
     random.seed(seed)
@@ -3554,8 +3740,16 @@ def test_global_tabular_max(ray_start_regular_shared, ds_format, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_groupby_tabular_mean(
+    ray_start_regular_shared,
+    use_polars,
+    ds_format,
+    num_parts,
+):
     # Test built-in mean aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_mean with: {seed}")
     random.seed(seed)
@@ -3628,7 +3822,16 @@ def test_groupby_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_global_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_global_tabular_mean(
+    ray_start_regular_shared,
+    use_polars,
+    ds_format,
+    num_parts,
+):
+    # Test built-in mean aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_global_arrow_mean with: {seed}")
     random.seed(seed)
@@ -3669,8 +3872,16 @@ def test_global_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_std(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_groupby_tabular_std(
+    ray_start_regular_shared,
+    use_polars,
+    ds_format,
+    num_parts,
+):
     # Test built-in std aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_std with: {seed}")
     random.seed(seed)
@@ -3710,6 +3921,7 @@ def test_groupby_tabular_std(ray_start_regular_shared, ds_format, num_parts):
     result = nan_agg_ds.to_pandas()["std(B)"].to_numpy()
     expected = nan_df.groupby("A")["B"].std().to_numpy()
     np.testing.assert_array_almost_equal(result, expected)
+
     # Test ignore_nulls=False
     nan_agg_ds = nan_grouped_ds.std("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
@@ -3717,6 +3929,7 @@ def test_groupby_tabular_std(ray_start_regular_shared, ds_format, num_parts):
     expected = nan_df.groupby("A")["B"].std()
     expected[0] = None
     np.testing.assert_array_almost_equal(result, expected)
+
     # Test all nans
     nan_df = pd.DataFrame({"A": [x % 3 for x in xs], "B": [None] * len(xs)})
     ds = ray.data.from_pandas(nan_df).repartition(num_parts)
@@ -3725,13 +3938,22 @@ def test_groupby_tabular_std(ray_start_regular_shared, ds_format, num_parts):
     nan_agg_ds = ds.groupby("A").std("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
     result = nan_agg_ds.to_pandas()["std(B)"].to_numpy()
-    expected = pd.Series([None] * 3)
+    if ds_format == "arrow" and use_polars:
+        # When using Arrow and Polars, all-nulls are properly represented as well-typed
+        # columns
+        expected = pd.Series([np.nan] * 3)
+    else:
+        expected = pd.Series([None] * 3)
     np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_global_tabular_std(ray_start_regular_shared, ds_format, num_parts):
+@pytest.mark.parametrize("use_polars", [True, False])
+def test_global_tabular_std(ray_start_regular_shared, use_polars, ds_format, num_parts):
+    # Test built-in std aggregation
+    ctx = DatasetContext.get_current()
+    ctx.use_polars = use_polars
     seed = int(time.time())
     print(f"Seeding RNG for test_global_arrow_std with: {seed}")
     random.seed(seed)
@@ -3744,7 +3966,7 @@ def test_global_tabular_std(ray_start_regular_shared, ds_format, num_parts):
     def _to_pandas(ds):
         return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
 
-    # Test built-in global max aggregation
+    # Test built-in global std aggregation
     df = pd.DataFrame({"A": xs})
     ds = ray.data.from_pandas(df).repartition(num_parts)
     if ds_format == "arrow":

--- a/python/requirements/data_processing/requirements_dataset.txt
+++ b/python/requirements/data_processing/requirements_dataset.txt
@@ -5,3 +5,4 @@ pickle5; python_version < '3.8'
 python-snappy
 tensorflow-datasets
 datasets
+polars>=0.14.0; python_version >= '3.7'

--- a/python/requirements_test.txt
+++ b/python/requirements_test.txt
@@ -77,7 +77,7 @@ pytest-docker-tools==3.1.3
 pytest-forked==1.4.0
 
 # For dataset tests
-polars==0.14.21
+polars==0.14.25
 
 # Some packages have downstream dependencies that we have to specify here to resolve conflicts.
 # Feel free to add (or remove!) packages here liberally.

--- a/python/setup.py
+++ b/python/setup.py
@@ -264,7 +264,7 @@ if setup_spec.type == SetupType.RAY:
     if RAY_EXTRA_CPP:
         setup_spec.extras["cpp"] = ["ray-cpp==" + setup_spec.version]
 
-    if sys.version_info >= (3, 7, 0):
+    if sys.version_info >= (3, 7):
         setup_spec.extras["k8s"].append("kopf")
 
     setup_spec.extras["rllib"] = setup_spec.extras["tune"] + [


### PR DESCRIPTION
This PR adds prototype support for using Polars for tabular aggregations, which should not only provide vectorized execution of column-wise aggregations (currently implemented) but should also provide column-wise parallelism for multi-aggregations and group-wise parallelism for each aggregation, among other optimizations.

Brief performance testing on a single aggregation over 10M rows shows an over 20x speedup:
```
In [8]: ctx.use_polars = False

In [9]: %time agg_ds = ds.groupby("A").sum("B")
CPU times: user 603 ms, sys: 88.3 ms, total: 691 ms
Wall time: 20.3 s

In [10]: ctx.use_polars = True

In [11]: %time agg_ds = ds.groupby("A").sum("B")
CPU times: user 303 ms, sys: 21.1 ms, total: 324 ms
Wall time: 742 ms
```

## Related issue number

Closes #26131

### TODOs

- [x] Support `ignore_nulls=False`.
- [x] Port remaining aggregations.
- [x] Provide a better (user-facing) API for custom aggregations.
- [x] Update Polars to include fix for allowing null propagation in partial aggregations involving struct types.
- [x] Add test including tensor extensions to test Arrow2's extension type handling.
- [ ] Decompose into stacked PRs