### PR TITLE
[air/tune] Remove postprocess_checkpoint

### DIFF
--- a/python/ray/ml/train/gbdt_trainer.py
+++ b/python/ray/ml/train/gbdt_trainer.py
@@ -6,6 +6,7 @@ import ray.cloudpickle as cpickle
 from ray.ml.trainer import GenDataset
 from ray.ml.config import ScalingConfig, RunConfig, ScalingConfigDataClass
 from ray.ml.preprocessor import Preprocessor
+from ray.tune.utils.trainable import TrainableUtil
 from ray.util.annotations import DeveloperAPI
 from ray.ml.trainer import Trainer
 from ray.ml.checkpoint import Checkpoint
@@ -198,18 +199,23 @@ class GBDTTrainer(Trainer):
         default_ray_params = self._default_ray_params
 
         class GBDTTrainable(trainable_cls):
+            def save_checkpoint(self, tmp_checkpoint_dir: str = ""):
+                checkpoint_path = super().save_checkpoint(
+                    tmp_checkpoint_dir=tmp_checkpoint_dir
+                )
+                parent_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
+
+                preprocessor = self._merged_config.get("preprocessor", None)
+                if parent_dir and preprocessor:
+                    with open(os.path.join(parent_dir, PREPROCESSOR_KEY), "wb") as f:
+                        cpickle.dump(preprocessor, f)
+                return checkpoint_path
+
             @classmethod
             def default_resource_request(cls, config):
                 updated_scaling_config = config.get("scaling_config", scaling_config)
                 return _convert_scaling_config_to_ray_params(
                     updated_scaling_config, ray_params_cls, default_ray_params
                 ).get_tune_resources()
-
-            def _postprocess_checkpoint(self, checkpoint_path: str):
-                preprocessor = self._merged_config.get("preprocessor", None)
-                if not checkpoint_path or preprocessor is None:
-                    return
-                with open(os.path.join(checkpoint_path, PREPROCESSOR_KEY), "wb") as f:
-                    cpickle.dump(preprocessor, f)
 
         return GBDTTrainable

--- a/python/ray/ml/train/gbdt_trainer.py
+++ b/python/ray/ml/train/gbdt_trainer.py
@@ -200,9 +200,7 @@ class GBDTTrainer(Trainer):
 
         class GBDTTrainable(trainable_cls):
             def save_checkpoint(self, tmp_checkpoint_dir: str = ""):
-                checkpoint_path = super().save_checkpoint(
-                    tmp_checkpoint_dir=tmp_checkpoint_dir
-                )
+                checkpoint_path = super().save_checkpoint()
                 parent_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
 
                 preprocessor = self._merged_config.get("preprocessor", None)

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -440,9 +440,9 @@ class FunctionRunner(Trainable):
     def execute(self, fn):
         return fn(self)
 
-    def save(self, checkpoint_path=None) -> str:
-        if checkpoint_path:
-            raise ValueError("Checkpoint path should not be used with function API.")
+    def save_checkpoint(self, tmp_checkpoint_dir: str = ""):
+        if tmp_checkpoint_dir:
+            raise ValueError("Checkpoint dir should not be used with function API.")
 
         checkpoint = self._status_reporter.get_checkpoint()
         state = self.get_state()
@@ -479,9 +479,15 @@ class FunctionRunner(Trainable):
         checkpoint_path = TrainableUtil.process_checkpoint(
             checkpoint, parent_dir, state
         )
+        return checkpoint_path
 
-        self._postprocess_checkpoint(checkpoint_path)
+    def save(self, checkpoint_path=None) -> str:
+        if checkpoint_path:
+            raise ValueError("Checkpoint path should not be used with function API.")
 
+        checkpoint_path = self.save_checkpoint()
+
+        parent_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
         self._maybe_save_to_cloud(parent_dir)
 
         return checkpoint_path

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -458,16 +458,10 @@ class Trainable:
             trainable_state=trainable_state,
         )
 
-        self._postprocess_checkpoint(checkpoint_dir)
-
         # Maybe sync to cloud
         self._maybe_save_to_cloud(checkpoint_dir)
 
         return checkpoint_path
-
-    def _postprocess_checkpoint(self, checkpoint_dir: str):
-        """Run extra postprocessing before the checkpoint is saved to cloud."""
-        pass
 
     def _maybe_save_to_cloud(self, checkpoint_dir: str):
         # Derived classes like the FunctionRunner might call this


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The postprocess checkpoint method was introduced to be able to add data to function runner checkpoint directories before they are uploaded to external (cloud) storage. Instead, we should just use the existing separation of `save_checkpoint()` and `save()`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
