### PR TITLE
[Datasets] Change `range_arrow()` API to `range_table()`

### DIFF
--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -130,7 +130,7 @@ Transformations are executed *eagerly* and block until the operation is finished
     def transform_batch(df: pandas.DataFrame) -> pd.DataFrame:
         return df.applymap(lambda x: x * 2)
 
-    ds = ray.data.range_arrow(10000)
+    ds = ray.data.range_table(10000)
     ds = ds.map_batches(transform_batch, batch_format="pandas")
     # -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1927.62it/s]
     ds.take(5)

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -7,7 +7,7 @@ Creating Datasets
 -----------------
 
 .. autofunction:: ray.data.range
-.. autofunction:: ray.data.range_arrow
+.. autofunction:: ray.data.range_table
 .. autofunction:: ray.data.range_tensor
 .. autofunction:: ray.data.read_csv
 .. autofunction:: ray.data.read_json

--- a/doc/source/data/random-access.rst
+++ b/doc/source/data/random-access.rst
@@ -7,7 +7,7 @@ Any Arrow-format dataset can be enabled for random access by calling ``dataset.t
 .. code-block:: python
 
     # Generate a dummy embedding table as an example.
-    ds = ray.data.range_arrow(100)
+    ds = ray.data.range_table(100)
     ds = ds.add_column("embedding", lambda b: b["value"] ** 2)
     # -> schema={value: int64, embedding: int64}
 

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -16,7 +16,7 @@ Transformations are executed *eagerly* and block until the operation is finished
     def transform_batch(df: pandas.DataFrame) -> pandas.DataFrame:
         return df.applymap(lambda x: x * 2)
 
-    ds = ray.data.range_arrow(10000)
+    ds = ray.data.range_table(10000)
     ds = ds.map_batches(transform_batch, batch_format="pandas")
     # -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1927.62it/s]
     ds.take(5)

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,7 +1,7 @@
 from ray.data.read_api import (
     from_items,
     range,
-    range_arrow,
+    range_table,
     range_tensor,
     read_parquet,
     read_parquet_bulk,
@@ -53,7 +53,7 @@ __all__ = [
     "from_spark",
     "from_huggingface",
     "range",
-    "range_arrow",
+    "range_table",
     "range_tensor",
     "read_text",
     "read_binary_files",

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,7 +1,8 @@
-from ray.data.read_api import (
+from ray.data.read_api import (  # noqa: F401
     from_items,
     range,
     range_table,
+    range_arrow,
     range_tensor,
     read_parquet,
     read_parquet_bulk,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -349,7 +349,7 @@ class Dataset(Generic[T]):
 
         Examples:
             >>> import ray
-            >>> ds = ray.data.range_arrow(100) # doctest: +SKIP
+            >>> ds = ray.data.range_table(100) # doctest: +SKIP
             >>> # Add a new column equal to value * 2.
             >>> ds = ds.add_column( # doctest: +SKIP
             ...     "new_col", lambda df: df["value"] * 2)
@@ -1108,7 +1108,7 @@ class Dataset(Generic[T]):
             >>> import ray
             >>> from ray.data.aggregate import Max, Mean
             >>> ray.data.range(100).aggregate(Max()) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).aggregate( # doctest: +SKIP
+            >>> ray.data.range_table(100).aggregate( # doctest: +SKIP
             ...    Max("value"), Mean("value")) # doctest: +SKIP
 
         Time complexity: O(dataset size / parallelism)
@@ -1141,7 +1141,7 @@ class Dataset(Generic[T]):
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     (i, i**2) # doctest: +SKIP
             ...     for i in range(100)]).sum(lambda x: x[1]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).sum("value") # doctest: +SKIP
+            >>> ray.data.range_table(100).sum("value") # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i, "B": i**2} # doctest: +SKIP
             ...     for i in range(100)]).sum(["A", "B"]) # doctest: +SKIP
@@ -1200,7 +1200,7 @@ class Dataset(Generic[T]):
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     (i, i**2) # doctest: +SKIP
             ...     for i in range(100)]).min(lambda x: x[1]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).min("value") # doctest: +SKIP
