### PR TITLE
[AIR] Add `trainer_resources` as a valid scaling config key for all Trainers

### DIFF
--- a/python/ray/ml/train/data_parallel_trainer.py
+++ b/python/ray/ml/train/data_parallel_trainer.py
@@ -224,7 +224,7 @@ class DataParallelTrainer(Trainer):
         TuneCheckpointManager
     ] = _DataParallelCheckpointManager
 
-    _scaling_config_allowed_keys = [
+    _scaling_config_allowed_keys = Trainer._scaling_config_allowed_keys + [
         "num_workers",
         "num_cpus_per_worker",
         "num_gpus_per_worker",

--- a/python/ray/ml/train/gbdt_trainer.py
+++ b/python/ray/ml/train/gbdt_trainer.py
@@ -65,7 +65,7 @@ class GBDTTrainer(Trainer):
         **train_kwargs: Additional kwargs passed to framework ``train()`` function.
     """
 
-    _scaling_config_allowed_keys = [
+    _scaling_config_allowed_keys = Trainer._scaling_config_allowed_keys + [
         "num_workers",
         "num_cpus_per_worker",
         "num_gpus_per_worker",

--- a/python/ray/ml/train/integrations/sklearn/sklearn_trainer.py
+++ b/python/ray/ml/train/integrations/sklearn/sklearn_trainer.py
@@ -156,8 +156,6 @@ class SklearnTrainer(Trainer):
             method.
     """
 
-    _scaling_config_allowed_keys = ["trainer_resources"]
-
     def __init__(
         self,
         *,

--- a/python/ray/ml/trainer.py
+++ b/python/ray/ml/trainer.py
@@ -136,7 +136,7 @@ class Trainer(abc.ABC):
         resume_from_checkpoint: A checkpoint to resume training from.
     """
 
-    _scaling_config_allowed_keys: List[str] = []
+    _scaling_config_allowed_keys: List[str] = ["trainer_resources"]
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
`trainer_resources` should be a valid scaling config key for all Trainers.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
