### PR TITLE
[Serve] Ensure SimpleSchemaIngress uses FastAPI custom serializers

### DIFF
--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -2,6 +2,7 @@ import inspect
 from abc import abstractmethod
 from typing import Any, Callable, Optional, Type, Union
 from pydantic import BaseModel
+from ray.serve.utils import install_serve_encoders_to_fastapi
 
 import starlette
 from fastapi import Body, Depends, FastAPI
@@ -56,6 +57,7 @@ class SimpleSchemaIngress:
               resolver. When you pass in a string, Serve will import it.
               Please refer to Serve HTTP adatper documentation to learn more.
         """
+        install_serve_encoders_to_fastapi()
         http_adapter = load_http_adapter(http_adapter)
         self.app = FastAPI()
 

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -16,6 +16,7 @@ import requests
 import numpy as np
 import pydantic
 import pydantic.json
+import fastapi.encoders
 
 import ray
 import ray.serialization_addons
@@ -80,6 +81,12 @@ def install_serve_encoders_to_fastapi():
     """Inject Serve's encoders so FastAPI's jsonable_encoder can pick it up."""
     # https://stackoverflow.com/questions/62311401/override-default-encoders-for-jsonable-encoder-in-fastapi # noqa
     pydantic.json.ENCODERS_BY_TYPE.update(serve_encoders)
+    # FastAPI cache these encoders at import time, so we also needs to refresh it.
+    fastapi.encoders.encoders_by_class_tuples = (
+        fastapi.encoders.generate_encoders_by_class_tuples(
+            pydantic.json.ENCODERS_BY_TYPE
+        )
+    )
 
 
 @ray.remote(num_cpus=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previous PRs only enabled it for FastAPI in bring your own app. This PR enables it for DAGDriver and ModelWrapper. I also tested @krfricke's repro script ensure it working. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
