### PR TITLE
Point to latest contributing doc

### DIFF
--- a/doc/source/_includes/_latest_contribution_doc.rst
+++ b/doc/source/_includes/_latest_contribution_doc.rst
@@ -1,0 +1,6 @@
+.. admonition:: Check your version!
+
+    Things can change quickly, and so does this contributor guide.
+    To make sure you've got the most cutting edge version of this guide,
+    go check out the
+    [latest version](https://docs.ray.io/en/master/ray-contribute/getting-involved.html).

--- a/doc/source/_includes/_latest_contribution_doc.rst
+++ b/doc/source/_includes/_latest_contribution_doc.rst
@@ -3,4 +3,4 @@
     Things can change quickly, and so does this contributor guide.
     To make sure you've got the most cutting edge version of this guide,
     go check out the
-    [latest version](https://docs.ray.io/en/master/ray-contribute/getting-involved.html).
+    `latest version <https://docs.ray.io/en/master/ray-contribute/getting-involved.html>`__.

--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -237,12 +237,12 @@ parts:
 
   - caption: Developer Guides
     chapters:
-      - url: https://docs.ray.io/en/master/ray-contribute/getting-involved.html
+      - file: ray-contribute/getting-involved
         sections:
-          - url: https://docs.ray.io/en/master/ray-contribute/development.html
-          - url: https://docs.ray.io/en/master/ray-contribute/docs.html
-          - url: https://docs.ray.io/en/master/ray-contribute/fake-autoscaler.html
-          - url: https://docs.ray.io/en/master/ray-core/examples/testing-tips.html
+          - file: ray-contribute/development
+          - file: ray-contribute/docs
+          - file: ray-contribute/fake-autoscaler
+          - file: ray-core/examples/testing-tips
       - file: ray-core/configure
       - file: ray-observability/index
       - file: ray-contribute/whitepaper

--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -237,12 +237,12 @@ parts:
 
   - caption: Developer Guides
     chapters:
-      - file: ray-contribute/getting-involved
+      - url: https://docs.ray.io/en/master/ray-contribute/getting-involved.html
         sections:
-          - file: ray-contribute/development
-          - file: ray-contribute/docs
-          - file: ray-contribute/fake-autoscaler
-          - file: ray-core/examples/testing-tips
+          - url: https://docs.ray.io/en/master/ray-contribute/development.html
+          - url: https://docs.ray.io/en/master/ray-contribute/docs.html
+          - url: https://docs.ray.io/en/master/ray-contribute/fake-autoscaler.html
+          - url: https://docs.ray.io/en/master/ray-core/examples/testing-tips.html
       - file: ray-core/configure
       - file: ray-observability/index
       - file: ray-contribute/whitepaper

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -103,7 +103,7 @@ Here's a list of tips for getting involved with the Ray community:
 ```{include} _includes/_contribute.md
 ```
 
-If you're interested in contributing to Ray, check out our [contributing guide](ray-contribute/getting-involved)
+If you're interested in contributing to Ray, check out our [contributing guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html)
 to read about the contribution process and see what you can work on.
 
 ## What documentation resource is right for you?
@@ -170,6 +170,6 @@ Our developer guides will help you get started.
 
 +++
 
-{link-badge}`ray-contribute/getting-involved.html,"Developer Guides",cls=badge-light`
+{link-badge}`https://docs.ray.io/en/master/ray-contribute/getting-involved.html,"Developer Guides",cls=badge-light`
 
 ````

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -103,7 +103,10 @@ Here's a list of tips for getting involved with the Ray community:
 ```{include} _includes/_contribute.md
 ```
 
-If you're interested in contributing to Ray, check out our [contributing guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html)
+If you're interested in contributing to Ray, check out our
+[contributing guide for this release](ray-contribute/getting-involved)
+or see the
+[latest version of our contributing guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html)
 to read about the contribution process and see what you can work on.
 
 ## What documentation resource is right for you?

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -1,3 +1,5 @@
+.. include:: /_includes/_latest_contribution_doc.rst
+
 .. _getting-involved:
 
 Getting Involved / Contributing


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Pointing to the latest documentation for contributor is important as the workflow is always evolving. E.g. the installation instructions for bazel are not representatives of the current state on release vs master. Hence, I propose to update contribution links in the documentation to point to the latest state on master.

## Related issue number

Closes #11687 (linked and could already be closed)

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
