### PR TITLE
find agent_pid even when using a PEP397 launcher

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -205,6 +205,9 @@ class DashboardAgent(object):
         # In a virtualenv, the agent PID could be the PEP397 launcher and
         # not the python process PID as reported by os.getpid()
         try:
+            # No launcher and process started via a service
+            # In normal ray operation, this will not happen since the agent
+            # is started by the raylet.exe process
             pid = parent.pid
         except AttributeError:
             pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using ray inside a virtualenv on windows, `python.exe` as reported by `sys.executable` is a PEP397 launcher to the actual python as reported by `os.getpid()`:
```
>>> import sys, os, psutil
>>> >>> print(sys.executable)
C:\temp\issue24361\Scripts\python.exe
>>> os.getpid()
2208
>>> child = psutil.Process(2208)
>>> child.cmdline()
['C:\\oss\\CPython38\\python.exe']
>>> child.parent().cmdline()
['C:\\temp\\issue24361\\Scripts\\python.exe']
>>> child.parent().pid
6424
```

When the `agent_manager` launches the agent process via `Process::Process()`, it gets the PID of the launcher process (6424), which is what is expected as an ID when registering the agent in the gRPC callback. But inside `agent.py`, the child process reports the PID via `os.getpid()`, which is 2208, and this is the wrong PID to register the agent.

The solution proposed here checks whether `os.getpid()`'s parent is a python process, and if so assumes it is the launcher. It then sets this PID as the `agent_pid`. A different solution would be to pass the agent_pid in to the process as a command line parameter or an environment variable.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24361, #23945
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

Is there a test for running the ray head process in a virtualenv (different than the runtime_env tests, which run the workers in a virtualenv/conda env)?