### PR TITLE
[minor] Fix `black` version check in `ci/lint/format.sh`

### DIFF
--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -48,9 +48,9 @@ builtin cd "$ROOT" || exit 1
 BLACK_VERSION_STR=$(black --version)
 if [[ "$BLACK_VERSION_STR" == *"compiled"* ]]
 then
-    BLACK_VERSION=$(echo $BLACK_VERSION_STR | awk '{print $2}')
+    BLACK_VERSION=$(echo "$BLACK_VERSION_STR" | awk '{print $2}')
 else
-    BLACK_VERSION=$(echo $BLACK_VERSION_STR | awk '{print $3}')
+    BLACK_VERSION=$(echo "$BLACK_VERSION_STR" | awk '{print $3}')
 fi
 FLAKE8_VERSION=$(flake8 --version | head -n 1 | awk '{print $1}')
 MYPY_VERSION=$(mypy --version | awk '{print $2}')

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -42,14 +42,15 @@ builtin cd "$(dirname "${BASH_SOURCE:-$0}")"
 ROOT="$(git rev-parse --show-toplevel)"
 builtin cd "$ROOT" || exit 1
 
-# black version string differs on intel and m1 macs :'(
-if [[ $(uname -m) == "arm64" ]]
+# black version differs based on installation method:
+#   1) 'black, 21.12b0 (compiled: no)'
+#   2) 'black, version 21.12b0'
+BLACK_VERSION_STR=$(black --version)
+if [[ "$BLACK_VERSION_STR" == *"compiled"* ]]
 then
-    # On m1 the version string looks like 'black, version 21.7b0'.
-    BLACK_VERSION=$(black --version | awk '{print $3}')
+    BLACK_VERSION=$(echo $BLACK_VERSION_STR | awk '{print $2}')
 else
-    # On intel the version string looks like 'black, 21.7b0 (compiled: no)'.
-    BLACK_VERSION=$(black --version | awk '{print $2}')
+    BLACK_VERSION=$(echo $BLACK_VERSION_STR | awk '{print $3}')
 fi
 FLAKE8_VERSION=$(flake8 --version | head -n 1 | awk '{print $1}')
 MYPY_VERSION=$(mypy --version | awk '{print $2}')

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -42,8 +42,16 @@ builtin cd "$(dirname "${BASH_SOURCE:-$0}")"
 ROOT="$(git rev-parse --show-toplevel)"
 builtin cd "$ROOT" || exit 1
 
+# black version string differs on intel and m1 macs :'(
+if [[ $(uname -m) == "arm64" ]]
+then
+    # On m1 the version string looks like 'black, version 21.7b0'.
+    BLACK_VERSION=$(black --version | awk '{print $3}')
+else
+    # On intel the version string looks like 'black, 21.7b0 (compiled: no)'.
+    BLACK_VERSION=$(black --version | awk '{print $2}')
+fi
 FLAKE8_VERSION=$(flake8 --version | head -n 1 | awk '{print $1}')
-BLACK_VERSION=$(black --version | awk '{print $3}')
 MYPY_VERSION=$(mypy --version | awk '{print $2}')
 GOOGLE_JAVA_FORMAT_JAR=/tmp/google-java-format-1.7-all-deps.jar
 

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -43,7 +43,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 builtin cd "$ROOT" || exit 1
 
 FLAKE8_VERSION=$(flake8 --version | head -n 1 | awk '{print $1}')
-BLACK_VERSION=$(black --version | awk '{print $2}')
+BLACK_VERSION=$(black --version | awk '{print $3}')
 MYPY_VERSION=$(mypy --version | awk '{print $2}')
 GOOGLE_JAVA_FORMAT_JAR=/tmp/google-java-format-1.7-all-deps.jar
 

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -42,9 +42,9 @@ builtin cd "$(dirname "${BASH_SOURCE:-$0}")"
 ROOT="$(git rev-parse --show-toplevel)"
 builtin cd "$ROOT" || exit 1
 
-# black version differs based on installation method:
-#   1) 'black, 21.12b0 (compiled: no)'
-#   2) 'black, version 21.12b0'
+# NOTE(edoakes): black version differs based on installation method:
+#   Option 1) 'black, 21.12b0 (compiled: no)'
+#   Option 2) 'black, version 21.12b0'
 BLACK_VERSION_STR=$(black --version)
 if [[ "$BLACK_VERSION_STR" == *"compiled"* ]]
 then


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Apparently the `black` version string differs based on installation method. On my (m1) laptop:
```
$ black --version
black, version 21.7b0
```

On @simon-mo's (intel) and @shrekris-anyscale's (m1) laptops:
```
$ black --version
black, 21.12b0 (compiled: no)
```

This adds a conditional in `ci/lint/format.sh` to handle both.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
