### PR TITLE
[RLlib] Fix CQL getting stuck when deprecated `timesteps_per_iteration` is used (use `min_train_timesteps_per_reporting` instead).

### DIFF
--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -191,7 +191,7 @@ cql-halfcheetahbulletenv-v0:
         prioritized_replay: false
         train_batch_size: 256
         target_network_update_freq: 0
-        timesteps_per_iteration: 1000
+        min_train_timesteps_per_reporting: 1000
         learning_starts: 256
         optimization:
             actor_learning_rate: 0.0001

--- a/release/rllib_tests/performance_tests/performance_tests.yaml
+++ b/release/rllib_tests/performance_tests/performance_tests.yaml
@@ -112,7 +112,7 @@ cql-halfcheetahbulletenv-v0:
         prioritized_replay: false
         train_batch_size: 256
         target_network_update_freq: 0
-        timesteps_per_iteration: 1000
+        min_train_timesteps_per_reporting: 1000
         learning_starts: 256
         optimization:
             actor_learning_rate: 0.0001

--- a/rllib/agents/cql/cql.py
+++ b/rllib/agents/cql/cql.py
@@ -19,7 +19,7 @@ from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils import merge_dicts
 from ray.rllib.utils.annotations import override
-from ray.rllib.utils.deprecation import DEPRECATED_VALUE
+from ray.rllib.utils.deprecation import DEPRECATED_VALUE, deprecation_warning
 from ray.rllib.utils.framework import try_import_tf, try_import_tfp
 from ray.rllib.utils.metrics import (
     LAST_TARGET_UPDATE_TS,
@@ -133,6 +133,20 @@ class CQLTrainer(SACTrainer):
 
     @override(SACTrainer)
     def validate_config(self, config: TrainerConfigDict) -> None:
+        # First check, whether old `timesteps_per_iteration` is used. If so
+        # convert right away as for CQL, we must measure in training timesteps,
+        # never sampling timesteps (CQL does not sample).
+        if config.get("timesteps_per_iteration", DEPRECATED_VALUE) != DEPRECATED_VALUE:
+            deprecation_warning(
+                old="timesteps_per_iteration",
+                new="min_train_timesteps_per_reporting",
+                error=False,
+            )
+            config["min_train_timesteps_per_reporting"] = config[
+                "timesteps_per_iteration"
+            ]
+            config["timesteps_per_iteration"] = DEPRECATED_VALUE
+
         # Call super's validation method.
         super().validate_config(config)
 

--- a/rllib/tuned_examples/cql/halfcheetah-bc.yaml
+++ b/rllib/tuned_examples/cql/halfcheetah-bc.yaml
@@ -29,7 +29,7 @@ halfcheetah_bc:
         prioritized_replay: false
         train_batch_size: 256
         target_network_update_freq: 0
-        timesteps_per_iteration: 1000
+        min_train_timesteps_per_reporting: 1000
         learning_starts: 10
         optimization:
           actor_learning_rate: 0.0001

--- a/rllib/tuned_examples/cql/halfcheetah-cql.yaml
+++ b/rllib/tuned_examples/cql/halfcheetah-cql.yaml
@@ -31,7 +31,7 @@ halfcheetah_cql:
         prioritized_replay: false
         train_batch_size: 256
         target_network_update_freq: 0
-        timesteps_per_iteration: 1000
+        min_train_timesteps_per_reporting: 1000
         learning_starts: 256
         optimization:
             actor_learning_rate: 0.0001

--- a/rllib/tuned_examples/cql/hopper-bc.yaml
+++ b/rllib/tuned_examples/cql/hopper-bc.yaml
@@ -29,7 +29,7 @@ hopper_bc:
         prioritized_replay: false
         train_batch_size: 256
         target_network_update_freq: 0
-        timesteps_per_iteration: 1000
+        min_train_timesteps_per_reporting: 1000
         learning_starts: 10
         optimization:
           actor_learning_rate: 0.0001

--- a/rllib/tuned_examples/cql/hopper-cql.yaml
+++ b/rllib/tuned_examples/cql/hopper-cql.yaml
@@ -29,7 +29,7 @@ hopper_cql:
         prioritized_replay: false
         train_batch_size: 256
         target_network_update_freq: 0
-        timesteps_per_iteration: 1000
+        min_train_timesteps_per_reporting: 1000
         learning_starts: 10
         optimization:
           actor_learning_rate: 0.0001


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix CQL getting stuck when deprecated `timesteps_per_iteration` is used (use `min_train_timesteps_per_reporting` instead).

CQL does not perform sampling timesteps and the deprecated `timesteps_per_iteration` is automatically translated into the new `min_sample_timesteps_per_reporting`, but should be translated (only for CQL and other purely offline RL algos) into `min_train_timesteps_per_reporting`.

If `timesteps_per_iteration`, CQL lever leaves the first iteration as it thinks it's not done yet (sample timesteps always remain at 0).


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
