### PR TITLE
Revert "[Core] allow using grpcio > 1.44.0 (#23722)"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -338,7 +338,7 @@
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - pip install "grpcio >= 1.28.1, != 1.44.0"
+    - pip install "grpcio >= 1.28.1, <= 1.43.0"
     - bazel test --config=ci --config=asan $(./ci/run/bazel_export_options)
       --config=asan-buildkite
       --test_tag_filters=-kubernetes,asan_tests

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -436,7 +436,7 @@ def test_runtime_env_log_msg(
 
     good_env = runtime_env_class(pip=["requests"])
     ray.get(f.options(runtime_env=good_env).remote())
-    sources = get_log_sources(p, timeout=10)
+    sources = get_log_sources(p, 5)
     if local_env_var_enabled:
         assert "runtime_env" in sources
     else:

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,7 +12,7 @@ cloudpickle
 filelock
 frozenlist
 gpustat >= 1.0.0b1
-grpcio >= 1.28.1, != 1.44.0
+grpcio >= 1.28.1, <= 1.43.0
 jsonschema
 msgpack >= 1.0.0, < 2.0.0
 numpy >= 1.16

--- a/python/setup.py
+++ b/python/setup.py
@@ -277,7 +277,7 @@ if setup_spec.type == SetupType.RAY:
         "click >= 7.0, <= 8.0.4",
         "dataclasses; python_version < '3.7'",
         "filelock",
-        "grpcio >= 1.28.1, != 1.44.0",
+        "grpcio >= 1.28.1, <= 1.43.0",
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",


### PR DESCRIPTION
This reverts commit b02029b29f77adf546d7907f7ef1bbbf8973f095.

It seems with grpc 1.46 and above, there is still logspam (#24917).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24917
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
