### PR TITLE
[Datasets] Note that explicit resource allocation is experimental, fix typos

### DIFF
--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -132,10 +132,14 @@ group by default. This can be thought of as Datasets requesting resources from t
 margins of the cluster, outside of those ML library placement groups.
 
 Although this is the default behavior, you can force all Datasets workloads to be
-schedule without a placement group by specifying a placement group as the global
+scheduled within a placement group by specifying a placement group as the global
 scheduling strategy for all Datasets tasks/actors, using the global
-:class:`DatasetContext <ray.data.DatasetContext>`:
+:class:`DatasetContext <ray.data.DatasetContext>`.
 
+.. note::
+
+  This is an experimental feature subject to change as we work to improve our
+  resource allocation model for Datasets.
 
 .. literalinclude:: ./doc_code/key_concepts.py
   :language: python


### PR DESCRIPTION
This PR fixes some typos in our resource allocation model docs, and notes that explicit resource allocation is experimental.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
