### PR TITLE
[hotfix][kuberay][docs] Match up Ray versions in example config

### DIFF
--- a/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
+++ b/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
@@ -58,6 +58,7 @@ spec:
         containers:
         # The Ray head pod
         - name: ray-head
+          # All Ray pods in the RayCluster should use the same version of Ray.
           image: rayproject/ray:1.12.0
           imagePullPolicy: Always
           # The KubeRay operator uses the ports specified on the ray-head container

--- a/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
+++ b/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
@@ -191,7 +191,8 @@ spec:
           command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]   
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:1.11.0
+          # All Ray pods in the RayCluster should use the same version of Ray.
+          image: rayproject/ray:1.12.0
           # environment variables to set in the container.Optional.
           # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
           env:

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -206,6 +206,21 @@ def test_autoscaling_config(
                 mock_logger.warning.assert_not_called()
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Not relevant.")
+def test_cr_image_consistency():
+    """Verify that the example config uses the same Ray image for all Ray pods."""
+    cr = _get_basic_ray_cr()
+
+    group_specs = [cr["spec"]["headGroupSpec"]] + cr["spec"]["workerGroupSpecs"]
+    assert len(group_specs) == 2
+
+    ray_images = set(
+        group_spec["template"]["spec"]["containers"][0]["image"]
+        for group_spec in group_specs
+    )
+    assert len(ray_images) == 1
+
+
 if __name__ == "__main__":
     import pytest
     import sys

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -214,11 +214,20 @@ def test_cr_image_consistency():
     group_specs = [cr["spec"]["headGroupSpec"]] + cr["spec"]["workerGroupSpecs"]
     assert len(group_specs) == 2
 
-    ray_images = set(
-        group_spec["template"]["spec"]["containers"][0]["image"]
-        for group_spec in group_specs
+    ray_containers = [
+        group_spec["template"]["spec"]["containers"][0] for group_spec in group_specs
+    ]
+
+    # All Ray containers in the example config have "ray-" in their name.
+    assert all("ray-" in ray_container["name"] for ray_container in ray_containers)
+
+    # All Ray images are from the Ray repo.
+    assert all(
+        "rayproject/ray" in ray_container["image"] for ray_container in ray_containers
     )
-    assert len(ray_images) == 1
+
+    # All Ray images are the same.
+    assert len({ray_container["image"] for ray_container in ray_containers}) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR fixes a typo in the KubeRay example config in Ray's docs.

### Specifics:

Ray versions in the Ray repo's example KubeRay CR were recently updated from 1.11.0 to 1.12.0.
However, the worker group's Ray version was accidentally left at 1.11.0. This leads to alarming crash-looping when deploying the example in the docs.

This PR matches up the Ray images by setting the worker group to `rayproject/ray:1.12.0`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
