### PR TITLE
[RLlib] Fix multi-agent env step counting with default policy

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1161,7 +1161,12 @@ class MultiAgentBatch:
             The single default policy's SampleBatch or a MultiAgentBatch
             (more than one policy).
         """
-        if len(policy_batches) == 1 and DEFAULT_POLICY_ID in policy_batches:
+        if (
+            len(policy_batches) == 1
+            and DEFAULT_POLICY_ID in policy_batches
+            # Otherwise: multi-agent case with DEFAULT_POLICY_ID
+            and policy_batches[DEFAULT_POLICY_ID].env_steps() == env_steps
+        ):
             return policy_batches[DEFAULT_POLICY_ID]
         return MultiAgentBatch(policy_batches=policy_batches, env_steps=env_steps)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In the multi-agent setting, `SampleBatch` is converted to `MultiAgentBatch` with:

```python
batch = MultiAgentBatch.wrap_as_needed(batch, env_steps=env_steps)
```

https://github.com/ray-project/ray/blob/1b67e6a8aeac72695247f35a4957ac5d6f688c54/rllib/evaluation/collectors/simple_list_collector.py#L965-L982

However, `wrap_as_needed` will not convert `SampleBatch` to `MultiAgentBatch` when there is only one policy `"default_policy"`.

https://github.com/ray-project/ray/blob/1b67e6a8aeac72695247f35a4957ac5d6f688c54/rllib/policy/sample_batch.py#L1233-L1250

For `SampleBatch`, `SampleBatch.count` is `len(batch)`, which is the sum of all agent steps.

https://github.com/ray-project/ray/blob/94432d64c96f6e3abed7ebe1d8c07332f8a6a585/rllib/execution/rollout_ops.py#L164-L171

See issue #24340 for more explanation.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes #24340

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
