### PR TITLE
Revert "Revert "[Datasets] [Tensor Story - 1/2] Automatically provide tensor views to UDFs and infer tensor blocks for pure-tensor datasets.""

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -3,6 +3,7 @@ import time
 from typing import (
     TypeVar,
     List,
+    Dict,
     Generic,
     Iterator,
     Tuple,
@@ -81,6 +82,10 @@ def _validate_key_fn(ds: "Dataset", key: KeyFn) -> None:
 # Block data can be accessed in a uniform way via ``BlockAccessors`` such as
 # ``SimpleBlockAccessor`` and ``ArrowBlockAccessor``.
 Block = Union[List[T], "pyarrow.Table", "pandas.DataFrame", bytes]
+
+# User-facing data batch type. This is the data type for data that is supplied to and
+# returned from batch UDFs.
+DataBatch = Union[Block, np.ndarray]
 
 # A list of block references pending computation by a single task. For example,
 # this may be the output of a task reading a file.
@@ -210,11 +215,13 @@ class BlockAccessor(Generic[T]):
         """Convert this block into a Pandas dataframe."""
         raise NotImplementedError
 
-    def to_numpy(self, column: str = None) -> np.ndarray:
-        """Convert this block (or column of block) into a NumPy ndarray.
+    def to_numpy(
+        self, columns: Optional[Union[str, List[str]]] = None
+    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
+        """Convert this block (or columns of block) into a NumPy ndarray.
 
         Args:
-            column: Name of column to convert, or None.
+            columns: Name of columns to convert, or None if converting all columns.
         """
         raise NotImplementedError
 
@@ -225,6 +232,10 @@ class BlockAccessor(Generic[T]):
     def to_block(self) -> Block:
         """Return the base block that this accessor wraps."""
         raise NotImplementedError
+
+    def to_native(self) -> Block:
+        """Return the native data format for this accessor."""
+        return self.to_block()
 
     def size_bytes(self) -> int:
         """Return the approximate size in bytes of this block."""
@@ -254,6 +265,15 @@ class BlockAccessor(Generic[T]):
     def builder() -> "BlockBuilder[T]":
         """Create a builder for this block type."""
         raise NotImplementedError
+
+    @staticmethod
+    def batch_to_block(batch: DataBatch) -> Block:
+        """Create a block from user-facing data formats."""
+        if isinstance(batch, np.ndarray):
+            from ray.data.impl.arrow_block import ArrowBlockAccessor
+
+            return ArrowBlockAccessor.numpy_to_block(batch)
+        return batch
 
     @staticmethod
     def for_block(block: Block) -> "BlockAccessor[T]":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -68,6 +68,7 @@ from ray.data.datasource.file_based_datasource import (
 from ray.data.row import TableRow
 from ray.data.aggregate import AggregateFn, Sum, Max, Min, Mean, Std
 from ray.data.random_access_dataset import RandomAccessDataset
+from ray.data.impl.table_block import VALUE_COL_NAME
 from ray.data.impl.remote_fn import cached_remote_fn
 from ray.data.impl.block_batching import batch_blocks, BatchType
 from ray.data.impl.plan import ExecutionPlan, OneToOneStage, AllToAllStage
@@ -234,8 +235,8 @@ class Dataset(Generic[T]):
 
         def transform(block: Block) -> Iterable[Block]:
             DatasetContext._set_current(context)
-            block = BlockAccessor.for_block(block)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
+            block = BlockAccessor.for_block(block)
             for row in block.iter_rows():
                 output_buffer.add(fn(row))
                 if output_buffer.has_next():
@@ -259,6 +260,9 @@ class Dataset(Generic[T]):
         **ray_remote_args,
     ) -> "Dataset[Any]":
         """Apply the given function to batches of records of this dataset.
+
+        The format of the data batch provided to ``fn`` can be controlled via the
+        ``batch_format`` argument, and the output of the UDF can be any batch type.
 
         This is a blocking operation.
 
@@ -306,10 +310,9 @@ class Dataset(Generic[T]):
                 blocks as batches. Defaults to a system-chosen batch size.
             compute: The compute strategy, either "tasks" (default) to use Ray
                 tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
-            batch_format: Specify "native" to use the native block format
-                (promotes Arrow to pandas), "pandas" to select
-                ``pandas.DataFrame`` as the batch format,
-                or "pyarrow" to select ``pyarrow.Table``.
+            batch_format: Specify "native" to use the native block format (promotes
+                tables to Pandas and tensors to NumPy), "pandas" to select
+                ``pandas.DataFrame``, or "pyarrow" to select `pyarrow.Table``.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
@@ -338,9 +341,7 @@ class Dataset(Generic[T]):
                 # bug where we include the entire base view on serialization.
                 view = block.slice(start, end, copy=batch_size is not None)
                 if batch_format == "native":
-                    # Always promote Arrow blocks to pandas for consistency.
-                    if isinstance(view, pa.Table) or isinstance(view, bytes):
-                        view = BlockAccessor.for_block(view).to_pandas()
+                    view = BlockAccessor.for_block(view).to_native()
                 elif batch_format == "pandas":
                     view = BlockAccessor.for_block(view).to_pandas()
                 elif batch_format == "pyarrow":
@@ -355,6 +356,7 @@ class Dataset(Generic[T]):
                 if not (
                     isinstance(applied, list)
                     or isinstance(applied, pa.Table)
+                    or isinstance(applied, np.ndarray)
                     or isinstance(applied, pd.core.frame.DataFrame)
                 ):
                     raise ValueError(
@@ -364,7 +366,7 @@ class Dataset(Generic[T]):
                         "The return type must be either list, "
                         "pandas.DataFrame, or pyarrow.Table"
                     )
-                output_buffer.add_block(applied)
+                output_buffer.add_batch(applied)
                 if output_buffer.has_next():
                     yield output_buffer.next()
 
@@ -701,6 +703,8 @@ class Dataset(Generic[T]):
                 )
             if isinstance(batch, pd.DataFrame):
                 return batch.sample(frac=fraction)
+            if isinstance(batch, np.ndarray):
+                return np.array([row for row in batch if random.random() <= fraction])
             raise ValueError(f"Unsupported batch type: {type(batch)}")
 
         return self.map_batches(process_batch)
@@ -2071,7 +2075,7 @@ class Dataset(Generic[T]):
         self,
         path: str,
         *,
-        column: str = "value",
+        column: str = VALUE_COL_NAME,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         try_create_dir: bool = True,
         arrow_open_stream_args: Optional[Dict[str, Any]] = None,
@@ -2099,7 +2103,8 @@ class Dataset(Generic[T]):
             path: The path to the destination root directory, where npy
                 files will be written to.
             column: The name of the table column that contains the tensor to
-                be written. This defaults to "value".
+                be written. The default is ``"__value__"``, the column name that
+                Datasets uses for storing tensors in single-column tables.
             filesystem: The filesystem implementation to write to.
             try_create_dir: Try to create all directories in destination path
                 if True. Does nothing if all directories already exist.
@@ -2246,10 +2251,10 @@ class Dataset(Generic[T]):
                 current block during the scan.
             batch_size: Record batch size, or None to let the system pick.
             batch_format: The format in which to return each batch.
-                Specify "native" to use the current block format (promoting
-                Arrow to pandas automatically), "pandas" to
-                select ``pandas.DataFrame`` or "pyarrow" to select
-                ``pyarrow.Table``. Default is "native".
+                Specify "native" to use the native block format (promoting
+                tables to Pandas and tensors to NumPy), "pandas" to select
+                ``pandas.DataFrame``, or "pyarrow" to select ``pyarrow.Table``. Default
+                is "native".
             drop_last: Whether to drop the last batch if it's incomplete.
 
         Returns:
@@ -2771,8 +2776,9 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
         Time complexity: O(dataset size / parallelism)
 
         Args:
-            column: The name of the column to convert to numpy, or None to
-                specify the entire row. Required for Arrow tables.
+            column: The name of the column to convert to numpy, or None to specify the
+            entire row. If not specified for Arrow or Pandas blocks, each returned
+            future will represent a dict of column ndarrays.
 
         Returns:
             A list of remote NumPy ndarrays created from this dataset.

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -192,14 +192,11 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
             elif block_format == "tensor":
                 import pyarrow as pa
 
-                tensor = TensorArray(
-                    np.ones(tensor_shape, dtype=np.int64)
-                    * np.expand_dims(
-                        np.arange(start, start + count),
-                        tuple(range(1, 1 + len(tensor_shape))),
-                    )
+                tensor = np.ones(tensor_shape, dtype=np.int64) * np.expand_dims(
+                    np.arange(start, start + count),
+                    tuple(range(1, 1 + len(tensor_shape))),
                 )
-                return pa.Table.from_pydict({"value": tensor})
+                return BlockAccessor.batch_to_block(tensor)
             else:
                 return list(builtins.range(start, start + count))
 
@@ -213,16 +210,12 @@ class RangeDatasource(Datasource[Union[ArrowRow, int]]):
                 schema = pa.Table.from_pydict({"value": [0]}).schema
             elif block_format == "tensor":
                 _check_pyarrow_version()
-                from ray.data.extensions import TensorArray
                 import pyarrow as pa
 
-                tensor = TensorArray(
-                    np.ones(tensor_shape, dtype=np.int64)
-                    * np.expand_dims(
-                        np.arange(0, 10), tuple(range(1, 1 + len(tensor_shape)))
-                    )
+                tensor = np.ones(tensor_shape, dtype=np.int64) * np.expand_dims(
+                    np.arange(0, 10), tuple(range(1, 1 + len(tensor_shape)))
                 )
-                schema = pa.Table.from_pydict({"value": tensor}).schema
+                schema = BlockAccessor.batch_to_block(tensor).schema
             elif block_format == "list":
                 schema = int
             else:

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -24,18 +24,13 @@ class NumpyDatasource(FileBasedDatasource):
     """
 
     def _read_file(self, f: "pyarrow.NativeFile", path: str, **reader_args):
-        from ray.data.extensions import TensorArray
-        import pyarrow as pa
-
         # TODO(ekl) Ideally numpy can read directly from the file, but it
         # seems like it requires the file to be seekable.
         buf = BytesIO()
         data = f.readall()
         buf.write(data)
         buf.seek(0)
-        return pa.Table.from_pydict(
-            {"value": TensorArray(np.load(buf, allow_pickle=True))}
-        )
+        return BlockAccessor.batch_to_block(np.load(buf, allow_pickle=True))
 
     def _write_block(
         self,

--- a/python/ray/data/impl/arrow_block.py
+++ b/python/ray/data/impl/arrow_block.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     List,
     Tuple,
+    Union,
     Iterator,
     Any,
     TypeVar,
@@ -30,7 +31,11 @@ from ray.data.block import (
     KeyType,
 )
 from ray.data.row import TableRow
-from ray.data.impl.table_block import TableBlockAccessor, TableBlockBuilder
+from ray.data.impl.table_block import (
+    TableBlockAccessor,
+    TableBlockBuilder,
+    VALUE_COL_NAME,
+)
 from ray.data.aggregate import AggregateFn
 
 if TYPE_CHECKING:
@@ -73,6 +78,13 @@ class ArrowBlockBuilder(TableBlockBuilder[T]):
         super().__init__(pyarrow.Table)
 
     def _table_from_pydict(self, columns: Dict[str, List[Any]]) -> Block:
+        for col_name, col in columns.items():
+            if col_name == VALUE_COL_NAME or isinstance(
+                next(iter(col), None), np.ndarray
+            ):
+                from ray.data.extensions.tensor_extension import ArrowTensorArray
+
+                columns[col_name] = ArrowTensorArray.from_numpy(col)
         return pyarrow.Table.from_pydict(columns)
 
     def _concat_tables(self, tables: List[Block]) -> Block:
@@ -84,18 +96,34 @@ class ArrowBlockBuilder(TableBlockBuilder[T]):
 
 
 class ArrowBlockAccessor(TableBlockAccessor):
+    ROW_TYPE = ArrowRow
+
     def __init__(self, table: "pyarrow.Table"):
         if pyarrow is None:
             raise ImportError("Run `pip install pyarrow` for Arrow support")
         super().__init__(table)
 
-    def _create_table_row(self, row: "pyarrow.Table") -> ArrowRow:
-        return ArrowRow(row)
+    def column_names(self) -> List[str]:
+        return self._table.column_names
 
     @classmethod
-    def from_bytes(cls, data: bytes):
+    def from_bytes(cls, data: bytes) -> "ArrowBlockAccessor":
         reader = pyarrow.ipc.open_stream(data)
         return cls(reader.read_all())
+
+    @staticmethod
+    def numpy_to_block(batch: np.ndarray) -> "pyarrow.Table":
+        import pyarrow as pa
+        from ray.data.extensions.tensor_extension import ArrowTensorArray
+
+        return pa.Table.from_pydict(
+            {VALUE_COL_NAME: ArrowTensorArray.from_numpy(batch)}
+        )
+
+    @staticmethod
+    def _build_tensor_row(row: ArrowRow) -> np.ndarray:
+        # Getting an item in a tensor column automatically does a NumPy conversion.
+        return row[VALUE_COL_NAME][0]
 
     def slice(self, start: int, end: int, copy: bool) -> "pyarrow.Table":
         view = self._table.slice(start, end - start)
@@ -105,7 +133,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
     def random_shuffle(self, random_seed: Optional[int]) -> "pyarrow.Table":
         random = np.random.RandomState(random_seed)
-        return self._table.take(random.permutation(self.num_rows()))
+        return self.take(random.permutation(self.num_rows()))
 
     def schema(self) -> "pyarrow.lib.Schema":
         return self._table.schema
@@ -113,26 +141,34 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def to_pandas(self) -> "pandas.DataFrame":
         return self._table.to_pandas()
 
-    def to_numpy(self, column: str = None) -> np.ndarray:
-        if column is None:
-            raise ValueError(
-                "`column` must be specified when calling .to_numpy() "
-                "on Arrow blocks."
-            )
-        if column not in self._table.column_names:
-            raise ValueError(
-                f"Cannot find column {column}, available columns: "
-                f"{self._table.column_names}"
-            )
-        array = self._table[column]
-        if array.num_chunks > 1:
-            # TODO(ekl) combine fails since we can't concat
-            # ArrowTensorType?
-            array = array.combine_chunks()
+    def to_numpy(
+        self, columns: Optional[Union[str, List[str]]] = None
+    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
+        if columns is None:
+            columns = self._table.column_names
+        if not isinstance(columns, list):
+            columns = [columns]
+        for column in columns:
+            if column not in self._table.column_names:
+                raise ValueError(
+                    f"Cannot find column {column}, available columns: "
+                    f"{self._table.column_names}"
+                )
+        arrays = []
+        for column in columns:
+            array = self._table[column]
+            if array.num_chunks == 0:
+                array = pyarrow.array([], type=array.type)
+            elif _is_column_extension_type(array):
+                array = _concatenate_extension_column(array)
+            else:
+                array = array.combine_chunks()
+            arrays.append(array.to_numpy(zero_copy_only=False))
+        if len(arrays) == 1:
+            arrays = arrays[0]
         else:
-            assert array.num_chunks == 1, array
-            array = array.chunk(0)
-        return array.to_numpy(zero_copy_only=False)
+            arrays = dict(zip(columns, arrays))
+        return arrays
 
     def to_arrow(self) -> "pyarrow.Table":
         return self._table
@@ -169,9 +205,45 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def _empty_table() -> "pyarrow.Table":
         return ArrowBlockBuilder._empty_table()
 
+    @staticmethod
+    def take_table(
+        table: "pyarrow.Table",
+        indices: Union[List[int], "pyarrow.Array", "pyarrow.ChunkedArray"],
+    ) -> "pyarrow.Table":
+        """Select rows from the table.
+
+        This method is an alternative to pyarrow.Table.take(), which breaks for
+        extension arrays. This is exposed as a static method for easier use on
+        intermediate tables, not underlying an ArrowBlockAccessor.
+        """
+        if any(_is_column_extension_type(col) for col in table.columns):
+            new_cols = []
+            for col in table.columns:
+                if _is_column_extension_type(col):
+                    # .take() will concatenate internally, which currently breaks for
+                    # extension arrays.
+                    col = _concatenate_extension_column(col)
+                new_cols.append(col.take(indices))
+            table = pyarrow.Table.from_arrays(new_cols, schema=table.schema)
+        else:
+            table = table.take(indices)
+        return table
+
+    def take(
+        self,
+        indices: Union[List[int], "pyarrow.Array", "pyarrow.ChunkedArray"],
+    ) -> "pyarrow.Table":
+        """Select rows from the underlying table.
+
+        This method is an alternative to pyarrow.Table.take(), which breaks for
+        extension arrays.
+        """
+        return self.take_table(self._table, indices)
+
     def _sample(self, n_samples: int, key: "SortKeyT") -> "pyarrow.Table":
         indices = random.sample(range(self._table.num_rows), n_samples)
-        return self._table.select([k[0] for k in key]).take(indices)
+        table = self._table.select([k[0] for k in key])
+        return self.take_table(table, indices)
 
     def count(self, on: KeyFn) -> Optional[U]:
         """Count the number of non-null values in the provided column."""
@@ -268,7 +340,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         import pyarrow.compute as pac
 
         indices = pac.sort_indices(self._table, sort_keys=key)
-        table = self._table.take(indices)
+        table = self.take(indices)
         if len(boundaries) == 0:
             return [table]
 
@@ -393,7 +465,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         else:
             ret = pyarrow.concat_tables(blocks, promote=True)
             indices = pyarrow.compute.sort_indices(ret, sort_keys=key)
-            ret = ret.take(indices)
+            ret = ArrowBlockAccessor.take_table(ret, indices)
         return ret, ArrowBlockAccessor(ret).get_metadata(None, exec_stats=stats.build())
 
     @staticmethod
@@ -489,6 +561,33 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return ret, ArrowBlockAccessor(ret).get_metadata(None, exec_stats=stats.build())
 
 
+def _is_column_extension_type(ca: "pyarrow.ChunkedArray") -> bool:
+    """Whether the provided Arrow Table column is an extension array, using an Arrow
+    extension type.
+    """
+    return isinstance(ca.type, pyarrow.ExtensionType)
+
+
+def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array":
+    """Concatenate chunks of an extension column into a contiguous array.
+
+    This concatenation is required for creating copies and for .take() to work on
+    extension arrays.
+    See https://issues.apache.org/jira/browse/ARROW-16503.
+    """
+    if not _is_column_extension_type(ca):
+        raise ValueError("Chunked array isn't an extension array: {ca}")
+
+    if ca.num_chunks == 0:
+        # No-op for no-chunk chunked arrays, since there's nothing to concatenate.
+        return ca
+
+    chunk = ca.chunk(0)
+    return type(chunk).from_storage(
+        chunk.type, pyarrow.concat_arrays([c.storage for c in ca.chunks])
+    )
+
+
 def _copy_table(table: "pyarrow.Table") -> "pyarrow.Table":
     """Copy the provided Arrow table."""
     import pyarrow as pa
@@ -498,14 +597,10 @@ def _copy_table(table: "pyarrow.Table") -> "pyarrow.Table":
     cols = table.columns
     new_cols = []
     for col in cols:
-        if col.num_chunks > 0 and isinstance(col.chunk(0), pa.ExtensionArray):
-            # If an extension array, we copy the underlying storage arrays.
-            chunk = col.chunk(0)
-            arr = type(chunk).from_storage(
-                chunk.type, pa.concat_arrays([c.storage for c in col.chunks])
-            )
+        if _is_column_extension_type(col):
+            # Extension arrays don't support concatenation.
+            arr = _concatenate_extension_column(col)
         else:
-            # Otherwise, we copy the top-level chunk arrays.
             arr = col.combine_chunks()
         new_cols.append(arr)
     return pa.Table.from_arrays(new_cols, schema=table.schema)

--- a/python/ray/data/impl/block_batching.py
+++ b/python/ray/data/impl/block_batching.py
@@ -93,26 +93,20 @@ def batch_blocks(
 
 
 def _format_batch(batch: Block, batch_format: str) -> BatchType:
-    import pyarrow as pa
-
     if batch_format == "native":
-        # Always promote Arrow blocks to pandas for consistency, since
-        # we lazily convert pandas->Arrow internally for efficiency.
-        if isinstance(batch, pa.Table) or isinstance(batch, bytes):
-            batch = BlockAccessor.for_block(batch)
-            batch = batch.to_pandas()
-        return batch
+        batch = BlockAccessor.for_block(batch).to_native()
     elif batch_format == "pandas":
-        batch = BlockAccessor.for_block(batch)
-        return batch.to_pandas()
+        batch = BlockAccessor.for_block(batch).to_pandas()
     elif batch_format == "pyarrow":
-        batch = BlockAccessor.for_block(batch)
-        return batch.to_arrow()
+        batch = BlockAccessor.for_block(batch).to_arrow()
+    elif batch_format == "numpy":
+        batch = BlockAccessor.for_block(batch).to_numpy()
     else:
         raise ValueError(
             f"The given batch format: {batch_format} "
             f"is invalid. Supported batch type: {BatchType}"
         )
+    return batch
 
 
 def _sliding_window(iterable: Iterable, n: int):

--- a/python/ray/data/impl/delegating_block_builder.py
+++ b/python/ray/data/impl/delegating_block_builder.py
@@ -1,6 +1,8 @@
 from typing import Any
 
-from ray.data.block import Block, T, BlockAccessor
+import numpy as np
+
+from ray.data.block import Block, DataBatch, T, BlockAccessor
 from ray.data.impl.block_builder import BlockBuilder
 from ray.data.impl.simple_block import SimpleBlockBuilder
 from ray.data.impl.arrow_block import ArrowRow, ArrowBlockBuilder
@@ -13,7 +15,6 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
         self._empty_block = None
 
     def add(self, item: Any) -> None:
-
         if self._builder is None:
             # TODO (kfstorm): Maybe we can use Pandas block format for dict.
             if isinstance(item, dict) or isinstance(item, ArrowRow):
@@ -26,13 +27,24 @@ class DelegatingBlockBuilder(BlockBuilder[T]):
                     self._builder = ArrowBlockBuilder()
                 except (TypeError, pyarrow.lib.ArrowInvalid):
                     self._builder = SimpleBlockBuilder()
+            elif isinstance(item, np.ndarray):
+                self._builder = ArrowBlockBuilder()
             elif isinstance(item, PandasRow):
                 self._builder = PandasBlockBuilder()
             else:
                 self._builder = SimpleBlockBuilder()
         self._builder.add(item)
 
-    def add_block(self, block: Block) -> None:
+    def add_batch(self, batch: DataBatch):
+        """Add a user-facing data batch to the builder.
+
+        This data batch will be converted to an internal block and then added to the
+        underlying builder.
+        """
+        block = BlockAccessor.batch_to_block(batch)
+        return self.add_block(block)
+
+    def add_block(self, block: Block):
         accessor = BlockAccessor.for_block(block)
         if accessor.num_rows() == 0:
             # Don't infer types of empty lists. Store the block and use it if no

--- a/python/ray/data/impl/output_buffer.py
+++ b/python/ray/data/impl/output_buffer.py
@@ -1,6 +1,6 @@
 from typing import Callable, Any, Optional
 
-from ray.data.block import Block, BlockAccessor
+from ray.data.block import Block, DataBatch, BlockAccessor
 from ray.data.impl.delegating_block_builder import DelegatingBlockBuilder
 
 
@@ -43,6 +43,11 @@ class BlockOutputBuffer(object):
         """Add a single item to this output buffer."""
         assert not self._finalized
         self._buffer.add(item)
+
+    def add_batch(self, batch: DataBatch) -> None:
+        """Add a data batch to this output buffer."""
+        assert not self._finalized
+        self._buffer.add_batch(batch)
 
     def add_block(self, block: Block) -> None:
         """Add a data block to this output buffer."""

--- a/python/ray/data/impl/pandas_block.py
+++ b/python/ray/data/impl/pandas_block.py
@@ -3,6 +3,7 @@ from typing import (
     Dict,
     List,
     Tuple,
+    Union,
     Iterator,
     Any,
     TypeVar,
@@ -15,7 +16,11 @@ import numpy as np
 
 from ray.data.block import BlockAccessor, BlockMetadata, KeyFn, U
 from ray.data.row import TableRow
-from ray.data.impl.table_block import TableBlockAccessor, TableBlockBuilder
+from ray.data.impl.table_block import (
+    TableBlockAccessor,
+    TableBlockBuilder,
+    VALUE_COL_NAME,
+)
 from ray.data.impl.arrow_block import ArrowBlockAccessor
 from ray.data.aggregate import AggregateFn
 
@@ -71,6 +76,13 @@ class PandasBlockBuilder(TableBlockBuilder[T]):
 
     def _table_from_pydict(self, columns: Dict[str, List[Any]]) -> "pandas.DataFrame":
         pandas = lazy_import_pandas()
+        for key, value in columns.items():
+            if key == VALUE_COL_NAME or isinstance(next(iter(value), None), np.ndarray):
+                from ray.data.extensions.tensor_extension import TensorArray
+
+                if len(value) == 1:
+                    value = value[0]
+                columns[key] = TensorArray(value)
         return pandas.DataFrame(columns)
 
     def _concat_tables(self, tables: List["pandas.DataFrame"]) -> "pandas.DataFrame":
@@ -89,11 +101,19 @@ PandasBlockSchema = collections.namedtuple("PandasBlockSchema", ["names", "types
 
 
 class PandasBlockAccessor(TableBlockAccessor):
+    ROW_TYPE = PandasRow
+
     def __init__(self, table: "pandas.DataFrame"):
         super().__init__(table)
 
-    def _create_table_row(self, row: "pandas.DataFrame") -> PandasRow:
-        return PandasRow(row)
+    def column_names(self) -> List[str]:
+        return self._table.columns.tolist()
+
+    @staticmethod
+    def _build_tensor_row(row: PandasRow) -> np.ndarray:
+        # Getting an item in a Pandas tensor column returns a TensorArrayElement, which
+        # we have to convert to an ndarray.
+        return row[VALUE_COL_NAME].iloc[0].to_numpy()
 
     def slice(self, start: int, end: int, copy: bool) -> "pandas.DataFrame":
         view = self._table[start:end]
@@ -122,19 +142,27 @@ class PandasBlockAccessor(TableBlockAccessor):
     def to_pandas(self) -> "pandas.DataFrame":
         return self._table
 
-    def to_numpy(self, column: str = None) -> np.ndarray:
-        if not column:
-            raise ValueError(
-                "`column` must be specified when calling .to_numpy() "
-                "on Pandas blocks."
-            )
-        if column not in self._table.columns:
-            raise ValueError(
-                "Cannot find column {}, available columns: {}".format(
-                    column, self._table.columns.tolist()
+    def to_numpy(
+        self, columns: Optional[Union[str, List[str]]] = None
+    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
+        if columns is None:
+            columns = self._table.columns.tolist()
+        if not isinstance(columns, list):
+            columns = [columns]
+        for column in columns:
+            if column not in self._table.columns:
+                raise ValueError(
+                    f"Cannot find column {column}, available columns: "
+                    f"{self._table.columns.tolist()}"
                 )
-            )
-        return self._table[column].to_numpy()
+        arrays = []
+        for column in columns:
+            arrays.append(self._table[column].to_numpy())
+        if len(arrays) == 1:
+            arrays = arrays[0]
+        else:
+            arrays = dict(zip(columns, arrays))
+        return arrays
 
     def to_arrow(self) -> "pyarrow.Table":
         import pyarrow

--- a/python/ray/data/impl/simple_block.py
+++ b/python/ray/data/impl/simple_block.py
@@ -1,7 +1,7 @@
 import random
 import sys
 import heapq
-from typing import Callable, Iterator, List, Tuple, Any, Optional, TYPE_CHECKING
+from typing import Union, Callable, Iterator, List, Tuple, Any, Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -84,9 +84,9 @@ class SimpleBlockAccessor(BlockAccessor):
 
         return pandas.DataFrame({"value": self._items})
 
-    def to_numpy(self, column: str = None) -> np.ndarray:
-        if column:
-            raise ValueError("`column` arg not supported for list block")
+    def to_numpy(self, columns: Optional[Union[str, List[str]]] = None) -> np.ndarray:
+        if columns:
+            raise ValueError("`columns` arg is not supported for list block.")
         return np.array(self._items)
 
     def to_arrow(self) -> "pyarrow.Table":

--- a/python/ray/data/impl/table_block.py
+++ b/python/ray/data/impl/table_block.py
@@ -1,6 +1,7 @@
 import collections
-
 from typing import Dict, Iterator, List, Union, Any, TypeVar, TYPE_CHECKING
+
+import numpy as np
 
 from ray.data.block import Block, BlockAccessor
 from ray.data.row import TableRow
@@ -9,6 +10,11 @@ from ray.data.impl.size_estimator import SizeEstimator
 
 if TYPE_CHECKING:
     from ray.data.impl.sort import SortKeyT
+
+
+# The internal column name used for pure-tensor datasets, represented as
+# single-tensor-column tables.
+VALUE_COL_NAME = "__value__"
 
 T = TypeVar("T")
 
@@ -30,9 +36,11 @@ class TableBlockBuilder(BlockBuilder[T]):
         self._num_compactions = 0
         self._block_type = block_type
 
-    def add(self, item: Union[dict, TableRow]) -> None:
+    def add(self, item: Union[dict, TableRow, np.ndarray]) -> None:
         if isinstance(item, TableRow):
             item = item.as_pydict()
+        elif isinstance(item, np.ndarray):
+            item = {VALUE_COL_NAME: item}
         if not isinstance(item, dict):
             raise ValueError(
                 "Returned elements of an TableBlock must be of type `dict`, "
@@ -100,16 +108,42 @@ class TableBlockBuilder(BlockBuilder[T]):
 
 
 class TableBlockAccessor(BlockAccessor):
+    ROW_TYPE: TableRow = TableRow
+
     def __init__(self, table: Any):
         self._table = table
 
-    def _create_table_row(self, row: Any) -> TableRow:
+    def _get_row(self, index: int, copy: bool = False) -> Union[TableRow, np.ndarray]:
+        row = self.slice(index, index + 1, copy=copy)
+        if self.is_tensor_wrapper():
+            row = self._build_tensor_row(row)
+        else:
+            row = self.ROW_TYPE(row)
+        return row
+
+    @staticmethod
+    def _build_tensor_row(row: TableRow) -> np.ndarray:
+        raise NotImplementedError
+
+    def to_native(self) -> Block:
+        if self.is_tensor_wrapper():
+            native = self.to_numpy()
+        else:
+            # Always promote Arrow blocks to pandas for consistency, since
+            # we lazily convert pandas->Arrow internally for efficiency.
+            native = self.to_pandas()
+        return native
+
+    def column_names(self) -> List[str]:
         raise NotImplementedError
 
     def to_block(self) -> Block:
         return self._table
 
-    def iter_rows(self) -> Iterator[TableRow]:
+    def is_tensor_wrapper(self) -> bool:
+        return self.column_names() == [VALUE_COL_NAME]
+
+    def iter_rows(self) -> Iterator[Union[TableRow, np.ndarray]]:
         outer = self
 
         class Iter:
@@ -122,10 +156,7 @@ class TableBlockAccessor(BlockAccessor):
             def __next__(self):
                 self._cur += 1
                 if self._cur < outer.num_rows():
-                    row = outer._create_table_row(
-                        outer.slice(self._cur, self._cur + 1, copy=False)
-                    )
-                    return row
+                    return outer._get_row(self._cur)
                 raise StopIteration
 
         return Iter()

--- a/python/ray/data/random_access_dataset.py
+++ b/python/ray/data/random_access_dataset.py
@@ -223,9 +223,7 @@ class _RandomAccessWorker:
             col = block[self.key_field]
             indices = np.searchsorted(col, keys)
             acc = BlockAccessor.for_block(block)
-            result = [
-                acc._create_table_row(acc.slice(i, i + 1, copy=True)) for i in indices
-            ]
+            result = [acc._get_row(i, copy=True) for i in indices]
             # assert result == [self._get(i, k) for i, k in zip(block_indices, keys)]
         else:
             result = [self._get(i, k) for i, k in zip(block_indices, keys)]
@@ -254,7 +252,7 @@ class _RandomAccessWorker:
         if i is None:
             return None
         acc = BlockAccessor.for_block(block)
-        return acc._create_table_row(acc.slice(i, i + 1, copy=True))
+        return acc._get_row(i, copy=True)
 
 
 def _binary_search_find(column, x):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -173,10 +173,10 @@ def range_tensor(
         >>> import ray
         >>> ds = ray.data.range_tensor(1000, shape=(3, 10)) # doctest: +SKIP
         >>> ds.map_batches( # doctest: +SKIP
-        ...     lambda arr: arr * 2, batch_format="pandas").show()
+        ...     lambda arr: arr * 2).show()
 
     This is similar to range_table(), but uses the ArrowTensorArray extension
-    type. The dataset elements take the form {"value": array(N, shape=shape)}.
+    type. The dataset elements take the form {VALUE_COL_NAME: array(N, shape=shape)}.
 
     Args:
         n: The upper bound of the range of integer records.
@@ -1019,16 +1019,11 @@ def _df_to_block(df: "pandas.DataFrame") -> Block[ArrowRow]:
 
 def _ndarray_to_block(ndarray: np.ndarray) -> Block[np.ndarray]:
     stats = BlockExecStats.builder()
-    import pyarrow as pa
-    from ray.data.extensions import TensorArray
-
-    table = pa.Table.from_pydict({"value": TensorArray(ndarray)})
-    return (
-        table,
-        BlockAccessor.for_block(table).get_metadata(
-            input_files=None, exec_stats=stats.build()
-        ),
+    block = BlockAccessor.batch_to_block(ndarray)
+    metadata = BlockAccessor.for_block(block).get_metadata(
+        input_files=None, exec_stats=stats.build()
     )
+    return block, metadata
 
 
 def _get_metadata(table: Union["pyarrow.Table", "pandas.DataFrame"]) -> BlockMetadata:

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -443,21 +443,138 @@ def test_range_table(ray_start_regular_shared):
     assert ds.take() == [{"value": i} for i in range(10)]
 
 
-def test_tensors(ray_start_regular_shared):
+def test_tensors_basic(ray_start_regular_shared):
     # Create directly.
-    ds = ray.data.range_tensor(5, shape=(3, 5))
+    tensor_shape = (3, 5)
+    ds = ray.data.range_tensor(6, shape=tensor_shape)
     assert str(ds) == (
-        "Dataset(num_blocks=5, num_rows=5, "
-        "schema={value: <ArrowTensorType: shape=(3, 5), dtype=int64>})"
+        "Dataset(num_blocks=6, num_rows=6, "
+        "schema={__value__: <ArrowTensorType: shape=(3, 5), dtype=int64>})"
     )
 
+    # Test row iterator yields tensors.
+    for tensor in ds.iter_rows():
+        assert isinstance(tensor, np.ndarray)
+        assert tensor.shape == tensor_shape
+
+    # Test batch iterator yields tensors.
+    for tensor in ds.iter_batches(batch_size=2):
+        assert isinstance(tensor, np.ndarray)
+        assert tensor.shape == (2,) + tensor_shape
+
+    # Native format.
+    def np_mapper(arr):
+        assert isinstance(arr, np.ndarray)
+        return arr + 1
+
+    res = ray.data.range_tensor(2, shape=(2, 2)).map(np_mapper).take()
+    np.testing.assert_equal(res, [np.ones((2, 2)), 2 * np.ones((2, 2))])
+
     # Pandas conversion.
-    res = (
-        ray.data.range_tensor(10)
-        .map_batches(lambda t: t + 2, batch_format="pandas")
-        .take(2)
+    def pd_mapper(df):
+        assert isinstance(df, pd.DataFrame)
+        return df + 2
+
+    res = ray.data.range_tensor(2).map_batches(pd_mapper, batch_format="pandas").take()
+    np.testing.assert_equal(res, [np.array([2]), np.array([3])])
+
+
+def test_tensors_shuffle(ray_start_regular_shared):
+    # Test Arrow table representation.
+    tensor_shape = (3, 5)
+    ds = ray.data.range_tensor(6, shape=tensor_shape)
+    shuffled_ds = ds.random_shuffle()
+    shuffled = shuffled_ds.take()
+    base = ds.take()
+    np.testing.assert_raises(
+        AssertionError,
+        np.testing.assert_equal,
+        shuffled,
+        base,
     )
-    assert str(res) == "[{'value': array([2])}, {'value': array([3])}]"
+    np.testing.assert_equal(
+        sorted(shuffled, key=lambda arr: arr.min()),
+        sorted(base, key=lambda arr: arr.min()),
+    )
+
+    # Test Pandas table representation.
+    tensor_shape = (3, 5)
+    ds = ray.data.range_tensor(6, shape=tensor_shape)
+    ds = ds.map_batches(lambda df: df, batch_format="pandas")
+    shuffled_ds = ds.random_shuffle()
+    shuffled = shuffled_ds.take()
+    base = ds.take()
+    np.testing.assert_raises(
+        AssertionError,
+        np.testing.assert_equal,
+        shuffled,
+        base,
+    )
+    np.testing.assert_equal(
+        sorted(shuffled, key=lambda arr: arr.min()),
+        sorted(base, key=lambda arr: arr.min()),
+    )
+
+
+def test_tensors_sort(ray_start_regular_shared):
+    # Test Arrow table representation.
+    t = pa.table({"a": TensorArray(np.arange(32).reshape((2, 4, 4))), "b": [1, 2]})
+    ds = ray.data.from_arrow(t)
+    sorted_ds = ds.sort(key="b", descending=True)
+    sorted_arrs = [row["a"] for row in sorted_ds.take()]
+    base = [row["a"] for row in ds.take()]
+    np.testing.assert_raises(
+        AssertionError,
+        np.testing.assert_equal,
+        sorted_arrs,
+        base,
+    )
+    np.testing.assert_equal(
+        sorted_arrs,
+        sorted(base, key=lambda arr: -arr.min()),
+    )
+
+    # Test Pandas table representation.
+    df = pd.DataFrame({"a": TensorArray(np.arange(32).reshape((2, 4, 4))), "b": [1, 2]})
+    ds = ray.data.from_pandas(df)
+    sorted_ds = ds.sort(key="b", descending=True)
+    sorted_arrs = [np.asarray(row["a"]) for row in sorted_ds.take()]
+    base = [np.asarray(row["a"]) for row in ds.take()]
+    np.testing.assert_raises(
+        AssertionError,
+        np.testing.assert_equal,
+        sorted_arrs,
+        base,
+    )
+    np.testing.assert_equal(
+        sorted_arrs,
+        sorted(base, key=lambda arr: -arr.min()),
+    )
+
+
+def test_tensors_inferred_from_map(ray_start_regular_shared):
+    # Test map.
+    ds = ray.data.range(10).map(lambda _: np.ones((4, 4)))
+    assert str(ds) == (
+        "Dataset(num_blocks=10, num_rows=10, "
+        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
+    )
+
+    # Test map_batches.
+    ds = ray.data.range(16, parallelism=4).map_batches(
+        lambda _: np.ones((3, 4, 4)), batch_size=2
+    )
+    assert str(ds) == (
+        "Dataset(num_blocks=4, num_rows=24, "
+        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
+    )
+
+    # Test flat_map.
+    ds = ray.data.range(10).flat_map(lambda _: [np.ones((4, 4)), np.ones((4, 4))])
+    assert str(ds) == (
+        "Dataset(num_blocks=10, num_rows=20, "
+        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
+    )
 
 
 def test_tensor_array_ops(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -121,7 +121,7 @@ def test_from_numpy(ray_start_regular_shared, from_ref):
         ds = ray.data.from_numpy_refs([ray.put(arr) for arr in arrs])
     else:
         ds = ray.data.from_numpy(arrs)
-    values = np.stack([x["value"] for x in ds.take(8)])
+    values = np.stack(ds.take(8))
     np.testing.assert_array_equal(values, np.concatenate((arr1, arr2)))
 
     # Test from single NumPy ndarray.
@@ -129,7 +129,7 @@ def test_from_numpy(ray_start_regular_shared, from_ref):
         ds = ray.data.from_numpy_refs(ray.put(arr1))
     else:
         ds = ray.data.from_numpy(arr1)
-    values = np.stack([x["value"] for x in ds.take(4)])
+    values = np.stack(ds.take(4))
     np.testing.assert_array_equal(values, arr1)
 
 
@@ -197,13 +197,27 @@ def test_to_numpy_refs(ray_start_regular_shared):
 
     # Tensor Dataset
     ds = ray.data.range_tensor(10, parallelism=2)
-    arr = np.concatenate(ray.get(ds.to_numpy_refs(column="value")))
+    arr = np.concatenate(ray.get(ds.to_numpy_refs()))
     np.testing.assert_equal(arr, np.expand_dims(np.arange(0, 10), 1))
 
     # Table Dataset
     ds = ray.data.range_table(10)
-    arr = np.concatenate(ray.get(ds.to_numpy_refs(column="value")))
+    arr = np.concatenate(ray.get(ds.to_numpy_refs()))
     np.testing.assert_equal(arr, np.arange(0, 10))
+
+    # Test multi-column Arrow dataset.
+    ds = ray.data.from_arrow(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    arrs = ray.get(ds.to_numpy_refs())
+    np.testing.assert_equal(
+        arrs, [{"a": np.array([1, 2, 3]), "b": np.array([4, 5, 6])}]
+    )
+
+    # Test multi-column Pandas dataset.
+    ds = ray.data.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    arrs = ray.get(ds.to_numpy_refs())
+    np.testing.assert_equal(
+        arrs, [{"a": np.array([1, 2, 3]), "b": np.array([4, 5, 6])}]
+    )
 
 
 def test_to_arrow_refs(ray_start_regular_shared):
@@ -998,9 +1012,9 @@ def test_numpy_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_numpy(data_path, filesystem=fs)
     assert str(ds) == (
         "Dataset(num_blocks=2, num_rows=None, "
-        "schema={value: <ArrowTensorType: shape=(1,), dtype=int64>})"
+        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
     )
-    assert str(ds.take(2)) == "[{'value': array([0])}, {'value': array([1])}]"
+    np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
 
 def test_numpy_read(ray_start_regular_shared, tmp_path):
@@ -1010,9 +1024,9 @@ def test_numpy_read(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path)
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        "schema={value: <ArrowTensorType: shape=(1,), dtype=int64>})"
+        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
     )
-    assert str(ds.take(2)) == "[{'value': array([0])}, {'value': array([1])}]"
+    np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
 
 def test_numpy_read_meta_provider(ray_start_regular_shared, tmp_path):
@@ -1023,9 +1037,9 @@ def test_numpy_read_meta_provider(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path, meta_provider=FastFileMetadataProvider())
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        "schema={value: <ArrowTensorType: shape=(1,), dtype=int64>})"
+        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
     )
-    assert str(ds.take(2)) == "[{'value': array([0])}, {'value': array([1])}]"
+    np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
     with pytest.raises(NotImplementedError):
         ray.data.read_binary_files(
@@ -1077,10 +1091,10 @@ def test_numpy_read_partitioned_with_filter(
         ds = ray.data.read_numpy(base_dir, partition_filter=partition_path_filter)
 
         vals = [[1, 0], [1, 1], [1, 2], [3, 3], [3, 4], [3, 5]]
-        val_str = "".join([f"{{'value': array({v}, dtype=int8)}}, " for v in vals])[:-2]
+        val_str = "".join(f"array({v}, dtype=int8), " for v in vals)[:-2]
         assert_base_partitioned_ds(
             ds,
-            schema="{value: <ArrowTensorType: shape=(2,), dtype=int8>}",
+            schema="{__value__: <ArrowTensorType: shape=(2,), dtype=int8>}",
             sorted_values=f"[[{val_str}]]",
             ds_take_transform_fn=lambda taken: [taken],
             sorted_values_transform_fn=lambda sorted_values: str(sorted_values),
@@ -1119,7 +1133,7 @@ def test_numpy_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     assert len(arr2) == 5
     assert arr1.sum() == 10
     assert arr2.sum() == 35
-    assert str(ds.take(1)) == "[{'value': array([0])}]"
+    np.testing.assert_equal(ds.take(1), [np.array([0])])
 
 
 @pytest.mark.parametrize(
@@ -1158,7 +1172,7 @@ def test_numpy_write_block_path_provider(
     assert len(arr2) == 5
     assert arr1.sum() == 10
     assert arr2.sum() == 35
-    assert str(ds.take(1)) == "[{'value': array([0])}]"
+    np.testing.assert_equal(ds.take(1), [np.array([0])])
 
 
 def test_read_text(ray_start_regular_shared, tmp_path):

--- a/python/ray/ml/utils/check_ingest.py
+++ b/python/ray/ml/utils/check_ingest.py
@@ -3,6 +3,7 @@
 import time
 import numpy as np
 from typing import Optional
+import sys
 
 import ray
 from ray import train
@@ -59,6 +60,8 @@ class DummyTrainer(DataParallelTrainer):
         """Make a debug train loop that runs for the given amount of runtime."""
 
         def train_loop_per_worker():
+            import pandas as pd
+
             rank = train.world_rank()
             data_shard = train.get_dataset_shard("train")
             start = time.perf_counter()
@@ -75,7 +78,16 @@ class DummyTrainer(DataParallelTrainer):
                     batch_delay = time.perf_counter() - batch_start
                     batch_delays.append(batch_delay)
                     num_batches += 1
-                    num_bytes += int(batch.memory_usage(index=True, deep=True).sum())
+                    if isinstance(batch, pd.DataFrame):
+                        num_bytes += int(
+                            batch.memory_usage(index=True, deep=True).sum()
+                        )
+                    elif isinstance(batch, np.ndarray):
+                        num_bytes += batch.nbytes
+                    else:
+                        # NOTE: This isn't recursive and will just return the size of
+                        # the object pointers if list of non-primitive types.
+                        num_bytes += sys.getsizeof(batch)
                     train.report(
                         bytes_read=num_bytes,
                         num_batches=num_batches,


### PR DESCRIPTION
Fixes the check ingest utility to handle non-Pandas native batches.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
