### PR TITLE
[tune] Fix `has_resources_for_trial`, leading to trials stuck in PENDING mode

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -626,6 +626,10 @@ class RayTrialExecutor(TrialExecutor):
         """
         return (
             trial in self._staged_trials
+            # or (
+            #     len(self._cached_actor_pg) > 0
+            #     and (self._pg_manager.has_cached_pg(trial.placement_group_factory))
+            # )
             or self._pg_manager.can_stage()
             or self._pg_manager.has_ready(trial, update=True)
         )

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -433,8 +433,7 @@ class RayTrialExecutor(TrialExecutor):
         self.restore(trial)
         self.set_status(trial, Trial.RUNNING)
 
-        if trial in self._staged_trials:
-            self._staged_trials.remove(trial)
+        self._staged_trials.discard(trial)
 
         if not trial.is_restoring:
             self._train(trial)
@@ -503,8 +502,7 @@ class RayTrialExecutor(TrialExecutor):
                     if self._trial_cleanup:  # force trial cleanup within a deadline
                         self._trial_cleanup.add(future)
 
-                if trial in self._staged_trials:
-                    self._staged_trials.remove(trial)
+                self._staged_trials.discard(trial)
 
         except Exception:
             logger.exception("Trial %s: Error stopping runner.", trial)
@@ -626,12 +624,13 @@ class RayTrialExecutor(TrialExecutor):
         """
         return (
             trial in self._staged_trials
-            # or (
-            #     len(self._cached_actor_pg) > 0
-            #     and (self._pg_manager.has_cached_pg(trial.placement_group_factory))
-            # )
+            or (
+                len(self._cached_actor_pg) > 0
+                and (self._pg_manager.has_cached_pg(trial.placement_group_factory))
+            )
             or self._pg_manager.can_stage()
             or self._pg_manager.has_ready(trial, update=True)
+            or self._pg_manager.has_staging(trial)
         )
 
     def debug_string(self) -> str:

--- a/python/ray/tune/utils/placement_groups.py
+++ b/python/ray/tune/utils/placement_groups.py
@@ -604,6 +604,10 @@ class PlacementGroupManager:
     def clean_cached_pg(self, pg: PlacementGroup):
         self._cached_pgs.pop(pg)
 
+    def has_cached_pg(self, pgf: PlacementGroupFactory):
+        """Check if a placement group for given factory has been cached"""
+        return any(cached_pgf == pgf for cached_pgf in self._cached_pgs.values())
+
     def remove_from_in_use(self, trial: "Trial") -> PlacementGroup:
         """Return pg back to Core scheduling.
 

--- a/python/ray/tune/utils/placement_groups.py
+++ b/python/ray/tune/utils/placement_groups.py
@@ -537,6 +537,21 @@ class PlacementGroupManager:
             self.update_status()
         return bool(self._ready[trial.placement_group_factory])
 
+    def has_staging(self, trial: "Trial", update: bool = False) -> bool:
+        """Return True if placement group for trial is staging.
+
+        Args:
+            trial: :obj:`Trial` object.
+            update: Update status first.
+
+        Returns:
+            Boolean.
+
+        """
+        if update:
+            self.update_status()
+        return bool(self._staging[trial.placement_group_factory])
+
     def trial_in_use(self, trial: "Trial"):
         return trial in self._in_use_trials
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Tune resource bookkeeping was broken. Specifically, this is what happened in the repro provided in #24259:

- Only one PG can be scheduled per time
- We staged resources for trial 1
- We run trial 1
- We stage resources for trial 2
- We pause trial 1, caching the placement group
- This removes the staged PG for trial 2 (as we return the PG for trial 1)
- However, now we `reconcile_placement_groups`, which re-stages a PG
- both trial 1 and trial 2 are now not in `RayTrialExecutor._staged_trials`
- A staging future is still there because of the reconciliation

This PR fixes this problem in two ways. `has_resources_per_trial` will check a) also for staging futures for the specific trial, and b) will also consider cached placement groups.

Generally, resource management in Tune is convoluted and hard to debug, and several classes share bookkeeping responsibilities (runner, executor, pg manager). We should refactor this.

## Related issue number

Closes #24259

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
