### PR TITLE
[kuberay] Add a test of the Ray Job Submission API to the KubeRay e2e tests.

### DIFF
--- a/python/ray/tests/kuberay/scripts/scale_up_custom.py
+++ b/python/ray/tests/kuberay/scripts/scale_up_custom.py
@@ -11,6 +11,8 @@ def main():
     Also, validates runtime env data submitted with the Ray Job that executes
     this script.
     """
+    # The next two lines validate the runtime env in which this code runs.
+    # (See the function ray_job_submit() in tests/kuberay/utils.py)
     assert pytest.__version__ == "6.0.0"
     assert os.getenv("key_foo") == "value_bar"
 

--- a/python/ray/tests/kuberay/scripts/scale_up_custom.py
+++ b/python/ray/tests/kuberay/scripts/scale_up_custom.py
@@ -1,14 +1,28 @@
+import os
+
+import pytest
+
 import ray
 
 
 def main():
-    """Submits custom resource request."""
+    """Submits custom resource request.
+
+    Also, validates runtime env data submitted with the Ray Job that executes
+    this script.
+    """
+    assert pytest.__version__ == "6.0.0"
+    assert os.getenv("key_foo") == "value_bar"
+
     # Workers and head are annotated as having 5 "Custom2" capacity each,
     # so this should trigger upscaling of two workers.
     # (One of the bundles will be "placed" on the head.)
     ray.autoscaler.sdk.request_resources(
         bundles=[{"Custom2": 3}, {"Custom2": 3}, {"Custom2": 3}]
     )
+
+    # Output something to validate the job logs.
+    print("Submitted custom scale request!")
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -267,8 +267,8 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         )
         # 2. Trigger GPU upscaling by requesting placement of a GPU actor.
         logger.info("Scheduling an Actor with GPU demands.")
-        # Use Ray client to validate that it works against KubeRay.
-        with ray_client_port_forward(  # Interaction mode #2: Ray client
+        # Use Ray Client to validate that it works against KubeRay.
+        with ray_client_port_forward(  # Interaction mode #2: Ray Client
             head_service="raycluster-complete-head-svc", ray_namespace="gpu-test"
         ):
             gpu_actor_placement.main()

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -234,7 +234,9 @@ class KubeRayAutoscalingTest(unittest.TestCase):
             pod_name_filter="raycluster-complete-head", namespace="default"
         )
         assert head_pod, "Could not find the Ray head pod."
-        import pdb; pdb.set_trace()
+        import pdb
+
+        pdb.set_trace()
         # Scale-up
         logger.info("Scaling up to one worker via Ray resource request.")
         # The request for 2 cpus should give us a 1-cpu head (already present) and a

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -192,6 +192,11 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         Items 1. and 2. protect the example in the documentation.
         Items 3. and 4. protect the autoscaler's ability to respond to Ray CR update.
 
+        Tests the following modes of interaction with the Ray cluster:
+        1. `kubectl exec`
+        2. Ray Client
+        3. Ray Job Submission.
+
         Resources requested by this test are safely within the bounds of an m5.xlarge
         instance.
 
@@ -229,6 +234,7 @@ class KubeRayAutoscalingTest(unittest.TestCase):
             pod_name_filter="raycluster-complete-head", namespace="default"
         )
         assert head_pod, "Could not find the Ray head pod."
+        import pdb; pdb.set_trace()
         # Scale-up
         logger.info("Scaling up to one worker via Ray resource request.")
         # The request for 2 cpus should give us a 1-cpu head (already present) and a
@@ -330,7 +336,7 @@ class KubeRayAutoscalingTest(unittest.TestCase):
             script_name="scale_up_custom.py",
             head_service="raycluster-complete-head-svc",
         )
-        assert "Submitted custom scale request!" in job_logs
+        assert job_logs == "Submitted custom scale request!\n"
 
         logger.info("Confirming two workers have scaled up.")
         wait_for_pods(goal_num_pods=3, namespace="default")

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -234,9 +234,6 @@ class KubeRayAutoscalingTest(unittest.TestCase):
             pod_name_filter="raycluster-complete-head", namespace="default"
         )
         assert head_pod, "Could not find the Ray head pod."
-        import pdb
-
-        pdb.set_trace()
         # Scale-up
         logger.info("Scaling up to one worker via Ray resource request.")
         # The request for 2 cpus should give us a 1-cpu head (already present) and a

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -238,14 +238,12 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         logger.info("Scaling up to one worker via Ray resource request.")
         # The request for 2 cpus should give us a 1-cpu head (already present) and a
         # 1-cpu worker (will await scale-up).
-        kubectl_exec_python_script(
+        kubectl_exec_python_script(  # Interaction mode #1: `kubectl exec`
             script_name="scale_up.py",
             pod=head_pod,
             container="ray-head",
             namespace="default",
         )
-        # TODO (Dmitri) Use Ray Client and/or Ray Job submission API to submit
-        # instead of `kubectl exec`.
         logger.info("Confirming number of workers.")
         wait_for_pods(goal_num_pods=2, namespace="default")
 
@@ -270,7 +268,7 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         # 2. Trigger GPU upscaling by requesting placement of a GPU actor.
         logger.info("Scheduling an Actor with GPU demands.")
         # Use Ray client to validate that it works against KubeRay.
-        with ray_client_port_forward(
+        with ray_client_port_forward(  # Interaction mode #2: Ray client
             head_service="raycluster-complete-head-svc", ray_namespace="gpu-test"
         ):
             gpu_actor_placement.main()
@@ -331,7 +329,7 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         # Submit two {"Custom2": 3} bundles to upscale two workers with 5
         # Custom2 capacity each.
         logger.info("Scaling up workers with request for custom resources.")
-        job_logs = ray_job_submit(
+        job_logs = ray_job_submit(  # Interaction mode #3: Ray Job Submission
             script_name="scale_up_custom.py",
             head_service="raycluster-complete-head-svc",
         )

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -15,6 +15,7 @@ from ray.tests.kuberay.utils import (
     get_pod_names,
     get_raycluster,
     ray_client_port_forward,
+    ray_job_submit,
     kubectl_exec_python_script,
     wait_for_pods,
     wait_for_pod_to_start,
@@ -325,12 +326,12 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         # Submit two {"Custom2": 3} bundles to upscale two workers with 5
         # Custom2 capacity each.
         logger.info("Scaling up workers with request for custom resources.")
-        kubectl_exec_python_script(
+        job_logs = ray_job_submit(
             script_name="scale_up_custom.py",
-            pod=head_pod,
-            container="ray-head",
-            namespace="default",
+            head_service="raycluster-complete-head-svc",
         )
+        assert "Submitted custom scale request!" in job_logs
+
         logger.info("Confirming two workers have scaled up.")
         wait_for_pods(goal_num_pods=3, namespace="default")
 

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -192,10 +192,10 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         Items 1. and 2. protect the example in the documentation.
         Items 3. and 4. protect the autoscaler's ability to respond to Ray CR update.
 
-        Tests the following modes of interaction with the Ray cluster:
-        1. `kubectl exec`
+        Tests the following modes of interaction with a Ray cluster on K8s:
+        1. kubectl exec
         2. Ray Client
-        3. Ray Job Submission.
+        3. Ray Job Submission
 
         Resources requested by this test are safely within the bounds of an m5.xlarge
         instance.

--- a/python/ray/tests/kuberay/utils.py
+++ b/python/ray/tests/kuberay/utils.py
@@ -349,7 +349,7 @@ def ray_job_submit(
     """Submits a Python script via the Ray Job Submission API, using the Python SDK.
     Waits for successful completion of the job and returns the job logs as a string.
 
