### PR TITLE
[tune/release] Make long running distributed PBT cheaper

### DIFF
--- a/release/long_running_distributed_tests/compute_tpl.yaml
+++ b/release/long_running_distributed_tests/compute_tpl.yaml
@@ -5,13 +5,13 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: g3.8xlarge
+    instance_type: g4ad.8xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: g3.8xlarge
-      min_workers: 3
-      max_workers: 3
+      instance_type: g4ad.8xlarge
+      min_workers: 2
+      max_workers: 2
       use_spot: false
 
 aws:

--- a/release/long_running_distributed_tests/compute_tpl.yaml
+++ b/release/long_running_distributed_tests/compute_tpl.yaml
@@ -5,11 +5,11 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: g4ad.8xlarge
+    instance_type: g3.8xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: g4ad.8xlarge
+      instance_type: g3.8xlarge
       min_workers: 2
       max_workers: 2
       use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test currently uses 6 GPUs out of 8 available, so we can get rid of one instance.

Savings will be 25% for one instance less (3 instead of 4).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
