### PR TITLE
[Release Test] Add perf alert for shuffle tests

### DIFF
--- a/release/nightly_tests/shuffle/shuffle_test.py
+++ b/release/nightly_tests/shuffle/shuffle_test.py
@@ -37,4 +37,16 @@ if __name__ == "__main__":
     delta = time.time() - start
 
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
-        f.write(json.dumps({"shuffle_time": delta, "success": 1}))
+        results = {
+            "shuffle_time": delta,
+            "success": 1,
+        }
+        results["perf_metrics"] = [
+            {
+                "perf_metric_name": "shuffle_time",
+                "perf_metric_value": delta,
+                "perf_metric_type": "LATENCY",
+            }
+        ]
+
+        f.write(json.dumps(results))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add perf alert for shuffle tests so we can catch https://github.com/ray-project/ray/issues/24740 earlier.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
