### PR TITLE
[serve] [docs] Streamlit + Serve example notebook

### DIFF
--- a/doc/source/serve/doc_code/streamlit_app.py
+++ b/doc/source/serve/doc_code/streamlit_app.py
@@ -1,0 +1,47 @@
+# __streamlit_imports_begin__
+import streamlit as st
+from ray import serve
+from transformers import pipeline
+import requests
+# __streamlit_imports_end__
+
+
+# __streamlit_model_begin__
+if 'model' not in st.session_state:
+    serve.start()
+
+    @serve.deployment
+    def model(request):
+        language_model = pipeline("text-generation", model="gpt2")
+        query = request.query_params["query"]
+        return language_model(query, max_length=100)
+
+    model.deploy()
+    st.session_state['model'] = True
+# __streamlit_model_end__
+
+# __streamlit_test_begin__
+example = "What's the meaning of life?"
+response = requests.get(f"http://localhost:8000/model?query={example}")
+print(response.text)
+# __streamlit_test_end__
+
+
+# __streamlit_gpt_begin__
+def gpt2(query):
+    response = requests.get(f"http://localhost:8000/model?query={query}")
+    return response.json()[0]["generated_text"]
+# __streamlit_gpt_end__
+
+
+# __streamlit_app_begin__
+st.title("Serving a GPT-2 model")
+
+query = st.text_input(label="Input prompt", value="What's the meaning of life?")
+
+if st.button('Run model'):
+    output = gpt2(query)
+
+    st.header("Model output")
+    st.text(output)
+# __streamlit_app_end__

--- a/doc/source/serve/doc_code/streamlit_app.py
+++ b/doc/source/serve/doc_code/streamlit_app.py
@@ -7,7 +7,7 @@ import requests
 
 
 # __streamlit_model_begin__
-if 'model' not in st.session_state:
+if "model" not in st.session_state:
     serve.start()
 
     @serve.deployment
@@ -17,7 +17,7 @@ if 'model' not in st.session_state:
         return language_model(query, max_length=100)
 
     model.deploy()
-    st.session_state['model'] = True
+    st.session_state["model"] = True
 # __streamlit_model_end__
 
 # __streamlit_test_begin__
@@ -39,7 +39,7 @@ st.title("Serving a GPT-2 model")
 
 query = st.text_input(label="Input prompt", value="What's the meaning of life?")
 
-if st.button('Run model'):
+if st.button("Run model"):
     output = gpt2(query)
 
     st.header("Model output")

--- a/doc/source/serve/tutorials/index.md
+++ b/doc/source/serve/tutorials/index.md
@@ -15,6 +15,7 @@ batch
 web-server-integration
 rllib
 gradio
+streamlit
 ```
 
 Other Topics:

--- a/doc/source/serve/tutorials/streamlit.md
+++ b/doc/source/serve/tutorials/streamlit.md
@@ -1,0 +1,105 @@
+(streamlit-serve-tutorial)=
+
+# Building a Streamlit app with Ray Serve
+
+In this example, we will show you how to wrap a machine learning model served
+by Ray Serve in a [Streamlit application](https://streamlit.io/).
+
+Specifically, we're going to download a GPT-2 model from the `transformer` library,
+define a Ray Serve deployment with it, and then define and launch a Streamlit app.
+Let's take a look.
+
+
+## Deploying a model with Ray Serve
+
+To start off, we import Ray Serve and Streamlit, as well as the
+`transformers` and `requests` libraries:
+
+```{eval-rst}
+.. literalinclude:: ../doc_code/streamlit_app.py
+    :language: python
+    :start-after: __streamlit_imports_begin__
+    :end-before: __streamlit_imports_end__
+```
+
+Next, we define a Ray Serve deployment with a GPT-2 model, by using the
+`@serve.deployment` decorator on a `model` function that takes a `request` argument.
+In this function we define a GPT-2 model with a call to `pipeline` and return
+the result of querying the model.
+Before defining the deployment, we start Ray Serve using `serve.start()`, and
+then proceed to deploy the model with `model.deploy()`.
+
+```{eval-rst}
+.. literalinclude:: ../doc_code/streamlit_app.py
+    :language: python
+    :start-after: __streamlit_model_begin__
+    :end-before: __streamlit_model_end__
+```
+
+Note that we're using Streamlit's `session_state` to make sure the deployment
+only gets run once.
+If we didn't use such a mechanism, Streamlit would simply run the whole script again,
+which is not what we want.
+
+To test this deployment we use a simple `example` query to get a `response` from
+the model running on `localhost:8000/model`.
+The first time you use this endpoint, the model will be downloaded first,
+which can take a while to complete.
+Subsequent calls will be faster.
+
+```{eval-rst}
+.. literalinclude:: ../doc_code/streamlit_app.py
+    :language: python
+    :start-after: __streamlit_test_begin__
+    :end-before: __streamlit_test_end__
+```
+
+## Defining and launching a Streamlit app
+
+To define a streamlit app, let's first create a convenient wrapper that takes
+a `query` argument and returns the result of querying the GPT model.
+
+```{eval-rst}
+.. literalinclude:: ../doc_code/streamlit_app.py
+    :language: python
+    :start-after: __streamlit_gpt_begin__
+    :end-before: __streamlit_gpt_end__
+```
+
+Apart from this `gpt2` function, the only other thing that we need is a way
+for users to specify the model input, and a way to display the result.
+Since our model takes text as input and output, this turns out to be pretty simple:
+
+```{eval-rst}
+.. literalinclude:: ../doc_code/streamlit_app.py
+    :language: python
+    :start-after: __streamlit_app_begin__
+    :end-before: __streamlit_app_end__
+```
+
+To serve this model with Streamlit, we use just a few simple text components,
+namely `st.title`, `st.header`, and
+`st.text` for output and `st.text_input` for getting the model input.
+We also use a button to trigger model inference for a new input prompt.
+There's much more you can do with Streamlit, but this is just a simple example.
+
+```{margin}
+The [Streamlit API documentation](https://docs.streamlit.io/library/api-reference)
+covers all viable Streamlit components in detail.
+```
+
+Finally, if you put everything we just did together in a single file
+called `streamlit_app.py`, you can run your Streamlit app with Ray Serve as follows:
+
+```python pycharm={"name": "#%% bash\n"}
+streamlit run streamlit_app.py
+```
+
+<!-- #region pycharm={"name": "#%% md\n"} -->
+This should launch an interface that you can interact with that looks like this:
+
+```{image} https://raw.githubusercontent.com/ray-project/images/master/docs/serve/streamlit_serve_gpt.png
+```
+
+To summarize, if you know the basics of Streamlit,
+it's straightforward to deploy a model with Ray Serve with it.


### PR DESCRIPTION
Signed-off-by: Max Pumperla <max.pumperla@googlemail.com>

Replacing https://github.com/ray-project/ray/pull/24219, but this time simply using `md`, since streamlit apps are not executable as notebooks on the nose anyway. Also, code is not duplicated anymore this way.