### PR TITLE
[Jobs] [Dashboard] Add job submission id as field to job snapshot

### DIFF
--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -137,7 +137,7 @@ class APIHead(dashboard_utils.DashboardHeadModule):
         for job_submission_id, job_info in self._job_info_client.get_all_jobs().items():
             if job_info is not None:
                 entry = {
-                    "job_submission_name": job_submission_id,
+                    "job_submission_id": job_submission_id,
                     "status": job_info.status,
                     "message": job_info.message,
                     "error_type": job_info.error_type,

--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -137,6 +137,7 @@ class APIHead(dashboard_utils.DashboardHeadModule):
         for job_submission_id, job_info in self._job_info_client.get_all_jobs().items():
             if job_info is not None:
                 entry = {
+                    "job_submission_name": job_submission_id,
                     "status": job_info.status,
                     "message": job_info.message,
                     "error_type": job_info.error_type,

--- a/dashboard/modules/snapshot/snapshot_schema.json
+++ b/dashboard/modules/snapshot/snapshot_schema.json
@@ -28,10 +28,16 @@
                   "type": "object",
                   "properties": {
                     "status": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "status_message": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "isDead": {
                       "type": "boolean"
@@ -77,23 +83,44 @@
                 "[0-9a-f]*": {
                   "type": "object",
                   "properties": {
+                    "jobSubmissionName": {
+                      "type": "string"
+                    },
                     "status": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "entrypoint": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "message": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "errorType": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "startTime": {
-                      "type": ["integer", "null"]
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
                     },
                     "endTime": {
-                      "type": ["integer", "null"]
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
                     },
                     "metadata": {
                       "type": "object"
@@ -173,7 +200,10 @@
                             "type": "string"
                           },
                           "version": {
-                            "type": ["string", "null"]
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           }
                         },
                         "required": [
@@ -219,7 +249,10 @@
                       "type": "integer"
                     },
                     "httpRoute": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "name": {
                       "type": "string"
@@ -234,7 +267,10 @@
                       "type": "string"
                     },
                     "version": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   },
                   "required": [

--- a/dashboard/modules/snapshot/snapshot_schema.json
+++ b/dashboard/modules/snapshot/snapshot_schema.json
@@ -130,6 +130,7 @@
                     }
                   },
                   "required": [
+                    "jobSubmissionName",
                     "status",
                     "entrypoint"
                   ]

--- a/dashboard/modules/snapshot/snapshot_schema.json
+++ b/dashboard/modules/snapshot/snapshot_schema.json
@@ -83,7 +83,7 @@
                 "[0-9a-f]*": {
                   "type": "object",
                   "properties": {
-                    "jobSubmissionName": {
+                    "jobSubmissionId": {
                       "type": "string"
                     },
                     "status": {
@@ -130,7 +130,7 @@
                     }
                   },
                   "required": [
-                    "jobSubmissionName",
+                    "jobSubmissionId",
                     "status",
                     "entrypoint"
                   ]

--- a/dashboard/modules/snapshot/tests/test_job_submission.py
+++ b/dashboard/modules/snapshot/tests/test_job_submission.py
@@ -76,6 +76,7 @@ def test_successful_job_status(
             "jobSubmission"
         ].items():
             if entry["status"] is not None:
+                assert entry["jobSubmissionName"] == job_id
                 assert entry["entrypoint"] == entrypoint
                 assert entry["status"] in {"PENDING", "RUNNING", "SUCCEEDED"}
                 assert entry["message"] is not None

--- a/dashboard/modules/snapshot/tests/test_job_submission.py
+++ b/dashboard/modules/snapshot/tests/test_job_submission.py
@@ -77,7 +77,7 @@ def test_successful_job_status(
             "jobSubmission"
         ].items():
             if entry["status"] is not None:
-                assert entry["jobSubmissionName"] == job_id
+                assert entry["jobSubmissionId"] == job_id
                 assert entry["entrypoint"] == entrypoint
                 assert entry["status"] in {"PENDING", "RUNNING", "SUCCEEDED"}
                 assert entry["message"] is not None
@@ -143,7 +143,7 @@ def test_failed_job_status(
             "jobSubmission"
         ].items():
             if entry["status"] is not None:
-                assert entry["jobSubmissionName"] == job_id
+                assert entry["jobSubmissionId"] == job_id
                 assert entry["entrypoint"] == entrypoint
                 assert entry["status"] in {"PENDING", "RUNNING", "FAILED"}
                 assert entry["message"] is not None

--- a/dashboard/modules/snapshot/tests/test_job_submission.py
+++ b/dashboard/modules/snapshot/tests/test_job_submission.py
@@ -26,33 +26,37 @@ def _get_snapshot(address: str):
     response.raise_for_status()
     data = response.json()
     schema_path = os.path.join(
-        os.path.dirname(dashboard.__file__),
-        "modules/snapshot/snapshot_schema.json")
+        os.path.dirname(dashboard.__file__), "modules/snapshot/snapshot_schema.json"
+    )
     pprint.pprint(data)
     jsonschema.validate(instance=data, schema=json.load(open(schema_path)))
     return data
 
 
-def test_successful_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
-                               enable_test_module):
+def test_successful_job_status(
+    ray_start_with_dashboard, disable_aiohttp_cache, enable_test_module
+):
     address = ray_start_with_dashboard.address_info["webui_url"]
     assert wait_until_server_available(address)
     address = format_web_url(address)
 
     job_sleep_time_s = 5
-    entrypoint = ('python -c"'
-                  "import ray;"
-                  "ray.init();"
-                  "import time;"
-                  f"time.sleep({job_sleep_time_s});"
-                  '"')
+    entrypoint = (
+        'python -c"'
+        "import ray;"
+        "ray.init();"
+        "import time;"
+        f"time.sleep({job_sleep_time_s});"
+        '"'
+    )
 
     client = JobSubmissionClient(address)
     start_time_s = int(time.time())
     runtime_env = {"env_vars": {"RAY_TEST_123": "123"}}
     metadata = {"ray_test_456": "456"}
     job_id = client.submit_job(
-        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env)
+        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env
+    )
 
     def wait_for_job_to_succeed():
         data = _get_snapshot(address)
@@ -62,63 +66,62 @@ def test_successful_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
         # Test legacy job snapshot (one driver per job).
         for job_entry in data["data"]["snapshot"]["jobs"].values():
             if job_entry["status"] is not None:
-                assert job_entry["config"]["metadata"][
-                    "jobSubmissionId"] == job_id
-                assert job_entry["status"] in {
-                    "PENDING", "RUNNING", "SUCCEEDED"
-                }
+                assert job_entry["config"]["metadata"]["jobSubmissionId"] == job_id
+                assert job_entry["status"] in {"PENDING", "RUNNING", "SUCCEEDED"}
                 assert job_entry["statusMessage"] is not None
                 legacy_job_succeeded = job_entry["status"] == "SUCCEEDED"
 
         # Test new jobs snapshot (0 to N drivers per job).
         assert data["data"]["snapshot"]["jobSubmission"]
         for job_submission_id, entry in data["data"]["snapshot"][
-                "jobSubmission"].items():
+            "jobSubmission"
+        ].items():
             if entry["status"] is not None:
                 assert entry["jobSubmissionName"] == job_id
                 assert entry["entrypoint"] == entrypoint
                 assert entry["status"] in {"PENDING", "RUNNING", "SUCCEEDED"}
                 assert entry["message"] is not None
                 # TODO(architkulkarni): Disable automatic camelcase.
-                assert entry["runtimeEnv"] == {
-                    "envVars": {
-                        "RAYTest123": "123"
-                    }
-                }
+                assert entry["runtimeEnv"] == {"envVars": {"RAYTest123": "123"}}
                 assert entry["metadata"] == {"rayTest456": "456"}
                 assert entry["errorType"] is None
                 assert abs(entry["startTime"] - start_time_s * 1000) <= 2000
                 if entry["status"] == "SUCCEEDED":
                     job_succeeded = True
-                    assert (entry["endTime"] >=
-                            entry["startTime"] + job_sleep_time_s * 1000)
+                    assert (
+                        entry["endTime"] >= entry["startTime"] + job_sleep_time_s * 1000
+                    )
 
         return legacy_job_succeeded and job_succeeded
 
     wait_for_condition(wait_for_job_to_succeed, timeout=30)
 
 
-def test_failed_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
-                           enable_test_module):
+def test_failed_job_status(
+    ray_start_with_dashboard, disable_aiohttp_cache, enable_test_module
+):
     address = ray_start_with_dashboard.address_info["webui_url"]
     assert wait_until_server_available(address)
     address = format_web_url(address)
 
     job_sleep_time_s = 5
