### PR TITLE
Don't show usage stats prompt in dashboard if prompt is disabled

### DIFF
--- a/dashboard/client/src/api.ts
+++ b/dashboard/client/src/api.ts
@@ -37,7 +37,8 @@ export type RayConfigResponse = {
 export const getRayConfig = () => get<RayConfigResponse>("/api/ray_config", {});
 
 export type UsageStatsEnabledResponse = {
-  enabled: boolean;
+  usageStatsEnabled: boolean;
+  usageStatsPromptEnabled: boolean;
 };
 
 export const getUsageStatsEnabled = () =>

--- a/dashboard/client/src/pages/dashboard/Dashboard.tsx
+++ b/dashboard/client/src/pages/dashboard/Dashboard.tsx
@@ -105,14 +105,12 @@ const Dashboard: React.FC = () => {
   }
 
   const SelectedComponent = tabs[tab].component;
+  const [usageStatsPromptEnabled, setUsageStatsPromptEnabled] = useState(false);
   const [usageStatsEnabled, setUsageStatsEnabled] = useState(false);
   useEffect(() => {
     getUsageStatsEnabled().then((res) => {
-      if (res.enabled) {
-        setUsageStatsEnabled(true);
-      } else {
-        setUsageStatsEnabled(false);
-      }
+      setUsageStatsPromptEnabled(res.usageStatsPromptEnabled);
+      setUsageStatsEnabled(res.usageStatsEnabled);
     });
   }, []);
   return (
@@ -139,26 +137,28 @@ const Dashboard: React.FC = () => {
         ))}
       </Tabs>
       <SelectedComponent />
-      <Alert style={{ marginTop: 30 }} severity="info">
-        {usageStatsEnabled ? (
-          <span>
-            Usage stats collection is enabled. To disable this, add
-            `--disable-usage-stats` to the command that starts the cluster, or
-            run the following command: `ray disable-usage-stats` before starting
-            the cluster. See{" "}
-            <a
-              href="https://docs.ray.io/en/master/cluster/usage-stats.html"
-              target="_blank"
-              rel="noreferrer"
-            >
-              https://docs.ray.io/en/master/cluster/usage-stats.html
-            </a>{" "}
-            for more details.
-          </span>
-        ) : (
-          <span>Usage stats collection is disabled.</span>
-        )}
-      </Alert>
+      {usageStatsPromptEnabled ? (
+        <Alert style={{ marginTop: 30 }} severity="info">
+          {usageStatsEnabled ? (
+            <span>
+              Usage stats collection is enabled. To disable this, add
+              `--disable-usage-stats` to the command that starts the cluster, or
+              run the following command: `ray disable-usage-stats` before
+              starting the cluster. See{" "}
+              <a
+                href="https://docs.ray.io/en/master/cluster/usage-stats.html"
+                target="_blank"
+                rel="noreferrer"
+              >
+                https://docs.ray.io/en/master/cluster/usage-stats.html
+              </a>{" "}
+              for more details.
+            </span>
+          ) : (
+            <span>Usage stats collection is disabled.</span>
+          )}
+        </Alert>
+      ) : null}
       <LastUpdated />
     </div>
   );

--- a/dashboard/modules/usage_stats/usage_stats_head.py
+++ b/dashboard/modules/usage_stats/usage_stats_head.py
@@ -18,6 +18,7 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, dashboard_head):
         super().__init__(dashboard_head)
         self.usage_stats_enabled = ray_usage_lib.usage_stats_enabled()
+        self.usage_stats_prompt_enabled = ray_usage_lib.usage_stats_prompt_enabled()
         self.cluster_metadata = ray_usage_lib.get_cluster_metadata(
             ray.experimental.internal_kv.internal_kv_get_gcs_client(),
             num_retries=20,
@@ -44,7 +45,8 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
             return ray.dashboard.optional_utils.rest_response(
                 success=True,
                 message="Fetched usage stats enabled",
-                enabled=self.usage_stats_enabled,
+                usage_stats_enabled=self.usage_stats_enabled,
+                usage_stats_prompt_enabled=self.usage_stats_prompt_enabled,
             )
 
     def _report_usage_sync(self):

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -258,7 +258,7 @@ def usage_stats_enabled() -> bool:
     return _usage_stats_enabledness() is not UsageStatsEnabledness.DISABLED_EXPLICITLY
 
 
-def _usage_stats_prompt_enabled():
+def usage_stats_prompt_enabled():
     return int(os.getenv("RAY_USAGE_STATS_PROMPT_ENABLED", "1")) == 1
 
 
@@ -287,7 +287,7 @@ def _generate_cluster_metadata():
 
 
 def show_usage_stats_prompt() -> None:
-    if not _usage_stats_prompt_enabled():
+    if not usage_stats_prompt_enabled():
         return
 
     from ray.autoscaler._private.cli_logger import cli_logger

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -16,7 +16,11 @@ from ray._private.usage.usage_lib import ClusterConfigToReport
 from ray._private.usage.usage_lib import UsageStatsEnabledness
 from ray.autoscaler._private.cli_logger import cli_logger
 
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import (
+    format_web_url,
+    wait_for_condition,
+    wait_until_server_available,
+)
 
 schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -283,6 +287,30 @@ def test_usage_lib_cluster_metadata_generation(monkeypatch, ray_start_cluster):
         assert cluster_metadata == ray_usage_lib.get_cluster_metadata(
             ray.experimental.internal_kv.internal_kv_get_gcs_client(), num_retries=20
         )
+
+
+def test_usage_stats_enabled_endpoint(monkeypatch, ray_start_cluster):
+    if os.environ.get("RAY_MINIMAL") == "1":
+        # Doesn't work with minimal installation
+        # since we need http server.
+        return
+
+    import requests
+
+    with monkeypatch.context() as m:
+        m.setenv("RAY_USAGE_STATS_ENABLED", "0")
+        m.setenv("RAY_USAGE_STATS_PROMPT_ENABLED", "0")
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=0)
+        context = ray.init(address=cluster.address)
+        webui_url = context["webui_url"]
+        assert wait_until_server_available(webui_url)
+        webui_url = format_web_url(webui_url)
+        response = requests.get(f"{webui_url}/usage_stats_enabled")
+        assert response.status_code == 200
+        assert response.json()["result"] is True
+        assert response.json()["data"]["usageStatsEnabled"] is False
+        assert response.json()["data"]["usageStatsPromptEnabled"] is False
 
 
 def test_library_usages():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Don't show usage stats prompt in dashboard if prompt is disabled
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
