### PR TITLE
[Core] Log restore errors by default

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -932,17 +932,16 @@ cdef int64_t restore_spilled_objects_handler(
                     ray_constants.WORKER_PROCESS_TYPE_RESTORE_WORKER_IDLE):
                 bytes_restored = external_storage.restore_spilled_objects(
                     object_refs, urls)
-        except Exception:
+        except Exception as err:
             exception_str = (
                 "An unexpected internal error occurred while the IO worker "
-                "was restoring spilled objects.")
+                "was restoring spilled objects. Attempted to restore URLS: {}, got {}".format(err))
             logger.exception(exception_str)
-            if os.getenv("RAY_BACKEND_LOG_LEVEL") == "debug":
-                ray._private.utils.push_error_to_driver(
-                    ray.worker.global_worker,
-                    "restore_objects_error",
-                    traceback.format_exc() + exception_str,
-                    job_id=None)
+            ray._private.utils.push_error_to_driver(
+                ray.worker.global_worker,
+                "restore_objects_error",
+                traceback.format_exc() + exception_str,
+                job_id=None)
     return bytes_restored
 
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -935,7 +935,8 @@ cdef int64_t restore_spilled_objects_handler(
         except Exception as err:
             exception_str = (
                 "An unexpected internal error occurred while the IO worker "
-                "was restoring spilled objects. Attempted to restore URLS: {}, got {}".format(err))
+                "was restoring spilled objects. "
+                "Attempted to restore URLS: {}, got {}".format(err))
             logger.exception(exception_str)
             ray._private.utils.push_error_to_driver(
                 ray.worker.global_worker,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Failed restores result in Ray silently hanging. This should alert users when restores have failed

## Related issue number

https://github.com/ray-project/ray/issues/24248

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
