### PR TITLE
[Workflow]Enable auto-config for persistent storage when connecting to existing cluster

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -415,6 +415,14 @@ def get_webui_url_from_internal_kv():
     return ray._private.utils.decode(webui_url) if webui_url is not None else None
 
 
+def get_storage_uri_from_internal_kv():
+    assert ray.experimental.internal_kv._internal_kv_initialized()
+    storage_uri = ray.experimental.internal_kv._internal_kv_get(
+        "storage", namespace=ray_constants.KV_NAMESPACE_SESSION
+    )
+    return ray._private.utils.decode(storage_uri) if storage_uri is not None else None
+
+
 def remaining_processes_alive():
     """See if the remaining processes are alive or not.
 

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -207,9 +207,11 @@ class Node:
         else:
             head_storage_uri = ray._private.services.get_storage_uri_from_internal_kv()
             if storage_uri is not None and storage_uri != head_storage_uri:
-                raise ValueError(f"You are using a storage '{storage_uri}' that is "
-                                 f"different from the storage set up in the cluster: "
-                                 f"'{head_storage_uri}'.")
+                raise ValueError(
+                    f"You are using a storage '{storage_uri}' that is "
+                    f"different from the storage set up in the cluster: "
+                    f"'{head_storage_uri}'."
+                )
             storage._init_storage(head_storage_uri, is_head=False)
 
         # If it is a head node, try validating if

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -201,18 +201,12 @@ class Node:
         self._init_temp()
 
         # Validate and initialize the persistent storage API.
-        storage_uri = ray_params.storage
         if head:
-            storage._init_storage(storage_uri, is_head=True)
+            storage._init_storage(ray_params.storage, is_head=True)
         else:
-            head_storage_uri = ray._private.services.get_storage_uri_from_internal_kv()
-            if storage_uri is not None and storage_uri != head_storage_uri:
-                raise ValueError(
-                    f"You are using a storage '{storage_uri}' that is "
-                    f"different from the storage set up in the cluster: "
-                    f"'{head_storage_uri}'."
-                )
-            storage._init_storage(head_storage_uri, is_head=False)
+            storage._init_storage(
+                ray._private.services.get_storage_uri_from_internal_kv(),
+                is_head=False)
 
         # If it is a head node, try validating if
         # external storage is configurable.

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -201,7 +201,10 @@ class Node:
         self._init_temp()
 
         # Validate and initialize the persistent storage API.
-        storage._init_storage(ray_params.storage, is_head=head)
+        if head:
+            storage._init_storage(ray_params.storage, is_head=True)
+        else:
+            storage._init_storage(ray._private.services.get_storage_uri_from_internal_kv(), is_head=False)
 
         # If it is a head node, try validating if
         # external storage is configurable.
@@ -283,6 +286,12 @@ class Node:
             self.get_gcs_client().internal_kv_put(
                 b"temp_dir",
                 self._temp_dir.encode(),
+                True,
+                ray_constants.KV_NAMESPACE_SESSION,
+            )
+            self.get_gcs_client().internal_kv_put(
+                b"storage",
+                ray_params.storage.encode(),
                 True,
                 ray_constants.KV_NAMESPACE_SESSION,
             )

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -201,10 +201,16 @@ class Node:
         self._init_temp()
 
         # Validate and initialize the persistent storage API.
+        storage_uri = ray_params.storage
         if head:
-            storage._init_storage(ray_params.storage, is_head=True)
+            storage._init_storage(storage_uri, is_head=True)
         else:
-            storage._init_storage(ray._private.services.get_storage_uri_from_internal_kv(), is_head=False)
+            head_storage_uri = ray._private.services.get_storage_uri_from_internal_kv()
+            if storage_uri is not None and storage_uri != head_storage_uri:
+                raise ValueError(f"You are using a storage '{storage_uri}' that is "
+                                 f"different from the storage set up in the cluster: "
+                                 f"'{head_storage_uri}'.")
+            storage._init_storage(head_storage_uri, is_head=False)
 
         # If it is a head node, try validating if
         # external storage is configurable.

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -205,8 +205,8 @@ class Node:
             storage._init_storage(ray_params.storage, is_head=True)
         else:
             storage._init_storage(
-                ray._private.services.get_storage_uri_from_internal_kv(),
-                is_head=False)
+                ray._private.services.get_storage_uri_from_internal_kv(), is_head=False
+            )
 
         # If it is a head node, try validating if
         # external storage is configurable.

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -291,12 +291,13 @@ class Node:
                 True,
                 ray_constants.KV_NAMESPACE_SESSION,
             )
-            self.get_gcs_client().internal_kv_put(
-                b"storage",
-                ray_params.storage.encode(),
-                True,
-                ray_constants.KV_NAMESPACE_SESSION,
-            )
+            if ray_params.storage is not None:
+                self.get_gcs_client().internal_kv_put(
+                    b"storage",
+                    ray_params.storage.encode(),
+                    True,
+                    ray_constants.KV_NAMESPACE_SESSION,
+                )
             # Add tracing_startup_hook to redis / internal kv manually
             # since internal kv is not yet initialized.
             if ray_params.tracing_startup_hook:

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -3,6 +3,7 @@ import urllib
 from pathlib import Path
 import pyarrow.fs
 import pytest
+import subprocess
 
 import ray
 import ray.internal.storage as storage

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -158,6 +158,7 @@ def test_connecting_to_cluster(shutdown_only, storage_type):
             subprocess.check_call(["ray", "start", "--head", "--storage", storage_uri])
             ray.init(address="auto")
             from ray.internal.storage import _storage_uri
+
             # make sure driver is using the same storage when connecting to a cluster
             assert _storage_uri == storage_uri
         finally:

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -150,6 +150,18 @@ def test_get_info_basic(shutdown_only, storage_type):
         assert client.get_info("").base_name == "ns"
 
 
+@pytest.mark.parametrize("storage_type", ["s3", "fs"])
+def test_cluster(shutdown_only, storage_type):
+    with simulate_storage(storage_type) as storage_uri:
+        subprocess.check_call(["ray", "start", "--head", "--storage", storage_uri])
+        # make sure driver is using the same storage when
+        # connecting to a cluster
+        ray.init(address="auto")
+        from ray.internal.storage import _storage_uri
+        assert _storage_uri == storage_uri
+        subprocess.check_call(["ray", "stop"])
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -154,8 +154,7 @@ def test_get_info_basic(shutdown_only, storage_type):
 def test_cluster(shutdown_only, storage_type):
     with simulate_storage(storage_type) as storage_uri:
         subprocess.check_call(["ray", "start", "--head", "--storage", storage_uri])
-        # make sure driver is using the same storage when
-        # connecting to a cluster
+        # make sure driver is using the same storage when connecting to a cluster
         ray.init(address="auto")
         from ray.internal.storage import _storage_uri
 

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -152,15 +152,16 @@ def test_get_info_basic(shutdown_only, storage_type):
 
 
 @pytest.mark.parametrize("storage_type", ["s3", "fs"])
-def test_cluster(shutdown_only, storage_type):
+def test_connecting_to_cluster(shutdown_only, storage_type):
     with simulate_storage(storage_type) as storage_uri:
-        subprocess.check_call(["ray", "start", "--head", "--storage", storage_uri])
-        # make sure driver is using the same storage when connecting to a cluster
-        ray.init(address="auto")
-        from ray.internal.storage import _storage_uri
-
-        assert _storage_uri == storage_uri
-        subprocess.check_call(["ray", "stop"])
+        try:
+            subprocess.check_call(["ray", "start", "--head", "--storage", storage_uri])
+            ray.init(address="auto")
+            from ray.internal.storage import _storage_uri
+            # make sure driver is using the same storage when connecting to a cluster
+            assert _storage_uri == storage_uri
+        finally:
+            subprocess.check_call(["ray", "stop"])
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -158,6 +158,7 @@ def test_cluster(shutdown_only, storage_type):
         # connecting to a cluster
         ray.init(address="auto")
         from ray.internal.storage import _storage_uri
+
         assert _storage_uri == storage_uri
         subprocess.check_call(["ray", "stop"])
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1064,6 +1064,11 @@ def init(
                 "When connecting to an existing cluster, "
                 "object_store_memory must not be provided."
             )
+        if storage is not None:
+            raise ValueError(
+                "When connecting to an existing cluster, "
+                "storage must not be provided."
+            )
         if _system_config is not None and len(_system_config) != 0:
             raise ValueError(
                 "When connecting to an existing cluster, "
@@ -1088,7 +1093,6 @@ def init(
             redis_address=redis_address,
             redis_password=_redis_password,
             object_ref_seed=None,
-            storage=storage,
             temp_dir=_temp_dir,
             _system_config=_system_config,
             enable_object_reconstruction=_enable_object_reconstruction,

--- a/python/ray/workflow/tests/test_lifetime.py
+++ b/python/ray/workflow/tests/test_lifetime.py
@@ -26,7 +26,7 @@ def foo(x):
 
 
 if __name__ == "__main__":
-    ray.init(storage="{}")
+    ray.init()
     output = workflow.create(foo.bind(0)).run_async(workflow_id="driver_terminated")
     time.sleep({})
 """
