### PR TITLE
Apex replay buffer config validation fix

### DIFF
--- a/rllib/agents/dqn/apex.py
+++ b/rllib/agents/dqn/apex.py
@@ -322,7 +322,7 @@ class ApexTrainer(DQNTrainer):
         # Update experience priorities post learning.
         def update_prio_and_stats(item: Tuple[ActorHandle, dict, int, int]) -> None:
             actor, prio_dict, env_count, agent_count = item
-            if config.get("prioritized_replay"):
+            if config["replay_buffer_config"].get("prioritized_replay_alpha") > 0:
                 actor.update_priorities.remote(prio_dict)
             metrics = _get_shared_metrics()
             # Manually update the steps trained counter since the learner
@@ -588,7 +588,10 @@ class ApexTrainer(DQNTrainer):
                     env_steps,
                     agent_steps,
                 ) = self.learner_thread.outqueue.get(timeout=0.001)
-                if self.config["prioritized_replay"]:
+                if (
+                    self.config["replay_buffer_config"].get("prioritized_replay_alpha")
+                    > 0
+                ):
                     replay_actor.update_priorities.remote(priority_dict)
                 num_samples_trained_this_itr += env_steps
                 self.update_target_networks(env_steps)


### PR DESCRIPTION
Shamelessly stolen from @ArturNiederfahrenhorst 

## Why are these changes needed?

`prioritized_replay` is deprecated, as we move to the new replay buffer API, we should instead set the `alpha` flag instead.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
