### PR TITLE
[client] fix OOM caused by debug log

### DIFF
--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -557,7 +557,7 @@ class Worker:
     def _call_schedule_for_task(
         self, task: ray_client_pb2.ClientTask, num_returns: int
     ) -> List[Future]:
-        logger.debug("Scheduling %s" % task)
+        logger.debug(f"Scheduling task {task.name} {task.type} {task.payload_id}")
         task.client_id = self._client_id
         if num_returns is None:
             num_returns = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


When this line tries to format the task into the string, it also attempts to format all of the serialized arguments passed to the task, which can be memory intensive, even if the debug log never gets displayed. Switch to only logging the task name, type and payload_id.

Repro script if you want to see how big a difference commenting out the debug log makes (takes up about 8GiB swap on my machine):
```
import ray
import numpy as np
import logging
ray.init("ray://localhost:10001")

@ray.remote
def run_ray_remote(np_array):
    return np_array.shape

a = np.random.random((1024, 1024, 128))  # approx 1GiB
b = run_ray_remote.remote(a) 
c = ray.get(b)
print(c)

```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
