### PR TITLE
[WIP][Core] skip flaky `test_worker_stats` on Windows

### DIFF
--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -1,6 +1,8 @@
 import os
 import grpc
+import pytest
 import requests
+import sys
 import time
 
 import ray
@@ -18,6 +20,7 @@ import psutil  # We must import psutil after ray because we bundle it with ray.
 _WIN32 = os.name == "nt"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Very flaky on Windows.")
 def test_worker_stats(shutdown_only):
     ray.init(num_cpus=1, include_dashboard=True)
     raylet = ray.nodes()[0]
@@ -90,10 +93,7 @@ def test_worker_stats(shutdown_only):
             assert stats.webui_display[""] == ""  # Empty proto
     assert target_worker_present
 
-    if _WIN32:
-        timeout_seconds = 40
-    else:
-        timeout_seconds = 20
+    timeout_seconds = 20
     start_time = time.time()
     while True:
         if time.time() - start_time > timeout_seconds:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
