### PR TITLE
Remove deprecated ray.worker.get_resource_ids()

### DIFF
--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -70,9 +70,9 @@ def test_many_fractional_resources(shutdown_only):
 
     @ray.remote
     def f(block, accepted_resources):
+        resources = ray.worker.global_worker.core_worker.resource_ids()
         true_resources = {
-            resource: value[0][1]
-            for resource, value in ray.worker.get_resource_ids().items()
+            resource: value[0][1] for resource, value in resources.items()
         }
         if block:
             ray.get(g.remote())

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -325,7 +325,7 @@ def test_placement_group_actor_resource_ids(ray_start_cluster, connect_to_client
     @ray.remote(num_cpus=1)
     class F:
         def f(self):
-            return ray.worker.get_resource_ids()
+            return ray.worker.global_worker.core_worker.resource_ids()
 
     cluster = ray_start_cluster
     num_nodes = 1
@@ -346,7 +346,7 @@ def test_placement_group_actor_resource_ids(ray_start_cluster, connect_to_client
 def test_placement_group_task_resource_ids(ray_start_cluster, connect_to_client):
     @ray.remote(num_cpus=1)
     def f():
-        return ray.worker.get_resource_ids()
+        return ray.worker.global_worker.core_worker.resource_ids()
 
     cluster = ray_start_cluster
     num_nodes = 1
@@ -378,7 +378,7 @@ def test_placement_group_task_resource_ids(ray_start_cluster, connect_to_client)
 def test_placement_group_hang(ray_start_cluster, connect_to_client):
     @ray.remote(num_cpus=1)
     def f():
-        return ray.worker.get_resource_ids()
+        return ray.worker.global_worker.core_worker.resource_ids()
 
     cluster = ray_start_cluster
     num_nodes = 1

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -559,6 +559,7 @@ def get_gpu_ids():
 @Deprecated
 def get_resource_ids():
     """Get the IDs of the resources that are available to the worker.
+
     Returns:
         A dictionary mapping the name of a resource to a list of pairs, where
         each pair consists of the ID of a resource and the fraction of that

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -556,6 +556,16 @@ def get_gpu_ids():
 
     return assigned_ids
 
+@Deprecated
+def get_resource_ids():
+    """Get the IDs of the resources that are available to the worker.
+    Returns:
+        A dictionary mapping the name of a resource to a list of pairs, where
+        each pair consists of the ID of a resource and the fraction of that
+        resource reserved for this worker.
+    """
+    raise DeprecationWarning("get_resource_ids() is deprecated")
+
 
 @Deprecated(message="Use ray.init()['webui_url'] instead.")
 def get_dashboard_url():

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -556,6 +556,7 @@ def get_gpu_ids():
 
     return assigned_ids
 
+
 @Deprecated
 def get_resource_ids():
     """Get the IDs of the resources that are available to the worker.
@@ -565,7 +566,9 @@ def get_resource_ids():
         each pair consists of the ID of a resource and the fraction of that
         resource reserved for this worker.
     """
-    raise DeprecationWarning("get_resource_ids() is deprecated")
+    raise DeprecationWarning(
+        "get_resource_ids() is deprecated, use get_gpu_ids() to get the IDs of GPUs"
+    )
 
 
 @Deprecated(message="Use ray.init()['webui_url'] instead.")

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -557,26 +557,6 @@ def get_gpu_ids():
     return assigned_ids
 
 
-@Deprecated
-def get_resource_ids():
-    """Get the IDs of the resources that are available to the worker.
-
-    Returns:
-        A dictionary mapping the name of a resource to a list of pairs, where
-        each pair consists of the ID of a resource and the fraction of that
-        resource reserved for this worker.
-    """
-    worker = global_worker
-    worker.check_connected()
-
-    if _mode() == LOCAL_MODE:
-        raise RuntimeError(
-            "ray.worker.get_resource_ids() currently does not work in local_mode."
-        )
-
-    return global_worker.core_worker.resource_ids()
-
-
 @Deprecated(message="Use ray.init()['webui_url'] instead.")
 def get_dashboard_url():
     """Get the URL to access the Ray dashboard.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This api is already marked as deprecated.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
