### PR TITLE
[flakey] Disable redis tests for `test_plugin_timeout` shortly.

### DIFF
--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -5,7 +5,7 @@ from time import sleep
 import pytest
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, test_external_redis
 from ray.exceptions import RuntimeEnvSetupError
 
 import ray
@@ -164,6 +164,7 @@ class DiasbleTimeoutPlugin(DummyPlugin):
         sleep(10)
 
 
+@pytest.mark.skipif(test_external_redis(), reason="Failing in redis mode.")
 def test_plugin_timeout(start_cluster):
     @ray.remote(num_cpus=0.1)
     def f():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This test is not running well in Redis mode. Given that the other tests are ok, I'd like to only disable this one instead of revert the whole commit to making sure the other tests don't have regression.

`linux://python/ray/tests:test_runtime_env_plugin::test_plugin_timeout`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
