### PR TITLE
[AIR] Don't use `df.transform` for `BatchMapper`

### DIFF
--- a/python/ray/ml/preprocessors/batch_mapper.py
+++ b/python/ray/ml/preprocessors/batch_mapper.py
@@ -23,7 +23,7 @@ class BatchMapper(Preprocessor):
         self.fn = fn
 
     def _transform_pandas(self, df: "pandas.DataFrame") -> "pandas.DataFrame":
-        return df.transform(self.fn)
+        return self.fn(df)
 
     def __repr__(self):
         fn_name = getattr(self.fn, "__name__", self.fn)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
`df.transform` has undefined behavior when the passed in function mutates the dataframe, as mentioned in the pandas docs. This is because I believe the implementation iterates through slices of the dataframe and passes these slices to the provided function. This "gotcha" exposes an implementation to users who are using `BatchMapper`.

It's pretty common to have preprocessors that mutates the dataframe, for example our own test does the following 
```
    def add_and_modify_udf(df: "pd.DataFrame"):
        df["new_col"] = df["old_column"] + 1
        df["to_be_modified"] *= 2
        return df
```

so instead of using `df.transform`, we instead do `self.fn(df)`. As the `df` is the output of Ray Datasets `iter_batches`, the provided function can safely mutate the dataset.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
