### PR TITLE
[minor] Make the max runtime_env size configurable

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -20,9 +20,11 @@ default_logger = logging.getLogger(__name__)
 
 # If an individual file is beyond this size, print a warning.
 FILE_SIZE_WARNING = 10 * 1024 * 1024  # 10MiB
-# NOTE(edoakes): we should be able to support up to 512 MiB based on the GCS'
-# limit, but for some reason that causes failures when downloading.
-GCS_STORAGE_MAX_SIZE = 100 * 1024 * 1024  # 100MiB
+# The size is bounded by the max gRPC message size. Raise a good error message early
+# if we are going to exceed it.
+GCS_STORAGE_MAX_SIZE = int(
+    os.environ.get("RAY_max_grpc_message_size", 100 * 1024 * 1024)
+)
 RAY_PKG_PREFIX = "_ray_pkg_"
 
 

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -20,10 +20,10 @@ default_logger = logging.getLogger(__name__)
 
 # If an individual file is beyond this size, print a warning.
 FILE_SIZE_WARNING = 10 * 1024 * 1024  # 10MiB
-# The size is bounded by the max gRPC message size. Raise a good error message early
-# if we are going to exceed it.
+# The size is bounded by the max gRPC message size.
+# Keep in sync with max_grpc_message_size in ray_config_def.h.
 GCS_STORAGE_MAX_SIZE = int(
-    os.environ.get("RAY_max_grpc_message_size", 100 * 1024 * 1024)
+    os.environ.get("RAY_max_grpc_message_size", 250 * 1024 * 1024)
 )
 RAY_PKG_PREFIX = "_ray_pkg_"
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -152,7 +152,8 @@ RAY_CONFIG(int64_t, max_direct_call_object_size, 100 * 1024)
 
 // The max gRPC message size (the gRPC internal default is 4MB). We use a higher
 // limit in Ray to avoid crashing with many small inlined task arguments.
-RAY_CONFIG(int64_t, max_grpc_message_size, 100 * 1024 * 1024)
+// Keep in sync with GCS_STORAGE_MAX_SIZE in packaging.py.
+RAY_CONFIG(int64_t, max_grpc_message_size, 250 * 1024 * 1024)
 
 // Retry timeout for trying to create a gRPC server. Only applies if the number
 // of retries is non zero.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Make the max runtime_env size configurable via the internal flags (grab any grpc max message size override). This allows experimentation with higher limits.