### PR TITLE
[CI] fix inter error2: Title underline too short.  

### DIFF
--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -125,7 +125,7 @@ Custom Datasource API
     :members:
 
 Datasource File Metadata API
----------------------
+----------------------------
 
 .. autoclass:: ray.data.datasource.FileMetadataProvider
     :members:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

e2ee2140f97ca08b70fd0f7561038b7f8d958d63 broke linter with following error:
```


Warning, treated as error:
--
  | /ray/doc/source/data/package-ref.rst:128:Title underline too short.


```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
