### PR TITLE
[runtime env] Remove plugin name from internal URI

### DIFF
--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -4,12 +4,6 @@ from ray.util.annotations import DeveloperAPI
 from ray._private.runtime_env.context import RuntimeEnvContext
 
 
-# TODO(SongGuyang): This function exists in both C++ and Python.
-# We should make this logic clearly.
-def encode_plugin_uri(plugin: str, uri: str) -> str:
-    return plugin + "|" + uri
-
-
 @DeveloperAPI
 class RuntimeEnvPlugin(ABC):
     @abstractstaticmethod

--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -10,7 +10,7 @@ from ray.core.generated.runtime_env_common_pb2 import (
     RuntimeEnv as ProtoRuntimeEnv,
     RuntimeEnvConfig as ProtoRuntimeEnvConfig,
 )
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin, encode_plugin_uri
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.runtime_env.validation import OPTION_TO_VALIDATION_FN
 from ray._private.utils import import_attr
 from ray._private.runtime_env.conda import (
@@ -423,18 +423,18 @@ class RuntimeEnv(dict):
         # URIs from all plugins.
         plugin_uris = []
         if "working_dir" in self:
-            plugin_uris.append(encode_plugin_uri("working_dir", self["working_dir"]))
+            plugin_uris.append(self["working_dir"])
         if "py_modules" in self:
             for uri in self["py_modules"]:
-                plugin_uris.append(encode_plugin_uri("py_modules", uri))
+                plugin_uris.append(uri)
         if "conda" in self:
             uri = get_conda_uri(self)
             if uri is not None:
-                plugin_uris.append(encode_plugin_uri("conda", uri))
+                plugin_uris.append(uri)
         if "pip" in self:
             uri = get_pip_uri(self)
             if uri is not None:
-                plugin_uris.append(encode_plugin_uri("pip", uri))
+                plugin_uris.append(uri)
 
         return plugin_uris
 

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -14,7 +14,6 @@ from ray._private.runtime_env.validation import (
     parse_and_validate_env_vars,
     parse_and_validate_py_modules,
 )
-from ray._private.runtime_env.plugin import encode_plugin_uri
 from ray.runtime_env import RuntimeEnv
 
 CONDA_DICT = {"dependencies": ["pip", {"pip": ["pip-install-test==0.5"]}]}
@@ -49,10 +48,6 @@ def test_directory():
 def test_key_with_value_none():
     parsed_runtime_env = RuntimeEnv(pip=None)
     assert parsed_runtime_env == {}
-
-
-def test_encode_plugin_uri():
-    assert encode_plugin_uri("plugin", "uri") == "plugin|uri"
 
 
 class TestValidateWorkingDir:

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1514,12 +1514,6 @@ rpc::RuntimeEnv CoreWorker::OverrideRuntimeEnv(
   return result_runtime_env;
 }
 
-// TODO(SongGuyang): This function exists in both C++ and Python. We should make this
-// logic clearly.
-static std::string encode_plugin_uri(std::string plugin, std::string uri) {
-  return plugin + "|" + uri;
-}
-
 static std::vector<std::string> GetUrisFromRuntimeEnv(
     const rpc::RuntimeEnv *runtime_env) {
   std::vector<std::string> result;
@@ -1528,21 +1522,21 @@ static std::vector<std::string> GetUrisFromRuntimeEnv(
   }
   if (!runtime_env->uris().working_dir_uri().empty()) {
     const auto &uri = runtime_env->uris().working_dir_uri();
-    result.emplace_back(encode_plugin_uri("working_dir", uri));
+    result.emplace_back(uri);
   }
   for (const auto &uri : runtime_env->uris().py_modules_uris()) {
-    result.emplace_back(encode_plugin_uri("py_modules", uri));
+    result.emplace_back(uri);
   }
   if (!runtime_env->uris().conda_uri().empty()) {
     const auto &uri = runtime_env->uris().conda_uri();
-    result.emplace_back(encode_plugin_uri("conda", uri));
+    result.emplace_back(uri);
   }
   if (!runtime_env->uris().pip_uri().empty()) {
     const auto &uri = runtime_env->uris().pip_uri();
-    result.emplace_back(encode_plugin_uri("pip", uri));
+    result.emplace_back(uri);
   }
   for (const auto &uri : runtime_env->uris().plugin_uris()) {
-    result.emplace_back(encode_plugin_uri("plugin", uri));
+    result.emplace_back(uri);
   }
   return result;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This was a holdover from when local resources for URIs were deleted directly from the runtime env agent, and the URI name itself needed to store the information of which plugin it corresponded to so the appropriate plugin's `delete()` function could be called.  After the URI reference refactor, I don't think this is needed anymore.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
