### PR TITLE
[ci/release] Fix ray version from init test

### DIFF
--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -32,7 +32,7 @@ class WheelsFinderTest(unittest.TestCase):
 
         with patch("urllib.request.urlopen", lambda _: content):
             version = get_ray_version(DEFAULT_REPO, commit="fake")
-            self.assertEqual(version, "2.0.0.dev0")
+            self.assertTrue(version)
 
         with patch("urllib.request.urlopen", lambda _: []), self.assertRaises(
             RayWheelsNotFoundError


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This release package unit test fails on release branches. Instead of checking for a hard-coded version number, we should just require the value to be non-empty.

See e.g. https://buildkite.com/ray-project/ray-builders-pr/builds/31295#b6c6c952-ce34-4521-9342-429e92560dd3

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
