### PR TITLE
[core] Update metadata in options properly

### DIFF
--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -221,3 +221,28 @@ def validate_actor_options(options: Dict[str, Any], in_options: bool):
     if options.get("get_if_exists") and not options.get("name"):
         raise ValueError("The actor name must be specified to use `get_if_exists`.")
     _check_deprecate_placement_group(options)
+
+
+def update_options(
+    original_options: Dict[str, Any], new_options: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Update original options with new options and return.
+    The returned updated options contain shallow copy of original options.
+    """
+
+    updated_options = {**original_options, **new_options}
+    # Ensure we update each namespace in "_metadata" independently.
+    # "_metadata" is a dict like {namespace1: config1, namespace2: config2}
+    if (
+        original_options.get("_metadata") is not None
+        and new_options.get("_metadata") is not None
+    ):
+        # make a shallow copy to avoid messing up the metadata dict in
+        # the original options.
+        metadata = original_options["_metadata"].copy()
+        for namespace, config in new_options["_metadata"].items():
+            metadata[namespace] = {**metadata.get(namespace, {}), **config}
+
+        updated_options["_metadata"] = metadata
+
+    return updated_options

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -547,7 +547,9 @@ class ActorClass:
         # "concurrency_groups" could not be used in ".options()",
         # we should remove it before merging options from '@ray.remote'.
         default_options.pop("concurrency_groups", None)
-        updated_options = {**default_options, **actor_options}
+        updated_options = ray_option_utils.update_options(
+            default_options, actor_options
+        )
         ray_option_utils.validate_actor_options(updated_options, in_options=True)
 
         # only update runtime_env when ".options()" specifies new runtime_env

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -143,7 +143,7 @@ class RemoteFunction:
         # max_calls could not be used in ".options()", we should remove it before
         # merging options from '@ray.remote'.
         default_options.pop("max_calls", None)
-        updated_options = {**default_options, **task_options}
+        updated_options = ray_option_utils.update_options(default_options, task_options)
         ray_option_utils.validate_task_options(updated_options, in_options=True)
 
         # only update runtime_env when ".options()" specifies new runtime_env

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -284,6 +284,32 @@ def test_options():
         with pytest.raises(TypeError):
             v.validate(k, unique_object)
 
+    # test updating "_metadata" with special rules
+    assert ray_option_utils.update_options(
+        {
+            "_metadata": {"ns1": {"a1": 1, "b1": 2, "c1": 3}, "ns2": {"a2": 1}},
+            "num_cpus": 1,
+            "xxx": {"x": 2},
+            "zzz": 42,
+        },
+        {
+            "_metadata": {"ns1": {"b1": 22}, "ns3": {"b3": 2}},
+            "num_cpus": 2,
+            "xxx": {"y": 2},
+            "yyy": 3,
+        },
+    ) == {
+        "_metadata": {
+            "ns1": {"a1": 1, "b1": 22, "c1": 3},
+            "ns2": {"a2": 1},
+            "ns3": {"b3": 2},
+        },
+        "num_cpus": 2,
+        "xxx": {"y": 2},
+        "yyy": 3,
+        "zzz": 42,
+    }
+
 
 # https://github.com/ray-project/ray/issues/17842
 def test_disable_cuda_devices():

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -284,7 +284,7 @@ def test_options():
         with pytest.raises(TypeError):
             v.validate(k, unique_object)
 
-    # test updating "_metadata" with special rules
+    # test updating each namespace of "_metadata" independently
     assert ray_option_utils.update_options(
         {
             "_metadata": {"ns1": {"a1": 1, "b1": 2, "c1": 3}, "ns2": {"a2": 1}},


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`_metadata` is a special keyword in Ray options that contains multiple namespaces. It is intended for config of different Ray libraries. However, current updating of options is incorrect for `_metadata`: it replaces all contents in `_metadata`, but what we really want is updating each namespace independently. For example:

```
old options: {"_metadata": {"workflow": {"a":1}}}
new options via ".options": {"_metadata": {"serve": {"b":2}}}
updated options: {"_metadata": {"serve": {"b":2}}}
expected result: {"_metadata": {"workflow": {"a":1}, "serve": {"b":2}}}

old options: {"_metadata": {"workflow": {"a":1}}}
new options via ".options": {"_metadata": {"workflow": {"b":2}}}
updated options: {"_metadata": {"workflow": {"b":2}}}
expected result: {"_metadata": {"workflow": {"a":1, "b":2}}}
```

This PR fixes this issue.

With this fix, we can support the follow syntax for updating workflow options:

```python
@PublicAPI(stability="beta")
class options:
    """This class serves both as a decorator and options for workflow.

    Examples:
        >>> import ray
        >>> from ray import workflow
        >>>
        >>> # specify workflow options with a decorator
        >>> @workflow.options(catch_exceptions=True):
        >>> @ray.remote
        >>> def foo():
        >>>     return 1
        >>>
        >>> # speficy workflow options in ".options"
        >>> foo_new = foo.options(**workflow.options(catch_exceptions=False))
    """

    def __init__(self, **workflow_options: Dict[str, Any]):
        # TODO(suquark): More rigid arguments check like @ray.remote arguments. This is
        # fairly complex, but we should enable it later.
        valid_options = {
            "name",
            "metadata",
            "catch_exceptions",
            "max_retries",
            "allow_inplace",
            "checkpoint",
        }
        invalid_keywords = set(workflow_options.keys()) - valid_options
        if invalid_keywords:
            raise ValueError(
                f"Invalid option keywords {invalid_keywords} for workflow steps. "
                f"Valid ones are {valid_options}."
            )
        from ray.workflow.common import WORKFLOW_OPTIONS

        self.options = {"_metadata": {WORKFLOW_OPTIONS: workflow_options}}

    def keys(self):
        return ("_metadata",)

    def __getitem__(self, key):
        return self.options[key]

    def __call__(self, f: RemoteFunction) -> RemoteFunction:
        if not isinstance(f, RemoteFunction):
            raise ValueError("Only apply 'workflow.options' to Ray remote functions.")
        f._default_options.update(self.options)
        return f
```

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
