### PR TITLE
[AIR] Fix `Categorizer.__repr__` attribute error

### DIFF
--- a/python/ray/ml/preprocessors/encoder.py
+++ b/python/ray/ml/preprocessors/encoder.py
@@ -168,7 +168,8 @@ class Categorizer(Preprocessor):
         return df
 
     def __repr__(self):
-        return f"<Categorizer columns={self.columns} stats={self.stats_}>"
+        stats = getattr(self, "stats_", None)
+        return f"<Categorizer columns={self.columns} stats={stats}>"
 
 
 def _get_unique_value_indices(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`__repr__` fails because `stats_` attribute is not assigned until `_fit` is called.
 
```
>>> Categorizer(columns=["X1", "X2"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/balaji/GitHub/ray/.venv/lib/python3.8/site-packages/ray/ml/preprocessors/encoder.py", line 171, in __repr__
    return f"<Categorizer columns={self.columns} stats={self.stats_}>"
AttributeError: 'Categorizer' object has no attribute 'stats_'
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
