### PR TITLE
[ci] Add flag for staging tests and disable the unstable one.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -357,7 +357,7 @@
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - bazel test --config=ci $(./scripts/bazel_export_options)
+    - sed -si 's/####//g' ./bazel/python.bzl && bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=client_tests,small_size_python_tests
       --test_env=RAY_use_ray_syncer=true
       -- python/ray/tests/...
@@ -366,12 +366,12 @@
   parallelism: 3
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RAY_use_ray_syncer=true . ./ci/ci.sh test_large
+    - sed -si 's/####//g' ./bazel/python.bzl && RAY_use_ray_syncer=true . ./ci/ci.sh test_large
 - label: ":construction: :python: (syncer) (Medium A-J)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - bazel test --config=ci $(./scripts/bazel_export_options)
+    - sed -si 's/####//g' ./bazel/python.bzl && bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,medium_size_python_tests_a_to_j
       --test_env=RAY_use_ray_syncer=true
       python/ray/tests/...
@@ -379,7 +379,7 @@
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - bazel test --config=ci $(./scripts/bazel_export_options)
+    - sed -si 's/####//g' ./bazel/python.bzl && bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,medium_size_python_tests_k_to_z
       --test_env=RAY_use_ray_syncer=true
       python/ray/tests/...

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -357,7 +357,7 @@
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - sed -si 's/####//g' ./bazel/python.bzl && bazel test --config=ci $(./scripts/bazel_export_options)
+    - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=client_tests,small_size_python_tests
       --test_env=RAY_use_ray_syncer=true
       -- python/ray/tests/...
@@ -366,22 +366,22 @@
   parallelism: 3
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - sed -si 's/####//g' ./bazel/python.bzl && RAY_use_ray_syncer=true . ./ci/ci.sh test_large
+    - RAY_use_ray_syncer=true . ./ci/ci.sh test_large --define=RAY_STAGING_TESTS=1
 - label: ":construction: :python: (syncer) (Medium A-J)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - sed -si 's/####//g' ./bazel/python.bzl && bazel test --config=ci $(./scripts/bazel_export_options)
+    - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,medium_size_python_tests_a_to_j
-      --test_env=RAY_use_ray_syncer=true
-      python/ray/tests/...
+      --test_env=RAY_use_ray_syncer=true --define=RAY_STAGING_TESTS=1
+      -- python/ray/tests/... -//python/ray/tests:test_actor_resources
 - label: ":construction: :python: (syncer) (Medium K-Z)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - sed -si 's/####//g' ./bazel/python.bzl && bazel test --config=ci $(./scripts/bazel_export_options)
+    - bazel test --config=ci $(./scripts/bazel_export_options)
       --test_tag_filters=-kubernetes,medium_size_python_tests_k_to_z
-      --test_env=RAY_use_ray_syncer=true
+      --test_env=RAY_use_ray_syncer=true --define=RAY_STAGING_TESTS=1
       python/ray/tests/...
 
 

--- a/bazel/python.bzl
+++ b/bazel/python.bzl
@@ -4,6 +4,7 @@ def py_test_module_list(files, size, deps, extra_srcs, name_suffix="", **kwargs)
     for file in files:
         # remove .py
         name = file[:-3] + name_suffix
+        ####name = "staging-" + name
         main = file
         native.py_test(
             name = name,

--- a/bazel/python.bzl
+++ b/bazel/python.bzl
@@ -4,7 +4,6 @@ def py_test_module_list(files, size, deps, extra_srcs, name_suffix="", **kwargs)
     for file in files:
         # remove .py
         name = file[:-3] + name_suffix
-        ####name = "staging-" + name
         main = file
         native.py_test(
             name = name,

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -195,7 +195,7 @@ test_large() {
   bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE \
       --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER \
       --test_env=CI --test_tag_filters="large_size_python_tests_shard_${BUILDKITE_PARALLEL_JOB}" \
-      -- python/ray/tests/...
+      -- python/ray/tests/... $@
 }
 
 test_cpp() {

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -194,8 +194,8 @@ test_large() {
   # shellcheck disable=SC2046
   bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE \
       --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER \
-      --test_env=CI --test_tag_filters="large_size_python_tests_shard_${BUILDKITE_PARALLEL_JOB}" \
-      -- python/ray/tests/... "$@"
+      --test_env=CI --test_tag_filters="large_size_python_tests_shard_${BUILDKITE_PARALLEL_JOB}"  "$@" \
+      -- python/ray/tests/...
 }
 
 test_cpp() {

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -195,7 +195,7 @@ test_large() {
   bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE \
       --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER \
       --test_env=CI --test_tag_filters="large_size_python_tests_shard_${BUILDKITE_PARALLEL_JOB}" \
-      -- python/ray/tests/... $@
+      -- python/ray/tests/... "$@"
 }
 
 test_cpp() {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR tries to add a prefix for the staging ci test. This is useful to separate staging tests from stable tests in `https://flakey-tests.ray.io/`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