-    entrypoint = ('python -c"'
-                  "import ray;"
-                  "ray.init();"
-                  "import time;"
-                  f"time.sleep({job_sleep_time_s});"
-                  "import sys;"
-                  "sys.exit(1);"
-                  '"')
+    entrypoint = (
+        'python -c"'
+        "import ray;"
+        "ray.init();"
+        "import time;"
+        f"time.sleep({job_sleep_time_s});"
+        "import sys;"
+        "sys.exit(1);"
+        '"'
+    )
     start_time_s = int(time.time())
     client = JobSubmissionClient(address)
     runtime_env = {"env_vars": {"RAY_TEST_456": "456"}}
     metadata = {"ray_test_789": "789"}
     job_id = client.submit_job(
-        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env)
+        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env
+    )
 
     def wait_for_job_to_fail():
         data = _get_snapshot(address)
@@ -129,8 +132,7 @@ def test_failed_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
         # Test legacy job snapshot (one driver per job).
         for job_entry in data["data"]["snapshot"]["jobs"].values():
             if job_entry["status"] is not None:
-                assert job_entry["config"]["metadata"][
-                    "jobSubmissionId"] == job_id
+                assert job_entry["config"]["metadata"]["jobSubmissionId"] == job_id
                 assert job_entry["status"] in {"PENDING", "RUNNING", "FAILED"}
                 assert job_entry["statusMessage"] is not None
                 legacy_job_failed = job_entry["status"] == "FAILED"
