### PR TITLE
use an agent-id rather than the process PID

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -43,18 +43,19 @@ class DashboardAgent(object):
         dashboard_agent_port,
         gcs_address,
         minimal,
-        temp_dir=None,
-        session_dir=None,
-        runtime_env_dir=None,
-        log_dir=None,
         metrics_export_port=None,
         node_manager_port=None,
         listen_port=0,
-        object_store_name=None,
-        raylet_name=None,
-        logging_params=None,
         disable_metrics_collection: bool = False,
-        agent_id: int = os.getpid(),
+        *,  # the following are required kwargs
+        object_store_name: str,
+        raylet_name: str,
+        log_dir: str,
+        temp_dir: str,
+        session_dir: str,
+        runtime_env_dir: str,
+        logging_params: dict,
+        agent_id: int,
     ):
         """Initialize the DashboardAgent object."""
         # Public attributes are accessible for all agent modules.

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -205,7 +205,7 @@ class DashboardAgent(object):
 
         await raylet_stub.RegisterAgent(
             agent_manager_pb2.RegisterAgentRequest(
-                agent_pid=self.agent_id,
+                agent_id=self.agent_id,
                 agent_port=self.grpc_port,
                 agent_ip_address=self.ip,
             )
@@ -358,10 +358,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--agent-id",
-        required=False,
+        required=True,
         type=int,
-        default=os.getpid(),
-        help="ID to report register with raylet, default is {}.".format(os.getpid()),
+        help="ID to report when registering with raylet",
     )
 
     args = parser.parse_args()

--- a/src/ray/protobuf/agent_manager.proto
+++ b/src/ray/protobuf/agent_manager.proto
@@ -25,7 +25,7 @@ enum AgentRpcStatus {
 }
 
 message RegisterAgentRequest {
-  int32 agent_pid = 1;
+  int32 agent_id = 1;
   int32 agent_port = 2;
   string agent_ip_address = 3;
 }

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -57,6 +57,10 @@ void AgentManager::StartAgent() {
   }
 
   // Create a non-zero random agent_id to pass to the child process
