### PR TITLE
Better message for connection to the head node when it's listening on localhost.

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -770,6 +770,17 @@ def start(
                 cf.bold("  ray start --address='{}'"),
                 bootstrap_addresses,
             )
+            if bootstrap_addresses.startswith("127.0.0.1:"):
+                cli_logger.print(
+                    "This Ray runtime only accepts connections from local host."
+                )
+                cli_logger.print(
+                    "To accept connections from remote hosts, "
+                    "specify a public ip when starting"
+                )
+                cli_logger.print(
+                    "the head node: ray start --head --node-ip-address=<public-ip>."
+                )
             cli_logger.newline()
             cli_logger.print("Alternatively, use the following Python code:")
             with cli_logger.indented():

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -262,7 +262,10 @@ def test_ray_start(configure_lang, monkeypatch, tmp_path):
 
     _die_on_error(runner.invoke(scripts.stop))
 
-    _check_output_via_pattern("test_ray_start.txt", result)
+    if ray.util.get_node_ip_address() == "127.0.0.1":
+        _check_output_via_pattern("test_ray_start_localhost.txt", result)
+    else:
+        _check_output_via_pattern("test_ray_start.txt", result)
 
 
 def _ray_start_hook(ray_params, head):

--- a/python/ray/tests/test_cli_patterns/test_ray_start_localhost.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_start_localhost.txt
@@ -1,0 +1,29 @@
+Usage stats collection is enabled by default without user confirmation because this stdin is detected to be non-interactively\..+
+
+Local node IP: .+
+
+--------------------
+Ray runtime started.
+--------------------
+
+Next steps
+  To connect to this Ray runtime from another node, run
+    ray start --address='.+'
+  This Ray runtime only accepts connections from local host.
+  To accept connections from remote hosts, specify a public ip when starting
+  the head node: ray start --head --node-ip-address=<public-ip>.
+
+  Alternatively, use the following Python code:
+    import ray
+    ray\.init\(address='auto'\)
+
+  To connect to this Ray runtime from outside of the cluster, for example to
+  connect to a remote cluster from your laptop directly, use the following
+  Python code:
+    import ray
+    ray\.init\(address='ray://.*'\)
+
+  If connection fails, check your firewall settings and network configuration.
+
+  To terminate the Ray runtime, run
+    ray stop


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For mac and windows, we default to start the head node with 127.0.0.1 to avoid security pop-ups and assume people won't use cluster mode a lot. However, when people do want to create a mac/windows cluster, our connection message is confusing since we cannot connect to the head node that's listening on 127.0.0.1. This PR tells people what to do in this case (e.g. use node-ip-address).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24130
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
