### PR TITLE
[Serve] Move deployment clean up under serve.run() api

### DIFF
--- a/dashboard/modules/serve/serve_head.py
+++ b/dashboard/modules/serve/serve_head.py
@@ -56,20 +56,10 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def put_all_deployments(self, req: Request) -> Response:
         from ray import serve
-        from ray.serve.context import get_global_client
         from ray.serve.application import Application
 
         app = Application.from_dict(await req.json())
         serve.run(app, _blocking=False)
-
-        new_names = set()
-        for deployment in app.deployments.values():
-            new_names.add(deployment.name)
-
-        all_deployments = serve.list_deployments()
-        all_names = set(all_deployments.keys())
-        names_to_delete = all_names.difference(new_names)
-        get_global_client().delete_deployments(names_to_delete)
 
         return Response()
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -638,10 +638,10 @@ def run(
             "route_prefix": deployment.route_prefix,
             "url": deployment.url,
         }
-
         parameter_group.append(deployment_parameters)
-
-    client.deploy_group(parameter_group, _blocking=_blocking)
+    client.deploy_group(
+        parameter_group, _blocking=_blocking, remove_past_deployments=True
+    )
 
     if ingress is not None:
         return ingress.get_handle()

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -409,6 +409,27 @@ def test_run_get_ingress_node(serve_instance):
     assert ray.get(ingress_handle.remote()) == "got f"
 
 
+def test_run_delete_old_deployments(serve_instance):
+    """Check that serve.run() can remove all old deployments"""
+
+    @serve.deployment(name="f", route_prefix="/test1")
+    def f():
+        return "got f"
+
+    @serve.deployment(name="g", route_prefix="/test2")
+    def g():
+        return "got g"
+
+    ingress_handle = serve.run(f.bind())
+    assert ray.get(ingress_handle.remote()) == "got f"
+
+    ingress_handle = serve.run(g.bind())
+    assert ray.get(ingress_handle.remote()) == "got g"
+
+    assert "g" in serve.list_deployments()
+    assert "f" not in serve.list_deployments()
+
+
 class TestSetOptions:
     def test_set_options_basic(self):
         @serve.deployment(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On the ServerHead level, it is talking to serve api and controller to do deployment and clean up now. With this pr, it hides the  deployment clean up logic into server.run() for code cleanness and easy to refactor in the future.

## Related issue number

Closes #23979

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
