### PR TITLE
[minor] Use np.searchsorted to speed up random access dataset

### DIFF
--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -215,8 +215,9 @@ class _RandomAccessWorker:
             col = block[self.key_field]
             indices = np.searchsorted(col, keys)
             acc = BlockAccessor.for_block(block)
-            result = [acc._create_table_row(acc.slice(i, i + 1, copy=True))
-                for i in indices]
+            result = [
+                acc._create_table_row(acc.slice(i, i + 1, copy=True)) for i in indices
+            ]
         else:
             result = [self._get(i, k) for i, k in zip(block_indices, keys)]
         self.total_time += time.perf_counter() - start

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -220,6 +220,7 @@ class _RandomAccessWorker:
             result = [
                 acc._create_table_row(acc.slice(i, i + 1, copy=True)) for i in indices
             ]
+            # assert result == [self._get(i, k) for i, k in zip(block_indices, keys)]
         else:
             result = [self._get(i, k) for i, k in zip(block_indices, keys)]
         self.total_time += time.perf_counter() - start

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -3,6 +3,7 @@ import logging
 import random
 import time
 from collections import defaultdict
+import numpy as np
 from typing import List, Any, Generic, Optional, TYPE_CHECKING
 
 import ray
@@ -209,7 +210,15 @@ class _RandomAccessWorker:
 
     def multiget(self, block_indices, keys):
         start = time.perf_counter()
-        result = [self._get(i, k) for i, k in zip(block_indices, keys)]
+        if self.dataset_format == "arrow" and len(set(block_indices)) == 1:
+            block = self.blocks[block_indices[0]]
+            col = block[self.key_field]
+            indices = np.searchsorted(col, keys)
+            acc = BlockAccessor.for_block(block)
+            result = [acc._create_table_row(acc.slice(i, i + 1, copy=True))
+                for i in indices]
+        else:
+            result = [self._get(i, k) for i, k in zip(block_indices, keys)]
         self.total_time += time.perf_counter() - start
         self.num_accesses += 1
         return result

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -211,6 +211,8 @@ class _RandomAccessWorker:
     def multiget(self, block_indices, keys):
         start = time.perf_counter()
         if self.dataset_format == "arrow" and len(set(block_indices)) == 1:
+            # Fast path: use np.searchsorted for vectorized search on a single block.
+            # This is ~3x faster than the naive case.
             block = self.blocks[block_indices[0]]
             col = block[self.key_field]
             indices = np.searchsorted(col, keys)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Use vectorized binary search (~3x faster than doing it in Python only) in the experimental random access module. This makes multigets considerably faster. In the nightly release test:

Vectorized:
```
Multiget throughput: 23030.114488820363 keys / second
```

Naive:
```
Multiget throughput: 14197.17020216249 keys / second
```