### PR TITLE
WINDOWS: move CI tests of runtime_env to the wheel build step

### DIFF
--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -37,10 +37,11 @@ steps:
     # The next command will be sharded into $parallelism shards.
     - . ./ci/ci.sh test_python
 
-- label: ":windows: Wheels"
+- label: ":windows: Wheels&runtime_env"
   commands:
     - *prelude_commands
     - export WINDOWS_WHEELS="1"
     - . ./ci/ci.sh init
     - . ./ci/ci.sh build
     - *upload_wheels_if_needed
+    - . ./ci/ci.sh test_windows_runtime_env 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -162,6 +162,25 @@ test_python() {
       -python/ray/tests:test_k8s_operator_unit_tests
       -python/ray/tests:test_tracing  # tracing not enabled on windows
       -python/ray/tests:kuberay/test_autoscaling_e2e # irrelevant on windows
+      -python/ray/tests:test_runtime_env.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_2.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_working_dir.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_working_dir_2.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_working_dir_3.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_working_dir_remote_uri.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_conda_and_pip.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_conda_and_pip_2.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_conda_and_pip_3.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_conda_and_pip_4.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_conda_and_pip_5.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_complicated.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_validation.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_ray_minimal.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_env_vars.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_packaging.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_plugin.py  # see test_windows_runtime_env
+      -python/ray/tests:test_runtime_env_fork_process.py  # see test_windows_runtime_env
+      
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?
@@ -176,17 +195,27 @@ test_python() {
     # It's unclear to me if this should be necessary, but this is to make tests run for now.
     # Check why this issue doesn't arise on Linux/Mac.
     # Ideally importing ray.cloudpickle should import pickle5 automatically.
-    # shellcheck disable=SC2046,SC2086
-    bazel test --config=ci \
-      --build_tests_only $(./ci/run/bazel_export_options) \
-      --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
-      --test_env=USERPROFILE="${USERPROFILE}" \
-      --test_env=CI=1 \
-      --test_env=RAY_CI_POST_WHEEL_TESTS=1 \
-      --test_output=streamed \
-      -- \
-      ${test_shard_selection};
+    test_windows  ${test_shard_selection};
   fi
+}
+
+test_windows_runtime_env() {
+  # These tests need to use WINDOWS_WHEELS=1. Maybe eventually move all
+  # the tests to use WINDOWS_WHEELS=1 like on linux?
+  test_windows $(ls python/ray/tests/test_runtime*.py | sed -e"s,^,python/ray/tests:,")
+}
+
+test_windows() {
+  # shellcheck disable=SC2046,SC2086
+  if [ -z "${args}" ]; then echo "test_windows called without tests" 1>&2; return 1; fi
+  bazel test --config=ci \
+    --build_tests_only $(./ci/run/bazel_export_options) \
+    --test_env=PYTHONPATH="${PYTHONPATH-}${pathsep}${WORKSPACE_DIR}/python/ray/pickle5_files" \
+    --test_env=USERPROFILE="${USERPROFILE}" \
+    --test_env=CI=1 \
+    --test_env=RAY_CI_POST_WHEEL_TESTS=1 \
+    --test_output=streamed \
+    -- $@;
 }
 
 # For running large Python tests on Linux and MacOS.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In discussion of PR #23613, @architkulkarni and I came to the conclusion that enabling `RAY_RUNTIME_ENV_LOCAL_DEV_MODE` slows down all the tests since it will always create runtime environments (creating files on windows is slow). A better approach is to enable `WINDOWS_WHEELS`, and use the wheels. This PR add the `runtime_env` tests to the wheel run and removes them from the regular windows tests runs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
