### PR TITLE
[Datasets] Miscellaneous GA docs P0s.

### DIFF
--- a/doc/source/data/advanced-pipelines.rst
+++ b/doc/source/data/advanced-pipelines.rst
@@ -140,6 +140,14 @@ Transformations made prior to the Dataset prior to the call to ``.repeat()`` are
 
 For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline.
 
+.. note::
+  Global per-epoch shuffling is an expensive operation that will slow down your ML
+  ingest pipeline, prevents you from using a fully-streaming ML ingest pipeline, and
+  can cause large increases in memory utilization and spilling to disk; only use
+  global per-epoch shuffling if your model benefits from it! If your model doesn't
+  benefit from global per-epoch shuffling and/or you run into performance or stability
+  issues, you should try out windowed or local per-epoch shuffling.
+
 **Code**:
 
 .. code-block:: python

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -303,6 +303,8 @@ This default parallelism can be overridden via the ``parallelism`` argument; see
 :ref:`performance guide <data_performance_tips>`  for tips on how to tune this read
 parallelism.
 
+.. _dataset_deferred_reading:
+
 Deferred Read Task Execution
 ============================
 

--- a/doc/source/data/doc_code/key_concepts.py
+++ b/doc/source/data/doc_code/key_concepts.py
@@ -1,0 +1,69 @@
+# flake8: noqa
+
+# fmt: off
+# __resource_allocation_begin__
+import ray
+from ray.data.context import DatasetContext
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+# Create a single-CPU local cluster.
+ray.init(num_cpus=1)
+ctx = DatasetContext.get_current()
+# Create a placement group that takes up the single core on the cluster.
+placement_group = ray.util.placement_group(
+    name="core_hog",
+    strategy="SPREAD",
+    bundles=[
+        {"CPU": 1},
+    ],
+)
+ray.get(placement_group.ready())
+
+# Tell Datasets to use the placement group for all Datasets tasks.
+ctx.scheduling_strategy = PlacementGroupSchedulingStrategy(placement_group)
+# This Dataset workload will use that placement group for all read and map tasks.
+ds = ray.data.range(100, parallelism=2) \
+    .map(lambda x: x + 1)
+
+assert ds.take_all() == list(range(1, 101))
+# __resource_allocation_end__
+# fmt: on
+
+# fmt: off
+# __block_move_begin__
+import ray
+from ray.data.context import DatasetContext
+
+ctx = DatasetContext.get_current()
+ctx.optimize_fuse_stages = False
+
+def map_udf(df):
+    df["sepal.area"] = df["sepal.length"] * df["sepal.width"]
+    return df
+
+ds = ray.data.read_parquet("example://iris.parquet") \
+    .experimental_lazy() \
+    .map_batches(map_df) \
+    .filter(lambda row: row["sepal.area"] > 15)
+# __block_move_end__
+# fmt: on
+
+# fmt: off
+# __dataset_pipelines_execution_begin__
+import ray
+
+# ML ingest re-reading from storage on every epoch.
+torch_ds = ray.data.read_parquet("example://iris.parquet") \
+    .repeat() \
+    .random_shuffle() \
+    .to_torch()
+
+# Streaming batch inference pipeline that pipelines the transforming of a single
+# file with the reading of a single file (at most 2 file's worth of data in-flight
+# at a time).
+infer_ds = ray.data.read_binary_files("example://mniset_subset_partitioned/") \
+    .window(blocks_per_window=1) \
+    .map(lambda bytes_: np.asarray(PIL.Image.open(BytesIO(bytes_)).convert("L"))) \
+    .map_batches(lambda imgs: [img.mean() > 0.5 for img in imgs])
+# __dataset_pipelines_execution_end__
+# fmt: on


### PR DESCRIPTION
This PR knocks off a few miscellaneous GA docs P0s given in our [docs tracker](https://github.com/ray-project/ray/issues/23091). Namely:

- Documents Datasets resource allocation model.
- De-emphasizes global/windowed shuffling.
- Documents lazy execution mode, and expands our execution model docs in general.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
