### PR TITLE
FIX: Failure in create_scheduler() with pb2 scheduler

### DIFF
--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -11,12 +11,12 @@ from ray.tune.schedulers.pbt import (
 from ray.tune.schedulers.resource_changing_scheduler import ResourceChangingScheduler
 
 
-def _pb2_importer(*args, **kwargs):
+def _pb2_importer():
     # PB2 introduces a GPy dependency which can be expensive, so we import
     # lazily.
     from ray.tune.schedulers.pb2 import PB2
 
-    return PB2(*args, **kwargs)
+    return PB2
 
 
 SCHEDULER_IMPORT = {
@@ -63,7 +63,11 @@ def create_scheduler(
             f"Got: {scheduler}"
         )
 
-    SchedulerClass = SCHEDULER_IMPORT[scheduler]
+    if scheduler == "pb2":
+        # run wrapper function to get relevant class
+        SchedulerClass = SCHEDULER_IMPORT[scheduler]()
+    else:
+        SchedulerClass = SCHEDULER_IMPORT[scheduler]
 
     scheduler_args = get_function_args(SchedulerClass)
     trimmed_kwargs = {k: v for k, v in kwargs.items() if k in scheduler_args}

--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -1,3 +1,5 @@
+import inspect
+
 from ray._private.utils import get_function_args
 from ray.tune.schedulers.trial_scheduler import TrialScheduler, FIFOScheduler
 from ray.tune.schedulers.hyperband import HyperBandScheduler
@@ -63,11 +65,11 @@ def create_scheduler(
             f"Got: {scheduler}"
         )
 
-    if scheduler == "pb2":
-        # run wrapper function to get relevant class
-        SchedulerClass = SCHEDULER_IMPORT[scheduler]()
-    else:
-        SchedulerClass = SCHEDULER_IMPORT[scheduler]
+    SchedulerClass = SCHEDULER_IMPORT[scheduler]
+
+    if inspect.isfunction(SchedulerClass):
+        # invoke the wrapper function to retrieve class
+        SchedulerClass = SchedulerClass()
 
     scheduler_args = get_function_args(SchedulerClass)
     trimmed_kwargs = {k: v for k, v in kwargs.items() if k in scheduler_args}

--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -20,6 +20,7 @@ def _pb2_importer():
 
     return PB2
 
+
 # Values in this dictionary will be one two kinds:
 #    class of the scheduler object to create
 #    wrapper function to support a lazy import of the scheduler class

--- a/python/ray/tune/schedulers/__init__.py
+++ b/python/ray/tune/schedulers/__init__.py
@@ -20,7 +20,9 @@ def _pb2_importer():
 
     return PB2
 
-
+# Values in this dictionary will be one two kinds:
+#    class of the scheduler object to create
+#    wrapper function to support a lazy import of the scheduler class
 SCHEDULER_IMPORT = {
     "fifo": FIFOScheduler,
     "async_hyperband": AsyncHyperBandScheduler,

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import os
 import pickle
 import shutil
@@ -1496,6 +1495,7 @@ class ShimCreationTest(unittest.TestCase):
             if scheduler_id == "pb2":
                 # handle special case of PB2 wrapping function
                 from ray.tune.schedulers.pb2 import PB2
+
                 SchedulerClass = SchedulerClass()
                 assert SchedulerClass == PB2
 

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1497,7 +1497,7 @@ class ShimCreationTest(unittest.TestCase):
                 from ray.tune.schedulers.pb2 import PB2
 
                 SchedulerClass = SchedulerClass()
-                assert SchedulerClass == PB2
+                assert SchedulerClass is PB2
 
             if scheduler_id in {"fifo", "resource_changing"}:
                 # for these cases, the scheduler class does not require

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -49,7 +49,6 @@ from ray.tune.schedulers import (
     TrialScheduler,
     FIFOScheduler,
     AsyncHyperBandScheduler,
-    SCHEDULER_IMPORT,
 )
 from ray.tune.schedulers.pb2 import PB2
 from ray.tune.stopper import (

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1476,7 +1476,7 @@ class ShimCreationTest(unittest.TestCase):
         kwargs = {"metric": "metric_foo", "mode": "min"}
 
         # get list of all schedulers to test
-        schedulers_to_test = [scheduler for scheduler in SCHEDULER_IMPORT.keys()]
+        schedulers_to_test = SCHEDULER_IMPORT.keys()
 
         for scheduler_id in schedulers_to_test:
             kwargs_for_test = kwargs.copy()
@@ -1498,13 +1498,15 @@ class ShimCreationTest(unittest.TestCase):
                 SchedulerClass = SchedulerClass()
 
             if scheduler_id in {"fifo", "resource_changing"}:
-                # for these cases, the scheduler class does not require parameters for test
+                # for these cases, the scheduler class does not require
+                # parameters for test
                 kwargs_for_test = {}
 
             # create scheduler object directly from the class
             real_scheduler = SchedulerClass(**kwargs_for_test)
 
-            # confirm shim created object is same as calling the scheduler class directly
+            # confirm shim created object is same as calling
+            # the scheduler class directly
             assert type(shim_scheduler) is type(real_scheduler)
 
     def testCreateSearcher(self):

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -1493,9 +1493,11 @@ class ShimCreationTest(unittest.TestCase):
 
             # create scheduler with actual class
             SchedulerClass = SCHEDULER_IMPORT[scheduler_id]
-            if inspect.isfunction(SchedulerClass):
-                # handle case of wrapping function
+            if scheduler_id == "pb2":
+                # handle special case of PB2 wrapping function
+                from ray.tune.schedulers.pb2 import PB2
                 SchedulerClass = SchedulerClass()
+                assert SchedulerClass == PB2
 
             if scheduler_id in {"fifo", "resource_changing"}:
                 # for these cases, the scheduler class does not require


### PR DESCRIPTION
## Why are these changes needed?
When `create_scheduler("pb2", ....)` is run a `TuneError` exception is raised.  See referenced issue below for details.

In addition to the fix, introduced a new test (`ray/tune/tests/test_api.py::ShimCreationTest.testCreateAllSchedulers`) to confirm that `tune.create_scheduler()` will work with all documented schedulers.   Results from a local test run:
```
root@4566d313f4e3:/opt/project# pytest -v  python/ray/tune/tests/test_api.py::ShimCreationTest
Test session starts (platform: linux, Python 3.8.13, pytest 5.4.3, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /opt/project/python
plugins: lazy-fixture-0.6.3, rerunfailures-10.2, anyio-3.6.1, sugar-0.9.4, asyncio-0.16.0, virtualenv-1.7.0, shutil-1.7.0, typeguard-2.13.3, remotedata-0.3.3, timeout-2.1.0
collecting ...
 ray/tune/tests/test_api.py::ShimCreationTest.testCreateAllSchedulers ✓                                                       25% ██▌
 ray/tune/tests/test_api.py::ShimCreationTest.testCreateScheduler ✓                                                           50% █████
 ray/tune/tests/test_api.py::ShimCreationTest.testCreateSearcher ✓                                                            75% ███████▌
 ray/tune/tests/test_api.py::ShimCreationTest.testExtraParams ✓                                                              100% ██████████
============================================================= warnings summary =============================================================
```

Note: `tesCreateAllTestSchedulers` is a superset of what is covered in `testCreateScheduer`.  It may be reasonable to retire the later test.

## Related issue number

Closes #24815 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.  
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
