### PR TITLE
Fix range_arrow(), which is replaced by range_table()

### DIFF
--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -74,7 +74,7 @@ serving as pointers to a collection of distributed data blocks.
     :start-after: __gen_synth_int_range_begin__
     :end-before: __gen_synth_int_range_end__
 
-.. tabbed:: Arrow Range
+.. tabbed:: Tabular Range
 
   Create an Arrow (tabular) ``Dataset`` from a range of integers,
   with a single column containing this integer range.

--- a/doc/source/data/creating-datasets.rst
+++ b/doc/source/data/creating-datasets.rst
@@ -81,8 +81,8 @@ serving as pointers to a collection of distributed data blocks.
 
   .. literalinclude:: ./doc_code/creating_datasets.py
     :language: python
-    :start-after: __gen_synth_arrow_range_begin__
-    :end-before: __gen_synth_arrow_range_end__
+    :start-after: __gen_synth_tabular_range_begin__
+    :end-before: __gen_synth_tabular_range_end__
 
 .. tabbed:: Tensor Range
 

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -18,14 +18,14 @@ ds.take(5)
 # fmt: on
 
 # fmt: off
-# __gen_synth_arrow_range_begin__
+# __gen_synth_tabular_range_begin__
 # Create a Dataset of Arrow records.
 ds = ray.data.range_table(10000)
 # -> Dataset(num_blocks=200, num_rows=10000, schema={value: int64})
 
 ds.take(5)
 # -> [{'value': 0}, {'value': 1}, {'value': 2}, {'value': 3}, {'value': 4}]
-# __gen_synth_arrow_range_end__
+# __gen_synth_tabular_range_end__
 # fmt: on
 
 # fmt: off

--- a/doc/source/data/doc_code/creating_datasets.py
+++ b/doc/source/data/doc_code/creating_datasets.py
@@ -20,7 +20,7 @@ ds.take(5)
 # fmt: off
 # __gen_synth_arrow_range_begin__
 # Create a Dataset of Arrow records.
-ds = ray.data.range_arrow(10000)
+ds = ray.data.range_table(10000)
 # -> Dataset(num_blocks=200, num_rows=10000, schema={value: int64})
 
 ds.take(5)


### PR DESCRIPTION
## Why are these changes needed?

The range_arrow() is deprecated and replaced with range_table().

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
