### PR TITLE
[RLlib] Fix est buffer size

### DIFF
--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -174,6 +174,8 @@ class ReplayBuffer:
             self._storage.append(item)
             self._est_size_bytes += item.size_bytes()
         else:
+            item_to_be_removed = self._storage[self._next_idx]
+            self._est_size_bytes -= item_to_be_removed.size_bytes()
             self._storage[self._next_idx] = item
 
         # Eviction of older samples has already started (buffer is "full").

--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -177,6 +177,7 @@ class ReplayBuffer:
             item_to_be_removed = self._storage[self._next_idx]
             self._est_size_bytes -= item_to_be_removed.size_bytes()
             self._storage[self._next_idx] = item
+            self._est_size_bytes += item.size_bytes()
 
         # Eviction of older samples has already started (buffer is "full").
         if self._eviction_started:

--- a/rllib/utils/replay_buffers/reservoir_buffer.py
+++ b/rllib/utils/replay_buffers/reservoir_buffer.py
@@ -76,6 +76,7 @@ class ReservoirBuffer(ReplayBuffer):
                 item_to_be_removed = self._storage[idx]
                 self._est_size_bytes -= item_to_be_removed.size_bytes()
                 self._storage[idx] = item
+                self._est_size_bytes += item.size_bytes()
 
                 assert item.count > 0, item
                 warn_replay_capacity(item=item, num_items=self.capacity / item.count)

--- a/rllib/utils/replay_buffers/reservoir_buffer.py
+++ b/rllib/utils/replay_buffers/reservoir_buffer.py
@@ -72,6 +72,9 @@ class ReservoirBuffer(ReplayBuffer):
                 self._next_idx = idx
                 self._evicted_hit_stats.push(self._hit_count[idx])
                 self._hit_count[idx] = 0
+
+                item_to_be_removed = self._storage[idx]
+                self._est_size_bytes -= item_to_be_removed.size_bytes()
                 self._storage[idx] = item
 
                 assert item.count > 0, item


### PR DESCRIPTION
## Why are these changes needed?

Traditionally, we have always estimated all buffer's size only while initially growing the buffer but not after eviction.
While this estimate might be accurate enough in many cases, I imagine that for cases where we store complete episodes, which are initially very short, the estimate might be off by a lot.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
