### PR TITLE
[core] [rfc] Use py_code_search_path for path setup.

### DIFF
--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -25,6 +25,7 @@ class JobConfig:
         num_java_workers_per_process=1,
         jvm_options=None,
         code_search_path=None,
+        py_code_search_path=None,
         runtime_env=None,
         client_job=False,
         metadata=None,
@@ -34,6 +35,7 @@ class JobConfig:
         self.num_java_workers_per_process = num_java_workers_per_process
         self.jvm_options = jvm_options or []
         self.code_search_path = code_search_path or []
+        self.py_code_search_path = py_code_search_path or []
         # It's difficult to find the error that caused by the
         # code_search_path is a string. So we assert here.
         assert isinstance(self.code_search_path, (list, tuple)), (
@@ -111,6 +113,7 @@ class JobConfig:
             pb.num_java_workers_per_process = self.num_java_workers_per_process
             pb.jvm_options.extend(self.jvm_options)
             pb.code_search_path.extend(self.code_search_path)
+            pb.py_code_search_path.extend(self.py_code_search_path)
             for k, v in self.metadata.items():
                 pb.metadata[k] = v
 
@@ -152,6 +155,7 @@ class JobConfig:
             ),
             jvm_options=job_config_json.get("jvm_options", None),
             code_search_path=job_config_json.get("code_search_path", None),
+            py_code_search_path=job_config_json.get("py_code_search_path", None),
             runtime_env=job_config_json.get("runtime_env", None),
             client_job=job_config_json.get("client_job", False),
             metadata=job_config_json.get("metadata", None),

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1550,7 +1550,6 @@ def connect(
     driver_name = ""
     log_stdout_file_path = ""
     log_stderr_file_path = ""
-    interactive_mode = False
     if mode == SCRIPT_MODE:
         import __main__ as main
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -269,6 +269,7 @@ message JobConfig {
   // search path for user code. This will be used as `CLASSPATH` in Java, and `PYTHONPATH`
   // in Python. In C++, libraries under these paths will be loaded by 'dlopen'.
   repeated string code_search_path = 3;
+  repeated string py_code_search_path = 8;
   // Runtime environment to run the code
   RuntimeEnvInfo runtime_env_info = 4;
   // The job's namespace. Named `ray_namespace` to avoid confusions when invoked in c++.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The current code setup the python code search path by using run_function_on_all_workers. This function will do the following work:
- register the function to run in GCS KV
- notify workers to run this function by GCS pubsub
- workers will import the function to run from GCS KV

This approach has the following limits:

- it depends on internal KV and also GCS pubsub to deliver message which is very complicated.
- it might have a race condition where functions are scheduled to run but the init function hasn't finished. This is because importing is happening in a separate thread and the main thread is not waiting until the init function is finished.

This PR suggests to use py_code_search_path in job_config to do this job:
- driver setup the fields to the path to be added
- worker will add them to sys.path.

In this way, we decouple the setup from the pubsub and kv to fix the two issues mentioned above.

## Related issue number
https://github.com/ray-project/ray/issues/24500
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
