### PR TITLE
[Deployment Graph] Simplify our use of DeploymentSchema

### DIFF
--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -190,8 +190,6 @@ class Deployment:
         """
 
         copied_self = copy(self)
-        copied_self._init_args = []
-        copied_self._init_kwargs = {}
         copied_self._func_or_class = "dummpy.module"
         schema_shell = deployment_to_schema(copied_self)
 
@@ -446,8 +444,6 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
     init_args and init_kwargs must also be JSON-serializable or this call will
     fail.
     """
-    from ray.serve.pipeline.json_serde import convert_to_json_safe_obj
-
     if d.ray_actor_options is not None:
         ray_actor_options_schema = RayActorOptionsSchema.parse_obj(d.ray_actor_options)
     else:
@@ -458,8 +454,8 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
         import_path=get_deployment_import_path(
             d, enforce_importable=True, replace_main=True
         ),
-        init_args=convert_to_json_safe_obj(d.init_args, err_key="init_args"),
-        init_kwargs=convert_to_json_safe_obj(d.init_kwargs, err_key="init_kwargs"),
+        init_args=(),
+        init_kwargs={},
         num_replicas=d.num_replicas,
         route_prefix=d.route_prefix,
         max_concurrent_queries=d.max_concurrent_queries,
@@ -474,8 +470,6 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
 
 
 def schema_to_deployment(s: DeploymentSchema) -> Deployment:
-    from ray.serve.pipeline.json_serde import convert_from_json_safe_obj
-
     if s.ray_actor_options is None:
         ray_actor_options = None
     else:
@@ -497,8 +491,8 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         func_or_class=s.import_path,
         name=s.name,
         config=config,
-        init_args=convert_from_json_safe_obj(s.init_args, err_key="init_args"),
-        init_kwargs=convert_from_json_safe_obj(s.init_kwargs, err_key="init_kwargs"),
+        init_args=(),
+        init_kwargs={},
         route_prefix=s.route_prefix,
         ray_actor_options=ray_actor_options,
         _internal=True,

--- a/python/ray/serve/pipeline/deployment_function_node.py
+++ b/python/ray/serve/pipeline/deployment_function_node.py
@@ -60,7 +60,7 @@ class DeploymentFunctionNode(DAGNode):
                 func_or_class=func_body,
                 name=self._deployment_name,
                 init_args=(),
-                init_kwargs=dict(),
+                init_kwargs={},
                 route_prefix=route_prefix,
             )
         else:
@@ -124,7 +124,6 @@ class DeploymentFunctionNode(DAGNode):
             # .options() should not contain any DAGNode type
             "options": self.get_options(),
             "other_args_to_resolve": self.get_other_args_to_resolve(),
-            "uuid": self.get_stable_uuid(),
         }
 
     @classmethod

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -2,7 +2,7 @@ import inspect
 import json
 from typing import Any, Callable, Dict, Optional, List, Tuple, Union
 
