### PR TITLE
[Datasets] Skip flaky pipelining memory release test

### DIFF
--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -81,6 +81,7 @@ class OnesSource(Datasource):
         return read_tasks
 
 
+@pytest.mark.skip(reason="Flaky, see https://github.com/ray-project/ray/issues/24757")
 @pytest.mark.parametrize("lazy_input", [True, False])
 def test_memory_release_pipeline(shutdown_only, lazy_input):
     context = DatasetContext.get_current()


### PR DESCRIPTION
[This](https://github.com/ray-project/ray/blob/8ec558dcb949ce39df5fd7a855001287de2ce73b/python/ray/data/tests/test_optimize.py#L85) pipelining memory release test is flaky; it was skipped in [this Polars PR](https://github.com/ray-project/ray/pull/24523), which was then [reverted](https://github.com/ray-project/ray/commit/dc69431b545427246e64cd51049adab85b09299d).

## Related issue number

https://github.com/ray-project/ray/issues/24757

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
