### PR TITLE
[AIR] Change key to model in TensorflowTrainer

### DIFF
--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -659,7 +659,7 @@ appropriately in distributed training.
 
             for epoch in range(config["num_epochs"]):
                 model.fit(X, Y, batch_size=20)
-                train.save_checkpoint(epoch=epoch, model_weights=model.get_weights())
+                train.save_checkpoint(epoch=epoch, model=model.get_weights())
 
 
         trainer = Trainer(backend="tensorflow", num_workers=2)
@@ -861,7 +861,7 @@ Checkpoints can be loaded into the training function in 2 steps:
 
             for epoch in range(start_epoch, config["num_epochs"]):
                 model.fit(X, Y, batch_size=20)
-                train.save_checkpoint(epoch=epoch, model_weights=model.get_weights())
+                train.save_checkpoint(epoch=epoch, model=model.get_weights())
 
 
         trainer = Trainer(backend="tensorflow", num_workers=2)


### PR DESCRIPTION
## Why are these changes needed?

As described in the related issue, using model_weight as the key throws an error.
This update points the user to use model as the key instead.

## Related issue number

Closes #25144 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
