### PR TITLE
Change hardcoded wheel link that works only for one OS+Python version

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -25,7 +25,7 @@ RLlib, Tune, Autoscaler, and most Python files do not require you to build and c
 
 .. code-block:: shell
 
-    pip install -U LINK_TO_WHEEL.whl # check :ref:`install-nightlies` for LINK_TO_WHEEL
+    pip install -U LINK_TO_WHEEL.whl # replace LINK_TO_WHEEL with actual wheel link (see above install-nightlies).
 
 2. Fork and clone the project to your machine. Connect your repository to the upstream (main project) ray repository.
 

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -25,7 +25,7 @@ RLlib, Tune, Autoscaler, and most Python files do not require you to build and c
 
 .. code-block:: shell
 
-    pip install -U https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+    pip install -U LINK_TO_WHEEL.whl # check :ref:`install-nightlies` for LINK_TO_WHEEL
 
 2. Fork and clone the project to your machine. Connect your repository to the upstream (main project) ray repository.
 


### PR DESCRIPTION
## Why are these changes needed?

The hardcoded wheel link that works only for one OS+Python version may look confusing.

## Related issue number

Closes #24533

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
