### PR TITLE
[Ray Collective] Add prefixes for original key to isolate gloo info in different jobs and different groups.

### DIFF
--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -62,7 +62,7 @@ class Rendezvous:
 
     def create_store(self, store_type):
         if store_type == "ray_internal_kv":
-            ray_internal_kv_store = gloo_util.RayInternalKvStore()
+            ray_internal_kv_store = gloo_util.RayInternalKvStore(self._group_name)
             self._store = pygloo.rendezvous.CustomStore(ray_internal_kv_store)
         elif store_type == "redis":
             redisStore = pygloo.rendezvous.RedisStore(

--- a/python/ray/util/collective/collective_group/gloo_util.py
+++ b/python/ray/util/collective/collective_group/gloo_util.py
@@ -301,5 +301,4 @@ class RayInternalKvStore:
     def __concat_key_with_prefixes(self, original_key):
         """Concat the necessary prefixes and key for isolation purpose for
            different jobs and different groups."""
-        return "{}-{}-{}".format(
-            self._job_id.hex(), self._group_name, original_key)
+        return f"{self._job_id.hex()}-{self._group_name}-{original_key}"

--- a/python/ray/util/collective/collective_group/gloo_util.py
+++ b/python/ray/util/collective/collective_group/gloo_util.py
@@ -297,8 +297,8 @@ class RayInternalKvStore:
             if all_exist:
                 return True
             time.sleep(1)
-    
+
     def __concat_key_with_prefixes(self, original_key):
         """Concat the necessary prefixes and key for isolation purpose for
-           different jobs and different groups."""
+        different jobs and different groups."""
         return f"{self._job_id.hex()}-{self._group_name}-{original_key}"

--- a/python/ray/util/collective/collective_group/gloo_util.py
+++ b/python/ray/util/collective/collective_group/gloo_util.py
@@ -268,16 +268,20 @@ class SignalActor:
 # The custom store which is implementated in Ray internal kv storage, helping
 # to store the rank meta information when setting up the gloo collective group.
 class RayInternalKvStore:
-    def __init__(self):
+    def __init__(self, group_name: str):
+        self._group_name = group_name
+        self._job_id = ray.get_runtime_context().job_id
         gcs_address = ray.worker._global_node.gcs_address
-        self._gcs_client = GcsClient(address=gcs_address, nums_reconnect_retry=0)
+        self._gcs_client = GcsClient(address=gcs_address, nums_reconnect_retry=10)
         internal_kv._initialize_internal_kv(self._gcs_client)
 
     def set(self, key: str, data: bytes) -> bool:
+        key = self.__concat_key_with_prefixes(key)
         ret = internal_kv._internal_kv_put(key, data)
         return ret
 
     def get(self, key: str) -> bytes:
+        key = self.__concat_key_with_prefixes(key)
         ret = internal_kv._internal_kv_get(key)
         return ret
 
@@ -285,6 +289,7 @@ class RayInternalKvStore:
         while True:
             all_exist = True
             for key in keys:
+                key = self.__concat_key_with_prefixes(key)
                 result = internal_kv._internal_kv_exists(key)
                 if not result:
                     all_exist = False
@@ -292,3 +297,9 @@ class RayInternalKvStore:
             if all_exist:
                 return True
             time.sleep(1)
+    
+    def __concat_key_with_prefixes(self, original_key):
+        """Concat the necessary prefixes and key for isolation purpose for
+           different jobs and different groups."""
+        return "{}-{}-{}".format(
+            self._job_id.hex(), self._group_name, original_key)

--- a/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
+++ b/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
@@ -14,7 +14,7 @@ class Worker:
        return True
 
 
-def test_two_groups_in_one_cluster():
+def test_two_groups_in_one_cluster(ray_start_regular_shared):
     w1 = Worker.remote()
     ret1 = w1.init_gloo_group.remote(1, 0, "name_1")
     w2 = Worker.remote()
@@ -23,7 +23,7 @@ def test_two_groups_in_one_cluster():
     assert ray.get(ret2)
 
 
-def test_failure_when_initializing():
+def test_failure_when_initializing(shutdown_only):
     # job1
     ray.init()
     w1 = Worker.remote()
@@ -36,7 +36,6 @@ def test_failure_when_initializing():
     w2 = Worker.remote()
     ret2 = w2.init_gloo_group.remote(1, 0, "name_1")
     assert ray.get(ret2)
-    ray.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
+++ b/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
@@ -28,6 +28,7 @@ def test_failure_when_initializing(shutdown_only):
     ray.init()
     w1 = Worker.remote()
     ret1 = w1.init_gloo_group.remote(2, 0, "name_1")
+    ray.wait([ret1], timeout=1)
     time.sleep(5)
     ray.shutdown()
 

--- a/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
+++ b/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
@@ -10,8 +10,8 @@ class Worker:
         pass
 
     def init_gloo_group(rank: int, world_size: int, group_name: str):
-       col.init_collective_group(world_size, rank, Backend.GLOO, group_name)
-       return True
+        col.init_collective_group(world_size, rank, Backend.GLOO, group_name)
+        return True
 
 
 def test_two_groups_in_one_cluster(ray_start_regular_shared):

--- a/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
+++ b/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
@@ -1,0 +1,46 @@
+from python.ray.util.collective.types import Backend
+import ray
+import ray.util.collective as col
+import time
+
+
+@ray.remote
+class Worker:
+    def __init__(self):
+        pass
+
+    def init_gloo_group(rank: int, world_size: int, group_name: str):
+       col.init_collective_group(world_size, rank, Backend.GLOO, group_name)
+       return True
+
+
+def test_two_groups_in_one_cluster():
+    w1 = Worker.remote()
+    ret1 = w1.init_gloo_group.remote(1, 0, "name_1")
+    w2 = Worker.remote()
+    ret2 = w2.init_gloo_group.remote(1, 0, "name_2")
+    assert ray.get(ret1)
+    assert ray.get(ret2)
+
+
+def test_failure_when_initializing():
+    # job1
+    ray.init()
+    w1 = Worker.remote()
+    ret1 = w1.init_gloo_group.remote(2, 0, "name_1")
+    time.sleep(5)
+    ray.shutdown()
+
+    # job2
+    ray.init()
+    w2 = Worker.remote()
+    ret2 = w2.init_gloo_group.remote(1, 0, "name_1")
+    assert ray.get(ret2)
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR uses the job id and group name as the prefix for storing meta information, aiming to provide the isolate ability for different jobs and different groups.

Before this PR, we can't use 2 groups in 1 Ray cluster, and we can not rerun a collective job once the last one is failed at initializing.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Close #24109
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
