### PR TITLE
[runtime env] Deflake test_usage_stats

### DIFF
--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -505,7 +505,7 @@ provider:
         Make sure report usage data works as expected
         """
 
-        @ray.remote(num_cpus=0, runtime_env={"pip": ["ray[serve]"]})
+        @ray.remote(num_cpus=0)
         class ServeInitator:
             def __init__(self):
                 # Start the ray serve server to verify requests are sent


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`test_usage_stats` was very flaky due to a runtime env setup error.

The test defined the runtime env `{pip: "ray[serve]"}` simultaneously in `ray.init()` and also in `ray.remote()` for the actor.  This is redundant but should be supported by runtime_env, but it turns out it reveals a bug in runtime_env.  The env appears to be installed twice concurrently in this situation, causing flakiness.  

I'll make a followup issue for the runtime env bug with more details and a simpler repro, and link it here.  Until then, we should merge this PR to deflake CI.  This PR only defines the runtime_env in `ray.init()`, and removes the redefinition in `ray.remote()`.  The actor will still inherit the correct runtime environment.

I tested manually by inspecting `dashboard_agent.log` locally. The `virtualenv` install commands were duplicated about 75% of the time before this PR, indicating the concurrent install.  But with this change, the commands were never duplicated in the 7-8 times that I ran it.  So this PR should deflake the test.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/23963
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
