### PR TITLE
PPO now errors on unused exploration config

### DIFF
--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -102,6 +102,12 @@ class PPOConfig(TrainerConfig):
         # fmt: on
 
     @override(TrainerConfig)
+    def exploration(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Policy-gradient methods like PPO cannot use custom exploration."
+        )
+
+    @override(TrainerConfig)
     def training(
         self,
         *,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We should not be able to do the following:
```python
PPOConfig().exploration(exploration_config={"type": "ThompsonSampling"}) 
```
because these exploration options really only make sense for DQN/etc. PPO will not actually use the `exploration_config`, but users might think they are successfully "changing" the exploration strategy.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
