### PR TITLE
[Shuffle][nightly-test] enable push based shuffle for 1.5tb data

### DIFF
--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -67,9 +67,9 @@ You can install the nightly Ray wheels via the following links. These daily rele
 .. _`MacOS Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-macosx_10_15_intel.whl
 .. _`MacOS Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp36-cp36m-macosx_10_15_intel.whl
 
-.. _`Windows Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-win_amd64.whl
-.. _`Windows Python 3.8`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-win_amd64.whl
-.. _`Windows Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-win_amd64.whl
+.. _`Windows Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp39-cp39-win_amd64.whl
+.. _`Windows Python 3.8`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-win_amd64.whl
+.. _`Windows Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-win_amd64.whl
 
 Installing from a specific commit
 ---------------------------------

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -16,6 +16,9 @@ ARG PYTHON_VERSION=3.7.7
 ARG RAY_UID=1000
 ARG RAY_GID=100
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub
+
 RUN apt-get update -y \
     && apt-get install -y sudo tzdata \
     && useradd -ms /bin/bash -d /home/ray ray --uid $RAY_UID --gid $RAY_GID \

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -17,8 +17,8 @@ head_node_type:
 worker_node_types:
     - name: memory_node
       instance_type: m5.4xlarge
-      min_workers: 40
-      max_workers: 40
+      min_workers: 20
+      max_workers: 20
       use_spot: false
     - name: gpu_node
       instance_type: m5.4xlarge

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -17,8 +17,8 @@ head_node_type:
 worker_node_types:
     - name: memory_node
       instance_type: m5.4xlarge
-      min_workers: 60
-      max_workers: 60
+      min_workers: 40
+      max_workers: 40
       use_spot: false
     - name: gpu_node
       instance_type: m5.4xlarge

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -12,16 +12,16 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: i3.8xlarge
+    instance_type: m5.4xlarge
 
 worker_node_types:
     - name: memory_node
-      instance_type: i3.8xlarge
+      instance_type: m5.4xlarge
       min_workers: 40
       max_workers: 40
       use_spot: false
     - name: gpu_node
-      instance_type: i3.8xlarge
+      instance_type: m5.4xlarge
       min_workers: 4
       max_workers: 4
       use_spot: false

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -17,8 +17,8 @@ head_node_type:
 worker_node_types:
     - name: memory_node
       instance_type: i3.8xlarge
-      min_workers: 20
-      max_workers: 20
+      min_workers: 40
+      max_workers: 40
       use_spot: false
     - name: gpu_node
       instance_type: i3.8xlarge

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -17,8 +17,8 @@ head_node_type:
 worker_node_types:
     - name: memory_node
       instance_type: m5.4xlarge
-      min_workers: 40
-      max_workers: 40
+      min_workers: 60
+      max_workers: 60
       use_spot: false
     - name: gpu_node
       instance_type: m5.4xlarge

--- a/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_compute.yaml
@@ -20,6 +20,9 @@ worker_node_types:
       min_workers: 20
       max_workers: 20
       use_spot: false