+            >>> ray.data.range_table(100).min("value") # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i, "B": i**2} # doctest: +SKIP
             ...     for i in range(100)]).min(["A", "B"]) # doctest: +SKIP
@@ -1259,7 +1259,7 @@ class Dataset(Generic[T]):
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     (i, i**2) # doctest: +SKIP
             ...     for i in range(100)]).max(lambda x: x[1]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).max("value") # doctest: +SKIP
+            >>> ray.data.range_table(100).max("value") # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i, "B": i**2} # doctest: +SKIP
             ...     for i in range(100)]).max(["A", "B"]) # doctest: +SKIP
@@ -1318,7 +1318,7 @@ class Dataset(Generic[T]):
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     (i, i**2) # doctest: +SKIP
             ...     for i in range(100)]).mean(lambda x: x[1]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).mean("value") # doctest: +SKIP
+            >>> ray.data.range_table(100).mean("value") # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i, "B": i**2} # doctest: +SKIP
             ...     for i in range(100)]).mean(["A", "B"]) # doctest: +SKIP
@@ -1380,7 +1380,7 @@ class Dataset(Generic[T]):
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     (i, i**2) # doctest: +SKIP
             ...     for i in range(100)]).std(lambda x: x[1]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).std("value", ddof=0) # doctest: +SKIP
+            >>> ray.data.range_table(100).std("value", ddof=0) # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i, "B": i**2} # doctest: +SKIP
             ...     for i in range(100)]).std(["A", "B"]) # doctest: +SKIP

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -184,10 +184,18 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
         # from an external system instead of generating dummy data.
         def make_block(start: int, count: int) -> Block:
             if block_format == "arrow":
-                return pyarrow.Table.from_arrays(
+                import pyarrow as pa
+
+                return pa.Table.from_arrays(
                     [np.arange(start, start + count)], names=["value"]
                 )
+            elif block_format == "pandas":
+                import pandas as pd
+
+                return pd.DataFrame({"value": np.arange(start, start + count)})
             elif block_format == "tensor":
+                import pyarrow as pa
+
                 tensor = TensorArray(
                     np.ones(tensor_shape, dtype=np.int64)
                     * np.expand_dims(
@@ -195,7 +203,7 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
                         tuple(range(1, 1 + len(tensor_shape))),
                     )
                 )
-                return pyarrow.Table.from_pydict({"value": tensor})
+                return pa.Table.from_pydict({"value": tensor})
             else:
                 return list(builtins.range(start, start + count))
 
@@ -204,13 +212,17 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
             count = min(block_size, n - i)
             if block_format == "arrow":
                 _check_pyarrow_version()
-                import pyarrow
+                import pyarrow as pa
 
-                schema = pyarrow.Table.from_pydict({"value": [0]}).schema
+                schema = pa.Table.from_pydict({"value": [0]}).schema
+            elif block_format == "pandas":
+                import pandas as pd
+
+                schema = BlockAccessor.for_block(pd.DataFrame({"value": [0]})).schema()
             elif block_format == "tensor":
                 _check_pyarrow_version()
                 from ray.data.extensions import TensorArray
-                import pyarrow
+                import pyarrow as pa
 
                 tensor = TensorArray(
                     np.ones(tensor_shape, dtype=np.int64)
@@ -218,7 +230,7 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
                         np.arange(0, 10), tuple(range(1, 1 + len(tensor_shape)))
                     )
                 )
-                schema = pyarrow.Table.from_pydict({"value": tensor}).schema
+                schema = pa.Table.from_pydict({"value": tensor}).schema
             elif block_format == "list":
                 schema = int
             else:

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -189,10 +189,6 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
                 return pa.Table.from_arrays(
                     [np.arange(start, start + count)], names=["value"]
                 )
-            elif block_format == "pandas":
-                import pandas as pd
-
-                return pd.DataFrame({"value": np.arange(start, start + count)})
             elif block_format == "tensor":
                 import pyarrow as pa
 
