### PR TITLE
[Doc] [Core] Enhance actor queue doc code

### DIFF
--- a/doc/source/ray-core/actors/concurrency_group_api.rst
+++ b/doc/source/ray-core/actors/concurrency_group_api.rst
@@ -123,7 +123,7 @@ The concurrency of the default group can be changed by setting the ``max_concurr
 
     .. code-block:: python
 
-        @ray.remote(concurrency_groups={"io": 2)
+        @ray.remote(concurrency_groups={"io": 2})
         class AsyncIOActor:
             async def f1(self):
                 pass

--- a/doc/source/ray-core/doc_code/actor-queue.py
+++ b/doc/source/ray-core/doc_code/actor-queue.py
@@ -7,11 +7,13 @@ queue = Queue(maxsize=100)
 
 
 @ray.remote
-def consumer(queue):
-    next_item = queue.get(block=True)
-    print(f"got work {next_item}")
-
-
-consumers = [consumer.remote(queue) for _ in range(2)]
+def consumer(id, queue):
+    while not queue.empty():
+        next_item = queue.get(block=True)
+        print(f"consumer {id} got work {next_item}")
 
 [queue.put(i) for i in range(10)]
+print("Put work 1 - 10 to queue...")
+
+consumers = [consumer.remote(id, queue) for id in range(2)]
+

--- a/doc/source/ray-core/doc_code/actor-queue.py
+++ b/doc/source/ray-core/doc_code/actor-queue.py
@@ -12,8 +12,8 @@ def consumer(id, queue):
         next_item = queue.get(block=True)
         print(f"consumer {id} got work {next_item}")
 
+
 [queue.put(i) for i in range(10)]
 print("Put work 1 - 10 to queue...")
 
 consumers = [consumer.remote(id, queue) for id in range(2)]
-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Current documentation code in [Message passing using Ray Queue](https://docs.ray.io/en/latest/ray-core/actors/actor-utils.html#message-passing-using-ray-queue) can be enhanced, for better demonstration of the message queue.

It creates 10 tasks but only 2 consumers, and each consumer consumes one task then exit. Therefore, the output is a bit vague:

```
(consumer pid=1022727) got work 0
(consumer pid=1022595) got work 1
```

So I make consumer working until the queue is empty. The output shows consumer 1 and 2 working in parallel:

```
(consumer pid=1030876) consumer 0 got work 0
(consumer pid=1030876) consumer 0 got work 1
(consumer pid=1030876) consumer 0 got work 3
(consumer pid=1030876) consumer 0 got work 5
(consumer pid=1030876) consumer 0 got work 7
(consumer pid=1030876) consumer 0 got work 9
(consumer pid=1030949) consumer 1 got work 2
(consumer pid=1030949) consumer 1 got work 4
(consumer pid=1030949) consumer 1 got work 6
(consumer pid=1030949) consumer 1 got work 8
```

P.S. Also fix a typo in doc.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
