### PR TITLE
[RLlib] R2D2 Replay Buffer API intrgration

### DIFF
--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -8,6 +8,7 @@ from ray.rllib.agents.trainer import Trainer
 from ray.rllib.policy.policy import Policy
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import TrainerConfigDict
+from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,6 @@ R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
         # state outputs of the immediately preceding sequence).
         "zero_init_states": True,
 
-
         # Whether to use the h-function from the paper [1] to scale target
         # values in the R2D2-loss function:
         # h(x) = sign(x)(􏰅|x| + 1 − 1) + εx
@@ -69,6 +69,10 @@ R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
 
         # Update the target network every `target_network_update_freq` steps.
         "target_network_update_freq": 2500,
+
+        # Deprecated keys:
+        # Use config["replay_buffer_config"]["replay_burn_in"] instead
+        "burn_in": DEPRECATED_VALUE
     },
     _allow_unknown_configs=True,
 )

--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -123,7 +123,8 @@ class R2D2Trainer(DQNTrainer):
         # Add the `burn_in` to the Model's max_seq_len.
         # Set the replay sequence length to the max_seq_len of the model.
         config["replay_buffer_config"]["replay_sequence_length"] = (
-            config["burn_in"] + config["model"]["max_seq_len"]
+            config["replay_buffer_config"]["replay_burn_in"]
+            + config["model"]["max_seq_len"]
         )
 
         if config.get("batch_mode") != "complete_episodes":

--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -41,6 +41,14 @@ R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
             # model->max_seq_len + burn_in.
             # Do not set this to any valid value!
             "replay_sequence_length": -1,
+            # If > 0, use the `replay_burn_in` first steps of each replay-sampled
+            # sequence (starting either from all 0.0-values if `zero_init_state=True` or
+            # from the already stored values) to calculate an even more accurate
+            # initial states for the actual sequence (starting after this burn-in
+            # window). In the burn-in case, the actual length of the sequence
+            # used for loss calculation is `n - replay_burn_in` time steps
+            # (n=LSTM’s/attention net’s max_seq_len).
+            "replay_burn_in": 0,
         },
         # If True, assume a zero-initialized state input (no matter where in
         # the episode the sequence is located).
@@ -49,14 +57,7 @@ R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
         # and update that initial state during training (from the internal
         # state outputs of the immediately preceding sequence).
         "zero_init_states": True,
-        # If > 0, use the `burn_in` first steps of each replay-sampled sequence
-        # (starting either from all 0.0-values if `zero_init_state=True` or
-        # from the already stored values) to calculate an even more accurate
-        # initial states for the actual sequence (starting after this burn-in
-        # window). In the burn-in case, the actual length of the sequence
-        # used for loss calculation is `n - burn_in` time steps
-        # (n=LSTM’s/attention net’s max_seq_len).
-        "burn_in": 0,
+
 
         # Whether to use the h-function from the paper [1] to scale target
         # values in the R2D2-loss function:

