### PR TITLE
[Datasets] [Tensor Story - 1/2] Automatically provide tensor views to UDFs and infer tensor blocks for pure-tensor datasets.

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -229,6 +229,10 @@ class BlockAccessor(Generic[T]):
         """Return the base block that this accessor wraps."""
         raise NotImplementedError
 
+    def to_native(self) -> Block:
+        """Return the native data format for this accessor."""
+        return self.to_block()
+
     def size_bytes(self) -> int:
         """Return the approximate size in bytes of this block."""
         raise NotImplementedError

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -68,6 +68,7 @@ from ray.data.datasource.file_based_datasource import (
 from ray.data.row import TableRow
 from ray.data.aggregate import AggregateFn, Sum, Max, Min, Mean, Std
 from ray.data.random_access_dataset import RandomAccessDataset
+from ray.data.impl.table_block import TENSOR_COL_NAME
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.block_batching import batch_blocks, BatchType
 from ray.data.impl.plan import ExecutionPlan, OneToOneStage, AllToAllStage
@@ -198,8 +199,8 @@ class Dataset(Generic[T]):
 
         def transform(block: Block) -> Iterable[Block]:
             DatasetContext._set_current(context)
-            block = BlockAccessor.for_block(block)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
+            block = BlockAccessor.for_block(block)
             for row in block.iter_rows():
                 output_buffer.add(fn(row))
                 if output_buffer.has_next():
@@ -223,6 +224,9 @@ class Dataset(Generic[T]):
         **ray_remote_args,
     ) -> "Dataset[Any]":
         """Apply the given function to batches of records of this dataset.
+
+        The format of the data batch provided to ``fn`` can be controlled via the
+        ``batch_format`` argument, and the output of the UDF can be any batch type.
 
         This is a blocking operation.
 
@@ -270,10 +274,10 @@ class Dataset(Generic[T]):
                 blocks as batches. Defaults to a system-chosen batch size.
             compute: The compute strategy, either "tasks" (default) to use Ray
                 tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
-            batch_format: Specify "native" to use the native block format
-                (promotes Arrow to pandas), "pandas" to select
-                ``pandas.DataFrame`` as the batch format,
-                or "pyarrow" to select ``pyarrow.Table``.
+            batch_format: Specify "native" to use the native block format (promotes
+                tabular Arrow to Pandas), "pandas" to select ``pandas.DataFrame``,
+                "numpy" to select ``numpy.ndarray``, or "pyarrow" to select
+                ``pyarrow.Table``.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
@@ -302,13 +306,21 @@ class Dataset(Generic[T]):
                 # bug where we include the entire base view on serialization.
                 view = block.slice(start, end, copy=batch_size is not None)
                 if batch_format == "native":
-                    # Always promote Arrow blocks to pandas for consistency.
-                    if isinstance(view, pa.Table) or isinstance(view, bytes):
+                    if isinstance(view, pa.Table):
+                        if view.column_names == [TENSOR_COL_NAME]:
+                            view = BlockAccessor.for_block(view).to_numpy()
+                        else:
+                            # Always promote non-tensor Arrow blocks to pandas for
+                            # consistency.
+                            view = BlockAccessor.for_block(view).to_pandas()
+                    elif isinstance(view, bytes):
                         view = BlockAccessor.for_block(view).to_pandas()
                 elif batch_format == "pandas":
                     view = BlockAccessor.for_block(view).to_pandas()
                 elif batch_format == "pyarrow":
                     view = BlockAccessor.for_block(view).to_arrow()
+                elif batch_format == "numpy":
+                    view = BlockAccessor.for_block(view).to_numpy()
                 else:
                     raise ValueError(
                         "The batch format must be one of 'native', 'pandas', "
@@ -319,6 +331,7 @@ class Dataset(Generic[T]):
                 if not (
                     isinstance(applied, list)
                     or isinstance(applied, pa.Table)
+                    or isinstance(applied, np.ndarray)
                     or isinstance(applied, pd.core.frame.DataFrame)
                 ):
                     raise ValueError(
@@ -2037,7 +2050,7 @@ class Dataset(Generic[T]):
         self,
         path: str,
         *,
-        column: str = "value",
+        column: str = TENSOR_COL_NAME,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         try_create_dir: bool = True,
         arrow_open_stream_args: Optional[Dict[str, Any]] = None,
@@ -2065,7 +2078,9 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where npy
                 files will be written to.
             column: The name of the table column that contains the tensor to
-                be written. This defaults to "value".
+                be written. The default is the column name that Datasets uses for
+                storing tensors in single-column tables. See
+                ``ray.data.impl.arrow_block.TENSOR_COL_NAME`` for the exact name.
             filesystem: The filesystem implementation to write to.
             try_create_dir: Try to create all directories in destination path
                 if True. Does nothing if all directories already exist.
@@ -2213,8 +2228,8 @@ class Dataset(Generic[T]):
             batch_size: Record batch size, or None to let the system pick.
             batch_format: The format in which to return each batch.
                 Specify "native" to use the current block format (promoting
-                Arrow to pandas automatically), "pandas" to
-                select ``pandas.DataFrame`` or "pyarrow" to select
+                Arrow to pandas automatically), "pandas" to select ``pandas.DataFrame``,
+                "numpy" to select ``numpy.ndarray``, or "pyarrow" to select
                 ``pyarrow.Table``. Default is "native".
             drop_last: Whether to drop the last batch if it's incomplete.
 
@@ -2737,8 +2752,9 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            column: The name of the column to convert to numpy, or None to
-                specify the entire row. Required for Arrow tables.
+            column: The name of the column to convert to numpy, or None to specify the
+            entire row. If not specified for Arrow or Pandas blocks, each returned
+            future will represent a dict of column ndarrays.
 
         Returns:
             A list of remote NumPy ndarrays created from this dataset.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -330,7 +330,7 @@ class Dataset(Generic[T]):
                         "The return type must be either list, "
                         "pandas.DataFrame, or pyarrow.Table"
                     )
-                output_buffer.add_block(applied)
+                output_buffer.add_batch(applied)
                 if output_buffer.has_next():
                     yield output_buffer.next()
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -276,8 +276,7 @@ class Dataset(Generic[T]):
                 tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
             batch_format: Specify "native" to use the native block format (promotes
                 tables to Pandas and tensors to NumPy), "pandas" to select
-                ``pandas.DataFrame``, "numpy" to select ``numpy.ndarray``,
-                or "pyarrow" to select `pyarrow.Table``.
+                ``pandas.DataFrame``, or "pyarrow" to select `pyarrow.Table``.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
@@ -311,8 +310,6 @@ class Dataset(Generic[T]):
                     view = BlockAccessor.for_block(view).to_pandas()
                 elif batch_format == "pyarrow":
                     view = BlockAccessor.for_block(view).to_arrow()
-                elif batch_format == "numpy":
-                    view = BlockAccessor.for_block(view).to_numpy()
                 else:
                     raise ValueError(
                         "The batch format must be one of 'native', 'pandas', "
@@ -2221,8 +2218,8 @@ class Dataset(Generic[T]):
             batch_format: The format in which to return each batch.
                 Specify "native" to use the native block format (promoting
                 tables to Pandas and tensors to NumPy), "pandas" to select
-                ``pandas.DataFrame``, "numpy" to select ``numpy.ndarray``, or "pyarrow"
-                to select ``pyarrow.Table``. Default is "native".
+                ``pandas.DataFrame``, or "pyarrow" to select ``pyarrow.Table``. Default
+                is "native".
             drop_last: Whether to drop the last batch if it's incomplete.
 
         Returns:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -669,6 +669,8 @@ class Dataset(Generic[T]):
                 )
             if isinstance(batch, pd.DataFrame):
                 return batch.sample(frac=fraction)
+            if isinstance(batch, np.ndarray):
+                return np.array([row for row in batch if random.random() <= fraction])
             raise ValueError(f"Unsupported batch type: {type(batch)}")
 
         return self.map_batches(process_batch)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2067,9 +2067,8 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where npy
                 files will be written to.
             column: The name of the table column that contains the tensor to
-                be written. The default is the column name that Datasets uses for
-                storing tensors in single-column tables. See
-                ``ray.data.impl.arrow_block.VALUE_COL_NAME`` for the exact name.
+                be written. The default is ``"__value__"``, the column name that
+                Datasets uses for storing tensors in single-column tables.
             filesystem: The filesystem implementation to write to.
             try_create_dir: Try to create all directories in destination path
                 if True. Does nothing if all directories already exist.

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -144,8 +144,7 @@ class ReadTask(Callable[[], BlockPartition]):
         if context.block_splitting_enabled:
             partition: BlockPartition = []
             for block in result:
-                accessor = BlockAccessor.for_block(block)
-                metadata = accessor.get_metadata(
+                metadata = BlockAccessor.for_block(block).get_metadata(
                     input_files=self._metadata.input_files, exec_stats=None
                 )  # No exec stats for the block splits.
                 assert context.block_owner

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -16,7 +16,7 @@ from ray.data.block import (
 )
 from ray.data.context import DatasetContext
 from ray.data.impl.arrow_block import ArrowRow
-from ray.data.impl.table_block import TENSOR_COL_NAME
+from ray.data.impl.table_block import VALUE_COL_NAME
 from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.impl.util import _check_pyarrow_version
 from ray.util.annotations import DeveloperAPI
@@ -203,7 +203,7 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
                         tuple(range(1, 1 + len(tensor_shape))),
                     )
                 )
-                return pa.Table.from_pydict({TENSOR_COL_NAME: tensor})
+                return pa.Table.from_pydict({VALUE_COL_NAME: tensor})
             else:
                 return list(builtins.range(start, start + count))
 
@@ -226,7 +226,7 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
                         np.arange(0, 10), tuple(range(1, 1 + len(tensor_shape)))
                     )
                 )
-                schema = pa.Table.from_pydict({TENSOR_COL_NAME: tensor}).schema
+                schema = pa.Table.from_pydict({VALUE_COL_NAME: tensor}).schema
             elif block_format == "list":
                 schema = int
             else:

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.data.impl.table_block import TENSOR_COL_NAME
+from ray.data.impl.table_block import VALUE_COL_NAME
 
 
 class NumpyDatasource(FileBasedDatasource):
@@ -35,7 +35,7 @@ class NumpyDatasource(FileBasedDatasource):
         buf.write(data)
         buf.seek(0)
         return pa.Table.from_pydict(
-            {TENSOR_COL_NAME: TensorArray(np.load(buf, allow_pickle=True))}
+            {VALUE_COL_NAME: TensorArray(np.load(buf, allow_pickle=True))}
         )
 
     def _write_block(

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
+from ray.data.impl.table_block import TENSOR_COL_NAME
 
 
 class NumpyDatasource(FileBasedDatasource):
@@ -34,7 +35,7 @@ class NumpyDatasource(FileBasedDatasource):
         buf.write(data)
         buf.seek(0)
         return pa.Table.from_pydict(
-            {"value": TensorArray(np.load(buf, allow_pickle=True))}
+            {TENSOR_COL_NAME: TensorArray(np.load(buf, allow_pickle=True))}
         )
 
     def _write_block(

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -107,19 +107,18 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return self._table.column_names
 
     @classmethod
-    def from_bytes(cls, data: bytes):
+    def from_bytes(cls, data: bytes) -> "ArrowBlockAccessor":
         reader = pyarrow.ipc.open_stream(data)
         return cls(reader.read_all())
 
-    @classmethod
-    def from_numpy(cls, data: Union[np.ndarray, List[np.ndarray]]):
+    @staticmethod
+    def numpy_to_block(batch: np.ndarray) -> "pyarrow.Table":
         import pyarrow as pa
         from ray.data.extensions.tensor_extension import ArrowTensorArray
 
-        table = pa.Table.from_pydict(
-            {VALUE_COL_NAME: ArrowTensorArray.from_numpy(data)}
+        return pa.Table.from_pydict(
+            {VALUE_COL_NAME: ArrowTensorArray.from_numpy(batch)}
         )
-        return cls(table)
 
     @staticmethod
     def _build_tensor_row(row: ArrowRow) -> np.ndarray:

--- a/python/ray/data/impl/output_buffer.py
+++ b/python/ray/data/impl/output_buffer.py
@@ -1,6 +1,6 @@
 from typing import Callable, Any, Optional
 
-from ray.data.block import Block, BlockAccessor
+from ray.data.block import Block, DataBatch, BlockAccessor
 from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
 
 
@@ -43,6 +43,11 @@ class BlockOutputBuffer(object):
         """Add a single item to this output buffer."""
         assert not self._finalized
         self._buffer.add(item)
+
+    def add_batch(self, batch: DataBatch) -> None:
+        """Add a data batch to this output buffer."""
+        assert not self._finalized
+        self._buffer.add_batch(batch)
 
     def add_block(self, block: Block) -> None:
         """Add a data block to this output buffer."""

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -15,7 +15,6 @@ import collections
 import numpy as np
 
 from ray.data.block import BlockAccessor, BlockMetadata, KeyFn, U
-from ray.data.extensions.tensor_extension import TensorArray
 from ray.data.row import TableRow
 from ray.data.impl.table_block import (
     TableBlockAccessor,
@@ -79,6 +78,8 @@ class PandasBlockBuilder(TableBlockBuilder[T]):
         pandas = lazy_import_pandas()
         for key, value in columns.items():
             if key == VALUE_COL_NAME or isinstance(next(iter(value), None), np.ndarray):
+                from ray.data.extensions.tensor_extension import TensorArray
+
                 if len(value) == 1:
                     value = value[0]
                 columns[key] = TensorArray(value)

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -108,6 +108,12 @@ class PandasBlockAccessor(TableBlockAccessor):
     def column_names(self) -> List[str]:
         return self._table.columns.tolist()
 
+    @staticmethod
+    def _build_tensor_row(row: PandasRow) -> np.ndarray:
+        # Getting an item in a Pandas tensor column returns a TensorArrayElement, which
+        # we have to convert to an ndarray.
+        return row[VALUE_COL_NAME].iloc[0].to_numpy()
+
     def slice(self, start: int, end: int, copy: bool) -> "pandas.DataFrame":
         view = self._table[start:end]
         if copy:

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -3,6 +3,7 @@ from typing import (
     Dict,
     List,
     Tuple,
+    Union,
     Iterator,
     Any,
     TypeVar,
@@ -14,8 +15,13 @@ import collections
 import numpy as np
 
 from ray.data.block import BlockAccessor, BlockMetadata, KeyFn, U
+from ray.data.extensions.tensor_extension import TensorArray
 from ray.data.row import TableRow
-from ray.data.impl.table_block import TableBlockAccessor, TableBlockBuilder
+from ray.data.impl.table_block import (
+    TableBlockAccessor,
+    TableBlockBuilder,
+    TENSOR_COL_NAME,
+)
 from ray.data.impl.arrow_block import ArrowBlockAccessor
 from ray.data.aggregate import AggregateFn
 
@@ -71,6 +77,13 @@ class PandasBlockBuilder(TableBlockBuilder[T]):
 
     def _table_from_pydict(self, columns: Dict[str, List[Any]]) -> "pandas.DataFrame":
         pandas = lazy_import_pandas()
+        for key, value in columns.items():
+            if key == TENSOR_COL_NAME or isinstance(
+                next(iter(value), None), np.ndarray
+            ):
+                if len(value) == 1:
+                    value = value[0]
+                columns[key] = TensorArray(value)
         return pandas.DataFrame(columns)
 
     def _concat_tables(self, tables: List["pandas.DataFrame"]) -> "pandas.DataFrame":
@@ -92,8 +105,13 @@ class PandasBlockAccessor(TableBlockAccessor):
     def __init__(self, table: "pandas.DataFrame"):
         super().__init__(table)
 
-    def _create_table_row(self, row: "pandas.DataFrame") -> PandasRow:
-        return PandasRow(row)
+    def _create_table_row(
+        self, row: "pandas.DataFrame"
+    ) -> Union[PandasRow, np.ndarray]:
+        if row.columns.tolist() == [TENSOR_COL_NAME]:
+            return row[TENSOR_COL_NAME][0]
+        else:
+            return PandasRow(row)
 
     def slice(self, start: int, end: int, copy: bool) -> "pandas.DataFrame":
         view = self._table[start:end]
@@ -122,19 +140,27 @@ class PandasBlockAccessor(TableBlockAccessor):
     def to_pandas(self) -> "pandas.DataFrame":
         return self._table
 
-    def to_numpy(self, column: str = None) -> np.ndarray:
-        if not column:
-            raise ValueError(
-                "`column` must be specified when calling .to_numpy() "
-                "on Pandas blocks."
-            )
-        if column not in self._table.columns:
-            raise ValueError(
-                "Cannot find column {}, available columns: {}".format(
-                    column, self._table.columns.tolist()
+    def to_numpy(
+        self, columns: Optional[Union[str, List[str]]] = None
+    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
+        if columns is None:
+            columns = self._table.columns.tolist()
+        if not isinstance(columns, list):
+            columns = [columns]
+        for column in columns:
+            if column not in self._table.columns:
+                raise ValueError(
+                    f"Cannot find column {column}, available columns: "
+                    f"{self._table.columns.tolist()}"
                 )
-            )
-        return self._table[column].to_numpy()
+        arrays = []
+        for column in columns:
+            arrays.append(self._table[column].to_numpy())
+        if len(arrays) == 1:
+            arrays = arrays[0]
+        else:
+            arrays = dict(zip(columns, arrays))
+        return arrays
 
     def to_arrow(self) -> "pyarrow.Table":
         import pyarrow

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -1,7 +1,7 @@
 import random
 import sys
 import heapq
-from typing import Callable, Iterator, List, Tuple, Any, Optional, TYPE_CHECKING
+from typing import Union, Callable, Iterator, List, Tuple, Any, Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -84,9 +84,9 @@ class SimpleBlockAccessor(BlockAccessor):
 
         return pandas.DataFrame({"value": self._items})
 
-    def to_numpy(self, column: str = None) -> np.ndarray:
-        if column:
-            raise ValueError("`column` arg not supported for list block")
+    def to_numpy(self, columns: Optional[Union[str, List[str]]] = None) -> np.ndarray:
+        if columns:
+            raise ValueError("`columns` arg is not supported for list block.")
         return np.array(self._items)
 
     def to_arrow(self) -> "pyarrow.Table":

--- a/python/ray/data/impl/table_block.py
+++ b/python/ray/data/impl/table_block.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from ray.data.impl.sort import SortKeyT
 
 
+# The internal column name used for pure-tensor datasets, represented as
+# single-tensor-column tables.
 VALUE_COL_NAME = "__value__"
 
 T = TypeVar("T")

--- a/python/ray/data/impl/table_block.py
+++ b/python/ray/data/impl/table_block.py
@@ -61,7 +61,6 @@ class TableBlockBuilder(BlockBuilder[T]):
                 f"{block}"
             )
         accessor = BlockAccessor.for_block(block)
-        block = accessor.to_block()
         self._tables.append(block)
         self._tables_size_bytes += accessor.size_bytes()
         self._num_rows += accessor.num_rows()

--- a/python/ray/data/impl/table_block.py
+++ b/python/ray/data/impl/table_block.py
@@ -117,10 +117,14 @@ class TableBlockAccessor(BlockAccessor):
     def _get_row(self, index: int, copy: bool = False) -> Union[TableRow, np.ndarray]:
         row = self.slice(index, index + 1, copy=copy)
         if self.is_tensor_wrapper():
-            row = row[VALUE_COL_NAME][0]
+            row = self._build_tensor_row(row)
         else:
             row = self.ROW_TYPE(row)
         return row
+
+    @staticmethod
+    def _build_tensor_row(row: TableRow) -> np.ndarray:
+        raise NotImplementedError
 
     def to_native(self) -> Block:
         if self.is_tensor_wrapper():

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -254,7 +254,7 @@ class _RandomAccessWorker:
         if i is None:
             return None
         acc = BlockAccessor.for_block(block)
-        return acc._create_table_row(acc.slice(i, i + 1, copy=True))
+        return acc._get_row(i, copy=True)
 
 
 def _binary_search_find(column, x):

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -223,9 +223,7 @@ class _RandomAccessWorker:
             col = block[self.key_field]
             indices = np.searchsorted(col, keys)
             acc = BlockAccessor.for_block(block)
-            result = [
-                acc._create_table_row(acc.slice(i, i + 1, copy=True)) for i in indices
-            ]
+            result = [acc._get_row(i, copy=True) for i in indices]
             # assert result == [self._get(i, k) for i, k in zip(block_indices, keys)]
         else:
             result = [self._get(i, k) for i, k in zip(block_indices, keys)]

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -173,7 +173,7 @@ def range_tensor(
         >>> import ray
         >>> ds = ray.data.range_tensor(1000, shape=(3, 10)) # doctest: +SKIP
         >>> ds.map_batches( # doctest: +SKIP
-        ...     lambda arr: arr * 2, batch_format="numpy").show()
+        ...     lambda arr: arr * 2).show()
 
     This is similar to range_table(), but uses the ArrowTensorArray extension
     type. The dataset elements take the form {VALUE_COL_NAME: array(N, shape=shape)}.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1019,11 +1019,11 @@ def _df_to_block(df: "pandas.DataFrame") -> Block[ArrowRow]:
 
 def _ndarray_to_block(ndarray: np.ndarray) -> Block[np.ndarray]:
     stats = BlockExecStats.builder()
-    accessor = BlockAccessor.for_block(ndarray)
-    return (
-        accessor.to_block(),
-        accessor.get_metadata(input_files=None, exec_stats=stats.build()),
+    block = BlockAccessor.batch_to_block(ndarray)
+    metadata = BlockAccessor.for_block(block).get_metadata(
+        input_files=None, exec_stats=stats.build()
     )
+    return block, metadata
 
 
 def _get_metadata(table: Union["pyarrow.Table", "pandas.DataFrame"]) -> BlockMetadata:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -176,7 +176,7 @@ def range_tensor(
         ...     lambda arr: arr * 2, batch_format="numpy").show()
 
     This is similar to range_table(), but uses the ArrowTensorArray extension
-    type. The dataset elements take the form {TENSOR_COL_NAME: array(N, shape=shape)}.
+    type. The dataset elements take the form {VALUE_COL_NAME: array(N, shape=shape)}.
 
     Args:
         n: The upper bound of the range of integer records.

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -22,7 +22,6 @@ from ray.data.impl.arrow_block import ArrowRow
 from ray.data.impl.block_builder import BlockBuilder
 from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.pandas_block import PandasRow
-from ray.data.impl.table_block import VALUE_COL_NAME
 from ray.data.aggregate import AggregateFn, Count, Sum, Min, Max, Mean, Std
 from ray.data.extensions.tensor_extension import (
     TensorArray,
@@ -450,7 +449,7 @@ def test_tensors_basic(ray_start_regular_shared):
     ds = ray.data.range_tensor(6, shape=tensor_shape)
     assert str(ds) == (
         "Dataset(num_blocks=6, num_rows=6, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(3, 5), dtype=int64>}})"
+        "schema={__value__: <ArrowTensorType: shape=(3, 5), dtype=int64>})"
     )
 
     # Test row iterator yields tensors.
@@ -485,7 +484,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     ds = ray.data.range(10).map(lambda _: np.ones((4, 4)))
     assert str(ds) == (
         "Dataset(num_blocks=10, num_rows=10, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
     )
 
     # Test map_batches.
@@ -496,7 +495,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     )
     assert str(ds) == (
         "Dataset(num_blocks=4, num_rows=24, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
     )
 
     #  - Test list of ndarrays.
@@ -505,14 +504,14 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     )
     assert str(ds) == (
         "Dataset(num_blocks=4, num_rows=16, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
     )
 
     # Test flat_map.
     ds = ray.data.range(10).flat_map(lambda _: [np.ones((4, 4)), np.ones((4, 4))])
     assert str(ds) == (
         "Dataset(num_blocks=10, num_rows=20, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
     )
 
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -561,22 +561,11 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     )
 
     # Test map_batches.
-
-    #  - Test top-level ndarray.
     ds = ray.data.range(16, parallelism=4).map_batches(
         lambda _: np.ones((3, 4, 4)), batch_size=2
     )
     assert str(ds) == (
         "Dataset(num_blocks=4, num_rows=24, "
-        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
-    )
-
-    #  - Test list of ndarrays.
-    ds = ray.data.range(16, parallelism=4).map_batches(
-        lambda _: [np.ones((4, 4)), np.ones((4, 4))], batch_size=2
-    )
-    assert str(ds) == (
-        "Dataset(num_blocks=4, num_rows=16, "
         "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
     )
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -22,7 +22,7 @@ from ray.data.impl.arrow_block import ArrowRow
 from ray.data.impl.block_builder import BlockBuilder
 from ray.data.impl.lazy_block_list import LazyBlockList
 from ray.data.impl.pandas_block import PandasRow
-from ray.data.impl.table_block import TENSOR_COL_NAME
+from ray.data.impl.table_block import VALUE_COL_NAME
 from ray.data.aggregate import AggregateFn, Count, Sum, Min, Max, Mean, Std
 from ray.data.extensions.tensor_extension import (
     TensorArray,
@@ -450,7 +450,7 @@ def test_tensors_basic(ray_start_regular_shared):
     ds = ray.data.range_tensor(6, shape=tensor_shape)
     assert str(ds) == (
         "Dataset(num_blocks=6, num_rows=6, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(3, 5), dtype=int64>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(3, 5), dtype=int64>}})"
     )
 
     # Test row iterator yields tensors.
@@ -531,7 +531,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     ds = ray.data.range(10).map(lambda _: np.ones((4, 4)))
     assert str(ds) == (
         "Dataset(num_blocks=10, num_rows=10, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
     )
 
     # Test map_batches.
@@ -542,7 +542,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     )
     assert str(ds) == (
         "Dataset(num_blocks=4, num_rows=24, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
     )
 
     #  - Test list of ndarrays.
@@ -551,14 +551,14 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     )
     assert str(ds) == (
         "Dataset(num_blocks=4, num_rows=16, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
     )
 
     # Test flat_map.
     ds = ray.data.range(10).flat_map(lambda _: [np.ones((4, 4)), np.ones((4, 4))])
     assert str(ds) == (
         "Dataset(num_blocks=10, num_rows=20, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(4, 4), dtype=double>}})"
     )
 
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -33,7 +33,7 @@ from ray.data.datasource import (
     WriteResult,
 )
 from ray.data.impl.arrow_block import ArrowRow
-from ray.data.impl.table_block import TENSOR_COL_NAME
+from ray.data.impl.table_block import VALUE_COL_NAME
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import PARALLELIZE_META_FETCH_THRESHOLD
 from ray.data.tests.conftest import *  # noqa
@@ -1013,7 +1013,7 @@ def test_numpy_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_numpy(data_path, filesystem=fs)
     assert str(ds) == (
         "Dataset(num_blocks=2, num_rows=None, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1025,7 +1025,7 @@ def test_numpy_read(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path)
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1038,7 +1038,7 @@ def test_numpy_read_meta_provider(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path, meta_provider=FastFileMetadataProvider())
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        f"schema={{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
+        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1095,7 +1095,7 @@ def test_numpy_read_partitioned_with_filter(
         val_str = "".join(f"array({v}, dtype=int8), " for v in vals)[:-2]
         assert_base_partitioned_ds(
             ds,
-            schema=f"{{{TENSOR_COL_NAME}: <ArrowTensorType: shape=(2,), dtype=int8>}}",
+            schema=f"{{{VALUE_COL_NAME}: <ArrowTensorType: shape=(2,), dtype=int8>}}",
             sorted_values=f"[[{val_str}]]",
             ds_take_transform_fn=lambda taken: [taken],
             sorted_values_transform_fn=lambda sorted_values: str(sorted_values),

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -33,7 +33,6 @@ from ray.data.datasource import (
     WriteResult,
 )
 from ray.data.impl.arrow_block import ArrowRow
-from ray.data.impl.table_block import VALUE_COL_NAME
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import PARALLELIZE_META_FETCH_THRESHOLD
 from ray.data.tests.conftest import *  # noqa
@@ -1013,7 +1012,7 @@ def test_numpy_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_numpy(data_path, filesystem=fs)
     assert str(ds) == (
         "Dataset(num_blocks=2, num_rows=None, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
+        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1025,7 +1024,7 @@ def test_numpy_read(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path)
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
+        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1038,7 +1037,7 @@ def test_numpy_read_meta_provider(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path, meta_provider=FastFileMetadataProvider())
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        f"schema={{{VALUE_COL_NAME}: <ArrowTensorType: shape=(1,), dtype=int64>}})"
+        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1095,7 +1094,7 @@ def test_numpy_read_partitioned_with_filter(
         val_str = "".join(f"array({v}, dtype=int8), " for v in vals)[:-2]
         assert_base_partitioned_ds(
             ds,
-            schema=f"{{{VALUE_COL_NAME}: <ArrowTensorType: shape=(2,), dtype=int8>}}",
+            schema="{__value__: <ArrowTensorType: shape=(2,), dtype=int8>}",
             sorted_values=f"[[{val_str}]]",
             ds_take_transform_fn=lambda taken: [taken],
             sorted_values_transform_fn=lambda sorted_values: str(sorted_values),


### PR DESCRIPTION
This PR makes several improvements to the Datasets tensor story. See the issues for each item for more details.

- Automatically infer tensor blocks (single-column tables representing a single tensor) when returning NumPy ndarrays from `map_batches()`, `map()`, and `flat_map()`: https://github.com/ray-project/ray/issues/24208
- Automatically infer tensor columns when building tabular blocks in general: https://github.com/ray-project/ray/issues/24207
- Fixes shuffling and sorting for tensor columns

This should improve the UX/efficiency of the following:
- Working with pure-tensor datasets in general.
- Mapping tensor UDFs over pure-tensor, a better foundation for tensor-native preprocessing for end-users and AIR.

## Example of the tensor-native UDF UX

Below is a motivating example for the automatic NumPy conversion for the default `"native"` format, showing the single-tensor-column case.

### Before

```python
ds = ray.data.range_tensor(16, shape=(4, 4), parallelism=4)

def mapper(df: pd.DataFrame) -> pd.DataFrame:
    # I have to know about this `"value"` column and the
    # internal tensor representation as this single-column table.
    df["value"] *= 2
    return df

# I have to convert it to Pandas even though I'm working with tensor data,
# which is not the API that I want to work with AND incurs expensive
# copies during the Arrow --> Pandas conversion.
ds = ds.map_batches(mapper, batch_size=2, batch_format="pandas")

for batch in ds.iter_batches(batch_size=2, batch_format="pandas"):
    # I again have to convert the batches to Pandas and then access this
    # dummy column.
    actual_batch = batch["value"]
```

### After

```python
ds = ray.data.range_tensor(16, shape=(4, 4), parallelism=4)

# UDF now takes and returns an ndarray, which will be zero-copy access
# to the underlying Arrow table, providing far better UX and less
# memory/perf overhead. The returned ndarray will be repacked into an
# Arrow table (again, zero-copy).
ds = ds.map_batches(lambda arr: 2*arr, batch_size=2)

for batch in ds.iter_batches(batch_size=2):
    # The batch is the underlying ndarray batch, as I would expect; I don't
    # have to know or care about the dummy column or the single-column
    # table representation.
    assert isinstance(batch, np.ndarray)
```

## Changed Semantics

This PR changes the semantics on how the default/`"native"` format is interpreted for **pure-tensor datasets**; i.e. datasets consisting of a single tensor column in an Arrow/Pandas table, with a dummy internal column name, such as those created by `ray.data.range_tensor()` or `ray.data.from_numpy()`. These changed semantics are described below for per-row UDFs, batch UDFs, and per-row and batch iterators.

The following are changed semantics for how UDF returns are interpreted.

- A per-row UDF returns a NumPy ndarray:
  - **Before:** Creates a simple block (list) of ndarrays.
  - **After:** Creates a single-tensor-column Arrow table.
- A batch UDF returns a NumPy ndarray:
  - **Before:** Raises an error.
  - **After:** Creates a single-tensor-column Arrow table.
- A batch UDF returns a list of NumPy ndarrays:
  - **Before:** Creates a simple block (list) of ndarrays.
  - **After:** Creates a single-tensor-column Arrow table.

The following are changed semantics for the format in which UDF data argument is supplied.

- A per-row UDF is called on a pure-tensor dataset.
  - **Before:** UDF receives a single-column `PandasRow` containing the tensor column element.
  - **After:** UDF receives the tensor column element as a NumPy ndarray.
- A batch UDF is called on a pure-tensor dataset:
  - **Before:** UDF receives a single-column Pandas table containing the tensor column.
  - **After:** UDF receives the tensor column as a NumPy ndarray.

The following are changed semantics for the format of consumed batches:

- A row iterator is consumed on a pure-tensor dataset:
  - **Before:** A single column tabular row (either `PandasRow` or `ArrowRow`) is returned containing the tensor column element.
  - **After:** The tensor column element is returned as a NumPy ndarray.
- A batch iterator is consumed on a pure-tensor dataset:
  - **Before:** A single-column Pandas table is returned containing the tensor column.
  - **After:** The tensor column is returned as a NumPy ndarray.

## Related issue number

Closes https://github.com/ray-project/ray/issues/24208, https://github.com/ray-project/ray/issues/24207

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