+  // We cannot use pid an id because os.getpid() from the python process is not
+  // reliable when using a launcher.
+  // See https://github.com/ray-project/ray/issues/24361 and Python issue
+  // https://github.com/python/cpython/issues/83086
   int agent_id = 0;
   while (agent_id == 0) {
     agent_id = rand();

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -29,19 +29,19 @@ namespace raylet {
 void AgentManager::HandleRegisterAgent(const rpc::RegisterAgentRequest &request,
                                        rpc::RegisterAgentReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) {
-  agent_ip_address_ = request.agent_ip_address();
-  agent_port_ = request.agent_port();
-  agent_pid_ = request.agent_pid();
+  reported_agent_ip_address_ = request.agent_ip_address();
+  reported_agent_port_ = request.agent_port();
+  reported_agent_id_ = request.agent_id();
   // TODO(SongGuyang): We should remove this after we find better port resolution.
   // Note: `agent_port_` should be 0 if the grpc port of agent is in conflict.
-  if (agent_port_ != 0) {
-    runtime_env_agent_client_ =
-        runtime_env_agent_client_factory_(agent_ip_address_, agent_port_);
-    RAY_LOG(INFO) << "HandleRegisterAgent, ip: " << agent_ip_address_
-                  << ", port: " << agent_port_ << ", pid: " << agent_pid_;
+  if (reported_agent_port_ != 0) {
+    runtime_env_agent_client_ = runtime_env_agent_client_factory_(
+        reported_agent_ip_address_, reported_agent_port_);
+    RAY_LOG(INFO) << "HandleRegisterAgent, ip: " << reported_agent_ip_address_
+                  << ", port: " << reported_agent_port_ << ", id: " << reported_agent_id_;
   } else {
     RAY_LOG(WARNING) << "The GRPC port of the Ray agent is invalid (0), ip: "
-                     << agent_ip_address_ << ", pid: " << agent_pid_
+                     << reported_agent_ip_address_ << ", id: " << reported_agent_id_
                      << ". The agent client in the raylet has been disabled.";
     disable_agent_client_ = true;
   }
@@ -56,8 +56,11 @@ void AgentManager::StartAgent() {
     return;
   }
 
-  // Create a random agent_id to pass to the child process
-  int agent_id = rand();
+  // Create a non-zero random agent_id to pass to the child process
+  int agent_id = 0;
+  while (agent_id == 0) {
+    agent_id = rand();
+  }
   const std::string agent_id_str = std::to_string(agent_id);
   std::vector<const char *> argv;
   for (const std::string &arg : options_.agent_commands) {
@@ -101,10 +104,17 @@ void AgentManager::StartAgent() {
                   << RayConfig::instance().agent_register_timeout_ms() << "ms.";
     auto timer = delay_executor_(
         [this, child, agent_id]() mutable {
-          if (agent_pid_ != agent_id) {
-            RAY_LOG(WARNING) << "Agent process with id " << agent_id
-                             << " has not registered. ip " << agent_ip_address_ << ", id "
-                             << agent_pid_;
+          if (reported_agent_id_ != agent_id) {
+            if (reported_agent_id_ == 0) {
+              RAY_LOG(WARNING) << "Agent process expected id " << agent_id
+                               << " timed out before registering. ip "
+                               << reported_agent_ip_address_ << ", id "
+                               << reported_agent_id_;
+            } else {
+              RAY_LOG(WARNING) << "Agent process expected id " << agent_id
+                               << " but got id " << reported_agent_id_
+                               << ", this is a fatal error";
+            }
             child.Kill();
           }
         },
@@ -113,8 +123,8 @@ void AgentManager::StartAgent() {
     int exit_code = child.Wait();
     timer->cancel();
     RAY_LOG(WARNING) << "Agent process with id " << agent_id << " exit, return value "
-                     << exit_code << ". ip " << agent_ip_address_ << ". pid "
-                     << agent_pid_;
+                     << exit_code << ". ip " << reported_agent_ip_address_ << ". id "
+                     << reported_agent_id_;
     RAY_LOG(ERROR)
         << "The raylet exited immediately because the Ray agent failed. "
            "The raylet fate shares with the agent. This can happen because the "

--- a/src/ray/raylet/agent_manager.h
+++ b/src/ray/raylet/agent_manager.h
@@ -93,12 +93,12 @@ class AgentManager : public rpc::AgentManagerServiceHandler {
 
  private:
   Options options_;
-  pid_t agent_pid_ = 0;
-  int agent_port_ = 0;
+  pid_t reported_agent_id_ = 0;
+  int reported_agent_port_ = 0;
   /// Whether or not we intend to start the agent.  This is false if we
   /// are missing Ray Dashboard dependencies, for example.
   bool should_start_agent_ = true;
-  std::string agent_ip_address_;
+  std::string reported_agent_ip_address_;
   DelayExecutorFn delay_executor_;
   RuntimeEnvAgentClientFactoryFn runtime_env_agent_client_factory_;
   std::shared_ptr<rpc::RuntimeEnvAgentClientInterface> runtime_env_agent_client_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using ray inside a virtualenv on windows, `python.exe` as reported by `sys.executable` is a PEP397 launcher to the actual python as reported by `os.getpid()`:
```
>>> import sys, os, psutil
>>> >>> print(sys.executable)
C:\temp\issue24361\Scripts\python.exe
>>> os.getpid()
2208
>>> child = psutil.Process(2208)
>>> child.cmdline()
['C:\\oss\\CPython38\\python.exe']
>>> child.parent().cmdline()
['C:\\temp\\issue24361\\Scripts\\python.exe']
>>> child.parent().pid
6424
```

When the `agent_manager` launches the agent process via `Process::Process()`, it gets the PID of the launcher process (6424), which is what is expected as an ID when registering the agent in the gRPC callback. But inside `agent.py`, the child process reports the PID via `os.getpid()`, which is 2208, and this is the wrong PID to register the agent.

The solution proposed here is another version of #24905 that creates a `int agent_id = rand();` before starting the python process, and passes the `agent_id` to the process.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24361, #23945

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
