### PR TITLE
Add doc for actor spread scheduling

### DIFF
--- a/doc/source/ray-core/actors/scheduling.rst
+++ b/doc/source/ray-core/actors/scheduling.rst
@@ -26,10 +26,13 @@ See :ref:`Placement Group <ray-placement-group-doc-ref>` for more details.
 Scheduling Strategy
 -------------------
 Actors support a ``scheduling_strategy`` option to specify the strategy used to decide the best node among available nodes.
-Currently the supported strategies for actors are ``"DEFAULT"`` and ``ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(node_id, soft: bool)``.
+Currently the supported strategies for actors are ``"DEFAULT"``, ``"SPREAD"`` and
+``ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(node_id, soft: bool)``.
 
 ``"DEFAULT"`` is the default strategy used by Ray. With the current implementation, Ray will try to pack actors on nodes
 until the resource utilization is beyond a certain threshold and spread actors afterwards.
+
+"SPREAD" strategy will try to spread the actors among available nodes.
 
 NodeAffinitySchedulingStrategy is a low-level strategy that allows an actor to be scheduled onto a particular node specified by its node id.
 The ``soft`` flag specifies whether the actor is allowed to run somewhere else if the specified node doesn't exist (e.g. if the node dies)
@@ -48,7 +51,7 @@ Since nodes are randomly chosen, actors that don't require any resources are eff
 
     .. code-block:: python
 
-        @ray.remote
+        @ray.remote(num_cpus=1)
         class Actor:
             pass
 
@@ -65,3 +68,6 @@ Since nodes are randomly chosen, actors that don't require any resources are eff
                 soft = False,
             )
         ).remote()
+
+        # Spread actors across the cluster.
+        actors = [Actor.options(scheduling_strategy="SPREAD").remote() for i in range(100)]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
grant_or_reject for raylet based actor scheduling is implemented as part of https://github.com/ray-project/ray/pull/23829, so spread scheduling now works for actors just like tasks.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
