### PR TITLE
Prefer conda based dependencies in doc for macOS build

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -64,6 +64,8 @@ Every time you want to update your local version you can pull the changes from t
     # Pull the latest changes from the main repository
     git pull upstream master
 
+.. _python-environment:
+
 Prepare the Python environment
 ------------------------------
 
@@ -162,15 +164,24 @@ Preparing to build Ray on MacOS
 
 .. tip:: Assuming you already have Brew and Bazel installed on your mac and you also have grpc and protobuf installed on your mac consider removing those (grpc and protobuf) for smooth build through the commands ``brew uninstall grpc``, ``brew uninstall protobuf``. If you have built the source code earlier and it still fails with errors like ``No such file or directory:``, try cleaning previous builds on your host by running the commands ``brew uninstall binutils`` and ``bazel clean --expunge``.
 
-To build Ray on MacOS, first install these dependencies:
+To build Ray on MacOS, it is recommended to use a conda environment to install
+the dependencies. See :ref:`python-environment` for more details.
 
-.. code-block:: bash
+.. tabbed:: Conda
 
-  brew update
-  brew install wget
+    .. code-block:: bash
 
-  # Install Bazel.
-  ray/ci/env/install-bazel.sh
+        conda install protobuf bazel
+
+.. tabbed:: Bash
+
+    .. code-block:: bash
+
+        brew update
+        brew install wget
+
+        # Install Bazel.
+        ray/ci/env/install-bazel.sh
 
 Building Ray on Linux & MacOS (full)
 ------------------------------------

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -171,7 +171,7 @@ the dependencies. See :ref:`python-environment` for more details.
 
     .. code-block:: bash
 
-        conda install protobuf bazel
+        conda install protobuf grpcio bazel
 
 .. tabbed:: Bash
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On macOS M1 (not sure it's related), I could not build due to `bazel`. I constantly had issues with:

```
[3,586 / 5,210] Compiling src/google/protobuf/descriptor.pb.cc; 4s darwin-sandbox ... (8 actions, 7 running)
    ERROR: /private/var/tmp/_bazel_tupui/10be470d37831321d293d4790072ed18/external/com_github_cncf_udpa/xds/type/v3/BUILD:5:18: Generating Descriptor Set proto_library @com_github_cncf_udpa//xds/type/v3:pkg failed: (Segmentation fault): protoc failed: error executing command
```

Changing `protobuf` version or provenance (brew, conda, nothing) did not do anything and only after I used `bazel` from conda, it worked just fine.

Hence, I think the contributing guide should invite to use conda in order to install dependencies.

## Related issue number

N/A

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
