### PR TITLE
[Tune] Fix Jupyter reporter with older IPython

### DIFF
--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -546,12 +546,12 @@ class JupyterNotebookReporter(TuneReporterBase, RemoteReporterMixin):
             self.display(progress_str)
 
     def display(self, string: str) -> None:
-        from IPython.core.display import display, HTML
+        from IPython.display import display, HTML, clear_output
 
         if not self._display_handle:
-            self._display_handle = display(
-                HTML(string), display_id=True, clear=self._overwrite
-            )
+            if self._overwrite:
+                clear_output(wait=True)
+            self._display_handle = display(HTML(string), display_id=True)
         else:
             self._display_handle.update(HTML(string))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes `JupyterNotebookReporter` not working with older IPython versions (eg. 5.5.0, installed on Google Colab).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
