### PR TITLE
[data] Fix pipeline pre-repeat caching, and improve the documentation

### DIFF
--- a/doc/source/data/advanced-pipelines.rst
+++ b/doc/source/data/advanced-pipelines.rst
@@ -136,7 +136,7 @@ Readers pulling batches from the pipeline will see the same data blocks repeated
 Pre-repeat vs post-repeat transforms
 ====================================
 
-Transformations made prior to the Dataset prior to the call to ``.repeat()`` may be re-used. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
+Transformations made prior to the call to ``.repeat()`` may be re-used. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
 
 For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline.
 

--- a/doc/source/data/advanced-pipelines.rst
+++ b/doc/source/data/advanced-pipelines.rst
@@ -136,9 +136,9 @@ Readers pulling batches from the pipeline will see the same data blocks repeated
 Pre-repeat vs post-repeat transforms
 ====================================
 
-Transformations made prior to the Dataset prior to the call to ``.repeat()`` may be re-used. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
+Transformations made prior to the Dataset prior to the call to ``.repeat()`` will be cached. However, note that the initial read will not be cached unless there is a subsequent transformation or ``.fully_executed()`` call. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
 
-For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline.
+For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline. However, if we omitted the map transformation, then the pipeline would re-read from the base data on each reptition.
 
 .. note::
   Global per-epoch shuffling is an expensive operation that will slow down your ML

--- a/doc/source/data/advanced-pipelines.rst
+++ b/doc/source/data/advanced-pipelines.rst
@@ -138,7 +138,7 @@ Pre-repeat vs post-repeat transforms
 
 Transformations prior to the call to ``.repeat()`` will be cached. However, note that the initial read will not be cached unless there is a subsequent transformation or ``.fully_executed()`` call. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
 
-For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline. However, if we omitted the map transformation, then the pipeline would re-read from the base data on each reptition.
+For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline. However, if we omitted the map transformation, then the pipeline would re-read from the base data on each repetition.
 
 .. note::
   Global per-epoch shuffling is an expensive operation that will slow down your ML

--- a/doc/source/data/advanced-pipelines.rst
+++ b/doc/source/data/advanced-pipelines.rst
@@ -136,7 +136,7 @@ Readers pulling batches from the pipeline will see the same data blocks repeated
 Pre-repeat vs post-repeat transforms
 ====================================
 
-Transformations made prior to the Dataset prior to the call to ``.repeat()`` are executed once. Transformations made to the DatasetPipeline after the repeat will be executed once for each repetition of the Dataset.
+Transformations made prior to the Dataset prior to the call to ``.repeat()`` may be re-used. Transformations made to the DatasetPipeline after the repeat will always be executed once for each repetition of the Dataset.
 
 For example, in the following pipeline, the ``map(func)`` transformation only occurs once. However, the random shuffle is applied to each repetition in the pipeline.
 
@@ -175,7 +175,7 @@ For example, in the following pipeline, the ``map(func)`` transformation only oc
 
 .. important::
 
-    Result caching only applies if there are *transformation* stages prior to the pipelining operation. If you ``repeat()`` or ``window()`` a Dataset right after the read call (e.g., ``ray.data.read_parquet(...).repeat()``), then the read will still be re-executed on each repetition. This optimization saves memory, at the cost of repeated reads from the datasource.
+    Result caching only applies if there are *transformation* stages prior to the pipelining operation. If you ``repeat()`` or ``window()`` a Dataset right after the read call (e.g., ``ray.data.read_parquet(...).repeat()``), then the read will still be re-executed on each repetition. This optimization saves memory, at the cost of repeated reads from the datasource. To force result caching in all cases, use ``.fully_executed().repeat()``.
 
 Splitting pipelines for distributed ingest
 ==========================================

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -376,6 +376,7 @@ class ExecutionPlan:
             self.has_lazy_input()
             and not self._stages_before_snapshot
             and not self._stages_after_snapshot
+            and (not self._snapshot_blocks or isinstance(self._snapshot_blocks, LazyBlockList))
         )
 
     def has_computed_output(self) -> bool:

--- a/python/ray/data/impl/plan.py
+++ b/python/ray/data/impl/plan.py
@@ -376,7 +376,10 @@ class ExecutionPlan:
             self.has_lazy_input()
             and not self._stages_before_snapshot
             and not self._stages_after_snapshot
-            and (not self._snapshot_blocks or isinstance(self._snapshot_blocks, LazyBlockList))
+            and (
+                not self._snapshot_blocks
+                or isinstance(self._snapshot_blocks, LazyBlockList)
+            )
         )
 
     def has_computed_output(self) -> bool:

--- a/python/ray/data/impl/stats.py
+++ b/python/ray/data/impl/stats.py
@@ -229,7 +229,7 @@ class DatasetStats:
             stage_uuid = self.dataset_uuid + stage_name
             out += "Stage {} {}: ".format(self.number, stage_name)
             if stage_uuid in already_printed:
-                out += "[execution cached]"
+                out += "[execution cached]\n"
             else:
                 already_printed.add(stage_uuid)
                 out += self._summarize_blocks(metadata, is_substage=False)
@@ -246,7 +246,7 @@ class DatasetStats:
                 out += "\n"
                 out += "\tSubstage {} {}: ".format(n, stage_name)
                 if stage_uuid in already_printed:
-                    out += "\t[execution cached]"
+                    out += "\t[execution cached]\n"
                 else:
                     already_printed.add(stage_uuid)
                     out += self._summarize_blocks(metadata, is_substage=True)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -208,6 +208,7 @@ Stage N map: N/N blocks executed in T
 
 == Pipeline Window N ==
 Stage N read->map_batches: [execution cached]
+
 Stage N map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
@@ -217,6 +218,7 @@ Stage N map: N/N blocks executed in T
 
 == Pipeline Window N ==
 Stage N read->map_batches: [execution cached]
+
 Stage N map: N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently the canonical way to cache a pipeline and repeat it: `ds.fully_executed().repeat()` crashes. Add a test, fix the docs and stats printing here.

Broken out from https://github.com/ray-project/ray/pull/25167/files