### PR TITLE
[Release Test] Mark dataset_shuffle_push_based_sort_1tb as stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3425,8 +3425,6 @@
     test_name: dataset_shuffle_random_shuffle_1tb
     test_suite: dataset_test
 
-  stable: true
-
   frequency: nightly
   team: core
   cluster:
@@ -3447,8 +3445,6 @@
   legacy:
     test_name: dataset_shuffle_sort_1tb
     test_suite: dataset_test
-
-  stable: true
 
   frequency: nightly
   team: core
@@ -3535,8 +3531,6 @@
   legacy:
     test_name: dataset_shuffle_push_based_sort_1tb
     test_suite: dataset_test
-
-  stable: false
 
   frequency: nightly
   team: core


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
dataset_shuffle_push_based_sort_1tb is consistently passing for weeks.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
