### PR TITLE
[data] Dataset pipeline window by bytes fails when read fusion disabled

### DIFF
--- a/python/ray/data/impl/lazy_block_list.py
+++ b/python/ray/data/impl/lazy_block_list.py
@@ -183,7 +183,7 @@ class LazyBlockList(BlockList):
                 cur_size = 0
             cur_tasks.append(t)
             cur_blocks.append(b)
-            cur_blocks_meta.append(b)
+            cur_blocks_meta.append(bm)
             cur_size += size
         if cur_blocks:
             output.append(LazyBlockList(cur_tasks, cur_blocks, cur_blocks_meta))

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -109,6 +109,11 @@ def test_window_by_bytes(ray_start_regular_shared):
     )
     assert str(pipe) == "DatasetPipeline(num_windows=8, num_stages=1)"
 
+    context = DatasetContext.get_current()
+    context.optimize_fuse_stages = False
+    dataset = ray.data.range(10).window(bytes_per_window=1)
+    assert dataset.take(10) == list(range(10))
+
 
 def test_epoch(ray_start_regular_shared):
     # Test dataset repeat.

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -110,9 +110,13 @@ def test_window_by_bytes(ray_start_regular_shared):
     assert str(pipe) == "DatasetPipeline(num_windows=8, num_stages=1)"
 
     context = DatasetContext.get_current()
-    context.optimize_fuse_read_stages = False
-    dataset = ray.data.range(10).window(bytes_per_window=1)
-    assert dataset.take(10) == list(range(10))
+    old = context.optimize_fuse_read_stages
+    try:
+        context.optimize_fuse_read_stages = False
+        dataset = ray.data.range(10).window(bytes_per_window=1)
+        assert dataset.take(10) == list(range(10))
+    finally:
+        context.optimize_fuse_read_stages = old
 
 
 def test_epoch(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -110,7 +110,7 @@ def test_window_by_bytes(ray_start_regular_shared):
     assert str(pipe) == "DatasetPipeline(num_windows=8, num_stages=1)"
 
     context = DatasetContext.get_current()
-    context.optimize_fuse_stages = False
+    context.optimize_fuse_read_stages = False
     dataset = ray.data.range(10).window(bytes_per_window=1)
     assert dataset.take(10) == list(range(10))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes `AttributeError: 'list' object has no attribute 'schema'` when read fusion is flag disabled and pipelines are windowed by bytes.

Broken out from https://github.com/ray-project/ray/pull/25167/files