### PR TITLE
[Core/PG/Schedule 1/2]Optimize the scheduling performance of actors/tasks with PG specified only for gcs schedule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2448,6 +2448,19 @@ cc_test(
 )
 
 cc_test(
+    name = "bundle_location_index_test",
+    srcs = [
+        "src/ray/common/test/bundle_location_index_test.cc",
+    ],
+    copts = COPTS,
+    tags = ["team:core"],
+    deps = [
+        ":ray_common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "callback_reply_test",
     size = "small",
     srcs = ["src/ray/gcs/test/callback_reply_test.cc"],

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -121,7 +121,10 @@ def test_placement_group_invalid_resource_request(shutdown_only):
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_pack(ray_start_cluster, connect_to_client):
+@pytest.mark.parametrize("gcs_actor_scheduling_enabled", [False, True])
+def test_placement_group_pack(
+    ray_start_cluster, connect_to_client, gcs_actor_scheduling_enabled
+):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -132,8 +135,15 @@ def test_placement_group_pack(ray_start_cluster, connect_to_client):
 
     cluster = ray_start_cluster
     num_nodes = 2
-    for _ in range(num_nodes):
-        cluster.add_node(num_cpus=4)
+    for i in range(num_nodes):
+        cluster.add_node(
+            num_cpus=4,
+            _system_config={
+                "gcs_actor_scheduling_enabled": gcs_actor_scheduling_enabled
+            }
+            if i == 0
+            else {},
+        )
     ray.init(address=cluster.address)
 
     with connect_to_client_or_not(connect_to_client):
@@ -229,7 +239,10 @@ def test_placement_group_strict_pack(ray_start_cluster, connect_to_client):
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_spread(ray_start_cluster, connect_to_client):
+@pytest.mark.parametrize("gcs_actor_scheduling_enabled", [False, True])
+def test_placement_group_spread(
+    ray_start_cluster, connect_to_client, gcs_actor_scheduling_enabled
+):
     @ray.remote
     class Actor(object):
         def __init__(self):
@@ -240,8 +253,15 @@ def test_placement_group_spread(ray_start_cluster, connect_to_client):
 
     cluster = ray_start_cluster
     num_nodes = 2
-    for _ in range(num_nodes):
-        cluster.add_node(num_cpus=4)
+    for i in range(num_nodes):
+        cluster.add_node(
+            num_cpus=4,
+            _system_config={
+                "gcs_actor_scheduling_enabled": gcs_actor_scheduling_enabled
+            }
+            if i == 0
+            else {},
+        )
     ray.init(address=cluster.address)
 
     with connect_to_client_or_not(connect_to_client):
@@ -275,7 +295,10 @@ def test_placement_group_spread(ray_start_cluster, connect_to_client):
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_strict_spread(ray_start_cluster, connect_to_client):
+@pytest.mark.parametrize("gcs_actor_scheduling_enabled", [False, True])
+def test_placement_group_strict_spread(
+    ray_start_cluster, connect_to_client, gcs_actor_scheduling_enabled
+):
     @ray.remote
     class Actor(object):
         def __init__(self):
@@ -286,8 +309,15 @@ def test_placement_group_strict_spread(ray_start_cluster, connect_to_client):
 
     cluster = ray_start_cluster
     num_nodes = 3
-    for _ in range(num_nodes):
-        cluster.add_node(num_cpus=4)
+    for i in range(num_nodes):
+        cluster.add_node(
+            num_cpus=4,
+            _system_config={
+                "gcs_actor_scheduling_enabled": gcs_actor_scheduling_enabled
+            }
+            if i == 0
+            else {},
+        )
     ray.init(address=cluster.address)
 
     with connect_to_client_or_not(connect_to_client):
@@ -301,7 +331,7 @@ def test_placement_group_strict_spread(ray_start_cluster, connect_to_client):
             Actor.options(
                 placement_group=placement_group,
                 placement_group_bundle_index=i,
-                num_cpus=2,
+                num_cpus=1,
             ).remote()
             for i in range(num_nodes)
         ]
@@ -316,6 +346,22 @@ def test_placement_group_strict_spread(ray_start_cluster, connect_to_client):
         assert are_pairwise_unique(
             [info_obj["Address"]["NodeID"] for info_obj in actor_info_objs]
         )
+
+        actors_no_special_bundle = [
+            Actor.options(
+                placement_group=placement_group,
+                num_cpus=1,
+            ).remote()
+            for _ in range(num_nodes)
+        ]
+        [ray.get(actor.value.remote()) for actor in actors_no_special_bundle]
+
+        actor_no_resource = Actor.options(
+            placement_group=placement_group,
+            num_cpus=2,
+        ).remote()
+        with pytest.raises(ray.exceptions.GetTimeoutError):
+            ray.get(actor_no_resource.value.remote(), timeout=1)
 
         placement_group_assert_no_leak([placement_group])
 

--- a/src/ray/common/bundle_location_index.cc
+++ b/src/ray/common/bundle_location_index.cc
@@ -1,0 +1,206 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/common/bundle_location_index.h"
+
+namespace ray {
+
+void BundleLocationIndex::AddBundleLocations(
+    const PlacementGroupID &placement_group_id,
+    std::shared_ptr<BundleLocations> bundle_locations) {
+  // Update `placement_group_to_bundle_locations_`.
+  // The placement group may be scheduled several times to succeed, so we need to merge
+  // `bundle_locations` instead of covering it directly.
+  auto iter = placement_group_to_bundle_locations_.find(placement_group_id);
+  if (iter == placement_group_to_bundle_locations_.end()) {
+    placement_group_to_bundle_locations_.emplace(placement_group_id, bundle_locations);
+  } else {
+    iter->second->insert(bundle_locations->begin(), bundle_locations->end());
+  }
+
+  // Update `node_to_leased_bundles_`.
+  for (auto iter : *bundle_locations) {
+    const auto &node_id = iter.second.first;
+    if (!node_to_leased_bundles_.contains(node_id)) {
+      node_to_leased_bundles_[node_id] = std::make_shared<BundleLocations>();
+    }
+    node_to_leased_bundles_[node_id]->emplace(iter.first, iter.second);
+  }
+}
+
+void BundleLocationIndex::AddOrUpdateBundleLocation(
+    const BundleID &bundle_id,
+    const NodeID &node_id,
+    std::shared_ptr<const BundleSpecification> bundle_specification) {
+  const auto &placement_group_id = bundle_id.first;
+  if (!placement_group_to_bundle_locations_.contains(placement_group_id)) {
+    placement_group_to_bundle_locations_[placement_group_id] =
+        std::make_shared<BundleLocations>();
+  }
+  const auto &bundle_locations = placement_group_to_bundle_locations_[placement_group_id];
+  if (bundle_locations->contains(bundle_id)) {
+    // If the bundle is on other nodes before, need to clean up node_to_bundles first.
+    const auto &old_pair = (*bundle_locations)[bundle_id];
+    if (old_pair.first != node_id) {
+      EraseBundleInNodeMap(old_pair.first, bundle_id);
+    }
+  }
+  (*bundle_locations)[bundle_id] = std::make_pair(node_id, bundle_specification);
+
+  if (!node_to_leased_bundles_.contains(node_id)) {
+    node_to_leased_bundles_[node_id] = std::make_shared<BundleLocations>();
+  }
+  (*node_to_leased_bundles_[node_id])[bundle_id] =
+      std::make_pair(node_id, bundle_specification);
+}
+
+void BundleLocationIndex::AddOrUpdateBundleLocations(
+    const std::shared_ptr<BundleLocations> &bundle_locations) {
+  for (const auto &iter : *bundle_locations) {
+    AddOrUpdateBundleLocation(iter.first, iter.second.first, iter.second.second);
+  }
+}
+
+bool BundleLocationIndex::Erase(const NodeID &node_id) {
+  const auto leased_bundles_it = node_to_leased_bundles_.find(node_id);
+  if (leased_bundles_it == node_to_leased_bundles_.end()) {
+    return false;
+  }
+
+  const auto &bundle_locations = leased_bundles_it->second;
+  for (const auto &bundle_location : *bundle_locations) {
+    // Remove corresponding placement group id.
+    const auto &bundle_id = bundle_location.first;
+    const auto placement_group_id = bundle_id.first;
+    auto placement_group_it =
+        placement_group_to_bundle_locations_.find(placement_group_id);
+    if (placement_group_it != placement_group_to_bundle_locations_.end()) {
+      auto &pg_bundle_locations = placement_group_it->second;
+      auto pg_bundle_it = pg_bundle_locations->find(bundle_id);
+      if (pg_bundle_it != pg_bundle_locations->end()) {
+        pg_bundle_locations->erase(pg_bundle_it);
+      }
+    }
+  }
+  node_to_leased_bundles_.erase(leased_bundles_it);
+  return true;
+}
+
+bool BundleLocationIndex::Erase(const PlacementGroupID &placement_group_id) {
+  auto it = placement_group_to_bundle_locations_.find(placement_group_id);
+  if (it == placement_group_to_bundle_locations_.end()) {
+    return false;
+  }
+
+  const auto &bundle_locations = it->second;
+  // Remove bundles from node_to_leased_bundles_ because bundles are removed now.
+  for (const auto &bundle_location : *bundle_locations) {
+    const auto &bundle_id = bundle_location.first;
+    const auto &node_id = bundle_location.second.first;
+    EraseBundleInNodeMap(node_id, bundle_id);
+  }
+  placement_group_to_bundle_locations_.erase(it);
+
+  return true;
+}
+
+const absl::optional<std::shared_ptr<BundleLocations> const>
+BundleLocationIndex::GetBundleLocations(
+    const PlacementGroupID &placement_group_id) const {
+  auto it = placement_group_to_bundle_locations_.find(placement_group_id);
+  if (it == placement_group_to_bundle_locations_.end()) {
+    return {};
+  }
+  return it->second;
+}
+
+const absl::optional<std::shared_ptr<BundleLocations> const>
+BundleLocationIndex::GetBundleLocationsOnNode(const NodeID &node_id) const {
+  auto it = node_to_leased_bundles_.find(node_id);
+  if (it == node_to_leased_bundles_.end()) {
+    return {};
+  }
+  return it->second;
+}
+
+std::optional<NodeID> BundleLocationIndex::GetBundleLocation(
+    const BundleID &bundle_id) const {
+  auto all_bundle_locations_opt = GetBundleLocations(bundle_id.first);
+  if (all_bundle_locations_opt) {
+    const auto &iter = (*all_bundle_locations_opt)->find(bundle_id);
+    if (iter != (*all_bundle_locations_opt)->end()) {
+      return std::make_optional(iter->second.first);
+    }
+  }
+  return std::nullopt;
+}
+
+void BundleLocationIndex::AddNodes(
+    const absl::flat_hash_map<NodeID, std::shared_ptr<ray::rpc::GcsNodeInfo>> &nodes) {
+  for (const auto &iter : nodes) {
+    if (!node_to_leased_bundles_.contains(iter.first)) {
+      node_to_leased_bundles_[iter.first] = std::make_shared<BundleLocations>();
+    }
+  }
+}
+
+std::string BundleLocationIndex::GetBundleLocationDebugString(
+    const BundleLocations &bundle_locations) const {
+  std::ostringstream ostr;
+  ostr << "[";
+  for (const auto &iter : bundle_locations) {
+    ostr << "{bundle_index:" << iter.first.second
+         << ", node_id:" << scheduling::NodeID(iter.second.first.Binary()).ToInt()
+         << "},\n";
+  }
+  ostr << "]";
+  return ostr.str();
+}
+
+std::string BundleLocationIndex::DebugString() const {
+  std::ostringstream ostr;
+  ostr << "{ \"placment group locations\": [";
+  for (const auto &iter : placement_group_to_bundle_locations_) {
+    ostr << "{placement group id: " << iter.first << ", ";
+    ostr << "bundle locations:" << GetBundleLocationDebugString(*iter.second);
+    ostr << "},";
+  }
+  ostr << "], \"node to bundles\": [";
+  for (const auto &iter : node_to_leased_bundles_) {
+    ostr << "{node id: " << scheduling::NodeID(iter.first.Binary()).ToInt() << ", ";
+    ostr << "bundles:";
+    ostr << "[";
+    for (const auto &bundle_iter : (*iter.second)) {
+      ostr << "{pg_id:" << bundle_iter.first.first
+           << ", bundle_index:" << bundle_iter.first.second << "},";
+    }
+    ostr << "]";
+    ostr << "},";
+  }
+  ostr << "]}";
+  return ostr.str();
+}
+
+void BundleLocationIndex::EraseBundleInNodeMap(const NodeID &node_id,
+                                               const BundleID &bundle_id) {
+  const auto &node_bundles_it = node_to_leased_bundles_.find(node_id);
+  if (node_bundles_it != node_to_leased_bundles_.end()) {
+    node_bundles_it->second->erase(bundle_id);
+    if (node_bundles_it->second->empty()) {
+      node_to_leased_bundles_.erase(node_bundles_it);
+    }
+  }
+}
+
+}  // namespace ray

--- a/src/ray/common/bundle_location_index.h
+++ b/src/ray/common/bundle_location_index.h
@@ -1,0 +1,107 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/id.h"
+#include "ray/common/placement_group.h"
+#include "src/ray/protobuf/gcs.pb.h"
+
+namespace ray {
+
+/// A data structure that helps fast bundle location lookup.
+class BundleLocationIndex {
+ public:
+  BundleLocationIndex() {}
+  ~BundleLocationIndex() = default;
+
+  /// Add bundle locations to index.
+  ///
+  /// \param placement_group_id
+  /// \param bundle_locations Bundle locations that will be associated with the placement
+  /// group id.
+  void AddBundleLocations(const PlacementGroupID &placement_group_id,
+                          std::shared_ptr<BundleLocations> bundle_locations);
+
+  /// Add or update bundles location to index. May be bundles of different PGs
+  ///
+  /// \param bundle_locations Bundles location
+  void AddOrUpdateBundleLocations(
+      const std::shared_ptr<BundleLocations> &bundle_locations);
+
+  /// Add or update a bundle location to index.
+  ///
+  /// \param bundle_id
+  /// \param node_id
+  /// \param bundle_specialication
+  void AddOrUpdateBundleLocation(
+      const BundleID &bundle_id,
+      const NodeID &node_id,
+      std::shared_ptr<const BundleSpecification> bundle_specialication = nullptr);
+
+  /// Erase bundle locations associated with a given node id.
+  ///
+  /// \param node_id The id of node.
+  /// \return True if succeed. False otherwise.
+  bool Erase(const NodeID &node_id);
+
+  /// Erase bundle locations associated with a given placement group id.
+  ///
+  /// \param placement_group_id Placement group id
+  /// \return True if succeed. False otherwise.
+  bool Erase(const PlacementGroupID &placement_group_id);
+
+  /// Get BundleLocation of placement group id.
+  ///
+  /// \param placement_group_id Placement group id of this bundle locations.
+  /// \return Bundle locations that are associated with a given placement group id.
+  const absl::optional<std::shared_ptr<BundleLocations> const> GetBundleLocations(
+      const PlacementGroupID &placement_group_id) const;
+
+  /// Get BundleLocation of node id.
+  ///
+  /// \param node_id Node id of this bundle locations.
+  /// \return Bundle locations that are associated with a given node id.
+  const absl::optional<std::shared_ptr<BundleLocations> const> GetBundleLocationsOnNode(
+      const NodeID &node_id) const;
+
+  std::optional<NodeID> GetBundleLocation(const BundleID &bundle_id) const;
+  /// Update the index to contain new node information. Should be used only when new node
+  /// is added to the cluster.
+  ///
+  /// \param alive_nodes map of alive nodes.
+  void AddNodes(
+      const absl::flat_hash_map<NodeID, std::shared_ptr<ray::rpc::GcsNodeInfo>> &nodes);
+
+  /// get bundle_locations debug string info
+  std::string GetBundleLocationDebugString(const BundleLocations &bundle_locations) const;
+
+  /// get all debug string info
+  std::string DebugString() const;
+
+ private:
+  /// only erase bundle in node_to_leased_bundles_
+  void EraseBundleInNodeMap(const NodeID &node_id, const BundleID &bundle_id);
+  /// Map from node ID to the set of bundles. This is used to lookup bundles at each node
+  /// when a node is dead.
+  absl::flat_hash_map<NodeID, std::shared_ptr<BundleLocations>> node_to_leased_bundles_;
+
+  /// A map from placement group id to bundle locations.
+  /// It is used to destroy bundles for the placement group.
+  /// NOTE: It is a reverse index of `node_to_leased_bundles`.
+  absl::flat_hash_map<PlacementGroupID, std::shared_ptr<BundleLocations>>
+      placement_group_to_bundle_locations_;
+};
+
+}  // namespace ray

--- a/src/ray/common/bundle_spec.h
+++ b/src/ray/common/bundle_spec.h
@@ -117,4 +117,15 @@ std::string GetOriginalResourceName(const std::string &resource);
 std::string GetDebugStringForBundles(
     const std::vector<std::shared_ptr<const BundleSpecification>> &bundles);
 
+/// Format the placement group resource set, e.g., CPU -> CPU_group_YYY_i
+std::unordered_map<std::string, double> AddPlacementGroupConstraint(
+    const std::unordered_map<std::string, double> &resources,
+    const PlacementGroupID &placement_group_id,
+    int64_t bundle_index);
+
+/// Format the placement group resource set, e.g., CPU -> CPU_group_YYY_i
+std::unordered_map<std::string, double> AddPlacementGroupConstraint(
+    const std::unordered_map<std::string, double> &resources,
+    const rpc::SchedulingStrategy &scheduling_strategy);
+
 }  // namespace ray

