### PR TITLE
[Datasets] Add explicit resource allocation option via a top-level scheduling strategy

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -4,6 +4,7 @@ import os
 
 import ray
 from ray.util.annotations import DeveloperAPI
+from ray.util.scheduling_strategies import SchedulingStrategyT
 
 # The context singleton on this process.
 _default_context: "Optional[DatasetContext]" = None
@@ -37,6 +38,9 @@ DEFAULT_USE_PUSH_BASED_SHUFFLE = bool(
     os.environ.get("RAY_DATASET_PUSH_BASED_SHUFFLE", None)
 )
 
+# The default global scheduling strategy.
+DEFAULT_SCHEDULING_STRATEGY = "DEFAULT"
+
 
 @DeveloperAPI
 class DatasetContext:
@@ -57,6 +61,7 @@ class DatasetContext:
         optimize_fuse_shuffle_stages: bool,
         actor_prefetcher_enabled: bool,
         use_push_based_shuffle: bool,
+        scheduling_strategy: SchedulingStrategyT,
     ):
         """Private constructor (use get_current() instead)."""
         self.block_owner = block_owner
@@ -68,6 +73,7 @@ class DatasetContext:
         self.optimize_fuse_shuffle_stages = optimize_fuse_shuffle_stages
         self.actor_prefetcher_enabled = actor_prefetcher_enabled
         self.use_push_based_shuffle = use_push_based_shuffle
+        self.scheduling_strategy = scheduling_strategy
 
     @staticmethod
     def get_current() -> "DatasetContext":
@@ -91,13 +97,16 @@ class DatasetContext:
                     optimize_fuse_shuffle_stages=DEFAULT_OPTIMIZE_FUSE_SHUFFLE_STAGES,
                     actor_prefetcher_enabled=DEFAULT_ACTOR_PREFETCHER_ENABLED,
                     use_push_based_shuffle=DEFAULT_USE_PUSH_BASED_SHUFFLE,
+                    scheduling_strategy=DEFAULT_SCHEDULING_STRATEGY,
                 )
 
             if (
                 _default_context.block_splitting_enabled
                 and _default_context.block_owner is None
             ):
-                owner = _DesignatedBlockOwner.remote()
+                owner = _DesignatedBlockOwner.options(
+                    scheduling_strategy=_default_context.scheduling_strategy
+                ).remote()
                 ray.get(owner.ping.remote())
 
                 # Clear the actor handle after Ray reinits since it's no longer
@@ -122,7 +131,7 @@ class DatasetContext:
         _default_context = context
 
 
-@ray.remote(num_cpus=0, placement_group=None)
+@ray.remote(num_cpus=0)
 class _DesignatedBlockOwner:
     def ping(self):
         return "ok"

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -285,9 +285,11 @@ class DatasetPipeline(Generic[T]):
             # will fate-share with the coordinator anyway.
             resources["node:{}".format(ray.util.get_node_ip_address())] = 0.0001
 
+        ctx = DatasetContext.get_current()
+
         coordinator = PipelineSplitExecutorCoordinator.options(
             resources=resources,
-            placement_group=None,
+            scheduling_strategy=ctx.scheduling_strategy,
         ).remote(self, n, splitter, DatasetContext.get_current())
         if self._executed[0]:
             raise RuntimeError("Pipeline cannot be read multiple times.")

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -250,9 +250,11 @@ class DummyOutputDatasource(Datasource[Union[ArrowRow, int]]):
     """
 
     def __init__(self):
+        ctx = DatasetContext.get_current()
+
         # Setup a dummy actor to send the data. In a real datasource, write
         # tasks would send data to an external system instead of a Ray actor.
-        @ray.remote
+        @ray.remote(scheduling_strategy=ctx.scheduling_strategy)
         class DataSink:
             def __init__(self):
                 self.rows_written = 0

--- a/python/ray/data/impl/block_batching.py
+++ b/python/ray/data/impl/block_batching.py
@@ -182,7 +182,7 @@ class ActorBlockPrefetcher(BlockPrefetcher):
         self.prefetch_actor.prefetch.remote(*blocks)
 
 
-@ray.remote(num_cpus=0, placement_group=None)
+@ray.remote(num_cpus=0)
 class _BlockPretcher:
     """Helper actor that prefetches blocks asynchronously."""
 

--- a/python/ray/data/impl/compute.py
+++ b/python/ray/data/impl/compute.py
@@ -179,6 +179,8 @@ class ActorPoolStrategy(ComputeStrategy):
         if not remote_args:
             remote_args["num_cpus"] = 1
 
+        remote_args["scheduling_strategy"] = context.scheduling_strategy
+
         BlockWorker = ray.remote(**remote_args)(BlockWorker)
 
         workers = [BlockWorker.remote() for _ in range(self.min_size)]

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -129,7 +129,7 @@ class PipelineExecutor:
         return output
 
 
-@ray.remote(num_cpus=0, placement_group=None)
+@ray.remote(num_cpus=0)
 class PipelineSplitExecutorCoordinator:
     def __init__(
         self,

--- a/python/ray/data/impl/remote_fn.py
+++ b/python/ray/data/impl/remote_fn.py
@@ -2,6 +2,8 @@ from typing import Any
 
 import ray
 
+from ray.data.context import DatasetContext
+
 CACHED_FUNCTIONS = {}
 
 
@@ -13,9 +15,10 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
     which means ray.remote cannot be used top-level in ray.data).
     """
     if fn not in CACHED_FUNCTIONS:
