### PR TITLE
[docs] After careful consideration, choose the lesser of two evils and set white-space: pre-wrap

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -146,3 +146,8 @@ img.horizontal-scroll {
     width: 150px;
     float: right;
 }
+
+/* Wrap code blocks instead of horizontal scrolling. */
+pre {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
Currently, the code blocks in our docs often triggers horizontal scrolls. This makes it quite difficult to skim through docs sometimes if you have to scroll.

As a workaround, enable word wrapping. While I think we should also improve our code to not wrap typically, this makes long lines much less of a nuisance by default.

Before:
![1](https://user-images.githubusercontent.com/14922/168729138-da34fb6c-958d-49a3-9217-6cc5ba9b1622.png)

After:
![2](https://user-images.githubusercontent.com/14922/168729150-d7dd51f7-c095-426b-88dd-8ca02927d2ac.png)

