### PR TITLE
Revert "[core] Resubscribe GCS in python when GCS restarts."

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -1,5 +1,5 @@
 from libcpp cimport bool as c_bool
-from libc.stdint cimport int64_t, uint64_t, uint32_t, int32_t
+from libc.stdint cimport int64_t, uint64_t, uint32_t
 from libcpp.string cimport string as c_string
 from libcpp.unordered_map cimport unordered_map
 
@@ -68,5 +68,3 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool start_python_importer_thread() const
 
         c_bool use_ray_syncer() const
-
-        int32_t gcs_rpc_server_reconnect_timeout_s() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -85,10 +85,6 @@ cdef class Config:
         return RayConfig.instance().object_manager_default_chunk_size()
 
     @staticmethod
-    def gcs_rpc_server_reconnect_timeout_s():
-        return RayConfig.instance().gcs_rpc_server_reconnect_timeout_s()
-
-    @staticmethod
     def maximum_gcs_deletion_batch_size():
         return RayConfig.instance().maximum_gcs_deletion_batch_size()
 

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -9,15 +9,10 @@ from time import sleep
 
 from ray._private.test_utils import (
     generate_system_config_map,
-    run_string_as_driver_nonblocking,
     wait_for_condition,
     wait_for_pid_to_exit,
     convert_actor_state,
 )
