### PR TITLE
[Datasets] Overhaul "Accessing Datasets" feature guide.

### DIFF
--- a/doc/source/data/accessing-datasets.rst
+++ b/doc/source/data/accessing-datasets.rst
@@ -4,47 +4,188 @@
 Accessing Datasets
 ===================
 
-Datasets can be passed to Ray tasks or actors and accessed with ``.iter_batches()`` or ``.iter_rows()``.
+The data underlying a ``Dataset`` can be accessed in several ways:
+
+* Retrieving a limited prefix of rows.
+* Iterating over rows and batches.
+* Converting into a Torch dataset or a TensorFlow dataset.
+* Converting into a RandomAccessDataset for random access.
+
+Retrieving limited set of rows
+==============================
+
+A limited set of rows can be retried from a ``Dataset`` via the
+:meth:`ds.take() <ray.data.Dataset.take>` API, along with its sibling helper APIs
+:meth:`ds.take_all() <ray.data.Dataset.take_all>`, for retrieving **all** rows, and
+:meth:`ds.show() <ray.data.Dataset.show>`, for printing a limited set of rows. These
+methods are convenient for quickly inspecting a subset (prefix) of rows. They have the
+benefit that, if used right after reading, they will only trigger more files to be
+read if needed to retrieve rows from that file; if inspecting a small prefix of rows,
+often only the first file will need to be read.
+
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __take_begin__
+  :end-before: __take_end__
+
+Iterating over Datasets
+=======================
+
+Datasets can be consumed a row at a time using the
+:meth:`ds.iter_rows() <ray.data.Dataset.iter_rows>` API
+
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __iter_rows_begin__
+  :end-before: __iter_rows_end__
+
+or a batch at a time using the
+:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` API, where you can specify
+batch size as well as the desired batch format. By default, the batch format is
+``"native"``, which means that the batch format that's native to the data type will be
+returned. For tabular data, the native format is a Pandas DataFrame; for Python objects,
+it's a list.
+
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __iter_batches_begin__
+  :end-before: __iter_batches_end__
+
+
+Datasets can be passed to Ray tasks or actors and accessed by these iteration methods.
 This does not incur a copy, since the blocks of the Dataset are passed by reference as Ray objects:
 
-.. code-block:: python
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __remote_iterators_begin__
+  :end-before: __remote_iterators_end__
 
-    @ray.remote
-    def consume(data: Dataset[int]) -> int:
-        num_batches = 0
-        for batch in data.iter_batches():
-            num_batches += 1
-        return num_batches
+Converting to Torch dataset
+===========================
 
-    ds = ray.data.range(10000)
-    ray.get(consume.remote(ds))
-    # -> 200
+For ingestion into one or more Torch trainers, Datasets offers a :meth:`ds.to_torch()
+<ray.data.Dataset.to_torch>` API that returns a
+`Torch IterableDataset <https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset>`__
+that the Torch trainers can consume. This API takes care of both batching and converting
+the underlying Datasets data to Torch tensors, building on top of the
+:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` API.
 
-Datasets can be split up into disjoint sub-datasets.
-Locality-aware splitting is supported if you pass in a list of actor handles to the ``split()`` function along with the number of desired splits.
-This is a common pattern useful for loading and splitting data between distributed training actors:
+.. note::
 
-.. code-block:: python
+  The returned ``torch.utils.data.IterableDataset`` instance should be consumed directly
+  in your training loop directly; it should **not** be used with the Torch data loader.
+  Using Torch's data loader isn't necessary because upstream Ray Datasets preprocessing
+  operations in conjunction with :meth:`ds.to_torch() <ray.data.Dataset.to_torch>`
+  implements the data loader functionality (shuffling, batching, prefetching, etc.). If
+  you use the Torch data loader with this ``IterableDataset``, it will perform
+  inefficient unbatching and rebatching without adding any value. 
 
-    @ray.remote(num_gpus=1)
-    class Worker:
-        def __init__(self, rank: int):
-            pass
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __torch_begin__
+  :end-before: __torch_end__
 
-        def train(self, shard: ray.data.Dataset[int]) -> int:
-            for batch in shard.iter_batches(batch_size=256):
-                pass
-            return shard.count()
+When performing supervised learning, we'll have both feature columns and a label column
+that we may want to split into separate tensors. By informing ``ds.to_torch()`` of the
+label column, it will yield ``(features, label)`` tensor pairs for each batch.
 
-    workers = [Worker.remote(i) for i in range(16)]
-    # -> [Actor(Worker, ...), Actor(Worker, ...), ...]
+.. note::
 
