### PR TITLE
[Datasets] mark nightly test `dataset_shuffle_sort_1tb_small_instances` stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3558,8 +3558,6 @@
     test_name: dataset_shuffle_sort_1tb_small_instances
     test_suite: dataset_test
 
-  stable: false
-
   frequency: nightly
   team: core
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test passed the last 6 runs. It should be ready to be marked stable:
<img width="1492" alt="image" src="https://user-images.githubusercontent.com/81660174/166840590-f617b3bb-c578-46df-a333-b5bf8c3d5e3e.png">

A similar test, `dataset_shuffle_random_shuffle_1tb_small_instances`, has failed twice out of the last 6 runs. I will wait a bit longer to troubleshoot / mark it stable.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
