### PR TITLE
HandlePinObjectIds should return error if the object doesn't exist

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2427,7 +2427,7 @@ bool CoreWorker::PinExistingReturnObject(const ObjectID &return_id,
         {return_id},
         [return_id, pinned_return_object](const Status &status,
                                           const rpc::PinObjectIDsReply &reply) {
-          if (!status.ok()) {
+          if (!status.ok() || !reply.success(0)) {
             RAY_LOG(INFO) << "Failed to pin existing copy of the task return object "
                           << return_id
                           << ". This object may get evicted while there are still "

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2427,7 +2427,7 @@ bool CoreWorker::PinExistingReturnObject(const ObjectID &return_id,
         {return_id},
         [return_id, pinned_return_object](const Status &status,
                                           const rpc::PinObjectIDsReply &reply) {
-          if (!status.ok() || !reply.success(0)) {
+          if (!status.ok() || !reply.successes(0)) {
             RAY_LOG(INFO) << "Failed to pin existing copy of the task return object "
                           << return_id
                           << ". This object may get evicted while there are still "

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -122,7 +122,7 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
                        {object_id},
                        [this, object_id, other_locations, node_id](
                            const Status &status, const rpc::PinObjectIDsReply &reply) {
-                         if (status.ok() && reply.success(0)) {
+                         if (status.ok() && reply.successes(0)) {
                            // TODO(swang): Make sure that the node is still alive when
                            // marking the object as pinned.
                            RAY_CHECK(in_memory_store_->Put(

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -122,7 +122,7 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
                        {object_id},
                        [this, object_id, other_locations, node_id](
                            const Status &status, const rpc::PinObjectIDsReply &reply) {
-                         if (status.ok()) {
+                         if (status.ok() && reply.success(0)) {
                            // TODO(swang): Make sure that the node is still alive when
                            // marking the object as pinned.
                            RAY_CHECK(in_memory_store_->Put(

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -66,14 +66,15 @@ class MockRayletClient : public PinObjectsInterface {
     callbacks.push_back(callback);
   }
 
-  size_t Flush() {
-    size_t flushed = callbacks.size();
-    for (const auto &callback : callbacks) {
+  size_t Flush(bool success=true) {
+    std::list<rpc::ClientCallback<rpc::PinObjectIDsReply>> callbacks_snapshot;
+    std::swap(callbacks_snapshot, callbacks);
+    size_t flushed = callbacks_snapshot.size();
+    for (const auto &callback : callbacks_snapshot) {
       rpc::PinObjectIDsReply reply;
-      reply.add_success(true);
+      reply.add_success(success);
       callback(Status::OK(), reply);
     }
-    callbacks.clear();
     return flushed;
   }
 
@@ -232,12 +233,15 @@ TEST_F(ObjectRecoveryManagerTest, TestPinNewCopy) {
                                0,
                                true,
                                /*add_local_ref=*/true);
-  std::vector<rpc::Address> addresses({rpc::Address()});
+  std::vector<rpc::Address> addresses({rpc::Address(), rpc::Address()});
   object_directory_->SetLocations(object_id, addresses);
 
   ASSERT_TRUE(manager_.RecoverObject(object_id));
   ASSERT_TRUE(object_directory_->Flush() == 1);
-  ASSERT_TRUE(raylet_client_->Flush() == 1);
+  // First copy is evicted so pin fails.
+  ASSERT_TRUE(raylet_client_->Flush(false) == 1);
+  // Second copy is present so pin succeeds.
+  ASSERT_TRUE(raylet_client_->Flush(true) == 1);
   ASSERT_TRUE(failed_reconstructions_.empty());
   ASSERT_EQ(task_resubmitter_->num_tasks_resubmitted, 0);
 }

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -66,7 +66,7 @@ class MockRayletClient : public PinObjectsInterface {
     callbacks.push_back(callback);
   }
 
-  size_t Flush(bool success=true) {
+  size_t Flush(bool success = true) {
     std::list<rpc::ClientCallback<rpc::PinObjectIDsReply>> callbacks_snapshot;
     std::swap(callbacks_snapshot, callbacks);
     size_t flushed = callbacks_snapshot.size();

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -72,7 +72,7 @@ class MockRayletClient : public PinObjectsInterface {
     size_t flushed = callbacks_snapshot.size();
     for (const auto &callback : callbacks_snapshot) {
       rpc::PinObjectIDsReply reply;
-      reply.add_success(success);
+      reply.add_successes(success);
       callback(Status::OK(), reply);
     }
     return flushed;

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -69,7 +69,9 @@ class MockRayletClient : public PinObjectsInterface {
   size_t Flush() {
     size_t flushed = callbacks.size();
     for (const auto &callback : callbacks) {
-      callback(Status::OK(), rpc::PinObjectIDsReply());
+      rpc::PinObjectIDsReply reply;
+      reply.add_success(true);
+      callback(Status::OK(), reply);
     }
     callbacks.clear();
     return flushed;

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -170,7 +170,8 @@ message PinObjectIDsRequest {
 }
 
 message PinObjectIDsReply {
-  repeated bool success = 1;
+  // Whether pinning the corresponding object succeeded or not.
+  repeated bool successes = 1;
 }
 
 message GetNodeStatsRequest {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -171,6 +171,7 @@ message PinObjectIDsRequest {
 
 message PinObjectIDsReply {
   // Whether pinning the corresponding object succeeded or not.
+  // Pin can fail if the object is already evicted.
   repeated bool successes = 1;
 }
 

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -169,7 +169,9 @@ message PinObjectIDsRequest {
   repeated bytes object_ids = 2;
 }
 
-message PinObjectIDsReply {}
+message PinObjectIDsReply {
+  repeated bool success = 1;
+}
 
 message GetNodeStatsRequest {
   // Whether to include memory stats. This could be large since it includes

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2374,7 +2374,7 @@ void NodeManager::HandlePinObjectIDs(const rpc::PinObjectIDsRequest &request,
   std::vector<std::unique_ptr<RayObject>> results;
   if (!GetObjectsFromPlasma(object_ids, &results)) {
     for (size_t i = 0; i < object_ids.size(); ++i) {
-      reply->add_success(false);
+      reply->add_successes(false);
     }
   } else {
     RAY_CHECK_EQ(object_ids.size(), results.size());
@@ -2387,18 +2387,18 @@ void NodeManager::HandlePinObjectIDs(const rpc::PinObjectIDsRequest &request,
                        << "secondary copy and it's evicted in the meantime";
         object_id_it = object_ids.erase(object_id_it);
         result_it = results.erase(result_it);
-        reply->add_success(false);
+        reply->add_successes(false);
       } else {
         ++object_id_it;
         ++result_it;
-        reply->add_success(true);
+        reply->add_successes(true);
       }
     }
     // Wait for the object to be freed by the owner, which keeps the ref count.
     local_object_manager_.PinObjectsAndWaitForFree(
         object_ids, std::move(results), owner_address);
   }
-  RAY_CHECK_EQ(request.object_ids_size(), reply->success_size());
+  RAY_CHECK_EQ(request.object_ids_size(), reply->successes_size());
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2373,16 +2373,32 @@ void NodeManager::HandlePinObjectIDs(const rpc::PinObjectIDsRequest &request,
   }
   std::vector<std::unique_ptr<RayObject>> results;
   if (!GetObjectsFromPlasma(object_ids, &results)) {
-    RAY_LOG(WARNING)
-        << "Failed to get objects that should have been in the object store. These "
-           "objects may have been evicted while there are still references in scope.";
-    // TODO(suquark): Maybe "Status::ObjectNotFound" is more accurate here.
-    send_reply_callback(Status::Invalid("Failed to get objects."), nullptr, nullptr);
-    return;
+    for (size_t i = 0; i < object_ids.size(); ++i) {
+      reply->add_success(false);
+    }
+  } else {
+    RAY_CHECK_EQ(object_ids.size(), results.size());
+    auto object_id_it = object_ids.begin();
+    auto result_it = results.begin();
+    while (object_id_it != object_ids.end()) {
+      if (*result_it == nullptr) {
+        RAY_LOG(DEBUG) << "Failed to get object in the object store: " << *object_id_it
+                       << ". This should only happen when the owner tries to pin a "
+                       << "secondary copy and it's evicted in the meantime";
+        object_id_it = object_ids.erase(object_id_it);
+        result_it = results.erase(result_it);
+        reply->add_success(false);
+      } else {
+        ++object_id_it;
+        ++result_it;
+        reply->add_success(true);
+      }
+    }
+    // Wait for the object to be freed by the owner, which keeps the ref count.
+    local_object_manager_.PinObjectsAndWaitForFree(
+        object_ids, std::move(results), owner_address);
   }
-  // Wait for the object to be freed by the owner, which keeps the ref count.
-  local_object_manager_.PinObjectsAndWaitForFree(
-      object_ids, std::move(results), owner_address);
+  RAY_CHECK_EQ(request.object_ids_size(), reply->success_size());
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When the primary copy of an object is lost, owner will try to pin the secondary copy. In the meantime, the secondary copy might be evicted. In this case, the PinObjectIDs rpc call should return error to let the owner know that the pin failed. Otherwise the owner will mistakenly think the secondary copy is pinned.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