+        ctx = DatasetContext.get_current()
         default_ray_remote_args = {
             "retry_exceptions": True,
-            "placement_group": None,
+            "scheduling_strategy": ctx.scheduling_strategy,
         }
         CACHED_FUNCTIONS[fn] = ray.remote(
             **{**default_ray_remote_args, **ray_remote_args}

--- a/python/ray/data/impl/stats.py
+++ b/python/ray/data/impl/stats.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import ray
 from ray.data.block import BlockMetadata
+from ray.data.context import DatasetContext
 from ray.data.impl.block_list import BlockList
 
 
@@ -77,7 +78,7 @@ class _DatasetStatsBuilder:
         return stats
 
 
-@ray.remote(num_cpus=0, placement_group=None)
+@ray.remote(num_cpus=0)
 class _StatsActor:
     """Actor holding stats for blocks created by LazyBlockList.
 
@@ -120,8 +121,11 @@ def _get_or_create_stats_actor():
         or not ray.is_initialized()
         or _stats_actor[1] != ray.get_runtime_context().job_id.hex()
     ):
+        ctx = DatasetContext.get_current()
         _stats_actor[0] = _StatsActor.options(
-            name="datasets_stats_actor", get_if_exists=True
+            name="datasets_stats_actor",
+            get_if_exists=True,
+            scheduling_strategy=ctx.scheduling_strategy,
         ).remote()
         _stats_actor[1] = ray.get_runtime_context().job_id.hex()
 

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -8,6 +8,7 @@ from typing import List, Any, Generic, Optional, TYPE_CHECKING
 import ray
 from ray.types import ObjectRef
 from ray.data.block import T, BlockAccessor
+from ray.data.context import DatasetContext, DEFAULT_SCHEDULING_STRATEGY
 from ray.data.impl.remote_fn import cached_remote_fn
 
 if TYPE_CHECKING:
@@ -56,8 +57,13 @@ class RandomAccessDataset(Generic[T]):
                 self._upper_bounds.append(b[1])
 
         logger.info("[setup] Creating {} random access workers.".format(num_workers))
+        ctx = DatasetContext.get_current()
+        if ctx.scheduling_strategy is not DEFAULT_SCHEDULING_STRATEGY:
+            scheduling_strategy = ctx.scheduling_strategy
+        else:
+            scheduling_strategy = "SPREAD"
         self._workers = [
-            _RandomAccessWorker.options(scheduling_strategy="SPREAD").remote(
+            _RandomAccessWorker.options(scheduling_strategy=scheduling_strategy).remote(
                 key, self._format
             )
             for _ in range(num_workers)
@@ -188,7 +194,7 @@ class RandomAccessDataset(Generic[T]):
         return i
 
 
-@ray.remote(num_cpus=0, placement_group=None)
+@ray.remote(num_cpus=0)
 class _RandomAccessWorker:
     def __init__(self, key_field, dataset_format):
         self.blocks = None

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -58,7 +58,7 @@ class RandomAccessDataset(Generic[T]):
 
         logger.info("[setup] Creating {} random access workers.".format(num_workers))
         ctx = DatasetContext.get_current()
-        if ctx.scheduling_strategy is not DEFAULT_SCHEDULING_STRATEGY:
+        if ctx.scheduling_strategy != DEFAULT_SCHEDULING_STRATEGY:
             scheduling_strategy = ctx.scheduling_strategy
         else:
             scheduling_strategy = "SPREAD"

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -31,7 +31,7 @@ from ray.data.block import (
     BlockMetadata,
     BlockExecStats,
 )
-from ray.data.context import DatasetContext
+from ray.data.context import DatasetContext, DEFAULT_SCHEDULING_STRATEGY
 from ray.data.dataset import Dataset
 from ray.data.datasource import (
     Datasource,
@@ -212,6 +212,7 @@ def read_datasource(
     Returns:
         Dataset holding the data read from the datasource.
     """
+    ctx = DatasetContext.get_current()
     # TODO(ekl) remove this feature flag.
     force_local = "RAY_DATASET_FORCE_LOCAL_METADATA" in os.environ
     pa_ds = _lazy_import_pyarrow_dataset()
@@ -229,7 +230,6 @@ def read_datasource(
     else:
         # Prepare read in a remote task so that in Ray client mode, we aren't
         # attempting metadata resolution from the client machine.
-        ctx = DatasetContext.get_current()
         prepare_read = cached_remote_fn(
             _prepare_read, retry_exceptions=False, num_cpus=0
         )
@@ -254,7 +254,10 @@ def read_datasource(
 
     if ray_remote_args is None:
         ray_remote_args = {}
-    if "scheduling_strategy" not in ray_remote_args:
+    if (
+        "scheduling_strategy" not in ray_remote_args
+        and ctx.scheduling_strategy == DEFAULT_SCHEDULING_STRATEGY
+    ):
         ray_remote_args["scheduling_strategy"] = "SPREAD"
 
     block_list = LazyBlockList(read_tasks, ray_remote_args=ray_remote_args)

--- a/python/ray/data/tests/test_context_propagation.py
+++ b/python/ray/data/tests/test_context_propagation.py
@@ -5,6 +5,7 @@ from ray.tests.conftest import *  # noqa
 from ray.data.block import BlockMetadata
 from ray.data.context import DatasetContext
 from ray.data.datasource import Datasource, ReadTask
+from ray._private.test_utils import run_string_as_driver_nonblocking, wait_for_condition
 
 
 def test_read(ray_start_regular_shared):
@@ -56,13 +57,53 @@ def test_map_batches(ray_start_regular_shared):
     assert ds.take_all()[0] == 70003
 
 
-def test_filter(ray_start_regular_shared):
+def test_filter(shutdown_only):
     context = DatasetContext.get_current()
     context.foo = 70004
     ds = ray.data.from_items([70004]).filter(
         lambda x: x == DatasetContext.get_current().foo
     )
     assert ds.take_all()[0] == 70004
+
+
+def test_context_placement_group():
+    driver_code = """
+import ray
+from ray.data.context import DatasetContext
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from ray._private.test_utils import placement_group_assert_no_leak
+
+ray.init(num_cpus=1)
+
+context = DatasetContext.get_current()
+# This placement group will take up all cores of the local cluster.
+placement_group = ray.util.placement_group(
+    name="core_hog",
+    strategy="SPREAD",
+    bundles=[
+        {"CPU": 1},
+    ],
+)
+ray.get(placement_group.ready())
+context.scheduling_strategy = PlacementGroupSchedulingStrategy(placement_group)
+pipe = ray.data.range(100, parallelism=2) \
+    .window(blocks_per_window=1) \
+    .map(lambda x: x + 1)
+assert pipe.take_all() == list(range(1, 101))
+placement_group_assert_no_leak([placement_group])
+ray.shutdown()
+    """
+    proc = run_string_as_driver_nonblocking(driver_code)
+
+    def is_job_done():
+        if proc.poll() is None:
+            return False
+        if proc.returncode:
+            print(ray._private.utils.decode(proc.stderr.read()))
+            raise RuntimeError("Test failed: ", proc.returncode)
+        return True
+
+    wait_for_condition(is_job_done, timeout=10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of letting Datasets implicitly use cluster resources in the margins of explicit allocations of other libraries, such as Tune, Datasets should provide an option for explicitly allocating resources for a Datasets workload for users that want to box Datasets in. This PR adds such an explicit resource allocation option, via exposing a top-level scheduling strategy on the `DatasetContext` with which a placement group can be given.

## Related issue number

Closes #24206 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
