### PR TITLE
[tune] File lock for syncing

### DIFF
--- a/python/ray/ml/utils/remote_storage.py
+++ b/python/ray/ml/utils/remote_storage.py
@@ -1,4 +1,5 @@
 import urllib.parse
+from filelock import FileLock
 from typing import Optional, Tuple
 
 try:
@@ -156,7 +157,8 @@ def download_from_uri(uri: str, local_path: str):
             f"Hint: {fs_hint(uri)}"
         )
 
-    pyarrow.fs.copy_files(bucket_path, local_path, source_filesystem=fs)
+    with FileLock(f"{local_path}.lock"):
+        pyarrow.fs.copy_files(bucket_path, local_path, source_filesystem=fs)
 
 
 def upload_to_uri(local_path: str, uri: str):

--- a/python/ray/tune/utils/file_transfer.py
+++ b/python/ray/tune/utils/file_transfer.py
@@ -370,7 +370,7 @@ def _unpack_from_actor(pack_actor: ray.ActorID, target_dir: str) -> None:
 def _copy_dir(source_dir: str, target_dir: str) -> None:
     """Copy dir with shutil on the actor."""
     with FileLock(f"{target_dir}.lock"):
-        _delete_path_unsafe(target_dir, filelock=False)
+        _delete_path_unsafe(target_dir)
         shutil.copytree(source_dir, target_dir)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds file locking to prevent parallel file system operations to Tune/AIR syncing functions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
