### PR TITLE
[Serve] Unify Starlette and FastAPI JSON serialization stack

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from fastapi import APIRouter, FastAPI
+import numpy as np
 from starlette.requests import Request
 from uvicorn.config import Config
 from uvicorn.lifespan.on import LifespanOn
@@ -44,6 +45,7 @@ from ray.serve.utils import (
     get_random_letters,
     in_interactive_shell,
     DEFAULT,
+    install_serve_encoders_to_fastapi,
 )
 from ray.util.annotations import PublicAPI
 import ray
@@ -289,6 +291,8 @@ def ingress(app: Union["FastAPI", "APIRouter", Callable]):
         class ASGIAppWrapper(cls):
             async def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
+
+                install_serve_encoders_to_fastapi()
 
                 self._serve_app = frozen_app
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -12,7 +12,6 @@ from typing import (
 )
 
 from fastapi import APIRouter, FastAPI
-import numpy as np
 from starlette.requests import Request
 from uvicorn.config import Config
 from uvicorn.lifespan.on import LifespanOn

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -29,7 +29,6 @@ from ray.serve.generated.serve_pb2 import (
     AutoscalingConfig as AutoscalingConfigProto,
     ReplicaConfig as ReplicaConfigProto,
 )
-from ray.serve.utils import ServeEncoder
 
 
 class AutoscalingConfig(BaseModel):
@@ -384,9 +383,7 @@ class ReplicaConfig:
         if self.init_kwargs:
             data["init_kwargs"] = cloudpickle.dumps(self.init_kwargs)
         if self.ray_actor_options:
-            data["ray_actor_options"] = json.dumps(
-                self.ray_actor_options, cls=ServeEncoder
-            )
+            data["ray_actor_options"] = json.dumps(self.ray_actor_options)
         return ReplicaConfigProto(**data)
 
     def to_proto_bytes(self):

--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -81,7 +81,7 @@ class Response:
 
             self.body = json.dumps(
                 jsonable_encoder(content, custom_encoder=serve_encoders)
-            )
+            ).encode()
             self.set_content_type("json")
 
     def set_content_type(self, content_type):

--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Type
 import starlette.responses
 import starlette.requests
 from starlette.types import Send, ASGIApp
+from fastapi.encoders import jsonable_encoder
 
 from ray.serve.exceptions import RayServeException
 
@@ -76,9 +77,11 @@ class Response:
             self.set_content_type("text-utf8")
         else:
             # Delayed import since utils depends on http_util
-            from ray.serve.utils import ServeEncoder
+            from ray.serve.utils import serve_encoders
 
-            self.body = json.dumps(content, cls=ServeEncoder, indent=2).encode()
+            self.body = json.dumps(
+                jsonable_encoder(content, custom_encoder=serve_encoders)
+            )
             self.set_content_type("json")
 
     def set_content_type(self, content_type):

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -1,6 +1,7 @@
 import time
 from typing import Any, List, Optional
 import tempfile
+import numpy as np
 
 import pytest
 import inspect
@@ -634,6 +635,24 @@ def test_fastapi_same_app_multiple_deployments(serve_instance):
     ]
     for path in should_404:
         assert requests.get("http://localhost:8000" + path).status_code == 404, path
+
+
+def test_fastapi_custom_serializers(serve_instance):
+    app = FastAPI()
+
+    @serve.deployment
+    @serve.ingress(app)
+    class D:
+        @app.get("/np_array")
+        def incr(self):
+            return np.zeros(2)
+
+    D.deploy()
+
+    resp = requests.get(D.url + "/np_array")
+    print(resp.text)
+    resp.raise_for_status()
+    assert resp.json() == [0, 0]
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -6,9 +6,15 @@ import sys
 import subprocess
 import pytest
 
+from fastapi.encoders import jsonable_encoder
+
 import ray
 from ray import serve
-from ray.serve.utils import ServeEncoder, get_deployment_import_path, node_id_to_ip_addr
+from ray.serve.utils import (
+    serve_encoders,
+    get_deployment_import_path,
+    node_id_to_ip_addr,
+)
 
 
 def test_node_id_to_ip_addr():
@@ -21,7 +27,7 @@ def test_node_id_to_ip_addr():
 def test_bytes_encoder():
     data_before = {"inp": {"nest": b"bytes"}}
     data_after = {"inp": {"nest": "bytes"}}
