### PR TITLE
[Core] Fix initization order of GcsServerAddressUpdater members

### DIFF
--- a/src/ray/core_worker/gcs_server_address_updater.h
+++ b/src/ray/core_worker/gcs_server_address_updater.h
@@ -38,11 +38,11 @@ class GcsServerAddressUpdater {
   /// Update gcs server address.
   void UpdateGcsServerAddress();
 
+  instrumented_io_context updater_io_service_;
   rpc::ClientCallManager client_call_manager_;
   /// A client connection to the raylet.
   raylet::RayletClient raylet_client_;
   std::function<void(std::string, int)> update_func_;
-  instrumented_io_context updater_io_service_;
   PeriodicalRunner updater_runner_;
   std::thread updater_thread_;
   int32_t failed_ping_count_ = 0;


### PR DESCRIPTION
## Why are these changes needed?

This change allows `bazel build -c fastbuild //:ray_pkg` to successfully build. Without this change, the build fails due to `GcsServerAddressUpdater.updater_io_service_` being uninitialized; this happens as a result of the `GcsServerAddressUpdater` constructor trying to initialize `client_call_manager_(updater_io_service_)` first.

## Related issue number

Closes #24984 by moving the `updater_io_service_` member of `GcsServerAddressUpdater` to above the `client_call_manager_` in order to initialize it first.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

**Note**: I'm still learning about the test suite on this project; I've run `bazel test $(bazel query 'kind(cc_test, ...)') --copt="-w"` locally a few times and gotten a few different failures each time. I'm assuming these are flaky tests.