@@ -36,8 +36,8 @@ def test_workflow_lifetime_1(workflow_start_cluster):
     # Case 1: driver exits normally
     address, storage_uri = workflow_start_cluster
     with patch.dict(os.environ, {"RAY_ADDRESS": address}):
-        ray.init(storage=storage_uri)
-        run_string_as_driver(driver_script.format(storage_uri, 5))
+        ray.init()
+        run_string_as_driver(driver_script.format(5))
         output = workflow.get_output("driver_terminated")
         assert ray.get(output) == 20
 
@@ -46,8 +46,8 @@ def test_workflow_lifetime_2(workflow_start_cluster):
     # Case 2: driver terminated
     address, storage_uri = workflow_start_cluster
     with patch.dict(os.environ, {"RAY_ADDRESS": address}):
-        ray.init(storage=storage_uri)
-        proc = run_string_as_driver_nonblocking(driver_script.format(storage_uri, 100))
+        ray.init()
+        proc = run_string_as_driver_nonblocking(driver_script.format(100))
         time.sleep(10)
         proc.kill()
         time.sleep(1)

--- a/python/ray/workflow/tests/test_logging.py
+++ b/python/ray/workflow/tests/test_logging.py
@@ -8,7 +8,7 @@ def test_basic_workflow_logs(workflow_start_regular):
 import ray
 from ray import workflow
 
