### PR TITLE
[docs] Restore external markdown stubs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from pathlib import Path
 import sys
 import os
 
@@ -8,9 +9,6 @@ from datetime import datetime
 
 # Mocking modules allows Sphinx to work without installing Ray.
 mock_modules()
-
-# Download docs from ecosystem library repos
-download_and_preprocess_ecosystem_docs()
 
 assert (
     "ray" not in sys.modules
@@ -295,3 +293,10 @@ def setup(app):
 
     # Custom docstring processor
     app.connect("autodoc-process-docstring", fix_xgb_lgbm_docs)
+
+    base_path = Path(__file__).parent
+    github_docs = DownloadAndPreprocessEcosystemDocs(base_path)
+    # Download docs from ecosystem library repos
+    app.connect("builder-inited", github_docs.write_new_docs)
+    # Restore original file content after build
+    app.connect("build-finished", github_docs.write_original_docs)

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1,4 +1,7 @@
+from pathlib import Path
 import urllib
+import urllib.request
+import requests
 import mock
 import sys
 from preprocess_github_markdown import preprocess_github_markdown_file
@@ -9,7 +12,7 @@ import scipy.linalg  # noqa: F401
 
 __all__ = [
     "fix_xgb_lgbm_docs",
-    "download_and_preprocess_ecosystem_docs",
+    "DownloadAndPreprocessEcosystemDocs",
     "mock_modules",
     "update_context",
 ]
@@ -186,9 +189,9 @@ EXTERNAL_MARKDOWN_FILES = [
 ]
 
 
-def download_and_preprocess_ecosystem_docs():
+class DownloadAndPreprocessEcosystemDocs:
     """
-    This function downloads markdown readme files for various
+    This class downloads markdown readme files for various
     ecosystem libraries, saves them in specified locations and preprocesses
     them before sphinx build starts.
 
@@ -197,25 +200,51 @@ def download_and_preprocess_ecosystem_docs():
     without the need for duplicate files. For more details, see ``doc/README.md``.
     """
 
-    import urllib.request
-    import requests
+    def __init__(self, base_path: str) -> None:
+        self.base_path = Path(base_path).absolute()
+        assert self.base_path.is_dir()
+        self.original_docs = {}
 
+    @staticmethod
     def get_latest_release_tag(repo: str) -> str:
         """repo is just the repo name, eg. ray-project/ray"""
         response = requests.get(f"https://api.github.com/repos/{repo}/releases/latest")
         return response.json()["tag_name"]
 
+    @staticmethod
     def get_file_from_github(
-        repo: str, ref: str, path_to_get: str, path_to_save_on_disk: str
+        repo: str, ref: str, path_to_get_from_repo: str, path_to_save_on_disk: str
     ) -> None:
         """If ``ref == "latest"``, use latest release"""
         if ref == "latest":
-            ref = get_latest_release_tag(repo)
+            ref = DownloadAndPreprocessEcosystemDocs.get_latest_release_tag(repo)
         urllib.request.urlretrieve(
-            f"https://raw.githubusercontent.com/{repo}/{ref}/{path_to_get}",
+            f"https://raw.githubusercontent.com/{repo}/{ref}/{path_to_get_from_repo}",
             path_to_save_on_disk,
         )
 
-    for x in EXTERNAL_MARKDOWN_FILES:
-        get_file_from_github(*x)
-        preprocess_github_markdown_file(x[-1])
+    def save_original_doc(self, path: str):
+        with open(path, "r") as f:
+            self.original_docs[path] = f.read()
+
+    def write_new_docs(self, *args, **kwargs):
+        for (
+            repo,
+            ref,
+            path_to_get_from_repo,
+            path_to_save_on_disk,
+        ) in EXTERNAL_MARKDOWN_FILES:
+            path_to_save_on_disk = self.base_path.joinpath(path_to_save_on_disk)
+            self.save_original_doc(path_to_save_on_disk)
+            self.get_file_from_github(
+                repo, ref, path_to_get_from_repo, path_to_save_on_disk
+            )
+            preprocess_github_markdown_file(path_to_save_on_disk)
+
+    def write_original_docs(self, *args, **kwargs):
+        for path, content in self.original_docs.items():
+            with open(path, "w") as f:
+                f.write(content)
+
+    def __call__(self):
+        self.write_new_docs()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR introduces a modification to the external markdown logic in doc build to restore the original file content after build is finished. This ensures that the files are not accidentally committed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
