### PR TITLE
[core] Fix the bug in task cancel hang.

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3035,7 +3035,7 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
     RAY_LOG(INFO) << "Cancelling a running task " << main_thread_task_id_;
     success = options_.kill_main();
   } else if (!requested_task_running) {
-    RAY_LOG(INFO) << "Cancelling a task " << main_thread_task_id_
+    RAY_LOG(INFO) << "Cancelling a task " << task_id
                   << " that's not running. Tasks will be removed from a queue.";
     // If the task is not currently running, check if it is in the worker's queue of
     // normal tasks, and remove it if found.
@@ -3043,8 +3043,8 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
   }
   if (request.recursive()) {
     auto recursive_cancel = CancelChildren(task_id, request.force_kill());
-    if (recursive_cancel.ok()) {
-      RAY_LOG(INFO) << "Recursive cancel failed for a task " << task_id;
+    if (!recursive_cancel.ok()) {
+      RAY_LOG(ERROR) << "Recursive cancel failed for a task " << task_id;
     }
   }
 
@@ -3052,6 +3052,7 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
   requested_task_running = main_thread_task_id_ == task_id;
 
   reply->set_attempt_succeeded(success);
+  reply->set_requested_task_running(requested_task_running);
   send_reply_callback(Status::OK(), nullptr, nullptr);
 
   // Do force kill after reply callback sent

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3044,7 +3044,8 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
   if (request.recursive()) {
     auto recursive_cancel = CancelChildren(task_id, request.force_kill());
     if (!recursive_cancel.ok()) {
-      RAY_LOG(ERROR) << "Recursive cancel failed for a task " << task_id;
+      RAY_LOG(ERROR) << "Recursive cancel failed for a task " << task_id
+                     << " due to reason: " << recursive_cancel.ToString();
     }
   }
 

--- a/src/ray/core_worker/test/scheduling_queue_test.cc
+++ b/src/ray/core_worker/test/scheduling_queue_test.cc
@@ -186,7 +186,7 @@ TEST(SchedulingQueueTest, TestSkipAlreadyProcessedByClient) {
 }
 
 TEST(SchedulingQueueTest, TestCancelQueuedTask) {
-  NormalSchedulingQueue *queue = new NormalSchedulingQueue();
+  std::unique_ptr<SchedulingQueue> queue = std::make_unique<NormalSchedulingQueue>();
   ASSERT_TRUE(queue->TaskQueueEmpty());
   int n_ok = 0;
   int n_rej = 0;
@@ -201,7 +201,7 @@ TEST(SchedulingQueueTest, TestCancelQueuedTask) {
   ASSERT_FALSE(queue->TaskQueueEmpty());
   queue->ScheduleRequests();
   ASSERT_EQ(n_ok, 4);
-  ASSERT_EQ(n_rej, 0);
+  ASSERT_EQ(n_rej, 1);
 }
 
 }  // namespace core

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -212,6 +212,8 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
                     dependencies);
   } else {
     // Add the normal task's callbacks to the non-actor scheduling queue.
+    RAY_LOG(DEBUG) << "Adding task " << task_spec.TaskId()
+                   << " to normal scheduling task queue.";
     normal_scheduling_queue_->Add(request.sequence_number(),
                                   request.client_processed_up_to(),
                                   std::move(accept_callback),

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -121,7 +121,7 @@ class CoreWorkerDirectTaskReceiver {
       actor_scheduling_queues_;
   // Queue of pending normal (non-actor) tasks.
   std::unique_ptr<SchedulingQueue> normal_scheduling_queue_ =
-      std::unique_ptr<SchedulingQueue>(new NormalSchedulingQueue());
+      std::make_unique<NormalSchedulingQueue>();
   /// The max number of concurrent calls to allow for fiber mode.
   /// 0 indicates that the value is not set yet.
   int fiber_max_concurrency_ = 0;

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -612,15 +612,15 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
     }
 
     auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
-    auto &scheduled_tasks = scheduling_key_entry.task_queue;
+    auto &scheduling_tasks = scheduling_key_entry.task_queue;
     // This cancels tasks that have completed dependencies and are awaiting
     // a worker lease.
-    if (!scheduled_tasks.empty()) {
-      for (auto spec = scheduled_tasks.begin(); spec != scheduled_tasks.end(); spec++) {
+    if (!scheduling_tasks.empty()) {
+      for (auto spec = scheduling_tasks.begin(); spec != scheduling_tasks.end(); spec++) {
         if (spec->TaskId() == task_spec.TaskId()) {
-          scheduled_tasks.erase(spec);
+          scheduling_tasks.erase(spec);
 
-          if (scheduled_tasks.empty()) {
+          if (scheduling_tasks.empty()) {
             CancelWorkerLeaseIfNeeded(scheduling_key);
           }
           RAY_UNUSED(task_finisher_->FailOrRetryPendingTask(
@@ -666,21 +666,32 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
       [this, task_spec, scheduling_key, force_kill, recursive](
           const Status &status, const rpc::CancelTaskReply &reply) {
         absl::MutexLock lock(&mu_);
+        RAY_LOG(DEBUG) << "CancelTask RPC response received for " << task_spec.TaskId()
+                       << " with status " << status.ToString();
         cancelled_tasks_.erase(task_spec.TaskId());
-
-        if (status.ok() && !reply.attempt_succeeded()) {
-          if (cancel_retry_timer_.has_value()) {
-            if (cancel_retry_timer_->expiry().time_since_epoch() <=
-                std::chrono::high_resolution_clock::now().time_since_epoch()) {
-              cancel_retry_timer_->expires_after(boost::asio::chrono::milliseconds(
-                  RayConfig::instance().cancellation_retry_ms()));
+        if (status.ok()) {
+          if (reply.requested_task_running()) {
+            if (!reply.attempt_succeeded()) {
+              // Retry cancel request if failed.
+              if (cancel_retry_timer_.has_value()) {
+                if (cancel_retry_timer_->expiry().time_since_epoch() <=
+                    std::chrono::high_resolution_clock::now().time_since_epoch()) {
+                  cancel_retry_timer_->expires_after(boost::asio::chrono::milliseconds(
+                      RayConfig::instance().cancellation_retry_ms()));
+                }
+                cancel_retry_timer_->async_wait(
+                    boost::bind(&CoreWorkerDirectTaskSubmitter::CancelTask,
+                                this,
+                                task_spec,
+                                force_kill,
+                                recursive));
+              }
             }
-            cancel_retry_timer_->async_wait(
-                boost::bind(&CoreWorkerDirectTaskSubmitter::CancelTask,
-                            this,
-                            task_spec,
-                            force_kill,
-                            recursive));
+          } else {
+            if (!reply.attempt_succeeded()) {
+              RAY_LOG(ERROR) << "Try to cancel task " << task_spec.TaskId()
+                             << " in a worker that doesn't have this task.";
+            }
           }
         }
         // Retry is not attempted if !status.ok() because force-kill may kill the worker

--- a/src/ray/core_worker/transport/normal_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/normal_scheduling_queue.cc
@@ -68,6 +68,7 @@ bool NormalSchedulingQueue::CancelTaskIfFound(TaskID task_id) {
        it != pending_normal_tasks_.rend();
        ++it) {
     if (it->TaskID() == task_id) {
+      it->Cancel();
       pending_normal_tasks_.erase(std::next(it).base());
       return true;
     }

--- a/src/ray/core_worker/transport/normal_scheduling_queue.h
+++ b/src/ray/core_worker/transport/normal_scheduling_queue.h
@@ -38,16 +38,15 @@ class NormalSchedulingQueue : public SchedulingQueue {
   size_t Size() const override;
 
   /// Add a new task's callbacks to the worker queue.
-  void Add(
-      int64_t seq_no,
-      int64_t client_processed_up_to,
-      std::function<void(rpc::SendReplyCallback)> accept_request,
-      std::function<void(rpc::SendReplyCallback)> reject_request,
-      rpc::SendReplyCallback send_reply_callback,
-      const std::string &concurrency_group_name = "",
-      const FunctionDescriptor &function_descriptor = FunctionDescriptorBuilder::Empty(),
-      TaskID task_id = TaskID::Nil(),
-      const std::vector<rpc::ObjectReference> &dependencies = {}) override;
+  void Add(int64_t seq_no,
+           int64_t client_processed_up_to,
+           std::function<void(rpc::SendReplyCallback)> accept_request,
+           std::function<void(rpc::SendReplyCallback)> reject_request,
+           rpc::SendReplyCallback send_reply_callback,
+           const std::string &concurrency_group_name,
+           const FunctionDescriptor &function_descriptor,
+           TaskID task_id,
+           const std::vector<rpc::ObjectReference> &dependencies) override;
 
   // Search for an InboundRequest associated with the task that we are trying to cancel.
   // If found, remove the InboundRequest from the queue and return true. Otherwise,

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -246,7 +246,9 @@ message CancelTaskRequest {
 
 message CancelTaskReply {
   // Whether the requested task is the currently running task.
-  bool attempt_succeeded = 1;
+  bool requested_task_running = 1;
+  // Whether the task is canceled.
+  bool attempt_succeeded = 2;
 }
 
 message RemoteCancelTaskRequest {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes a bug: when the task is pushed to a core worker but hasn't been scheduled to run cancel is not called which will lead to the get request hanging forever.

The fix is to call the `Cancel`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24359 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
