### PR TITLE
[ci/release] Fix module import errors in release tests

### DIFF
--- a/release/ray_release/command_runner/client_runner.py
+++ b/release/ray_release/command_runner/client_runner.py
@@ -55,7 +55,9 @@ class ClientRunner(CommandRunner):
         self.result_output_json = tempfile.mktemp()
 
     def prepare_remote_env(self):
-        pass
+        # Give 5 seconds of slack time for the cluster to start up properly.
+        # This is to avoid e.g. Ray client connection timeouts.
+        time.sleep(5)
 
     def prepare_local_env(self, ray_wheels_url: Optional[str] = None):
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After https://github.com/ray-project/ray/pull/24066, some release tests are running into:

```
ModuleNotFoundError: No module named 'ray.train.impl'
```

This PR simply adds a `__init__.py` file to resolve this.

We also add a 5 wecond delay for client runners in release test to give clusters a bit of slack to come up (and avoid ray client connection errors)

## Related issue number
Closes #24325

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
