### PR TITLE
[Metrics] Allow to completely disable metrics collection

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -53,6 +53,7 @@ class DashboardAgent(object):
         object_store_name=None,
         raylet_name=None,
         logging_params=None,
+        disable_metrics_collection: bool = False,
     ):
         """Initialize the DashboardAgent object."""
         # Public attributes are accessible for all agent modules.
@@ -74,6 +75,7 @@ class DashboardAgent(object):
         self.raylet_name = raylet_name
         self.logging_params = logging_params
         self.node_id = os.environ["RAY_NODE_ID"]
+        self.metrics_collection_disabled = disable_metrics_collection
         # TODO(edoakes): RAY_RAYLET_PID isn't properly set on Windows. This is
         # only used for fate-sharing with the raylet and we need a different
         # fate-sharing mechanism for Windows anyways.
@@ -347,6 +349,11 @@ if __name__ == "__main__":
             "by `pip install ray[default]`."
         ),
     )
+    parser.add_argument(
+        "--disable-metrics-collection",
+        action="store_true",
+        help=("If this arg is set, metrics report won't be enabled from the agent."),
+    )
 
     args = parser.parse_args()
     try:
@@ -375,6 +382,7 @@ if __name__ == "__main__":
             object_store_name=args.object_store_name,
             raylet_name=args.raylet_name,
             logging_params=logging_params,
+            disable_metrics_collection=args.disable_metrics_collection,
         )
         if os.environ.get("_RAY_AGENT_FAILING"):
             raise Exception("Failure injection failure.")

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -101,7 +101,8 @@ _AUTOSCALER_METRICS = [
 
 
 @pytest.fixture
-def _setup_cluster_for_test(ray_start_cluster):
+def _setup_cluster_for_test(request, ray_start_cluster):
+    enable_metrics_collection = request.param
     NUM_NODES = 2
     cluster = ray_start_cluster
     # Add a head node.
@@ -110,6 +111,7 @@ def _setup_cluster_for_test(ray_start_cluster):
             "metrics_report_interval_ms": 1000,
             "event_stats_print_interval_ms": 500,
             "event_stats": True,
+            "enable_metrics_collection": enable_metrics_collection,
         }
     )
     # Add worker nodes.
@@ -136,7 +138,6 @@ def _setup_cluster_for_test(ray_start_cluster):
     # Generate some metrics for the placement group.
     pg = ray.util.placement_group(bundles=[{"CPU": 1}])
     ray.get(pg.ready())
-    print(ray.util.placement_group_table())
     ray.util.remove_placement_group(pg)
 
     @ray.remote
@@ -146,14 +147,13 @@ def _setup_cluster_for_test(ray_start_cluster):
                 "test_histogram", description="desc", boundaries=[0.1, 1.6]
             )
             histogram = ray.get(ray.put(histogram))  # Test serialization.
-            histogram.record(1.5)
+            histogram.observe(1.5)
             ray.get(worker_should_exit.wait.remote())
 
     a = A.remote()
     obj_refs = [f.remote(), a.ping.remote()]
     # Infeasible task
     b = f.options(resources={"a": 1})
-    print(b)
 
     node_info_list = ray.nodes()
     prom_addresses = []
@@ -173,9 +173,9 @@ def _setup_cluster_for_test(ray_start_cluster):
 
 
 @pytest.mark.skipif(prometheus_client is None, reason="Prometheus not installed")
+@pytest.mark.parametrize("_setup_cluster_for_test", [True], indirect=True)
 def test_metrics_export_end_to_end(_setup_cluster_for_test):
     TEST_TIMEOUT_S = 30
-
     prom_addresses, autoscaler_export_addr = _setup_cluster_for_test
 
     def test_cases():
@@ -372,12 +372,12 @@ def test_custom_metrics_default_tags(metric_mock):
     histogram._metric = metric_mock
 
     # Check specifying non-default tags.
