### PR TITLE
Fix broken documentation URL

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -466,7 +466,7 @@ class FunctionActorManager:
             msg = (
                 "Could not serialize the actor class "
                 f"{actor_creation_function_descriptor.repr}. "
-                "Check https://docs.ray.io/en/master/serialization.html#troubleshooting "  # noqa
+                "Check https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting "  # noqa
                 "for more information."
             )
             raise TypeError(msg) from e

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -418,7 +418,7 @@ cdef prepare_args_internal(
                     "Could not serialize the argument "
                     f"{repr(arg)} for a task or actor "
                     f"{function_descriptor.repr}. Check "
-                    "https://docs.ray.io/en/master/serialization.html#troubleshooting " # noqa
+                    "https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting " # noqa
                     "for more information.")
                 raise TypeError(msg) from e
             metadata = serialized_arg.metadata

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -204,7 +204,7 @@ class RemoteFunction:
                 msg = (
                     "Could not serialize the function "
                     f"{self._function_descriptor.repr}. Check "
-                    "https://docs.ray.io/en/master/serialization.html#troubleshooting "
+                    "https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting "
                     "for more information."
                 )
                 raise TypeError(msg) from e

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -204,7 +204,7 @@ class RemoteFunction:
                 msg = (
                     "Could not serialize the function "
                     f"{self._function_descriptor.repr}. Check "
-                    "https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting "
+                    "https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting "  # noqa
                     "for more information."
                 )
                 raise TypeError(msg) from e

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -319,10 +319,10 @@ RuntimeError: Failed to unpickle serialized exception"""
 
 
 def test_serialization_error_message(shutdown_only):
-    expected_output_task = """Could not serialize the argument <unlocked _thread.lock object at ADDRESS> for a task or actor test_traceback.test_serialization_error_message.<locals>.task_with_unserializable_arg. Check https://docs.ray.io/en/master/serialization.html#troubleshooting for more information."""  # noqa
-    expected_output_actor = """Could not serialize the argument <unlocked _thread.lock object at ADDRESS> for a task or actor test_traceback.test_serialization_error_message.<locals>.A.__init__. Check https://docs.ray.io/en/master/serialization.html#troubleshooting for more information."""  # noqa
-    expected_capture_output_task = """Could not serialize the function test_traceback.test_serialization_error_message.<locals>.capture_lock. Check https://docs.ray.io/en/master/serialization.html#troubleshooting for more information."""  # noqa
-    expected_capture_output_actor = """Could not serialize the actor class test_traceback.test_serialization_error_message.<locals>.B.__init__. Check https://docs.ray.io/en/master/serialization.html#troubleshooting for more information."""  # noqa
+    expected_output_task = """Could not serialize the argument <unlocked _thread.lock object at ADDRESS> for a task or actor test_traceback.test_serialization_error_message.<locals>.task_with_unserializable_arg. Check https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting for more information."""  # noqa
+    expected_output_actor = """Could not serialize the argument <unlocked _thread.lock object at ADDRESS> for a task or actor test_traceback.test_serialization_error_message.<locals>.A.__init__. Check https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting for more information."""  # noqa
+    expected_capture_output_task = """Could not serialize the function test_traceback.test_serialization_error_message.<locals>.capture_lock. Check https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting for more information."""  # noqa
+    expected_capture_output_actor = """Could not serialize the actor class test_traceback.test_serialization_error_message.<locals>.B.__init__. Check https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting for more information."""  # noqa
     ray.init(num_cpus=1)
     lock = threading.Lock()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The link to the documentation to troubleshoot `TypeError: Could not serialize the function ...` is broken. This PR fixes the link by replacing it with the correct URL.

## Related issue number

NA

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] (**not applicable**) I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] (**not applicable**) I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] (**not applicable**) Unit tests
   - [ ] (**not applicable**) Release tests
   - [ ] (**not applicable**) This PR is not tested :(
