### PR TITLE
[tune] Allow iterators in tune.grid_search

### DIFF
--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import re
 from collections.abc import Mapping
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple
 
 import numpy
 import random
@@ -58,14 +58,13 @@ def generate_variants(
         yield resolved_vars, spec
 
 
-def grid_search(values: List) -> Dict[str, List]:
+def grid_search(values: Iterable) -> Dict[str, List]:
     """Convenience method for specifying grid search over a value.
 
     Arguments:
         values: An iterable whose parameters will be gridded.
     """
-
-    return {"grid_search": values}
+    return {"grid_search": list(values)}
 
 
 _STANDARD_IMPORTS = {

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple
 import numpy
 import random
 
-from ray.tune import TuneError
 from ray.tune.sample import Categorical, Domain, Function, RandomState
 from ray.util.annotations import DeveloperAPI
 
@@ -64,7 +63,7 @@ def grid_search(values: Iterable) -> Dict[str, List]:
     Arguments:
         values: An iterable whose parameters will be gridded.
     """
-    return {"grid_search": list(values)}
+    return {"grid_search": values}
 
 
 _STANDARD_IMPORTS = {
@@ -405,10 +404,6 @@ def _try_resolve(v) -> Tuple[bool, Any]:
     elif isinstance(v, dict) and len(v) == 1 and "grid_search" in v:
         # Grid search values
         grid_values = v["grid_search"]
-        if not isinstance(grid_values, list):
-            raise TuneError(
-                "Grid search expected list of values, got: {}".format(grid_values)
-            )
         return False, Categorical(grid_values).grid()
     return True, v
 

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -1894,6 +1894,21 @@ class SearchSpaceTest(unittest.TestCase):
                 ("Pre-set value `2` is not equal to the value of parameter `a`: 1",),
             )
 
+    def testGridSearchGenerator(self):
+        from ray.tune.suggest.basic_variant import BasicVariantGenerator
+
+        searcher = BasicVariantGenerator(constant_grid_search=False)
+        exp = Experiment(
+            run=_mock_objective,
+            name="test",
+            config={"parameter": tune.grid_search(range(10))},
+            num_samples=1,
+        )
+        searcher.add_configurations(exp)
+
+        trials = [searcher.next_trial() for i in range(10)]
+        assert [t.config["parameter"] for t in trials] == list(range(10))
+
     def testConstantGridSearchBasicVariant(self):
         config = {
             "grid": tune.grid_search([1, 2, 3]),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`tune.choice` already accepts iterables, the same should be true for `tune.grid_search`.

## Related issue number

Closes #25212

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
