### PR TITLE
[Datasets] Revert Spark-on-Ray test revert

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2492,13 +2492,8 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
         """
         import raydp
 
-        core_worker = ray.worker.global_worker.core_worker
-        locations = [
-            core_worker.get_owner_address(block)
-            for block in self.get_internal_block_refs()
-        ]
         return raydp.spark.ray_dataset_to_spark_dataframe(
-            spark, self.schema(), self.get_internal_block_refs(), locations
+            spark, self.schema(), self.get_internal_block_refs()
         )
 
     def to_pandas(self, limit: int = 100000) -> "pandas.DataFrame":

--- a/python/ray/data/tests/test_raydp_dataset.py
+++ b/python/ray/data/tests/test_raydp_dataset.py
@@ -5,26 +5,19 @@ import torch
 
 
 @pytest.fixture(scope="function")
-def spark_on_ray_small(request):
+def spark(request):
     ray.init(num_cpus=2, include_dashboard=False)
-    spark = raydp.init_spark("test", 1, 1, "500 M")
+    spark_session = raydp.init_spark("test", 1, 1, "500 M")
 
     def stop_all():
         raydp.stop_spark()
         ray.shutdown()
 
     request.addfinalizer(stop_all)
-    return spark
+    return spark_session
 
 
-@pytest.mark.skip(
-    reason=(
-        "raydp.spark.spark_dataframe_to_ray_dataset needs to be updated to "
-        "use ray.data.from_arrow_refs."
-    )
-)
-def test_raydp_roundtrip(spark_on_ray_small):
-    spark = spark_on_ray_small
+def test_raydp_roundtrip(spark):
     spark_df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["one", "two"])
     rows = [(r.one, r.two) for r in spark_df.take(3)]
     ds = ray.data.from_spark(spark_df)
@@ -35,11 +28,7 @@ def test_raydp_roundtrip(spark_on_ray_small):
     assert values == rows_2
 
 
-@pytest.mark.skip(
-    reason="raydp need to be updated to work without redis.",
-)
-def test_raydp_to_spark(spark_on_ray_small):
-    spark = spark_on_ray_small
+def test_raydp_to_spark(spark):
     n = 5
     ds = ray.data.range_arrow(n)
     values = [r["value"] for r in ds.take(5)]

--- a/python/ray/data/tests/test_raydp_dataset.py
+++ b/python/ray/data/tests/test_raydp_dataset.py
@@ -37,8 +37,7 @@ def test_raydp_to_spark(spark):
     assert values == rows
 
 
-def test_raydp_to_torch_iter(spark_on_ray_small):
-    spark = spark_on_ray_small
+def test_raydp_to_torch_iter(spark):
     spark_df = spark.createDataFrame([(1, 0), (2, 0), (3, 1)], ["feature", "label"])
     data_size = spark_df.count()
     features = [r["feature"] for r in spark_df.take(data_size)]


### PR DESCRIPTION
A bad merge/stale CI resulted in a fixture renaming not propagating to all uses. This PR reverts the [recent revert](https://github.com/ray-project/ray/commit/15d66a8dd71c98b1224cfbe0d579537e692841e1), and fixes the test.
