### PR TITLE
[tune] Limit progress table column length

### DIFF
--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import datetime
+import numbers
 from typing import Any, Dict, List, Optional, Union
 
 import collections
@@ -779,17 +780,22 @@ def trial_progress_str(
     return delim.join(messages)
 
 
-def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> str:
+def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> Any:
     """Abbreviate a string representation of an object to `max_len` characters.
+
+    For numbers, booleans and None, the original value will be returned for
+    correct rendering in the table formatting tool.
 
     Args:
         value: Object to be represented as a string.
         max_len: Maximum return string length.
         add_addr: If True, will add part of the object address to the end of the
             string, e.g. to identify different instances of the same class. If
-            False or if the value is an int, float, or bool, three dots
-            (``...``) will be used instead.
+            False, three dots (``...``) will be used instead.
     """
+    if value is None or isinstance(value, (int, float, numbers.Number, bool)):
+        return value
+
     string = str(value)
     if len(string) <= max_len:
         return string

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -780,6 +780,16 @@ def trial_progress_str(
 
 
 def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> str:
+    """Abbreviate a string representation of an object to `max_len` characters.
+
+    Args:
+        value: Object to be represented as a string.
+        max_len: Maximum return string length.
+        add_addr: If True, will add part of the object address to the end of the
+            string, e.g. to identify different instances of the same class. If
+            False or if the value is an int, float, or bool, three dots
+            (``...``) will be used instead.
+    """
     string = str(value)
     if len(string) <= max_len:
         return string

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Any
 
 import collections
 import os
@@ -129,6 +129,8 @@ class TuneReporterBase(ProgressReporter):
         max_error_rows: Maximum number of rows to print in the
             error table. The error table lists the error file, if any,
             corresponding to each trial. Defaults to 20.
+        max_column_length: Maximum column length (in characters). Column
+            headers and values longer than this will be abbreviated.
         max_report_frequency: Maximum report frequency in seconds.
             Defaults to 5s.
         infer_limit: Maximum number of metrics to automatically infer
@@ -169,11 +171,13 @@ class TuneReporterBase(ProgressReporter):
 
     def __init__(
         self,
+        *,
         metric_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         total_samples: Optional[int] = None,
         max_progress_rows: int = 20,
         max_error_rows: int = 20,
+        max_column_length: int = 20,
         max_report_frequency: int = 5,
         infer_limit: int = 3,
         print_intermediate_tables: Optional[bool] = None,
@@ -188,6 +192,7 @@ class TuneReporterBase(ProgressReporter):
         self._parameter_columns = parameter_columns or []
         self._max_progress_rows = max_progress_rows
         self._max_error_rows = max_error_rows
+        self._max_column_length = max_column_length
         self._infer_limit = infer_limit
 
         if print_intermediate_tables is None:
@@ -360,6 +365,7 @@ class TuneReporterBase(ProgressReporter):
                     force_table=self._print_intermediate_tables,
                     fmt=fmt,
                     max_rows=max_progress,
+                    max_column_length=self._max_column_length,
                     done=done,
                     metric=self._metric,
                     mode=self._mode,
@@ -461,6 +467,8 @@ class JupyterNotebookReporter(TuneReporterBase, RemoteReporterMixin):
         max_error_rows: Maximum number of rows to print in the
             error table. The error table lists the error file, if any,
             corresponding to each trial. Defaults to 20.
+        max_column_length: Maximum column length (in characters). Column
+            headers and values longer than this will be abbreviated.
         max_report_frequency: Maximum report frequency in seconds.
             Defaults to 5s.
         infer_limit: Maximum number of metrics to automatically infer
@@ -480,12 +488,14 @@ class JupyterNotebookReporter(TuneReporterBase, RemoteReporterMixin):
 
     def __init__(
         self,
+        *,
         overwrite: bool = True,
         metric_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         total_samples: Optional[int] = None,
         max_progress_rows: int = 20,
         max_error_rows: int = 20,
+        max_column_length: int = 20,
         max_report_frequency: int = 5,
         infer_limit: int = 3,
         print_intermediate_tables: Optional[bool] = None,
@@ -494,17 +504,18 @@ class JupyterNotebookReporter(TuneReporterBase, RemoteReporterMixin):
         sort_by_metric: bool = False,
     ):
         super(JupyterNotebookReporter, self).__init__(
-            metric_columns,
-            parameter_columns,
-            total_samples,
-            max_progress_rows,
-            max_error_rows,
-            max_report_frequency,
-            infer_limit,
-            print_intermediate_tables,
-            metric,
-            mode,
-            sort_by_metric,
+            metric_columns=metric_columns,
+            parameter_columns=parameter_columns,
+            total_samples=total_samples,
+            max_progress_rows=max_progress_rows,
+            max_error_rows=max_error_rows,
+            max_column_length=max_column_length,
+            max_report_frequency=max_report_frequency,
+            infer_limit=infer_limit,
+            print_intermediate_tables=print_intermediate_tables,
+            metric=metric,
+            mode=mode,
+            sort_by_metric=sort_by_metric,
         )
 
         if not IS_NOTEBOOK:
@@ -564,6 +575,8 @@ class CLIReporter(TuneReporterBase):
         max_error_rows: Maximum number of rows to print in the
             error table. The error table lists the error file, if any,
             corresponding to each trial. Defaults to 20.
+        max_column_length: Maximum column length (in characters). Column
+            headers and values longer than this will be abbreviated.
         max_report_frequency: Maximum report frequency in seconds.
             Defaults to 5s.
         infer_limit: Maximum number of metrics to automatically infer
@@ -583,11 +596,13 @@ class CLIReporter(TuneReporterBase):
 
     def __init__(
         self,
+        *,
         metric_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
         total_samples: Optional[int] = None,
         max_progress_rows: int = 20,
         max_error_rows: int = 20,
+        max_column_length: int = 20,
         max_report_frequency: int = 5,
         infer_limit: int = 3,
         print_intermediate_tables: Optional[bool] = None,
@@ -597,17 +612,18 @@ class CLIReporter(TuneReporterBase):
     ):
 
         super(CLIReporter, self).__init__(
-            metric_columns,
-            parameter_columns,
-            total_samples,
-            max_progress_rows,
-            max_error_rows,
-            max_report_frequency,
-            infer_limit,
-            print_intermediate_tables,
-            metric,
-            mode,
-            sort_by_metric,
+            metric_columns=metric_columns,
+            parameter_columns=parameter_columns,
+            total_samples=total_samples,
+            max_progress_rows=max_progress_rows,
+            max_error_rows=max_error_rows,
+            max_column_length=max_column_length,
+            max_report_frequency=max_report_frequency,
+            infer_limit=infer_limit,
+            print_intermediate_tables=print_intermediate_tables,
+            metric=metric,
+            mode=mode,
+            sort_by_metric=sort_by_metric,
         )
 
     def report(self, trials: List[Trial], done: bool, *sys_info: Dict):
@@ -683,6 +699,7 @@ def trial_progress_str(
     force_table: bool = False,
     fmt: str = "psql",
     max_rows: Optional[int] = None,
+    max_column_length: int = 20,
     done: bool = False,
     metric: Optional[str] = None,
     mode: Optional[str] = None,
@@ -711,6 +728,7 @@ def trial_progress_str(
         fmt: Output format (see tablefmt in tabulate API).
         max_rows: Maximum number of rows in the trial table. Defaults to
             unlimited.
+        max_column_length: Maximum column length (in characters).
         done: True indicates that the tuning run finished.
         metric: Metric used to sort trials.
         mode: One of [min, max]. Determines whether objective is
@@ -747,17 +765,33 @@ def trial_progress_str(
 
     if force_table or (has_verbosity(Verbosity.V2_TRIAL_NORM) and done):
         messages += trial_progress_table(
-            trials,
-            metric_columns,
-            parameter_columns,
-            fmt,
-            max_rows,
-            metric,
-            mode,
-            sort_by_metric,
+            trials=trials,
+            metric_columns=metric_columns,
+            parameter_columns=parameter_columns,
+            fmt=fmt,
+            max_rows=max_rows,
+            metric=metric,
+            mode=mode,
+            sort_by_metric=sort_by_metric,
+            max_column_length=max_column_length,
         )
 
     return delim.join(messages)
+
+
+def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> str:
+    string = str(value)
+    if len(string) <= max_len:
+        return string
+
+    if add_addr and not isinstance(value, (int, float, bool)):
+        result = string[: (max_len - 5)]
+        result += "_" + hex(id(value))[-4:]
+        return result
+
+    result = string[: (max_len - 3)]
+    result += "..."
+    return result
 
 
 def trial_progress_table(
@@ -769,6 +803,7 @@ def trial_progress_table(
     metric: Optional[str] = None,
     mode: Optional[str] = None,
     sort_by_metric: bool = False,
+    max_column_length: int = 20,
 ):
     messages = []
     num_trials = len(trials)
@@ -840,17 +875,29 @@ def trial_progress_table(
 
     # Build trial rows.
     trial_table = [
-        _get_trial_info(trial, parameter_keys, metric_keys) for trial in trials
+        _get_trial_info(
+            trial, parameter_keys, metric_keys, max_column_length=max_column_length
+        )
+        for trial in trials
     ]
     # Format column headings
     if isinstance(metric_columns, Mapping):
-        formatted_metric_columns = [metric_columns[k] for k in metric_keys]
+        formatted_metric_columns = [
+            _max_len(metric_columns[k], max_len=max_column_length, add_addr=False)
+            for k in metric_keys
+        ]
     else:
         formatted_metric_columns = metric_keys
     if isinstance(parameter_columns, Mapping):
-        formatted_parameter_columns = [parameter_columns[k] for k in parameter_keys]
+        formatted_parameter_columns = [
+            _max_len(parameter_columns[k], max_len=max_column_length, add_addr=False)
+            for k in parameter_keys
+        ]
     else:
-        formatted_parameter_columns = parameter_keys
+        formatted_parameter_columns = [
+            _max_len(k, max_len=max_column_length, add_addr=False)
+            for k in parameter_keys
+        ]
     columns = (
         ["Trial name", "status", "loc"]
         + formatted_parameter_columns
@@ -972,7 +1019,9 @@ def _get_trial_location(trial: Trial, result: dict) -> Location:
     return location
 
 
-def _get_trial_info(trial: Trial, parameters: List[str], metrics: List[str]):
+def _get_trial_info(
+    trial: Trial, parameters: List[str], metrics: List[str], max_column_length: int = 20
+):
     """Returns the following information about a trial:
 
     name | status | loc | params... | metrics...
@@ -981,16 +1030,27 @@ def _get_trial_info(trial: Trial, parameters: List[str], metrics: List[str]):
         trial: Trial to get information for.
         parameters: Names of trial parameters to include.
         metrics: Names of metrics to include.
+        max_column_length: Maximum column length (in characters).
     """
     result = trial.last_result
     config = trial.config
     location = _get_trial_location(trial, result)
     trial_info = [str(trial), trial.status, str(location)]
     trial_info += [
-        unflattened_lookup(param, config, default=None) for param in parameters
+        _max_len(
+            unflattened_lookup(param, config, default=None),
+            max_len=max_column_length,
+            add_addr=True,
+        )
+        for param in parameters
     ]
     trial_info += [
-        unflattened_lookup(metric, result, default=None) for metric in metrics
+        _max_len(
+            unflattened_lookup(metric, result, default=None),
+            max_len=max_column_length,
+            add_addr=True,
+        )
+        for metric in metrics
     ]
     return trial_info
 

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import datetime
-from typing import Dict, List, Optional, Union, Any
+from typing import Any, Dict, List, Optional, Union
 
 import collections
 import os

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -795,12 +795,10 @@ def _max_len(value: Any, max_len: int = 20, add_addr: bool = False) -> str:
         return string
 
     if add_addr and not isinstance(value, (int, float, bool)):
-        result = string[: (max_len - 5)]
-        result += "_" + hex(id(value))[-4:]
+        result = f"{string[: (max_len - 5)]}_{hex(id(value))[-4:]}"
         return result
 
-    result = string[: (max_len - 3)]
-    result += "..."
+    result = f"{string[: (max_len - 3)]}..."
     return result
 
 

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -694,6 +694,25 @@ class ProgressReporterTest(unittest.TestCase):
 
         tune.run(lambda config: 2, num_samples=1, progress_reporter=CustomReporter())
 
+    def testMaxLen(self):
+        trials = []
+        for i in range(5):
+            t = Mock()
+            t.status = "TERMINATED"
+            t.trial_id = "%05d" % i
+            t.local_dir = "/foo"
+            t.location = "here"
+            t.config = {"verylong" * 20: i}
+            t.evaluated_params = {"verylong" * 20: i}
+            t.last_result = {"some_metric": "evenlonger" * 100}
+            t.__str__ = lambda self: self.trial_id
+            trials.append(t)
+
+        progress_str = trial_progress_str(
+            trials, metric_columns=["some_metric"], force_table=True
+        )
+        assert any(len(row) <= 90 for row in progress_str.split("\n"))
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Especially when using datasets, we sometimes run into very long string representations. Tune should make sure to cut these according to a specified maximum length.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
