### PR TITLE
[tune] Fix stray extra log from runtime_env setup

### DIFF
--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -67,7 +67,7 @@ class RuntimeEnvContext:
 
         exec_command = " ".join([f"{executable}"] + passthrough_args)
         command_str = " && ".join(self.command_prefix + [exec_command])
-        logger.info(f"Exec'ing worker with command: {command_str}")
+        logger.debug(f"Exec'ing worker with command: {command_str}")
         if sys.platform == "win32":
             os.system(command_str)
         else:

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -595,7 +595,7 @@ class ProgressReporterTest(unittest.TestCase):
             try:
                 assert EXPECTED_END_TO_END_START in output
                 assert EXPECTED_END_TO_END_END in output
-                assert "(raylet)" not in output
+                assert "(raylet)" not in output, "Unexpected raylet log messages"
             except Exception:
                 print("*** BEGIN OUTPUT ***")
                 print(output)

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -595,6 +595,7 @@ class ProgressReporterTest(unittest.TestCase):
             try:
                 assert EXPECTED_END_TO_END_START in output
                 assert EXPECTED_END_TO_END_END in output
+                assert "(raylet)" not in output
             except Exception:
                 print("*** BEGIN OUTPUT ***")
                 print(output)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```
commit 40774ac219dc660f7ce269ea330725bdc2d9943b
Author: Qing Wang <kingchin1218@gmail.com>
Date:   Tue May 17 11:33:59 2022 +0800

    Minor changes for Java runtime env. (#24840)
```

Introduced an extra log message that spams stdout when running with Tune. Move this log line to debug and add an e2e test check.