+      resources:
+        cpu: 8
+        gpu: 0
     - name: gpu_node
       instance_type: m5.4xlarge
       min_workers: 4

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -261,7 +261,9 @@ def create_dataset(
         if num_windows > 1:
             window_size = max(ds.num_blocks() // num_windows, 1)
             ds = ds.window(blocks_per_window=window_size)
+        print("start repartition")
         ds = ds.repartition(num_blocks=2000)
+        print("repartition done")
         pipe = ds.repeat(epochs)
         pipe = pipe.random_shuffle_each_window()
         pipe_shards = pipe.split(num_workers, equal=True)

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -250,7 +250,6 @@ def create_dataset(
                 return lambda: ray.data.read_parquet(list(split))
 
         pipe = DatasetPipeline.from_iterable(Windower())
-        pipe = pipe.repartition(num_blocks=2000)
         split_indices = [
             i * num_rows // num_windows // num_workers for i in range(1, num_workers)
         ]
@@ -261,9 +260,6 @@ def create_dataset(
         if num_windows > 1:
             window_size = max(ds.num_blocks() // num_windows, 1)
             ds = ds.window(blocks_per_window=window_size)
-        print("start repartition")
-        ds = ds.repartition(num_blocks=2000)
-        print("repartition done")
         print(f"total data size: {ds.size_bytes()}")
         pipe = ds.repeat(epochs)
         pipe = pipe.random_shuffle_each_window()
@@ -289,10 +285,16 @@ if __name__ == "__main__":
 
     num = args.num_files
 
+    # files = [
+    #     f"s3://shuffling-data-loader-benchmarks/data/r10_000_000_000-f1000"
+    #     f"/input_data_{i}.parquet.snappy"
+    #     for i in range(args.num_files)
+    # ]
+
     files = [
-        f"s3://shuffling-data-loader-benchmarks/data/r10_000_000_000-f1000"
-        f"/input_data_{i}.parquet.snappy"
-        for i in range(args.num_files)
+        f"s3://shuffling-data-loader-benchmarks/data/100mb"
+        f"/input_data_{0}.parquet.snappy"
+        for _ in range(args.num_files)
     ]
 
     start = time.time()

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -264,6 +264,7 @@ def create_dataset(
         print("start repartition")
         ds = ds.repartition(num_blocks=2000)
         print("repartition done")
+        print(f"total data size: {ds.size_bytes()}")
         pipe = ds.repeat(epochs)
         pipe = pipe.random_shuffle_each_window()
         pipe_shards = pipe.split(num_workers, equal=True)

--- a/release/nightly_tests/dataset/pipelined_training.py
+++ b/release/nightly_tests/dataset/pipelined_training.py
@@ -250,6 +250,7 @@ def create_dataset(
                 return lambda: ray.data.read_parquet(list(split))
 
         pipe = DatasetPipeline.from_iterable(Windower())
+        pipe = pipe.repartition(num_blocks=2000)
         split_indices = [
             i * num_rows // num_windows // num_workers for i in range(1, num_workers)
         ]
@@ -260,6 +261,7 @@ def create_dataset(
         if num_windows > 1:
             window_size = max(ds.num_blocks() // num_windows, 1)
             ds = ds.window(blocks_per_window=window_size)
+        ds = ds.repartition(num_blocks=2000)
         pipe = ds.repeat(epochs)
         pipe = pipe.random_shuffle_each_window()
         pipe_shards = pipe.split(num_workers, equal=True)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3334,7 +3334,7 @@
       --debug
 
     wait_for_nodes:
-      num_nodes: 41
+      num_nodes: 21
 
     type: sdk_command
     file_manager: sdk

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3334,7 +3334,7 @@
       --debug
 
     wait_for_nodes:
-      num_nodes: 21
+      num_nodes: 61
 
     type: sdk_command
     file_manager: sdk

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3330,7 +3330,7 @@
 
   run:
     timeout: 9600
-    script: python pipelined_training.py --epochs 2 --num-windows 2 --num-files 915
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python pipelined_training.py --epochs 2 --num-windows 1 --num-files 915
       --debug
 
     wait_for_nodes:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3334,7 +3334,7 @@
       --debug
 
     wait_for_nodes:
-      num_nodes: 61
+      num_nodes: 41
 
     type: sdk_command
     file_manager: sdk

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3315,7 +3315,7 @@
     type: sdk_command
     file_manager: sdk
 
-- name: pipelined_ingestion_1500_gb
+- name: pipelined_ingestion_1000_gb
   group: core-dataset-tests
   working_dir: nightly_tests/dataset
   legacy:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3330,7 +3330,7 @@
 
   run:
     timeout: 9600
-    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python pipelined_training.py --epochs 2 --num-windows 1 --num-files 915
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python pipelined_training.py --epochs 2 --num-windows 1 --num-files 620
       --debug
 
     wait_for_nodes:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3330,7 +3330,7 @@
 
   run:
     timeout: 9600
-    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python pipelined_training.py --epochs 2 --num-windows 1 --num-files 620
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python pipelined_training.py --epochs 1 --num-windows 1 --num-files 3000 
       --debug
 
     wait_for_nodes:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Enable push based shuffle for 1.5tb dataset with a single window.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests running here: https://console.anyscale.com/o/anyscale-internal/configurations/app-config-details/bld_kSKYk1ED2NeNUatAXEtAiFVh
   - [ ] This PR is not tested :(
