### PR TITLE
Revert "[core] Adjust worker OOM scores to prioritize the raylet during memory pressure"

### DIFF
--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -186,19 +186,6 @@ def test_function_table_gc_actor(call_ray_start):
     wait_for_condition(lambda: function_entry_num(job_id) == 0)
 
 
-def test_worker_oom_score(shutdown_only):
-    @ray.remote
-    def get_oom_score():
-        import os
-
-        pid = os.getpid()
-        with open(f"/proc/{pid}/oom_score", "r") as f:
-            oom_score = f.read()
-            return int(oom_score)
-
-    assert ray.get(get_oom_score.remote()) >= 1000
-
-
 if __name__ == "__main__":
     import pytest
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -236,12 +236,6 @@ RAY_CONFIG(int64_t, worker_register_timeout_seconds, 60)
 /// The maximum number of workers to iterate whenever we analyze the resources usage.
 RAY_CONFIG(uint32_t, worker_max_resource_analysis_iteration, 128);
 
-/// A value to add to workers' OOM score adjustment, so that the OS prioritizes
-/// killing these over the raylet. 0 or positive values only (negative values
-/// require sudo permissions).
-/// NOTE(swang): Linux only.
-RAY_CONFIG(int, worker_oom_score_adjustment, 1000)
-
 /// Allow up to 60 seconds for connecting to Redis.
 RAY_CONFIG(int64_t, redis_db_connect_retries, 600)
 RAY_CONFIG(int64_t, redis_db_connect_wait_milliseconds, 100)

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -463,7 +463,6 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
   RAY_LOG(INFO) << "Started worker process of " << workers_to_start
                 << " worker(s) with pid " << proc.GetId() << ", the token "
                 << worker_startup_token_counter_;
-  AdjustWorkerOomScore(proc.GetId());
   MonitorStartingWorkerProcess(
       proc, worker_startup_token_counter_, language, worker_type);
   AddWorkerProcess(state, workers_to_start, worker_type, proc, start, runtime_env_info);
@@ -474,27 +473,6 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
     io_worker_state.num_starting_io_workers++;
   }
   return {proc, worker_startup_token};
-}
-
-void WorkerPool::AdjustWorkerOomScore(pid_t pid) const {
-#ifdef __linux__
-  std::ofstream oom_score_file;
-  std::string filename("/proc/" + std::to_string(pid) + "/oom_score_adj");
-  oom_score_file.open(filename, std::ofstream::out);
-  int oom_score_adj = RayConfig::instance().worker_oom_score_adjustment();
-  oom_score_adj = std::max(oom_score_adj, 0);
-  oom_score_adj = std::min(oom_score_adj, 1000);
-  if (oom_score_file.is_open()) {
-    // Adjust worker's OOM score so that the OS prioritizes killing these
-    // processes over the raylet.
-    oom_score_file << std::to_string(oom_score_adj);
-  }
-  if (oom_score_file.fail()) {
-    RAY_LOG(INFO) << "Failed to set OOM score adjustment for worker with PID " << pid
-                  << ", error: " << strerror(errno);
-  }
-  oom_score_file.close();
-#endif
 }
 
 void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -692,10 +692,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   void RemoveWorkerProcess(State &state, const StartupToken &proc_startup_token);
 
-  /// Increase worker OOM scores to avoid raylet crashes from heap memory
-  /// pressure.
-  void AdjustWorkerOomScore(pid_t pid) const;
-
   /// For Process class for managing subprocesses (e.g. reaping zombies).
   instrumented_io_context *io_service_;
   /// Node ID of the current node.


### PR DESCRIPTION
Reverts ray-project/ray#24623

This breaks windows test:

```


c:\install\ray\python\ray\_private\client_mode_hook.py:105: in wrapper
--
  | return func(*args, **kwargs)
  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  |  
  | object_refs = [ObjectRef(93bbe20ceda6a745ffffffffffffffffffffffff0100000001000000)]
  |  
  | @PublicAPI
  | @client_mode_hook(auto_init=True)
  | def get(
  | object_refs: Union[ray.ObjectRef, List[ray.ObjectRef]],
  | *,
  | timeout: Optional[float] = None,
  | ) -> Union[Any, List[Any]]:
  | """Get a remote object or a list of remote objects from the object store.
  |  
  | This method blocks until the object corresponding to the object ref is
  | available in the local object store. If this object is not in the local
  | object store, it will be shipped from an object store that has it (once the
  | object has been created). If object_refs is a list, then the objects
  | corresponding to each object in the list will be returned.
  |  
  | Ordering for an input list of object refs is preserved for each object
  | returned. That is, if an object ref to A precedes an object ref to B in the
  | input list, then A will precede B in the returned list.
  |  
  | This method will issue a warning if it's running inside async context,
  | you can use ``await object_ref`` instead of ``ray.get(object_ref)``. For
  | a list of object refs, you can use ``await asyncio.gather(*object_refs)``.
  |  
  | Args:
  | object_refs: Object ref of the object to get or a list of object refs
  | to get.
  | timeout (Optional[float]): The maximum amount of time in seconds to
  | wait before returning.
  |  
  | Returns:
  | A Python object or a list of Python objects.
  |  
  | Raises:
  | GetTimeoutError: A GetTimeoutError is raised if a timeout is set and
  | the get takes longer than timeout to return.
  | Exception: An exception is raised if the task that created the object
  | or that created one of the objects raised an exception.
  | """
  | worker = global_worker
  | worker.check_connected()
  |  
  | if hasattr(worker, "core_worker") and worker.core_worker.current_actor_is_asyncio():
  | global blocking_get_inside_async_warned
  | if not blocking_get_inside_async_warned:
  | logger.warning(
  | "Using blocking ray.get inside async actor. "
  | "This blocks the event loop. Please use `await` "
  | "on object ref with asyncio.gather if you want to "
  | "yield execution to the event loop instead."
  | )
  | blocking_get_inside_async_warned = True
  |  
  | with profiling.profile("ray.get"):
  | is_individual_id = isinstance(object_refs, ray.ObjectRef)
  | if is_individual_id:
  | object_refs = [object_refs]
  |  
  | if not isinstance(object_refs, list):
  | raise ValueError(
  | "'object_refs' must either be an object ref "
  | "or a list of object refs."
  | )
  |  
  | # TODO(ujvl): Consider how to allow user to retrieve the ready objects.
  | values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  | for i, value in enumerate(values):
  | if isinstance(value, RayError):
  | if isinstance(value, ray.exceptions.ObjectLostError):
  | worker.core_worker.dump_object_store_memory_usage()
  | if isinstance(value, RayTaskError):
  | >                       raise value.as_instanceof_cause()
  | E                       ray.exceptions.RayTaskError(FileNotFoundError): ray::get_oom_score() (pid=7916, ip=127.0.0.1)
  | E                         File "python\ray\_raylet.pyx", line 665, in ray._raylet.execute_task
  | E                         File "python\ray\_raylet.pyx", line 669, in ray._raylet.execute_task
  | E                         File "\\?\C:\Users\ContainerAdministrator\AppData\Local\temp\Bazel.runfiles_52oldysj\runfiles\com_github_ray_project_ray\python\ray\tests\test_advanced_9.py", line 195, in get_oom_score
  | E                           with open(f"/proc/{pid}/oom_score", "r") as f:
  | E                       FileNotFoundError: [Errno 2] No such file or directory: '/proc/7916/oom_score'

```