### PR TITLE
Add a hook that runs at the beginning of ray start

### DIFF
--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -72,6 +72,10 @@ RAY_STORAGE_ENVIRONMENT_VARIABLE = "RAY_STORAGE"
 # unconditionally given the runtime_env dict passed for ray.init. It must return
 # a rewritten runtime_env dict. Example: "your.module.runtime_env_hook".
 RAY_RUNTIME_ENV_HOOK = "RAY_RUNTIME_ENV_HOOK"
+# Hook that is invoked on `ray start`. It will be given the cluster parameters and
+# whether we are the head node as arguments. The function can modify the params class,
+# but otherwise returns void. Example: "your.module.ray_start_hook".
+RAY_START_HOOK = "RAY_START_HOOK"
 
 DEFAULT_DASHBOARD_IP = "127.0.0.1"
 DEFAULT_DASHBOARD_PORT = 8265

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -40,7 +40,7 @@ ID_SIZE = 28
 
 # The default maximum number of bytes to allocate to the object store unless
 # overridden by the user.
-DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10 ** 9
+DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10**9
 # The default proportion of available memory allocated to the object store
 DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 # The smallest cap on the memory used by the object store that we allow.
@@ -48,18 +48,18 @@ DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 OBJECT_STORE_MINIMUM_MEMORY_BYTES = 75 * 1024 * 1024
 # The default maximum number of bytes that the non-primary Redis shards are
 # allowed to use unless overridden by the user.
-DEFAULT_REDIS_MAX_MEMORY_BYTES = 10 ** 10
+DEFAULT_REDIS_MAX_MEMORY_BYTES = 10**10
 # The smallest cap on the memory used by Redis that we allow.
-REDIS_MINIMUM_MEMORY_BYTES = 10 ** 7
+REDIS_MINIMUM_MEMORY_BYTES = 10**7
 # Above this number of bytes, raise an error by default unless the user sets
 # RAY_ALLOW_SLOW_STORAGE=1. This avoids swapping with large object stores.
-REQUIRE_SHM_SIZE_THRESHOLD = 10 ** 10
+REQUIRE_SHM_SIZE_THRESHOLD = 10**10
 # Mac with 16GB memory has degraded performance when the object store size is
 # greater than 2GB.
 # (see https://github.com/ray-project/ray/issues/20388 for details)
 # The workaround here is to limit capacity to 2GB for Mac by default,
 # and raise error if the capacity is overwritten by user.
-MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2 ** 30
+MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2**30
 # If a user does not specify a port for the primary Ray service,
 # we attempt to start the service running at this port.
 DEFAULT_PORT = 6379
@@ -97,8 +97,8 @@ DEFAULT_CLIENT_RECONNECT_GRACE_PERIOD = 30
 
 # If a remote function or actor (or some other export) has serialized size
 # greater than this quantity, print an warning.
-FUNCTION_SIZE_WARN_THRESHOLD = 10 ** 7
-FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10 ** 8))
+FUNCTION_SIZE_WARN_THRESHOLD = 10**7
+FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10**8))
 
 # If remote functions with the same source are imported this many times, then
 # print a warning.

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -40,7 +40,7 @@ ID_SIZE = 28
 
 # The default maximum number of bytes to allocate to the object store unless
 # overridden by the user.
-DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10**9
+DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10 ** 9
 # The default proportion of available memory allocated to the object store
 DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 # The smallest cap on the memory used by the object store that we allow.
@@ -48,18 +48,18 @@ DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
 OBJECT_STORE_MINIMUM_MEMORY_BYTES = 75 * 1024 * 1024
 # The default maximum number of bytes that the non-primary Redis shards are
 # allowed to use unless overridden by the user.
-DEFAULT_REDIS_MAX_MEMORY_BYTES = 10**10
+DEFAULT_REDIS_MAX_MEMORY_BYTES = 10 ** 10
 # The smallest cap on the memory used by Redis that we allow.
-REDIS_MINIMUM_MEMORY_BYTES = 10**7
+REDIS_MINIMUM_MEMORY_BYTES = 10 ** 7
 # Above this number of bytes, raise an error by default unless the user sets
 # RAY_ALLOW_SLOW_STORAGE=1. This avoids swapping with large object stores.