-ray.init(address='auto', storage="{_storage_uri}")
+ray.init(address='auto')
 
 @workflow.step(name="f")
 def f():
@@ -35,7 +35,7 @@ def test_chained_workflow_logs(workflow_start_regular):
 import ray
 from ray import workflow
 
-ray.init(address='auto', storage="{_storage_uri}")
+ray.init(address='auto')
 
 @workflow.step(name="f1")
 def f1():
@@ -68,7 +68,7 @@ def test_dynamic_workflow_logs(workflow_start_regular):
 import ray
 from ray import workflow
 
-ray.init(address='auto', storage="{_storage_uri}")
+ray.init(address='auto')
 
 @workflow.step(name="f3")
 def f3(x):
@@ -101,7 +101,7 @@ def test_virtual_actor_logs(workflow_start_regular):
 import ray
 from ray import workflow
 
-ray.init(address='auto', storage="{_storage_uri}")
+ray.init(address='auto')
 
 @workflow.virtual_actor
 class Counter:

--- a/python/ray/workflow/tests/test_logging.py
+++ b/python/ray/workflow/tests/test_logging.py
@@ -2,7 +2,7 @@ from ray._private.test_utils import run_string_as_driver_nonblocking
 
 
 def test_basic_workflow_logs(workflow_start_regular):
-    script = f"""
+    script = """
 import ray
 from ray import workflow
 
