### PR TITLE
[core] Adjust worker OOM scores to prioritize the raylet during memory pressure

### DIFF
--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -186,6 +186,19 @@ def test_function_table_gc_actor(call_ray_start):
     wait_for_condition(lambda: function_entry_num(job_id) == 0)
 
 
+def test_worker_oom_score(shutdown_only):
+    @ray.remote
+    def get_oom_score():
+        import os
+
+        pid = os.getpid()
+        with open(f"/proc/{pid}/oom_score", "r") as f:
+            oom_score = f.read()
+            return int(oom_score)
+
+    assert ray.get(get_oom_score.remote()) >= 1000
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -224,6 +224,12 @@ RAY_CONFIG(int64_t, worker_register_timeout_seconds, 60)
 /// The maximum number of workers to iterate whenever we analyze the resources usage.
 RAY_CONFIG(uint32_t, worker_max_resource_analysis_iteration, 128);
 
+/// A value to add to workers' OOM score adjustment, so that the OS prioritizes
+/// killing these over the raylet. 0 or positive values only (negative values
+/// require sudo permissions).
+/// NOTE(swang): Linux only.
+RAY_CONFIG(int, worker_oom_score_adjustment, 1000)
+
 /// Allow up to 60 seconds for connecting to Redis.
 RAY_CONFIG(int64_t, redis_db_connect_retries, 600)
 RAY_CONFIG(int64_t, redis_db_connect_wait_milliseconds, 100)

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -692,6 +692,10 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   void RemoveWorkerProcess(State &state, const StartupToken &proc_startup_token);
 
+  /// Increase worker OOM scores to avoid raylet crashes from heap memory
+  /// pressure.
+  void AdjustWorkerOomScore(pid_t pid) const;
+
   /// For Process class for managing subprocesses (e.g. reaping zombies).
   instrumented_io_context *io_service_;
   /// Node ID of the current node.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Under heap memory pressure, the raylet is often killed by the OS OOM killer. This is bad because it can cause whole system crashes and it is difficult to find the error afterwards. This PR adjusts the OOM score for any workers that the raylet spawns so that the OOM killer will hopefully prioritize killing those instead of the raylet.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
