### PR TITLE
[debug] Add a small delay prior to timeline generation

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -456,6 +456,13 @@ class GlobalState:
 
         self._check_connected()
 
+        # Add a small delay to account for propagation delay of events to the GCS.
+        # This should be harmless enough but prevents calls to timeline() from
+        # missing recent timeline data.
+        import time
+
+        time.sleep(1)
+
         profile_table = self.profile_table()
         all_events = []
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Per https://discuss.ray.io/t/ray-timeline-no-profiling-events-found/5933, it can be confusing in toy examples when timelines are missing recent events. Add a small delay to avoid this problem as a workaround for now.