### PR TITLE
[serve] [WIP] Prototype gradio integration

### DIFF
--- a/python/ray/serve/demo.py
+++ b/python/ray/serve/demo.py
@@ -1,0 +1,38 @@
+import ray
+from ray import serve
+from ray.serve.experimental.gradio import GradioIngress
+
+import gradio as gr
+
+
+@serve.deployment
+class Model:
+    def __init__(self, name: str):
+        self._name = name
+
+    def __call__(self, inp: str):
+        return inp + self._name
+
+
+@serve.deployment
+class MyGradioUI(GradioIngress):
+    def __init__(self, downstream_model_1, downstream_model_2):
+        self._d1 = downstream_model_1
+        self._d2 = downstream_model_2
+
+        io = gr.Interface(self.fanout, "textbox", "textbox")
+        super().__init__(io)  # This API is kinda weird?
+
+    def fanout(self, input):
+        [result1, result2] = ray.get([self._d1.remote(input), self._d2.remote(input)])
+        return f"{result1} | {result2}"
+
+
+m1 = Model.bind("Alice")
+m2 = Model.bind("Bob")
+app = MyGradioUI.bind(m1, m2)
+
+
+# Open questions:
+# - Is this running in a thread for every call?
+# - Support `async def`?

--- a/python/ray/serve/experimental/gradio.py
+++ b/python/ray/serve/experimental/gradio.py
@@ -1,0 +1,14 @@
+import gradio as gr
+import starlette
+
+from ray.serve.http_util import ASGIHTTPSender
+
+
+class GradioIngress:
+    def __init__(self, io):
+        self.app = gr.networking.configure_app(gr.routes.create_app(), io)
+
+    async def __call__(self, request: starlette.requests.Request):
+        sender = ASGIHTTPSender()
+        await self.app(request.scope, receive=request.receive, send=sender)
+        return sender.build_asgi_response()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Try it out:

`serve run demo:app`

`demo.py`:
```python
import ray
from ray import serve
from ray.serve.experimental.gradio import GradioIngress

import gradio as gr


@serve.deployment
class Model:
    def __init__(self, name: str):
        self._name = name

    def __call__(self, inp: str):
        return inp + self._name


@serve.deployment
class MyGradioUI(GradioIngress):
    def __init__(self, downstream_model_1, downstream_model_2):
        self._d1 = downstream_model_1
        self._d2 = downstream_model_2

        io = gr.Interface(self.fanout, "textbox", "textbox")
        super().__init__(io)

    def fanout(self, input):
        [result1, result2] = ray.get([self._d1.remote(input), self._d2.remote(input)])
        return f"{result1} | {result2}"


m1 = Model.bind("Alice")
m2 = Model.bind("Bob")
app = MyGradioUI.bind(m1, m2)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
