### PR TITLE
[Tune] Bug fix - HEBOSearch - accept iterables as a config search space

### DIFF
--- a/python/ray/tune/suggest/hebo.py
+++ b/python/ray/tune/suggest/hebo.py
@@ -272,7 +272,7 @@ class HEBOSearch(Searcher):
 
         if self._initial_points:
             params = self._initial_points.pop(0)
-            suggestion = pd.DataFrame(params, index=[0])
+            suggestion = pd.DataFrame([params], index=[0])
         else:
             if (
                 self._batch_filled
@@ -283,7 +283,7 @@ class HEBOSearch(Searcher):
                 suggestion = self._opt.suggest(n_suggestions=self._max_concurrent)
                 self._suggestions_cache = suggestion.to_dict("records")
             params = self._suggestions_cache.pop(0)
-            suggestion = pd.DataFrame(params, index=[0])
+            suggestion = pd.DataFrame([params], index=[0])
         self._live_trial_mapping[trial_id] = suggestion
         if len(self._live_trial_mapping) >= self._max_concurrent:
             self._batch_filled = True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->

HEBOSearch algorithm currently fails if the config search space contains a categorical parameter where each category is an iterable.

For instance, choosing the hidden layers of a NN:
` hyperparam_search_space = {'hidden_sizes': tune.choice([[512, 256, 128], [1024, 512, 256]])}`

This is due to the creation of the Pandas DataFrame with HEBO suggested parameters, without explicitly telling Pandas that the hyper-parameter suggestion is a single row of data while the index is being defined as a single row. This results in an exception such as "ValueError: Length of values (3) does not match length of index (1)".

<!-- ## Related issue number -->

<!-- For example: "Closes #1234" -->

## Checks
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
