### PR TITLE
[tune] Move wandb logging directory into trial logdir

### DIFF
--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -201,10 +201,17 @@ class _WandbLoggingProcess(Process):
     """
 
     def __init__(
-        self, queue: Queue, exclude: List[str], to_config: List[str], *args, **kwargs
+        self,
+        logdir: str,
+        queue: Queue,
+        exclude: List[str],
+        to_config: List[str],
+        *args,
+        **kwargs,
     ):
         super(_WandbLoggingProcess, self).__init__()
 
+        os.chdir(logdir)
         self.queue = queue
         self._exclude = set(exclude)
         self._to_config = set(to_config)
@@ -400,6 +407,7 @@ class WandbLoggerCallback(LoggerCallback):
 
         self._trial_queues[trial] = Queue()
         self._trial_processes[trial] = self._logger_process_cls(
+            logdir=trial.logdir,
             queue=self._trial_queues[trial],
             exclude=exclude_results,
             to_config=self._config_results,

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -31,6 +31,7 @@ class Trial(
             "trial_name",
             "trainable_name",
             "placement_group_factory",
+            "logdir",
         ],
     )
 ):
@@ -103,7 +104,12 @@ class WandbIntegrationTest(unittest.TestCase):
     def testWandbLoggerConfig(self):
         trial_config = {"par1": 4, "par2": 9.12345678}
         trial = Trial(
-            trial_config, 0, "trial_0", "trainable", PlacementGroupFactory([{"CPU": 1}])
+            trial_config,
+            0,
+            "trial_0",
+            "trainable",
+            PlacementGroupFactory([{"CPU": 1}]),
+            "/tmp",
         )
 
         if WANDB_ENV_VAR in os.environ:
@@ -178,7 +184,12 @@ class WandbIntegrationTest(unittest.TestCase):
     def testWandbLoggerReporting(self):
         trial_config = {"par1": 4, "par2": 9.12345678}
         trial = Trial(
-            trial_config, 0, "trial_0", "trainable", PlacementGroupFactory([{"CPU": 1}])
+            trial_config,
+            0,
+            "trial_0",
+            "trainable",
+            PlacementGroupFactory([{"CPU": 1}]),
+            "/tmp",
         )
 
         logger = WandbTestExperimentLogger(
@@ -210,7 +221,12 @@ class WandbIntegrationTest(unittest.TestCase):
     def testWandbMixinConfig(self):
         config = {"par1": 4, "par2": 9.12345678}
         trial = Trial(
-            config, 0, "trial_0", "trainable", PlacementGroupFactory([{"CPU": 1}])
+            config,
+            0,
+            "trial_0",
+            "trainable",
+            PlacementGroupFactory([{"CPU": 1}]),
+            "/tmp",
         )
         trial_info = TrialInfo(trial)
 
@@ -267,7 +283,12 @@ class WandbIntegrationTest(unittest.TestCase):
     def testWandbDecoratorConfig(self):
         config = {"par1": 4, "par2": 9.12345678}
         trial = Trial(
-            config, 0, "trial_0", "trainable", PlacementGroupFactory([{"CPU": 1}])
+            config,
+            0,
+            "trial_0",
+            "trainable",
+            PlacementGroupFactory([{"CPU": 1}]),
+            "/tmp",
         )
         trial_info = TrialInfo(trial)
 

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -42,9 +42,9 @@ class Trial(
 
 
 class _MockWandbLoggingProcess(_WandbLoggingProcess):
-    def __init__(self, queue, exclude, to_config, *args, **kwargs):
+    def __init__(self, logdir, queue, exclude, to_config, *args, **kwargs):
         super(_MockWandbLoggingProcess, self).__init__(
-            queue, exclude, to_config, *args, **kwargs
+            logdir, queue, exclude, to_config, *args, **kwargs
         )
 
         self.logs = Queue()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Weights and biases creates a `wandb` directory to collect intermediate logs and artifacts before uploading them. This directory should be in the respective trial directories. This also means we can re-enable auto resuming.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