--- a/src/ray/common/test/bundle_location_index_test.cc
+++ b/src/ray/common/test/bundle_location_index_test.cc
@@ -1,0 +1,98 @@
+
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/common/bundle_location_index.h"
+
+#include "gtest/gtest.h"
+
+namespace ray {
+
+class BundleLocationIndexTest : public ::testing::Test {
+ public:
+  PlacementGroupID pg_1 = PlacementGroupID::Of(JobID::FromInt(1));
+  PlacementGroupID pg_2 = PlacementGroupID::Of(JobID::FromInt(2));
+  BundleID bundle_0 = std::make_pair(pg_1, 0);
+  BundleID bundle_1 = std::make_pair(pg_1, 2);
+  BundleID bundle_2 = std::make_pair(pg_1, 3);
+
+  BundleID pg_2_bundle_0 = std::make_pair(pg_2, 0);
+  BundleID pg_2_bundle_1 = std::make_pair(pg_2, 1);
+
+  NodeID node_0 = NodeID::FromRandom();
+  NodeID node_1 = NodeID::FromRandom();
+  NodeID node_2 = NodeID::FromRandom();
+};
+
+TEST_F(BundleLocationIndexTest, BesicTest) {
+  BundleLocationIndex pg_location_index;
+
+  ASSERT_FALSE(pg_location_index.GetBundleLocations(pg_1));
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(bundle_1));
+
+  // test add and get
+  auto bundle_locations = std::make_shared<BundleLocations>();
+  (*bundle_locations)[bundle_0] = std::make_pair(node_0, nullptr);
+  (*bundle_locations)[bundle_1] = std::make_pair(node_1, nullptr);
+  pg_location_index.AddOrUpdateBundleLocations(bundle_locations);
+  auto pg_bundles_location = pg_location_index.GetBundleLocations(pg_1);
+  ASSERT_TRUE(pg_bundles_location);
+  ASSERT_EQ((**pg_bundles_location)[bundle_0].first, node_0);
+  ASSERT_EQ((**pg_bundles_location)[bundle_1].first, node_1);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_0)), node_0);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_1)), node_1);
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(bundle_2));
+
+  bundle_locations = std::make_shared<BundleLocations>();
+  (*bundle_locations)[bundle_2] = std::make_pair(node_2, nullptr);
+  pg_location_index.AddOrUpdateBundleLocations(bundle_locations);
+  bundle_locations = std::make_shared<BundleLocations>();
+  (*bundle_locations)[pg_2_bundle_0] = std::make_pair(node_0, nullptr);
+  (*bundle_locations)[pg_2_bundle_1] = std::make_pair(node_1, nullptr);
+
+  pg_location_index.AddOrUpdateBundleLocations(bundle_locations);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_0)), node_0);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_1)), node_1);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_2)), node_2);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(pg_2_bundle_0)), node_0);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(pg_2_bundle_1)), node_1);
+  ASSERT_EQ((*pg_location_index.GetBundleLocations(pg_1))->size(), 3);
+
+  // test erase
+  pg_location_index.Erase(node_0);
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(bundle_0));
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(pg_2_bundle_0));
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_1)), node_1);
+
+  pg_location_index.Erase(pg_1);
+  ASSERT_FALSE(pg_location_index.GetBundleLocations(pg_1));
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(bundle_1));
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(bundle_2));
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(pg_2_bundle_1)), node_1);
+
+  // test add again
+  bundle_locations = std::make_shared<BundleLocations>();
+  (*bundle_locations)[bundle_0] = std::make_pair(node_0, nullptr);
+  (*bundle_locations)[bundle_1] = std::make_pair(node_1, nullptr);
+  pg_location_index.AddOrUpdateBundleLocations(bundle_locations);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_0)), node_0);
+  ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_1)), node_1);
+}
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1447,38 +1447,6 @@ void CoreWorker::SpillOwnedObject(const ObjectID &object_id,
       });
 }
 
