### PR TITLE
[data] [API] Add max_epoch argument to iter_epochs() for AIR

### DIFF
--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -121,6 +121,11 @@ def test_epoch(ray_start_regular_shared):
     results = [p.take() for p in pipe.iter_epochs()]
     assert results == [[0, 1, 2], [0, 1, 2], [0, 1, 2]]
 
+    # Test max epochs.
+    pipe = ray.data.range(3).window(blocks_per_window=2).repeat(3)
+    results = [p.take() for p in pipe.iter_epochs(2)]
+    assert results == [[0, 1, 2], [0, 1, 2]]
+
     # Test nested repeat.
     pipe = ray.data.range(5).repeat(2).repeat(2)
     results = [p.take() for p in pipe.iter_epochs()]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For AIR ingest, having max_epoch argument simplifies a lot of user code around using this to train for a given number of epochs. Broken out from https://github.com/ray-project/ray/pull/25167