### PR TITLE
[AIR] Allow users to configure verbosity

### DIFF
--- a/python/ray/ml/config.py
+++ b/python/ray/ml/config.py
@@ -11,6 +11,7 @@ from typing import (
 )
 
 from ray.tune.syncer import SyncConfig
+from ray.tune.utils.log import Verbosity
 from ray.util import PublicAPI
 
 if TYPE_CHECKING:
@@ -156,6 +157,9 @@ class RunConfig:
             and thus will not take effect in resumed runs).
         failure: The failure mode configuration.
         sync_config: Configuration object for syncing. See tune.SyncConfig.
+        verbose: 0, 1, 2, or 3. Verbosity mode.
+            0 = silent, 1 = only status updates, 2 = status and brief
+            results, 3 = status and detailed results. Defaults to 2.
     """
 
     # TODO(xwjiang): Add more.
@@ -165,3 +169,4 @@ class RunConfig:
     stop: Optional[Union[Mapping, "Stopper", Callable[[str, Mapping], bool]]] = None
     failure: Optional[FailureConfig] = None
     sync_config: Optional[SyncConfig] = None
+    verbose: Union[int, Verbosity] = Verbosity.V2_TRIAL_NORM

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -180,6 +180,7 @@ class TunerInternal:
             ),
             _experiment_checkpoint_dir=self._experiment_checkpoint_dir,
             raise_on_failed_trial=False,
+            verbose=self._run_config.verbose,
             **self._tuner_kwargs,
         )
         return analysis


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Makes verbosity a configurable parameter in `RunConfig`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