@@ -27,7 +27,7 @@ f.step().run("wid")
 
 
 def test_chained_workflow_logs(workflow_start_regular):
-    script = f"""
+    script = """
 import ray
 from ray import workflow
 
@@ -58,7 +58,7 @@ f2.step(f1.step()).run("wid1")
 
 
 def test_dynamic_workflow_logs(workflow_start_regular):
-    script = f"""
+    script = """
 import ray
 from ray import workflow
 
@@ -89,7 +89,7 @@ f4.step(10).run("wid2")
 
 
 def test_virtual_actor_logs(workflow_start_regular):
-    script = f"""
+    script = """
 import ray
 from ray import workflow
 

--- a/python/ray/workflow/tests/test_logging.py
+++ b/python/ray/workflow/tests/test_logging.py
@@ -2,8 +2,6 @@ from ray._private.test_utils import run_string_as_driver_nonblocking
 
 
 def test_basic_workflow_logs(workflow_start_regular):
-    from ray.internal.storage import _storage_uri
-
     script = f"""
 import ray
 from ray import workflow
@@ -29,8 +27,6 @@ f.step().run("wid")
 
 
 def test_chained_workflow_logs(workflow_start_regular):
-    from ray.internal.storage import _storage_uri
-
     script = f"""
 import ray
 from ray import workflow
@@ -62,8 +58,6 @@ f2.step(f1.step()).run("wid1")
 
 
 def test_dynamic_workflow_logs(workflow_start_regular):
-    from ray.internal.storage import _storage_uri
-
     script = f"""
 import ray
 from ray import workflow
@@ -95,8 +89,6 @@ f4.step(10).run("wid2")
 
 
 def test_virtual_actor_logs(workflow_start_regular):
-    from ray.internal.storage import _storage_uri
-
     script = f"""
 import ray
 from ray import workflow

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -238,7 +238,9 @@ f.step().run()
     script1 = script.format("ray.init(address='auto')")
     script2 = script.format(f"ray.init(address='auto', storage='{tmp_path}')")
     another_tmp_path = tempfile.TemporaryDirectory()
-    script3 = script.format(f"ray.init(address='auto', storage='{another_tmp_path.name}')")
+    script3 = script.format(
+        f"ray.init(address='auto', storage='{another_tmp_path.name}')"
+    )
 
     proc1 = run_string_as_driver_nonblocking(script1)
     out_str1 = proc1.stdout.read().decode("ascii") + proc1.stderr.read().decode("ascii")
@@ -256,7 +258,6 @@ f.step().run()
     proc3.kill()
     another_tmp_path.cleanup()
     subprocess.check_call(["ray", "stop"])
-
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -1,7 +1,7 @@
 import pytest
 import ray
 from ray._private import signature
-from ray._private.test_utils import run_string_as_driver_nonblocking, simulate_storage
+from ray._private.test_utils import simulate_storage
 from ray.tests.conftest import *  # noqa
 from ray import workflow
 from ray.workflow import workflow_storage
@@ -11,7 +11,6 @@ from ray.workflow.common import (
     WorkflowNotFoundError,
 )
 from ray.workflow.tests import utils
-import tempfile
 import subprocess
 import time
 

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -11,6 +11,7 @@ from ray.workflow.common import (
     WorkflowNotFoundError,
 )
 from ray.workflow.tests import utils
+import tempfile
 import subprocess
 import time
 
@@ -241,7 +242,10 @@ f.step().run()
     script3 = script.format(
         f"ray.init(address='auto', storage='{another_tmp_path.name}')"
     )
-    err_str = "ValueError: When connecting to an existing cluster, storage must not be provided."
+    err_str = (
+        "ValueError: When connecting to an existing cluster, "
+        "storage must not be provided."
+    )
 
     proc1 = run_string_as_driver_nonblocking(script1)
     out_str1 = proc1.stdout.read().decode("ascii") + proc1.stderr.read().decode("ascii")

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -221,29 +221,25 @@ def test_workflow_storage(workflow_start_regular):
     assert not inspect_result.is_recoverable()
 
 
