### PR TITLE
[serve] Fix circular imports in `api.py`'s `serve.run()` and `build()` functions

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -58,6 +58,8 @@ from ray.serve.context import (
     get_internal_replica_context,
     ReplicaContext,
 )
+from ray.serve.pipeline.api import build as pipeline_build
+from ray.serve.pipeline.api import get_and_validate_ingress_deployment
 from ray._private.usage import usage_lib
 
 logger = logging.getLogger(__file__)
@@ -592,9 +594,6 @@ def run(
         RayServeHandle: A regular ray serve handle that can be called by user
             to execute the serve DAG.
     """
-    # TODO (jiaodong): Resolve circular reference in pipeline codebase and serve
-    from ray.serve.pipeline.api import build as pipeline_build
-    from ray.serve.pipeline.api import get_and_validate_ingress_deployment
 
     client = start(detached=True, http_options={"host": host, "port": port})
 
@@ -668,8 +667,6 @@ def build(target: Union[ClassNode, FunctionNode]) -> Application:
     The returned Application object can be exported to a dictionary or YAML
     config.
     """
-    # TODO (jiaodong): Resolve circular reference in pipeline codebase and serve
-    from ray.serve.pipeline.api import build as pipeline_build
 
     if in_interactive_shell():
         raise RuntimeError(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There are delayed imports in the [`run()`](https://github.com/ray-project/ray/blob/master/python/ray/serve/api.py#L596-L597) and [`build()`](https://github.com/ray-project/ray/blob/master/python/ray/serve/api.py#L672) functions in [`api.py`](https://github.com/ray-project/ray/blob/master/python/ray/serve/api.py). These imports are no longer circular due to recent refactoring (see #23578 and #23759). This change promotes them to top-level imports.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
