### PR TITLE
[Dashboard][K8s] Add toggle to enable showing node disk usage on K8s

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -31,8 +31,9 @@ enable_gpu_usage_check = True
 
 # Are we in a K8s pod?
 IN_KUBERNETES_POD = "KUBERNETES_SERVICE_HOST" in os.environ
-# Flag to enable showing disk usage stats for the HOST running a
-# Ray pod on K8s.
+# Flag to enable showing disk usage when running in a K8s pod,
+# disk usage defined as the result of running psutil.disk_usage("/")
+# in the Ray container.
 ENABLE_K8S_DISK_USAGE = os.environ.get("ENABLE_K8S_DISK_USAGE", False)
 
 try:

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -31,6 +31,9 @@ enable_gpu_usage_check = True
 
 # Are we in a K8s pod?
 IN_KUBERNETES_POD = "KUBERNETES_SERVICE_HOST" in os.environ
+# Flag to enable showing disk usage stats for the HOST running a
+# Ray pod on K8s.
+ENABLE_K8S_DISK_USAGE = os.environ.get("ENABLE_K8S_DISK_USAGE", False)
 
 try:
     import gpustat.core as gpustat
@@ -304,7 +307,7 @@ class ReporterAgent(
 
     @staticmethod
     def _get_disk_usage():
-        if IN_KUBERNETES_POD:
+        if IN_KUBERNETES_POD and not ENABLE_K8S_DISK_USAGE:
             # If in a K8s pod, disable disk display by passing in dummy values.
             return {
                 "/": psutil._common.sdiskusage(total=1, used=0, free=1, percent=0.0)

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -34,7 +34,7 @@ IN_KUBERNETES_POD = "KUBERNETES_SERVICE_HOST" in os.environ
 # Flag to enable showing disk usage when running in a K8s pod,
 # disk usage defined as the result of running psutil.disk_usage("/")
 # in the Ray container.
-ENABLE_K8S_DISK_USAGE = os.environ.get("ENABLE_K8S_DISK_USAGE", False)
+ENABLE_K8S_DISK_USAGE = os.environ.get("RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE") == "1"
 
 try:
     import gpustat.core as gpustat

--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import logging
+from mock import patch
 import requests
 import time
+
 
 import pytest
 import ray
@@ -245,6 +247,25 @@ def test_report_stats():
     cluster_stats = {}
     records = ReporterAgent._record_stats(obj, test_stats, cluster_stats)
     assert len(records) == 24
+
+
+@pytest.mark.parametrize("enable_k8s_disk_usage", [True, False])
+def test_enable_k8s_disk_usage(enable_k8s_disk_usage: bool):
+    """Test enabling display of K8s node disk usage when in a K8s pod."""
+    with patch.multiple(
+        "ray.dashboard.modules.reporter.reporter_agent",
+        IN_KUBERNETES_POD=True,
+        ENABLE_K8S_DISK_USAGE=enable_k8s_disk_usage,
+    ):
+        root_usage = ReporterAgent._get_disk_usage()["/"]
+        if enable_k8s_disk_usage:
+            # Since K8s disk usage is enabled, we shouuld get non-dummy values.
+            assert root_usage.total != 1
+            assert root_usage.free != 1
+        else:
+            # Unless K8s disk usage display is enabled, we should get dummy values.
+            assert root_usage.total == 1
+            assert root_usage.free == 1
 
 
 if __name__ == "__main__":

--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -5,7 +5,6 @@ from mock import patch
 import requests
 import time
 
-
 import pytest
 import ray
 from ray import ray_constants


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/14676 disabled the disk usage/total display for Ray nodes on K8s, because Ray nodes on K8s are run as pods, which in general do not use up the entire machine.

However, in some situations, it is useful to run one Ray pod per K8s node and report the disk usage.

This PR adds a flag to enable displaying disk usage in those situations.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   
 Todo: Manual test on K8s
