### PR TITLE
[AIR] Support array output from Torch model

### DIFF
--- a/python/ray/ml/predictors/integrations/torch/torch_predictor.py
+++ b/python/ray/ml/predictors/integrations/torch/torch_predictor.py
@@ -82,7 +82,11 @@ class TorchPredictor(Predictor):
     def _predict(self, tensor: torch.Tensor) -> pd.DataFrame:
         """Handle actual prediction."""
         prediction = self.model(tensor).cpu().detach().numpy()
-        return pd.DataFrame(prediction, columns=["predictions"])
+        # If model has outputs a Numpy array (for example outputting logits),
+        # these cannot be used as values in a Pandas Dataframe.
+        # We have to convert the outermost dimension to a python list (but the values
+        # in the list can still be Numpy arrays).
+        return pd.DataFrame({"predictions": list(prediction)}, columns=["predictions"])
 
     def predict(
         self,
@@ -112,10 +116,10 @@ class TorchPredictor(Predictor):
                 format of ``feature_columns``, or be a single dtype, in which
                 case it will be applied to all tensors.
                 If None, then automatically infer the dtype.
-            unsqueeze_feature_tensors (bool): If set to True, the features tensors
-                will be unsqueezed (reshaped to (N, 1)) before being concatenated into
-                the final features tensor. Otherwise, they will be left as is, that is
-                (N, ). Defaults to True.
+            unsqueeze (bool): If set to True, the features tensors will be unsqueezed
+                (reshaped to (N, 1)) before being concatenated into the final features
+                tensor. Otherwise, they will be left as is, that is (N, ).
+                Defaults to True.
 
         Examples:
 

--- a/python/ray/ml/tests/test_torch_predictor.py
+++ b/python/ray/ml/tests/test_torch_predictor.py
@@ -1,10 +1,12 @@
+import pytest
+
+import numpy as np
+import torch
+
 from ray.ml.predictors.integrations.torch import TorchPredictor
 from ray.ml.preprocessor import Preprocessor
 from ray.ml.checkpoint import Checkpoint
 from ray.ml.constants import PREPROCESSOR_KEY, MODEL_KEY
-
-import numpy as np
-import torch
 
 
 class DummyPreprocessor(Preprocessor):
@@ -17,11 +19,17 @@ class DummyModel(torch.nn.Linear):
         return input * 2
 
 
-model = DummyModel(1, 1)
-preprocessor = DummyPreprocessor()
+@pytest.fixture
+def model():
+    return DummyModel(1, 1)
 
 
-def test_init():
+@pytest.fixture
+def preprocessor():
+    return DummyPreprocessor()
+
+
+def test_init(model, preprocessor):
     predictor = TorchPredictor(model=model, preprocessor=preprocessor)
 
     checkpoint = {MODEL_KEY: model, PREPROCESSOR_KEY: preprocessor}
@@ -35,7 +43,17 @@ def test_init():
     assert not predictor.model.training
 
 
-def test_predict():
+def test_predict_no_preprocessor(model):
+    predictor = TorchPredictor(model=model)
+
+    data_batch = np.array([[1], [2], [3]])
+    predictions = predictor.predict(data_batch)
+
+    assert len(predictions) == 3
+    assert predictions.to_numpy().flatten().tolist() == [2, 4, 6]
+
+
+def test_predict_with_preprocessor(model, preprocessor):
     predictor = TorchPredictor(model=model, preprocessor=preprocessor)
 
     data_batch = np.array([[1], [2], [3]])
@@ -45,31 +63,31 @@ def test_predict():
     assert predictions.to_numpy().flatten().tolist() == [4, 8, 12]
 
 
-def test_predict_array_output():
+def test_predict_array_output(model):
     """Tests if predictor works if model outputs an array instead of single value."""
 
-    predictor = TorchPredictor(model=model, preprocessor=preprocessor)
+    predictor = TorchPredictor(model=model)
 
     data_batch = np.array([[1, 1], [2, 2], [3, 3]])
     predictions = predictor.predict(data_batch)
 
     assert len(predictions) == 3
     assert np.array_equal(
-        predictions.to_numpy().flatten().tolist(), [[4, 4], [8, 8], [12, 12]]
+        predictions.to_numpy().flatten().tolist(), [[2, 2], [4, 4], [6, 6]]
     )
 
 
-def test_predict_feature_columns():
-    predictor = TorchPredictor(model=model, preprocessor=preprocessor)
+def test_predict_feature_columns(model):
+    predictor = TorchPredictor(model=model)
 
     data_batch = np.array([[1, 4], [2, 5], [3, 6]])
     predictions = predictor.predict(data_batch, feature_columns=[0])
 
     assert len(predictions) == 3
-    assert predictions.to_numpy().flatten().tolist() == [4, 8, 12]
+    assert predictions.to_numpy().flatten().tolist() == [2, 4, 6]
 
 
-def test_predict_no_preprocessor():
+def test_predict_from_checkpoint_no_preprocessor(model):
     checkpoint = Checkpoint.from_dict({MODEL_KEY: model})
     predictor = TorchPredictor.from_checkpoint(checkpoint)
 

--- a/python/ray/ml/tests/test_torch_predictor.py
+++ b/python/ray/ml/tests/test_torch_predictor.py
@@ -45,6 +45,20 @@ def test_predict():
     assert predictions.to_numpy().flatten().tolist() == [4, 8, 12]
 
 
+def test_predict_array_output():
+    """Tests if predictor works if model outputs an array instead of single value."""
+
+    predictor = TorchPredictor(model=model, preprocessor=preprocessor)
+
+    data_batch = np.array([[1, 1], [2, 2], [3, 3]])
+    predictions = predictor.predict(data_batch)
+
+    assert len(predictions) == 3
+    assert np.array_equal(
+        predictions.to_numpy().flatten().tolist(), [[4, 4], [8, 8], [12, 12]]
+    )
+
+
 def test_predict_feature_columns():
     predictor = TorchPredictor(model=model, preprocessor=preprocessor)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
The previous implementation of `TorchPredictor` failed when the model outputted an array for each sample (for example outputting logits). This is because Pandas Dataframes cannot hold numpy arrays of more than 1 element. We have to convert the outermost numpy array returned by the model to a list so that it be can stored in a Pandas Dataframe.

The newly added test fails under the old implementation.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