-    ds = ray.data.range(10000)
-    # -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)
+  We set ``unsqueeze_label_tensor=False`` in order to remove a redundant unit column
+  dimension. E.g., with ``batch_size=2`` and ``unsqueeze_label_tensor=True``, you would
+  get ``(2, 1)``-shaped label tensor batches instead of the desired ``(2,)`` shape.
 
-    shards = ds.split(n=16, locality_hints=workers)
-    # -> [Dataset(num_blocks=13, num_rows=650, schema=<class 'int'>),
-    #     Dataset(num_blocks=13, num_rows=650, schema=<class 'int'>), ...]
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __torch_with_label_begin__
+  :end-before: __torch_with_label_end__
 
-    ray.get([w.train.remote(s) for w, s in zip(workers, shards)])
-    # -> [650, 650, ...]
+The types of the label and feature columns will be inferred from the data by default;
+these can be overridden with the ``label_column_dtype`` and ``feature_column_dtypes``
+args.
+
+By default, all feature columns will be concatenated into a single tensor; however,
+depending on the structure of the ``feature_columns`` argument, you can also get feature
+column batches as a list of tensors or a dict of tensors (with one or more column in
+each tensor). See the :meth:`.to_torch() API docs <ray.data.Dataset.to_torch>` for
+details.
+
+.. note::
+
+  If we have tensor feature columns (where each item in the column is an multi-dimensional
+  tensor) and any of the feature columns are different shapes, these columns are
+  incompatible and we will not be able to stack the column tensors into a single tensor.
+  Instead, we will need to group the columns by compatibility in the ``feature_columns``
+  argument.
+
+  Check out the :ref:`tensor data feature guide <datasets_tensor_ml_exchange>` for more
+  information on how to handle this.
+
+Converting to TensorFlow dataset
+================================
+
+For ingestion into one or more TensorFlow trainers, Datasets offers a :meth:`ds.to_tf()
+<ray.data.Dataset.to_tf>` API that returns a
+`tf.data.Dataset <https://www.tensorflow.org/api_docs/python/tf/data/Dataset>`__
+that the TensorFlow trainers can consume. This API takes care of both batching and converting
+the underlying Datasets data to TensorFlow tensors, building on top of the
+:meth:`ds.iter_batches() <ray.data.Dataset.iter_batches>` API.
+
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __tf_begin__
+  :end-before: __tf_end__
+
+When performing supervised learning, we'll have both feature columns and a label column
+that we may want to split into separate tensors. By informing ``ds.to_tf()`` of the
+label column, it will yield ``(features, label)`` tensor pairs for each batch.
+
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __tf_with_label_begin__
+  :end-before: __tf_with_label_end__
+
+The types of the label and feature columns will be inferred from the data by default;
+these can be overridden with the ``label_column_dtype`` and ``feature_column_dtypes``
+args.
+
+By default, all feature columns will be concatenated into a single tensor; however,
+depending on the structure of the ``feature_columns`` argument, you can also get feature
+column batches as a list of tensors or a dict of tensors (with one or more column in
+each tensor). See the :meth:`.to_tf() API docs <ray.data.Dataset.to_tf>` for
+details.
+
+.. note::
+
+  If we have tensor feature columns (where each item in the column is an multi-dimensional
+  tensor) and any of the feature columns are different shapes, these columns are
+  incompatible and we will not be able to stack the column tensors into a single tensor.
+  Instead, we will need to group the columns by compatibility in the ``feature_columns``
+  argument.
+
+  Check out the :ref:`tensor data feature guide <datasets_tensor_ml_exchange>` for more
+  information on how to handle this.
+
+Splitting Into and Consuming Shards
+===================================
+
+Datasets can be split up into disjoint sub-datasets, or shards.
+Locality-aware splitting is supported if you pass in a list of actor handles to the
+:meth:`ds.split() <ray.data.Dataset.split>` function along with the number of desired splits.
+This is a common pattern useful for loading and sharding data between distributed training actors:
+
+.. literalinclude:: ./doc_code/accessing_datasets.py
+  :language: python
+  :start-after: __split_begin__
+  :end-before: __split_end__
+
+Random Access Datasets
+======================
+
+Datasets can be converted to a format that supports efficient random access with
+:meth:`ds.to_random_access_dataset() API <ray.data.Dataset.to_random_access_dataset>`,
+which partitions the dataset on a sort key and provides random access via distributed
+binary search.
+
+See the :ref:`random access feature guide <datasets_random_access>` for more
+information.

--- a/doc/source/data/accessing-datasets.rst
+++ b/doc/source/data/accessing-datasets.rst
@@ -9,7 +9,7 @@ The data underlying a ``Dataset`` can be accessed in several ways:
 * Retrieving a limited prefix of rows.
 * Iterating over rows and batches.
 * Converting into a Torch dataset or a TensorFlow dataset.
