### PR TITLE
[Pubsub] raise exception when publishing fails

### DIFF
--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -188,7 +188,7 @@ class GcsPublisher(_PublisherBase):
                 pass
             time.sleep(1)
             count -= 1
-        raise
+        raise TimeoutError(f"Failed to publish after retries: {req}")
 
 
 class _SyncSubscriber(_SubscriberBase):

--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -286,7 +286,10 @@ class LogMonitor:
                     "actor_name": file_info.actor_name,
                     "task_name": file_info.task_name,
                 }
-                self.publisher.publish_logs(data)
+                try:
+                    self.publisher.publish_logs(data)
+                except Exception:
+                    logger.exception(f"Failed to publish log messages {data}")
                 anything_published = True
                 lines_to_publish = []
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -162,7 +162,10 @@ def publish_error_to_driver(
         job_id = ray.JobID.nil()
     assert isinstance(job_id, ray.JobID)
     error_data = construct_error_message(job_id, error_type, message, time.time())
-    gcs_publisher.publish_error(job_id.hex().encode(), error_data)
+    try:
+        gcs_publisher.publish_error(job_id.hex().encode(), error_data)
+    except Exception:
+        logger.exception(f"Failed to publish error {error_data}")
 
 
 def random_string():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It seems `_InactiveRpcError` is not saved as the last exception. Raise an explicit error when publishing fails after retries.

For log and error publishing, dropping messages should be tolerable so log the exception instead.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
