### PR TITLE
[AIR] Run `test_torch_predictor.py` tests and fix failing `test_init`

### DIFF
--- a/python/ray/ml/predictors/integrations/torch/torch_predictor.py
+++ b/python/ray/ml/predictors/integrations/torch/torch_predictor.py
@@ -26,6 +26,8 @@ class TorchPredictor(Predictor):
         self.model = model
         self.preprocessor = preprocessor
 
+        self.model.eval()
+
     @classmethod
     def from_checkpoint(
         cls, checkpoint: Checkpoint, model: Optional[torch.nn.Module] = None
@@ -159,8 +161,6 @@ class TorchPredictor(Predictor):
         Returns:
             DataBatchType: Prediction result.
         """
-        self.model.eval()
-
         if self.preprocessor:
             data = self.preprocessor.transform_batch(data)
 

--- a/python/ray/ml/predictors/integrations/torch/torch_predictor.py
+++ b/python/ray/ml/predictors/integrations/torch/torch_predictor.py
@@ -26,8 +26,6 @@ class TorchPredictor(Predictor):
         self.model = model
         self.preprocessor = preprocessor
 
-        self.model.eval()
-
     @classmethod
     def from_checkpoint(
         cls, checkpoint: Checkpoint, model: Optional[torch.nn.Module] = None
@@ -161,6 +159,8 @@ class TorchPredictor(Predictor):
         Returns:
             DataBatchType: Prediction result.
         """
+        self.model.eval()
+
         if self.preprocessor:
             data = self.preprocessor.transform_batch(data)
 

--- a/python/ray/ml/tests/test_torch_predictor.py
+++ b/python/ray/ml/tests/test_torch_predictor.py
@@ -96,3 +96,10 @@ def test_predict_from_checkpoint_no_preprocessor(model):
 
     assert len(predictions) == 3
     assert predictions.to_numpy().flatten().tolist() == [2, 4, 6]
+
+
+if __name__ == "__main__":
+    import pytest
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/ml/tests/test_torch_predictor.py
+++ b/python/ray/ml/tests/test_torch_predictor.py
@@ -40,6 +40,13 @@ def test_init(model, preprocessor):
     assert checkpoint_predictor.model == predictor.model
     assert checkpoint_predictor.preprocessor == predictor.preprocessor
 
+
+def test_predict_model_not_training(model):
+    predictor = TorchPredictor(model=model)
+
+    data_batch = np.array([1])
+    predictor.predict(data_batch)
+
     assert not predictor.model.training
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The tests in `test_torch_predictor.py` weren't in running CI. Also `test_torch_predictor.py::test_init` was failing. 

## Related issue number

<!-- For example: "Closes #1234" -->

Towards #25209 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
