### PR TITLE
bring back rllib performance regression tests.

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2231,6 +2231,29 @@
 
   alert: default
 
+- name: rllib_performance_tests
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  legacy:
+    test_name: performance_tests
+    test_suite: rllib_tests
+
+  frequency: nightly
+  team: ml
+
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: 12gpus_192cpus.yaml
+
+  run:
+    timeout: 14400
+    script: python performance_tests/run.py
+    type: sdk_command
+    file_manager: job
+
+  alert: default
+
 ########################
 # Core Nightly Tests
 ########################


### PR DESCRIPTION
## Why are these changes needed?

This was left out when tests were migrated.

## Related issue number


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
