### PR TITLE
Adds 'episode.hist_data' to the 'atari_metrics' to ensure custom user metrics are kept

### DIFF
--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -848,7 +848,10 @@ def _process_observations(
                 if atari_metrics is not None:
                     for m in atari_metrics:
                         outputs.append(
-                            m._replace(custom_metrics=episode.custom_metrics)
+                            m._replace(
+                                custom_metrics=episode.custom_metrics,
+                                hist_data=episode.hist_data,
+                            )
                         )
                 else:
                     outputs.append(


### PR DESCRIPTION
## Why are these changes needed?

When creating custo metrics users can also add data to the `hist_data` attribute of the `Episode` object. However, when using Atari environments these `hist_data` metrics do not get considered and are basically lost. 

This PR intends to fix this loss by adding the `hist_data` from the `Episode` to the `hist_data` attribute of the Atari metrics.

## Related issue number

Non so far

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
