### PR TITLE
[workflow] Defining and updating workflow options

### DIFF
--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -358,7 +358,7 @@ def test_workflow_error_message():
     assert str(e.value) == expected_error_msg
 
 
-def test_options_update(workflow_start_regular_shared):
+def test_options_update():
     from ray.workflow.common import WORKFLOW_OPTIONS
 
     # Options are given in decorator first, then in the first .options()
@@ -373,19 +373,18 @@ def test_options_update(workflow_start_regular_shared):
     # metadata and ray_options are "updated"
     # max_retries only defined in the decorator and it got preserved all the way
     new_f = f.options(
-        **workflow.options(
-            name="new_name", num_returns=2, metadata={"extra_k2": "extra_v2"}
-        )
+        num_returns=2,
+        **workflow.options(name="new_name", metadata={"extra_k2": "extra_v2"}),
     )
     options = new_f.bind().get_options()
     assert options == {
         "num_cpus": 2,
+        "num_returns": 2,
         "_metadata": {
             WORKFLOW_OPTIONS: {
                 "name": "new_name",
                 "metadata": {"extra_k2": "extra_v2"},
                 "max_retries": 1,
-                "num_returns": 2,
             }
         },
     }

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -7,7 +7,6 @@ import pytest
 import ray
 from ray import workflow
 from ray.workflow import workflow_access
-from ray.workflow.tests.utils import update_workflow_options
 
 
 def test_basic_workflows(workflow_start_regular_shared):
@@ -208,29 +207,31 @@ def test_step_failure(workflow_start_regular_shared, tmp_path):
         return v
 
     with pytest.raises(Exception):
