### PR TITLE
[Datasets] Add example protocol for reading canned in-package example data.

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 import posixpath
 from typing import (
     Callable,
@@ -422,6 +423,7 @@ def _resolve_paths_and_filesystem(
 
     resolved_paths = []
     for path in paths:
+        path = _resolve_example_path(path)
         try:
             resolved_filesystem, resolved_path = _resolve_filesystem_and_path(
                 path, filesystem
@@ -442,6 +444,26 @@ def _resolve_paths_and_filesystem(
         resolved_paths.append(resolved_path)
 
     return resolved_paths, filesystem
+
+
+def _resolve_example_path(path: str) -> str:
+    """If an example path adhering to the example protocol, resolve to the true
+    underlying file path.
+
+    If the path does not adhere to the example protocol, it is returned untouched.
+
+    Args:
+        path: A file path possibly adhering to the example protocol.
+
+    Returns:
+        A resolved concrete file path.
+    """
+    example_protocol_scheme = "example://"
+    if path.startswith(example_protocol_scheme):
+        example_data_path = pathlib.Path(__file__).parent.parent / "examples" / "data"
+        path = example_data_path / path[len(example_protocol_scheme) :]
+        path = str(path.resolve())
+    return path
 
 
 def _expand_directory(

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -281,6 +281,20 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     assert ds_df.equals(df)
 
 
+def test_read_example_data(ray_start_regular_shared, tmp_path):
+    ds = ray.data.read_csv("example://iris.csv")
+    assert ds.count() == 150
+    assert ds.take(1) == [
+        {
+            "sepal.length": 5.1,
+            "sepal.width": 3.5,
+            "petal.length": 1.4,
+            "petal.width": 0.2,
+            "variety": "Setosa",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     "fs,data_path",
     [


### PR DESCRIPTION
Providing easy-access datasets is table stakes for a good Getting Started UX, but even with good in-package data, it can be difficult to make these paths accessible to the user. This PR adds an `example://` protocol that will resolve passed paths directly to our canned in-package example data.

We may decide that this is too auto-magic. See alternatives for a few other options.

## Alternatives

### Explicit example path resolution

Another option would be providing a `ray.data.get_example_path("iris.csv")` that would make this path resolution much more explicit. However, this would make examples a bit more verbose/clunky:
```python
ds = ray.data.read_csv(ray.data.get_example_path("iris.csv"))

# vs

ds = ray.data.read_csv("example://iris.csv")
```

### Example data fallback

If a local relative path is provided and resolution fails in the current working directory, transparently fall back to using the ray package as as the root:
```python
ds = ray.data.read_csv("data/examples/data/iris.csv")
```
This may be too magic and could lead to silently using the wrong data; however, this would have the benefit of directing users to look at the example data directory to see other options.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
