### PR TITLE
[ci] Protobuf < 4 only in requirements.txt to unblock CI

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,7 @@ msgpack >= 1.0.0, < 2.0.0
 numpy >= 1.16
 opencensus
 prometheus_client >= 0.7.1, < 0.14.0
-protobuf >= 3.8.0
+protobuf >= 3.8.0, < 4.0.0
 py-spy >= 0.2.0
 pydantic >= 1.8
 pyyaml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#25211 pins protobuf to < 4 because a recent release broke our CI. However, this needs codeowner approval, and to unblock work in EU timezone, this PR adds the pin just to requirements.txt.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