-        workflow.create(update_workflow_options(unstable_step, max_retries=-2).bind())
+        workflow.create(
+            unstable_step.options(**workflow.options(max_retries=-2).bind())
+        )
 
     with pytest.raises(Exception):
         workflow.create(
-            update_workflow_options(unstable_step, max_retries=2).bind()
+            unstable_step.options(**workflow.options(max_retries=2)).bind()
         ).run()
     assert (
         10
         == workflow.create(
-            update_workflow_options(unstable_step, max_retries=7).bind()
+            unstable_step.options(**workflow.options(max_retries=7)).bind()
         ).run()
     )
     (tmp_path / "test").write_text("0")
     (ret, err) = workflow.create(
-        update_workflow_options(
-            unstable_step, max_retries=2, catch_exceptions=True
+        unstable_step.options(
+            **workflow.options(max_retries=2, catch_exceptions=True)
         ).bind()
     ).run()
     assert ret is None
     assert isinstance(err, ValueError)
     (ret, err) = workflow.create(
-        update_workflow_options(
-            unstable_step, max_retries=7, catch_exceptions=True
+        unstable_step.options(
+            **workflow.options(max_retries=7, catch_exceptions=True)
         ).bind()
     ).run()
     assert ret == 10
@@ -293,7 +294,7 @@ def test_nested_catch_exception(workflow_start_regular_shared, tmp_path):
         return workflow.continuation(f2.bind())
 
     assert (10, None) == workflow.create(
-        update_workflow_options(f1, catch_exceptions=True).bind()
+        f1.options(**workflow.options(catch_exceptions=True)).bind()
     ).run()
 
 
@@ -306,7 +307,7 @@ def test_nested_catch_exception_2(workflow_start_regular_shared, tmp_path):
             return workflow.continuation(f1.bind(n - 1))
 
     ret, err = workflow.create(
-        update_workflow_options(f1, catch_exceptions=True).bind(5)
+        f1.options(**workflow.options(catch_exceptions=True)).bind(5)
     ).run()
     assert ret is None
     assert isinstance(err, ValueError)
@@ -319,7 +320,7 @@ def test_dynamic_output(workflow_start_regular_shared):
             if n < 3:
                 raise Exception("Failed intentionally")
             return workflow.continuation(
-                update_workflow_options(exponential_fail, name=f"step_{n}").bind(
+                exponential_fail.options(**workflow.options(name=f"step_{n}")).bind(
                     k * 2, n - 1
                 )
             )
@@ -329,7 +330,7 @@ def test_dynamic_output(workflow_start_regular_shared):
     # latest successful step.
     try:
         workflow.create(
-            update_workflow_options(exponential_fail, name="step_0").bind(3, 10)
+            exponential_fail.options(**workflow.options(name="step_0")).bind(3, 10)
         ).run(workflow_id="dynamic_output")
     except Exception:
         pass
@@ -371,8 +372,10 @@ def test_options_update(workflow_start_regular_shared):
     # .options(), then preserved in the second options.
     # metadata and ray_options are "updated"
     # max_retries only defined in the decorator and it got preserved all the way
-    new_f = update_workflow_options(
-        f, name="new_name", num_returns=2, metadata={"extra_k2": "extra_v2"}
+    new_f = f.options(
+        **workflow.options(
+            name="new_name", num_returns=2, metadata={"extra_k2": "extra_v2"}
+        )
     )
     options = new_f.bind().get_options()
     assert options == {

--- a/python/ray/workflow/tests/test_checkpoint.py
+++ b/python/ray/workflow/tests/test_checkpoint.py
@@ -28,7 +28,7 @@ def checkpoint_dag(checkpoint):
         **workflow.options(name="identity", checkpoint=checkpoint)
     ).bind(x)
     return workflow.continuation(
-        average.options(workflow.options(name="average")).bind(y)
+        average.options(**workflow.options(name="average")).bind(y)
     )
 
 

--- a/python/ray/workflow/tests/test_checkpoint.py
+++ b/python/ray/workflow/tests/test_checkpoint.py
@@ -4,7 +4,6 @@ from ray.tests.conftest import *  # noqa
 
 import numpy as np
 from ray import workflow
-from ray.workflow.tests import utils
 from ray.workflow import workflow_storage
 
 
@@ -22,14 +21,14 @@ def checkpoint_dag(checkpoint):
     def average(x):
         return np.mean(x)
 
-    x = utils.update_workflow_options(
-        large_input, name="large_input", checkpoint=checkpoint
+    x = large_input.options(
+        **workflow.options(name="large_input", checkpoint=checkpoint)
     ).bind()
-    y = utils.update_workflow_options(
-        identity, name="identity", checkpoint=checkpoint
+    y = identity.options(
+        **workflow.options(name="identity", checkpoint=checkpoint)
     ).bind(x)
     return workflow.continuation(
-        utils.update_workflow_options(average, name="average").bind(y)
+        average.options(workflow.options(name="average")).bind(y)
     )
 
 
@@ -54,13 +53,11 @@ def _assert_step_checkpoints(wf_storage, step_id, mode):
 
 
 def test_checkpoint_dag_skip_all(workflow_start_regular_shared):
-    outputs = utils.run_workflow_dag_with_options(
-        checkpoint_dag,
-        (False,),
-        workflow_id="checkpoint_skip",
-        name="checkpoint_dag",
-        checkpoint=False,
-    )
+    outputs = workflow.create(
+        checkpoint_dag.options(
+            **workflow.options(name="checkpoint_dag", checkpoint=False)
+        ).bind(False)
+    ).run(workflow_id="checkpoint_skip")
     assert np.isclose(outputs, 8388607.5)
     recovered = ray.get(workflow.resume("checkpoint_skip"))
     assert np.isclose(recovered, 8388607.5)
@@ -73,12 +70,9 @@ def test_checkpoint_dag_skip_all(workflow_start_regular_shared):
 
 
 def test_checkpoint_dag_skip_partial(workflow_start_regular_shared):
-    outputs = utils.run_workflow_dag_with_options(
-        checkpoint_dag,
-        (False,),
-        workflow_id="checkpoint_partial",
-        name="checkpoint_dag",
-    )
+    outputs = workflow.create(
+        checkpoint_dag.options(**workflow.options(name="checkpoint_dag")).bind(False)
+    ).run(workflow_id="checkpoint_partial")
     assert np.isclose(outputs, 8388607.5)
     recovered = ray.get(workflow.resume("checkpoint_partial"))
     assert np.isclose(recovered, 8388607.5)
@@ -91,9 +85,9 @@ def test_checkpoint_dag_skip_partial(workflow_start_regular_shared):
 
 
 def test_checkpoint_dag_full(workflow_start_regular_shared):
-    outputs = utils.run_workflow_dag_with_options(
-        checkpoint_dag, (True,), workflow_id="checkpoint_whole", name="checkpoint_dag"
-    )
+    outputs = workflow.create(
+        checkpoint_dag.options(**workflow.options(name="checkpoint_dag")).bind(True)
+    ).run(workflow_id="checkpoint_whole")
     assert np.isclose(outputs, 8388607.5)
     recovered = ray.get(workflow.resume("checkpoint_whole"))
     assert np.isclose(recovered, 8388607.5)

--- a/python/ray/workflow/tests/test_inplace_workflows.py
+++ b/python/ray/workflow/tests/test_inplace_workflows.py
@@ -3,7 +3,6 @@ from ray.tests.conftest import *  # noqa
 
 import pytest
 from ray import workflow
-from ray.workflow.tests.utils import update_workflow_options
 
 
 @ray.remote
@@ -21,11 +20,13 @@ def inplace_test():
     from ray.worker import global_worker
 
     worker_id = global_worker.worker_id
-    x = update_workflow_options(check_and_update, allow_inplace=True).bind(
+    x = check_and_update.options(**workflow.options(allow_inplace=True)).bind(
         "@", worker_id
     )
     y = check_and_update.bind(x, worker_id)
-    z = update_workflow_options(check_and_update, allow_inplace=True).bind(y, worker_id)
+    z = check_and_update.options(**workflow.options(allow_inplace=True)).bind(
+        y, worker_id
+    )
     return workflow.continuation(z)
 
 
@@ -42,7 +43,7 @@ def exp_inplace(k, n, worker_id=None):
     if n == 0:
         return k
     return workflow.continuation(
-        update_workflow_options(exp_inplace, allow_inplace=True).bind(
+        exp_inplace.options(**workflow.options(allow_inplace=True)).bind(
             2 * k, n - 1, worker_id
         )
     )
@@ -81,7 +82,7 @@ def test_tail_recursion_optimization(workflow_start_regular_shared):
         if n <= 0:
             return "ok"
         return workflow.continuation(
-            update_workflow_options(tail_recursion, allow_inplace=True).bind(n - 1)
+            tail_recursion.options(**workflow.options(allow_inplace=True)).bind(n - 1)
         )
 
     workflow.create(tail_recursion.bind(30)).run()

--- a/python/ray/workflow/tests/test_metadata.py
+++ b/python/ray/workflow/tests/test_metadata.py
@@ -5,7 +5,6 @@ from ray.tests.conftest import *  # noqa
 import pytest
 import ray
 from ray import workflow
-from ray.workflow.tests.utils import update_workflow_options
 
 
 def test_user_metadata(workflow_start_regular):
@@ -51,7 +50,7 @@ def test_user_metadata_not_dict(workflow_start_regular):
         return 0
 
     with pytest.raises(ValueError):
-        workflow.create(update_workflow_options(simple, metadata="x").bind())
+        workflow.create(simple.options(**workflow.options(metadata="x")).bind())
 
     with pytest.raises(ValueError):
         workflow.create(simple.bind()).run(metadata="x")
@@ -66,7 +65,7 @@ def test_user_metadata_not_json_serializable(workflow_start_regular):
         pass
 
     with pytest.raises(ValueError):
-        workflow.create(update_workflow_options(simple, metadata={"x": X()}).bind())
+        workflow.create(simple.options(**workflow.options(metadata={"x": X()})).bind())
 
     with pytest.raises(ValueError):
         workflow.create(simple.bind()).run(metadata={"x": X()})

--- a/python/ray/workflow/tests/utils.py
+++ b/python/ray/workflow/tests/utils.py
@@ -1,10 +1,6 @@
 import pathlib
 import tempfile
 
-from ray.remote_function import RemoteFunction
-from ray import workflow
-from ray.workflow.common import WORKFLOW_OPTIONS
-
 _GLOBAL_MARK_PATH = pathlib.Path(tempfile.gettempdir())
 
 
@@ -32,19 +28,3 @@ def clear_marks():
     files = _GLOBAL_MARK_PATH.glob("**/workflow-*")
     for file in files:
         file.unlink()
-
-
-def update_workflow_options(f: RemoteFunction, **workflow_options) -> RemoteFunction:
-    new_metadata = f._default_options.get("_metadata", {}).copy()
-    # copy again because the origina copy is shallow copy
-    new_workflow_options = new_metadata.get(WORKFLOW_OPTIONS, {}).copy()
-    new_workflow_options.update(**workflow_options)
-    new_metadata[WORKFLOW_OPTIONS] = new_workflow_options
-    return f.options(_metadata=new_metadata)
-
-
-def run_workflow_dag_with_options(
-    f: RemoteFunction, args, workflow_id=None, **workflow_options
-):
-    wf = workflow.create(update_workflow_options(f, **workflow_options).bind(*args))
-    return wf.run(workflow_id=workflow_id)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR enables 2 ways to update workflow options on Ray remote functions.

```python
# 1. decorator
@workflow.options(catch_exception=True)
@ray.remote(num_cpus=2)
def foo(): ...

# 2. via ".options", semantics is same as other arguments in options
foo.options(**workflow.options(catch_exception=False), num_cpus=1)
```

Will update the doc with another PR.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
