### PR TITLE
[deps] Use protobuf < 4.0 in py.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,7 @@ msgpack >= 1.0.0, < 2.0.0
 numpy >= 1.16
 opencensus
 prometheus_client >= 0.7.1, < 0.14.0
-protobuf >= 3.8.0
+protobuf >= 3.8.0, < 4.0.0
 py-spy >= 0.2.0
 pydantic >= 1.8
 pyyaml

--- a/python/setup.py
+++ b/python/setup.py
@@ -282,7 +282,7 @@ if setup_spec.type == SetupType.RAY:
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",
         "numpy >= 1.19.3; python_version >= '3.9'",
-        "protobuf >= 3.15.3",
+        "protobuf >= 3.15.3, < 4.0.0",
         "pyyaml",
         "aiosignal",
         "frozenlist",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Test failed due to protobuf version problem:

```
(raylet) More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
  | (raylet) [2022-05-26 01:52:27,562 E 10316 10316] (raylet) worker_pool.cc:498: Some workers of the worker process(11044) have not registered within the timeout. The process is dead, probably it crashed during start.
  | (raylet) Traceback (most recent call last):
  | (raylet)   File "/ray/python/ray/workers/default_worker.py", line 8, in <module>
  | (raylet)     import ray
  | (raylet)   File "/ray/python/ray/__init__.py", line 115, in <module>
  | (raylet)     import ray._raylet  # noqa: E402
  | (raylet)   File "python/ray/_raylet.pyx", line 116, in init ray._raylet
  | (raylet)   File "/ray/python/ray/exceptions.py", line 7, in <module>
  | (raylet)     from ray.core.generated.common_pb2 import RayException, Language, PYTHON
  | (raylet)   File "/ray/python/ray/core/generated/common_pb2.py", line 15, in <module>
  | (raylet)     from . import runtime_env_common_pb2 as src_dot_ray_dot_protobuf_dot_runtime__env__common__pb2
  | (raylet)   File "/ray/python/ray/core/generated/runtime_env_common_pb2.py", line 42, in <module>
  | (raylet)     serialized_options=None, json_name='packages', file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
  | (raylet)   File "/tmp/ray/session_2022-05-26_01-42-02_431980_9214/runtime_resources/conda/a6ff561ba9229e48b1e71b5dba39510e8d1ba907/lib/python3.7/site-packages/google/protobuf/descriptor.py", line 560, in __new__
  | (raylet)     _message.Message._CheckCalledFromGeneratedFile()
  | (raylet) TypeError: Descriptors cannot not be created directly.
  | (raylet) If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
  | (raylet) If you cannot immediately regenerate your protos, some other possible workarounds are:
  | (raylet)  1. Downgrade the protobuf package to 3.20.x or lower.
  | (raylet)  2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).-- Test timed out at 2022-05-26 01:55:19 UTC --

```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
