### PR TITLE
[core] Forward task lineage when putting object with assigned owner

### DIFF
--- a/src/mock/ray/core_worker/core_worker.h
+++ b/src/mock/ray/core_worker/core_worker.h
@@ -165,6 +165,12 @@ class MockCoreWorker : public CoreWorker {
                rpc::AssignObjectOwnerReply *reply,
                rpc::SendReplyCallback send_reply_callback),
               (override));
+  MOCK_METHOD(void,
+              HandleForwardLineage,
+              (const rpc::ForwardLineageRequest &request,
+               rpc::ForwardLineageReply *reply,
+               rpc::SendReplyCallback send_reply_callback),
+              (override));
 };
 
 }  // namespace core

--- a/src/mock/ray/rpc/worker/core_worker_client.h
+++ b/src/mock/ray/rpc/worker/core_worker_client.h
@@ -129,6 +129,11 @@ class MockCoreWorkerClientInterface : public ray::pubsub::MockSubscriberClientIn
               (const AssignObjectOwnerRequest &request,
                const ClientCallback<AssignObjectOwnerReply> &callback),
               (override));
+  MOCK_METHOD(void,
+              ForwardLineage,
+              (const ForwardLineageRequest &request,
+               const ClientCallback<ForwardLineageReply> &callback),
+              (override));
   MOCK_METHOD(int64_t, ClientProcessedUpToSeqno, (), (override));
 };
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -966,7 +966,7 @@ Status CoreWorker::CreateOwnedAndIncrementLocalRef(
     rpc::ForwardLineageRequest forward_request;
     std::promise<Status> status_promise;
     conn->ForwardLineage(forward_request,
-                        [&status_promise, object_id](const Status &returned_status,
+                        [&status_promise, &object_id](const Status &returned_status,
                                     const rpc::ForwardLineageReply &reply) {
                           *object_id = ObjectID::FromBinary(reply.object_id());
                           status_promise.set_value(returned_status);
@@ -3278,7 +3278,7 @@ void CoreWorker::HandleExit(const rpc::ExitRequest &request,
 void CoreWorker::HandleForwardLineage(const rpc::ForwardLineageRequest &request,
                                          rpc::ForwardLineageReply *reply,
                                          rpc::SendReplyCallback send_reply_callback) {
-  reply->set_object_id(ObjectID::FromIndex(worker_context_.GetCurrentInternalTaskId(),
+  reply->set_object_id(ObjectID::FromIndex(worker_context_.GetCurrentTaskID(),
                                      worker_context_.GetNextPutIndex()).Binary());
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -769,6 +769,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                   rpc::ExitReply *reply,
                   rpc::SendReplyCallback send_reply_callback) override;
 
+  // 
+  void HandleForwardLineage(const rpc::ForwardLineageRequest &request,
+                               rpc::ForwardLineageReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override;
+
   // Set local worker as the owner of object.
   // Request by borrower's worker, execute by owner's worker.
   void HandleAssignObjectOwner(const rpc::AssignObjectOwnerRequest &request,

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -349,6 +349,14 @@ message AssignObjectOwnerRequest {
 message AssignObjectOwnerReply {
 }
 
+message ForwardLineageRequest {
+}
+
+message ForwardLineageReply {
+  // The ID of added object.
+  bytes object_id = 1;
+}
+
 service CoreWorkerService {
   // Push a task directly to this worker from another.
   rpc PushTask(PushTaskRequest) returns (PushTaskReply);
@@ -399,4 +407,6 @@ service CoreWorkerService {
   rpc Exit(ExitRequest) returns (ExitReply);
   // Assign the owner of an object to the intended worker.
   rpc AssignObjectOwner(AssignObjectOwnerRequest) returns (AssignObjectOwnerReply);
+  //
+  rpc ForwardLineage(ForwardLineageRequest) returns (ForwardLineageReply);
 }

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -193,6 +193,10 @@ class CoreWorkerClientInterface : public pubsub::SubscriberClientInterface {
                                  const ClientCallback<AssignObjectOwnerReply> &callback) {
   }
 
+  virtual void ForwardLineage(const ForwardLineageRequest &request,
+                              const ClientCallback<ForwardLineageReply> &callback) {
+  }
+
   /// Returns the max acked sequence number, useful for checking on progress.
   virtual int64_t ClientProcessedUpToSeqno() { return -1; }
 
@@ -317,6 +321,12 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   VOID_RPC_CLIENT_METHOD(CoreWorkerService,
                          AssignObjectOwner,
+                         grpc_client_,
+                         /*method_timeout_ms*/ -1,
+                         override)
+
+  VOID_RPC_CLIENT_METHOD(CoreWorkerService,
+                         ForwardLineage,
                          grpc_client_,
                          /*method_timeout_ms*/ -1,
                          override)

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -46,7 +46,8 @@ namespace rpc {
   RPC_SERVICE_HANDLER(CoreWorkerService, DeleteSpilledObjects, -1)           \
   RPC_SERVICE_HANDLER(CoreWorkerService, PlasmaObjectReady, -1)              \
   RPC_SERVICE_HANDLER(CoreWorkerService, Exit, -1)                           \
-  RPC_SERVICE_HANDLER(CoreWorkerService, AssignObjectOwner, -1)
+  RPC_SERVICE_HANDLER(CoreWorkerService, AssignObjectOwner, -1)              \
+  RPC_SERVICE_HANDLER(CoreWorkerService, ForwardLineage, -1)
 
 #define RAY_CORE_WORKER_DECLARE_RPC_HANDLERS                              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PushTask)                       \
@@ -67,7 +68,8 @@ namespace rpc {
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(DeleteSpilledObjects)           \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PlasmaObjectReady)              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(Exit)                           \
-  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(AssignObjectOwner)
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(AssignObjectOwner)              \
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(ForwardLineage)
 
 /// Interface of the `CoreWorkerServiceHandler`, see `src/ray/protobuf/core_worker.proto`.
 class CoreWorkerServiceHandler {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently objects converted from raydp dataframe is not recoverable. This PR solves this problem.

## Related issue number
#23824 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