-    histogram.record(10, tags={"a": "a"})
+    histogram.observe(10, tags={"a": "a"})
     metric_mock.record.assert_called_with(10, tags={"a": "a", "b": "b"})
 
     # Check overriding default tags.
     tags = {"a": "10", "b": "c"}
-    histogram.record(8, tags=tags)
+    histogram.observe(8, tags=tags)
     metric_mock.record.assert_called_with(8, tags=tags)
 
 
@@ -418,7 +418,8 @@ def test_metrics_override_shouldnt_warn(ray_start_regular, log_pubsub):
     assert len(match) == 0, match
 
 
-def test_custom_metrics_validation(ray_start_regular_shared):
+def test_custom_metrics_validation(shutdown_only):
+    ray.init()
     # Missing tag(s) from tag_keys.
     metric = Counter("name", tag_keys=("a", "b"))
     metric.set_default_tags({"a": "1"})
@@ -454,6 +455,34 @@ def test_custom_metrics_validation(ray_start_regular_shared):
     # Tag value must be str.
     with pytest.raises(TypeError):
         metric.inc(1.0, {"a": 1})
+
+
+@pytest.mark.parametrize("_setup_cluster_for_test", [False], indirect=True)
+def test_metrics_disablement(_setup_cluster_for_test):
+    """Make sure the metrics are not exported when it is disabled."""
+    prom_addresses, autoscaler_export_addr = _setup_cluster_for_test
+
+    def verify_metrics_not_collected():
+        components_dict, metric_names, _ = fetch_prometheus(prom_addresses)
+        # Make sure no component is reported.
+        for _, comp in components_dict.items():
+            if len(comp) > 0:
+                print(f"metrics from a component {comp} exists although it should not.")
+                return False
+
+        # Make sure metrics are not there.
+        for metric in _METRICS + _AUTOSCALER_METRICS:
+            if metric in metric_names:
+                print("f{metric} exists although it should not.")
+                return False
+        return True
+
+    # Make sure metrics are not collected for more than 10 seconds.
+    for _ in range(10):
+        assert verify_metrics_not_collected()
+        import time
+
+        time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -153,7 +153,7 @@ def _setup_cluster_for_test(request, ray_start_cluster):
     a = A.remote()
     obj_refs = [f.remote(), a.ping.remote()]
     # Infeasible task
-    b = f.options(resources={"a": 1}) # noqa
+    b = f.options(resources={"a": 1})  # noqa
 
     node_info_list = ray.nodes()
     prom_addresses = []

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -153,7 +153,7 @@ def _setup_cluster_for_test(request, ray_start_cluster):
     a = A.remote()
     obj_refs = [f.remote(), a.ping.remote()]
     # Infeasible task
-    b = f.options(resources={"a": 1})
+    b = f.options(resources={"a": 1}) # noqa
 
     node_info_list = ray.nodes()
     prom_addresses = []

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -342,7 +342,7 @@ RAY_CONFIG(uint64_t, gcs_service_address_check_interval_milliseconds, 1000)
 RAY_CONFIG(int64_t, metrics_report_batch_size, 100)
 
 /// Whether or not we enable metrics collection.
-RAY_CONFIG(int64_t, enable_metrics_collection, true)
+RAY_CONFIG(bool, enable_metrics_collection, true)
 
 // Max number bytes of inlined objects in a task rpc request/response.
 RAY_CONFIG(int64_t, task_rpc_inlined_bytes_limit, 10 * 1024 * 1024)

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -71,6 +71,10 @@ void AgentManager::StartAgent() {
   for (const std::string &arg : options_.agent_commands) {
     argv.push_back(arg.c_str());
   }
+  // Disable metrics report if needed.
+  if (!RayConfig::instance().enable_metrics_collection()) {
+    argv.push_back("--disable-metrics-collection");
+  }
   argv.push_back(NULL);
   // Set node id to agent.
   ProcessEnvironment env;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR allows for Ray to disable metrics collection. It was possible with `RAY_enable_metrics_collection`, but it didn't fully disable collection because there was a metrics collection happening from agent that wasn't properly disabled. This PR also adds tests. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