-    assert json.loads(json.dumps(data_before, cls=ServeEncoder)) == data_after
+    assert json.loads(json.dumps(jsonable_encoder(data_before))) == data_after
 
 
 def test_numpy_encoding():
@@ -30,9 +36,23 @@ def test_numpy_encoding():
     ints = floats.astype(np.int32)
     uints = floats.astype(np.uint32)
 
-    assert json.loads(json.dumps(floats, cls=ServeEncoder)) == data
-    assert json.loads(json.dumps(ints, cls=ServeEncoder)) == data
-    assert json.loads(json.dumps(uints, cls=ServeEncoder)) == data
+    assert (
+        json.loads(json.dumps(jsonable_encoder(floats, custom_encoder=serve_encoders)))
+        == data
+    )
+    assert (
+        json.loads(json.dumps(jsonable_encoder(ints, custom_encoder=serve_encoders)))
+        == data
+    )
+    assert (
+        json.loads(json.dumps(jsonable_encoder(uints, custom_encoder=serve_encoders)))
+        == data
+    )
+
+    nested = {"a": np.array([1, 2])}
+    assert json.loads(
+        json.dumps(jsonable_encoder(nested, custom_encoder=serve_encoders))
+    ) == {"a": [1, 2]}
 
 
 @serve.deployment

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -47,7 +47,7 @@ def parse_request_item(request_item):
 
 
 class _ServeCustomEncoders:
-    """Groups of custom encoders for common types that's not handled by FastAPI."""
+    """Group of custom encoders for common types that's not handled by FastAPI."""
 
     @staticmethod
     def encode_np_array(obj):

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import importlib
 from itertools import groupby
-import json
 import pickle
 import random
 import string
@@ -16,6 +15,7 @@ from ray.actor import ActorHandle
 import requests
 import numpy as np
 import pydantic
+import pydantic.json
 
 import ray
 import ray.serialization_addons
@@ -46,28 +46,34 @@ def parse_request_item(request_item):
     return request_item.args, request_item.kwargs
 
 
-class ServeEncoder(json.JSONEncoder):
-    """Ray.Serve's utility JSON encoder. Adds support for:
-    - bytes
-    - Pydantic types
-    - Exceptions
-    - numpy.ndarray
-    """
+class _ServeCustomEncoders:
+    """Groups of custom encoders for common types that's not handled by FastAPI."""
 
-    def default(self, o):  # pylint: disable=E0202
-        if isinstance(o, bytes):
-            return o.decode("utf-8")
-        if isinstance(o, pydantic.BaseModel):
-            return o.dict()
-        if isinstance(o, Exception):
-            return str(o)
-        if isinstance(o, np.ndarray):
-            if o.dtype.kind == "f":  # floats
-                o = o.astype(float)
-            if o.dtype.kind in {"i", "u"}:  # signed and unsigned integers.
-                o = o.astype(int)
-            return o.tolist()
-        return super().default(o)
+    @staticmethod
+    def encode_np_array(obj):
+        assert isinstance(obj, np.ndarray)
+        if obj.dtype.kind == "f":  # floats
+            obj = obj.astype(float)
+        if obj.dtype.kind in {"i", "u"}:  # signed and unsigned integers.
+            obj = obj.astype(int)
+        return obj.tolist()
+
+    @staticmethod
+    def encode_exception(obj):
+        assert isinstance(obj, Exception)
+        return str(obj)
+
+
+serve_encoders = {
+    np.ndarray: _ServeCustomEncoders.encode_np_array,
+    Exception: _ServeCustomEncoders.encode_exception,
+}
+
+
+def install_serve_encoders_to_fastapi():
+    """Inject Serve's encoders so FastAPI's jsonable_encoder can pick it up."""
+    # https://stackoverflow.com/questions/62311401/override-default-encoders-for-jsonable-encoder-in-fastapi # noqa
+    pydantic.json.ENCODERS_BY_TYPE.update(serve_encoders)
 
 
 @ray.remote(num_cpus=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Serve always had default JSON serializer for `np.ndarray` as a quality of life feature that many users appreciate about.
With introduction of FastAPI, this feature is lost. Leading to confusing error messages.
This PR fixes that by:
- Make sure Starlette stack uses the same JSON encoders as FastAPI. (which occurs to me that we can potentially unify the starlette stack with FastAPI stack, but more on that in 2.0). 
- Ensure users don't need to configure anything and get np.ndarray serialization out of the box.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24240 
Unblock #24215 (cc @krfricke)
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
