### PR TITLE
[core] Remove more expensive shuffle tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3429,7 +3429,7 @@
   team: core
   cluster:
     cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_large_scale.yaml
+    cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
 
   run:
     timeout: 7200
@@ -3444,48 +3444,6 @@
   working_dir: nightly_tests
   legacy:
     test_name: dataset_shuffle_sort_1tb
-    test_suite: dataset_test
-
-  frequency: nightly
-  team: core
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/shuffle_compute_large_scale.yaml
-
-  run:
-    timeout: 7200
-    script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9
-    wait_for_nodes:
-      num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
-
-- name: dataset_shuffle_random_shuffle_1tb_small_instances
-  group: core-dataset-tests
-  working_dir: nightly_tests
-  legacy:
-    test_name: dataset_shuffle_random_shuffle_1tb_small_instances
-    test_suite: dataset_test
-
-  frequency: nightly
-  team: core
-  cluster:
-    cluster_env: shuffle/shuffle_app_config.yaml
-    cluster_compute: shuffle/datasets_large_scale_compute_small_instances.yaml
-
-  run:
-    timeout: 7200
-    script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
-    wait_for_nodes:
-      num_nodes: 20
-    type: sdk_command
-    file_manager: sdk
-
-- name: dataset_shuffle_sort_1tb_small_instances
-  group: core-dataset-tests
-  working_dir: nightly_tests
-  legacy:
-    test_name: dataset_shuffle_sort_1tb_small_instances
     test_suite: dataset_test
 
   frequency: nightly


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Now that the "smaller_instances" versions of these tests are stable, we can stop running the version that uses bigger instances.