### PR TITLE
[flakey] Deflakey `test_gcs_fault_tollerance.py` 

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -285,6 +285,9 @@ def test_worker_raylet_resubscription(tmp_path, ray_start_regular_with_external_
     ray.worker._global_node.kill_gcs_server()
     ray.worker._global_node.start_gcs_server()
     # make sure resubscription is done
+    # TODO(iycheng): The current way of resubscription potentially will lose
+    # worker failure message because we don't ask for the snapshot of worker
+    # status for now. We need to fix it.
     sleep(4)
 
     # then kill the owner

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -243,7 +243,7 @@ def test_del_actor_after_gcs_server_restart(ray_start_regular_with_external_redi
     ],
     indirect=True,
 )
-def test_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
+def test_worker_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
     # This test is to make sure resubscription in raylet is working.
     # When subscription failed, raylet will not get worker failure error
     # and thus, it won't kill the worker which is fate sharing with the failed
@@ -283,12 +283,13 @@ def test_raylet_resubscription(tmp_path, ray_start_regular_with_external_redis):
 
     # kill the gcs
     ray.worker._global_node.kill_gcs_server()
+    ray.worker._global_node.start_gcs_server()
+    # make sure resubscription is done
+    sleep(4)
 
     # then kill the owner
     p = psutil.Process(pid)
     p.kill()
-
-    ray.worker._global_node.start_gcs_server()
 
     # The long_run_pid should exit
     wait_for_pid_to_exit(long_run_pid, 5)

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -847,6 +847,8 @@ Status WorkerInfoAccessor::AsyncSubscribeToWorkerFailures(
 }
 
 void WorkerInfoAccessor::AsyncResubscribe() {
+  // TODO(iycheng): Fix the case where messages has been pushed to GCS but
+  // resubscribe hasn't been done yet. In this case, we'll lose that message.
   RAY_LOG(DEBUG) << "Reestablishing subscription for worker failures.";
   // The pub-sub server has restarted, we need to resubscribe to the pub-sub server.
   if (subscribe_operation_ != nullptr) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There is a race condition where the failure message is sent but resubscription hasn't been established. In this case, we'll lose this message.

This PR fixes the test case only by making sure resubscription is done before killing the worker.

We are not going to fix this issue for the first version of GCS HA because:
1. Right now, only failed worker will be reported and it'll be used to eagerly kill the unnecessary workers. From correctness, it's ok.
2. worker/task support is not P0 for GCS HA (Ray Serve). Actor doesn't have this issue since the subscription for the actor is by actor id and raylet will fetch the actor status when resubscribing.

Things are not working:
- we won't kill workers which are not useful anymore. So for a very extreme case (the worker hangs), it'll have a resource leak.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
