### PR TITLE
remove TABLE_PREFIX_MAX from TablePrefix

### DIFF
--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -47,6 +47,7 @@ enum TablePrefix {
   KV = 19;
   ACTOR_TASK_SPEC = 20;
   // NOTE: This is the placeholder for the enumeration number.
+  // It must be placed at the end of TablePrefix.
   TABLE_PREFIX_MAX = 21;
 }
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -46,9 +46,6 @@ enum TablePrefix {
   PLACEMENT_GROUP = 18;
   KV = 19;
   ACTOR_TASK_SPEC = 20;
-  // NOTE: This is the placeholder for the enumeration number.
-  // It must be placed at the end of TablePrefix.
-  TABLE_PREFIX_MAX = 21;
 }
 
 // The channel that Add operations to the Table should be published on, if any.

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -42,11 +42,12 @@ enum TablePrefix {
   // WORKER is already used in WorkerType, so use WORKERS here.
   WORKERS = 15;
   INTERNAL_CONFIG = 16;
-  TABLE_PREFIX_MAX = 17;
-  PLACEMENT_GROUP_SCHEDULE = 18;
-  PLACEMENT_GROUP = 19;
-  KV = 20;
-  ACTOR_TASK_SPEC = 21;
+  PLACEMENT_GROUP_SCHEDULE = 17;
+  PLACEMENT_GROUP = 18;
+  KV = 19;
+  ACTOR_TASK_SPEC = 20;
+  // NOTE: This is the placeholder for the enumeration number.
+  TABLE_PREFIX_MAX = 21;
 }
 
 // The channel that Add operations to the Table should be published on, if any.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`TABLE_PREFIX_MAX` should be placed at the end of `TablePrefix`.
As @iycheng suggested, I will delete it because it never be used.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