@@ -138,25 +140,23 @@ def test_failed_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
         # Test new jobs snapshot (0 to N drivers per job).
         assert data["data"]["snapshot"]["jobSubmission"]
         for job_submission_id, entry in data["data"]["snapshot"][
-                "jobSubmission"].items():
+            "jobSubmission"
+        ].items():
             if entry["status"] is not None:
                 assert entry["jobSubmissionName"] == job_id
                 assert entry["entrypoint"] == entrypoint
                 assert entry["status"] in {"PENDING", "RUNNING", "FAILED"}
                 assert entry["message"] is not None
                 # TODO(architkulkarni): Disable automatic camelcase.
-                assert entry["runtimeEnv"] == {
-                    "envVars": {
-                        "RAYTest456": "456"
-                    }
-                }
+                assert entry["runtimeEnv"] == {"envVars": {"RAYTest456": "456"}}
                 assert entry["metadata"] == {"rayTest789": "789"}
                 assert entry["errorType"] is None
                 assert abs(entry["startTime"] - start_time_s * 1000) <= 2000
                 if entry["status"] == "FAILED":
                     job_failed = True
-                    assert (entry["endTime"] >=
-                            entry["startTime"] + job_sleep_time_s * 1000)
+                    assert (
+                        entry["endTime"] >= entry["startTime"] + job_sleep_time_s * 1000
+                    )
         return legacy_job_failed and job_failed
 
     wait_for_condition(wait_for_job_to_fail, timeout=25)

