### PR TITLE
[docs] Update limit-tasks.rst

### DIFF
--- a/doc/source/ray-core/tasks/patterns/limit-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/limit-tasks.rst
@@ -46,7 +46,9 @@ Code example
         # 4000 of the object_refs in result_refs are ready
         # and available.
           if len(result_refs) > 1000:
-            num_ready = i-1000
-            ray.wait(result_refs, num_returns=num_ready)
+            num_ready = min(i-1000, len(result_refs))
+            # update result_refs to only
+            # track the remaining tasks.
+            _, result_refs = ray.wait(result_refs, num_returns=num_ready)
 
         result_refs.append(actor.heavy_compute.remote(large_array))


### PR DESCRIPTION
The `for` loop currently calls `ray.wait` on every iteration as soon as `result_refs` gets to 1000 elements
This change prevents that, by updating result_refs to only track the remaining tasks


Note: there is one anti-pattern in this example - the creation and sending of `large_array` on every loop iteration
I'm unsure if that's intentional or not;
## Why are these changes needed?

The code runs slower than needed, and calling wait on every iteration is likely an anti-pattern.

## Related issue number
None

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
