### PR TITLE
Fix check failure when DisconnectClient happens before AnnounceWorkerPort (#24403)

### DIFF
--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -114,6 +114,7 @@ class WorkerInterface {
   FRIEND_TEST(WorkerPoolTest, TestWorkerCappingLaterNWorkersNotOwningObjects);
   FRIEND_TEST(WorkerPoolTest, TestWorkerCappingWithExitDelay);
   FRIEND_TEST(WorkerPoolTest, MaximumStartupConcurrency);
+  FRIEND_TEST(WorkerPoolTest, HandleWorkerRegistration);
 };
 
 /// Worker class encapsulates the implementation details of a worker. A worker

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -280,8 +280,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   ///
   /// \param worker The worker to disconnect. The worker must be registered.
   /// \param disconnect_type Type of a worker exit.
-  /// \return Whether the given worker was in the pool of idle workers.
-  bool DisconnectWorker(const std::shared_ptr<WorkerInterface> &worker,
+  void DisconnectWorker(const std::shared_ptr<WorkerInterface> &worker,
                         rpc::WorkerExitType disconnect_type);
 
   /// Disconnect a registered driver.
@@ -467,7 +466,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     std::queue<std::function<void(std::shared_ptr<WorkerInterface>)>> pending_io_tasks;
     /// All I/O workers that have registered and are still connected, including both
     /// idle and executing.
-    std::unordered_set<std::shared_ptr<WorkerInterface>> registered_io_workers;
+    std::unordered_set<std::shared_ptr<WorkerInterface>> started_io_workers;
     /// Number of starting I/O workers.
     int num_starting_io_workers = 0;
   };

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -217,6 +217,11 @@ class WorkerPoolMock : public WorkerPool {
     return state.spill_io_worker_state.num_starting_io_workers;
   }
 
+  int NumSpillWorkerStarted() const {
+    auto state = states_by_lang_.find(Language::PYTHON)->second;
+    return state.spill_io_worker_state.started_io_workers.size();
+  }
+
   int NumRestoreWorkerStarting() const {
     auto state = states_by_lang_.find(Language::PYTHON)->second;
     return state.restore_io_worker_state.num_starting_io_workers;
@@ -635,6 +640,21 @@ TEST_F(WorkerPoolTest, HandleWorkerRegistration) {
         worker, /*disconnect_type=*/rpc::WorkerExitType::INTENDED_EXIT);
     // Check that we cannot lookup the worker after it's disconnected.
     ASSERT_EQ(worker_pool_->GetRegisteredWorker(worker->Connection()), nullptr);
+  }
+
+  {
+    // Test the case where DisconnectClient happens after RegisterClientRequest but before
+    // AnnounceWorkerPort.
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
+        Language::PYTHON, rpc::WorkerType::WORKER, JOB_ID, &status);
+    auto worker = worker_pool_->CreateWorker(Process(), Language::PYTHON);
+    ASSERT_EQ(worker_pool_->NumWorkersStarting(), 1);
+    RAY_CHECK_OK(worker_pool_->RegisterWorker(
+        worker, proc.GetId(), worker_pool_->GetStartupToken(proc), [](Status, int) {}));
+    worker->SetStartupToken(worker_pool_->GetStartupToken(proc));
+    worker_pool_->DisconnectWorker(
+        worker, /*disconnect_type=*/rpc::WorkerExitType::INTENDED_EXIT);
+    ASSERT_EQ(worker_pool_->NumWorkersStarting(), 0);
   }
 }
 
@@ -1924,6 +1944,24 @@ TEST_F(WorkerPoolTest, TestIOWorkerFailureAndSpawn) {
     worker_pool_->OnWorkerStarted(worker);
     worker_pool_->PushSpillWorker(worker);
   }
+
+  {
+    // Test the case where DisconnectClient happens after RegisterClientRequest but before
+    // AnnounceWorkerPort.
+    auto status = PopWorkerStatus::OK;
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
+        rpc::Language::PYTHON, rpc::WorkerType::SPILL_WORKER, JobID::Nil(), &status);
+    ASSERT_EQ(status, PopWorkerStatus::OK);
+    auto worker = CreateSpillWorker(Process());
+    RAY_CHECK_OK(
+        worker_pool_->RegisterWorker(worker, proc.GetId(), token, [](Status, int) {}));
+    // The worker failed before announcing the worker port (i.e. OnworkerStarted)
+    worker_pool_->DisconnectWorker(
+        worker, /*disconnect_type=*/rpc::WorkerExitType::SYSTEM_ERROR_EXIT);
+  }
+
+  ASSERT_EQ(worker_pool_->NumSpillWorkerStarting(), 0);
+  ASSERT_EQ(worker_pool_->NumSpillWorkerStarted(), MAX_IO_WORKER_SIZE);
 
   // Pop spill workers should work.
 


### PR DESCRIPTION

We have several issues if DisconnectClient happens before AnnounceWorkerPort:

- Check failure for removing io worker from registered_io_workers since the io worker is only added to that set after AnnounceWorkerPort.
- num_starting_(io)_workers is not decremented.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