-def test_cluster_storage_init(storage_type, tmp_path):
-    with simulate_storage(storage_type) as storage_uri:
-        subprocess.check_call(["ray", "start", "--head", "--storage", storage_uri])
+def test_cluster_storage_init(workflow_start_cluster, tmp_path):
+    address, storage_uri = workflow_start_cluster
 
-        err_msg = "When connecting to an existing cluster, "
-        "storage must not be provided."
+    err_msg = "When connecting to an existing cluster, "
+    "storage must not be provided."
 
-        with pytest.raises(ValueError, match=err_msg):
-            ray.init(address="auto", storage=str(tmp_path))
+    with pytest.raises(ValueError, match=err_msg):
+        ray.init(address=address, storage=str(tmp_path))
 
-        with pytest.raises(ValueError, match=err_msg):
-            ray.init(address="auto", storage=storage_uri)
+    with pytest.raises(ValueError, match=err_msg):
+        ray.init(address=address, storage=storage_uri)
 
-        ray.init(address="auto")
+    ray.init(address=address)
 
-        @workflow.step
-        def f():
-            return 10
+    @workflow.step
+    def f():
+        return 10
 
-        assert f.step().run() == 10
-
-        ray.shutdown()
-        subprocess.check_call(["ray", "stop"])
+    assert f.step().run() == 10
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -241,20 +241,21 @@ f.step().run()
     script3 = script.format(
         f"ray.init(address='auto', storage='{another_tmp_path.name}')"
     )
+    err_str = "ValueError: When connecting to an existing cluster, storage must not be provided."
 
     proc1 = run_string_as_driver_nonblocking(script1)
     out_str1 = proc1.stdout.read().decode("ascii") + proc1.stderr.read().decode("ascii")
-    assert "ValueError" not in out_str1
+    assert err_str not in out_str1
     proc1.kill()
 
     proc2 = run_string_as_driver_nonblocking(script2)
     out_str2 = proc2.stdout.read().decode("ascii") + proc2.stderr.read().decode("ascii")
-    assert "ValueError" not in out_str2
+    assert err_str in out_str2
     proc2.kill()
 
     proc3 = run_string_as_driver_nonblocking(script3)
     out_str3 = proc3.stdout.read().decode("ascii") + proc3.stderr.read().decode("ascii")
-    assert "ValueError" in out_str3
+    assert err_str in out_str3
     proc3.kill()
     another_tmp_path.cleanup()
     subprocess.check_call(["ray", "stop"])

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -236,9 +236,11 @@ def test_cluster_storage_init(storage_type, tmp_path):
             ray.init(address="auto", storage=storage_uri)
 
         ray.init(address="auto")
+
         @workflow.step
         def f():
             return 10
+
         assert f.step().run() == 10
 
         ray.shutdown()

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -1,7 +1,6 @@
 import pytest
 import ray
 from ray._private import signature
-from ray._private.test_utils import simulate_storage
 from ray.tests.conftest import *  # noqa
 from ray import workflow
 from ray.workflow import workflow_storage


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently it is required to set `storage` parameter (i.e. persistent storage) inside all `ray.init()` calls in order to use persistent storage (e.g. workflow), even it is connecting to an existing cluster (e.g. `address="auto"`) that has storage already set up.

This behavior can be less preferred because:
1. users might not have the info on which storage is used in the existing cluster that they are connecting, and we should let them to use the simple `ray.init(address="auto")` to connect to the cluster and use the already-set-up storage.
2. It doesn't make much sense to enforce inputting the identical storage URI when ray init is called in non-head processes.

### New Behavior
1. storage is only required when creating a new cluster.
2. we will throw error if storage is given when connecting to an existing cluster.

### Implementation
When creating a new cluster, after head is started, we will put storage uri in kv store.  When connecting to the cluster, we will fetch this value and use it to do `_init_storage` to push value to `_storage_uri` so the new process is aware of the storage.



## Related issue number

https://github.com/ray-project/ray/issues/24394

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
