### PR TITLE
[Nightly test] Move two line downloads to one line.

### DIFF
--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO(sang): Move the class to state/state_manager.py.
-# TODO(sang): Remove *State and replaces with Pydantic or protobuf
+# TODO(sang): Remove *State and replaces with Pydantic or protobuf.
 # (depending on API interface standardization).
 class StateAPIManager:
     """A class to query states from data source, caches, and post-processes

--- a/release/air_tests/horovod/app_config_master.yaml
+++ b/release/air_tests/horovod/app_config_master.yaml
@@ -10,8 +10,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip3 uninstall ray -y || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install 'ray[tune]'
   - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_PYTORCH=1 pip3 install -U git+https://github.com/horovod/horovod.git
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -14,8 +14,7 @@ python:
   conda_packages: [ ]
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -15,8 +15,7 @@ python:
   conda_packages: [ ]
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}

--- a/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
+++ b/release/golden_notebook_tests/torch_tune_serve_app_config.yaml
@@ -15,6 +15,5 @@ python:
   conda_packages: [ ]
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/jobs_tests/app_config.yaml
+++ b/release/jobs_tests/app_config.yaml
@@ -10,6 +10,5 @@ python:
 
 post_build_cmds:
   - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/lightgbm_tests/app_config.yaml
+++ b/release/lightgbm_tests/app_config.yaml
@@ -12,8 +12,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install ray[default] # Needed for Ray Client to work.
   - pip3 install -U "xgboost<1.5" xgboost_ray petastorm  # Install latest releases, pin xgboost to <1.5
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/lightgbm_tests/app_config_gpu.yaml
+++ b/release/lightgbm_tests/app_config_gpu.yaml
@@ -11,8 +11,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip install -U xgboost xgboost_ray petastorm  # Install latest releases
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true

--- a/release/long_running_distributed_tests/app_config.yaml
+++ b/release/long_running_distributed_tests/app_config.yaml
@@ -11,6 +11,5 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -22,6 +22,5 @@ post_build_cmds:
     - pip3 install ray[all]
     # TODO (Alex): Ideally we would install all the dependencies from the new
     # version too, but pip won't be able to find the new version of ray-cpp.
-    - pip3 uninstall ray -y || true
-    - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+    - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
     - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/microbenchmark/app_config.yaml
+++ b/release/microbenchmark/app_config.yaml
@@ -7,6 +7,5 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/ml_user_tests/horovod/app_config.yaml
+++ b/release/ml_user_tests/horovod/app_config.yaml
@@ -10,8 +10,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip3 uninstall ray -y || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install 'ray[tune]'
   - pip3 install torch torchvision
   - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_PYTORCH=1 pip3 install -U horovod

--- a/release/ml_user_tests/horovod/app_config_master.yaml
+++ b/release/ml_user_tests/horovod/app_config_master.yaml
@@ -10,8 +10,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip3 uninstall ray -y || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall ray -y || true  && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install 'ray[tune]'
   - pip3 install torch torchvision
   - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_PYTORCH=1 pip3 install -U git+https://github.com/horovod/horovod.git

--- a/release/ml_user_tests/ray-lightning/app_config.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config.yaml
@@ -10,8 +10,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the Ray Lightning version, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}

--- a/release/ml_user_tests/ray-lightning/app_config_master.yaml
+++ b/release/ml_user_tests/ray-lightning/app_config_master.yaml
@@ -11,8 +11,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the Ray Lightning version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}

--- a/release/ml_user_tests/train/app_config.yaml
+++ b/release/ml_user_tests/train/app_config.yaml
@@ -11,6 +11,5 @@ python:
     conda_packages: [ ]
 
 post_build_cmds:
-    - pip3 uninstall -y ray || true
-    - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+    - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
     - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/ml_user_tests/xgboost/app_config_gpu.yaml
+++ b/release/ml_user_tests/xgboost/app_config_gpu.yaml
@@ -12,8 +12,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U xgboost xgboost_ray petastorm  # Install latest releases, pin xgboost to <1.5
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true

--- a/release/ml_user_tests/xgboost/app_config_gpu_master.yaml
+++ b/release/ml_user_tests/xgboost/app_config_gpu_master.yaml
@@ -12,8 +12,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip install -U "git+https://github.com/ray-project/xgboost_ray@master#egg=xgboost_ray" petastorm
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true

--- a/release/nightly_tests/chaos_test/app_config.yaml
+++ b/release/nightly_tests/chaos_test/app_config.yaml
@@ -7,7 +7,6 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
+++ b/release/nightly_tests/chaos_test/dask_on_ray_app_config_reconstruction.yaml
@@ -8,7 +8,6 @@ python:
 
 post_build_cmds:
   # - pip install fastparquet
-  - pip3 uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install ray[default]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/dask_on_ray_app_config.yaml
@@ -7,8 +7,7 @@ python:
 
 post_build_cmds:
   # - pip install fastparquet
-  - pip3 uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - echo {{env["DATESTAMP"]}}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
+++ b/release/nightly_tests/dask_on_ray/large_scale_dask_on_ray_app_config.yaml
@@ -7,9 +7,8 @@ python:
 
 post_build_cmds:
   # - pip install fastparquet
-  - pip3 uninstall -y ray
   - pip3 install -U pytest
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  -  pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - echo {{env["DATESTAMP"]}}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/dataset/app_config.yaml
+++ b/release/nightly_tests/dataset/app_config.yaml
@@ -8,8 +8,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   # TODO (Alex): We need to do this because the ray-ml image pins
   # tensorflow=2.6, which requires numpy~=1.19.2. This is ok because the test
   # doesn't actually use tensorflow, but in the long term, but we should

--- a/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_ingestion_app.yaml
@@ -7,8 +7,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip3 uninstall ray -y || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip install -U git+https://github.com/ray-project/ray_shuffling_data_loader.git@add-embedding-model
   - pip install ray[default]
   - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_PYTORCH=1 pip install -U git+https://github.com/horovod/horovod.git

--- a/release/nightly_tests/dataset/pipelined_training_app.yaml
+++ b/release/nightly_tests/dataset/pipelined_training_app.yaml
@@ -7,8 +7,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip3 uninstall ray -y || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip install -U git+https://github.com/ray-project/ray_shuffling_data_loader.git@add-embedding-model
   - pip install ray[default]
   - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_PYTORCH=1 pip install -U git+https://github.com/horovod/horovod.git

--- a/release/nightly_tests/dataset/ray_sgd_training_app.yaml
+++ b/release/nightly_tests/dataset/ray_sgd_training_app.yaml
@@ -6,8 +6,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-    - pip uninstall -y ray
-    - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+    - pip uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
     - pip3 install llvmlite --ignore-installed
     - pip3 install -U torch==1.6 dask dask_ml mlflow tensorboard torchvision pickle5 s3fs
     - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/dataset/shuffle_app_config.yaml
+++ b/release/nightly_tests/dataset/shuffle_app_config.yaml
@@ -7,7 +7,6 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
+++ b/release/nightly_tests/decision_tree/decision_tree_app_config.yaml
@@ -7,8 +7,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - echo {{env["DATESTAMP"]}}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/many_nodes_tests/app_config.yaml
+++ b/release/nightly_tests/many_nodes_tests/app_config.yaml
@@ -7,8 +7,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - echo {{env["DATESTAMP"]}}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/placement_group_tests/app_config.yaml
+++ b/release/nightly_tests/placement_group_tests/app_config.yaml
@@ -6,7 +6,6 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/shuffle/shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config.yaml
@@ -6,7 +6,6 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install -U ray[default]
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_app_config.yaml
@@ -9,8 +9,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install ray[default]
   - echo {{env["DATESTAMP"]}}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -12,8 +12,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # TODO(jungong): remove once nightly image gets upgraded.
   - pip install -U pybullet==3.2.0

--- a/release/runtime_env_tests/app_config.yaml
+++ b/release/runtime_env_tests/app_config.yaml
@@ -7,6 +7,5 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/serve_tests/app_config.yaml
+++ b/release/serve_tests/app_config.yaml
@@ -10,7 +10,6 @@ python:
 
 post_build_cmds:
   - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - pip install pytest

--- a/release/train_tests/horovod/app_config.yaml
+++ b/release/train_tests/horovod/app_config.yaml
@@ -10,8 +10,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip3 uninstall ray -y || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall ray -y || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install 'ray[tune]'
   - pip3 install torch torchvision
   - HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_TENSORFLOW=1 HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITH_PYTORCH=1 pip3 install -U horovod

--- a/release/tune_tests/cloud_tests/app_config.yaml
+++ b/release/tune_tests/cloud_tests/app_config.yaml
@@ -14,7 +14,6 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
   # Install Ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/tune_tests/cloud_tests/app_config_ml.yaml
+++ b/release/tune_tests/cloud_tests/app_config_ml.yaml
@@ -14,7 +14,6 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
   # Install Ray
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/tune_tests/scalability_tests/app_config.yaml
+++ b/release/tune_tests/scalability_tests/app_config.yaml
@@ -11,6 +11,5 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/tune_tests/scalability_tests/app_config_data.yaml
+++ b/release/tune_tests/scalability_tests/app_config_data.yaml
@@ -12,8 +12,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true
   - sudo chown ray:1000 /data || true

--- a/release/xgboost_tests/app_config.yaml
+++ b/release/xgboost_tests/app_config.yaml
@@ -12,8 +12,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install ray[default] # Needed for Ray Client to work.
   - pip3 install -U "xgboost<1.5" xgboost_ray petastorm  # Install latest releases, pin xgboost to <1.5
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/xgboost_tests/app_config_gpu.yaml
+++ b/release/xgboost_tests/app_config_gpu.yaml
@@ -11,8 +11,7 @@ python:
   conda_packages: []
 
 post_build_cmds:
-  - pip uninstall -y ray || true
-  - pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip install -U xgboost xgboost_ray petastorm  # Install latest releases
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   - sudo mkdir -p /data || true


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It fixes the mysterious error when all cluster env build is failing when pip uninstall / pip install is written in 2 lines. The root cause will be fixed later

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
