### PR TITLE
[RLlib] Issue 24082: WorkerSet.policies_to_train (deprecated) - if still used - returns wrong values

### DIFF
--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -710,8 +710,8 @@ class WorkerSet:
         local_worker = self.local_worker()
         if local_worker is not None:
             return [
-                local_worker.is_policy_to_train(pid, None)
-                for pid in local_worker.policy_map.keys()
+                pid for pid in local_worker.policy_map.keys()
+                if local_worker.is_policy_to_train(pid, None)
             ]
         else:
             raise NotImplementedError

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -710,7 +710,8 @@ class WorkerSet:
         local_worker = self.local_worker()
         if local_worker is not None:
             return [
-                pid for pid in local_worker.policy_map.keys()
+                pid
+                for pid in local_worker.policy_map.keys()
                 if local_worker.is_policy_to_train(pid, None)
             ]
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 24082: WorkerSet.policies_to_train (deprecated) - if still used - returns wrong values

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Issue #24082 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #24082
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
