### PR TITLE
[Doc] Fix ray core doc

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -406,7 +406,7 @@ The runtime environment is inheritable, so it will apply to all tasks/actors wit
   # ChildActor's actual `runtime_env` (specify runtime_env overrides)
   {"env_vars": {"A": "a", "B": "b"}}
 
-3. If you'd like to still use current runtime env, you can use the API :ref:`ray.get_current_runtime_env() <runtime-env-apis>` to get the current runtime env and modify it by yourself.
+3. If you'd like to still use current runtime env, you can use the API :ref:`ray.get_runtime_context().runtime_env <runtime-context-apis>` to get the current runtime env and modify it by yourself.
 
 .. code-block:: python
 

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -182,11 +182,13 @@ class RuntimeContext(object):
         current runtime env by this API and modify it by yourself.
 
         Example:
-        >>> # Inherit current runtime env, except `env_vars`
-        >>> Actor.options( # doctest: +SKIP
-        ...     runtime_env=ray.get_runtime_context().runtime_env.update(
-        ...     {"env_vars": {"A": "a", "B": "b"}})
-        ... ) # doctest: +SKIP
+
+            >>> # Inherit current runtime env, except `env_vars`
+            >>> Actor.options( # doctest: +SKIP
+            ...     runtime_env=ray.get_runtime_context().runtime_env.update(
+            ...     {"env_vars": {"A": "a", "B": "b"}})
+            ... )
+
         """
 
         return RuntimeEnv.deserialize(self._get_runtime_env_string())
@@ -226,11 +228,13 @@ def get_runtime_context():
     """Get the runtime context of the current driver/worker.
 
     Example:
-    >>> import ray
-    >>> # Get the job id.
-    >>> ray.get_runtime_context().job_id # doctest: +SKIP
-    >>> # Get all the metadata.
-    >>> ray.get_runtime_context().get() # doctest: +SKIP
+
+        >>> import ray
+        >>> # Get the job id.
+        >>> ray.get_runtime_context().job_id # doctest: +SKIP
+        >>> # Get all the metadata.
+        >>> ray.get_runtime_context().get() # doctest: +SKIP
+
     """
     global _runtime_context
     if _runtime_context is None:

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -53,12 +53,14 @@ class PlacementGroup:
         It is compatible to ray.get and ray.wait.
 
         Example:
-        >>> import ray
-        >>> from ray.util.placement_group import PlacementGroup
-        >>> pg = PlacementGroup([{"CPU": 1}]) # doctest: +SKIP
-        >>> ray.get(pg.ready()) # doctest: +SKIP
-        >>> pg = PlacementGroup([{"CPU": 1}]) # doctest: +SKIP
-        >>> ray.wait([pg.ready()], timeout=0) # doctest: +SKIP
+
+            >>> import ray
+            >>> from ray.util.placement_group import PlacementGroup
+            >>> pg = PlacementGroup([{"CPU": 1}]) # doctest: +SKIP
+            >>> ray.get(pg.ready()) # doctest: +SKIP
+            >>> pg = PlacementGroup([{"CPU": 1}]) # doctest: +SKIP
+            >>> ray.wait([pg.ready()], timeout=0) # doctest: +SKIP
+
         """
         self._fill_bundle_cache_if_needed()
 


### PR DESCRIPTION
## Why are these changes needed?

- Fix bad doc like:
![image](https://user-images.githubusercontent.com/26714159/169446594-30ecb2cf-0fe4-4fde-b206-58ce3c2f704a.png)
- Use the API `ray.get_runtime_context().runtime_env` instead of `ray.get_current_runtime_env()`