### PR TITLE
[Serve] Run health check in separate thread

### DIFF
--- a/python/ray/serve/common.py
+++ b/python/ray/serve/common.py
@@ -46,6 +46,12 @@ class DeploymentStatusInfo:
         )
 
 
+HEALTH_CHECK_CONCURRENCY_GROUP = "health_check"
+REPLICA_DEFAULT_ACTOR_OPTIONS = {
+    "concurrency_groups": {HEALTH_CHECK_CONCURRENCY_GROUP: 1}
+}
+
+
 class DeploymentInfo:
     def __init__(
         self,
@@ -95,14 +101,14 @@ class DeploymentInfo:
                 or self.serialized_deployment_def is not None
             )
             if self.replica_config.import_path is not None:
-                self._cached_actor_def = ray.remote(
+                self._cached_actor_def = ray.remote(**REPLICA_DEFAULT_ACTOR_OPTIONS)(
                     create_replica_wrapper(
                         self.actor_name,
                         import_path=self.replica_config.import_path,
                     )
                 )
             else:
-                self._cached_actor_def = ray.remote(
+                self._cached_actor_def = ray.remote(**REPLICA_DEFAULT_ACTOR_OPTIONS)(
                     create_replica_wrapper(
                         self.actor_name,
                         serialized_deployment_def=self.serialized_deployment_def,

--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -18,7 +18,7 @@ from ray.util import metrics
 from ray._private.async_compat import sync_to_async
 
 from ray.serve.autoscaling_metrics import start_metrics_pusher
-from ray.serve.common import ReplicaTag
+from ray.serve.common import HEALTH_CHECK_CONCURRENCY_GROUP, ReplicaTag
 from ray.serve.config import DeploymentConfig
 from ray.serve.constants import (
     HEALTH_CHECK_METHOD,
@@ -219,6 +219,7 @@ def create_replica_wrapper(
             if self.replica is not None:
                 return await self.replica.prepare_for_shutdown()
 
+        @ray.method(concurrency_group=HEALTH_CHECK_CONCURRENCY_GROUP)
         async def check_health(self):
             await self.replica.check_health()
 

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -1,6 +1,5 @@
 import gc
 import asyncio
-import time
 
 import numpy as np
 import requests


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR make sure health check is executed in a separate Python thread, so heavy compute/blocking compute in main thread won't cause false alarm and shutdown the replica. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24554 #24419 #24228
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
