### PR TITLE
[docs] Fix example in ray-get-loop.rst

### DIFF
--- a/doc/source/ray-core/tasks/patterns/ray-get-loop.rst
+++ b/doc/source/ray-core/tasks/patterns/ray-get-loop.rst
@@ -20,18 +20,18 @@ Code example
     ray.init()
 
     @ray.remote
-    def f():
-        pass
+    def f(i):
+        return i
 
     # Antipattern: no parallelism due to calling ray.get inside of the loop.
     returns = []
-    for _ in range(100):
-        returns.append(ray.get(f.remote()))
+    for i in range(100):
+        returns.append(ray.get(f.remote(i)))
 
     # Better approach: parallelism because the tasks are spawned in parallel.
     refs = []
-    for _ in range(100):
-        refs.append(f.remote())
+    for i in range(100):
+        refs.append(f.remote(i))
 
     returns = ray.get(refs)
 

--- a/doc/source/ray-core/tasks/patterns/ray-get-loop.rst
+++ b/doc/source/ray-core/tasks/patterns/ray-get-loop.rst
@@ -19,6 +19,7 @@ Code example
     import ray
     ray.init()
 
+    @ray.remote
     def f():
         pass
 

--- a/doc/source/ray-core/tasks/patterns/ray-get-loop.rst
+++ b/doc/source/ray-core/tasks/patterns/ray-get-loop.rst
@@ -24,13 +24,13 @@ Code example
 
     # Antipattern: no parallelism due to calling ray.get inside of the loop.
     returns = []
-    for i in range(100):
-        returns.append(ray.get(f.remote(i)))
+    for _ in range(100):
+        returns.append(ray.get(f.remote()))
 
     # Better approach: parallelism because the tasks are spawned in parallel.
     refs = []
-    for i in range(100):
-        refs.append(f.remote(i))
+    for _ in range(100):
+        refs.append(f.remote())
 
     returns = ray.get(refs)
 


### PR DESCRIPTION
Removes sending `i` to function `f`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
