### PR TITLE
change docs for ray.remote num_gpus

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2218,7 +2218,7 @@ def remote(*args, **kwargs):
             the remote function invocation.
         num_cpus (float): The quantity of CPU cores to reserve
             for this task or for the lifetime of the actor.
-        num_gpus (int): The quantity of GPUs to reserve
+        num_gpus (float): The quantity of GPUs to reserve
             for this task or for the lifetime of the actor.
         resources (Dict[str, float]): The quantity of various custom resources
             to reserve for this task or for the lifetime of the actor.


### PR DESCRIPTION
This change only affects documentation for `num_gpus` on the ray.remote decortator.

## Why are these changes needed?

A customer noticed that the documentation says that `@ray.remote` can take fractional `num_gpus` which is true, but the documentation lists it as an integer.  I think this is strictly a problem in the docs.

## Related issue number

Reported in slack - happy to create a ticket as needed.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
