### PR TITLE
[rllib] Fix doctest failure

### DIFF
--- a/rllib/utils/numpy.py
+++ b/rllib/utils/numpy.py
@@ -323,6 +323,7 @@ def make_action_immutable(obj):
     Examples:
         >>> import tree
         >>> import numpy as np
+        >>> from ray.rllib.utils.numpy import make_action_immutable
         >>> arr = np.arange(1,10)
         >>> d = dict(a = 1, b = (arr, arr))
         >>> tree.traverse(make_action_immutable, d, top_down=False)

--- a/rllib/utils/numpy.py
+++ b/rllib/utils/numpy.py
@@ -326,7 +326,7 @@ def make_action_immutable(obj):
         >>> from ray.rllib.utils.numpy import make_action_immutable
         >>> arr = np.arange(1,10)
         >>> d = dict(a = 1, b = (arr, arr))
-        >>> tree.traverse(make_action_immutable, d, top_down=False)
+        >>> tree.traverse(make_action_immutable, d, top_down=False) # doctest: +SKIP
     """
     if isinstance(obj, np.ndarray):
         obj.setflags(write=False)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Lint was still failing (but only caught with doctest):

```
File "../../python/ray/rllib/utils/numpy.py", line ?, in default

Failed example:

    tree.traverse(make_action_immutable, d, top_down=False)

Exception raised:

    Traceback (most recent call last):

      File "/opt/miniconda/lib/python3.6/doctest.py", line 1330, in __run

        compileflags, 1), test.globs)

      File "<doctest default[4]>", line 1, in <module>

        tree.traverse(make_action_immutable, d, top_down=False)

    NameError: name 'make_action_immutable' is not defined

```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
