### PR TITLE
[Java] Shade jackson to avoid conflict.

### DIFF
--- a/java/shade_rule
+++ b/java/shade_rule
@@ -1,6 +1,6 @@
 rule com.google.common.** io.ray.shaded.com.google.common.@1
 rule com.google.protobuf.** io.ray.shaded.com.google.protobuf.@1
 rule com.google.thirdparty.** io.ray.shaded.com.google.thirdparty.@1
-# jackson jar is introduced in `de.ruedigermoeller:fst:2.57.3-SNAPSHOT`. It's easy to be
+# jackson jar is introduced in `de.ruedigermoeller:fst`. It's easy to be
 # conflict with users'.
 rule com.fasterxml.jackson.** io.ray.shaded.com.fasterxml.jackson.@1

--- a/java/shade_rule
+++ b/java/shade_rule
@@ -1,3 +1,6 @@
 rule com.google.common.** io.ray.shaded.com.google.common.@1
 rule com.google.protobuf.** io.ray.shaded.com.google.protobuf.@1
 rule com.google.thirdparty.** io.ray.shaded.com.google.thirdparty.@1
+# jackson jar is introduced in `de.ruedigermoeller:fst:2.57.3-SNAPSHOT`. It's easy to be
+# conflict with users'.
+rule com.fasterxml.jackson.** io.ray.shaded.com.fasterxml.jackson.@1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Jackson is a widely-used utility. User from Ant reports the jackson class is conflicted between Ray jar and user's jar.
This PR shade the jackson in Ray jar to avoid the conflict.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Close #24301

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

