### PR TITLE
[RLlib] Curiosity Bug Fix

### DIFF
--- a/rllib/utils/exploration/curiosity.py
+++ b/rllib/utils/exploration/curiosity.py
@@ -341,8 +341,12 @@ class Curiosity(Exploration):
             {
                 SampleBatch.OBS: torch.cat(
                     [
-                        torch.from_numpy(sample_batch[SampleBatch.OBS]).to(policy.device),
-                        torch.from_numpy(sample_batch[SampleBatch.NEXT_OBS]).to(policy.device),
+                        torch.from_numpy(sample_batch[SampleBatch.OBS]).to(
+                            policy.device
+                        ),
+                        torch.from_numpy(sample_batch[SampleBatch.NEXT_OBS]).to(
+                            policy.device
+                        ),
                     ]
                 )
             }

--- a/rllib/utils/exploration/curiosity.py
+++ b/rllib/utils/exploration/curiosity.py
@@ -341,8 +341,8 @@ class Curiosity(Exploration):
             {
                 SampleBatch.OBS: torch.cat(
                     [
-                        torch.from_numpy(sample_batch[SampleBatch.OBS]),
-                        torch.from_numpy(sample_batch[SampleBatch.NEXT_OBS]),
+                        torch.from_numpy(sample_batch[SampleBatch.OBS]).to(policy.device),
+                        torch.from_numpy(sample_batch[SampleBatch.NEXT_OBS]).to(policy.device),
                     ]
                 )
             }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I have been facing an issue when using PPO with curiosity and Torch, on a machine with at least one available GPU. In particular:

```RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!```


## Related issue number

Closes #24558

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
