### PR TITLE
[workflow] Fast workflow indexing

### DIFF
--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -286,7 +286,7 @@ def list_all(
                 f" {status_filter}"
             )
     elif status_filter is None:
-        status_filter = set(WorkflowStatus.__members__.keys())
+        status_filter = set(WorkflowStatus)
     else:
         raise TypeError(
             "status_filter must be WorkflowStatus or a set of WorkflowStatus."

--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -287,6 +287,7 @@ def list_all(
             )
     elif status_filter is None:
         status_filter = set(WorkflowStatus)
+        status_filter.discard(WorkflowStatus.NONE)
     else:
         raise TypeError(
             "status_filter must be WorkflowStatus or a set of WorkflowStatus."

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -140,6 +140,8 @@ class WorkflowStaticRef:
 @PublicAPI(stability="beta")
 @unique
 class WorkflowStatus(str, Enum):
+    # No status is set for this workflow.
+    NONE = "NONE"
     # There is at least a remote task running in ray cluster
     RUNNING = "RUNNING"
     # It got canceled and can't be resumed later.

--- a/python/ray/workflow/execution.py
+++ b/python/ray/workflow/execution.py
@@ -142,7 +142,7 @@ def get_status(workflow_id: str) -> Optional[WorkflowStatus]:
     if running:
         return WorkflowStatus.RUNNING
     store = workflow_storage.get_workflow_storage(workflow_id)
-    status = store.load_and_fix_workflow_status()
+    status = store.load_workflow_status()
     if status == WorkflowStatus.NONE:
         raise WorkflowNotFoundError(workflow_id)
     if status == WorkflowStatus.RUNNING:

--- a/python/ray/workflow/execution.py
+++ b/python/ray/workflow/execution.py
@@ -10,7 +10,6 @@ from ray.workflow import workflow_storage
 from ray.workflow.common import (
     Workflow,
     WorkflowStatus,
-    WorkflowMetaData,
     StepType,
     WorkflowNotFoundError,
     validate_user_metadata,
@@ -143,12 +142,12 @@ def get_status(workflow_id: str) -> Optional[WorkflowStatus]:
     if running:
         return WorkflowStatus.RUNNING
     store = workflow_storage.get_workflow_storage(workflow_id)
-    meta = store.load_workflow_meta()
-    if meta is None:
+    status = store.load_and_fix_workflow_status()
+    if status == WorkflowStatus.NONE:
         raise WorkflowNotFoundError(workflow_id)
-    if meta.status == WorkflowStatus.RUNNING:
+    if status == WorkflowStatus.RUNNING:
         return WorkflowStatus.RESUMABLE
-    return meta.status
+    return status
 
 
 def get_metadata(workflow_id: str, name: Optional[str]) -> Dict[str, Any]:

--- a/python/ray/workflow/execution.py
+++ b/python/ray/workflow/execution.py
@@ -131,7 +131,7 @@ def cancel(workflow_id: str) -> None:
         ray.get(workflow_manager.cancel_workflow.remote(workflow_id))
     except ValueError:
         wf_store = workflow_storage.get_workflow_storage(workflow_id)
-        wf_store.save_workflow_meta(WorkflowMetaData(WorkflowStatus.CANCELED))
+        wf_store.update_workflow_status(WorkflowStatus.CANCELED)
 
 
 def get_status(workflow_id: str) -> Optional[WorkflowStatus]:

--- a/python/ray/workflow/tests/test_workflow_indexing.py
+++ b/python/ray/workflow/tests/test_workflow_indexing.py
@@ -9,10 +9,7 @@ def test_workflow_status_update(workflow_start_regular):
     store = WorkflowIndexingStorage()
     assert not store.list_workflow()
     for i in range(100):
-        assert (
-            store.load_and_fix_workflow_status(workflow_id=str(i))
-            == WorkflowStatus.NONE
-        )
+        assert store.load_workflow_status(workflow_id=str(i)) == WorkflowStatus.NONE
 
     for i in range(100):
         store.update_workflow_status(str(i), WorkflowStatus.RUNNING)
@@ -51,21 +48,19 @@ def test_workflow_auto_fix_status(workflow_start_regular):
 
     store._key_workflow_with_status = _key_workflow_with_status
 
-    # when list workflow, we recovery failed status automatically
     assert sorted(store.list_workflow()) == sorted(
         [(str(i), WorkflowStatus.RUNNING) for i in range(100)]
     )
 
-    store._key_workflow_with_status = None
     for i in range(100):
         try:
+            # when update workflow, we fix failed status
             store.update_workflow_status(str(i), WorkflowStatus.RESUMABLE)
         except Exception:
             pass
 
-    store._key_workflow_with_status = _key_workflow_with_status
     for i in range(100):
-        assert store.load_and_fix_workflow_status(str(i)) == WorkflowStatus.RESUMABLE
+        assert store.load_workflow_status(str(i)) == WorkflowStatus.RESUMABLE
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_workflow_indexing.py
+++ b/python/ray/workflow/tests/test_workflow_indexing.py
@@ -1,0 +1,76 @@
+from ray.workflow.common import WorkflowStatus
+from ray.workflow.workflow_storage import WorkflowIndexingStorage
+
+
+def test_workflow_status_update(workflow_start_regular):
+    # Test workflow status update is working.
+    store = WorkflowIndexingStorage()
+    assert not store.list_workflow()
+    for i in range(100):
+        assert (
+            store.load_and_fix_workflow_status(workflow_id=str(i))
+            == WorkflowStatus.NONE
+        )
+
+    for i in range(100):
+        store.update_workflow_status(
+            str(i), WorkflowStatus.RUNNING, WorkflowStatus.NONE
+        )
+
+    assert sorted(store.list_workflow()) == sorted(
+        [(str(i), WorkflowStatus.RUNNING) for i in range(100)]
+    )
+
+    for i in range(100):
+        store.update_workflow_status(
+            str(i), WorkflowStatus.RESUMABLE, WorkflowStatus.RUNNING
+        )
+
+    assert sorted(store.list_workflow()) == sorted(
+        [(str(i), WorkflowStatus.RESUMABLE) for i in range(100)]
+    )
+
+    for i in range(100):
+        store.update_workflow_status(
+            str(i), WorkflowStatus.FAILED, WorkflowStatus.RESUMABLE
+        )
+
+    assert sorted(store.list_workflow()) == sorted(
+        [(str(i), WorkflowStatus.FAILED) for i in range(100)]
+    )
+
+
+def test_workflow_auto_fix_status(workflow_start_regular):
+    # Test workflow can recovery from corrupted status updating.
+    store = WorkflowIndexingStorage()
+    assert not store.list_workflow()
+    # this is a hack to crash status updating
+    _key_workflow_with_status = store._key_workflow_with_status
+    store._key_workflow_with_status = None
+    for i in range(100):
+        try:
+            store.update_workflow_status(
+                str(i), WorkflowStatus.RUNNING, WorkflowStatus.NONE
+            )
+        except Exception:
+            pass
+
+    store._key_workflow_with_status = _key_workflow_with_status
+
+    # when list workflow, we recovery failed status automatically
+    assert sorted(store.list_workflow()) == sorted(
+        [(str(i), WorkflowStatus.RUNNING) for i in range(100)]
+    )
+
+    store._key_workflow_with_status = None
+    for i in range(100):
+        try:
+            store.update_workflow_status(
+                str(i), WorkflowStatus.RESUMABLE, WorkflowStatus.RUNNING
+            )
+        except Exception:
+            pass
+
+    store._key_workflow_with_status = _key_workflow_with_status
+    for i in range(100):
+        assert store.load_and_fix_workflow_status(str(i)) == WorkflowStatus.RESUMABLE

--- a/python/ray/workflow/tests/test_workflow_indexing.py
+++ b/python/ray/workflow/tests/test_workflow_indexing.py
@@ -18,12 +18,20 @@ def test_workflow_status_update(workflow_start_regular):
         [(str(i), WorkflowStatus.RUNNING) for i in range(100)]
     )
 
+    assert sorted(store.list_workflow({WorkflowStatus.RUNNING})) == sorted(
+        [(str(i), WorkflowStatus.RUNNING) for i in range(100)]
+    )
+
+    assert sorted(store.list_workflow({WorkflowStatus.RESUMABLE})) == []
+
     for i in range(100):
         store.update_workflow_status(str(i), WorkflowStatus.RESUMABLE)
 
-    assert sorted(store.list_workflow()) == sorted(
+    assert sorted(store.list_workflow({WorkflowStatus.RESUMABLE})) == sorted(
         [(str(i), WorkflowStatus.RESUMABLE) for i in range(100)]
     )
+
+    assert sorted(store.list_workflow({WorkflowStatus.FAILED})) == []
 
     for i in range(100):
         store.update_workflow_status(str(i), WorkflowStatus.FAILED)
@@ -31,6 +39,12 @@ def test_workflow_status_update(workflow_start_regular):
     assert sorted(store.list_workflow()) == sorted(
         [(str(i), WorkflowStatus.FAILED) for i in range(100)]
     )
+
+    assert sorted(store.list_workflow({WorkflowStatus.FAILED})) == sorted(
+        [(str(i), WorkflowStatus.FAILED) for i in range(100)]
+    )
+
+    assert sorted(store.list_workflow({WorkflowStatus.RUNNING})) == []
 
 
 def test_workflow_auto_fix_status(workflow_start_regular):
@@ -43,7 +57,7 @@ def test_workflow_auto_fix_status(workflow_start_regular):
     for i in range(100):
         try:
             store.update_workflow_status(str(i), WorkflowStatus.RUNNING)
-        except Exception:
+        except TypeError:
             pass
 
     store._key_workflow_with_status = _key_workflow_with_status
@@ -56,7 +70,7 @@ def test_workflow_auto_fix_status(workflow_start_regular):
         try:
             # when update workflow, we fix failed status
             store.update_workflow_status(str(i), WorkflowStatus.RESUMABLE)
-        except Exception:
+        except TypeError:
             pass
 
     for i in range(100):

--- a/python/ray/workflow/tests/test_workflow_indexing.py
+++ b/python/ray/workflow/tests/test_workflow_indexing.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ray.workflow.common import WorkflowStatus
 from ray.workflow.workflow_storage import WorkflowIndexingStorage
 
@@ -13,27 +15,21 @@ def test_workflow_status_update(workflow_start_regular):
         )
 
     for i in range(100):
-        store.update_workflow_status(
-            str(i), WorkflowStatus.RUNNING, WorkflowStatus.NONE
-        )
+        store.update_workflow_status(str(i), WorkflowStatus.RUNNING)
 
     assert sorted(store.list_workflow()) == sorted(
         [(str(i), WorkflowStatus.RUNNING) for i in range(100)]
     )
 
     for i in range(100):
-        store.update_workflow_status(
-            str(i), WorkflowStatus.RESUMABLE, WorkflowStatus.RUNNING
-        )
+        store.update_workflow_status(str(i), WorkflowStatus.RESUMABLE)
 
     assert sorted(store.list_workflow()) == sorted(
         [(str(i), WorkflowStatus.RESUMABLE) for i in range(100)]
     )
 
     for i in range(100):
-        store.update_workflow_status(
-            str(i), WorkflowStatus.FAILED, WorkflowStatus.RESUMABLE
-        )
+        store.update_workflow_status(str(i), WorkflowStatus.FAILED)
 
     assert sorted(store.list_workflow()) == sorted(
         [(str(i), WorkflowStatus.FAILED) for i in range(100)]
@@ -49,9 +45,7 @@ def test_workflow_auto_fix_status(workflow_start_regular):
     store._key_workflow_with_status = None
     for i in range(100):
         try:
-            store.update_workflow_status(
-                str(i), WorkflowStatus.RUNNING, WorkflowStatus.NONE
-            )
+            store.update_workflow_status(str(i), WorkflowStatus.RUNNING)
         except Exception:
             pass
 
@@ -65,12 +59,16 @@ def test_workflow_auto_fix_status(workflow_start_regular):
     store._key_workflow_with_status = None
     for i in range(100):
         try:
-            store.update_workflow_status(
-                str(i), WorkflowStatus.RESUMABLE, WorkflowStatus.RUNNING
-            )
+            store.update_workflow_status(str(i), WorkflowStatus.RESUMABLE)
         except Exception:
             pass
 
     store._key_workflow_with_status = _key_workflow_with_status
     for i in range(100):
         assert store.load_and_fix_workflow_status(str(i)) == WorkflowStatus.RESUMABLE
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -314,8 +314,8 @@ class WorkflowManagementActor:
         if workflow_id in self._workflow_outputs and name is None:
             return self._workflow_outputs[workflow_id].output
         wf_store = workflow_storage.WorkflowStorage(workflow_id)
-        meta = wf_store.load_workflow_meta()
-        if meta is None:
+        meta = wf_store.load_and_fix_workflow_status()
+        if meta == common.WorkflowStatus.NONE:
             raise ValueError(f"No such workflow {workflow_id}")
         if meta == common.WorkflowStatus.CANCELED:
             raise ValueError(f"Workflow {workflow_id} is canceled")

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -135,6 +135,7 @@ class WorkflowManagementActor:
         self._step_output_cache: Dict[Tuple[str, str], LatestWorkflowOutput] = {}
         self._actor_initialized: Dict[str, ray.ObjectRef] = {}
         self._step_status: Dict[str, Dict[str, common.WorkflowStatus]] = {}
+        self._workflow_status: Dict[str, common.WorkflowStatus] = {}
 
     def get_cached_step_output(
         self, workflow_id: str, step_id: "StepID"
@@ -194,9 +195,7 @@ class WorkflowManagementActor:
         )
         self._step_output_cache[(workflow_id, step_id)] = latest_output
 
-        wf_store.save_workflow_meta(
-            common.WorkflowMetaData(common.WorkflowStatus.RUNNING)
-        )
+        self._update_workflow_status(common.WorkflowStatus.RUNNING)
 
         if workflow_id not in self._step_status:
             self._step_status[workflow_id] = {}
@@ -210,6 +209,12 @@ class WorkflowManagementActor:
             return step_name
         else:
             return f"{step_name}_{idx}"
+
+    def _update_workflow_status(self, workflow_id: str, status: common.WorkflowStatus):
+        wf_store = workflow_storage.WorkflowStorage(workflow_id)
+        if workflow_id not in self._workflow_status:
+            self._workflow_status[workflow_id] = wf_store.load_and_fix_workflow_status()
+        wf_store.update_workflow_status(status, self._workflow_status[workflow_id])
 
     def update_step_status(
         self,
@@ -233,30 +238,21 @@ class WorkflowManagementActor:
         if status != common.WorkflowStatus.FAILED and remaining != 0:
             return
 
-        wf_store = workflow_storage.WorkflowStorage(workflow_id)
-
         if status == common.WorkflowStatus.FAILED:
             if workflow_id in self._workflow_outputs:
                 cancel_job(self._workflow_outputs.pop(workflow_id).output)
-            wf_store.save_workflow_meta(
-                common.WorkflowMetaData(common.WorkflowStatus.FAILED)
-            )
+            self._update_workflow_status(common.WorkflowStatus.FAILED)
             self._step_status.pop(workflow_id)
         else:
-            wf_store.save_workflow_meta(
-                common.WorkflowMetaData(common.WorkflowStatus.SUCCESSFUL)
-            )
+            self._update_workflow_status(common.WorkflowStatus.SUCCESSFUL)
             self._step_status.pop(workflow_id)
-        workflow_postrun_metadata = {"end_time": time.time()}
-        wf_store.save_workflow_postrun_metadata(workflow_postrun_metadata)
+        wf_store = workflow_storage.WorkflowStorage(workflow_id)
+        wf_store.save_workflow_postrun_metadata({"end_time": time.time()})
 
     def cancel_workflow(self, workflow_id: str) -> None:
         self._step_status.pop(workflow_id)
         cancel_job(self._workflow_outputs.pop(workflow_id).output)
-        wf_store = workflow_storage.WorkflowStorage(workflow_id)
-        wf_store.save_workflow_meta(
-            common.WorkflowMetaData(common.WorkflowStatus.CANCELED)
-        )
+        self._update_workflow_status(common.WorkflowStatus.CANCELED)
 
     def is_workflow_running(self, workflow_id: str) -> bool:
         return (

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -213,7 +213,7 @@ class WorkflowManagementActor:
     def _update_workflow_status(self, workflow_id: str, status: common.WorkflowStatus):
         wf_store = workflow_storage.WorkflowStorage(workflow_id)
         if workflow_id not in self._workflow_status:
-            self._workflow_status[workflow_id] = wf_store.load_and_fix_workflow_status()
+            self._workflow_status[workflow_id] = wf_store.load_workflow_status()
         wf_store.update_workflow_status(status, self._workflow_status[workflow_id])
         self._workflow_status[workflow_id] = status
 
@@ -315,7 +315,7 @@ class WorkflowManagementActor:
         if workflow_id in self._workflow_outputs and name is None:
             return self._workflow_outputs[workflow_id].output
         wf_store = workflow_storage.WorkflowStorage(workflow_id)
-        meta = wf_store.load_and_fix_workflow_status()
+        meta = wf_store.load_workflow_status()
         if meta == common.WorkflowStatus.NONE:
             raise ValueError(f"No such workflow {workflow_id}")
         if meta == common.WorkflowStatus.CANCELED:

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -215,6 +215,7 @@ class WorkflowManagementActor:
         if workflow_id not in self._workflow_status:
             self._workflow_status[workflow_id] = wf_store.load_and_fix_workflow_status()
         wf_store.update_workflow_status(status, self._workflow_status[workflow_id])
+        self._workflow_status[workflow_id] = status
 
     def update_step_status(
         self,

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -212,9 +212,7 @@ class WorkflowManagementActor:
 
     def _update_workflow_status(self, workflow_id: str, status: common.WorkflowStatus):
         wf_store = workflow_storage.WorkflowStorage(workflow_id)
-        if workflow_id not in self._workflow_status:
-            self._workflow_status[workflow_id] = wf_store.load_workflow_status()
-        wf_store.update_workflow_status(status, self._workflow_status[workflow_id])
+        wf_store.update_workflow_status(status)
         self._workflow_status[workflow_id] = status
 
     def update_step_status(
@@ -315,15 +313,15 @@ class WorkflowManagementActor:
         if workflow_id in self._workflow_outputs and name is None:
             return self._workflow_outputs[workflow_id].output
         wf_store = workflow_storage.WorkflowStorage(workflow_id)
-        meta = wf_store.load_workflow_status()
-        if meta == common.WorkflowStatus.NONE:
+        status = wf_store.load_workflow_status()
+        if status == common.WorkflowStatus.NONE:
             raise ValueError(f"No such workflow {workflow_id}")
-        if meta == common.WorkflowStatus.CANCELED:
+        if status == common.WorkflowStatus.CANCELED:
             raise ValueError(f"Workflow {workflow_id} is canceled")
         if name is None:
             # For resumable workflow, the workflow result is not ready.
             # It has to be resumed first.
-            if meta == common.WorkflowStatus.RESUMABLE:
+            if status == common.WorkflowStatus.RESUMABLE:
                 raise ValueError(
                     f"Workflow {workflow_id} is in resumable status, "
                     "please resume it"

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -195,7 +195,7 @@ class WorkflowManagementActor:
         )
         self._step_output_cache[(workflow_id, step_id)] = latest_output
 
-        self._update_workflow_status(common.WorkflowStatus.RUNNING)
+        self._update_workflow_status(workflow_id, common.WorkflowStatus.RUNNING)
 
         if workflow_id not in self._step_status:
             self._step_status[workflow_id] = {}
@@ -241,10 +241,10 @@ class WorkflowManagementActor:
         if status == common.WorkflowStatus.FAILED:
             if workflow_id in self._workflow_outputs:
                 cancel_job(self._workflow_outputs.pop(workflow_id).output)
-            self._update_workflow_status(common.WorkflowStatus.FAILED)
+            self._update_workflow_status(workflow_id, common.WorkflowStatus.FAILED)
             self._step_status.pop(workflow_id)
         else:
-            self._update_workflow_status(common.WorkflowStatus.SUCCESSFUL)
+            self._update_workflow_status(workflow_id, common.WorkflowStatus.SUCCESSFUL)
             self._step_status.pop(workflow_id)
         wf_store = workflow_storage.WorkflowStorage(workflow_id)
         wf_store.save_workflow_postrun_metadata({"end_time": time.time()})
@@ -252,7 +252,7 @@ class WorkflowManagementActor:
     def cancel_workflow(self, workflow_id: str) -> None:
         self._step_status.pop(workflow_id)
         cancel_job(self._workflow_outputs.pop(workflow_id).output)
-        self._update_workflow_status(common.WorkflowStatus.CANCELED)
+        self._update_workflow_status(workflow_id, common.WorkflowStatus.CANCELED)
 
     def is_workflow_running(self, workflow_id: str) -> bool:
         return (

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -675,14 +675,12 @@ class WorkflowStorage:
     ):
         """Update the status of the workflow."""
         if prev_status is None:
-            prev_status = self._status_storage.load_and_fix_workflow_status(
-                self._workflow_id
-            )
+            prev_status = self.load_workflow_status()
         self._status_storage.update_workflow_status(
             self._workflow_id, status, prev_status
         )
 
-    def load_and_fix_workflow_status(self):
+    def load_workflow_status(self):
         """Load workflow status. If we find the previous status updating failed,
         fix it with redo-log transaction recovery."""
         return self._status_storage.load_and_fix_workflow_status(self._workflow_id)

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -179,7 +179,11 @@ class WorkflowIndexingStorage:
         """
         if status_filter is None:
             status_filter = set(WorkflowStatus)
-        status_filter.discard(WorkflowStatus.NONE)
+            status_filter.discard(WorkflowStatus.NONE)
+        elif not isinstance(status_filter, set):
+            raise TypeError("'status_filter' should either be 'None' or a set.")
+        elif WorkflowStatus.NONE in status_filter:
+            raise ValueError("'WorkflowStatus.NONE' is not a valid filter value.")
 
         results = {}
         for status in status_filter:

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -93,10 +93,9 @@ class WorkflowIndexingStorage:
     def __init__(self):
         self._storage = storage.get_client(WORKFLOW_ROOT)
 
-    def update_workflow_status(
-        self, workflow_id: str, status: WorkflowStatus, prev_status: WorkflowStatus
-    ):
+    def update_workflow_status(self, workflow_id: str, status: WorkflowStatus):
         """Update the status of the workflow."""
+        prev_status = self.load_and_fix_workflow_status(workflow_id)
         if prev_status != status:
             # Transactional update of workflow status
             self._storage.put(self._key_workflow_status_on_change(workflow_id), b"")
@@ -677,15 +676,9 @@ class WorkflowStorage:
         if not found:
             raise WorkflowNotFoundError(self._workflow_id)
 
-    def update_workflow_status(
-        self, status: WorkflowStatus, prev_status: Optional[WorkflowStatus] = None
-    ):
+    def update_workflow_status(self, status: WorkflowStatus):
         """Update the status of the workflow."""
-        if prev_status is None:
-            prev_status = self.load_workflow_status()
-        self._status_storage.update_workflow_status(
-            self._workflow_id, status, prev_status
-        )
+        self._status_storage.update_workflow_status(self._workflow_id, status)
 
     def load_workflow_status(self):
         """Load workflow status. If we find the previous status updating failed,

--- a/python/ray/workflow/workflow_storage.py
+++ b/python/ray/workflow/workflow_storage.py
@@ -159,6 +159,12 @@ class WorkflowIndexingStorage:
                     pass
         return results
 
+    def delete_workflow_status(self, workflow_id: str):
+        """Delete status indexing for the workflow."""
+        status = self.load_and_fix_workflow_status(workflow_id)
+        if status != WorkflowStatus.NONE:
+            self._storage.delete(self._key_workflow_with_status(workflow_id, status))
+
     def _key_workflow_with_status(self, workflow_id: str, status: WorkflowStatus):
         return os.path.join(WORKFLOW_STATUS_DIR, status.value, workflow_id)
 
@@ -662,6 +668,7 @@ class WorkflowStorage:
     def delete_workflow(self) -> None:
         # TODO (Alex): There's a race condition here if someone tries to
         # start the workflow between these ops.
+        self._status_storage.delete_workflow_status(self._workflow_id)
         found = self._storage.delete_dir("")
         # TODO (Alex): Different file systems seem to have different
         # behavior when deleting a prefix that doesn't exist, so we may


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR enables indexing for workflow status. So it would be much faster to list workflows and status.

The indexing is done by creating keys under corresponding status directories. For example, `RUNNING` directory contains all keys (named with workflow ids), which the corresponding workflow is running.

One issue is that the cluster / workflow maybe crashed while updating the status, this would result in inconsistency status, because we have to create the new key, delete the old key and update workflow metadata, these actions cannot be combined as a single atomic operation. We use a special directory marking the status updating is underway. This makes us possible to detect unfinished status updating and fixing them. (See examples in newly added tests).

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