-
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 @ray.remote
@@ -341,83 +336,6 @@ def test_core_worker_resubscription(tmp_path, ray_start_regular_with_external_re
     # Test the resubscribe works: if not, it'll timeout because worker
     # will think the actor is not ready.
     ray.get(r, timeout=5)
-
-
-@pytest.mark.parametrize(
-    "ray_start_regular_with_external_redis",
-    [
-        generate_system_config_map(
-            num_heartbeats_timeout=20, gcs_rpc_server_reconnect_timeout_s=60
-        )
-    ],
-    indirect=True,
-)
-def test_py_resubscription(tmp_path, ray_start_regular_with_external_redis):
-    # This test is to ensure python pubsub works
-    from filelock import FileLock
-
-    lock_file1 = str(tmp_path / "lock1")
-    lock1 = FileLock(lock_file1)
-    lock1.acquire()
-
-    lock_file2 = str(tmp_path / "lock2")
-    lock2 = FileLock(lock_file2)
-
-    script = f"""
-from filelock import FileLock
-import ray
-
-@ray.remote
-def f():
-    print("OK1", flush=True)
-    # wait until log_monitor push this
-    from time import sleep
-    sleep(2)
-    lock1 = FileLock(r"{lock_file1}")
-    lock2 = FileLock(r"{lock_file2}")
-
-    lock2.acquire()
-    lock1.acquire()
-
-    # wait until log_monitor push this
-    from time import sleep
-    sleep(2)
-    print("OK2", flush=True)
-
-ray.init(address='auto')
-ray.get(f.remote())
-ray.shutdown()
-"""
-    proc = run_string_as_driver_nonblocking(script)
-
-    def condition():
-        import filelock
-
-        try:
-            lock2.acquire(timeout=1)
-        except filelock.Timeout:
-            return True
-
-        lock2.release()
-        return False
-
-    # make sure the script has printed "OK1"
-    wait_for_condition(condition, timeout=10)
-
-    ray.worker._global_node.kill_gcs_server()
-    import time
-
-    time.sleep(2)
-    ray.worker._global_node.start_gcs_server()
-
-    lock1.release()
-    proc.wait()
-    output = proc.stdout.read()
-    # Print logs which are useful for debugging in CI
-    print("=================== OUTPUTS ============")
-    print(output.decode())
-    assert b"OK1" in output
-    assert b"OK2" in output
 
 
 @pytest.mark.parametrize("auto_reconnect", [True, False])

--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -1,7 +1,6 @@
 import sys
 import threading
 
-import ray
 from ray._private.gcs_pubsub import (
     GcsPublisher,
     GcsErrorSubscriber,
@@ -35,72 +34,6 @@ def test_publish_and_subscribe_error_info(ray_start_regular):
     subscriber.close()
 
 
-def test_publish_and_subscribe_error_info_ft(ray_start_regular_with_external_redis):
-    address_info = ray_start_regular_with_external_redis
-    gcs_server_addr = address_info["gcs_address"]
-    from threading import Barrier, Thread
-
-    subscriber = GcsErrorSubscriber(address=gcs_server_addr)
-    subscriber.subscribe()
-
-    publisher = GcsPublisher(address=gcs_server_addr)
-
-    err1 = ErrorTableData(error_message="test error message 1")
-    err2 = ErrorTableData(error_message="test error message 2")
-    err3 = ErrorTableData(error_message="test error message 3")
-    err4 = ErrorTableData(error_message="test error message 4")
-    b = Barrier(3)
-
-    def publisher_func():
-        print("Publisher HERE")
-        publisher.publish_error(b"aaa_id", err1)
-        publisher.publish_error(b"bbb_id", err2)
-
-        b.wait()
-
-        print("Publisher HERE")
-        # Wait fo subscriber to subscribe first.
-        # It's ok to loose log messages.
-        from time import sleep
-
-        sleep(5)
-        publisher.publish_error(b"aaa_id", err3)
-        print("pub err1")
-        publisher.publish_error(b"bbb_id", err4)
-        print("pub err2")
-        print("DONE")
-
-    def subscriber_func():
-        print("Subscriber HERE")
-        assert subscriber.poll() == (b"aaa_id", err1)
-        assert subscriber.poll() == (b"bbb_id", err2)
-
-        b.wait()
-        assert subscriber.poll() == (b"aaa_id", err3)
-        print("sub err1")
-        assert subscriber.poll() == (b"bbb_id", err4)
-        print("sub err2")
-
-        subscriber.close()
-        print("DONE")
-
-    t1 = Thread(target=publisher_func)
-    t2 = Thread(target=subscriber_func)
-    t1.start()
-    t2.start()
-    b.wait()
-
-    ray.worker._global_node.kill_gcs_server()
-    from time import sleep
-
-    sleep(1)
-    ray.worker._global_node.start_gcs_server()
-    sleep(1)
-
-    t1.join()
-    t2.join()
-
-
 @pytest.mark.asyncio
 async def test_aio_publish_and_subscribe_error_info(ray_start_regular):
     address_info = ray_start_regular
@@ -119,61 +52,6 @@ async def test_aio_publish_and_subscribe_error_info(ray_start_regular):
     assert await subscriber.poll() == (b"bbb_id", err2)
 
     await subscriber.close()
-
-
-@pytest.mark.asyncio
-async def test_aio_publish_and_subscribe_error_info_ft(
-    ray_start_regular_with_external_redis,
-):
-    address_info = ray_start_regular_with_external_redis
-    gcs_server_addr = address_info["gcs_address"]
-
-    subscriber = GcsAioErrorSubscriber(address=gcs_server_addr)
-    await subscriber.subscribe()
-
-    err1 = ErrorTableData(error_message="test error message 1")
-    err2 = ErrorTableData(error_message="test error message 2")
-    err3 = ErrorTableData(error_message="test error message 3")
-    err4 = ErrorTableData(error_message="test error message 4")
-
-    def restart_gcs_server():
-        import asyncio
-
-        asyncio.set_event_loop(asyncio.new_event_loop())
-        from time import sleep
-
-        publisher = GcsAioPublisher(address=gcs_server_addr)
-        asyncio.get_event_loop().run_until_complete(
-            publisher.publish_error(b"aaa_id", err1)
-        )
-        asyncio.get_event_loop().run_until_complete(
-            publisher.publish_error(b"bbb_id", err2)
-        )
-
-        # wait until subscribe consume everything
-        sleep(5)
-        ray.worker._global_node.kill_gcs_server()
-        sleep(1)
-        ray.worker._global_node.start_gcs_server()
-        # wait until subscriber resubscribed
-        sleep(5)
-
-        asyncio.get_event_loop().run_until_complete(
-            publisher.publish_error(b"aaa_id", err3)
-        )
-        asyncio.get_event_loop().run_until_complete(
-            publisher.publish_error(b"bbb_id", err4)
-        )
-
-    t1 = threading.Thread(target=restart_gcs_server)
-    t1.start()
-    assert await subscriber.poll() == (b"aaa_id", err1)
-    assert await subscriber.poll() == (b"bbb_id", err2)
-    assert await subscriber.poll() == (b"aaa_id", err3)
-    assert await subscriber.poll() == (b"bbb_id", err4)
-
-    await subscriber.close()
-    t1.join()
 
 
 def test_publish_and_subscribe_logs(ray_start_regular):


### PR DESCRIPTION
Reverts ray-project/ray#24887

May be causing flakiness for `//python/ray/tests:test_multiprocessing`.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/81660174/170142084-bedc75c3-f964-4f6a-9439-a70fd6f6a9fc.png">

But let me know if the flakiness is caused by something else.