### PR TITLE
[RLlib] introduce utils to serialize gym spaces and view requirements

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1504,7 +1504,7 @@ py_test(
 # --------------------------------------------------------------------
 
 py_test(
-    name = "test_utils_serialization",
+    name = "test_serialization",
     tags = ["team:ml", "utils"],
     size = "large",
     srcs = ["utils/tests/test_serialization.py"]

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1488,12 +1488,27 @@ py_test(
     srcs = ["policy/tests/test_sample_batch.py"]
 )
 
+py_test(
+    name = "policy/tests/test_view_requirement",
+    tags = ["team:ml", "policy"],
+    size = "small",
+    srcs = ["policy/tests/test_view_requirement.py"]
+)
+
+
 # --------------------------------------------------------------------
 # Utils:
 # rllib/utils/
 #
 # Tag: utils
 # --------------------------------------------------------------------
+
+py_test(
+    name = "test_utils_serialization",
+    tags = ["team:ml", "utils"],
+    size = "large",
+    srcs = ["utils/tests/test_serialization.py"]
+)
 
 py_test(
     name = "test_curiosity",

--- a/rllib/policy/tests/test_view_requirement.py
+++ b/rllib/policy/tests/test_view_requirement.py
@@ -17,7 +17,7 @@ class TestViewRequirement(unittest.TestCase):
         )
         d = vr.to_dict()
         self.assertEqual(d["data_col"], "obs")
-        self.assertEqual(d["space"]["type"], "box")
+        self.assertEqual(d["space"]["space"], "box")
 
         # Make sure serialized dict is JSON serializable.
         s = json.dumps(d)

--- a/rllib/policy/tests/test_view_requirement.py
+++ b/rllib/policy/tests/test_view_requirement.py
@@ -1,0 +1,38 @@
+import gym
+import json
+import unittest
+
+from ray.rllib.policy.view_requirement import ViewRequirement
+
+
+class TestViewRequirement(unittest.TestCase):
+    def test_serialize_view_requirement(self):
+        """Test serializing simple ViewRequirement into JSON serializable dict"""
+        vr = ViewRequirement(
+            "obs",
+            shift=[-1],
+            used_for_training=False,
+            used_for_compute_actions=True,
+            batch_repeat_value=1,
+        )
+        d = vr.to_dict()
+        self.assertEqual(d["data_col"], "obs")
+        self.assertEqual(d["space"]["type"], "box")
+
+        # Make sure serialized dict is JSON serializable.
+        s = json.dumps(d)
+        d2 = json.loads(s)
+
+        self.assertEqual(d2["used_for_training"], False)
+        self.assertEqual(d2["used_for_compute_actions"], True)
+
+        vr2 = ViewRequirement.from_dict(d2)
+        self.assertEqual(vr2.data_col, "obs")
+        self.assertTrue(isinstance(vr2.space, gym.spaces.Box))
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/policy/view_requirement.py
+++ b/rllib/policy/view_requirement.py
@@ -1,8 +1,11 @@
 import gym
-import numpy as np
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.serialization import (
+    gym_space_to_dict,
+    gym_space_from_dict,
+)
 
 torch, _ = try_import_torch()
 
@@ -74,8 +77,6 @@ class ViewRequirement:
         )
 
         self.shift = shift
-        if isinstance(self.shift, (list, tuple)):
-            self.shift = np.array(self.shift)
 
         # Special case: Providing a (probably larger) range of indices, e.g.
         # "-100:0" (past 100 timesteps plus current one).
@@ -90,3 +91,40 @@ class ViewRequirement:
 
         self.used_for_compute_actions = used_for_compute_actions
         self.used_for_training = used_for_training
+
+    def __str__(self):
+        """For easier inspection of view requirements."""
+        return "|".join(
+            [
+                str(v)
+                for v in [
+                    self.data_col,
+                    self.space,
+                    self.shift,
+                    self.shift_from,
+                    self.shift_to,
+                    self.index,
+                    self.batch_repeat_value,
+                    self.used_for_training,
+                    self.used_for_compute_actions,
+                ]
+            ]
+        )
+
+    def to_dict(self) -> Dict:
+        """Return a dict for this ViewRequirement that can be JSON serialized."""
+        return {
+            "data_col": self.data_col,
+            "space": gym_space_to_dict(self.space),
+            "shift": self.shift,
+            "index": self.index,
+            "batch_repeat_value": self.batch_repeat_value,
+            "used_for_training": self.used_for_training,
+            "used_for_compute_actions": self.used_for_compute_actions,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict):
+        """Construct a ViewRequirement instance from JSON deserialized dict."""
+        d["space"] = gym_space_from_dict(d["space"])
+        return cls(**d)

--- a/rllib/utils/serialization.py
+++ b/rllib/utils/serialization.py
@@ -6,32 +6,42 @@ from typing import Dict
 import zlib
 
 
-def serialize_ndarray(d: np.ndarray) -> str:
+def serialize_ndarray(array: np.ndarray) -> str:
     """Pack numpy ndarray into Base64 encoded strings for serialization.
 
     This function uses numpy.save() instead of pickling to ensure
     compatibility.
 
     Args:
-        d: numpy ndarray.
+        array: numpy ndarray.
 
     Returns:
         b64 escaped string.
     """
     buf = io.BytesIO()
-    np.save(buf, d)
+    np.save(buf, array)
     return base64.b64encode(zlib.compress(buf.getvalue())).decode("ascii")
 
 
-def deserialize_ndarray(s: str) -> np.ndarray:
-    return np.load(io.BytesIO(zlib.decompress(base64.b64decode(s))))
+def deserialize_ndarray(b64_string: str) -> np.ndarray:
+    """Unpack b64 escaped string into numpy ndarray.
+
+    This function assumes the unescaped bytes are of npy format.
+
+    Args:
+        b64_string: Base64 escaped string.
+
+    Returns:
+        numpy ndarray.
+    """
+    return np.load(io.BytesIO(zlib.decompress(base64.b64decode(b64_string))))
 
 
-def gym_space_to_dict(sp: gym.spaces.Space) -> Dict:
+def gym_space_to_dict(space: gym.spaces.Space) -> Dict:
     """Serialize a gym Space into JSON-serializable dict.
 
     Args:
-        sp: gym.spaces.Space
+        space: gym.spaces.Space
 
     Returns:
         Serialized JSON string.
@@ -39,7 +49,7 @@ def gym_space_to_dict(sp: gym.spaces.Space) -> Dict:
 
     def _box(sp: gym.spaces.Box) -> Dict:
         return {
-            "type": "box",
+            "space": "box",
             "low": serialize_ndarray(sp.low),
             "high": serialize_ndarray(sp.high),
             "shape": sp._shape,  # shape is a tuple.
@@ -48,7 +58,7 @@ def gym_space_to_dict(sp: gym.spaces.Space) -> Dict:
 
     def _discrete(sp: gym.spaces.Discrete) -> Dict:
         d = {
-            "type": "discrete",
+            "space": "discrete",
             "n": sp.n,
         }
         # Offset is a relatively new Discrete space feature.
@@ -58,35 +68,35 @@ def gym_space_to_dict(sp: gym.spaces.Space) -> Dict:
 
     def _multi_discrete(sp: gym.spaces.MultiDiscrete) -> Dict:
         return {
-            "type": "multi-discrete",
+            "space": "multi-discrete",
             "nvec": serialize_ndarray(sp.nvec),
             "dtype": sp.dtype.str,
         }
 
     def _tuple(sp: gym.spaces.Tuple) -> Dict:
         return {
-            "type": "tuple",
+            "space": "tuple",
             "spaces": [gym_space_to_dict(sp) for sp in sp.spaces],
         }
 
     def _dict(sp: gym.spaces.Dict) -> Dict:
         return {
-            "type": "dict",
+            "space": "dict",
             "spaces": {k: gym_space_to_dict(sp) for k, sp in sp.spaces.items()},
         }
 
-    if isinstance(sp, gym.spaces.Box):
-        return _box(sp)
-    elif isinstance(sp, gym.spaces.Discrete):
-        return _discrete(sp)
-    elif isinstance(sp, gym.spaces.MultiDiscrete):
-        return _multi_discrete(sp)
-    elif isinstance(sp, gym.spaces.Tuple):
-        return _tuple(sp)
-    elif isinstance(sp, gym.spaces.Dict):
-        return _dict(sp)
+    if isinstance(space, gym.spaces.Box):
+        return _box(space)
+    elif isinstance(space, gym.spaces.Discrete):
+        return _discrete(space)
+    elif isinstance(space, gym.spaces.MultiDiscrete):
+        return _multi_discrete(space)
+    elif isinstance(space, gym.spaces.Tuple):
+        return _tuple(space)
+    elif isinstance(space, gym.spaces.Dict):
+        return _dict(space)
     else:
-        raise ValueError("Unknown space type for serialization, ", type(sp))
+        raise ValueError("Unknown space type for serialization, ", type(space))
 
 
 def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
@@ -101,7 +111,7 @@ def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
 
     def __common(d: Dict):
         """Common updates to the dict before we use it to construct spaces"""
-        del d["type"]
+        del d["space"]
         if "dtype" in d:
             d["dtype"] = np.dtype(d["dtype"])
         return d
@@ -134,16 +144,16 @@ def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
         spaces = {k: gym_space_from_dict(sp) for k, sp in d["spaces"].items()}
         return gym.spaces.Dict(spaces=spaces)
 
-    type = d["type"]
-    if type == "box":
-        return _box(d)
-    elif type == "discrete":
-        return _discrete(d)
-    elif type == "multi-discrete":
-        return _multi_discrete(d)
-    elif type == "tuple":
-        return _tuple(d)
-    elif type == "dict":
-        return _dict(d)
-    else:
-        raise ValueError("Unknown space type for de-serialization, ", type)
+    space_map = {
+        "box": _box,
+        "discrete": _discrete,
+        "multi-discrete": _multi_discrete,
+        "tuple": _tuple,
+        "dict": _dict,
+    }
+
+    space_type = d["space"]
+    if space_type not in space_map:
+        raise ValueError("Unknown space type for de-serialization, ", space_type)
+
+    return space_map[space_type](d)

--- a/rllib/utils/serialization.py
+++ b/rllib/utils/serialization.py
@@ -1,0 +1,149 @@
+import base64
+import gym
+import io
+import numpy as np
+from typing import Dict
+import zlib
+
+
+def serialize_ndarray(d: np.ndarray) -> str:
+    """Pack numpy ndarray into Base64 encoded strings for serialization.
+
+    This function uses numpy.save() instead of pickling to ensure
+    compatibility.
+
+    Args:
+        d: numpy ndarray.
+
+    Returns:
+        b64 escaped string.
+    """
+    buf = io.BytesIO()
+    np.save(buf, d)
+    return base64.b64encode(zlib.compress(buf.getvalue())).decode("ascii")
+
+
+def deserialize_ndarray(s: str) -> np.ndarray:
+    return np.load(io.BytesIO(zlib.decompress(base64.b64decode(s))))
+
+
+def gym_space_to_dict(sp: gym.spaces.Space) -> Dict:
+    """Serialize a gym Space into JSON-serializable dict.
+
+    Args:
+        sp: gym.spaces.Space
+
+    Returns:
+        Serialized JSON string.
+    """
+
+    def _box(sp: gym.spaces.Box) -> Dict:
+        return {
+            "type": "box",
+            "low": serialize_ndarray(sp.low),
+            "high": serialize_ndarray(sp.high),
+            "shape": sp._shape,  # shape is a tuple.
+            "dtype": sp.dtype.str,
+        }
+
+    def _discrete(sp: gym.spaces.Discrete) -> Dict:
+        d = {
+            "type": "discrete",
+            "n": sp.n,
+        }
+        # Offset is a relatively new Discrete space feature.
+        if hasattr(sp, "start"):
+            d["start"] = sp.start
+        return d
+
+    def _multi_discrete(sp: gym.spaces.MultiDiscrete) -> Dict:
+        return {
+            "type": "multi-discrete",
+            "nvec": serialize_ndarray(sp.nvec),
+            "dtype": sp.dtype.str,
+        }
+
+    def _tuple(sp: gym.spaces.Tuple) -> Dict:
+        return {
+            "type": "tuple",
+            "spaces": [gym_space_to_dict(sp) for sp in sp.spaces],
+        }
+
+    def _dict(sp: gym.spaces.Dict) -> Dict:
+        return {
+            "type": "dict",
+            "spaces": {k: gym_space_to_dict(sp) for k, sp in sp.spaces.items()},
+        }
+
+    if isinstance(sp, gym.spaces.Box):
+        return _box(sp)
+    elif isinstance(sp, gym.spaces.Discrete):
+        return _discrete(sp)
+    elif isinstance(sp, gym.spaces.MultiDiscrete):
+        return _multi_discrete(sp)
+    elif isinstance(sp, gym.spaces.Tuple):
+        return _tuple(sp)
+    elif isinstance(sp, gym.spaces.Dict):
+        return _dict(sp)
+    else:
+        raise ValueError("Unknown space type for serialization, ", type(sp))
+
+
+def gym_space_from_dict(d: Dict) -> gym.spaces.Space:
+    """De-serialize a dict into gym Space.
+
+    Args:
+        str: serialized JSON str.
+
+    Returns:
+        De-serialized gym space.
+    """
+
+    def __common(d: Dict):
+        """Common updates to the dict before we use it to construct spaces"""
+        del d["type"]
+        if "dtype" in d:
+            d["dtype"] = np.dtype(d["dtype"])
+        return d
+
+    def _box(d: Dict) -> gym.spaces.Box:
+        d.update(
+            {
+                "low": deserialize_ndarray(d["low"]),
+                "high": deserialize_ndarray(d["high"]),
+            }
+        )
+        return gym.spaces.Box(**__common(d))
+
+    def _discrete(d: Dict) -> gym.spaces.Discrete:
+        return gym.spaces.Discrete(**__common(d))
+
+    def _multi_discrete(d: Dict) -> gym.spaces.Discrete:
+        d.update(
+            {
+                "nvec": deserialize_ndarray(d["nvec"]),
+            }
+        )
+        return gym.spaces.MultiDiscrete(**__common(d))
+
+    def _tuple(d: Dict) -> gym.spaces.Discrete:
+        spaces = [gym_space_from_dict(sp) for sp in d["spaces"]]
+        return gym.spaces.Tuple(spaces=spaces)
+
+    def _dict(d: Dict) -> gym.spaces.Discrete:
+        spaces = {k: gym_space_from_dict(sp) for k, sp in d["spaces"].items()}
+        return gym.spaces.Dict(spaces=spaces)
+
+    type = d["type"]
+    if type == "box":
+        return _box(d)
+    elif type == "discrete":
+        return _discrete(d)
+    elif type == "multi-discrete":
+        return _multi_discrete(d)
+    elif type == "tuple":
+        return _tuple(d)
+    elif type == "dict":
+        return _dict(d)
+    else:
+        raise ValueError("Unknown space type for de-serialization, ", type)

--- a/rllib/utils/tests/test_serialization.py
+++ b/rllib/utils/tests/test_serialization.py
@@ -1,0 +1,109 @@
+import gym
+import numpy as np
+import unittest
+
+from ray.rllib.utils.serialization import (
+    gym_space_from_dict,
+    gym_space_to_dict,
+)
+
+
+def _assert_array_equal(eq, a1, a2, margin=None):
+    if margin:
+        for a in zip(a1, a2):
+            eq(a[0], a[1], margin)
+    else:
+        for a in zip(a1, a2):
+            eq(a[0], a[1])
+
+
+class TestGymCheckEnv(unittest.TestCase):
+    def test_box_space(self):
+        env = gym.make("CartPole-v0")
+        d = gym_space_to_dict(env.observation_space)
+        sp = gym_space_from_dict(d)
+
+        obs_space = env.observation_space
+        _assert_array_equal(
+            self.assertAlmostEqual, sp.low.tolist(), obs_space.low.tolist(), 0.001
+        )
+        _assert_array_equal(
+            self.assertAlmostEqual, sp.high.tolist(), obs_space.high.tolist(), 0.001
+        )
+        _assert_array_equal(self.assertEqual, sp._shape, obs_space._shape)
+        self.assertEqual(sp.dtype, obs_space.dtype)
+
+    def test_discrete_space(self):
+        env = gym.make("CartPole-v0")
+        d = gym_space_to_dict(env.action_space)
+        sp = gym_space_from_dict(d)
+
+        action_space = env.action_space
+        self.assertEqual(sp.n, action_space.n)
+
+    def test_multi_discrete_space(self):
+        md_space = gym.spaces.MultiDiscrete(nvec=np.array([3, 4, 5]))
+        d = gym_space_to_dict(md_space)
+        sp = gym_space_from_dict(d)
+
+        _assert_array_equal(self.assertAlmostEqual, sp.nvec, md_space.nvec, 0.001)
+        self.assertEqual(md_space.dtype, sp.dtype)
+
+    def test_tuple_space(self):
+        env = gym.make("CartPole-v0")
+        space = gym.spaces.Tuple(spaces=[env.observation_space, env.action_space])
+        d = gym_space_to_dict(space)
+        sp = gym_space_from_dict(d)
+
+        _assert_array_equal(
+            self.assertAlmostEqual,
+            sp.spaces[0].low.tolist(),
+            space.spaces[0].low.tolist(),
+            0.001,
+        )
+        _assert_array_equal(
+            self.assertAlmostEqual,
+            sp.spaces[0].high.tolist(),
+            space.spaces[0].high.tolist(),
+            0.001,
+        )
+        _assert_array_equal(
+            self.assertEqual, sp.spaces[0]._shape, space.spaces[0]._shape
+        )
+        self.assertEqual(sp.dtype, space.dtype)
+
+        self.assertEqual(sp.spaces[1].n, space.spaces[1].n)
+
+    def test_dict_space(self):
+        env = gym.make("CartPole-v0")
+        space = gym.spaces.Dict(
+            spaces={"obs": env.observation_space, "action": env.action_space}
+        )
+        d = gym_space_to_dict(space)
+        sp = gym_space_from_dict(d)
+
+        _assert_array_equal(
+            self.assertAlmostEqual,
+            sp.spaces["obs"].low.tolist(),
+            space.spaces["obs"].low.tolist(),
+            0.001,
+        )
+        _assert_array_equal(
+            self.assertAlmostEqual,
+            sp.spaces["obs"].high.tolist(),
+            space.spaces["obs"].high.tolist(),
+            0.001,
+        )
+        _assert_array_equal(
+            self.assertEqual, sp.spaces["obs"]._shape, space.spaces["obs"]._shape
+        )
+        self.assertEqual(sp.dtype, space.dtype)
+
+        self.assertEqual(sp.spaces["action"].n, space.spaces["action"].n)
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/utils/tests/test_serialization.py
+++ b/rllib/utils/tests/test_serialization.py
@@ -9,12 +9,8 @@ from ray.rllib.utils.serialization import (
 
 
 def _assert_array_equal(eq, a1, a2, margin=None):
-    if margin:
-        for a in zip(a1, a2):
-            eq(a[0], a[1], margin)
-    else:
-        for a in zip(a1, a2):
-            eq(a[0], a[1])
+    for a in zip(a1, a2):
+        eq(a[0], a[1], margin)
 
 
 class TestGymCheckEnv(unittest.TestCase):


### PR DESCRIPTION
into JSON-serializable dicts.

This is for safe checkpointing of RLlib policy's obs and action spaces, and view requirements (which currently contains a space attribute).

## Why are these changes needed?

This is so we can checkpoint everything a policy needs to run independently.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
