### PR TITLE
[Datasets] Fix #24296 by limiting parallelism in FileBasedDatasource

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -327,6 +327,9 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
             if output_buffer.has_next():
                 yield output_buffer.next()
 
+        # fix https://github.com/ray-project/ray/issues/24296
+        parallelism = min(parallelism, len(paths), len(file_sizes))
+
         read_tasks = []
         for read_paths, file_sizes in zip(
             np.array_split(paths, parallelism), np.array_split(file_sizes, parallelism)

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -328,7 +328,7 @@ class FileBasedDatasource(Datasource[Union[ArrowRow, Any]]):
                 yield output_buffer.next()
 
         # fix https://github.com/ray-project/ray/issues/24296
-        parallelism = min(parallelism, len(paths), len(file_sizes))
+        parallelism = min(parallelism, len(paths))
 
         read_tasks = []
         for read_paths, file_sizes in zip(


### PR DESCRIPTION
## Why are these changes needed?

This prevents a MemoryError when a high value is provided to parallelism to ensure exactly one ReadTask is created per file.

## Related issue number

#24296

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
