### PR TITLE
[Cherry-pick] Fix check failure when DisconnectClient happens before AnnounceWorker…

### DIFF
--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -114,6 +114,7 @@ class WorkerInterface {
   FRIEND_TEST(WorkerPoolTest, TestWorkerCappingLaterNWorkersNotOwningObjects);
   FRIEND_TEST(WorkerPoolTest, TestWorkerCappingWithExitDelay);
   FRIEND_TEST(WorkerPoolTest, MaximumStartupConcurrency);
+  FRIEND_TEST(WorkerPoolTest, HandleWorkerRegistration);
 };
 
 /// Worker class encapsulates the implementation details of a worker. A worker

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -280,8 +280,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   ///
   /// \param worker The worker to disconnect. The worker must be registered.
   /// \param disconnect_type Type of a worker exit.
-  /// \return Whether the given worker was in the pool of idle workers.
-  bool DisconnectWorker(const std::shared_ptr<WorkerInterface> &worker,
+  void DisconnectWorker(const std::shared_ptr<WorkerInterface> &worker,
                         rpc::WorkerExitType disconnect_type);
 
   /// Disconnect a registered driver.
@@ -467,7 +466,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     std::queue<std::function<void(std::shared_ptr<WorkerInterface>)>> pending_io_tasks;
     /// All I/O workers that have registered and are still connected, including both
     /// idle and executing.
-    std::unordered_set<std::shared_ptr<WorkerInterface>> registered_io_workers;
+    std::unordered_set<std::shared_ptr<WorkerInterface>> started_io_workers;
     /// Number of starting I/O workers.
     int num_starting_io_workers = 0;
   };

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -217,6 +217,11 @@ class WorkerPoolMock : public WorkerPool {
     return state.spill_io_worker_state.num_starting_io_workers;
   }
 
+  int NumSpillWorkerStarted() const {
+    auto state = states_by_lang_.find(Language::PYTHON)->second;
+    return state.spill_io_worker_state.started_io_workers.size();
+  }
+
   int NumRestoreWorkerStarting() const {
     auto state = states_by_lang_.find(Language::PYTHON)->second;
     return state.restore_io_worker_state.num_starting_io_workers;
@@ -635,6 +640,21 @@ TEST_F(WorkerPoolTest, HandleWorkerRegistration) {
         worker, /*disconnect_type=*/rpc::WorkerExitType::INTENDED_EXIT);
     // Check that we cannot lookup the worker after it's disconnected.
     ASSERT_EQ(worker_pool_->GetRegisteredWorker(worker->Connection()), nullptr);
+  }
+
+  {
+    // Test the case where DisconnectClient happens after RegisterClientRequest but before
+    // AnnounceWorkerPort.
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
+        Language::PYTHON, rpc::WorkerType::WORKER, JOB_ID, &status);
+    auto worker = worker_pool_->CreateWorker(Process(), Language::PYTHON);
+    ASSERT_EQ(worker_pool_->NumWorkersStarting(), 1);
+    RAY_CHECK_OK(worker_pool_->RegisterWorker(
+        worker, proc.GetId(), worker_pool_->GetStartupToken(proc), [](Status, int) {}));
+    worker->SetStartupToken(worker_pool_->GetStartupToken(proc));
+    worker_pool_->DisconnectWorker(
+        worker, /*disconnect_type=*/rpc::WorkerExitType::INTENDED_EXIT);
+    ASSERT_EQ(worker_pool_->NumWorkersStarting(), 0);
   }
 }
 
@@ -1924,6 +1944,24 @@ TEST_F(WorkerPoolTest, TestIOWorkerFailureAndSpawn) {
     worker_pool_->OnWorkerStarted(worker);
     worker_pool_->PushSpillWorker(worker);
   }
