### PR TITLE
[tune] Fix checkpoint manager with nan checkpoints

### DIFF
--- a/python/ray/tune/tests/test_checkpoint_manager.py
+++ b/python/ray/tune/tests/test_checkpoint_manager.py
@@ -94,6 +94,7 @@ class CheckpointManagerTest(unittest.TestCase):
             _TuneCheckpoint(_TuneCheckpoint.PERSISTENT, i, self.mock_result(i, i))
             for i in range(16)
         ]
+        random.seed(1)
         random.shuffle(checkpoints)
 
         for checkpoint in checkpoints:
@@ -116,13 +117,14 @@ class CheckpointManagerTest(unittest.TestCase):
             )
             for i in range(2)
         ]
-        checkpoints += [
-            _TuneCheckpoint(_TuneCheckpoint.PERSISTENT, 3, self.mock_result(0, 3))
-        ]
-        random.shuffle(checkpoints)
 
         for checkpoint in checkpoints:
             checkpoint_manager.on_checkpoint(checkpoint)
+
+        print(checkpoint_manager._membership)
+        print(checkpoint_manager.best_checkpoints())
+
+        checkpoint_manager.on_checkpoint(_TuneCheckpoint(_TuneCheckpoint.PERSISTENT, 3, self.mock_result(0, 3)))
 
         best_checkpoints = checkpoint_manager.best_checkpoints()
         # best_checkpoints is sorted from worst to best

--- a/python/ray/tune/tests/test_checkpoint_manager.py
+++ b/python/ray/tune/tests/test_checkpoint_manager.py
@@ -117,14 +117,12 @@ class CheckpointManagerTest(unittest.TestCase):
             )
             for i in range(2)
         ]
+        checkpoints += [
+            _TuneCheckpoint(_TuneCheckpoint.PERSISTENT, 3, self.mock_result(0, 3))
+        ]
 
         for checkpoint in checkpoints:
             checkpoint_manager.on_checkpoint(checkpoint)
-
-        print(checkpoint_manager._membership)
-        print(checkpoint_manager.best_checkpoints())
-
-        checkpoint_manager.on_checkpoint(_TuneCheckpoint(_TuneCheckpoint.PERSISTENT, 3, self.mock_result(0, 3)))
 
         best_checkpoints = checkpoint_manager.best_checkpoints()
         # best_checkpoints is sorted from worst to best

--- a/python/ray/tune/tests/test_checkpoint_manager.py
+++ b/python/ray/tune/tests/test_checkpoint_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
+import itertools
 import os
-import random
 import sys
 import tempfile
 import unittest
@@ -89,46 +89,44 @@ class CheckpointManagerTest(unittest.TestCase):
         Tests that the best checkpoints are tracked and ordered correctly.
         """
         keep_checkpoints_num = 4
-        checkpoint_manager = self.checkpoint_manager(keep_checkpoints_num)
         checkpoints = [
             _TuneCheckpoint(_TuneCheckpoint.PERSISTENT, i, self.mock_result(i, i))
-            for i in range(16)
+            for i in range(8)
         ]
-        random.seed(1)
-        random.shuffle(checkpoints)
 
-        for checkpoint in checkpoints:
-            checkpoint_manager.on_checkpoint(checkpoint)
+        for permutation in itertools.permutations(checkpoints):
+            checkpoint_manager = self.checkpoint_manager(keep_checkpoints_num)
 
-        best_checkpoints = checkpoint_manager.best_checkpoints()
-        self.assertEqual(len(best_checkpoints), keep_checkpoints_num)
-        for i in range(len(best_checkpoints)):
-            self.assertEqual(best_checkpoints[i].value, i + 12)
+            for checkpoint in permutation:
+                checkpoint_manager.on_checkpoint(checkpoint)
+
+            best_checkpoints = checkpoint_manager.best_checkpoints()
+            self.assertEqual(len(best_checkpoints), keep_checkpoints_num)
+            for i in range(len(best_checkpoints)):
+                self.assertEqual(best_checkpoints[i].value, i + 4)
 
     def testBestCheckpointsWithNan(self):
         """
         Tests that checkpoints with nan priority are handled correctly.
         """
         keep_checkpoints_num = 2
-        checkpoint_manager = self.checkpoint_manager(keep_checkpoints_num)
         checkpoints = [
             _TuneCheckpoint(
                 _TuneCheckpoint.PERSISTENT, None, self.mock_result(float("nan"), i)
             )
             for i in range(2)
-        ]
-        checkpoints += [
-            _TuneCheckpoint(_TuneCheckpoint.PERSISTENT, 3, self.mock_result(0, 3))
-        ]
+        ] + [_TuneCheckpoint(_TuneCheckpoint.PERSISTENT, 3, self.mock_result(0, 3))]
 
-        for checkpoint in checkpoints:
-            checkpoint_manager.on_checkpoint(checkpoint)
+        for permutation in itertools.permutations(checkpoints):
+            checkpoint_manager = self.checkpoint_manager(keep_checkpoints_num)
+            for checkpoint in permutation:
+                checkpoint_manager.on_checkpoint(checkpoint)
 
-        best_checkpoints = checkpoint_manager.best_checkpoints()
-        # best_checkpoints is sorted from worst to best
-        self.assertEqual(len(best_checkpoints), keep_checkpoints_num)
-        self.assertEqual(best_checkpoints[0].value, None)
-        self.assertEqual(best_checkpoints[1].value, 3)
+            best_checkpoints = checkpoint_manager.best_checkpoints()
+            # best_checkpoints is sorted from worst to best
+            self.assertEqual(len(best_checkpoints), keep_checkpoints_num)
+            self.assertEqual(best_checkpoints[0].value, None)
+            self.assertEqual(best_checkpoints[1].value, 3)
 
     def testBestCheckpointsOnlyNan(self):
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes checkpoints not being recorded in Tune's checkpoint manager if the first checkpoint has None value. This also deflakes `test_checkpoint_manager.py::CheckpointManagerTest`. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
#24087

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
