### PR TITLE
[docs] Fix broken code example in docstring for DataParallelTrainer args

### DIFF
--- a/python/ray/ml/train/data_parallel_trainer.py
+++ b/python/ray/ml/train/data_parallel_trainer.py
@@ -186,7 +186,9 @@ class DataParallelTrainer(Trainer):
             def __init__(self, train_loop_per_worker, my_backend_config:
                 MyBackendConfig, **kwargs):
 
-                super().__init__(train_loop_per_worker, my_backend_config, **kwargs)
+                super().__init__(
+                    train_loop_per_worker,
+                    backend_config=my_backend_config, **kwargs)
 
     Args:
         train_loop_per_worker: The training function to execute.
@@ -222,8 +224,8 @@ class DataParallelTrainer(Trainer):
 
     def __init__(
         self,
-        *,
         train_loop_per_worker: Union[Callable[[], None], Callable[[Dict], None]],
+        *,
         train_loop_config: Optional[Dict] = None,
         backend_config: Optional[BackendConfig] = None,
         scaling_config: Optional[ScalingConfig] = None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Seems we changed required kwargs but didn't update the example. I'm moving the train loop back to non-required since it's positional.