### PR TITLE
[Serve] Add serve handle graph workload tests

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -93,6 +93,42 @@ py_test(
 )
 
 py_test(
+    name = "serve_handle_long_chain",
+    size = "medium",
+    srcs = test_srcs,
+    env = {
+        "IS_SMOKE_TEST": "1",
+    },
+    main = "serve_handle_long_chain.py",
+    tags = [
+        "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        "//:ray_lib",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
+py_test(
+    name = "serve_handle_wide_ensemble",
+    size = "medium",
+    srcs = test_srcs,
+    env = {
+        "IS_SMOKE_TEST": "1",
+    },
+    main = "serve_handle_wide_ensemble.py",
+    tags = [
+        "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        "//:ray_lib",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
+py_test(
     name = "autoscaling_single_deployment_smoke_test",
     size = "medium",
     srcs = test_srcs,

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2024,6 +2024,56 @@
   alert: default
   stable: False
 
+- name: serve_handle_long_chain
+  group: Serve tests
+  working_dir: serve_tests
+
+  legacy:
+    test_name: serve_handle_long_chain
+    test_suite: serve_tests
+
+  frequency: nightly
+  team: serve
+
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: compute_tpl_single_node_32_cpu.yaml
+
+  run:
+    timeout: 3600
+    long_running: false
+    script: python workloads/serve_handle_long_chain.py --chain-length=10 --num-clients=4 --local-test=False
+    type: sdk_command
+    file_manager: job
+
+  alert: default
+  stable: False
+
+- name: serve_handle_wide_ensemble
+  group: Serve tests
+  working_dir: serve_tests
+
+  legacy:
+    test_name: serve_handle_wide_ensemble
+    test_suite: serve_tests
+
+  frequency: nightly
+  team: serve
+
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: compute_tpl_single_node_32_cpu.yaml
+
+  run:
+    timeout: 3600
+    long_running: false
+    script: python workloads/serve_handle_wide_ensemble.py --fanout-degree=10 --num-clients=4 --local-test=False
+    type: sdk_command
+    file_manager: job
+
+  alert: default
+  stable: False
+
 ########################
 # Train tests
 ########################

--- a/release/serve_tests/workloads/serve_handle_long_chain.py
+++ b/release/serve_tests/workloads/serve_handle_long_chain.py
@@ -1,0 +1,186 @@
+"""
+This test is parity of
+release/serve_tests/workloads/deployment_graph_long_chain.py
+Instead of using graph api, the test is using pure handle to
+test long chain graph.
+
+INPUT -> Node_1 -> Node_2 -> ... -> Node_10 -> OUTPUT
+
+ 1) Intermediate blob size can be large / small
+ 2) Compute time each node can be long / short
+ 3) Init time can be long / short
+"""
+
+import time
+import asyncio
+import click
+
+from typing import Optional
+
+import ray
+from ray import serve
+from ray.serve.context import get_global_client
+from serve_test_cluster_utils import (
+    setup_local_single_node_cluster,
+    setup_anyscale_cluster,
+)
+from serve_test_utils import save_test_results
+from benchmark_utils import benchmark_throughput_tps, benchmark_latency_ms
+
+DEFAULT_CHAIN_LENGTH = 4
+
+DEFAULT_NUM_REQUESTS_PER_CLIENT = 20  # request sent for latency test
+DEFAULT_NUM_CLIENTS = 1  # Clients concurrently sending request to deployment
+
+DEFAULT_THROUGHPUT_TRIAL_DURATION_SECS = 10
+
+
+@serve.deployment
+class Node:
+    def __init__(
+        self,
+        id: int,
+        prev_node=None,
+        init_delay_secs=0,
+        compute_delay_secs=0,
+        sync_handle=True,
+    ):
+        time.sleep(init_delay_secs)
+        self.id = id
+        self.prev_node = prev_node
+        self.compute_delay_secs = compute_delay_secs
+        self.sync_handle = sync_handle
+
+    async def predict(self, input_data: int):
+        await asyncio.sleep(self.compute_delay_secs)
+        if self.prev_node:
+            if self.sync_handle:
+                return await self.prev_node.predict.remote(input_data) + 1
+            else:
+                return await (await self.prev_node.predict.remote(input_data)) + 1
+        else:
+            return input_data + 1
+
+
+def construct_long_chain_graph_with_pure_handle(
+    chain_length, sync_handle: bool, init_delay_secs=0, compute_delay_secs=0
+):
+    prev_handle = None
+    for id in range(chain_length):
+        Node.options(name=str(id)).deploy(
+            id, prev_handle, init_delay_secs, compute_delay_secs, sync_handle
+        )
+        prev_handle = get_global_client().get_handle(str(id), sync=sync_handle)
+    return prev_handle
+
+
+async def sanity_check_graph_deployment_with_async_handle(handle, expected_result):
+    assert await (await handle.predict.remote(0)) == expected_result
+
+
+@click.command()
+@click.option("--chain-length", type=int, default=DEFAULT_CHAIN_LENGTH)
+@click.option("--init-delay-secs", type=int, default=0)
+@click.option("--compute-delay-secs", type=int, default=0)
+@click.option(
+    "--num-requests-per-client",
+    type=int,
+    default=DEFAULT_NUM_REQUESTS_PER_CLIENT,
+)
+@click.option("--num-clients", type=int, default=DEFAULT_NUM_CLIENTS)
+@click.option(
+    "--throughput-trial-duration-secs",
+    type=int,
+    default=DEFAULT_THROUGHPUT_TRIAL_DURATION_SECS,
+)
+@click.option("--local-test", type=bool, default=True)
+@click.option("--sync-handle", type=bool, default=True)
+def main(
+    chain_length: Optional[int],
+    init_delay_secs: Optional[int],
+    compute_delay_secs: Optional[int],
+    num_requests_per_client: Optional[int],
+    num_clients: Optional[int],
+    throughput_trial_duration_secs: Optional[int],
+    local_test: Optional[bool],
+    sync_handle: Optional[bool],
+):
+    if local_test:
+        setup_local_single_node_cluster(1, num_cpu_per_node=8)
+    else:
+        setup_anyscale_cluster()
+
+    handle = construct_long_chain_graph_with_pure_handle(
+        chain_length,
+        sync_handle,
+        init_delay_secs=init_delay_secs,
+        compute_delay_secs=compute_delay_secs,
+    )
+    if sync_handle:
+        assert ray.get(handle.predict.remote(0)) == chain_length
+    else:
+        sanity_check_graph_deployment_with_async_handle(handle, chain_length)
+    loop = asyncio.get_event_loop()
+
+    throughput_mean_tps, throughput_std_tps = loop.run_until_complete(
+        benchmark_throughput_tps(
+            handle,
+            chain_length,
+            duration_secs=throughput_trial_duration_secs,
+            num_clients=num_clients,
+        )
+    )
+    latency_mean_ms, latency_std_ms = loop.run_until_complete(
+        benchmark_latency_ms(
+            handle,
+            chain_length,
+            num_requests=num_requests_per_client,
+            num_clients=num_clients,
+        )
+    )
+
+    print(f"chain_length: {chain_length}, num_clients: {num_clients}")
+    print(f"latency_mean_ms: {latency_mean_ms}, " f"latency_std_ms: {latency_std_ms}")
+    print(
+        f"throughput_mean_tps: {throughput_mean_tps}, "
+        f"throughput_std_tps: {throughput_std_tps}"
+    )
+
+    results = {
+        "chain_length": chain_length,
+        "init_delay_secs": init_delay_secs,
+        "compute_delay_secs": compute_delay_secs,
+        "local_test": local_test,
+        "sync_handle": sync_handle,
+    }
+    results["perf_metrics"] = [
+        {
+            "perf_metric_name": "throughput_mean_tps",
+            "perf_metric_value": throughput_mean_tps,
+            "perf_metric_type": "THROUGHPUT",
+        },
+        {
+            "perf_metric_name": "throughput_std_tps",
+            "perf_metric_value": throughput_std_tps,
+            "perf_metric_type": "THROUGHPUT",
+        },
+        {
+            "perf_metric_name": "latency_mean_ms",
+            "perf_metric_value": latency_mean_ms,
+            "perf_metric_type": "LATENCY",
+        },
+        {
+            "perf_metric_name": "latency_std_ms",
+            "perf_metric_value": latency_std_ms,
+            "perf_metric_type": "LATENCY",
+        },
+    ]
+    save_test_results(results)
+
+
+if __name__ == "__main__":
+    main()
+    import sys
+    import pytest
+
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/release/serve_tests/workloads/serve_handle_wide_ensemble.py
+++ b/release/serve_tests/workloads/serve_handle_wide_ensemble.py
@@ -2,7 +2,7 @@
 This test is parity of
 release/serve_tests/workloads/deployment_graph_wide_ensemble.py
 Instead of using graph api, the test is using pure handle to
-test wide fanout graph.
+test wide fanout graph
 
 
        -> Node_1

--- a/release/serve_tests/workloads/serve_handle_wide_ensemble.py
+++ b/release/serve_tests/workloads/serve_handle_wide_ensemble.py
@@ -1,0 +1,206 @@
+"""
+This test is parity of
+release/serve_tests/workloads/deployment_graph_wide_ensemble.py
+Instead of using graph api, the test is using pure handle to
+test wide fanout graph.
+
+
+       -> Node_1
+      /          \
+INPUT --> Node_2  --> combine -> OUTPUT
+      \    ...   /
+       -> Node_10
+
+ 1) Intermediate blob size can be large / small
+ 2) Compute time each node can be long / short
+ 3) Init time can be long / short
+"""
+
+import time
+import asyncio
+import click
+
+from typing import List
+from typing import Optional
+
+import ray
+from ray import serve
+from ray.serve.handle import RayServeSyncHandle
+from ray.serve.context import get_global_client
+from serve_test_cluster_utils import (
+    setup_local_single_node_cluster,
+    setup_anyscale_cluster,
+)
+from serve_test_utils import save_test_results
+from benchmark_utils import benchmark_throughput_tps, benchmark_latency_ms
+
+DEFAULT_FANOUT_DEGREE = 4
+
+DEFAULT_NUM_REQUESTS_PER_CLIENT = 20  # request sent for latency test
+DEFAULT_NUM_CLIENTS = 1  # Clients concurrently sending request to deployment
+
+DEFAULT_THROUGHPUT_TRIAL_DURATION_SECS = 10
+
+
+@serve.deployment
+class Node:
+    def __init__(self, id: int, init_delay_secs=0):
+        time.sleep(init_delay_secs)
+        self.id = id
+
+    async def predict(self, input_data, compute_delay_secs=0):
+        await asyncio.sleep(compute_delay_secs)
+
+        return input_data + self.id
+
+
+@serve.deployment
+class CombineNode:
+    def __init__(
+        self,
+        input_nodes: List[RayServeSyncHandle],
+        compute_delay_secs,
+        sync_handle=True,
+    ):
+        assert type(input_nodes) == list
+        self.input_nodes = input_nodes
+        self.compute_delay_secs = compute_delay_secs
+        self.sync_handle = sync_handle
+
+    async def predict(self, data):
+        results = [
+            node.predict.remote(data, self.compute_delay_secs)
+            for node in self.input_nodes
+        ]
+        if self.sync_handle:
+            results = await asyncio.gather(*results)
+        else:
+            results = await asyncio.gather(*await asyncio.gather(*results))
+        return sum(results)
+
+
+def construct_wide_fanout_graph_with_pure_handle(
+    fanout_degree, sync_handle: bool, init_delay_secs=0, compute_delay_secs=0
+) -> RayServeSyncHandle:
+    nodes = []
+    for id in range(fanout_degree):
+        Node.options(name=str(id)).deploy(id, init_delay_secs=init_delay_secs)
+        nodes.append(get_global_client().get_handle(str(id), sync=sync_handle))
+    CombineNode.options(name="combine").deploy(
+        nodes, compute_delay_secs, sync_handle=sync_handle
+    )
+    return get_global_client().get_handle("combine", sync=sync_handle)
+
+
+async def sanity_check_graph_deployment_with_async_handle(handle, expected_result):
+    assert await (await handle.predict.remote(0)) == expected_result
+
+
+@click.command()
+@click.option("--fanout-degree", type=int, default=DEFAULT_FANOUT_DEGREE)
+@click.option("--init-delay-secs", type=int, default=0)
+@click.option("--compute-delay-secs", type=int, default=0)
+@click.option(
+    "--num-requests-per-client",
+    type=int,
+    default=DEFAULT_NUM_REQUESTS_PER_CLIENT,
+)
+@click.option("--num-clients", type=int, default=DEFAULT_NUM_CLIENTS)
+@click.option(
+    "--throughput-trial-duration-secs",
+    type=int,
+    default=DEFAULT_THROUGHPUT_TRIAL_DURATION_SECS,
+)
+@click.option("--local-test", type=bool, default=True)
+@click.option("--sync-handle", type=bool, default=True)
+def main(
+    fanout_degree: Optional[int],
+    init_delay_secs: Optional[int],
+    compute_delay_secs: Optional[int],
+    num_requests_per_client: Optional[int],
+    num_clients: Optional[int],
+    throughput_trial_duration_secs: Optional[int],
+    local_test: Optional[bool],
+    sync_handle: Optional[bool],
+):
+    if local_test:
+        setup_local_single_node_cluster(1, num_cpu_per_node=8)
+    else:
+        setup_anyscale_cluster()
+
+    handle = construct_wide_fanout_graph_with_pure_handle(
+        fanout_degree,
+        sync_handle,
+        init_delay_secs=init_delay_secs,
+        compute_delay_secs=compute_delay_secs,
+    )
+
+    # 0 + 1 + 2 + 3 + 4 + ... + (fanout_degree - 1)
+    expected = ((0 + fanout_degree - 1) * fanout_degree) / 2
+    if sync_handle:
+        assert ray.get(handle.predict.remote(0)) == expected
+    else:
+        sanity_check_graph_deployment_with_async_handle(handle, expected)
+    loop = asyncio.get_event_loop()
+
+    throughput_mean_tps, throughput_std_tps = loop.run_until_complete(
+        benchmark_throughput_tps(
+            handle,
+            expected,
+            duration_secs=throughput_trial_duration_secs,
+            num_clients=num_clients,
+        )
+    )
+    latency_mean_ms, latency_std_ms = loop.run_until_complete(
+        benchmark_latency_ms(
+            handle,
+            expected,
+            num_requests=num_requests_per_client,
+            num_clients=num_clients,
+        )
+    )
+    print(f"fanout_degree: {fanout_degree}, num_clients: {num_clients}")
+    print(f"latency_mean_ms: {latency_mean_ms}, " f"latency_std_ms: {latency_std_ms}")
+    print(
+        f"throughput_mean_tps: {throughput_mean_tps}, "
+        f"throughput_std_tps: {throughput_std_tps}"
+    )
+
+    results = {
+        "fanout_degree": fanout_degree,
+        "init_delay_secs": init_delay_secs,
+        "compute_delay_secs": compute_delay_secs,
+        "local_test": local_test,
+        "sync_handle": sync_handle,
+    }
+    results["perf_metrics"] = [
+        {
+            "perf_metric_name": "throughput_mean_tps",
+            "perf_metric_value": throughput_mean_tps,
+            "perf_metric_type": "THROUGHPUT",
+        },
+        {
+            "perf_metric_name": "throughput_std_tps",
+            "perf_metric_value": throughput_std_tps,
+            "perf_metric_type": "THROUGHPUT",
+        },
+        {
+            "perf_metric_name": "latency_mean_ms",
+            "perf_metric_value": latency_mean_ms,
+            "perf_metric_type": "LATENCY",
+        },
+        {
+            "perf_metric_name": "latency_std_ms",
+            "perf_metric_value": latency_std_ms,
+            "perf_metric_type": "LATENCY",
+        },
+    ]
+    save_test_results(results)
+
+
+if __name__ == "__main__":
+    main()
+    import sys
+    import pytest
+
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add serve handle graph tests as a baseline for graph tests comparison

## Related issue number

Closes #24406

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(


Local run result:
serve_handle_long_chain
<img width="1691" alt="image" src="https://user-images.githubusercontent.com/6515354/166591069-bcdb859f-1e53-4871-bf5e-09759578cdb5.png">
serve_handle_wide_ensemble
<img width="1721" alt="image" src="https://user-images.githubusercontent.com/6515354/166591202-0ecdc26f-7ca7-44da-859f-74a77d05dd6e.png">

