### PR TITLE
[serve] Fix replica leak in anonymous namespaces

### DIFF
--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -437,7 +437,9 @@ class ActorReplicaWrapper:
         Returns the timeout after which to kill the actor.
         """
         try:
-            handle = ray.get_actor(self._actor_name)
+            handle = ray.get_actor(
+                self._actor_name, namespace=self._controller_namespace
+            )
             self._graceful_shutdown_ref = handle.prepare_for_shutdown.remote()
         except ValueError:
             pass
@@ -447,7 +449,9 @@ class ActorReplicaWrapper:
     def check_stopped(self) -> bool:
         """Check if the actor has exited."""
         try:
-            handle = ray.get_actor(self._actor_name)
+            handle = ray.get_actor(
+                self._actor_name, namespace=self._controller_namespace
+            )
             stopped = self._check_obj_ref_ready(self._graceful_shutdown_ref)
             if stopped:
                 ray.kill(handle, no_restart=True)
@@ -580,7 +584,9 @@ class ActorReplicaWrapper:
     def force_stop(self):
         """Force the actor to exit without shutting down gracefully."""
         try:
-            ray.kill(ray.get_actor(self._actor_name))
+            ray.kill(
+                ray.get_actor(self._actor_name, namespace=self._controller_namespace)
+            )
         except ValueError:
             pass
 

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -78,6 +78,28 @@ def test_deploy_with_overriden_namespace(shutdown_ray, detached):
 
 
 @pytest.mark.parametrize("detached", [True, False])
+def test_update_num_replicas_anonymous_namespace(shutdown_ray, detached):
+    """Test updating num_replicas with anonymous namespace."""
+
+    ray.init()
+    serve.start(detached=detached)
+
+    @serve.deployment(num_replicas=1)
+    def f(*args):
+        return "got f"
+
+    f.deploy()
+
+    num_actors = len(ray.util.list_named_actors(all_namespaces=True))
+
+    for _ in range(5):
+        f.deploy()
+        assert num_actors == len(ray.util.list_named_actors(all_namespaces=True))
+
+    serve.shutdown()
+
+
+@pytest.mark.parametrize("detached", [True, False])
 def test_update_num_replicas_with_overriden_namespace(shutdown_ray, detached):
     """Test updating num_replicas with overriden namespace."""
 

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -78,6 +78,39 @@ def test_deploy_with_overriden_namespace(shutdown_ray, detached):
 
 
 @pytest.mark.parametrize("detached", [True, False])
+def test_update_num_replicas_with_overriden_namespace(shutdown_ray, detached):
+    """Test updating num_replicas with overriden namespace."""
+
+    ray_namespace = "ray_namespace"
+    controller_namespace = "controller_namespace"
+
+    ray.init(namespace=ray_namespace)
+    serve.start(detached=detached, _override_controller_namespace=controller_namespace)
+
+    @serve.deployment(num_replicas=2)
+    def f(*args):
+        return "got f"
+
+    f.deploy()
+
+    actors = ray.util.list_named_actors(all_namespaces=True)
+
+    f.options(num_replicas=4).deploy()
+    updated_actors = ray.util.list_named_actors(all_namespaces=True)
+
+    # Check that only 2 new replicas were created
+    assert len(updated_actors) == len(actors) + 2
+
+    f.options(num_replicas=1).deploy()
+    updated_actors = ray.util.list_named_actors(all_namespaces=True)
+
+    # Check that all but 1 replica has spun down
+    assert len(updated_actors) == len(actors) - 1
+
+    serve.shutdown()
+
+
+@pytest.mark.parametrize("detached", [True, False])
 def test_refresh_controller_after_death(shutdown_ray, detached):
     """Check if serve.start() refreshes the controller handle if it's dead."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When Ray starts in an anonymous namespace, replicas don't shut down correctly, causing a replica leak. This change adds fixes introduced in #23896 to Ray 1.12.1, and it adds a new unit test to check replica updates in anonymous namespaces.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #24260.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - Unit tests added to `test_standalone2.py`.