-std::unordered_map<std::string, double> AddPlacementGroupConstraint(
-    const std::unordered_map<std::string, double> &resources,
-    const rpc::SchedulingStrategy &scheduling_strategy) {
-  auto placement_group_id = PlacementGroupID::Nil();
-  auto bundle_index = -1;
-  if (scheduling_strategy.scheduling_strategy_case() ==
-      rpc::SchedulingStrategy::SchedulingStrategyCase::
-          kPlacementGroupSchedulingStrategy) {
-    placement_group_id = PlacementGroupID::FromBinary(
-        scheduling_strategy.placement_group_scheduling_strategy().placement_group_id());
-    bundle_index = scheduling_strategy.placement_group_scheduling_strategy()
-                       .placement_group_bundle_index();
-  }
-  if (bundle_index < 0) {
-    RAY_CHECK(bundle_index == -1) << "Invalid bundle index " << bundle_index;
-  }
-  std::unordered_map<std::string, double> new_resources;
-  if (placement_group_id != PlacementGroupID::Nil()) {
-    for (auto iter = resources.begin(); iter != resources.end(); iter++) {
-      auto new_name = FormatPlacementGroupResource(iter->first, placement_group_id, -1);
-      new_resources[new_name] = iter->second;
-      if (bundle_index >= 0) {
-        auto index_name =
-            FormatPlacementGroupResource(iter->first, placement_group_id, bundle_index);
-        new_resources[index_name] = iter->second;
-      }
-    }
-    return new_resources;
-  }
-  return resources;
-}
-
 rpc::RuntimeEnv CoreWorker::OverrideRuntimeEnv(
     const rpc::RuntimeEnv &child, const std::shared_ptr<rpc::RuntimeEnv> parent) {
   // By default, the child runtime env inherits non-specified options from the

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -764,7 +764,7 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestStrictSpreadStrategyResourceCheck) {
 }
 
 TEST_F(GcsPlacementGroupSchedulerTest, TestBundleLocationIndex) {
-  gcs::BundleLocationIndex bundle_location_index;
+  BundleLocationIndex bundle_location_index;
   /// Generate data.
   const auto node1 = NodeID::FromRandom();
   const auto node2 = NodeID::FromRandom();

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -270,6 +270,11 @@ void ClusterResourceManager::DebugString(std::stringstream &buffer) const {
     buffer << "node id: " << node.first.ToInt();
     buffer << node.second.GetLocalView().DebugString();
   }
+  buffer << bundle_location_index_.DebugString();
+}
+
+BundleLocationIndex &ClusterResourceManager::GetBundleLocationIndex() {
+  return bundle_location_index_;
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -22,6 +22,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "ray/common/bundle_location_index.h"
 #include "ray/raylet/scheduling/cluster_resource_data.h"
 #include "ray/raylet/scheduling/fixed_point.h"
 #include "ray/raylet/scheduling/local_resource_manager.h"
@@ -127,6 +128,8 @@ class ClusterResourceManager {
 
   void DebugString(std::stringstream &buffer) const;
 
+  BundleLocationIndex &GetBundleLocationIndex();
+
  private:
   friend class ClusterResourceScheduler;
   friend class gcs::GcsActorSchedulerTest;
@@ -150,6 +153,8 @@ class ClusterResourceManager {
   /// The key of the map is the node ID.
   absl::flat_hash_map<scheduling::NodeID, Node> nodes_;
 
+  BundleLocationIndex bundle_location_index_;
+
   friend class ClusterResourceSchedulerTest;
   friend struct ClusterResourceManagerTest;
   friend class raylet::ClusterTaskManagerTest;
@@ -172,6 +177,7 @@ class ClusterResourceManager {
   FRIEND_TEST(ClusterResourceSchedulerTest, DynamicResourceTest);
   FRIEND_TEST(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources);
   FRIEND_TEST(ClusterResourceSchedulerTest, TestForceSpillback);
+  FRIEND_TEST(ClusterResourceSchedulerTest, AffinityWithBundleScheduleTest);
 
   friend class raylet::SchedulingPolicyTest;
 };

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -189,6 +189,8 @@ class ClusterResourceScheduler {
       int64_t *violations,
       bool *is_infeasible);
 
+  /// Judging whether it affinity with placement group bundle
+  bool IsAffinityWithBundleSchedule(const rpc::SchedulingStrategy &scheduling_strategy);
   /// Identifier of local node.
   scheduling::NodeID local_node_id_;
   /// Callback to check if node is available.
@@ -226,6 +228,7 @@ class ClusterResourceScheduler {
   FRIEND_TEST(ClusterResourceSchedulerTest, DynamicResourceTest);
   FRIEND_TEST(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources);
   FRIEND_TEST(ClusterResourceSchedulerTest, TestForceSpillback);
+  FRIEND_TEST(ClusterResourceSchedulerTest, AffinityWithBundleScheduleTest);
 };
 
 }  // end namespace ray

--- a/src/ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.cc
@@ -1,0 +1,59 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.h"
+
+namespace ray {
+namespace raylet_scheduling_policy {
+
+bool AffinityWithBundleSchedulingPolicy::IsNodeFeasibleAndAvailable(
+    const scheduling::NodeID &node_id, const ResourceRequest &resource_request) {
+  return nodes_.contains(node_id) && is_node_alive_(node_id) &&
+         nodes_.at(node_id).GetLocalView().IsFeasible(resource_request) &&
+         nodes_.at(node_id).GetLocalView().IsAvailable(resource_request);
+}
+
+scheduling::NodeID AffinityWithBundleSchedulingPolicy::Schedule(
+    const ResourceRequest &resource_request, SchedulingOptions options) {
+  RAY_CHECK(options.scheduling_type == SchedulingType::AFFINITY_WITH_BUNDLE);
+
+  auto bundle_scheduling_context =
+      dynamic_cast<const AffinityWithBundleSchedulingContext *>(
+          options.scheduling_context.get());
+  const BundleID &bundle_id = bundle_scheduling_context->GetAffinityBundleID();
+  if (bundle_id.second != -1) {
+    const auto &node_id_opt = bundle_location_index_.GetBundleLocation(bundle_id);
+    if (node_id_opt) {
+      auto target_node_id = scheduling::NodeID(node_id_opt.value().Binary());
+      if (IsNodeFeasibleAndAvailable(target_node_id, resource_request)) {
+        return target_node_id;
+      }
+    }
+  } else {
+    const PlacementGroupID &pg_id = bundle_id.first;
+    const auto &bundle_locations_opt = bundle_location_index_.GetBundleLocations(pg_id);
+    if (bundle_locations_opt) {
+      for (const auto &iter : *(bundle_locations_opt.value())) {
+        auto target_node_id = scheduling::NodeID(iter.second.first.Binary());
+        if (IsNodeFeasibleAndAvailable(target_node_id, resource_request)) {
+          return target_node_id;
+        }
+      }
+    }
+  }
+  return scheduling::NodeID::Nil();
+}
+
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.h
@@ -1,0 +1,49 @@
+// Copyright 2021 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "ray/common/bundle_location_index.h"
+#include "ray/raylet/scheduling/policy/scheduling_policy.h"
+
+namespace ray {
+namespace raylet_scheduling_policy {
+
+// Select the node based on placement group id that the user specified.
+class AffinityWithBundleSchedulingPolicy : public ISchedulingPolicy {
+ public:
+  AffinityWithBundleSchedulingPolicy(
+      scheduling::NodeID local_node_id,
+      const absl::flat_hash_map<scheduling::NodeID, Node> &nodes,
+      std::function<bool(scheduling::NodeID)> is_node_alive,
+      const BundleLocationIndex &pg_location_index)
+      : local_node_id_(local_node_id),
+        nodes_(nodes),
+        is_node_alive_(is_node_alive),
+        bundle_location_index_(pg_location_index) {}
+
+  scheduling::NodeID Schedule(const ResourceRequest &resource_request,
+                              SchedulingOptions options) override;
+
+  const scheduling::NodeID local_node_id_;
+  const absl::flat_hash_map<scheduling::NodeID, Node> &nodes_;
+  std::function<bool(scheduling::NodeID)> is_node_alive_;
+  const BundleLocationIndex &bundle_location_index_;
+
+ private:
+  bool IsNodeFeasibleAndAvailable(const scheduling::NodeID &node_id,
+                                  const ResourceRequest &resource_request);
+};
+}  // namespace raylet_scheduling_policy
+}  // namespace ray

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc
@@ -34,6 +34,8 @@ scheduling::NodeID CompositeSchedulingPolicy::Schedule(
     return hybrid_policy_.Schedule(resource_request, options);
   case SchedulingType::NODE_AFFINITY:
     return node_affinity_policy_.Schedule(resource_request, options);
+  case SchedulingType::AFFINITY_WITH_BUNDLE:
+    return affinity_with_bundle_policy_.Schedule(resource_request, options);
   default:
     RAY_LOG(FATAL) << "Unsupported scheduling type: "
                    << static_cast<typename std::underlying_type<SchedulingType>::type>(

--- a/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/composite_scheduling_policy.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "ray/raylet/scheduling/cluster_resource_manager.h"
+#include "ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/bundle_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/hybrid_scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/node_affinity_scheduling_policy.h"
@@ -39,9 +40,12 @@ class CompositeSchedulingPolicy : public ISchedulingPolicy {
             local_node_id, cluster_resource_manager.GetResourceView(), is_node_available),
         spread_policy_(
             local_node_id, cluster_resource_manager.GetResourceView(), is_node_available),
-        node_affinity_policy_(local_node_id,
-                              cluster_resource_manager.GetResourceView(),
-                              is_node_available) {}
+        node_affinity_policy_(
+            local_node_id, cluster_resource_manager.GetResourceView(), is_node_available),
+        affinity_with_bundle_policy_(local_node_id,
+                                     cluster_resource_manager.GetResourceView(),
+                                     is_node_available,
+                                     cluster_resource_manager.GetBundleLocationIndex()) {}
 
   scheduling::NodeID Schedule(const ResourceRequest &resource_request,
                               SchedulingOptions options) override;
@@ -51,6 +55,7 @@ class CompositeSchedulingPolicy : public ISchedulingPolicy {
   RandomSchedulingPolicy random_policy_;
   SpreadSchedulingPolicy spread_policy_;
   NodeAffinitySchedulingPolicy node_affinity_policy_;
+  AffinityWithBundleSchedulingPolicy affinity_with_bundle_policy_;
 };
 
 /// A composite scheduling policy that routes the request to the underlining

--- a/src/ray/raylet/scheduling/policy/scheduling_context.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_context.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "absl/container/flat_hash_map.h"
+#include "ray/common/bundle_location_index.h"
 #include "ray/common/bundle_spec.h"
 #include "ray/common/id.h"
 #include "ray/common/placement_group.h"
@@ -35,6 +36,16 @@ struct BundleSchedulingContext : public SchedulingContext {
 
   /// The locations of existing bundles for this placement group.
   absl::optional<std::shared_ptr<BundleLocations>> bundle_locations_;
+};
+
+struct AffinityWithBundleSchedulingContext : public SchedulingContext {
+ public:
+  explicit AffinityWithBundleSchedulingContext(const BundleID &bundle_id)
+      : affinity_bundle_id_(bundle_id) {}
+  const BundleID &GetAffinityBundleID() const { return affinity_bundle_id_; }
+
+ private:
+  BundleID affinity_bundle_id_;
 };
 
 }  // namespace raylet_scheduling_policy

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -34,6 +34,7 @@ enum class SchedulingType {
   BUNDLE_SPREAD = 5,
   BUNDLE_STRICT_PACK = 6,
   BUNDLE_STRICT_SPREAD = 7,
+  AFFINITY_WITH_BUNDLE = 8
 };
 
 // Options that controls the scheduling behavior.
@@ -112,6 +113,18 @@ struct SchedulingOptions {
                              /*require_node_available*/ true,
                              /*avoid_gpu_nodes*/ false,
                              /*scheduling_context*/ std::move(scheduling_context));
+  }
+
+  // construct option for affinity with bundle scheduling policy.
+  static SchedulingOptions AffinityWithBundle(const BundleID &bundle_id) {
+    auto scheduling_context =
+        std::make_unique<AffinityWithBundleSchedulingContext>(bundle_id);
+    return SchedulingOptions(SchedulingType::AFFINITY_WITH_BUNDLE,
+                             /*spread_threshold*/ 0,
+                             /*avoid_local_node*/ false,
+                             /*require_node_available*/ true,
+                             /*avoid_gpu_nodes*/ false,
+                             std::move(scheduling_context));
   }
 
   SchedulingType scheduling_type;


### PR DESCRIPTION
## Why are these changes needed?

When  schedule actors on pg, instead of iterating all nodes in the cluster resource, This optimize will directly queries corresponding nodes by looking at pg location index.
This optimization can reduce the complexity of the algorithm from O (N) to o (1)，and N is the number of nodes. In particular, the more nodes in large-scale clusters, the better the optimization effect.

**This PR only optimize schedule by gcs, I will submit a PR for raylet scheduling later.**

In ant group, Now we have achieved the optimization in the GCS scheduling mode and obtained the following performance test results.
1、The average time of selecting nodes is reduced from 330us to 30us, and the performance is improved by about 11 times.
2、The total time of creating & executing 12,000 actors ranges from 271 (s) - > 225 (s) on average. Reduce time consumption by 17%.

More detailed solution information is in the issue.

## Related issue number

[Core/PG/Schedule]Optimize the scheduling performance of actors/tasks with PG specified #23881

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
