### PR TITLE
[Serve] Add short-hand for pydantic http adapter

### DIFF
--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -215,10 +215,29 @@ With :ref:`model wrappers<air-serve-integration>`, you can specify it via the ``
         http_adapter=json_to_ndarray
     )
 
+.. note::
+
+    Serve also support pydantic model as short-hand for http adapter in model wrapper. Instead of function,
+    you can directly pass in a pydantic model class to mean "validate http body with this schema".
+    Once validated, the model instances will passed to predictor.
+
+    .. code-block:: python
+
+        from pydantic import BaseModel
+
+        class User(BaseModel):
+            user_id: int
+            user_name: str
+        
+        ...
+        ModelWrapperDeployment.deploy(..., http_adapter=User)
+
+
 Serve Deployment Graph ``DAGDriver``
 """"""""""""""""""""""""""""""""""""
 In :ref:`Serve Deployment Graph <serve-deployment-graph>`, you can configure
 ``ray.serve.drivers.DAGDriver`` to accept an http adapter via it's ``http_adapter`` field. 
+
 
 For example, the json request adapters parse JSON in HTTP body:
 
@@ -231,6 +250,24 @@ For example, the json request adapters parse JSON in HTTP body:
     with InputNode() as input_node:
         ...
         dag = DAGDriver.bind(other_node, http_adapter=json_request)
+
+
+.. note::
+
+    Serve also support pydantic model as short-hand for http adapter in DAGDriver. Instead of function,
+    you can directly pass in a pydantic model to signify "validate this schema with http body".
+    Once validated, the model instances will passed as ``input_node`` variable.
+
+    .. code-block:: python
+
+        from pydantic import BaseModel
+
+        class User(BaseModel):
+            user_id: int
+            user_name: str
+        
+        ...
+        DAGDriver.bind(other_node, http_adapter=User)
 
 
 Embedded in Bring Your Own ``FastAPI`` Application

--- a/doc/source/serve/http-servehandle.rst
+++ b/doc/source/serve/http-servehandle.rst
@@ -217,9 +217,9 @@ With :ref:`model wrappers<air-serve-integration>`, you can specify it via the ``
 
 .. note::
 
-    Serve also support pydantic model as short-hand for http adapter in model wrapper. Instead of function,
-    you can directly pass in a pydantic model class to mean "validate http body with this schema".
-    Once validated, the model instances will passed to predictor.
+    Serve also supports pydantic models as a short-hand for HTTP adapters in model wrappers. Instead of functions,
+    you can directly pass in a pydantic model class to mean "validate the HTTP body with this schema".
+    Once validated, the model instance will passed to the predictor.
 
     .. code-block:: python
 
@@ -254,9 +254,9 @@ For example, the json request adapters parse JSON in HTTP body:
 
 .. note::
 
-    Serve also support pydantic model as short-hand for http adapter in DAGDriver. Instead of function,
-    you can directly pass in a pydantic model to signify "validate this schema with http body".
-    Once validated, the model instances will passed as ``input_node`` variable.
+    Serve also supports pydantic models as a short-hand for HTTP adapters in model wrappers. Instead of functions,
+    you can directly pass in a pydantic model class to mean "validate the HTTP body with this schema".
+    Once validated, the model instance will passed as ``input_node`` variable.
 
     .. code-block:: python
 

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -24,7 +24,7 @@ def load_http_adapter(
     if isinstance(http_adapter, str):
         http_adapter = import_attr(http_adapter)
 
-    if issubclass(http_adapter, BaseModel):
+    if inspect.isclass(http_adapter) and issubclass(http_adapter, BaseModel):
 
         def http_adapter(inp: http_adapter = Body(...)):
             return inp

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -30,7 +30,9 @@ def load_http_adapter(
             return inp
 
     if not inspect.isfunction(http_adapter):
-        raise ValueError("input schema must be a callable function.")
+        raise ValueError(
+            "input schema must be a callable function or pydantic model class."
+        )
 
     if any(
         param.annotation == inspect.Parameter.empty


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Allow users to pass in a pydantic schema as http_adapter directly, instead of writing more one-liners. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24193
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