-* Converting into a RandomAccessDataset for random access.
+* Converting into a RandomAccessDataset for random access (experimental).
 
 Retrieving limited set of rows
 ==============================
@@ -174,13 +174,18 @@ Locality-aware splitting is supported if you pass in a list of actor handles to 
 :meth:`ds.split() <ray.data.Dataset.split>` function along with the number of desired splits.
 This is a common pattern useful for loading and sharding data between distributed training actors:
 
+.. note::
+
+  If using :ref:`Ray Train <train-docs>` for distributed training, you do not need to split the dataset; Ray
+  Train will automatically do locality-aware splitting into per-trainer shards for you!
+
 .. literalinclude:: ./doc_code/accessing_datasets.py
   :language: python
   :start-after: __split_begin__
   :end-before: __split_end__
 
-Random Access Datasets
-======================
+Random Access Datasets (Experimental)
+=====================================
 
 Datasets can be converted to a format that supports efficient random access with
 :meth:`ds.to_random_access_dataset() API <ray.data.Dataset.to_random_access_dataset>`,

--- a/doc/source/data/dataset-tensor-support.rst
+++ b/doc/source/data/dataset-tensor-support.rst
@@ -145,6 +145,8 @@ This dataset can then be written to Parquet files. The tensor column schema will
     # -> one: int64
     #    two: extension<arrow.py_extension_type<ArrowTensorType>>
 
+.. _datasets_tensor_ml_exchange:
+
 Converting to a Torch/TensorFlow Dataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -223,7 +225,7 @@ Torch/TensorFlow tensor without incurring any copies.
     for X, y in tf_ds:
         # Train model(X, y)
 
-If your columns have different types **OR** your (tensor) columns have different shapes,
+If your (tensor) columns have different shapes,
 these columns are incompatible and you will not be able to stack the column tensors
 into a single tensor. Instead, you will need to group the columns by compatibility in
 the ``feature_columns`` argument.

