### PR TITLE
[Docs] Added a Ray Latency "Rules of Thumb" table.

### DIFF
--- a/doc/source/ray-overview/learn-more.md
+++ b/doc/source/ray-overview/learn-more.md
@@ -9,8 +9,8 @@ Please raise an issue if any of the below links are broken, or if you'd like to 
 | --- | --- | 
 | Typical Ray cluster startup time | ~6 minutes |
 | Max size of Ray cluster | ~500 machines |
-| Typical base image size (compressed) | ~4GB | 
-| Typical base image size for GPU (compressed) | ~9GB | 
+| Typical base Docker image size (compressed) | ~4GB | 
+| Typical base Docker image size for GPU (compressed) | ~9GB | 
 | Max number of actors | ~10,000 |
 | Task latency in Ray (add 2 numbers) | ~200us |
 | Tasks processed per second (add 2 numbers | ~20,000/second |

--- a/doc/source/ray-overview/learn-more.md
+++ b/doc/source/ray-overview/learn-more.md
@@ -12,7 +12,7 @@ Please raise an issue if any of the below links are broken, or if you'd like to 
 | Typical base image size (compressed) | ~4GB | 
 | Typical base image size for GPU (compressed) | ~9GB | 
 | Max number of actors | ~10,000 |
-| Task latency in Ray (add 2 numbers) | ~10ms |
+| Task latency in Ray (add 2 numbers) | ~200us |
 | Tasks processed per second (add 2 numbers | ~20,000/second |
 | Minimal memory footprint of a task (Python) | ~200MB |
 | Minimal memory footprint of an actor (Python) | ~200MB |

--- a/doc/source/ray-overview/learn-more.md
+++ b/doc/source/ray-overview/learn-more.md
@@ -14,8 +14,8 @@ Please raise an issue if any of the below links are broken, or if you'd like to 
 | Max number of actors | ~10,000 |
 | Task latency in Ray (add 2 numbers) | ~200us |
 | Tasks processed per second (add 2 numbers | ~20,000/second |
-| Minimal memory footprint of a task (Python) | ~200MB |
-| Minimal memory footprint of an actor (Python) | ~200MB |
+| Minimal memory footprint of a Python worker | ~200MB |
+| Minimal memory footprint of an Python actor | ~200MB |
 | Average access time for object in the object store | ~100µs |
 
 [_Inspired by the excellent blog post from Peter Norvig, and talk from Jeff Dean._](https://colin-scott.github.io/personal_website/research/interactive_latency.html)

--- a/doc/source/ray-overview/learn-more.md
+++ b/doc/source/ray-overview/learn-more.md
@@ -1,7 +1,24 @@
 # Learn More
 
-Here are some talks, papers, and press coverage involving Ray and its libraries.
+Here are some general rules of thumb, talks, papers, and press coverage involving Ray and its libraries.
 Please raise an issue if any of the below links are broken, or if you'd like to add your own talk!
+
+## Latency numbers every Ray programmer should know
+
+| Stat | Value |
+| --- | --- | 
+| Typical Ray cluster startup time | ~6 minutes |
+| Max size of Ray cluster | ~500 machines |
+| Typical base image size (compressed) | ~4GB | 
+| Typical base image size for GPU (compressed) | ~9GB | 
+| Max number of actors | ~10,000 |
+| Task latency in Ray (add 2 numbers) | ~10ms |
+| Tasks processed per second (add 2 numbers | ~20,000/second |
+| Minimal memory footprint of a task (Python) | ~200MB |
+| Minimal memory footprint of an actor (Python) | ~200MB |
+| Average access time for object in the object store | ~100µs |
+
+[_Inspired by the excellent blog post from Peter Norvig, and talk from Jeff Dean._](https://colin-scott.github.io/personal_website/research/interactive_latency.html)
 
 ## Blog and Press
 


### PR DESCRIPTION
...modeled after the excellent blog post from Peter Norvig, and the 2010 talk from Jeff Dean. 

https://colin-scott.github.io/personal_website/research/interactive_latency.html

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
