### PR TITLE
[Doc] [Serve] Add note about relationship between serve autoscaler and ray autoscaler

### DIFF
--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -250,7 +250,7 @@ code and set this number based on end to end latency objective.
 
 .. note::
   The Ray Serve Autoscaler is an application-level autoscaler that sits on top of the :ref:`Ray Autoscaler<cluster-index>`.  
-  Concretely, this means that the Ray Serve autoscaler asks Ray to start a number of actors, one for each replica, based on ``num_replicas``.
+  Concretely, this means that the Ray Serve autoscaler asks Ray to start a number of replica actors based on the request demand.
   If the Ray Autoscaler determines there aren't enough available CPUs to place these actors, it responds by adding more nodes.
   Similarly, when Ray Serve scales down and terminates some replica actors, it may result in some nodes being empty, at which point the Ray autoscaler will remove those nodes.
 

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -248,6 +248,11 @@ code and set this number based on end to end latency objective.
   The ``version`` field is required for autoscaling. We are actively working on removing
   this limitation.
 
+.. note::
+  The Ray Serve Autoscaler is an application-level autoscaler that sits on top of the :ref:`Ray Autoscaler<cluster-index>`.  
+  Concretely, this means that the Ray Serve autoscaler asks Ray to start a number of actors, one for each replica, based on `num_replicas`.
+  If the Ray Autoscaler determines there aren't enough available CPUs to place these actors, it responds by adding more nodes.
+  Similarly, when Ray Serve scales down and terminates some replica actors, it may result in some nodes being empty, at which point the Ray autoscaler will remove those nodes.
 
 .. _`serve-cpus-gpus`:
 

--- a/doc/source/serve/core-apis.rst
+++ b/doc/source/serve/core-apis.rst
@@ -250,7 +250,7 @@ code and set this number based on end to end latency objective.
 
 .. note::
   The Ray Serve Autoscaler is an application-level autoscaler that sits on top of the :ref:`Ray Autoscaler<cluster-index>`.  
-  Concretely, this means that the Ray Serve autoscaler asks Ray to start a number of actors, one for each replica, based on `num_replicas`.
+  Concretely, this means that the Ray Serve autoscaler asks Ray to start a number of actors, one for each replica, based on ``num_replicas``.
   If the Ray Autoscaler determines there aren't enough available CPUs to place these actors, it responds by adding more nodes.
   Similarly, when Ray Serve scales down and terminates some replica actors, it may result in some nodes being empty, at which point the Ray autoscaler will remove those nodes.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The relationship between the Ray autoscaler and the Ray Serve autoscaler is not obvious to users, and deserves more description in the doc.  This PR adds this documentation.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
