### PR TITLE
[RLlib] Do not print warning message during env pre-checking, if there is nothing wrong with user envs.

### DIFF
--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1794,17 +1794,18 @@ class RolloutWorker(ParallelIteratorWorker):
             env = env_creator(env_ctx)
             # Validate first.
             if not disable_env_checking:
-                if log_once("env_creator_warning"):
+                try:
+                    check_env(env)
+                except:
                     logger.warning(
                         "We've added a module for checking environments that "
-                        "are used in experiments. It will cause your "
-                        "environment to fail if your environment is not set up"
-                        "correctly. You can disable check env by setting "
+                        "are used in experiments. Your env may not be set up"
+                        "correctly. You can disable env checking for now by setting "
                         "`disable_env_checking` to True in your experiment config "
                         "dictionary. You can run the environment checking module "
                         "standalone by calling ray.rllib.utils.check_env(env)."
                     )
-                check_env(env)
+                    raise
             # Custom validation function given by user.
             if validate_env is not None:
                 validate_env(env, env_ctx)

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -1796,7 +1796,7 @@ class RolloutWorker(ParallelIteratorWorker):
             if not disable_env_checking:
                 try:
                     check_env(env)
-                except:
+                except Exception as e:
                     logger.warning(
                         "We've added a module for checking environments that "
                         "are used in experiments. Your env may not be set up"
@@ -1805,7 +1805,7 @@ class RolloutWorker(ParallelIteratorWorker):
                         "dictionary. You can run the environment checking module "
                         "standalone by calling ray.rllib.utils.check_env(env)."
                     )
-                    raise
+                    raise e
             # Custom validation function given by user.
             if validate_env is not None:
                 validate_env(env, env_ctx)


### PR DESCRIPTION
## Why are these changes needed?

Printing warning msg when there is nothing wrong is confusing.
This also floods the output log which users complain.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