+
+  {
+    // Test the case where DisconnectClient happens after RegisterClientRequest but before
+    // AnnounceWorkerPort.
+    auto status = PopWorkerStatus::OK;
+    auto [proc, token] = worker_pool_->StartWorkerProcess(
+        rpc::Language::PYTHON, rpc::WorkerType::SPILL_WORKER, JobID::Nil(), &status);
+    ASSERT_EQ(status, PopWorkerStatus::OK);
+    auto worker = CreateSpillWorker(Process());
+    RAY_CHECK_OK(
+        worker_pool_->RegisterWorker(worker, proc.GetId(), token, [](Status, int) {}));
+    // The worker failed before announcing the worker port (i.e. OnworkerStarted)
+    worker_pool_->DisconnectWorker(
+        worker, /*disconnect_type=*/rpc::WorkerExitType::SYSTEM_ERROR_EXIT);
+  }
+
+  ASSERT_EQ(worker_pool_->NumSpillWorkerStarting(), 0);
+  ASSERT_EQ(worker_pool_->NumSpillWorkerStarted(), MAX_IO_WORKER_SIZE);
 
   // Pop spill workers should work.
 


### PR DESCRIPTION
closes/fixes problem with #24661

the failed shuffle_1tb_5000 partitions test in 1.13.0rc0 has shown the same stacktraces where #24403 fixed. thus we should cherry-pick #24403 to fix the issue.


```
[2m[33m(raylet, ip=172.31.79.139)[0m [2022-05-10 10:44:45,723 E 130 130] (raylet) worker_pool.cc:502: Some workers of the worker process(1393) have not registered within the timeout. The process is still alive, probably it's hanging during start.
[2m[33m(raylet, ip=172.31.79.139)[0m [2022-05-10 10:44:45,769 E 130 130] (raylet) worker_pool.cc:502: Some workers of the worker process(1394) have not registered within the timeout. The process is still alive, probably it's hanging during start.
[2m[33m(raylet, ip=172.31.79.139)[0m [2022-05-10 10:44:45,811 E 130 130] (raylet) worker_pool.cc:502: Some workers of the worker process(1395) have not registered within the timeout. The process is still alive, probably it's hanging during start.
[2m[33m(raylet, ip=172.31.79.139)[0m [2022-05-10 10:44:45,853 E 130 130] (raylet) worker_pool.cc:502: Some workers of the worker process(1398) have not registered within the timeout. The process is still alive, probably it's hanging during start.
[2m[33m(raylet, ip=172.31.79.139)[0m [2022-05-10 10:44:46,094 C 130 130] (raylet) worker_pool.cc:1373:  Check failed: RemoveWorker(io_worker_state.registered_io_workers, worker) 
[2m[33m(raylet, ip=172.31.79.139)[0m *** StackTrace Information ***
[2m[33m(raylet, ip=172.31.79.139)[0m     ray::SpdLogMessage::Flush()
[2m[33m(raylet, ip=172.31.79.139)[0m     ray::RayLog::~RayLog()
[2m[33m(raylet, ip=172.31.79.139)[0m     ray::raylet::WorkerPool::DisconnectWorker()
[2m[33m(raylet, ip=172.31.79.139)[0m     ray::raylet::NodeManager::DisconnectClient()
[2m[33m(raylet, ip=172.31.79.139)[0m     ray::raylet::NodeManager::ProcessDisconnectClientMessage()
[2m[33m(raylet, ip=172.31.79.139)[0m     ray::raylet::NodeManager::ProcessClientMessage()
[2m[33m(raylet, ip=172.31.79.139)[0m     std::_Function_handler<>::_M_invoke()
[2m[33m(raylet, ip=172.31.79.139)[0m     ray::ClientConnection::ProcessMessage()
[2m[33m(raylet, ip=172.31.79.139)[0m     EventTracker::RecordExecution()
[2m[33m(raylet, ip=172.31.79.139)[0m     boost::asio::detail::read_op<>::operator()()
[2m[33m(raylet, ip=172.31.79.139)[0m     boost::asio::detail::reactive_socket_recv_op<>::do_complete()
[2m[33m(raylet, ip=172.31.79.139)[0m     boost::asio::detail::scheduler::do_run_one()
[2m[33m(raylet, ip=172.31.79.139)[0m     boost::asio::detail::scheduler::run()
[2m[33m(raylet, ip=172.31.79.139)[0m     boost::asio::io_context::run()
[2m[33m(raylet, ip=172.31.79.139)[0m     main
[2m[33m(raylet, ip=172.31.79.139)[0m     __libc_start_main
[2m[33m(raylet, ip=172.31.79.139)[0m 
````


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