@@ -215,10 +211,6 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
                 import pyarrow as pa
 
                 schema = pa.Table.from_pydict({"value": [0]}).schema
-            elif block_format == "pandas":
-                import pandas as pd
-
-                schema = BlockAccessor.for_block(pd.DataFrame({"value": [0]})).schema()
             elif block_format == "tensor":
                 _check_pyarrow_version()
                 from ray.data.extensions import TensorArray

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -308,7 +308,7 @@ class GroupedDataset(Generic[T]):
             ...     for i in range(100)]) \ # doctest: +SKIP
             ...     .groupby(lambda x: x[0] % 3) \ # doctest: +SKIP
             ...     .sum(lambda x: x[2]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).groupby("value").sum() # doctest: +SKIP
+            >>> ray.data.range_table(100).groupby("value").sum() # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i % 3, "B": i, "C": i**2} # doctest: +SKIP
             ...     for i in range(100)]) \ # doctest: +SKIP
@@ -369,7 +369,7 @@ class GroupedDataset(Generic[T]):
             ...     for i in range(100)]) \ # doctest: +SKIP
             ...     .groupby(lambda x: x[0] % 3) \ # doctest: +SKIP
             ...     .min(lambda x: x[2]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).groupby("value").min() # doctest: +SKIP
+            >>> ray.data.range_table(100).groupby("value").min() # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i % 3, "B": i, "C": i**2} # doctest: +SKIP
             ...     for i in range(100)]) \ # doctest: +SKIP
@@ -430,7 +430,7 @@ class GroupedDataset(Generic[T]):
             ...     for i in range(100)]) \ # doctest: +SKIP
             ...     .groupby(lambda x: x[0] % 3) \ # doctest: +SKIP
             ...     .max(lambda x: x[2]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).groupby("value").max() # doctest: +SKIP
+            >>> ray.data.range_table(100).groupby("value").max() # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i % 3, "B": i, "C": i**2} # doctest: +SKIP
             ...     for i in range(100)]) \ # doctest: +SKIP
@@ -491,7 +491,7 @@ class GroupedDataset(Generic[T]):
             ...     for i in range(100)]) \ # doctest: +SKIP
             ...     .groupby(lambda x: x[0] % 3) \ # doctest: +SKIP
             ...     .mean(lambda x: x[2]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).groupby("value").mean() # doctest: +SKIP
+            >>> ray.data.range_table(100).groupby("value").mean() # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i % 3, "B": i, "C": i**2} # doctest: +SKIP
             ...     for i in range(100)]) \ # doctest: +SKIP
@@ -556,7 +556,7 @@ class GroupedDataset(Generic[T]):
             ...     for i in range(100)]) \ # doctest: +SKIP
             ...     .groupby(lambda x: x[0] % 3) \ # doctest: +SKIP
             ...     .std(lambda x: x[2]) # doctest: +SKIP
-            >>> ray.data.range_arrow(100).groupby("value").std(ddof=0) # doctest: +SKIP
+            >>> ray.data.range_table(100).groupby("value").std(ddof=0) # doctest: +SKIP
             >>> ray.data.from_items([ # doctest: +SKIP
             ...     {"A": i % 3, "B": i, "C": i**2} # doctest: +SKIP
             ...     for i in range(100)]) \ # doctest: +SKIP

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -58,6 +58,7 @@ from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.impl.arrow_block import ArrowRow
 from ray.data.impl.block_list import BlockList
 from ray.data.impl.lazy_block_list import LazyBlockList
