### PR TITLE
[Core] Use newly pushed actor for existing pending tasks

### DIFF
--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -220,7 +220,7 @@ def test_push(init):
             return 2 * x
 
     a1, a2, a3 = MyActor.remote(), MyActor.remote(), MyActor.remote()
-    pool = ActorPoolCustom([a1])
+    pool = ActorPool([a1])
 
     pool.submit(lambda a, v: a.double.remote(v), 1)
     assert pool.has_free() is False  # actor is busy

--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -234,7 +234,7 @@ def test_push(init):
     assert pool.has_free() is False
     assert len(pool._pending_submits) == 1
     pool.push(a3)
-    assert pool.has_free() is False # a3 is used for pending submit
+    assert pool.has_free() is False  # a3 is used for pending submit
     assert len(pool._pending_submits) == 0
 
 

--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -219,8 +219,8 @@ def test_push(init):
         def double(self, x):
             return 2 * x
 
-    a1, a2 = MyActor.remote(), MyActor.remote()
-    pool = ActorPool([a1])
+    a1, a2, a3 = MyActor.remote(), MyActor.remote(), MyActor.remote()
+    pool = ActorPoolCustom([a1])
 
     pool.submit(lambda a, v: a.double.remote(v), 1)
     assert pool.has_free() is False  # actor is busy
@@ -228,6 +228,14 @@ def test_push(init):
         pool.push(a1)
     pool.push(a2)
     assert pool.has_free()  # a2 is available
+
+    pool.submit(lambda a, v: a.double.remote(v), 1)
+    pool.submit(lambda a, v: a.double.remote(v), 1)
+    assert pool.has_free() is False
+    assert len(pool._pending_submits) == 1
+    pool.push(a3)
+    assert pool.has_free() is False # a3 is used for pending submit
+    assert len(pool._pending_submits) == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -315,4 +315,4 @@ class ActorPool:
         if actor in self._idle_actors or actor in busy_actors:
             raise ValueError("Actor already belongs to current ActorPool")
         else:
-            self._idle_actors.append(actor)
+            self._return_actor(actor)


### PR DESCRIPTION
## Why are these changes needed?
Newly pushed actors will never be used with existing pending submits, so the worker will not be used to speed up existing tasks. If _return_actor is called at the end of push instead, the actor is pushed to _idle_actors and immediately used if there are pending submits.

## Related issue number
Closes #24921

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
