### PR TITLE
[GCP] Update TPU Region

### DIFF
--- a/python/ray/autoscaler/gcp/tpu.yaml
+++ b/python/ray/autoscaler/gcp/tpu.yaml
@@ -39,7 +39,7 @@ available_node_types:
 provider:
     type: gcp
     region: us-central1
-    availability_zone: us-central1-f
+    availability_zone: us-central1-b
     project_id: null  # replace with your GCP project id
 
 setup_commands: []


### PR DESCRIPTION
changed, there is no `central1-f` now.

see 
<img width="451" alt="image" src="https://user-images.githubusercontent.com/20907377/169951474-2056982c-3431-47b7-ba73-3cba7339a60e.png">


@Yard1 