### PR TITLE
[Serve] Support serializing numpy scaler

### DIFF
--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -35,20 +35,15 @@ def test_numpy_encoding():
     floats = np.array(data).astype(np.float32)
     ints = floats.astype(np.int32)
     uints = floats.astype(np.uint32)
+    list_of_uints = [np.int64(1), np.int64(2)]
 
-    assert (
-        json.loads(json.dumps(jsonable_encoder(floats, custom_encoder=serve_encoders)))
-        == data
-    )
-    assert (
-        json.loads(json.dumps(jsonable_encoder(ints, custom_encoder=serve_encoders)))
-        == data
-    )
-    assert (
-        json.loads(json.dumps(jsonable_encoder(uints, custom_encoder=serve_encoders)))
-        == data
-    )
-
+    for np_data in [floats, ints, uints, list_of_uints]:
+        assert (
+            json.loads(
+                json.dumps(jsonable_encoder(np_data, custom_encoder=serve_encoders))
+            )
+            == data
+        )
     nested = {"a": np.array([1, 2])}
     assert json.loads(
         json.dumps(jsonable_encoder(nested, custom_encoder=serve_encoders))

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -59,6 +59,11 @@ class _ServeCustomEncoders:
         return obj.tolist()
 
     @staticmethod
+    def encode_np_scaler(obj):
+        assert isinstance(obj, np.generic)
+        return obj.item()
+
+    @staticmethod
     def encode_exception(obj):
         assert isinstance(obj, Exception)
         return str(obj)
@@ -66,6 +71,7 @@ class _ServeCustomEncoders:
 
 serve_encoders = {
     np.ndarray: _ServeCustomEncoders.encode_np_array,
+    np.generic: _ServeCustomEncoders.encode_np_scaler,
     Exception: _ServeCustomEncoders.encode_exception,
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In previous PR we unified the existing Starlette and FastAPI custom serializers for numpy arrays. However, it is common for RLlib and other libraries to return a list of numpy scaler values: `[np.int(1), np.int(2)]`. This PR adds support for that. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