--- a/doc/source/data/doc_code/accessing_datasets.py
+++ b/doc/source/data/doc_code/accessing_datasets.py
@@ -1,0 +1,238 @@
+# flake8: noqa
+
+# fmt: off
+# __take_begin__
+import ray
+
+ds = ray.data.range(10000)
+
+print(ds.take(5))
+# -> [0, 1, 2, 3, 4]
+
+# Warning: This will print all of the rows!
+print(ds.take_all())
+
+ds.show(5)
+# -> 0
+#    1
+#    2
+#    3
+#    4
+# __take_end__
+# fmt: on
+
+# fmt: off
+# __iter_rows_begin__
+import ray
+
+ds = ray.data.range(10000)
+num_rows = 0
+
+# Consume all rows in the Dataset.
+for row in ds.iter_rows():
+    assert isinstance(row, int)
+    num_rows += 1
+
+print(num_rows)
+# -> 10000
+# __iter_rows_end__
+# fmt: on
+
+# fmt: off
+# __iter_batches_begin__
+import ray
+import pandas as pd
+
+ds = ray.data.range(10000)
+num_batches = 0
+
+# Consume all batches in the Dataset.
+for batch in ds.iter_batches(batch_size=2):
+    assert isinstance(batch, list)
+    num_batches += 1
+
+print(num_batches)
+# -> 5000
+
+# Consume data as Pandas DataFrame batches.
+cum_sum = 0
+for batch in ds.iter_batches(batch_size=2, batch_format="pandas"):
+    assert isinstance(batch, pd.DataFrame)
+    # Simple integer Dataset is converted to a single-column Pandas DataFrame.
+    cum_sum += batch["value"]
+print(cum_sum)
+# -> 49995000
+
+# __iter_batches_end__
+# fmt: on
+
+# fmt: off
+# __remote_iterators_begin__
+import ray
+
+@ray.remote
+def consume(data: ray.data.Dataset[int]) -> int:
+    num_batches = 0
+    # Consume data in 2-record batches.
+    for batch in data.iter_batches(batch_size=2):
+        assert len(batch) == 2
+        num_batches += 1
+    return num_batches
+
+ds = ray.data.range(10000)
+ray.get(consume.remote(ds))
+# -> 5000
+# __remote_iterators_end__
+# fmt: on
+
+# fmt: off
+# __torch_begin__
+import ray
+import torch
+
+ds = ray.data.range(10000)
+
+torch_ds: torch.utils.data.IterableDataset = ds.to_torch(batch_size=2)
+
+num_batches = 0
+for batch, _ in torch_ds:
+    assert isinstance(batch, torch.Tensor)
+    assert batch.size(dim=0) == 2
+    num_batches += 1
+
+print(num_batches)
+# -> 5000
+# __torch_end__
+# fmt: on
+
+# fmt: off
+# __torch_with_label_begin__
+import ray
+import torch
+import pandas as pd
+
+df = pd.DataFrame({
+    "feature1": list(range(4)),
+    "feature2": [2 * i for i in range(4)],
+    "label": [True, False, True, False],
+})
+ds = ray.data.from_pandas(df)
+
+# Specify the label column; all other columns will be treated as feature columns and
+# will be concatenated into the same Torch tensor.
+# We set unsqueeze_label_tensor=False in order to remove a redundant unit column
+# dimension.
+torch_ds: torch.utils.data.IterableDataset = ds.to_torch(
+    label_column="label",
+    batch_size=2,
+    unsqueeze_label_tensor=False,
+)
+
+num_batches = 0
+for feature, label in torch_ds:
+    assert isinstance(feature, torch.Tensor)
+    assert isinstance(label, torch.Tensor)
+    # Batch dimension.
+    assert feature.size(dim=0) == 2
+    # Column dimension.
+    assert feature.size(dim=1) == 2
+    # Batch dimension.
+    assert label.size(dim=0) == 2
+    num_batches += 1
+
+print(num_batches)
+# -> 2
+# __torch_with_label_end__
+# fmt: on
+
+# fmt: off
+# __tf_begin__
+import ray
+import tensorflow as tf
+
+ds = ray.data.range(10000)
+
+tf_ds: tf.data.Dataset = ds.to_tf(
+    batch_size=2,
+    output_signature=tf.TensorSpec(shape=(None, 1), dtype=tf.int64),
+)
+
+num_batches = 0
+for batch in tf_ds:
+    assert isinstance(batch, tf.Tensor)
+    assert batch.shape[0] == 2, batch.shape
+    num_batches += 1
+
+print(num_batches)
+# -> 5000
+# __tf_end__
+# fmt: on
+
+# fmt: off
+# __tf_with_label_begin__
+import ray
+import tensorflow as tf
+import pandas as pd
+
+df = pd.DataFrame({
+    "feature1": list(range(4)),
+    "feature2": [2 * i for i in range(4)],
+    "label": [True, False, True, False],
+})
+ds = ray.data.from_pandas(df)
+
+# Specify the label column; all other columns will be treated as feature columns and
+# will be concatenated into the same TensorFlow tensor.
+tf_ds: tf.data.Dataset = ds.to_tf(
+    label_column="label",
+    batch_size=2,
+    output_signature=(
+        tf.TensorSpec(shape=(None, 2), dtype=tf.int64),
+        tf.TensorSpec(shape=(None,), dtype=tf.int64),
+    ),
+)
+
+num_batches = 0
+for feature, label in tf_ds:
+    assert isinstance(feature, tf.Tensor)
+    assert isinstance(label, tf.Tensor)
+    # Batch dimension.
+    assert feature.shape[0] == 2
+    # Column dimension.
+    assert feature.shape[1] == 2
+    # Batch dimension.
+    assert label.shape[0] == 2
+    num_batches += 1
+
+print(num_batches)
+# -> 2
+# __tf_with_label_end__
+# fmt: on
+
+# fmt: off
+# __split_begin__
+# @ray.remote(num_gpus=1)  # Uncomment this to run on GPUs.
+@ray.remote
+class Worker:
+    def __init__(self, rank: int):
+        pass
+
+    def train(self, shard: ray.data.Dataset[int]) -> int:
+        for batch in shard.to_torch(batch_size=256):
+            pass
+        return shard.count()
+
+workers = [Worker.remote(i) for i in range(4)]
+# -> [Actor(Worker, ...), Actor(Worker, ...), ...]
+
+ds = ray.data.range(10000)
+# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)
+
+shards = ds.split(n=4, locality_hints=workers)
+# -> [Dataset(num_blocks=13, num_rows=2500, schema=<class 'int'>),
+#     Dataset(num_blocks=13, num_rows=2500, schema=<class 'int'>), ...]
+
+ray.get([w.train.remote(s) for w, s in zip(workers, shards)])
+# -> [2500, 2500, 2500, 2500]
+# __split_end__
+# fmt: on

--- a/doc/source/data/random-access.rst
+++ b/doc/source/data/random-access.rst
@@ -1,3 +1,5 @@
+.. _datasets_random_access:
+
 ---------------------------------
 Random Data Access (Experimental)
 ---------------------------------


### PR DESCRIPTION
This PR overhauls the "Accessing Datasets", adding proper coverage of each data consuming methods, including the ML framework exchange APIs (`to_torch()` and `to_tf()`).

Docs preview: https://ray--24963.org.readthedocs.build/en/24963/

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