--- a/dashboard/modules/snapshot/tests/test_job_submission.py
+++ b/dashboard/modules/snapshot/tests/test_job_submission.py
@@ -26,37 +26,33 @@ def _get_snapshot(address: str):
     response.raise_for_status()
     data = response.json()
     schema_path = os.path.join(
-        os.path.dirname(dashboard.__file__), "modules/snapshot/snapshot_schema.json"
-    )
+        os.path.dirname(dashboard.__file__),
+        "modules/snapshot/snapshot_schema.json")
     pprint.pprint(data)
     jsonschema.validate(instance=data, schema=json.load(open(schema_path)))
     return data
 
 
-def test_successful_job_status(
-    ray_start_with_dashboard, disable_aiohttp_cache, enable_test_module
-):
+def test_successful_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
+                               enable_test_module):
     address = ray_start_with_dashboard.address_info["webui_url"]
     assert wait_until_server_available(address)
     address = format_web_url(address)
 
     job_sleep_time_s = 5
-    entrypoint = (
-        'python -c"'
-        "import ray;"
-        "ray.init();"
-        "import time;"
-        f"time.sleep({job_sleep_time_s});"
-        '"'
-    )
+    entrypoint = ('python -c"'
+                  "import ray;"
+                  "ray.init();"
+                  "import time;"
+                  f"time.sleep({job_sleep_time_s});"
+                  '"')
 
     client = JobSubmissionClient(address)
     start_time_s = int(time.time())
     runtime_env = {"env_vars": {"RAY_TEST_123": "123"}}
     metadata = {"ray_test_456": "456"}
     job_id = client.submit_job(
-        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env
-    )
+        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env)
 
     def wait_for_job_to_succeed():
         data = _get_snapshot(address)
@@ -66,61 +62,63 @@ def test_successful_job_status(
         # Test legacy job snapshot (one driver per job).
         for job_entry in data["data"]["snapshot"]["jobs"].values():
             if job_entry["status"] is not None:
-                assert job_entry["config"]["metadata"]["jobSubmissionId"] == job_id
-                assert job_entry["status"] in {"PENDING", "RUNNING", "SUCCEEDED"}
+                assert job_entry["config"]["metadata"][
+                    "jobSubmissionId"] == job_id
+                assert job_entry["status"] in {
+                    "PENDING", "RUNNING", "SUCCEEDED"
+                }
                 assert job_entry["statusMessage"] is not None
                 legacy_job_succeeded = job_entry["status"] == "SUCCEEDED"
 
         # Test new jobs snapshot (0 to N drivers per job).
+        assert data["data"]["snapshot"]["jobSubmission"]
         for job_submission_id, entry in data["data"]["snapshot"][
-            "jobSubmission"
-        ].items():
+                "jobSubmission"].items():
             if entry["status"] is not None:
                 assert entry["jobSubmissionName"] == job_id
                 assert entry["entrypoint"] == entrypoint
                 assert entry["status"] in {"PENDING", "RUNNING", "SUCCEEDED"}
                 assert entry["message"] is not None
                 # TODO(architkulkarni): Disable automatic camelcase.
-                assert entry["runtimeEnv"] == {"envVars": {"RAYTest123": "123"}}
+                assert entry["runtimeEnv"] == {
+                    "envVars": {
+                        "RAYTest123": "123"
+                    }
+                }
                 assert entry["metadata"] == {"rayTest456": "456"}
                 assert entry["errorType"] is None
                 assert abs(entry["startTime"] - start_time_s * 1000) <= 2000
                 if entry["status"] == "SUCCEEDED":
                     job_succeeded = True
