### PR TITLE
[Release] prefer last cluster env version in release tests

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -201,6 +201,9 @@ if __name__ == "__main__":
             elif any(changed_file.startswith(prefix) for prefix in skip_prefix_list):
                 # nothing is run but linting in these cases
                 pass
+            elif changed_file.startswith("release/ray_release/"):
+                # Tests for release/ray_release always run. Other tests are irrelevant.
+                pass
             elif changed_file.endswith("build-docker-images.py"):
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -202,7 +202,8 @@ if __name__ == "__main__":
                 # nothing is run but linting in these cases
                 pass
             elif changed_file.startswith("release/ray_release/"):
-                # Tests for release/ray_release always run. Other tests are irrelevant.
+                # Tests for release/ray_release always run, so it is unnecessary to
+                # tag affected tests.
                 pass
             elif changed_file.endswith("build-docker-images.py"):
                 RAY_CI_DOCKER_AFFECTED = 1

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -411,6 +411,37 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.assertEqual(len(self.sdk.call_counter), 1)
 
     @patch("time.sleep", lambda *a, **kw: None)
+    def testBuildClusterEnvSelectLastBuild(self):
+        self.cluster_manager.set_cluster_env(self.cluster_env)
+        self.cluster_manager.cluster_env_id = "correct"
+        # (Second) build succeeded
+        self.cluster_manager.cluster_env_build_id = None
+        self.sdk.reset()
+        self.sdk.returns["list_cluster_environment_builds"] = APIDict(
+            results=[
+                APIDict(
+                    id="build_succeeded",
+                    status="succeeded",
+                    created_at=0,
+                    error_message=None,
+                    config_json={},
+                ),
+                APIDict(
+                    id="build_succeeded_2",
+                    status="succeeded",
+                    created_at=1,
+                    error_message=None,
+                    config_json={},
+                ),
+            ]
+        )
+        self.cluster_manager.build_cluster_env(timeout=600)
+        self.assertTrue(self.cluster_manager.cluster_env_build_id)
+        self.assertEqual(self.cluster_manager.cluster_env_build_id, "build_succeeded_2")
+        self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
+        self.assertEqual(len(self.sdk.call_counter), 1)
+
+    @patch("time.sleep", lambda *a, **kw: None)
     def testBuildClusterBuildFails(self):
         self.cluster_manager.set_cluster_env(self.cluster_env)
         self.cluster_manager.cluster_env_id = "correct"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently the release test runner prefers the first successfully version of a cluster env, instead of the last version. But sometimes a cluster env may build successfully on Anyscale but cannot launch cluster successfully (e.g. [version 2 here](https://console.anyscale.com/o/anyscale-internal/configurations/app-config-versions/apt_zQJupHXbpLBRuq9QbrTHCE6s)) or new dependencies need to be installed, so a new version needs to be built. The existing logic always picks up the 1st successful build and cannot pick up the new cluster env version.

Although this is an edge case (tweaking cluster env versions, with the same Ray wheel or cluster env name), I believe it is possible for others to run into it.

Also, avoid running most of the CI tests for changes under `release/ray_release/`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