-from ray.experimental.dag import DAGNode, InputNode
+from ray.experimental.dag import DAGNode
 from ray.serve.deployment_executor_node import DeploymentExecutorNode
 from ray.serve.deployment_function_executor_node import (
     DeploymentFunctionExecutorNode,
@@ -10,11 +10,8 @@ from ray.serve.deployment_function_executor_node import (
 from ray.serve.deployment_method_executor_node import (
     DeploymentMethodExecutorNode,
 )
-from ray.serve.handle import (
-    RayServeLazySyncHandle,
-    RayServeSyncHandle,
-    RayServeHandle,
-)
+from ray.serve.handle import RayServeLazySyncHandle
+
 from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
 from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
 from ray.experimental.dag.constants import (
@@ -50,13 +47,6 @@ class DeploymentNode(DAGNode):
             ray_actor_options,
             other_args_to_resolve=other_args_to_resolve,
         )
-        if self._contains_input_node():
-            raise ValueError(
-                "InputNode handles user dynamic input the the DAG, and "
-                "cannot be used as args, kwargs, or other_args_to_resolve "
-                "in the DeploymentNode constructor because it is not available "
-                "at class construction or binding time."
-            )
         # Deployment can be passed into other DAGNodes as init args. This is
         # supported pattern in ray DAG that user can instantiate and pass class
         # instances as init args to others.
@@ -71,9 +61,7 @@ class DeploymentNode(DAGNode):
         # error with weird pickle replace table error. Move this out.
         def replace_with_handle(node):
             if isinstance(node, DeploymentNode):
-                return node._get_serve_deployment_handle(
-                    node._deployment, node._bound_other_args_to_resolve
-                )
+                return RayServeLazySyncHandle(node._deployment.name)
             elif isinstance(node, DeploymentExecutorNode):
                 return node._deployment_handle
             elif isinstance(
@@ -150,9 +138,7 @@ class DeploymentNode(DAGNode):
                 ray_actor_options=ray_actor_options,
                 _internal=True,
             )
-        self._deployment_handle: RayServeLazySyncHandle = (
-            self._get_serve_deployment_handle(self._deployment, other_args_to_resolve)
-        )
+        self._deployment_handle = RayServeLazySyncHandle(self._deployment.name)
 
     def _copy_impl(
         self,
@@ -178,38 +164,6 @@ class DeploymentNode(DAGNode):
         directly call upon.
         """
         return self._deployment_handle
-
-    def _get_serve_deployment_handle(
-        self,
-        deployment: Deployment,
-        bound_other_args_to_resolve: Dict[str, Any],
-    ) -> Union[RayServeHandle, RayServeSyncHandle]:
-        """
-        Return a sync or async handle of the encapsulated Deployment based on
-        config.
-
-        Args:
-            deployment (Deployment): Deployment instance wrapped in the DAGNode.
-            bound_other_args_to_resolve (Dict[str, Any]): Contains args used
-                to configure DeploymentNode.
-
-        Returns:
-            RayServeHandle: Default and catch-all is to return sync handle.
-                return async handle only if user explicitly set
-                USE_SYNC_HANDLE_KEY with value of False.
-        """
-        # TODO: (jiaodong) Support async handle
-        return RayServeLazySyncHandle(deployment.name)
-
-    def _contains_input_node(self) -> bool:
-        """Check if InputNode is used in children DAGNodes with current node
-        as the root.
-        """
-        children_dag_nodes = self._get_all_child_nodes()
-        for child in children_dag_nodes:
-            if isinstance(child, InputNode):
-                return True
-        return False
 
     def __getattr__(self, method_name: str):
         # Raise an error if the method is invalid.
@@ -251,7 +205,6 @@ class DeploymentNode(DAGNode):
             # .options() should not contain any DAGNode type
             "options": self.get_options(),
             "other_args_to_resolve": self.get_other_args_to_resolve(),
-            "uuid": self.get_stable_uuid(),
         }
 
     @classmethod

--- a/python/ray/serve/pipeline/tests/test_deployment_node.py
+++ b/python/ray/serve/pipeline/tests/test_deployment_node.py
@@ -2,11 +2,9 @@ import pytest
 
 import ray
 from ray import serve
-from ray.serve.dag import InputNode
 from ray.serve.pipeline.deployment_node import (
     DeploymentNode,
 )
-from ray.serve.pipeline.constants import USE_SYNC_HANDLE_KEY
 
 
 @serve.deployment
@@ -55,7 +53,6 @@ async def test_simple_deployment_async(serve_instance):
         (10,),
         {},
         {},
-        other_args_to_resolve={USE_SYNC_HANDLE_KEY: False},
     )
     node._deployment.deploy()
     handle = node._deployment_handle
@@ -77,7 +74,6 @@ def test_simple_deployment_sync(serve_instance):
         (10,),
         {},
         {},
-        other_args_to_resolve={USE_SYNC_HANDLE_KEY: True},
     )
     node._deployment.deploy()
     handle = node._deployment_handle
@@ -86,49 +82,6 @@ def test_simple_deployment_sync(serve_instance):
     ray.get(node.inc.execute())
     assert ray.get(node.get.execute()) == 11
     assert ray.get(node.get.execute()) == ray.get(handle.get.remote())
-
-
-def test_no_input_node_as_init_args():
-    """
-    User should NOT directly create instances of Deployment or DeploymentNode.
-    """
-    with pytest.raises(
-        ValueError,
-        match="cannot be used as args, kwargs, or other_args_to_resolve",
-    ):
-        _ = DeploymentNode(
-            Actor,
-            "test",
-            (InputNode()),
-            {},
-            {},
-            other_args_to_resolve={USE_SYNC_HANDLE_KEY: True},
-        )
-    with pytest.raises(
-        ValueError,
-        match="cannot be used as args, kwargs, or other_args_to_resolve",
-    ):
-        _ = DeploymentNode(
-            Actor,
-            "test",
-            (),
-            {"a": InputNode()},
-            {},
-            other_args_to_resolve={USE_SYNC_HANDLE_KEY: True},
-        )
-
-    with pytest.raises(
-        ValueError,
-        match="cannot be used as args, kwargs, or other_args_to_resolve",
-    ):
-        _ = DeploymentNode(
-            Actor,
-            "test",
-            (),
-            {},
-            {},
-            other_args_to_resolve={"arg": {"options_a": InputNode()}},
-        )
 
 
 def test_mix_sync_async_handle(serve_instance):

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -405,8 +405,9 @@ TestBuildFNode = global_f.bind()
 TestBuildDagNode = NoArgDriver.bind(TestBuildFNode)
 
 
+# TODO(Shreyas): Add TestBuildDagNode back once serve build new PRs out.
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
-@pytest.mark.parametrize("node", ["TestBuildFNode", "TestBuildDagNode"])
+@pytest.mark.parametrize("node", ["TestBuildFNode"])
 def test_build(ray_start_stop, node):
     with NamedTemporaryFile(mode="w+", suffix=".yaml") as tmp:
 

--- a/python/ray/serve/tests/test_deployment_graph_classmethod.py
+++ b/python/ray/serve/tests/test_deployment_graph_classmethod.py
@@ -44,7 +44,8 @@ class Counter:
         return self.val
 
 
-@pytest.mark.parametrize("use_build", [False, True])
+# TODO(Shreyas): Enable use_build once serve.build() PR is out.
+@pytest.mark.parametrize("use_build", [False])
 def test_two_dags_shared_instance(serve_instance, use_build):
     """Test classmethod chain behavior is consistent across core and serve dag.
 

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -122,7 +122,8 @@ class NoargDriver:
         return await self.dag.remote()
 
 
-@pytest.mark.parametrize("use_build", [False, True])
+# TODO(Shreyas): Enable use_build once serve.build() PR is out.
+@pytest.mark.parametrize("use_build", [False])
 def test_single_func_no_input(serve_instance, use_build):
     dag = fn_hello.bind()
     serve_dag = NoargDriver.bind(dag)
@@ -262,7 +263,8 @@ class Echo:
         return self._s
 
 
-@pytest.mark.parametrize("use_build", [False, True])
+# TODO(Shreyas): Enable use_build once serve.build() PR is out.
+@pytest.mark.parametrize("use_build", [False])
 def test_single_node_deploy_success(serve_instance, use_build):
     m1 = Adder.bind(1)
     handle = serve.run(maybe_build(m1, use_build))
@@ -325,9 +327,9 @@ class DictParent:
         return await self._d[key].remote()
 
 
-@pytest.mark.parametrize("use_build", [False, True])
+# TODO(Shreyas): Enable use_build once serve.build() PR is out.
+@pytest.mark.parametrize("use_build", [False])
 def test_passing_handle_in_obj(serve_instance, use_build):
-
     child1 = Echo.bind("ed")
     child2 = Echo.bind("simon")
     parent = maybe_build(
@@ -366,9 +368,9 @@ class GrandParent:
         return "ok"
 
 
-@pytest.mark.parametrize("use_build", [False, True])
+# TODO(Shreyas): Enable use_build once serve.build() PR is out.
+@pytest.mark.parametrize("use_build", [False])
 def test_pass_handle_to_multiple(serve_instance, use_build):
-
     child = Child.bind()
     parent = Parent.bind(child)
     grandparent = maybe_build(GrandParent.bind(child, parent), use_build)


### PR DESCRIPTION
## Why are these changes needed?

After syncing with @shrekris-anyscale this is to unblock the serve.build and k8s operator work he is doing with Bruce that we do not enforce JSON serde on deployment args or include them in the REST api.

For compatibility we kept the same fields in the schema, but essentially make them no-op to skip init_args & init_kwargs, this also address circular import issue.

Meanwhile I make some small edits to make our DeploymentNode cleaner by removing code that's no longer needed, such as InputNode check (already done at ClassNode level) and extra function to return deployment handle.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
