### PR TITLE
[Autoscaler][Local Node Provider] Log a warning if max_workers < len(worker_ips)

### DIFF
--- a/python/ray/autoscaler/_private/local/config.py
+++ b/python/ray/autoscaler/_private/local/config.py
@@ -100,6 +100,13 @@ def prepare_manual(config: Dict[str, Any]) -> Dict[str, Any]:
     else:
         node_type["max_workers"] = max_workers
 
+    if max_workers < num_ips:
+        cli_logger.warning(
+            f"The value of `max_workers` supplied ({max_workers}) is less"
+            f" than the number of available worker ips ({num_ips})."
+            f" At most {max_workers} Ray worker nodes will connect to the cluster."
+        )
+
     return config
 
 

--- a/python/ray/autoscaler/local/development-example.yaml
+++ b/python/ray/autoscaler/local/development-example.yaml
@@ -1,11 +1,7 @@
 cluster_name: default
-min_workers: 0
-max_workers: 0
 docker:
     image: ""
     container_name: ""
-upscaling_speed: 1.0
-idle_timeout_minutes: 5
 provider:
     type: local
     head_ip: YOUR_HEAD_NODE_HOSTNAME

--- a/python/ray/autoscaler/local/example-full.yaml
+++ b/python/ray/autoscaler/local/example-full.yaml
@@ -45,12 +45,14 @@ auth:
 # The minimum number of workers nodes to launch in addition to the head
 # node. This number should be >= 0.
 # Typically, min_workers == max_workers == len(worker_ips).
-min_workers: 0
+# This field is optional.
+min_workers: TYPICALLY_THE_NUMBER_OF_WORKER_IPS
 
 # The maximum number of workers nodes to launch in addition to the head node.
 # This takes precedence over min_workers.
 # Typically, min_workers == max_workers == len(worker_ips).
-max_workers: 0
+# This field is optional.
+max_workers: TYPICALLY_THE_NUMBER_OF_WORKER_IPS
 # The default behavior for manually managed clusters is
 # min_workers == max_workers == len(worker_ips),
 # meaning that Ray is started on all available nodes of the cluster.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Follow-up to https://github.com/ray-project/ray/pull/21710.

Resolves some of the UX problems expressed in https://stackoverflow.com/questions/72060228/ray-cluster-connection-closed-example-script-displays-127-0-0-1-instead-of-head/72089615?noredirect=1#comment127388667_72089615

Logs a warning when a user sets max_workers for local node provider less than the number of available ips. 

Also removes defaults of 0 for min_workers and max_workers from example configs to help prevent users inadvertantly setting `max_workers=0` again.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
