### PR TITLE
[Datasets] Add `unsqueeze_label_tensor` to `Dataset.to_tf`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2462,6 +2462,7 @@ Dict[str, List[str]]]): The names of the columns
         prefetch_blocks: int = 0,
         batch_size: int = 1,
         drop_last: bool = False,
+        unsqueeze_label_tensor: bool = False,
     ) -> "tf.data.Dataset":
         """Return a TF Dataset over this dataset.
 
@@ -2485,6 +2486,12 @@ Dict[str, List[str]]]): The names of the columns
           {key1: (N, n1),..., keyN: (N, nk)}, with columns of each
           tensor corresponding to the value of ``feature_columns`` under the
           key.
+
+        If ``unsqueeze_label_tensor=True``, the label tensor will be
+        of shape (N, 1). Otherwise, it will be of shape (N,).
+        If ``label_column`` is specified as ``None``, then no column from the
+        ``Dataset`` will be treated as the label, and the output label tensor
+        will be ``None``.
 
         This is only supported for datasets convertible to Arrow records.
 
@@ -2521,6 +2528,11 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
                 if the dataset size is not divisible by the batch size. If
                 False and the size of dataset is not divisible by the batch
                 size, then the last batch will be smaller. Defaults to False.
+            unsqueeze_label_tensor (bool): If set to True, the label tensor
+                will be unsqueezed (reshaped to (N, 1)). Otherwise, it will
+                be left as is, that is (N, ). In general, regression loss
+                functions expect an unsqueezed tensor, while classification
+                loss functions expect a squeezed one. Defaults to False.
 
         Returns:
             A tf.data.Dataset.
@@ -2594,6 +2606,9 @@ List[str]]]): The names of the columns to use as the features. Can be a list of 
                         "Expected `feature_columns` to be a list or a dictionary, "
                         f"but got a `{type(feature_columns).__name__}` instead."
                     )
+
+                if unsqueeze_label_tensor:
+                    targets = np.expand_dims(targets, axis=-1)
 
                 if label_column:
                     yield features, targets

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1827,6 +1827,26 @@ def test_to_tf(ray_start_regular_shared, pipelined):
     assert np.array_equal(df.values, combined_iterations)
 
 
+def test_to_tf_unsqueeze_label_tensor():
+    import tensorflow as tf
+
+    df = pd.DataFrame({"features": [0, 0], "label": [0, 0]})
+    ds = ray.data.from_pandas(df)
+
+    dataset = ds.to_tf(
+        label_column="label",
+        output_signature=(
+            tf.TensorSpec(shape=(None, 1)),
+            tf.TensorSpec(shape=(None, 1), dtype=tf.int32),
+        ),
+        unsqueeze_label_tensor=True,
+        batch_size=2,
+    )
+
+    _, labels = next(iter(dataset))
+    tf.debugging.assert_equal(labels, tf.constant([[0], [0]]))
+
+
 def test_to_tf_feature_columns_list(ray_start_regular_shared):
     import tensorflow as tf
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I'm actually not sure if we need to make this change.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
