### PR TITLE
Don't send dev usage report by default

### DIFF
--- a/ci/build/build-multinode-image.py
+++ b/ci/build/build-multinode-image.py
@@ -16,7 +16,7 @@ def build_multinode_image(source_image: str, target_image: str):
     dockerfile = os.path.join(tempdir, "Dockerfile")
     with open(dockerfile, "wt") as f:
         f.write(f"FROM {source_image}\n")
-        f.write("ENV RAY_USAGE_STATS_REPORT_URL=http://127.0.0.1:8000")
+        f.write("ENV RAY_USAGE_STATS_REPORT_URL=http://127.0.0.1:8000\n")
         f.write("RUN sudo apt update\n")
         f.write("RUN sudo apt install -y openssh-server\n")
 

--- a/ci/build/build-multinode-image.py
+++ b/ci/build/build-multinode-image.py
@@ -16,6 +16,7 @@ def build_multinode_image(source_image: str, target_image: str):
     dockerfile = os.path.join(tempdir, "Dockerfile")
     with open(dockerfile, "wt") as f:
         f.write(f"FROM {source_image}\n")
+        f.write("ENV RAY_USAGE_STATS_REPORT_URL=http://127.0.0.1:8000")
         f.write("RUN sudo apt update\n")
         f.write("RUN sudo apt install -y openssh-server\n")
 

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -186,14 +186,10 @@ def _usage_stats_report_url():
     # The usage collection server URL.
     # The environment variable is testing-purpose only.
     default_url = "https://usage-stats.ray.io/"
-    """
     if ray.__commit__ == "{{RAY_COMMIT_SHA}}":
         # By default, don't send dev usage report to the server.
         default_url = "http://127.0.0.1:8000"
-    """
-    url = os.getenv("RAY_USAGE_STATS_REPORT_URL", default_url)
-    assert url != "https://usage-stats.ray.io/"
-    return url
+    return os.getenv("RAY_USAGE_STATS_REPORT_URL", default_url)
 
 
 def _usage_stats_report_interval_s():

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -186,9 +186,11 @@ def _usage_stats_report_url():
     # The usage collection server URL.
     # The environment variable is testing-purpose only.
     default_url = "https://usage-stats.ray.io/"
+    """
     if ray.__commit__ == "{{RAY_COMMIT_SHA}}":
         # By default, don't send dev usage report to the server.
         default_url = "http://127.0.0.1:8000"
+    """
     url = os.getenv("RAY_USAGE_STATS_REPORT_URL", default_url)
     assert url != "https://usage-stats.ray.io/"
     return url

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -185,7 +185,13 @@ ray.worker._post_init_hooks.append(_put_pre_init_library_usages)
 def _usage_stats_report_url():
     # The usage collection server URL.
     # The environment variable is testing-purpose only.
-    return os.getenv("RAY_USAGE_STATS_REPORT_URL", "https://usage-stats.ray.io/")
+    default_url = "https://usage-stats.ray.io/"
+    if ray.__commit__ == "{{RAY_COMMIT_SHA}}":
+        # By default, don't send dev usage report to the server.
+        default_url = "http://127.0.0.1:8000"
+    url = os.getenv("RAY_USAGE_STATS_REPORT_URL", default_url)
+    assert url != "https://usage-stats.ray.io/"
+    return url
 
 
 def _usage_stats_report_interval_s():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Don't send usage reports from unit tests and dev. They are now the majority of usage reports we received.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