+from ray.data.impl.pandas_block import PandasRow
 from ray.data.impl.plan import ExecutionPlan
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.stats import DatasetStats
@@ -156,6 +157,31 @@ def range_arrow(n: int, *, parallelism: int = 200) -> Dataset[ArrowRow]:
     """
     return read_datasource(
         RangeDatasource(), parallelism=parallelism, n=n, block_format="arrow"
+    )
+
+
+@PublicAPI
+def range_pandas(n: int, *, parallelism: int = 200) -> Dataset[PandasRow]:
+    """Create a Pandas dataset from a range of integers [0..n).
+
+    Examples:
+        >>> import ray
+        >>> ds = ray.data.range_pandas(1000) # doctest: +SKIP
+        >>> ds.map(lambda r: {"v2": r["value"] * 2}).show() # doctest: +SKIP
+
+    This is similar to range(), but uses Pandas DataFrames to hold the integers
+    in Pandas records. The dataset elements take the form {"value": N}.
+
+    Args:
+        n: The upper bound of the range of integer records.
+        parallelism: The amount of parallelism to use for the dataset.
+            Parallelism may be limited by the number of items.
+
+    Returns:
+        Dataset holding the integers as Pandas records.
+    """
+    return read_datasource(
+        RangeDatasource(), parallelism=parallelism, n=n, block_format="pandas"
     )
 
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -58,7 +58,6 @@ from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.impl.arrow_block import ArrowRow
 from ray.data.impl.block_list import BlockList
 from ray.data.impl.lazy_block_list import LazyBlockList
-from ray.data.impl.pandas_block import PandasRow
 from ray.data.impl.plan import ExecutionPlan
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.stats import DatasetStats
@@ -136,12 +135,12 @@ def range(n: int, *, parallelism: int = 200) -> Dataset[int]:
 
 
 @PublicAPI
-def range_arrow(n: int, *, parallelism: int = 200) -> Dataset[ArrowRow]:
-    """Create an Arrow dataset from a range of integers [0..n).
+def range_table(n: int, *, parallelism: int = 200) -> Dataset[ArrowRow]:
+    """Create a tabular dataset from a range of integers [0..n).
 
     Examples:
         >>> import ray
-        >>> ds = ray.data.range_arrow(1000) # doctest: +SKIP
+        >>> ds = ray.data.range_table(1000) # doctest: +SKIP
         >>> ds.map(lambda r: {"v2": r["value"] * 2}).show() # doctest: +SKIP
 
     This is similar to range(), but uses Arrow tables to hold the integers
@@ -161,31 +160,6 @@ def range_arrow(n: int, *, parallelism: int = 200) -> Dataset[ArrowRow]:
 
 
 @PublicAPI
-def range_pandas(n: int, *, parallelism: int = 200) -> Dataset[PandasRow]:
-    """Create a Pandas dataset from a range of integers [0..n).
-
-    Examples:
-        >>> import ray
-        >>> ds = ray.data.range_pandas(1000) # doctest: +SKIP
-        >>> ds.map(lambda r: {"v2": r["value"] * 2}).show() # doctest: +SKIP
-
-    This is similar to range(), but uses Pandas DataFrames to hold the integers
-    in Pandas records. The dataset elements take the form {"value": N}.
-
-    Args:
-        n: The upper bound of the range of integer records.
-        parallelism: The amount of parallelism to use for the dataset.
-            Parallelism may be limited by the number of items.
-
-    Returns:
-        Dataset holding the integers as Pandas records.
-    """
-    return read_datasource(
-        RangeDatasource(), parallelism=parallelism, n=n, block_format="pandas"
-    )
-
-
-@PublicAPI
 def range_tensor(
     n: int, *, shape: Tuple = (1,), parallelism: int = 200
 ) -> Dataset[ArrowRow]:
@@ -197,7 +171,7 @@ def range_tensor(
         >>> ds.map_batches( # doctest: +SKIP
         ...     lambda arr: arr * 2, batch_format="pandas").show()
 
-    This is similar to range_arrow(), but uses the ArrowTensorArray extension
+    This is similar to range_table(), but uses the ArrowTensorArray extension
     type. The dataset elements take the form {"value": array(N, shape=shape)}.
 
     Args:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -159,6 +159,10 @@ def range_table(n: int, *, parallelism: int = 200) -> Dataset[ArrowRow]:
     )
 
 
+def range_arrow(*args, **kwargs):
+    raise DeprecationWarning("range_arrow() is deprecated, use range_table() instead.")
+
+
 @PublicAPI
 def range_tensor(
     n: int, *, shape: Tuple = (1,), parallelism: int = 200

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -431,6 +431,21 @@ def test_arrow_block_slice_copy_empty():
     assert table2.num_rows == 0
 
 
+def test_range_pandas(ray_start_regular_shared):
+    ds = ray.data.range_pandas(10)
+    pd.testing.assert_frame_equal(
+        ds.to_pandas(),
+        pd.DataFrame({"value": list(range(10))}),
+    )
+
+    ds = ray.data.range_pandas(10, parallelism=2)
+    assert ds.num_blocks() == 2
+    pd.testing.assert_frame_equal(
+        ds.to_pandas(),
+        pd.DataFrame({"value": list(range(10))}),
+    )
+
+
 def test_tensors(ray_start_regular_shared):
     # Create directly.
     ds = ray.data.range_tensor(5, shape=(3, 5))

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -168,7 +168,7 @@ def test_from_arrow_refs(ray_start_regular_shared):
 def test_to_pandas(ray_start_regular_shared):
     n = 5
     df = pd.DataFrame({"value": list(range(n))})
-    ds = ray.data.range_arrow(n)
+    ds = ray.data.range_table(n)
     dfds = ds.to_pandas()
     assert df.equals(dfds)
 
@@ -184,7 +184,7 @@ def test_to_pandas(ray_start_regular_shared):
 def test_to_pandas_refs(ray_start_regular_shared):
     n = 5
     df = pd.DataFrame({"value": list(range(n))})
-    ds = ray.data.range_arrow(n)
+    ds = ray.data.range_table(n)
     dfds = pd.concat(ray.get(ds.to_pandas_refs()), ignore_index=True)
     assert df.equals(dfds)
 
@@ -201,7 +201,7 @@ def test_to_numpy_refs(ray_start_regular_shared):
     np.testing.assert_equal(arr, np.expand_dims(np.arange(0, 10), 1))
 
     # Table Dataset
-    ds = ray.data.range_arrow(10)
+    ds = ray.data.range_table(10)
     arr = np.concatenate(ray.get(ds.to_numpy_refs(column="value")))
     np.testing.assert_equal(arr, np.arange(0, 10))
 
@@ -211,7 +211,7 @@ def test_to_arrow_refs(ray_start_regular_shared):
 
     # Zero-copy.
     df = pd.DataFrame({"value": list(range(n))})
-    ds = ray.data.range_arrow(n)
+    ds = ray.data.range_table(n)
     dfds = pd.concat(
         [t.to_pandas() for t in ray.get(ds.to_arrow_refs())], ignore_index=True
     )

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -77,12 +77,12 @@ def test_pipeline_is_parallel(shutdown_only):
 
 def test_window_by_bytes(ray_start_regular_shared):
     with pytest.raises(ValueError):
-        ray.data.range_arrow(10).window(blocks_per_window=2, bytes_per_window=2)
+        ray.data.range_table(10).window(blocks_per_window=2, bytes_per_window=2)
 
-    pipe = ray.data.range_arrow(10000000, parallelism=100).window(blocks_per_window=2)
+    pipe = ray.data.range_table(10000000, parallelism=100).window(blocks_per_window=2)
     assert str(pipe) == "DatasetPipeline(num_windows=50, num_stages=2)"
 
-    pipe = ray.data.range_arrow(10000000, parallelism=100).window(
+    pipe = ray.data.range_table(10000000, parallelism=100).window(
         bytes_per_window=10 * 1024 * 1024
     )
     assert str(pipe) == "DatasetPipeline(num_windows=8, num_stages=2)"
@@ -91,19 +91,19 @@ def test_window_by_bytes(ray_start_regular_shared):
     for ds in dss[:-1]:
         assert ds.num_blocks() in [12, 13]
 
-    pipe = ray.data.range_arrow(10000000, parallelism=100).window(bytes_per_window=1)
+    pipe = ray.data.range_table(10000000, parallelism=100).window(bytes_per_window=1)
     assert str(pipe) == "DatasetPipeline(num_windows=100, num_stages=2)"
     for ds in pipe.iter_datasets():
         assert ds.num_blocks() == 1
 
-    pipe = ray.data.range_arrow(10000000, parallelism=100).window(bytes_per_window=1e9)
+    pipe = ray.data.range_table(10000000, parallelism=100).window(bytes_per_window=1e9)
     assert str(pipe) == "DatasetPipeline(num_windows=1, num_stages=2)"
     for ds in pipe.iter_datasets():
         assert ds.num_blocks() == 100
 
     # Test creating from non-lazy BlockList.
     pipe = (
-        ray.data.range_arrow(10000000, parallelism=100)
+        ray.data.range_table(10000000, parallelism=100)
         .map_batches(lambda x: x)
         .window(bytes_per_window=10 * 1024 * 1024)
     )

--- a/python/ray/data/tests/test_random_access.py
+++ b/python/ray/data/tests/test_random_access.py
@@ -8,7 +8,7 @@ from ray.tests.conftest import *  # noqa
 
 @pytest.mark.parametrize("pandas", [False, True])
 def test_basic(ray_start_regular_shared, pandas):
-    ds = ray.data.range_arrow(100, parallelism=10)
+    ds = ray.data.range_table(100, parallelism=10)
     ds = ds.add_column("embedding", lambda b: b["value"] ** 2)
     if pandas:
         assert ds._dataset_format() == "pandas"
@@ -33,7 +33,7 @@ def test_basic(ray_start_regular_shared, pandas):
 
 
 def test_empty_blocks(ray_start_regular_shared):
-    ds = ray.data.range_arrow(10).repartition(20)
+    ds = ray.data.range_table(10).repartition(20)
     assert ds.num_blocks() == 20
     rad = ds.to_random_access_dataset("value")
     for i in range(10):
@@ -45,13 +45,13 @@ def test_errors(ray_start_regular_shared):
     with pytest.raises(ValueError):
         ds.to_random_access_dataset("value")
 
-    ds = ray.data.range_arrow(10)
+    ds = ray.data.range_table(10)
     with pytest.raises(ValueError):
         ds.to_random_access_dataset("invalid")
 
 
 def test_stats(ray_start_regular_shared):
-    ds = ray.data.range_arrow(100, parallelism=10)
+    ds = ray.data.range_table(100, parallelism=10)
     rad = ds.to_random_access_dataset("value", num_workers=1)
     stats = rad.stats()
     assert "Accesses per worker: 0 min, 0 max, 0 mean" in stats, stats

--- a/python/ray/data/tests/test_raydp_dataset.py
+++ b/python/ray/data/tests/test_raydp_dataset.py
@@ -30,7 +30,7 @@ def test_raydp_roundtrip(spark):
 
 def test_raydp_to_spark(spark):
     n = 5
-    ds = ray.data.range_arrow(n)
+    ds = ray.data.range_table(n)
     values = [r["value"] for r in ds.take(5)]
     df = ds.to_spark(spark)
     rows = [r.value for r in df.take(5)]

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -151,7 +151,7 @@ def test_sort_arrow_with_empty_blocks(ray_start_regular, use_push_based_shuffle)
         ]
 
         # Test empty dataset.
-        ds = ray.data.range_arrow(10).filter(lambda r: r["value"] > 10)
+        ds = ray.data.range_table(10).filter(lambda r: r["value"] > 10)
         assert (
             len(
                 ray.data.impl.sort.sample_boundaries(

--- a/release/nightly_tests/dataset/dataset_random_access.py
+++ b/release/nightly_tests/dataset/dataset_random_access.py
@@ -26,7 +26,7 @@ def main():
         num_workers = 400
         run_time = 15
 
-    ds = ray.data.range_arrow(nrow, parallelism=parallelism)
+    ds = ray.data.range_table(nrow, parallelism=parallelism)
     rmap = ds.to_random_access_dataset("value", num_workers=num_workers)
 
     print("Multiget throughput: ", end="")


### PR DESCRIPTION
This PR changes the `ray.data.range_arrow()` to `ray.data.range_table()`, making the Arrow representation an implementation detail.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
