### PR TITLE
[RLlib] Release learning tests for SlateQ have wrong yaml structure

### DIFF
--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -456,10 +456,11 @@ sac-halfcheetahbulletenv-v0:
 slateq-interest-evolution-recsim-env:
     env: ray.rllib.examples.env.recommender_system_envs_with_recsim.InterestEvolutionRecSimEnv
     run: SlateQ
-    stop:
+    pass_criteria:
         episode_reward_mean: 162.0
         timesteps_total: 300000
-
+    stop:
+        time_total_s: 7200
     config:
         # increase num sampling workers for faster sampling.
         num_workers: 12

--- a/release/rllib_tests/learning_tests/hard_learning_tests.yaml
+++ b/release/rllib_tests/learning_tests/hard_learning_tests.yaml
@@ -468,11 +468,6 @@ slateq-interest-evolution-recsim-env:
         env_config:
             # Env class specified above takes one `config` arg in its c'tor:
             config:
-                # GPU support currently does not work for tensorflow. For the learning
-                # test for now, we'll use pytorch, and investigate why tensorflow is not working.
-                # One indication of the issue is that the loss inputs are not flattened from the
-                # original dictionary spaces.
-                framework: tf
                 # Each step, sample `num_candidates` documents using the env-internal
                 # document sampler model (a logic that creates n documents to select
                 # the slate from).

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -603,6 +603,10 @@ def run_learning_tests_from_yaml(
         smoke_test (bool): Whether this is just a smoke-test. If True,
             set time_total_s to 5min and don't early out due to rewards
             or timesteps reached.
+
+    Returns:
+        A results dict mapping strings (e.g. "time_taken", "stats", "passed") to
+            the respective stats/values.
     """
     print("Will run the following yaml files:")
     for yaml_file in yaml_files:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

* `pass_criteria` missing, `stop` missing.
* Not setup for tf + torch.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
