### PR TITLE
[RLlib] Issue 24340: When multi-agent env run with only `default_policy`, env vs agent counters are incorrect.

### DIFF
--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -970,11 +970,11 @@ class SimpleListCollector(SampleCollector):
         for pid, collector in episode.batch_builder.policy_collectors.items():
             if collector.agent_steps > 0:
                 ma_batch[pid] = collector.build()
-        # Create the batch.
-        ma_batch = MultiAgentBatch(policy_batches=ma_batch, env_steps=episode.batch_builder.env_steps)
-        #ma_batch = MultiAgentBatch.wrap_as_needed(
-        #    ma_batch, env_steps=episode.batch_builder.env_steps
-        #)
+        # Create the multi-agent batch.
+        ma_batch = MultiAgentBatch(
+            policy_batches=ma_batch,
+            env_steps=episode.batch_builder.env_steps,
+        )
 
         # PolicyCollectorGroup is empty.
         episode.batch_builder.env_steps = 0

--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -971,9 +971,10 @@ class SimpleListCollector(SampleCollector):
             if collector.agent_steps > 0:
                 ma_batch[pid] = collector.build()
         # Create the batch.
-        ma_batch = MultiAgentBatch.wrap_as_needed(
-            ma_batch, env_steps=episode.batch_builder.env_steps
-        )
+        ma_batch = MultiAgentBatch(policy_batches=ma_batch, env_steps=episode.batch_builder.env_steps)
+        #ma_batch = MultiAgentBatch.wrap_as_needed(
+        #    ma_batch, env_steps=episode.batch_builder.env_steps
+        #)
 
         # PolicyCollectorGroup is empty.
         episode.batch_builder.env_steps = 0

--- a/rllib/tests/test_multi_agent_env.py
+++ b/rllib/tests/test_multi_agent_env.py
@@ -306,10 +306,11 @@ class TestMultiAgentEnv(unittest.TestCase):
         )
         batch = ev.sample()
         self.assertEqual(batch.count, 5)
-        self.assertEqual(batch["state_in_0"][0], {})
-        self.assertEqual(batch["state_out_0"][0], h)
-        self.assertEqual(batch["state_in_0"][1], h)
-        self.assertEqual(batch["state_out_0"][1], h)
+        single_batch = batch.policy_batches["default_policy"]
+        self.assertEqual(single_batch["state_in_0"][0], {})
+        self.assertEqual(single_batch["state_out_0"][0], h)
+        self.assertEqual(single_batch["state_in_0"][1], h)
+        self.assertEqual(single_batch["state_out_0"][1], h)
 
     def test_returning_model_based_rollouts_data(self):
         class ModelBasedPolicy(DQNTFPolicy):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 24340: When multi-agent env run with only `default_policy`, env vs agent counters are incorrect.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Issue #24340 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #24340
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
