### PR TITLE
[script] expose options of xxx_port in 'ray start' command

### DIFF
--- a/doc/source/ray-core/configure.rst
+++ b/doc/source/ray-core/configure.rst
@@ -101,6 +101,12 @@ All Nodes
 
 The node manager and object manager run as separate processes with their own ports for communication.
 
+The following options specify the ports used by dashboard agent process.
+
+- ``--dashboard-agent-grpc-port``: The port to listen for grpc on. Default: Random value.
+- ``--dashboard-agent-listen-port``: The port to listen for http on. Default: Random value.
+- ``--metrics-export-port``: The port to use to expose Ray metrics. Default: Random value.
+
 The following options specify the range of ports used by worker processes across machines. All ports in the range should be open.
 
 - ``--min-worker-port``: Minimum port number worker can be bound to. Default: 10002.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -413,14 +413,12 @@ def debug(address):
 @click.option(
     "--dashboard-agent-listen-port",
     type=int,
-    hidden=True,
     default=0,
     help="the port for dashboard agents to listen for http on.",
 )
 @click.option(
     "--dashboard-agent-grpc-port",
     type=int,
-    hidden=True,
     default=None,
     help="the port for dashboard agents to listen for grpc on.",
 )
@@ -486,7 +484,6 @@ def debug(address):
 @click.option(
     "--metrics-export-port",
     type=int,
-    hidden=True,
     default=None,
     help="the port to use to expose Ray metrics through a Prometheus endpoint.",
 )


### PR DESCRIPTION
## Why are these changes needed?
We need to expose the options of  xxx_port in 'ray start' command because of some port conflict issues such as https://discuss.ray.io/t/runtime-env-fails-when-running-ray-in-docker/5508