### PR TITLE
[Datasets] [Tensor Story - 2/2] Add `"numpy"` batch format for batch mapping and batch consumption.

### DIFF
--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -145,15 +145,6 @@ MYPY_FILES=(
     '_private/gcs_utils.py'
 )
 
-ISORT_PATHS=(
-    # TODO: Expand this list and remove once it is applied to the entire codebase.
-    'python/ray/autoscaler/'
-    'doc/'
-)
-
-ISORT_GIT_LS_EXCLUDES=(
-  ':(exclude)doc/**/doc_code/*'
-)
 
 BLACK_EXCLUDES=(
     '--force-exclude' 'python/ray/cloudpickle/*'

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -145,6 +145,15 @@ MYPY_FILES=(
     '_private/gcs_utils.py'
 )
 
+ISORT_PATHS=(
+    # TODO: Expand this list and remove once it is applied to the entire codebase.
+    'python/ray/autoscaler/'
+    'doc/'
+)
+
+ISORT_GIT_LS_EXCLUDES=(
+  ':(exclude)doc/**/doc_code/*'
+)
 
 BLACK_EXCLUDES=(
     '--force-exclude' 'python/ray/cloudpickle/*'

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -136,7 +136,7 @@ In this section, we demonstrate creating a ``Dataset`` from single-node in-memor
 
   Create a ``Dataset`` from a NumPy ndarray. This constructs a ``Dataset``
   backed by a single-column Arrow table block; the outer dimension of the ndarray
-  will be treated as the row dimension, and the column with have name ``"value"``.
+  will be treated as the row dimension, and the column will have name ``"__value__"``.
 
   .. literalinclude:: ./doc_code/creating_datasets.py
     :language: python

--- a/doc/source/data/doc_code/transforming_datasets.py
+++ b/doc/source/data/doc_code/transforming_datasets.py
@@ -77,73 +77,92 @@ ds.groupby("variety").count().show()
 # fmt: on
 
 # fmt: off
-# __writing_udfs_begin__
+# __writing_native_udfs_begin__
 import ray
-import numpy as np
 import pandas as pd
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+
+# UDF as a function on Pandas DataFrame batches.
+def pandas_transform(df: pd.DataFrame) -> pd.DataFrame:
+    # Filter rows.
+    df = df[df["variety"] == "Versicolor"]
+    # Add derived column.
+    df["normalized.sepal.length"] =  df["sepal.length"] / df["sepal.length"].max()
+    # Drop column.
+    df = df.drop(columns=["sepal.length"])
+    return df
+
+ds.map_batches(pandas_transform).show(2)
+# -> {'sepal.width': 3.2, 'petal.length': 4.7, 'petal.width': 1.4,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 1.0}
+# -> {'sepal.width': 3.2, 'petal.length': 4.5, 'petal.width': 1.5,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 0.9142857142857144}
+# __writing_native_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_pandas_udfs_begin__
+import ray
+import pandas as pd
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+
+# UDF as a function on Pandas DataFrame batches.
+def pandas_transform(df: pd.DataFrame) -> pd.DataFrame:
+    # Filter rows.
+    df = df[df["variety"] == "Versicolor"]
+    # Add derived column.
+    df["normalized.sepal.length"] =  df["sepal.length"] / df["sepal.length"].max()
+    # Drop column.
+    df = df.drop(columns=["sepal.length"])
+    return df
+
+ds.map_batches(pandas_transform).show(2)
+# -> {'sepal.width': 3.2, 'petal.length': 4.7, 'petal.width': 1.4,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 1.0}
+# -> {'sepal.width': 3.2, 'petal.length': 4.5, 'petal.width': 1.5,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 0.9142857142857144}
+# __writing_pandas_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_arrow_udfs_begin__
+import ray
 import pyarrow as pa
 import pyarrow.compute as pac
 
 # Load dataset.
 ds = ray.data.read_csv("example://iris.csv")
 
-# UDF as a function on Pandas DataFrame.
-def pandas_filter_rows(df: pd.DataFrame) -> pd.DataFrame:
-    return df[df["variety"] == "Versicolor"]
+# UDF as a function on Arrow Table batches.
+def pyarrow_transform(batch: pa.Table) -> pa.Table:
+    batch = batch.filter(pac.equal(batch["variety"], "Versicolor"))
+    batch = batch.append_column(
+        "normalized.sepal.length",
+        pac.divide(batch["sepal.length"], pac.max(batch["sepal.length"])),
+    )
+    return batch.drop(["sepal.length"])
 
-ds.map_batches(pandas_filter_rows).show(2)
-# -> {'sepal.length': 7.0, 'sepal.width': 3.2,
-#     'petal.length': 4.7, 'petal.width': 1.4, 'variety': 'Versicolor'}
-# -> {'sepal.length': 6.4, 'sepal.width': 3.2,
-#     'petal.length': 4.5, 'petal.width': 1.5, 'variety': 'Versicolor'}
+ds.map_batches(pyarrow_transform, batch_format="pyarrow").show(2)
+# -> {'sepal.width': 3.2, 'petal.length': 4.7, 'petal.width': 1.4,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 1.0}
+# -> {'sepal.width': 3.2, 'petal.length': 4.5, 'petal.width': 1.5,
+#     'variety': 'Versicolor', 'normalized.sepal.length': 0.9142857142857144}
+# __writing_arrow_udfs_end__
+# fmt: on
 
-# UDF as a function on PyArrow Table.
-def pyarrow_filter_rows(batch: pa.Table) -> pa.Table:
-    return batch.filter(pac.equal(batch["variety"], "Versicolor"))
+# fmt: off
+# __writing_numpy_udfs_begin__
+import ray
+import numpy as np
 
-ds.map_batches(pyarrow_filter_rows, batch_format="pyarrow").show(2)
-# -> {'sepal.length': 7.0, 'sepal.width': 3.2,
-#     'petal.length': 4.7, 'petal.width': 1.4, 'variety': 'Versicolor'}
-# -> {'sepal.length': 6.4, 'sepal.width': 3.2,
-#     'petal.length': 4.5, 'petal.width': 1.5, 'variety': 'Versicolor'}
+# Load dataset.
+ds = ray.data.read_numpy("example://mnist_subset.npy")
 
-# UDF as a callable class on Pandas DataFrame.
-class UDFClassOnPandas:
-    def __int__(self):
-        pass
-
-    def __call__(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df[df["variety"] == "Versicolor"]
-
-ds.map_batches(UDFClassOnPandas, compute="actors").show(2)
-# -> {'sepal.length': 7.0, 'sepal.width': 3.2,
-#     'petal.length': 4.7, 'petal.width': 1.4, 'variety': 'Versicolor'}
-# -> {'sepal.length': 6.4, 'sepal.width': 3.2,
-#     'petal.length': 4.5, 'petal.width': 1.5, 'variety': 'Versicolor'}
-
-# More UDF examples: Add a column.
-def add_column(df: pd.DataFrame) -> pd.DataFrame:
-    df["normalized.sepal.length"] =  df["sepal.length"] / df["sepal.length"].max()
-    return df
-
-ds.map_batches(add_column).show(2)
-# -> {'sepal.length': 5.1, 'sepal.width': 3.5, 'petal.length': 1.4, 'petal.width': 0.2,
-#     'variety': 'Setosa', 'normalized.sepal.length': 0.6455696202531644}
-# -> {'sepal.length': 4.9, 'sepal.width': 3.0, 'petal.length': 1.4, 'petal.width': 0.2,
-#     'variety': 'Setosa', 'normalized.sepal.length': 0.620253164556962}
-
-# More UDF examples: Drop a column.
-def drop_column(df: pd.DataFrame) -> pd.DataFrame:
-    return df.drop(columns=["sepal.length"])
-
-ds.map_batches(drop_column).show(2)
-# -> {'sepal.width': 3.5, 'petal.length': 1.4, 'petal.width': 0.2, 'variety': 'Setosa'}
-# -> {'sepal.width': 3.0, 'petal.length': 1.4, 'petal.width': 0.2, 'variety': 'Setosa'}
-
-# Tensor example.
-tensor_ds = ray.data.read_numpy("example://mnist_subset.npy")
-
-# UDF as a function on NumPy ndarray.
+# UDF as a function on NumPy ndarray batches.
 def normalize(arr: np.ndarray) -> np.ndarray:
     # Normalizes each image to [0, 1] range.
     mins = arr.min((1, 2))[:, np.newaxis, np.newaxis]
@@ -154,13 +173,349 @@ def normalize(arr: np.ndarray) -> np.ndarray:
     range_[idx] = 1
     return (arr - mins) / range_
 
-tensor_ds.map_batches(normalize, batch_format="numpy")
+ds.map_batches(normalize, batch_format="numpy")
 # -> Dataset(
 #        num_blocks=1,
 #        num_rows=3,
 #        schema={__value__: <ArrowTensorType: shape=(28, 28), dtype=double>}
 #    )
-# __writing_udfs_end__
+# __writing_numpy_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_callable_classes_udfs_begin__
+import ray
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+
+# UDF as a function on Pandas DataFrame batches.
+class ModelUDF:
+    def __init__(self):
+        self.model = lambda df: df["sepal.length"] > 0.65
+
+    def __call__(self, df: pd.DataFrame) -> pd.DataFrame:
+        # Filter rows.
+        df = df[df["variety"] == "Versicolor"]
+        # Apply model.
+        df["output"] = self.model(df)
+        return df
+
+ds.map_batches(ModelUDF, compute="actors").show(2)
+# -> {'sepal.length': 7.0, 'sepal.width': 3.2, 'petal.length': 4.7, 'petal.width': 1.4,
+#     'variety': 'Versicolor', 'output': True}
+# -> {'sepal.length': 6.4, 'sepal.width': 3.2, 'petal.length': 4.5, 'petal.width': 1.5,
+#     'variety': 'Versicolor', 'output': False}`
+# __writing_callable_classes_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_pandas_out_udfs_begin__
+import ray
+import pandas as pd
+from typing import List
+
+# Load dataset.
+ds = ray.data.read_text("example://sms_spam_collection_subset.txt")
+# -> Dataset(num_blocks=1, num_rows=10, schema=<class 'str'>)
+
+# Convert to Pandas.
+def convert_to_pandas(text: List[str]) -> pd.DataFrame:
+    return pd.DataFrame({"text": text})
+
+ds = ds.map_batches(convert_to_pandas)
+# -> Dataset(num_blocks=1, num_rows=10, schema={text: object})
+
+ds.show(2)
+# -> {
+#        'text': (
+#            'ham\tGo until jurong point, crazy.. Available only in bugis n great '
+#            'world la e buffet... Cine there got amore wat...'
+#        ),
+#    }
+# -> {'text': 'ham\tOk lar... Joking wif u oni...'}
+# __writing_pandas_out_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_arrow_out_udfs_begin__
+import ray
+import pyarrow as pa
+from typing import List
+
+# Load dataset.
+ds = ray.data.read_text("example://sms_spam_collection_subset.txt")
+# -> Dataset(num_blocks=1, num_rows=10, schema=<class 'str'>)
+
+# Convert to Arrow.
+def convert_to_arrow(text: List[str]) -> pa.Table:
+    return pa.table({"text": text})
+
+ds = ds.map_batches(convert_to_arrow)
+# -> Dataset(num_blocks=1, num_rows=10, schema={text: object})
+
+ds.show(2)
+# -> {
+#        'text': (
+#            'ham\tGo until jurong point, crazy.. Available only in bugis n great '
+#            'world la e buffet... Cine there got amore wat...'
+#        ),
+#    }
+# -> {'text': 'ham\tOk lar... Joking wif u oni...'}
+# __writing_arrow_out_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_numpy_out_udfs_begin__
+import ray
+import pandas as pd
+import numpy as np
+from typing import Dict
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={
+#            sepal.length: double,
+#            sepal.width: double,
+#            petal.length: double,
+#            petal.width: double,
+#            variety: string,
+#        },
+#   )
+
+# Convert to NumPy.
+def convert_to_numpy(df: pd.DataFrame) -> np.ndarray:
+    return df[["sepal.length", "sepal.width"]].to_numpy()
+
+ds = ds.map_batches(convert_to_numpy)
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={__value__: <ArrowTensorType: shape=(2,), dtype=double>},
+#    )
+
+ds.show(2)
+# -> [5.1 3.5]
+#    [4.9 3. ]
+# __writing_numpy_out_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_numpy_dict_out_udfs_begin__
+import ray
+import pandas as pd
+import numpy as np
+from typing import Dict
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={
+#            sepal.length: double,
+#            sepal.width: double,
+#            petal.length: double,
+#            petal.width: double,
+#            variety: string,
+#        },
+#   )
+
+# Convert to dict of NumPy ndarrays.
+def convert_to_numpy(df: pd.DataFrame) -> Dict[str, np.ndarray]:
+    return {
+        "sepal_len_and_width": df[["sepal.length", "sepal.width"]].to_numpy(),
+        "petal_len": df["petal.length"].to_numpy(),
+        "petal_width": df["petal.width"].to_numpy(),
+    }
+
+ds = ds.map_batches(convert_to_numpy)
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={
+#            sepal_len_and_width: <ArrowTensorType: shape=(2,), dtype=double>,
+#            petal_len: double,
+#            petal_width: double,
+#        },
+#    )
+
+ds.show(2)
+# -> {'sepal_len_and_width': array([5.1, 3.5]), 'petal_len': 1.4, 'petal_width': 0.2}
+# -> {'sepal_len_and_width': array([4.9, 3. ]), 'petal_len': 1.4, 'petal_width': 0.2}
+# __writing_numpy_dict_out_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_simple_out_udfs_begin__
+import ray
+import pandas as pd
+from typing import List
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={
+#            sepal.length: double,
+#            sepal.width: double,
+#            petal.length: double,
+#            petal.width: double,
+#            variety: string,
+#        },
+#   )
+
+# Convert to list of dicts.
+def convert_to_list(df: pd.DataFrame) -> List[dict]:
+    return df.to_dict("records")
+
+ds = ds.map_batches(convert_to_list)
+# -> Dataset(num_blocks=1, num_rows=150, schema=<class 'dict'>)
+
+ds.show(2)
+# -> {'sepal.length': 5.1, 'sepal.width': 3.5, 'petal.length': 1.4, 'petal.width': 0.2,
+#     'variety': 'Setosa'}
+# -> {'sepal.length': 4.9, 'sepal.width': 3.0, 'petal.length': 1.4, 'petal.width': 0.2,
+#     'variety': 'Setosa'}
+# __writing_simple_out_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_dict_out_row_udfs_begin__
+import ray
+import pandas as pd
+from typing import Dict
+
+# Load dataset.
+ds = ray.data.range(10)
+# -> Dataset(num_blocks=10, num_rows=10, schema=<class 'int'>)
+
+# Convert row to dict.
+def row_to_dict(row: int) -> Dict[str, int]:
+    return {"foo": row}
+
+ds = ds.map(row_to_dict)
+# -> Dataset(num_blocks=10, num_rows=10, schema={foo: int64})
+
+ds.show(2)
+# -> {'foo': 0}
+# -> {'foo': 1}
+# __writing_dict_out_row_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_table_row_out_row_udfs_begin__
+import ray
+import pandas as pd
+from typing import Dict
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={
+#            sepal.length: double,
+#            sepal.width: double,
+#            petal.length: double,
+#            petal.width: double,
+#            variety: string,
+#        },
+#   )
+
+# Treat row as dict.
+def map_row(row: TableRow) -> TableRow:
+    row = row.as_pydict()
+    row["sepal.area"] = row["sepal.length"] * row["sepal.width"]
+    return row
+
+ds = ds.map(map_row)
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={
+#            sepal.length: double,
+#            sepal.width: double,
+#            petal.length: double,
+#            petal.width: double,
+#            variety: string,
+#            sepal.area: double,
+#        },
+#   )
+
+ds.show(2)
+# -> {'sepal.length': 5.1, 'sepal.width': 3.5, 'petal.length': 1.4, 'petal.width': 0.2,
+#     'variety': 'Setosa', 'sepal.area': 17.849999999999998}
+# -> {'sepal.length': 4.9, 'sepal.width': 3.0, 'petal.length': 1.4, 'petal.width': 0.2,
+#     'variety': 'Setosa', 'sepal.area': 14.700000000000001}
+# __writing_table_row_out_row_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_numpy_out_row_udfs_begin__
+import ray
+import numpy as np
+from typing import Dict
+
+# Load dataset.
+ds = ray.data.range(10)
+# -> Dataset(num_blocks=10, num_rows=10, schema=<class 'int'>)
+
+# Convert row to NumPy ndarray.
+def row_to_numpy(row: int) -> np.ndarray:
+    return np.full(shape=(2, 2), fill_value=row)
+
+ds = ds.map(row_to_numpy)
+# -> Dataset(
+#        num_blocks=10,
+#        num_rows=10,
+#        schema={__value__: <ArrowTensorType: shape=(2, 2), dtype=int64>},
+#    )
+
+ds.show(2)
+# -> [[0 0]
+#     [0 0]]
+#    [[1 1]
+#     [1 1]]
+# __writing_numpy_out_row_udfs_end__
+# fmt: on
+
+# fmt: off
+# __writing_simple_out_row_udfs_begin__
+import ray
+from typing import List
+
+# Load dataset.
+ds = ray.data.read_csv("example://iris.csv")
+# -> Dataset(
+#        num_blocks=1,
+#        num_rows=150,
+#        schema={
+#            sepal.length: double,
+#            sepal.width: double,
+#            petal.length: double,
+#            petal.width: double,
+#            variety: string,
+#        },
+#   )
+
+# Convert row to simple (opaque) row.
+def map_row(row: TableRow) -> tuple:
+    return tuple(row.items())
+
+ds = ds.map(map_row)
+# -> Dataset(num_blocks=1, num_rows=150, schema=<class 'tuple'>)
+
+ds.show(2)
+# -> (('sepal.length', 5.1), ('sepal.width', 3.5), ('petal.length', 1.4),
+#     ('petal.width', 0.2), ('variety', 'Setosa'))
+# -> (('sepal.length', 4.9), ('sepal.width', 3.0), ('petal.length', 1.4),
+#     ('petal.width', 0.2), ('variety', 'Setosa'))
+# __writing_simple_out_row_udfs_end__
 # fmt: on
 
 # fmt: off

--- a/doc/source/data/getting-started.rst
+++ b/doc/source/data/getting-started.rst
@@ -49,6 +49,9 @@ or remote storage in desired format, using ``.write_csv()``, ``.write_json()``, 
    :start-after: __save_dataset_begin__
    :end-before: __save_dataset_end__
 
+See the :ref:`Creating Datasets <creating_datasets>` and :ref:`Saving Datasets
+<saving_datasets>` guides for more details on how to create and save datasets.
+
 
 Transforming Datasets
 ---------------------
@@ -76,6 +79,9 @@ actor pool of ``min`` to ``max`` actors to execute your transforms. This will ca
 the stateful setup at the actor creation time, which is particularly useful if the
 setup is expensive.
 
+See the :ref:`Transforming Datasets guide <transforming_datasets>` for an in-depth guide
+on transforming datasets.
+
 Passing and accessing datasets
 ------------------------------
 
@@ -101,3 +107,6 @@ training actors:
    :language: python
    :start-after: __dataset_split_begin__
    :end-before: __dataset_split_end__
+
+See the :ref:`Accessing Datasets guide <accessing_datasets>` for an in-depth guide
+on accessing and exchanging datasets.

--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -87,6 +87,9 @@ files, enabling inspection functions like :meth:`ds.schema() <ray.data.Dataset.s
 and :meth:`ds.show() <ray.data.Dataset.show>` to be used right away. Executing further
 transformations on the Dataset will trigger execution of all read tasks.
 
+See the :ref:`Creating Datasets guide <creating_datasets>` for details on how to read
+data into datasets.
+
 Dataset Transforms
 ==================
 
@@ -101,6 +104,9 @@ Datasets use either Ray tasks or Ray actors to transform datasets (i.e., for
 
 ..
   https://docs.google.com/drawings/d/1MGlGsPyTOgBXswJyLZemqJO1Mf7d-WiEFptIulvcfWE/edit
+
+See the :ref:`Transforming Datasets guide <transforming_datasets>` for an in-depth guide
+on transforming datasets.
 
 Shuffling Data
 ==============

--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -100,6 +100,8 @@ RandomAccessDataset API
 .. autoclass:: ray.data.random_access_dataset.RandomAccessDataset
     :members:
 
+.. _dataset-tensor-extension-api:
+
 Tensor Column Extension API
 ---------------------------
 

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -147,7 +147,10 @@ batches that are passed to the provided batch UDF.
     `numpy.ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`__.
   * **Simple Datasets:** Each batch will be a Python list.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_native_udfs_begin__
+    :end-before: __writing_native_udfs_end__
 
 .. tabbed:: "pandas"
 
@@ -159,7 +162,10 @@ batches that are passed to the provided batch UDF.
   If the underlying datasets data is not already in Pandas DataFrame format, the
   batch format conversion will incur a copy for each batch.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_pandas_udfs_begin__
+    :end-before: __writing_pandas_udfs_end__
 
 .. tabbed:: "pyarrow"
 
@@ -171,7 +177,10 @@ batches that are passed to the provided batch UDF.
   If the underlying datasets data is not already in Arrow Table format, the
   batch format conversion will incur a copy for each batch.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_arrow_udfs_begin__
+    :end-before: __writing_arrow_udfs_end__
 
 .. tabbed:: "numpy"
 
@@ -200,7 +209,41 @@ batches that are passed to the provided batch UDF.
     the batch items aren't supported in the NumPy dtype system (since NumPy will create
     an ndarray of ``np.object`` pointers to the batch items in that case).
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_numpy_udfs_begin__
+    :end-before: __writing_numpy_udfs_end__
+
+You should reference the `pyarrow.Table APIs
+<https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__, the
+`pandas.DataFrame APIs <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__,
+or the `numpy.ndarray APIs <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`__
+when writing batch UDFs.
+
+.. tip::
+
+   Write your UDFs to leverage built-in vectorized operations on the ``pandas.DataFrame``,
+   ``pyarrow.Table``, and ``numpy.ndarray`` abstractions for better performance. For
+   example, suppose you want to compute the sum of a column in ``pandas.DataFrame``:
+   instead of iterating over each row of a batch and summing up values of that column,
+   you should use ``df_batch["col_foo"].sum()``.
+
+Callable Class UDFs
+===================
+
+When using the actor compute strategy, per-row and per-batch UDFs can also be
+**callable classes**, i.e. classes that implement the ``__call__`` magic method. The
+constructor of the class can be used for stateful setup, and will be only invoked once
+per actor worker.
+
+.. note::
+  These transformation APIs take the uninstantiated callable class as an argument,
+  **not** an instance of the class!
+
+.. literalinclude:: ./doc_code/transforming_datasets.py
+   :language: python
+   :start-after: __writing_callable_classes_udfs_begin__
+   :end-before: __writing_callable_classes_udfs_end__
 
 Batch UDF Output Types
 ======================
@@ -218,7 +261,10 @@ by Datasets when constructing its internal blocks:
   `Pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__
   blocks.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_pandas_out_udfs_begin__
+    :end-before: __writing_pandas_out_udfs_end__
 
 .. tabbed:: pa.Table
 
@@ -226,7 +272,10 @@ by Datasets when constructing its internal blocks:
   `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
   blocks.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_arrow_out_udfs_begin__
+    :end-before: __writing_arrow_out_udfs_end__
 
 .. tabbed:: np.ndarray
 
@@ -236,7 +285,10 @@ by Datasets when constructing its internal blocks:
   :ref:`tensor extension type <dataset-tensor-extension-api>` to embed the tensor in
   these tables under a single ``"__value__"`` column.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_numpy_out_udfs_begin__
+    :end-before: __writing_numpy_out_udfs_end__
 
 .. tabbed:: Dict[str, np.ndarray]
 
@@ -250,13 +302,19 @@ by Datasets when constructing its internal blocks:
   :ref:`tensor extension type <dataset-tensor-extension-api>` to embed these
   n-dimensional tensors in the Arrow table.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_numpy_dict_out_udfs_begin__
+    :end-before: __writing_numpy_dict_out_udfs_end__
 
 .. tabbed:: list
 
   Simple dataset containing Python list blocks.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_simple_out_udfs_begin__
+    :end-before: __writing_simple_out_udfs_end__
 
 Row UDF Output Types
 ====================
@@ -278,7 +336,10 @@ when constructing its internal blocks:
   being supported by Arrow, then Datasets will fall back to a simple dataset containing
   Python list blocks.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_dict_out_row_udfs_begin__
+    :end-before: __writing_dict_out_row_udfs_end__
 
 .. tabbed:: PandasRow
 
@@ -293,7 +354,15 @@ when constructing its internal blocks:
   dictionary. See the :class:`TableRow API <ray.data.row.TableRow>` for more information
   on this row view object.
 
-  **TODO:** Add example.
+  Note that a ``PandasRow`` is immmutable, so this row mapping cannot be updated
+  in-place. If wanting to update the row, copy this zero-copy row view into a plain
+  Python dictionary with :meth:`TableRow.as_pydict() <ray.data.row.TableRow.as_pydict>`
+  and then mutate and return that dictionary.
+
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_table_row_out_row_udfs_begin__
+    :end-before: __writing_table_row_out_row_udfs_end__
 
 .. tabbed:: ArrowRow
 
@@ -309,7 +378,15 @@ when constructing its internal blocks:
   dictionary. See the :class:`TableRow API <ray.data.row.TableRow>` for more information
   on this row view object.
 
-  **TODO:** Add example.
+  Note that an ``ArrowRow`` is immmutable, so this row mapping cannot be updated
+  in-place. If wanting to update the row, copy this zero-copy row view into a plain
+  Python dictionary with :meth:`TableRow.as_pydict() <ray.data.row.TableRow.as_pydict>`
+  and then mutate and return that dictionary.
+
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_table_row_out_row_udfs_begin__
+    :end-before: __writing_table_row_out_row_udfs_end__
 
 .. tabbed:: np.ndarray
 
@@ -320,35 +397,19 @@ when constructing its internal blocks:
   these tables under a single ``"__value__"`` column. Each such ``ndarray`` will be
   treated as a row in this column.
 
-  **TODO:** Add example.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_numpy_out_row_udfs_begin__
+    :end-before: __writing_numpy_out_row_udfs_end__
 
 .. tabbed:: Any
 
   All other return row types will result in a simple dataset containing list blocks.
 
-  **TODO:** Add example.
-
-The following are some UDF examples.
-
-.. literalinclude:: ./doc_code/transforming_datasets.py
-   :language: python
-   :start-after: __writing_udfs_begin__
-   :end-before: __writing_udfs_end__
-
-You should reference the `pyarrow.Table APIs
-<https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__, the
-`pandas.DataFrame APIs
-<https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>__`, or the
-`numpy.ndarray APIs <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>__`
-when writing batch UDFs.
-
-.. tip::
-
-   Write your UDFs to leverage built-in vectorized operations on the ``pandas.DataFrame``,
-   ``pyarrow.Table``, and ``numpy.ndarray`` abstractions for better performance. For
-   example, suppose you want to compute the sum of a column in ``pandas.DataFrame``:
-   instead of iterating over each row of a batch and summing up values of that column,
-   you should use ``df_batch["col_foo"].sum()``.
+  .. literalinclude:: ./doc_code/transforming_datasets.py
+    :language: python
+    :start-after: __writing_simple_out_row_udfs_begin__
+    :end-before: __writing_simple_out_row_udfs_end__
 
 ----------------
 Compute Strategy

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -80,13 +80,18 @@ API in Datasets.
 
 A UDF can be a function or a callable class, which has the following input/output:
 
-* **Input type**: a ``pandas.DataFrame``, ``pyarrow.Table`` or a Python list. You can
-  control the input type fed to your UDF by specifying the ``batch_format`` parameter in
-  :meth:`.map_batches() <ray.data.Dataset.map_batches>`. By default, the ``batch_format``
-  is "native", which will feed ``pandas.DataFrame`` to UDF regardless of the underlying
-  batch type.
-* **Output type**: a ``pandas.DataFrame``, ``pyarrow.Table`` or a Python list. Note
-  the output type doesn't need to be the same as input type.
+* **Input type**: a ``pandas.DataFrame``, ``pyarrow.Table``, ``numpy.ndarray``,
+  column-dictionary of ``numpy.ndarray``, or a Python list. You can control the input
+  type fed to your UDF by specifying the ``batch_format`` parameter in
+  :meth:`.map_batches() <ray.data.Dataset.map_batches>`. By default, the
+  ``batch_format`` is ``"native"``, which will feed data batches in the
+  canonical/"native" format for each data type, namely: ``pandas.DataFrame``
+  batches on tabular (Arrow or Pandas) data, ``numpy.ndarray`` batches on tensor data,
+  and Python lists on simple Python list data.
+* **Output type**: a ``pandas.DataFrame``, ``pyarrow.Table``, ``numpy.ndarray``,
+  column-dictionary of ``numpy.ndarray``, or a Python list. Note that the output type
+  doesn't need to be the same as input type, which allows you to dynamically convert
+  between data formats.
 
 The following are some UDF examples.
 
@@ -95,16 +100,20 @@ The following are some UDF examples.
    :start-after: __writing_udfs_begin__
    :end-before: __writing_udfs_end__
 
-You may reference the `pyarrow.Table APIs <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
-or the `pandas.DataFrame APIs <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__
-in writing UDFs.
+You may reference the `pyarrow.Table APIs
+<https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__, the
+`pandas.DataFrame APIs
+<https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>__`, or the
+`numpy.ndarray APIs <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>__`
+when writing batch UDFs.
 
 .. tip::
 
-   Write your UDFs to leverage built-in vectorized operations in ``pandas.DataFrame``
-   or ``pyarrow.Table`` for better performance. For example, suppose you want to compute
-   the sum of a column in ``pandas.DataFrame``, instead of iterating each row of a batch
-   and sum up values of that column, you may want to use ``df_batch["col_foo"].sum()``.
+   Write your UDFs to leverage built-in vectorized operations on the ``pandas.DataFrame``,
+   ``pyarrow.Table``, and ``numpy.ndarray`` abstractions for better performance. For
+   example, suppose you want to compute the sum of a column in ``pandas.DataFrame``:
+   instead of iterating over each row of a batch and summing up values of that column,
+   you should use ``df_batch["col_foo"].sum()``.
 
 Compute Strategy
 ----------------

--- a/doc/source/data/transforming-datasets.rst
+++ b/doc/source/data/transforming-datasets.rst
@@ -11,6 +11,7 @@ transformations are **composable**. Operations can be further applied on the res
 dataset, forming a chain of transformations to express more complex computations.
 Transformations are the core for expressing business logic in Datasets.
 
+---------------
 Transformations
 ---------------
 
@@ -68,6 +69,7 @@ the Iris dataset.
    :start-after: __dataset_transformation_begin__
    :end-before: __dataset_transformation_end__
 
+------------
 Writing UDFs
 ------------
 
@@ -78,20 +80,253 @@ express your customized business logic in transformations. Here we will focus on
 :meth:`.map_batches() <ray.data.Dataset.map_batches>` as it's the primary mapping
 API in Datasets.
 
-A UDF can be a function or a callable class, which has the following input/output:
+A batch UDF can be a function or, if using the actor compute strategy, a callable class.
+These UDFs have several batch format options, which control the format of the
+batches that are passed to the provided batch UDF. Depending on the underlying dataset
+format, using a particular batch format may or may not incur a data conversion cost
+(e.g. convertion an Arrow Table to a Pandas DataFrame, or creating an Arrow Table from a
+Pyhton list, both of which would incur a full copy of the data).
 
-* **Input type**: a ``pandas.DataFrame``, ``pyarrow.Table``, ``numpy.ndarray``,
-  column-dictionary of ``numpy.ndarray``, or a Python list. You can control the input
-  type fed to your UDF by specifying the ``batch_format`` parameter in
-  :meth:`.map_batches() <ray.data.Dataset.map_batches>`. By default, the
-  ``batch_format`` is ``"native"``, which will feed data batches in the
-  canonical/"native" format for each data type, namely: ``pandas.DataFrame``
-  batches on tabular (Arrow or Pandas) data, ``numpy.ndarray`` batches on tensor data,
-  and Python lists on simple Python list data.
-* **Output type**: a ``pandas.DataFrame``, ``pyarrow.Table``, ``numpy.ndarray``,
-  column-dictionary of ``numpy.ndarray``, or a Python list. Note that the output type
-  doesn't need to be the same as input type, which allows you to dynamically convert
-  between data formats.
+Dataset Formats
+===============
+
+* **Tabular (Arrow or Pandas) Datasets:** Represented under-the-hood as
+  `Arrow Tables <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  or
+  `Pandas DataFrames <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__.
+  Tabular datasets are created by reading on-disk tabular data (Parquet, CSV, JSON),
+  converting from in-memory tabular data (Pandas DataFrames, Arrow Tables,
+  dictionaries, Dask DataFrames, Modin DataFrames, Spark DataFrames, Mars DataFrames)
+  and by returning tabular data (Arrow, Pandas, dictionaries) from previous batch
+  UDFs.
+
+  Datasets will minimize conversions between the Arrow and Pandas
+  representation: tabular data read from disk will always be read as Arrow Tables, but
+  in-memory conversions of Pandas DataFrame data to a ``Dataset`` (e.g. converting from
+  Pandas, Dask, Modin, Spark, and Mars) will use Pandas DataFrames as the internal data
+  representation in order to avoid extra data conversions/copies.
+
+* **Tensor Datasets:** Represented under-the-hood as a single-column
+  `Arrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  or
+  `Pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__,
+  using our :ref:`tensor extension type <dataset-tensor-extension-api>` to embed the
+  tensor in these tables under a single ``"__value__"`` column. Tensor datasets are
+  created by reading on-disk tensor data (NPY), converting from in-memory tensor data
+  (NumPy), and by returning tensor data (NumPy) from previous batch UDFs.
+
+  Note that converting the underlying tabular representation to a NumPy ndarray is
+  zero-copy, including converting the entire column to an ndarray and converting just
+  a single column element to an ndarray.
+
+* **Simple Datasets:** Represented under-the-hood as plain Python lists. Simple
+  datasets are created by reading on-disk binary and plain-text data, converting from
+  in-memory simple data (Python lists), and by returning simple data (Python lists)
+  from previou batch UDFs.
+
+  Simple datasets are mostly used as an escape hatch for data that's not cleanly
+  representable in Arrow Tables and Pandas DataFrames.
+
+Batch Formats
+=============
+
+Batch UDFs have the following batch format options, which control the format of the data
+batches that are passed to the provided batch UDF.
+
+.. tabbed:: "native" (default)
+
+  The ``"native"`` batch format presents batches in the canonical format for each dataset
+  type:
+
+  * **Tabular (Arrow or Pandas) Datasets:** Each batch will be a
+    `pandas.DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__.
+    If the dataset is represented as Arrow Tables under-th-ehood, the conversion to the
+    Pandas DataFrame batch format will incur a conversion cost (i.e., a full copy of
+    each batch will be created in order to convert it).
+  * **Tensor Datasets:** Each batch will be a
+    `numpy.ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`__.
+  * **Simple Datasets:** Each batch will be a Python list.
+
+  **TODO:** Add example.
+
+.. tabbed:: "pandas"
+
+  The ``"pandas"`` batch format provides batches in a
+  `pandas.DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__
+  format. If converting a simple dataset to Pandas DataFrame batches, a single-column
+  dataframe with the column ``"value"`` will be created.
+
+  If the underlying datasets data is not already in Pandas DataFrame format, the
+  batch format conversion will incur a copy for each batch.
+
+  **TODO:** Add example.
+
+.. tabbed:: "pyarrow"
+
+  The ``"pyarrow"`` batch format provides batches in a
+  `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  format. If converting a simple dataset to Arrow Table batches, a single-column table
+  with the column ``"value"`` will be created.
+
+  If the underlying datasets data is not already in Arrow Table format, the
+  batch format conversion will incur a copy for each batch.
+
+  **TODO:** Add example.
+
+.. tabbed:: "numpy"
+
+  The ``"numpy"`` batch format provides batches in a
+  `numpy.ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`__
+  format. The following details how each dataset format is converted into a NumPy batch:
+
+  * **Tensor Datasets:** Each batch will be a single
+    `numpy.ndarray <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`__
+    containing the single-tensor-column for this batch.
+
+    Note that this conversion should always be zero-copy.
+
+  * **Tabular (Arrow or Pandas) Datasets:** Each batch will be a dictionary of NumPy
+    ndarrays (``Dict[str, np.ndarray]``), with each key-value pair representing a column
+    in the table.
+
+    Note that this conversion should usually be zero-copy.
+
+  * **Simple Datasets:** Each batch will be a single NumPy ndarray, where Datasets will
+    attempt to convert each list-batch to an ndarray.
+
+    Note that this conversion will
+    incur a copy for primitive types that are representable as a NumPy dtype (since
+    NumPy will create a continguous ndarray in that case), and will not incur a copy if
+    the batch items aren't supported in the NumPy dtype system (since NumPy will create
+    an ndarray of ``np.object`` pointers to the batch items in that case).
+
+  **TODO:** Add example.
+
+Batch UDF Output Types
+======================
+
+The return type of a batch UDF will determine the format of the resulting dataset. This
+allows you to dynamically convert between data formats during batch transformations.
+
+The following details how each **batch** UDF (as used in
+:meth:`ds.map_batches() <ray.data.Dataset.map_batches>`) return type will be interpreted
+by Datasets when constructing its internal blocks:
+
+.. tabbed:: pd.DataFrame
+
+  Tabular dataset containing
+  `Pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__
+  blocks.
+
+  **TODO:** Add example.
+
+.. tabbed:: pa.Table
+
+  Tabular dataset containing
+  `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  blocks.
+
+  **TODO:** Add example.
+
+.. tabbed:: np.ndarray
+
+  Tensor dataset containing
+  `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  blocks, representing the tensor using our
+  :ref:`tensor extension type <dataset-tensor-extension-api>` to embed the tensor in
+  these tables under a single ``"__value__"`` column.
+
+  **TODO:** Add example.
+
+.. tabbed:: Dict[str, np.ndarray]
+
+  Tabular dataset containing
+  `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  blocks, where each key-value pair treats the key as the column name as the value as
+  the column tensor.
+
+  If a column tensor is 1-dimensional, then the native Arrow 1D list
+  type is used; if a column tensor has 2 or more dimensions, then we use our
+  :ref:`tensor extension type <dataset-tensor-extension-api>` to embed these
+  n-dimensional tensors in the Arrow table.
+
+  **TODO:** Add example.
+
+.. tabbed:: list
+
+  Simple dataset containing Python list blocks.
+
+  **TODO:** Add example.
+
+Row UDF Output Types
+====================
+
+The return type of a row UDF will determine the format of the resulting dataset. This
+allows you to dynamically convert between data formats during row-based transformations.
+
+The following details how each **row** UDF (as used in
+:meth:`ds.map() <ray.data.Dataset.map>`) return type will be interpreted by Datasets
+when constructing its internal blocks:
+
+.. tabbed:: dict
+
+  Tabular dataset containing
+  `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  blocks, treating the keys as the column names and the values as the column elements.
+
+  If Arrow Table construction fails due to a value type in the dictionary not
+  being supported by Arrow, then Datasets will fall back to a simple dataset containing
+  Python list blocks.
+
+  **TODO:** Add example.
+
+.. tabbed:: PandasRow
+
+  Tabular dataset containing
+  `Pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__
+  blocks.
+
+  A ``PandasRow`` object is a zero-copy row view on an underlying Pandas DataFrame block
+  that Datasets provides to per-row UDFs (:meth:`ds.map() <ray.data.Dataset.map>`) and
+  returns in the row iterators (:meth:`ds.iter_rows <ray.data.Dataset.iter_rows>`).
+  This row view provides a dictionary interface and can be transparently used as a
+  dictionary. See the :class:`TableRow API <ray.data.row.TableRow>` for more information
+  on this row view object.
+
+  **TODO:** Add example.
+
+.. tabbed:: ArrowRow
+
+  Tabular dataset containing
+  `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  blocks.
+
+  An ``ArrowRow`` object is a zero-copy row view on an underlying Arrow Table block
+  that Datasets provides to per-row UDFs (``ds.map()``) and returns in the row
+  that Datasets provides to per-row UDFs (:meth:`ds.map() <ray.data.Dataset.map>`) and
+  returns in the row iterators (:meth:`ds.iter_rows <ray.data.Dataset.iter_rows>`).
+  This row view provides a dictionary interface and can be transparently used as a
+  dictionary. See the :class:`TableRow API <ray.data.row.TableRow>` for more information
+  on this row view object.
+
+  **TODO:** Add example.
+
+.. tabbed:: np.ndarray
+
+  Tensor dataset containing
+  `pyarrow.Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__
+  blocks, representing the tensor using our
+  :ref:`tensor extension type <dataset-tensor-extension-api>` to embed the tensor in
+  these tables under a single ``"__value__"`` column. Each such ``ndarray`` will be
+  treated as a row in this column.
+
+  **TODO:** Add example.
+
+.. tabbed:: Any
+
+  All other return row types will result in a simple dataset containing list blocks.
+
+  **TODO:** Add example.
 
 The following are some UDF examples.
 
@@ -100,7 +335,7 @@ The following are some UDF examples.
    :start-after: __writing_udfs_begin__
    :end-before: __writing_udfs_end__
 
-You may reference the `pyarrow.Table APIs
+You should reference the `pyarrow.Table APIs
 <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__, the
 `pandas.DataFrame APIs
 <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>__`, or the
@@ -115,6 +350,7 @@ when writing batch UDFs.
    instead of iterating over each row of a batch and summing up values of that column,
    you should use ``df_batch["col_foo"].sum()``.
 
+----------------
 Compute Strategy
 ----------------
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -144,11 +144,16 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
         if isinstance(batch, np.ndarray):
             batch = {VALUE_COL_NAME: batch}
-        else:
-            assert isinstance(batch, dict)
-            assert all(isinstance(col, np.ndarray) for col in batch.values())
+        elif not isinstance(batch, dict) or any(
+            not isinstance(col, np.ndarray) for col in batch.values()
+        ):
+            raise ValueError(
+                "Batch must be an ndarray or dictionary of ndarrays when converting "
+                f"a numpy batch to a block, got: {type(batch)}"
+            )
         new_batch = {}
         for col_name, col in batch.items():
+            # Use Arrow's native *List types for 1-dimensional ndarrays.
             if col.ndim > 1:
                 try:
                     col = ArrowTensorArray.from_numpy(col)

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -135,14 +135,32 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return cls(reader.read_all())
 
     @staticmethod
-    def numpy_to_block(batch: np.ndarray) -> "pyarrow.Table":
+    def numpy_to_block(
+        batch: Union[np.ndarray, Dict[str, np.ndarray]],
+    ) -> "pyarrow.Table":
         import pyarrow as pa
 
         from ray.data.extensions.tensor_extension import ArrowTensorArray
 
-        return pa.Table.from_pydict(
-            {VALUE_COL_NAME: ArrowTensorArray.from_numpy(batch)}
-        )
+        if isinstance(batch, np.ndarray):
+            batch = {VALUE_COL_NAME: batch}
+        else:
+            assert isinstance(batch, dict)
+            assert all(isinstance(col, np.ndarray) for col in batch.values())
+        new_batch = {}
+        for col_name, col in batch.items():
+            if col.ndim > 1:
+                try:
+                    col = ArrowTensorArray.from_numpy(col)
+                except pa.ArrowNotImplementedError as e:
+                    raise ValueError(
+                        "Failed to convert multi-dimensional ndarray of dtype "
+                        f"{col.dtype} to our tensor extension since this dtype is not "
+                        "supported by Arrow. If encountering this due to string data, "
+                        'cast the ndarray to a string dtype, e.g. a.astype("U").'
+                    ) from e
+            new_batch[col_name] = col
+        return pa.Table.from_pydict(new_batch)
 
     @staticmethod
     def _build_tensor_row(row: ArrowRow) -> np.ndarray:

--- a/python/ray/data/_internal/block_batching.py
+++ b/python/ray/data/_internal/block_batching.py
@@ -1,6 +1,6 @@
 import collections
 import itertools
-from typing import Iterator, Iterable, Union, Optional, TYPE_CHECKING
+from typing import Dict, Iterator, Iterable, Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pyarrow
@@ -18,7 +18,13 @@ from ray.data._internal.stats import DatasetStats, DatasetPipelineStats
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 # An output type of iter_batches() determined by the batch_format parameter.
-BatchType = Union["pandas.DataFrame", "pyarrow.Table", np.ndarray, list]
+BatchType = Union[
+    "pandas.DataFrame",
+    "pyarrow.Table",
+    np.ndarray,
+    Dict[str, np.ndarray],
+    list,
+]
 PREFETCHER_ACTOR_NAMESPACE = "ray.dataset"
 
 

--- a/python/ray/data/_internal/block_batching.py
+++ b/python/ray/data/_internal/block_batching.py
@@ -1,21 +1,22 @@
 import collections
 import itertools
-from typing import Dict, Iterator, Iterable, Union, Optional, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import pyarrow
-    import pandas
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, Optional, Union
 
 import numpy as np
 
 import ray
 from ray.actor import ActorHandle
-from ray.types import ObjectRef
+from ray.data._internal.batcher import Batcher
+from ray.data._internal.stats import DatasetPipelineStats, DatasetStats
 from ray.data.block import Block, BlockAccessor
 from ray.data.context import DatasetContext
-from ray.data._internal.batcher import Batcher
-from ray.data._internal.stats import DatasetStats, DatasetPipelineStats
+from ray.types import ObjectRef
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+if TYPE_CHECKING:
+    import pandas
+    import pyarrow
+
 
 # An output type of iter_batches() determined by the batch_format parameter.
 BatchType = Union[

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2301,7 +2301,8 @@ class Dataset(Generic[T]):
                 Specify "native" to use the native block format (promoting
                 tables to Pandas and tensors to NumPy), "pandas" to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or "numpy"
-                to select ``numpy.ndarray``. Default is "native".
+                to select ``numpy.ndarray`` for tensor datasets and
+                ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "native".
             drop_last: Whether to drop the last batch if it's incomplete.
 
         Returns:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -52,6 +52,7 @@ from ray.data.block import (
     T,
     U,
     _validate_key_fn,
+    VALID_BATCH_FORMATS,
 )
 from ray.data.context import DatasetContext
 from ray.data.datasource import (
@@ -314,7 +315,8 @@ class Dataset(Generic[T]):
                 tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
             batch_format: Specify "native" to use the native block format (promotes
                 tables to Pandas and tensors to NumPy), "pandas" to select
-                ``pandas.DataFrame``, or "pyarrow" to select `pyarrow.Table``.
+                ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or "numpy"
+                to select ``numpy.ndarray``. Default is "native".
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
@@ -323,6 +325,12 @@ class Dataset(Generic[T]):
 
         if batch_size is not None and batch_size < 1:
             raise ValueError("Batch size cannot be negative or 0")
+
+        if batch_format not in VALID_BATCH_FORMATS:
+            raise ValueError(
+                f"The batch format must be one of {VALID_BATCH_FORMATS}, got: "
+                f"{batch_format}"
+            )
 
         fn = cache_wrapper(fn, compute)
         context = DatasetContext.get_current()
@@ -342,31 +350,25 @@ class Dataset(Generic[T]):
                 # Make sure to copy if slicing to avoid the Arrow serialization
                 # bug where we include the entire base view on serialization.
                 view = block.slice(start, end, copy=batch_size is not None)
-                if batch_format == "native":
-                    view = BlockAccessor.for_block(view).to_native()
-                elif batch_format == "pandas":
-                    view = BlockAccessor.for_block(view).to_pandas()
-                elif batch_format == "pyarrow":
-                    view = BlockAccessor.for_block(view).to_arrow()
-                else:
-                    raise ValueError(
-                        "The batch format must be one of 'native', 'pandas', "
-                        "or 'pyarrow', got: {}".format(batch_format)
-                    )
+                # Convert to batch format.
+                view = BlockAccessor.for_block(view).to_batch_format(batch_format)
 
                 applied = fn(view)
                 if not (
                     isinstance(applied, list)
                     or isinstance(applied, pa.Table)
                     or isinstance(applied, np.ndarray)
+                    or (
+                        isinstance(applied, dict)
+                        and all(isinstance(col, np.ndarray) for col in applied.values())
+                    )
                     or isinstance(applied, pd.core.frame.DataFrame)
                 ):
                     raise ValueError(
                         "The map batches UDF returned the value "
                         f"{applied} of type {type(applied)}, "
                         "which is not allowed. "
-                        "The return type must be either list, "
-                        "pandas.DataFrame, or pyarrow.Table"
+                        f"The return type must be one of: {BatchType}"
                     )
                 output_buffer.add_batch(applied)
                 if output_buffer.has_next():
@@ -2297,8 +2299,8 @@ class Dataset(Generic[T]):
             batch_format: The format in which to return each batch.
                 Specify "native" to use the native block format (promoting
                 tables to Pandas and tensors to NumPy), "pandas" to select
-                ``pandas.DataFrame``, or "pyarrow" to select ``pyarrow.Table``. Default
-                is "native".
+                ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or "numpy"
+                to select ``numpy.ndarray``. Default is "native".
             drop_last: Whether to drop the last batch if it's incomplete.
 
         Returns:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -42,6 +42,7 @@ from ray.data._internal.stats import DatasetStats
 from ray.data._internal.table_block import VALUE_COL_NAME
 from ray.data.aggregate import AggregateFn, Max, Mean, Min, Std, Sum
 from ray.data.block import (
+    VALID_BATCH_FORMATS,
     Block,
     BlockAccessor,
     BlockExecStats,
@@ -52,7 +53,6 @@ from ray.data.block import (
     T,
     U,
     _validate_key_fn,
-    VALID_BATCH_FORMATS,
 )
 from ray.data.context import DatasetContext
 from ray.data.datasource import (

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -316,7 +316,8 @@ class Dataset(Generic[T]):
             batch_format: Specify "native" to use the native block format (promotes
                 tables to Pandas and tensors to NumPy), "pandas" to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or "numpy"
-                to select ``numpy.ndarray``. Default is "native".
+                to select ``numpy.ndarray`` for tensor datasets and
+                ``Dict[str, numpy.ndarray]`` for tabular datasets. Default is "native".
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """


### PR DESCRIPTION
This PR adds a NumPy `"numpy"` batch format for batch transformations and batch consumption that works with all block types. See https://github.com/ray-project/ray/issues/24811.

Note that this PR is stacked on top of https://github.com/ray-project/ray/pull/24812.

This should improve the UX/efficiency of the following:
- Mapping tensor UDFs over tabular datasets, a better foundation for tensor-native preprocessing for end-users and AIR.
- Efficient (zero-copy) exchange between tabular blocks and ML training frameworks (`to_torch()` and `to_tf()`).

## Example for `"numpy"` batch format

Below is a motivating example for the `"numpy"` batch format, showing the single-tensor-column case.

### Before

```python
ds = ray.data.range_tensor(16, shape=(4, 4), parallelism=4)

def mapper(df: pd.DataFrame) -> pd.DataFrame:
    # I have to know about this `"value"` column and the
    # internal tensor representation as this single-column table.
    df["value"] *= 2
    return df

# I have to convert it to Pandas even though I'm working with tensor data,
# which is not the API that I want to work with AND incurs expensive
# copies during the Arrow --> Pandas conversion.
ds = ds.map_batches(mapper, batch_size=2, batch_format="pandas")

for batch in ds.iter_batches(batch_size=2, batch_format="pandas"):
    # I again have to convert the batches to Pandas and then access this
    # dummy column.
    actual_batch = batch["value"]
```

### After

```python
ds = ray.data.range_tensor(16, shape=(4, 4), parallelism=4)

# UDF now takes and returns an ndarray, which will be zero-copy access
# to the underlying Arrow table, providing far better UX and less
# memory/perf overhead. The returned ndarray will be repacked into an
# Arrow table (again, zero-copy).
ds = ds.map_batches(lambda arr: 2*arr, batch_size=2, batch_format="numpy")

for batch in ds.iter_batches(batch_size=2, batch_format="numpy"):
    # The batch is the underlying ndarray batch, as I would expect; I don't
    # have to know or care about the dummy column or the single-column
    # table representation.
    assert isinstance(batch, np.ndarray)
```

Note that there's also benefits for the `to_torch()` and `to_tf()` APIs in the generic tabular block case, where a conversion from Arrow --> Pandas before converting to the ML framework tensor will no longer be necessary. See https://github.com/ray-project/ray/issues/24811

## Related issue number

Closes https://github.com/ray-project/ray/issues/24811

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
