### PR TITLE
[RLlib] IMPALAConfig small fix (double defined config key).

### DIFF
--- a/rllib/agents/impala/impala.py
+++ b/rllib/agents/impala/impala.py
@@ -136,13 +136,10 @@ class ImpalaConfig(TrainerConfig):
         self.num_gpus = 1
         self.lr = 0.0005
         self.min_time_s_per_reporting = 10
-        # IMPALA and APPO are not on the new training_iteration API yet.
-        self._disable_execution_plan_api = False
         # __sphinx_doc_end__
         # fmt: on
 
         # Deprecated value.
-        self._disable_execution_plan_api = True
         self.num_data_loader_buffers = DEPRECATED_VALUE
 
     @override(TrainerConfig)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

MPALAConfig small fix (double defined config key).
* The config key `_disable_execution_plan_api` is defined twice, probably caused by a bad merge.
* No negative effect though as the second definition of the property has the correct value either way.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