-REQUIRE_SHM_SIZE_THRESHOLD = 10**10
+REQUIRE_SHM_SIZE_THRESHOLD = 10 ** 10
 # Mac with 16GB memory has degraded performance when the object store size is
 # greater than 2GB.
 # (see https://github.com/ray-project/ray/issues/20388 for details)
 # The workaround here is to limit capacity to 2GB for Mac by default,
 # and raise error if the capacity is overwritten by user.
-MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2**30
+MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT = 2 * 2 ** 30
 # If a user does not specify a port for the primary Ray service,
 # we attempt to start the service running at this port.
 DEFAULT_PORT = 6379
@@ -97,8 +97,8 @@ DEFAULT_CLIENT_RECONNECT_GRACE_PERIOD = 30
 
 # If a remote function or actor (or some other export) has serialized size
 # greater than this quantity, print an warning.
-FUNCTION_SIZE_WARN_THRESHOLD = 10**7
-FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10**8))
+FUNCTION_SIZE_WARN_THRESHOLD = 10 ** 7
+FUNCTION_SIZE_ERROR_THRESHOLD = env_integer("FUNCTION_SIZE_ERROR_THRESHOLD", (10 ** 8))
 
 # If remote functions with the same source are imported this many times, then
 # print a warning.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -39,6 +39,7 @@ from ray.autoscaler._private.constants import RAY_PROCESSES
 from ray.autoscaler._private.fake_multi_node.node_provider import FAKE_HEAD_NODE_ID
 from ray.autoscaler._private.kuberay.run_autoscaler import run_autoscaler_with_retries
 from ray.internal.internal_api import memory_summary
+from ray.internal.storage import _load_class
 from ray.autoscaler._private.cli_logger import add_click_logging_options, cli_logger, cf
 from ray.dashboard.modules.job.cli import job_cli_group
 from ray.experimental.state.state_cli import list_state_cli_group
@@ -630,6 +631,9 @@ def start(
         tracing_startup_hook=tracing_startup_hook,
         ray_debugger_external=ray_debugger_external,
     )
+
+    if ray_constants.RAY_START_HOOK in os.environ:
+        _load_class(os.environ[ray_constants.RAY_START_HOOK])(ray_params, head)
 
     if head:
         # Start head node.

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -265,6 +265,41 @@ def test_ray_start(configure_lang, monkeypatch, tmp_path):
     _check_output_via_pattern("test_ray_start.txt", result)
 
 
+def _ray_start_hook(ray_params, head):
+    os.makedirs(ray_params.temp_dir, exist_ok=True)
+    with open(os.path.join(ray_params.temp_dir, "ray_hook_ok"), "w") as f:
+        f.write("HOOK_OK")
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin" and "travis" in os.environ.get("USER", ""),
+    reason=("Mac builds don't provide proper locale support"),
+)
+def test_ray_start_hook(configure_lang, monkeypatch, tmp_path):
+    monkeypatch.setenv("RAY_START_HOOK", "ray.tests.test_cli._ray_start_hook")
+    runner = CliRunner()
+    temp_dir = os.path.join("/tmp", uuid.uuid4().hex)
+    result = runner.invoke(
+        scripts.start,
+        [
+            "--head",
+            "--log-style=pretty",
+            "--log-color",
+            "False",
+            "--port",
+            "0",
+            "--temp-dir",
+            temp_dir,
+        ],
+    )
+
+    # Check that the hook executed.
+    assert os.path.exists(temp_dir)
+    assert os.path.exists(os.path.join(temp_dir, "ray_hook_ok"))
+
+    _die_on_error(runner.invoke(scripts.stop))
+
+
 @pytest.mark.skipif(
     sys.platform == "darwin" and "travis" in os.environ.get("USER", ""),
     reason=("Mac builds don't provide proper locale support"),

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -279,7 +279,7 @@ def test_ray_start_hook(configure_lang, monkeypatch, tmp_path):
     monkeypatch.setenv("RAY_START_HOOK", "ray.tests.test_cli._ray_start_hook")
     runner = CliRunner()
     temp_dir = os.path.join("/tmp", uuid.uuid4().hex)
-    result = runner.invoke(
+    runner.invoke(
         scripts.start,
         [
             "--head",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Similar to https://github.com/ray-project/ray/pull/24036, add a hook that allows the user to specify a function to run at the beginning of Ray start. This could be used for a variety of reasons, such as ensuring a service is running before Ray has started, or inspection of the Ray start arguments.