### PR TITLE
[Test] Add grace period to long running actor test failure

### DIFF
--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -86,7 +86,13 @@ class Parent(object):
 
     def kill(self):
         # Clean up children.
-        ray.get([child.__ray_terminate__.remote() for child in self.children])
+        try:
+            ray.get([child.__ray_terminate__.remote() for child in self.children])
+        except ray.exceptions.RayActorError as e:
+            # Sleep for 30 more seconds so that drivers will get more
+            # information from GCS when actors are unexpectedly failed.
+            time.sleep(30)
+            raise e
 
 
 parents = [Parent.remote(num_children, death_probability) for _ in range(num_parents)]

--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -91,6 +91,7 @@ class Parent(object):
         except ray.exceptions.RayActorError as e:
             # Sleep for 30 more seconds so that drivers will get more
             # information from GCS when actors are unexpectedly failed.
+            print("Failed to kill a children actor. Error: ", e)
             time.sleep(30)
             raise e
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add 30 seconds grace period before raising an exception from this test failure (https://console.anyscale.com/o/anyscale-internal/projects/prj_2xR6uT6t7jJuu1aCwWMsle/clusters/ses_1FL4g3cMg1wYifWf52tAaWtJ?command-history-section=command_history). What I'd like to see is some sort of error messages are propagated to the driver if this is due to some unexpected issues. 

Note that this PR also adds more detailed exit information to all worker failures, but this is still WIP https://github.com/ray-project/ray/pull/24468

## Related issue number

https://github.com/ray-project/ray/issues/23994

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
