### PR TITLE
[docs] Fix import error in Ray Data "getting started"

### DIFF
--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -127,7 +127,7 @@ Transformations are executed *eagerly* and block until the operation is finished
 
 .. code-block:: python
 
-    def transform_batch(df: pandas.DataFrame) -> pandas.DataFrame:
+    def transform_batch(df: pandas.DataFrame) -> pd.DataFrame:
         return df.applymap(lambda x: x * 2)
 
     ds = ray.data.range_arrow(10000)


### PR DESCRIPTION
We did `import pandas as pd` but here we are using it as `pandas`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The code snippet for "[Transforming Datasets](https://docs.ray.io/en/master/data/getting-started.html#transforming-datasets)" won't work

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
