### PR TITLE
[datasets] Fix scheduling strategy propagation and stats collection in push-based shuffle

### DIFF
--- a/python/ray/data/impl/push_based_shuffle.py
+++ b/python/ray/data/impl/push_based_shuffle.py
@@ -138,6 +138,7 @@ class PushBasedShufflePlan(ShuffleOp):
         # The placement strategy for reduce tasks is overwritten to colocate
         # them with their inputs from the merge stage, so remove any
         # pre-specified scheduling strategy here.
+        reduce_ray_remote_args = reduce_ray_remote_args.copy()
         reduce_ray_remote_args.pop("scheduling_strategy", None)
 
         map_fn = self._map_partition
@@ -249,6 +250,7 @@ class PushBasedShufflePlan(ShuffleOp):
                 last_merge_metadata_results,
                 merge_args,
             )
+            shuffle_merge_metadata += prev_merge_metadata
             for merge_idx, merge_result in enumerate(merge_results):
                 all_merge_results[merge_idx].append(merge_result)
             del merge_results

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -3802,33 +3802,47 @@ def test_random_shuffle_check_random(shutdown_only):
             prev = x
 
 
-def test_random_shuffle_spread(ray_start_cluster):
-    cluster = ray_start_cluster
-    cluster.add_node(
-        resources={"bar:1": 100},
-        num_cpus=10,
-        _system_config={"max_direct_call_object_size": 0},
-    )
-    cluster.add_node(resources={"bar:2": 100}, num_cpus=10)
-    cluster.add_node(resources={"bar:3": 100}, num_cpus=0)
+@pytest.mark.parametrize("use_push_based_shuffle", [False, True])
+def test_random_shuffle_spread(ray_start_cluster, use_push_based_shuffle):
+    ctx = ray.data.context.DatasetContext.get_current()
+    try:
+        original = ctx.use_push_based_shuffle
+        ctx.use_push_based_shuffle = use_push_based_shuffle
 
-    ray.init(cluster.address)
+        cluster = ray_start_cluster
+        cluster.add_node(
+            resources={"bar:1": 100},
+            num_cpus=10,
+            _system_config={"max_direct_call_object_size": 0},
+        )
+        cluster.add_node(resources={"bar:2": 100}, num_cpus=10)
+        cluster.add_node(resources={"bar:3": 100}, num_cpus=0)
 
-    @ray.remote
-    def get_node_id():
-        return ray.get_runtime_context().node_id.hex()
+        ray.init(cluster.address)
 
-    node1_id = ray.get(get_node_id.options(resources={"bar:1": 1}).remote())
-    node2_id = ray.get(get_node_id.options(resources={"bar:2": 1}).remote())
+        @ray.remote
+        def get_node_id():
+            return ray.get_runtime_context().node_id.hex()
 
-    ds = ray.data.range(100, parallelism=2).random_shuffle()
-    blocks = ds.get_internal_block_refs()
-    ray.wait(blocks, num_returns=len(blocks), fetch_local=False)
-    location_data = ray.experimental.get_object_locations(blocks)
-    locations = []
-    for block in blocks:
-        locations.extend(location_data[block]["node_ids"])
-    assert set(locations) == {node1_id, node2_id}
+        node1_id = ray.get(get_node_id.options(resources={"bar:1": 1}).remote())
+        node2_id = ray.get(get_node_id.options(resources={"bar:2": 1}).remote())
+
+        ds = ray.data.range(100, parallelism=2).random_shuffle()
+        blocks = ds.get_internal_block_refs()
+        ray.wait(blocks, num_returns=len(blocks), fetch_local=False)
+        location_data = ray.experimental.get_object_locations(blocks)
+        locations = []
+        for block in blocks:
+            locations.extend(location_data[block]["node_ids"])
+        assert "2 nodes used" in ds.stats()
+
+        if not use_push_based_shuffle:
+            # We don't check this for push-based shuffle since it will try to
+            # colocate reduce tasks to improve locality.
+            assert set(locations) == {node1_id, node2_id}
+
+    finally:
+        ctx.use_push_based_shuffle = original
 
 
 def test_parquet_read_spread(ray_start_cluster, tmp_path):

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -239,7 +239,13 @@ def test_push_based_shuffle_stats(ray_start_cluster):
         # Check all merge tasks are included in stats.
         internal_stats = ds._plan.stats()
         num_merge_tasks = len(internal_stats.stages["random_shuffle_merge"])
-        assert parallelism // 3 <= num_merge_tasks <= parallelism // 2
+        # Merge factor is 2 for random_shuffle ops.
+        merge_factor = 2
+        assert (
+            parallelism // (merge_factor + 1)
+            <= num_merge_tasks
+            <= parallelism // merge_factor
+        )
 
     finally:
         ctx.use_push_based_shuffle = original


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes two bugs in Datasets push-based shuffle:
1. Scheduling strategy specified by the caller was not getting propagated correctly to the map stage in push-based shuffle. This is because the map and reduce stages shared the same ray.remote options dict, and we deleted the caller-specified scheduling strategy from the reduce stage so that we could specify a NodeAffinitySchedulingStrategy instead.
2. We were only reporting partial stats for the merge stage.

## Related issue number

Issue 1 is necessary for performance at large-scale (#24480).

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
