### PR TITLE
[ci/release] Use fullmatch instead of match for regex filters

### DIFF
--- a/release/ray_release/buildkite/filter.py
+++ b/release/ray_release/buildkite/filter.py
@@ -20,7 +20,7 @@ def filter_tests(
         # First, filter by string attributes
         attr_mismatch = False
         for attr, regex in test_attr_regex_filters.items():
-            if not re.match(regex, test[attr]):
+            if not re.fullmatch(regex, test[attr]):
                 attr_mismatch = True
                 break
         if attr_mismatch:

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -449,7 +449,7 @@ class BuildkiteSettingsTest(unittest.TestCase):
         filtered = self._filter_names_smoke(
             tests,
             frequency=Frequency.NIGHTLY,
-            test_attr_regex_filters={"name": "other"},
+            test_attr_regex_filters={"name": "other.*"},
         )
         self.assertSequenceEqual(
             filtered,
@@ -459,18 +459,32 @@ class BuildkiteSettingsTest(unittest.TestCase):
         )
 
         filtered = self._filter_names_smoke(
-            tests, frequency=Frequency.NIGHTLY, test_attr_regex_filters={"name": "test"}
+            tests,
+            frequency=Frequency.NIGHTLY,
+            test_attr_regex_filters={"name": "test.*"},
         )
         self.assertSequenceEqual(
             filtered, [("test_1", False), ("test_2", True), ("test_3", False)]
         )
 
         filtered = self._filter_names_smoke(
+            tests, frequency=Frequency.NIGHTLY, test_attr_regex_filters={"name": "test"}
+        )
+        self.assertSequenceEqual(filtered, [])
+
+        filtered = self._filter_names_smoke(
             tests,
             frequency=Frequency.NIGHTLY,
-            test_attr_regex_filters={"name": "test", "team": "team_1"},
+            test_attr_regex_filters={"name": "test.*", "team": "team_1"},
         )
         self.assertSequenceEqual(filtered, [("test_1", False)])
+
+        filtered = self._filter_names_smoke(
+            tests,
+            frequency=Frequency.NIGHTLY,
+            test_attr_regex_filters={"name": "test_1|test_2"},
+        )
+        self.assertSequenceEqual(filtered, [("test_1", False), ("test_2", True)])
 
     def testGroupTests(self):
         tests = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `name:many_actors` matches e.g. `many_actors` and `many_actors_smoke_test`, but it should just match one test. Thus we should use `re.fullmatch` instead of `re.match` (which would require `name:many_actors.*` to match both.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
