### PR TITLE
[core] Fix bug in spilling objects that have empty data field

### DIFF
--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -131,19 +131,15 @@ class ExternalStorage(metaclass=abc.ABCMeta):
             if buf is None and len(metadata) == 0:
                 error = f"Object {ref.hex()} does not exist."
                 raise ValueError(error)
-            if buf is None:
-                buf_len = 0
-            else:
-                buf_len = len(buf)
+            buf_len = 0 if buf is None else len(buf)
             payload = (
                 address_len.to_bytes(8, byteorder="little")
                 + metadata_len.to_bytes(8, byteorder="little")
                 + buf_len.to_bytes(8, byteorder="little")
                 + owner_address
                 + metadata
+                + (memoryview(buf) if buf_len else b"")
             )
-            if buf is not None:
-                payload += memoryview(buf)
             # 24 bytes to store owner address, metadata, and buffer lengths.
             payload_len = len(payload)
             assert (

--- a/python/ray/external_storage.py
+++ b/python/ray/external_storage.py
@@ -128,22 +128,22 @@ class ExternalStorage(metaclass=abc.ABCMeta):
         ):
             address_len = len(owner_address)
             metadata_len = len(metadata)
-            if buf is None:
-                error = f"object ref {ref.hex()} does not exist."
-                # empty data and 1 byte metadata, this object is
-                # marked as failed.
-                if metadata_len == 1:
-                    error += " This is probably since its owner has failed."
+            if buf is None and len(metadata) == 0:
+                error = f"Object {ref.hex()} does not exist."
                 raise ValueError(error)
-            buf_len = len(buf)
+            if buf is None:
+                buf_len = 0
+            else:
+                buf_len = len(buf)
             payload = (
                 address_len.to_bytes(8, byteorder="little")
                 + metadata_len.to_bytes(8, byteorder="little")
                 + buf_len.to_bytes(8, byteorder="little")
                 + owner_address
                 + metadata
-                + memoryview(buf)
             )
+            if buf is not None:
+                payload += memoryview(buf)
             # 24 bytes to store owner address, metadata, and buffer lengths.
             payload_len = len(payload)
             assert (

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -319,5 +319,44 @@ def test_spill_deadlock(object_spilling_config, shutdown_only):
     assert_no_thrashing(address["address"])
 
 
+def test_spill_reconstruction_errors(ray_start_cluster, object_spilling_config):
+    config = {
+        "num_heartbeats_timeout": 10,
+        "raylet_heartbeat_period_milliseconds": 100,
+        "max_direct_call_object_size": 100,
+        "task_retry_delay_ms": 100,
+        "object_timeout_milliseconds": 200,
+    }
+    cluster = ray_start_cluster
+    # Head node with no resources.
+    cluster.add_node(num_cpus=0, _system_config=config, object_store_memory=10 ** 8)
+    ray.init(address=cluster.address)
+    # Node to place the initial object.
+    node_to_kill = cluster.add_node(num_cpus=1, object_store_memory=10 ** 8)
+
+    @ray.remote
+    def put():
+        return np.zeros(10 ** 5, dtype=np.uint8)
+
+    @ray.remote
+    def check(x):
+        return
+
+    ref = put.remote()
+    for _ in range(4):
+        ray.get(check.remote(ref))
+        cluster.remove_node(node_to_kill, allow_graceful=False)
+        node_to_kill = cluster.add_node(num_cpus=1, object_store_memory=10 ** 8)
+
+    # All reconstruction attempts used up. The object's value should now be an
+    # error in the local store.
+    # Force object spilling and check that it can complete.
+    xs = []
+    for _ in range(20):
+        xs.append(ray.put(np.zeros(10 ** 7, dtype=np.uint8)))
+    for x in xs:
+        ray.get(x, timeout=10)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -357,6 +357,9 @@ def test_spill_reconstruction_errors(ray_start_cluster, object_spilling_config):
     for x in xs:
         ray.get(x, timeout=10)
 
+    with pytest.raises(ray.exceptions.ObjectLostError):
+        ray.get(ref)
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray sometimes stores errors as the object value in shared memory. These objects have no data since the error is stored in the metadata field. #25085 describes a bug where these objects fail to spill because the IO worker assumes that the data field must be non-empty. This would cause head-of-line blocking for any other objects to spill and cause the whole job to hang. This PR fixes the issue by spilling these objects anyway.

## Related issue number

Closes #25085.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
