### PR TITLE
[Core] add-better-error-msg-on-node-failure

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -208,12 +208,14 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
       // TODO(rkn): Define this constant somewhere else.
       std::string type = "node_removed";
       std::ostringstream error_message;
-      error_message << "The node with node id: " << node_id
-                    << " and address: " << removed_node->node_manager_address()
-                    << " and node name: " << removed_node->node_name()
-                    << " has been marked dead because the detector"
-                    << " has missed too many heartbeats from it. This can happen when a "
-                       "raylet crashes unexpectedly or has lagging heartbeats.";
+      error_message
+          << "The node with node id: " << node_id
+          << " and address: " << removed_node->node_manager_address()
+          << " and node name: " << removed_node->node_name()
+          << " has been marked dead because the detector"
+          << " has missed too many heartbeats from it. This can happen when a "
+             "\t(1) raylet crashes unexpectedly (OOM, preempted node, etc.) \n"
+          << "\t(2) raylet has lagging heartbeats due to slow network or busy workload.";
       RAY_EVENT(ERROR, EL_RAY_NODE_REMOVED)
               .WithField("node_id", node_id.Hex())
               .WithField("ip", removed_node->node_manager_address())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This enhances the error message printed to the driver when the node is unexpectedly failed 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