--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -31,7 +31,6 @@ R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
 
         # === Replay buffer ===
         "replay_buffer_config": {
-            # For now we don't use the new ReplayBuffer API here
             "_enable_replay_buffer_api": True,
             "type": "MultiAgentReplayBuffer",
             # Size of the replay buffer (in sequences, not timesteps).

--- a/rllib/agents/dqn/r2d2.py
+++ b/rllib/agents/dqn/r2d2.py
@@ -32,14 +32,8 @@ R2D2_DEFAULT_CONFIG = Trainer.merge_trainer_configs(
         # === Replay buffer ===
         "replay_buffer_config": {
             # For now we don't use the new ReplayBuffer API here
-            "_enable_replay_buffer_api": False,
+            "_enable_replay_buffer_api": True,
             "type": "MultiAgentReplayBuffer",
-            "prioritized_replay": False,
-            "prioritized_replay_alpha": 0.6,
-            # Beta parameter for sampling from prioritized replay buffer.
-            "prioritized_replay_beta": 0.4,
-            # Epsilon to add to the TD errors when updating priorities.
-            "prioritized_replay_eps": 1e-6,
             # Size of the replay buffer (in sequences, not timesteps).
             "capacity": 100000,
             # Set automatically: The number

--- a/rllib/agents/dqn/r2d2_tf_policy.py
+++ b/rllib/agents/dqn/r2d2_tf_policy.py
@@ -159,7 +159,7 @@ def r2d2_loss(policy: Policy, model, _, train_batch: SampleBatch) -> TensorType:
         # Seq-mask all loss-related terms.
         seq_mask = tf.sequence_mask(train_batch[SampleBatch.SEQ_LENS], T)[:, :-1]
         # Mask away also the burn-in sequence at the beginning.
-        burn_in = policy.config["burn_in"]
+        burn_in = policy.config["replay_buffer_config"]["replay_burn_in"]
         # Making sure, this works for both static graph and eager.
         if burn_in > 0:
             seq_mask = tf.cond(

--- a/rllib/agents/dqn/r2d2_torch_policy.py
+++ b/rllib/agents/dqn/r2d2_torch_policy.py
@@ -170,7 +170,7 @@ def r2d2_loss(policy: Policy, model, _, train_batch: SampleBatch) -> TensorType:
         # Seq-mask all loss-related terms.
         seq_mask = sequence_mask(train_batch[SampleBatch.SEQ_LENS], T)[:, :-1]
         # Mask away also the burn-in sequence at the beginning.
-        burn_in = policy.config["burn_in"]
+        burn_in = policy.config["replay_buffer_config"]["replay_burn_in"]
         if burn_in > 0 and burn_in < T:
             seq_mask[:, :burn_in] = False
 

--- a/rllib/agents/dqn/tests/test_r2d2.py
+++ b/rllib/agents/dqn/tests/test_r2d2.py
@@ -32,7 +32,7 @@ class TestR2D2(unittest.TestCase):
         config["model"]["fcnet_hiddens"] = [32]
         config["model"]["lstm_cell_size"] = 64
 
-        config["burn_in"] = 20
+        config["replay_buffer_config"]["replay_burn_in"] = 20
         config["zero_init_states"] = True
 
         config["dueling"] = False

--- a/rllib/tuned_examples/dqn/stateless-cartpole-r2d2-fake-gpus.yaml
+++ b/rllib/tuned_examples/dqn/stateless-cartpole-r2d2-fake-gpus.yaml
@@ -9,7 +9,8 @@ stateless-cartpole-r2d2:
         framework: tf
         num_workers: 0
         # R2D2 settings.
-        burn_in: 20
+        replay_buffer_config:
+          replay_burn_in: 20
         zero_init_states: true
         #dueling: false
         lr: 0.0005

--- a/rllib/tuned_examples/dqn/stateless-cartpole-r2d2.yaml
+++ b/rllib/tuned_examples/dqn/stateless-cartpole-r2d2.yaml
@@ -9,7 +9,8 @@ stateless-cartpole-r2d2:
         framework: tf
         num_workers: 0
         # R2D2 settings.
-        burn_in: 20
+        replay_buffer_config:
+          replay_burn_in: 20
         zero_init_states: true
         #dueling: false
         lr: 0.0005

--- a/rllib/utils/replay_buffers/multi_agent_replay_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_replay_buffer.py
@@ -122,7 +122,19 @@ class MultiAgentReplayBuffer(ReplayBuffer):
         else:
             self.underlying_buffer_call_args = {}
 
-        self.replay_batch_size = replay_batch_size
+        if replay_sequence_length > 1:
+            self.replay_batch_size = int(
+                max(1, replay_batch_size // replay_sequence_length)
+            )
+            logger.info(
+                "Since replay_sequence_length={} and replay_batch_size={}, "
+                "we will replay {} sequences at a time.".format(
+                    replay_sequence_length, replay_batch_size, self.replay_batch_size
+                )
+            )
+        else:
+            self.replay_batch_size = replay_batch_size
+
         self.replay_starts = learning_starts // num_shards
         self.replay_mode = replay_mode
         self.replay_sequence_length = replay_sequence_length


### PR DESCRIPTION
## Why are these changes needed?

Move R2D2 to new Replay Buffer API

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
