### PR TITLE
[core] Don't adjust OOM score for IO workers

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -444,7 +444,9 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
   stats::NumWorkersStarted.Record(1);
   RAY_LOG(INFO) << "Started worker process with pid " << proc.GetId() << ", the token is "
                 << worker_startup_token_counter_;
-  AdjustWorkerOomScore(proc.GetId());
+  if (!IsIOWorkerType(worker_type)) {
+    AdjustWorkerOomScore(proc.GetId());
+  }
   MonitorStartingWorkerProcess(
       proc, worker_startup_token_counter_, language, worker_type);
   AddWorkerProcess(state, worker_type, proc, start, runtime_env_info);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We should try to avoid killing IO workers, since this can disrupt spilling and add a lot of load on Ray core. This will make it so taht we prioritize workers running application tasks instead.