### PR TITLE
[air] Fix training_iteration key error

### DIFF
--- a/python/ray/tune/result.py
+++ b/python/ray/tune/result.py
@@ -82,6 +82,7 @@ DEBUG_METRICS = (
     HOSTNAME,
     NODE_IP,
     "config",
+    TRAINING_ITERATION,
 )
 
 # Make sure this doesn't regress

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -261,6 +261,7 @@ class Trainable:
             "timesteps_since_restore": self._timesteps_since_restore,
             "iterations_since_restore": self._iterations_since_restore,
             "warmup_time": self._warmup_time,
+            "training_iteration": 0,
         }
         if debug_metrics_only:
             autofilled = {k: v for k, v in autofilled.items() if k in DEBUG_METRICS}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fix training_iteration key error by adding `training_iteration=0` in `get_auto_filled_metrics`.

## Related issue number

<!-- For example: "Closes #1234" -->
#24593
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
