### PR TITLE
Spread scheduling the tasks reading metadata

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -218,8 +218,11 @@ def _fetch_metadata_remotely(
         for pcs in np.array_split(pieces, parallelism):
             if len(pcs) == 0:
                 continue
-            metas.append(remote_fetch_metadata.options(
-                scheduling_strategy="SPREAD").remote(cloudpickle.dumps(pcs)))
+            metas.append(
+                remote_fetch_metadata.options(scheduling_strategy="SPREAD").remote(
+                    cloudpickle.dumps(pcs)
+                )
+            )
     finally:
         _deregister_parquet_file_fragment_serialization()
     metas = meta_fetch_bar.fetch_until_complete(metas)

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -218,7 +218,8 @@ def _fetch_metadata_remotely(
         for pcs in np.array_split(pieces, parallelism):
             if len(pcs) == 0:
                 continue
-            metas.append(remote_fetch_metadata.remote(cloudpickle.dumps(pcs)))
+            metas.append(remote_fetch_metadata.options(
+                scheduling_strategy="SPREAD").remote(cloudpickle.dumps(pcs)))
     finally:
         _deregister_parquet_file_fragment_serialization()
     metas = meta_fetch_bar.fetch_until_complete(metas)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -233,7 +233,7 @@ def read_datasource(
             _prepare_read, retry_exceptions=False, num_cpus=0
         )
         read_tasks = ray.get(
-            prepare_read.options(scheduling_strategy="SPREAD").remote(
+            prepare_read.remote(
                 datasource,
                 ctx,
                 parallelism,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -233,7 +233,7 @@ def read_datasource(
             _prepare_read, retry_exceptions=False, num_cpus=0
         )
         read_tasks = ray.get(
-            prepare_read.remote(
+            prepare_read.options(scheduling_strategy="SPREAD").remote(
                 datasource,
                 ctx,
                 parallelism,


### PR DESCRIPTION
## Why are these changes needed?
Currently all the block metadata are read by/to head node. Users observe the sizable memory usage on head node. Spread scheduling the metadata reading tasks will even out the memory usage.

## Related issue number

Uber support.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
