### PR TITLE
[runtime env] Remove skip local gc env var

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -373,8 +373,6 @@ Runtime environment resources on each node (such as conda environments, pip pack
 
 When the cache size limit is exceeded, resources not currently used by any actor, task or job will be deleted.
 
-To disable all deletion behavior (for example, for debugging purposes) you may set the environment variable ``RAY_RUNTIME_ENV_SKIP_LOCAL_GC`` to ``1`` on each node in your cluster before starting Ray.
-
 Inheritance
 """""""""""
 

--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -145,47 +145,5 @@ class TestGC:
             assert not check_local_files_gced(cluster)
 
 
-# Set scope to "class" to force this to run before start_cluster, whose scope
-# is "function".  We need these env vars to be set before Ray is started.
-@pytest.fixture(scope="class")
-def skip_local_gc():
-    with mock.patch.dict(
-        os.environ,
-        {
-            "RAY_RUNTIME_ENV_SKIP_LOCAL_GC": "1",
-        },
-    ):
-        print("RAY_RUNTIME_ENV_SKIP_LOCAL_GC enabled.")
-        yield
-
-
-class TestSkipLocalGC:
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason="Requires PR wheels built in CI, so only run on linux CI machines.",
-    )
-    @pytest.mark.parametrize("field", ["conda", "pip"])
-    def test_skip_local_gc_env_var(self, skip_local_gc, start_cluster, field, tmp_path):
-        cluster, address = start_cluster
-        runtime_env = generate_runtime_env_dict(field, "python_object", tmp_path)
-        ray.init(address, namespace="test", runtime_env=runtime_env)
-
-        @ray.remote
-        def f():
-            import pip_install_test  # noqa: F401
-
-            return True
-
-        assert ray.get(f.remote())
-
-        ray.shutdown()
-
-        # Give enough time for potentially uninstalling a conda env
-        time.sleep(10)
-
-        # Check nothing was GC'ed
-        assert not check_local_files_gced(cluster)
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import sys
-import time
 
 from ray._private.test_utils import (
     wait_for_condition,
@@ -9,8 +8,6 @@ from ray._private.test_utils import (
     generate_runtime_env_dict,
 )
 import ray
-
-from unittest import mock
 
 if not os.environ.get("CI"):
     # This flags turns on the local development that link against current ray

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -552,9 +552,6 @@ RAY_CONFIG(std::string, event_level, "warning")
 /// Whether to avoid scheduling cpu requests on gpu nodes
 RAY_CONFIG(bool, scheduler_avoid_gpu_nodes, true)
 
-/// Whether to skip running local GC in runtime env.
-RAY_CONFIG(bool, runtime_env_skip_local_gc, false)
-
 /// Whether or not use TLS.
 RAY_CONFIG(bool, USE_TLS, false)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This environment variable was removed a few months ago, but it remained in the docs and in some tests that were spuriously passing.  The same functionality can still be achieved by setting the runtime env cache size to something very large.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
