### PR TITLE
[Core][Python 3.10] fix get_module in the interactive mode.

### DIFF
--- a/python/ray/includes/function_descriptor.pxi
+++ b/python/ray/includes/function_descriptor.pxi
@@ -309,7 +309,7 @@ cdef class PythonFunctionDescriptor(FunctionDescriptor):
                 n = inspect.getmodulename(file_path)
                 if n:
                     module_name = n
-            except TypeError:
+            except (TypeError, OSError):
                 pass
         return module_name
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

in python3.10, it fixed a bug that a interactively defined class was tagged with a wrong type during inspection; which now throws OSError.  detailed pr https://github.com/python/cpython/pull/27171

we need to handle this case properly in otherwise ray actor definition will throw in interactive mode. please refer to #25026 for repo.

## Related issue number

closes #25026

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually tested this fixed  #25026