-    Portforwards the dashboard port to make this possible.
+    Uses `kubectl port-forward` to access the dashboard port.
 
     Scripts live in `tests/kuberay/scripts`. This directory is used as the working
     dir for the job.

--- a/python/ray/tests/kuberay/utils.py
+++ b/python/ray/tests/kuberay/utils.py
@@ -349,7 +349,7 @@ def ray_job_submit(
     """Submits a Python script via the Ray Job Submission API, using the Python SDK.
     Waits for successful completion of the job and returns the job logs as a string.
 
-    Uses `kubectl port-forward` to access the dashboard port.
+    Uses `kubectl port-forward` to access the Ray head's dashboard port.
 
     Scripts live in `tests/kuberay/scripts`. This directory is used as the working
     dir for the job.

--- a/python/ray/tests/kuberay/utils.py
+++ b/python/ray/tests/kuberay/utils.py
@@ -11,8 +11,15 @@ from typing import Any, Dict, Generator, List, Optional
 import yaml
 
 import ray
+from ray.job_submission import (
+    JobStatus,
+    JobSubmissionClient
+)
+
 
 logger = logging.getLogger(__name__)
+
+SCRIPTS_DIR = pathlib.Path(__file__).resolve().parent / "scripts"
 
 
 def wait_for_crd(crd_name: str, tries=60, backoff_s=5):
@@ -211,7 +218,7 @@ def kubectl_exec_python_script(
 
     Prints and return kubectl's output as a string.
     """
-    script_path = pathlib.Path(__file__).resolve().parent / "scripts" / script_name
+    script_path = SCRIPTS_DIR / script_name
     with open(script_path) as script_file:
         script_string = script_file.read()
     return kubectl_exec(["python", "-c", script_string], pod, namespace, container)
@@ -334,3 +341,51 @@ def ray_client_port_forward(
     ) as local_port:
         with ray.init(f"ray://127.0.0.1:{local_port}", namespace=ray_namespace):
             yield
+
+
+def ray_job_submit(
+    script_name: str,
+    head_service: str,
+    k8s_namespace: str = "default",
+    ray_dashboard_port: int = 8265,
+) -> str:
+    """Submits a Python script via the Ray Job Submission API, using the Python SDK.
+    Waits for successful completion of the job and returns the job logs as a string.
+
+    Portforwards the dashboard port to make this possible.
+
+    Scripts live in `tests/kuberay/scripts`. This directory is used as the working
+    dir for the job.
+
+    Args:
+        script_name: The name of the script to submit.
+        head_service: The name of the Ray head K8s service.
+        k8s_namespace: K8s namespace the Ray cluster belongs to.
+        ray_dashboard_port: The port on which the Ray head is running the Ray dashboard.
+    """
+    with _kubectl_port_forward(
+        service=head_service, namespace=k8s_namespace, target_port=ray_dashboard_port
+    ) as local_port:
+        client = JobSubmissionClient(f"http://127.0.0.1:{local_port}")
+        job_id = client.submit_job(
+            entrypoint=f"python {script_name}",
+            runtime_env={
+                "working_dir": SCRIPTS_DIR,
+                # Throw in some extra data for fun, to validate runtime envs.
+                "pip": ["pytest==6.0.0"],
+                "env_vars": {"key_foo": "value_bar"}
+            }
+        )
+        # Wait for the job to complete successfully.
+        # This logic is copied verbatim from the Job Submission docs.
+        start = time.time()
+        timeout = 5
+        while time.time() - start <= timeout:
+            status = client.get_job_status(job_id)
+            print(f"status: {status}")
+            if status in {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}:
+                break
+            time.sleep(1)
+
+        assert status == JobStatus.SUCCEEDED
+        return client.get_job_logs(job_id)

--- a/python/ray/tests/kuberay/utils.py
+++ b/python/ray/tests/kuberay/utils.py
@@ -11,10 +11,7 @@ from typing import Any, Dict, Generator, List, Optional
 import yaml
 
 import ray
-from ray.job_submission import (
-    JobStatus,
-    JobSubmissionClient
-)
+from ray.job_submission import JobStatus, JobSubmissionClient
 
 
 logger = logging.getLogger(__name__)
@@ -384,8 +381,8 @@ def ray_job_submit(
                 "working_dir": SCRIPTS_DIR,
                 # Throw in some extra data for fun, to validate runtime envs.
                 "pip": ["pytest==6.0.0"],
-                "env_vars": {"key_foo": "value_bar"}
-            }
+                "env_vars": {"key_foo": "value_bar"},
+            },
         )
         # Wait for the job to complete successfully.
         # This logic is copied from the Job Submission docs.

--- a/python/ray/tests/kuberay/utils.py
+++ b/python/ray/tests/kuberay/utils.py
@@ -364,8 +364,8 @@ def ray_job_submit(
         service=head_service, namespace=k8s_namespace, target_port=ray_dashboard_port
     ) as local_port:
         # It takes a bit of time to establish the connection.
-        # Try a few times to instantiate the JobSubmissionClient, as the client itself
-        # does not retry on connection errors.
+        # Try a few times to instantiate the JobSubmissionClient, as the client's
+        # instantiation does not retry on connection errors.
         for trie in range(1, 7):
             time.sleep(5)
             try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR modifies the KubeRay e2e autoscaling test so that one of its scaling commands is sent via the Ray Job Submission API.

This validates that the Ray Job Submission API works with KubeRay and, in particular, that the Ray Dashboard is correctly exposed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] E2e test
