### PR TITLE
[data] [API] Remove unnecessary public argument in `fully_executed()`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3054,28 +3054,17 @@ class Dataset(Generic[T]):
             )
         return pipe
 
-    def fully_executed(self, preserve_original: bool = True) -> "Dataset[T]":
+    def fully_executed(self) -> "Dataset[T]":
         """Force full evaluation of the blocks of this dataset.
 
         This can be used to read all blocks into memory. By default, Datasets
         doesn't read blocks from the datasource until the first transform.
 
-        Args:
-            preserve_original: Whether the original unexecuted dataset should be
-                preserved. If False, this function will mutate the original dataset,
-                which can more efficiently reclaim memory.
-
         Returns:
             A Dataset with all blocks fully materialized in memory.
         """
-        if preserve_original:
-            plan = self._plan.deep_copy(preserve_uuid=True)
-            ds = Dataset(plan, self._epoch, self._lazy)
-            ds._set_uuid(self._get_uuid())
-        else:
-            ds = self
-        ds._plan.execute(force_read=True)
-        return ds
+        self._plan.execute(force_read=True)
+        return self
 
     def is_fully_executed(self) -> bool:
         """Returns whether this Dataset has been fully executed.

--- a/python/ray/data/impl/pipeline_executor.py
+++ b/python/ray/data/impl/pipeline_executor.py
@@ -19,7 +19,7 @@ def pipeline_stage(fn: Callable[[], Dataset[T]]) -> Dataset[T]:
     # Force eager evaluation of all blocks in the pipeline stage. This
     # prevents resource deadlocks due to overlapping stage execution (e.g.,
     # task -> actor stage).
-    return fn().fully_executed(preserve_original=False)
+    return fn().fully_executed()
 
 
 class PipelineExecutor:

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -257,25 +257,6 @@ def test_spread_hint_inherit(ray_start_regular_shared):
     assert optimized_stages[0].ray_remote_args == {"scheduling_strategy": "SPREAD"}
 
 
-def test_execution_preserves_original(ray_start_regular_shared):
-    ds = ray.data.range(10).map(lambda x: x + 1).experimental_lazy()
-    ds1 = ds.map(lambda x: x + 1)
-    assert ds1._plan._snapshot_blocks is not None
-    assert len(ds1._plan._stages_after_snapshot) == 1
-    ds2 = ds1.fully_executed()
-    # Confirm that snapshot blocks and stages on original lazy dataset have not changed.
-    assert ds1._plan._snapshot_blocks is not None
-    assert len(ds1._plan._stages_after_snapshot) == 1
-    # Confirm that UUID on executed dataset is properly set.
-    assert ds2._get_uuid() == ds1._get_uuid()
-    # Check content.
-    assert ds2.take() == list(range(2, 12))
-    # Check original lazy dataset content.
-    assert ds1.take() == list(range(2, 12))
-    # Check source lazy dataset content.
-    assert ds.take() == list(range(1, 11))
-
-
 def _assert_has_stages(stages, stage_names):
     assert len(stages) == len(stage_names)
     for stage, name in zip(stages, stage_names):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Remove the preserve_original arg on fully_executed(). This should always be set to False, and can just be part of the API contract for this advanced API call.