### PR TITLE
[AIR] Don't ravel predictions in `TensorflowPrediction.predict`

### DIFF
--- a/python/ray/ml/predictors/integrations/tensorflow/tensorflow_predictor.py
+++ b/python/ray/ml/predictors/integrations/tensorflow/tensorflow_predictor.py
@@ -147,5 +147,5 @@ class TensorflowPredictor(Predictor):
         if self.model_weights:
             model.set_weights(self.model_weights)
 
-        prediction = model(tensor).numpy().ravel()
-        return pd.DataFrame(prediction, columns=["predictions"])
+        prediction = list(model(tensor).numpy())
+        return pd.DataFrame({"predictions": prediction}, columns=["predictions"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`TensorflowPredictor.predict` doesn't correctly produce logits. For more information, see #25137.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes #25137 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
