### PR TITLE
[flakey] Deflakey `test_gcs_fault_tollerance.py`

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -279,7 +279,7 @@ def test_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
         long_run_pid = int((tmp_path / "long_run.pid").read_text())
         return True
 
-    wait_for_condition(condition, timeout=5)
+    wait_for_condition(condition, timeout=10)
 
     # kill the gcs
     ray.worker._global_node.kill_gcs_server()
@@ -291,7 +291,7 @@ def test_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
     ray.worker._global_node.start_gcs_server()
 
     # The long_run_pid should exit
-    wait_for_pid_to_exit(long_run_pid, 5)
+    wait_for_pid_to_exit(long_run_pid, 10)
 
 
 @pytest.mark.parametrize(
@@ -331,7 +331,7 @@ def test_core_worker_resubscription(tmp_path, ray_start_regular_with_external_re
     ray.worker._global_node.start_gcs_server()
     # Test the resubscribe works: if not, it'll timeout because worker
     # will think the actor is not ready.
-    ray.get(r, timeout=5)
+    ray.get(r, timeout=10)
 
 
 @pytest.mark.parametrize("auto_reconnect", [True, False])

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -283,12 +283,13 @@ def test_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
 
     # kill the gcs
     ray.worker._global_node.kill_gcs_server()
+    sleep(1)
+    ray.worker._global_node.start_gcs_server()
+    sleep(1)
 
     # then kill the owner
     p = psutil.Process(pid)
     p.kill()
-
-    ray.worker._global_node.start_gcs_server()
 
     # The long_run_pid should exit
     wait_for_pid_to_exit(long_run_pid, 10)

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -279,7 +279,7 @@ def test_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
         long_run_pid = int((tmp_path / "long_run.pid").read_text())
         return True
 
-    wait_for_condition(condition, timeout=10)
+    wait_for_condition(condition, timeout=5)
 
     # kill the gcs
     ray.worker._global_node.kill_gcs_server()
@@ -292,7 +292,7 @@ def test_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
     p.kill()
 
     # The long_run_pid should exit
-    wait_for_pid_to_exit(long_run_pid, 10)
+    wait_for_pid_to_exit(long_run_pid, 5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The root cause here is a race condition where a report might fail:

1. GCS failed
2. Raylet reports worker failure
3. GCS started
4. GCS broadcast this info to other raylets

If 2) is successful in raylet, but GCS failed before reporting this to other raylets, we are losing this message.

Resubscribe still works, but the message is lost. To fix this, we need to remove the worker failure reporting from the code and use something else.

It's not a hi-priority issue given that 1) in this case, some leased worker is not released immediately and they should finish eventually (no leak for most cases); 2) we only have limited support for tasks; 3) this is not a P0 for serve HA.

This fix is to make sure resubscribe in raylet is working.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