-                    assert (
-                        entry["endTime"] >= entry["startTime"] + job_sleep_time_s * 1000
-                    )
+                    assert (entry["endTime"] >=
+                            entry["startTime"] + job_sleep_time_s * 1000)
 
         return legacy_job_succeeded and job_succeeded
 
     wait_for_condition(wait_for_job_to_succeed, timeout=30)
 
 
-def test_failed_job_status(
-    ray_start_with_dashboard, disable_aiohttp_cache, enable_test_module
-):
+def test_failed_job_status(ray_start_with_dashboard, disable_aiohttp_cache,
+                           enable_test_module):
     address = ray_start_with_dashboard.address_info["webui_url"]
     assert wait_until_server_available(address)
     address = format_web_url(address)
 
     job_sleep_time_s = 5
-    entrypoint = (
-        'python -c"'
-        "import ray;"
-        "ray.init();"
-        "import time;"
-        f"time.sleep({job_sleep_time_s});"
-        "import sys;"
-        "sys.exit(1);"
-        '"'
-    )
+    entrypoint = ('python -c"'
+                  "import ray;"
+                  "ray.init();"
+                  "import time;"
+                  f"time.sleep({job_sleep_time_s});"
+                  "import sys;"
+                  "sys.exit(1);"
+                  '"')
     start_time_s = int(time.time())
     client = JobSubmissionClient(address)
     runtime_env = {"env_vars": {"RAY_TEST_456": "456"}}
     metadata = {"ray_test_789": "789"}
     job_id = client.submit_job(
-        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env
-    )
+        entrypoint=entrypoint, metadata=metadata, runtime_env=runtime_env)
 
     def wait_for_job_to_fail():
         data = _get_snapshot(address)
@@ -131,29 +129,34 @@ def test_failed_job_status(
         # Test legacy job snapshot (one driver per job).
         for job_entry in data["data"]["snapshot"]["jobs"].values():
             if job_entry["status"] is not None:
-                assert job_entry["config"]["metadata"]["jobSubmissionId"] == job_id
+                assert job_entry["config"]["metadata"][
+                    "jobSubmissionId"] == job_id
                 assert job_entry["status"] in {"PENDING", "RUNNING", "FAILED"}
                 assert job_entry["statusMessage"] is not None
                 legacy_job_failed = job_entry["status"] == "FAILED"
 
         # Test new jobs snapshot (0 to N drivers per job).
+        assert data["data"]["snapshot"]["jobSubmission"]
         for job_submission_id, entry in data["data"]["snapshot"][
-            "jobSubmission"
-        ].items():
+                "jobSubmission"].items():
             if entry["status"] is not None:
+                assert entry["jobSubmissionName"] == job_id
                 assert entry["entrypoint"] == entrypoint
                 assert entry["status"] in {"PENDING", "RUNNING", "FAILED"}
                 assert entry["message"] is not None
                 # TODO(architkulkarni): Disable automatic camelcase.
-                assert entry["runtimeEnv"] == {"envVars": {"RAYTest456": "456"}}
+                assert entry["runtimeEnv"] == {
+                    "envVars": {
+                        "RAYTest456": "456"
+                    }
+                }
                 assert entry["metadata"] == {"rayTest789": "789"}
                 assert entry["errorType"] is None
                 assert abs(entry["startTime"] - start_time_s * 1000) <= 2000
                 if entry["status"] == "FAILED":
                     job_failed = True
-                    assert (
-                        entry["endTime"] >= entry["startTime"] + job_sleep_time_s * 1000
-                    )
+                    assert (entry["endTime"] >=
+                            entry["startTime"] + job_sleep_time_s * 1000)
         return legacy_job_failed and job_failed
 
     wait_for_condition(wait_for_job_to_fail, timeout=25)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Closes https://github.com/ray-project/ray/issues/24300

Adds a field to the job submission snapshot that matches the job name in the existing snapshot.  Before this PR, the job submission name was camelcased because all snapshot keys are automatically camelcased.  This PR allows jobs from the old job field to be linked to ones in the new job submission snapshot.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
