### PR TITLE
[Datasets] Remove `FastFileMetadataProvider` warning

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -196,11 +196,6 @@ class FastFileMetadataProvider(DefaultFileMetadataProvider):
         paths: List[str],
         filesystem: "pyarrow.fs.FileSystem",
     ) -> Tuple[List[str], List[Optional[int]]]:
-        logger.warning(
-            f"Skipping expansion of {len(paths)} path(s). If your paths contain "
-            f"directories or if file size collection is required, try rerunning this "
-            f"read with `meta_provider=DefaultFileMetadataProvider()`."
-        )
         import numpy as np
 
         return paths, np.empty(len(paths), dtype=object)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you use a datasource that uses `FastFileMetadataProvider` (e.g., `ImageFolderDatasource`), a warning is raised:

> (_prepare_read pid=43380) 2022-05-11 02:11:33,272 WARNING [file_meta_provider.py:199](http://file_meta_provider.py:199/) -- Skipping expansion of 2 path(s). If your paths contain directories or if file size collection is required, try rerunning this read with meta_provider=DefaultFileMetadataProvider().

This may confuse users because:

* It has nothing to do with the user's problem
* It leaks an implementation detail
* It can't be resolved (there's no issue in the first place)

## Related issue number

<!-- For example: "Closes #1234" -->

See #24641 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
