### PR TITLE
[RLlib] Policy V2 unify APIs (part 1)

### DIFF
--- a/doc/source/rllib/package_ref/policy/custom_policies.rst
+++ b/doc/source/rllib/package_ref/policy/custom_policies.rst
@@ -24,9 +24,9 @@ Then override one or more of these class' methods. The methods of interest are i
 * :py:meth:`~ray.rllib.policy.policy.Policy.make_model`
 * :py:meth:`~ray.rllib.policy.policy.Policy.compute_actions`
 * :py:meth:`~ray.rllib.policy.policy.Policy.loss`
-* :py:meth:`~ray.rllib.policy.policy.Policy.process_gradients`
 * :py:meth:`~ray.rllib.policy.policy.Policy.stats_fn`
 * :py:meth:`~ray.rllib.policy.policy.Policy.postprocess_trajectory`
 
-
 `See here for an example on how to override TorchPolicy <https://github.com/ray-project/ray/blob/master/rllib/agents/ppo/ppo_torch_policy.py>`_.
+
+

--- a/doc/source/rllib/package_ref/policy/custom_policies.rst
+++ b/doc/source/rllib/package_ref/policy/custom_policies.rst
@@ -8,19 +8,25 @@ Building Custom Policy Classes
     ``build_tf_policy()`` utility functions for creating custom Policy sub-classes.
     Instead, follow the simple guidelines here for directly sub-classing from
     either one of the built-in types:
-    :py:class:`~ray.rllib.policy.dynamic_tf_policy.DynamicTFPolicy`
+    :py:class:`~ray.rllib.policy.dynamic_tf_policy_v2.DynamicTFPolicyV2`,
+    :py:class:`~ray.rllib.policy.eager_tf_policy_v2.EagerTFPolicyV2`
     or
-    :py:class:`~ray.rllib.policy.torch_policy.TorchPolicy`
+    :py:class:`~ray.rllib.policy.torch_policy_v2.TorchPolicyV2`
 
 In order to create a custom Policy, sub-class :py:class:`~ray.rllib.policy.policy.Policy` (for a generic,
 framework-agnostic policy),
 :py:class:`~ray.rllib.policy.torch_policy.TorchPolicy`
 (for a PyTorch specific policy), or
-:py:class:`~ray.rllib.policy.dynamic_tf_policy.DynamicTFPolicy`
-(for a TensorFlow specific policy) and override one or more of their methods. Those are in particular:
+:py:class:`~ray.rllib.policy.dynamic_tf_policy_v2.DynamicTFPolicyV2` / :py:class:`~ray.rllib.policy.eager_tf_policy_v2.EagerTFPolicyV2`
+(for a TensorFlow specific policy).
+Then override one or more of these class' methods. The methods of interest are in particular:
 
-* :py:meth:`~ray.rllib.policy.policy.Policy.compute_actions_from_input_dict`
-* :py:meth:`~ray.rllib.policy.policy.Policy.postprocess_trajectory`
+* :py:meth:`~ray.rllib.policy.policy.Policy.make_model`
+* :py:meth:`~ray.rllib.policy.policy.Policy.compute_actions`
 * :py:meth:`~ray.rllib.policy.policy.Policy.loss`
+* :py:meth:`~ray.rllib.policy.policy.Policy.process_gradients`
+* :py:meth:`~ray.rllib.policy.policy.Policy.stats_fn`
+* :py:meth:`~ray.rllib.policy.policy.Policy.postprocess_trajectory`
+
 
 `See here for an example on how to override TorchPolicy <https://github.com/ray-project/ray/blob/master/rllib/agents/ppo/ppo_torch_policy.py>`_.

--- a/rllib/agents/a3c/a3c_tf_policy.py
+++ b/rllib/agents/a3c/a3c_tf_policy.py
@@ -81,7 +81,7 @@ def get_a3c_tf_policy(base: TFPolicyV2Type) -> TFPolicyV2Type:
 
             # Note: this is a bit ugly, but loss and optimizer initialization must
             # happen after all the MixIns are initialized.
-            self.maybe_initialize_optimizer_and_loss()
+            self.initialize_optimizer_and_loss_if_necessary()
 
         @override(base)
         def loss(

--- a/rllib/agents/a3c/a3c_torch_policy.py
+++ b/rllib/agents/a3c/a3c_torch_policy.py
@@ -117,13 +117,6 @@ class A3CTorchPolicy(
         return total_loss
 
     @override(TorchPolicyV2)
-    def optimizer(
-        self,
-    ) -> Union[List["torch.optim.Optimizer"], "torch.optim.Optimizer"]:
-        """Returns a torch optimizer (Adam) for A3C."""
-        return torch.optim.Adam(self.model.parameters(), lr=self.config["lr"])
-
-    @override(TorchPolicyV2)
     def stats_fn(self, train_batch: SampleBatch) -> Dict[str, TensorType]:
         return convert_to_numpy(
             {

--- a/rllib/agents/impala/vtrace_tf_policy.py
+++ b/rllib/agents/impala/vtrace_tf_policy.py
@@ -304,7 +304,7 @@ def get_vtrace_tf_policy(base: type) -> type:
 
             # Note: this is a bit ugly, but loss and optimizer initialization must
             # happen after all the MixIns are initialized.
-            self.maybe_initialize_optimizer_and_loss()
+            self.initialize_optimizer_and_loss_if_necessary()
 
         @override(base)
         def loss(

--- a/rllib/agents/impala/vtrace_tf_policy.py
+++ b/rllib/agents/impala/vtrace_tf_policy.py
@@ -219,7 +219,7 @@ class VTraceOptimizer:
 
     # TODO: maybe standardize this function, so the choice of optimizers are more
     # predictable for common agents.
-    def optimizer(
+    def make_optimizer(
         self,
     ) -> Union["tf.keras.optimizers.Optimizer", List["tf.keras.optimizers.Optimizer"]]:
         config = self.config

--- a/rllib/agents/impala/vtrace_torch_policy.py
+++ b/rllib/agents/impala/vtrace_torch_policy.py
@@ -170,7 +170,7 @@ class VTraceOptimizer:
         pass
 
     @override(TorchPolicyV2)
-    def optimizer(
+    def make_optimizer(
         self,
     ) -> Union[List["torch.optim.Optimizer"], "torch.optim.Optimizer"]:
         if self.config["opt_type"] == "adam":

--- a/rllib/agents/ppo/appo_tf_policy.py
+++ b/rllib/agents/ppo/appo_tf_policy.py
@@ -173,7 +173,7 @@ def get_appo_tf_policy(base: type) -> type:
 
             # Note: this is a bit ugly, but loss and optimizer initialization must
             # happen after all the MixIns are initialized.
-            self.maybe_initialize_optimizer_and_loss()
+            self.initialize_optimizer_and_loss_if_necessary()
 
             # Initiate TargetNetwork ops after loss initialization.
             TargetNetworkMixin.__init__(self, obs_space, action_space, config)

--- a/rllib/agents/ppo/ppo_tf_policy.py
+++ b/rllib/agents/ppo/ppo_tf_policy.py
@@ -104,7 +104,7 @@ def get_ppo_tf_policy(base: TFPolicyV2Type) -> TFPolicyV2Type:
 
             # Note: this is a bit ugly, but loss and optimizer initialization must
             # happen after all the MixIns are initialized.
-            self.maybe_initialize_optimizer_and_loss()
+            self.initialize_optimizer_and_loss_if_necessary()
 
         @override(base)
         def loss(

--- a/rllib/agents/ppo/ppo_torch_policy.py
+++ b/rllib/agents/ppo/ppo_torch_policy.py
@@ -42,7 +42,7 @@ class PPOTorchPolicy(
     """PyTorch policy class used with PPOTrainer."""
 
     def __init__(self, observation_space, action_space, config):
-        config = dict(ray.rllib.agents.ppo.ppo.DEFAULT_CONFIG, **config)
+        config = dict(ray.rllib.agents.ppo.PPOConfig().to_dict(), **config)
         validate_config(config)
 
         TorchPolicyV2.__init__(

--- a/rllib/agents/ppo/tests/test_appo.py
+++ b/rllib/agents/ppo/tests/test_appo.py
@@ -5,7 +5,7 @@ import ray.rllib.agents.ppo as ppo
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO, LEARNER_STATS_KEY
 from ray.rllib.utils.test_utils import (
-    check_compute_single_action,
+    check_compute_actions_v2,
     check_train_results,
     framework_iterator,
 )
@@ -33,7 +33,7 @@ class TestAPPO(unittest.TestCase):
                 results = trainer.train()
                 check_train_results(results)
                 print(results)
-            check_compute_single_action(trainer)
+            check_compute_actions_v2(trainer)
             trainer.stop()
 
             print("w/ v-trace")
@@ -43,7 +43,7 @@ class TestAPPO(unittest.TestCase):
                 results = trainer.train()
                 check_train_results(results)
                 print(results)
-            check_compute_single_action(trainer)
+            check_compute_actions_v2(trainer)
             trainer.stop()
 
     def test_appo_compilation_use_kl_loss(self):
@@ -61,7 +61,7 @@ class TestAPPO(unittest.TestCase):
                 results = trainer.train()
                 check_train_results(results)
                 print(results)
-            check_compute_single_action(trainer)
+            check_compute_actions_v2(trainer)
             trainer.stop()
 
     def test_appo_two_tf_optimizers(self):
@@ -85,7 +85,7 @@ class TestAPPO(unittest.TestCase):
                 results = trainer.train()
                 check_train_results(results)
                 print(results)
-            check_compute_single_action(trainer)
+            check_compute_actions_v2(trainer)
             trainer.stop()
 
     def test_appo_entropy_coeff_schedule(self):

--- a/rllib/agents/ppo/tests/test_ppo.py
+++ b/rllib/agents/ppo/tests/test_ppo.py
@@ -148,7 +148,7 @@ class TestPPO(unittest.TestCase):
                         check_train_results(results)
                         print(results)
 
-                    #check_compute_single_action(
+                    # check_compute_single_action(
                     #    trainer, include_prev_action_reward=True, include_state=lstm
                     # )
                     trainer.stop()

--- a/rllib/agents/ppo/tests/test_ppo.py
+++ b/rllib/agents/ppo/tests/test_ppo.py
@@ -19,6 +19,7 @@ from ray.rllib.utils.numpy import fc
 from ray.rllib.utils.test_utils import (
     check,
     check_train_results,
+    check_compute_actions_v2,
     framework_iterator,
 )
 
@@ -147,9 +148,9 @@ class TestPPO(unittest.TestCase):
                         check_train_results(results)
                         print(results)
 
-                    # check_compute_single_action(
-                    #    trainer, include_prev_action_reward=True, include_state=lstm
-                    # )
+                    check_compute_actions_v2(
+                        trainer, include_prev_action_reward=True, include_state=lstm
+                    )
                     trainer.stop()
 
     def test_ppo_exploration_setup(self):

--- a/rllib/agents/ppo/tests/test_ppo.py
+++ b/rllib/agents/ppo/tests/test_ppo.py
@@ -18,7 +18,6 @@ from ray.rllib.utils.metrics.learner_info import LEARNER_INFO, LEARNER_STATS_KEY
 from ray.rllib.utils.numpy import fc
 from ray.rllib.utils.test_utils import (
     check,
-    check_compute_single_action,
     check_train_results,
     framework_iterator,
 )

--- a/rllib/agents/ppo/tests/test_ppo.py
+++ b/rllib/agents/ppo/tests/test_ppo.py
@@ -102,19 +102,17 @@ class TestPPO(unittest.TestCase):
                 # overridden by the schedule below (which is expected).
                 entropy_coeff=100.0,
                 entropy_coeff_schedule=[[0, 0.1], [256, 0.0]],
-            )
-            .rollouts(
-                num_rollout_workers=1,
-                # Test with compression.
-                compress_observations=True,
-            )
-            .training(
                 train_batch_size=128,
                 model=dict(
                     # Settings in case we use an LSTM.
                     lstm_cell_size=10,
                     max_seq_len=20,
                 ),
+            )
+            .rollouts(
+                num_rollout_workers=1,
+                # Test with compression.
+                compress_observations=True,
             )
             .callbacks(MyCallbacks)
         )  # For checking lr-schedule correctness.
@@ -150,9 +148,9 @@ class TestPPO(unittest.TestCase):
                         check_train_results(results)
                         print(results)
 
-                    check_compute_single_action(
-                        trainer, include_prev_action_reward=True, include_state=lstm
-                    )
+                    #check_compute_single_action(
+                    #    trainer, include_prev_action_reward=True, include_state=lstm
+                    #)
                     trainer.stop()
 
     def test_ppo_exploration_setup(self):

--- a/rllib/agents/ppo/tests/test_ppo.py
+++ b/rllib/agents/ppo/tests/test_ppo.py
@@ -150,7 +150,7 @@ class TestPPO(unittest.TestCase):
 
                     #check_compute_single_action(
                     #    trainer, include_prev_action_reward=True, include_state=lstm
-                    #)
+                    # )
                     trainer.stop()
 
     def test_ppo_exploration_setup(self):

--- a/rllib/algorithms/maml/maml_tf_policy.py
+++ b/rllib/algorithms/maml/maml_tf_policy.py
@@ -467,7 +467,7 @@ def get_maml_tf_policy(base: type) -> type:
             return self.loss_obj.loss
 
         @override(base)
-        def optimizer(
+        def make_optimizer(
             self,
         ) -> Union[
             "tf.keras.optimizers.Optimizer", List["tf.keras.optimizers.Optimizer"]

--- a/rllib/algorithms/maml/maml_tf_policy.py
+++ b/rllib/algorithms/maml/maml_tf_policy.py
@@ -409,7 +409,7 @@ def get_maml_tf_policy(base: type) -> type:
 
             # Note: this is a bit ugly, but loss and optimizer initialization must
             # happen after all the MixIns are initialized.
-            self.maybe_initialize_optimizer_and_loss()
+            self.initialize_optimizer_and_loss_if_necessary()
 
         @override(base)
         def loss(

--- a/rllib/algorithms/maml/maml_torch_policy.py
+++ b/rllib/algorithms/maml/maml_torch_policy.py
@@ -388,7 +388,7 @@ class MAMLTorchPolicy(ValueNetworkMixin, KLCoeffMixin, TorchPolicyV2):
         return self.loss_obj.loss
 
     @override(TorchPolicyV2)
-    def optimizer(
+    def make_optimizer(
         self,
     ) -> Union[List["torch.optim.Optimizer"], "torch.optim.Optimizer"]:
         """

--- a/rllib/algorithms/marwil/marwil_tf_policy.py
+++ b/rllib/algorithms/marwil/marwil_tf_policy.py
@@ -202,7 +202,7 @@ def get_marwil_tf_policy(base: type) -> type:
 
             # Note: this is a bit ugly, but loss and optimizer initialization must
             # happen after all the MixIns are initialized.
-            self.maybe_initialize_optimizer_and_loss()
+            self.initialize_optimizer_and_loss_if_necessary()
 
         @override(base)
         def loss(

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -1179,13 +1179,15 @@ def _do_policy_eval(
         # actions is `compute_actions()`.
         if isinstance(policy, (DynamicTFPolicyV2, EagerTFPolicyV2, TorchPolicyV2)):
             # Call the policy's `compute_actions` method.
-            eval_results[policy_id] = convert_to_numpy(policy.compute_actions(
-                input_dict=input_dict,
-                timestep=policy.global_timestep,
-                explore=None,
-                episodes=[active_episodes[t.env_id] for t in eval_data],
-                is_training=False,
-            ))
+            eval_results[policy_id] = convert_to_numpy(
+                policy.compute_actions(
+                    input_dict=input_dict,
+                    timestep=policy.global_timestep,
+                    explore=None,
+                    episodes=[active_episodes[t.env_id] for t in eval_data],
+                    is_training=False,
+                )
+            )
         # Old Policy API. Use `compute_actions_from_input_dict()`.
         else:
             eval_results[policy_id] = policy.compute_actions_from_input_dict(

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -153,9 +153,8 @@ class SamplerInput(InputReader, metaclass=ABCMeta):
         MultiAgentBatches that the user has provided thus-far. Users can
         add these "extra batches" to an episode by calling the episode's
         `add_extra_batch([SampleBatchType])` method. This can be done from
-        inside an overridden `Policy.compute_actions_from_input_dict(...,
-        episodes)` or from a custom callback's `on_episode_[start|step|end]()`
-        methods.
+        inside an overridden `Policy.compute_actions(..., episodes)` or from a
+        custom callback's `on_episode_[start|step|end]()` methods.
 
         Returns:
             List of SamplesBatches or MultiAgentBatches provided thus-far by
@@ -1149,6 +1148,10 @@ def _do_policy_eval(
     Returns:
         Dict mapping PolicyIDs to compute_actions_from_input_dict() outputs.
     """
+    # Avoids cyclic imports.
+    from ray.rllib.policy.dynamic_tf_policy_v2 import DynamicTFPolicyV2
+    from ray.rllib.policy.eager_tf_policy_v2 import EagerTFPolicyV2
+    from ray.rllib.policy.torch_policy_v2 import TorchPolicyV2
 
     eval_results: Dict[PolicyID, TensorStructType] = {}
 
@@ -1172,11 +1175,24 @@ def _do_policy_eval(
             policy: Policy = _get_or_raise(policies, policy_id)
 
         input_dict = sample_collector.get_inference_input_dict(policy_id)
-        eval_results[policy_id] = policy.compute_actions_from_input_dict(
-            input_dict,
-            timestep=policy.global_timestep,
-            episodes=[active_episodes[t.env_id] for t in eval_data],
-        )
+        # New Policy API: Only method to ever use (and override) to get and compute
+        # actions is `compute_actions()`.
+        if isinstance(policy, (DynamicTFPolicyV2, EagerTFPolicyV2, TorchPolicyV2)):
+            # Call the policy's `compute_actions` method.
+            eval_results[policy_id] = convert_to_numpy(policy.compute_actions(
+                input_dict=input_dict,
+                timestep=policy.global_timestep,
+                explore=None,
+                episodes=[active_episodes[t.env_id] for t in eval_data],
+                is_training=False,
+            ))
+        # Old Policy API. Use `compute_actions_from_input_dict()`.
+        else:
+            eval_results[policy_id] = policy.compute_actions_from_input_dict(
+                input_dict,
+                timestep=policy.global_timestep,
+                episodes=[active_episodes[t.env_id] for t in eval_data],
+            )
 
     if log_once("compute_actions_result"):
         logger.info(

--- a/rllib/policy/dynamic_tf_policy_v2.py
+++ b/rllib/policy/dynamic_tf_policy_v2.py
@@ -156,6 +156,8 @@ class DynamicTFPolicyV2(TFPolicy):
     ):
         return {}
 
+    @override(Policy)
+    @OverrideToImplementCustomLogic
     def compute_actions(
         self,
         *,
@@ -172,7 +174,7 @@ class DynamicTFPolicyV2(TFPolicy):
         info_batch: Optional[Dict[str, list]] = None,
         # Kwargs for forward compatibility.
         **kwargs,
-    ):
+    ) -> Tuple[TensorStructType, List[TensorType], Dict[str, TensorStructType]]:
         # Default distribution generation behavior:
         # Pass through model. E.g., PG, PPO.
         if isinstance(self.model, tf.keras.Model):
@@ -223,6 +225,7 @@ class DynamicTFPolicyV2(TFPolicy):
         # Initialize again after loss and tower init.
         self.get_session().run(tf1.global_variables_initializer())
 
+    @DeveloperAPI
     @override(TFPolicy)
     @OverrideToImplementCustomLogic
     def make_optimizer(

--- a/rllib/policy/dynamic_tf_policy_v2.py
+++ b/rllib/policy/dynamic_tf_policy_v2.py
@@ -3,10 +3,9 @@ import gym
 import logging
 import re
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, Tuple, Type, TYPE_CHECKING, Union
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 from ray.util.debug import log_once
-from ray.rllib.models.tf.tf_action_dist import TFActionDistribution
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.policy.dynamic_tf_policy import TFMultiGPUTowerStack
 from ray.rllib.policy.policy import Policy

--- a/rllib/policy/dynamic_tf_policy_v2.py
+++ b/rllib/policy/dynamic_tf_policy_v2.py
@@ -224,27 +224,6 @@ class DynamicTFPolicyV2(TFPolicy):
         # Initialize again after loss and tower init.
         self.get_session().run(tf1.global_variables_initializer())
 
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    @override(Policy)
-    def loss(
-        self,
-        model: Union[ModelV2, "tf.keras.Model"],
-        dist_class: Type[TFActionDistribution],
-        train_batch: SampleBatch,
-    ) -> Union[TensorType, List[TensorType]]:
-        """Constructs loss computation graph for this TF1 policy.
-
-        Args:
-            model: The Model to calculate the loss for.
-            dist_class: The action distr. class.
-            train_batch: The training data.
-
-        Returns:
-            A single loss tensor or a list of loss tensors.
-        """
-        raise NotImplementedError
-
     @override(TFPolicy)
     @OverrideToImplementCustomLogic
     def make_optimizer(

--- a/rllib/policy/eager_tf_policy_v2.py
+++ b/rllib/policy/eager_tf_policy_v2.py
@@ -7,13 +7,11 @@ import gym
 import logging
 import threading
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from ray.util.debug import log_once
 from ray.rllib.evaluation.episode import Episode
 from ray.rllib.models.catalog import ModelCatalog
-from ray.rllib.models.modelv2 import ModelV2
-from ray.rllib.models.tf.tf_action_dist import TFActionDistribution
 from ray.rllib.policy.eager_tf_policy import (
     _convert_to_tf,
     _disallow_var_creation,

--- a/rllib/policy/eager_tf_policy_v2.py
+++ b/rllib/policy/eager_tf_policy_v2.py
@@ -31,6 +31,7 @@ from ray.rllib.utils.annotations import (
     is_overridden,
     override,
 )
+from ray.rllib.utils.deprecation import deprecation_warning
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.metrics import NUM_AGENT_STEPS_TRAINED
 from ray.rllib.utils.metrics.learner_info import LEARNER_STATS_KEY
@@ -41,6 +42,7 @@ from ray.rllib.utils.threading import with_lock
 from ray.rllib.utils.typing import (
     LocalOptimizer,
     ModelGradients,
+    TensorStructType,
     TensorType,
     TrainerConfigDict,
 )
@@ -151,55 +153,6 @@ class EagerTFPolicyV2(Policy):
 
     @DeveloperAPI
     @OverrideToImplementCustomLogic
-    @override(Policy)
-    def loss(
-        self,
-        model: Union[ModelV2, "tf.keras.Model"],
-        dist_class: Type[TFActionDistribution],
-        train_batch: SampleBatch,
-    ) -> Union[TensorType, List[TensorType]]:
-        """Compute loss for this policy using model, dist_class and a train_batch.
-
-        Args:
-            model: The Model to calculate the loss for.
-            dist_class: The action distr. class.
-            train_batch: The training data.
-
-        Returns:
-            A single loss tensor or a list of loss tensors.
-        """
-        raise NotImplementedError
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    def stats_fn(self, train_batch: SampleBatch) -> Dict[str, TensorType]:
-        """Stats function. Returns a dict of statistics.
-
-        Args:
-            train_batch: The SampleBatch (already) used for training.
-
-        Returns:
-            The stats dict.
-        """
-        return {}
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    def grad_stats_fn(
-        self, train_batch: SampleBatch, grads: ModelGradients
-    ) -> Dict[str, TensorType]:
-        """Gradient stats function. Returns a dict of statistics.
-
-        Args:
-            train_batch: The SampleBatch (already) used for training.
-
-        Returns:
-            The stats dict.
-        """
-        return {}
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
     def make_model(self) -> ModelV2:
         """Build underlying model for this Policy.
 
@@ -218,219 +171,64 @@ class EagerTFPolicyV2(Policy):
             framework=self.framework,
         )
 
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    def compute_gradients_fn(
-        self, policy: Policy, optimizer: LocalOptimizer, loss: TensorType
-    ) -> ModelGradients:
-        """Gradients computing function (from loss tensor, using local optimizer).
-
-        Args:
-            policy (Policy): The Policy object that generated the loss tensor and
-                that holds the given local optimizer.
-            optimizer (LocalOptimizer): The tf (local) optimizer object to
-                calculate the gradients with.
-            loss (TensorType): The loss tensor for which gradients should be
-                calculated.
-
-        Returns:
-            ModelGradients: List of the possibly clipped gradients- and variable
-                tuples.
-        """
-        return None
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    def apply_gradients_fn(
-        self,
-        policy: Policy,
-        optimizer: "tf.keras.optimizers.Optimizer",
-        grads: ModelGradients,
-    ) -> "tf.Operation":
-        """Gradients computing function (from loss tensor, using local optimizer).
-
-        Args:
-            policy (Policy): The Policy object that generated the loss tensor and
-                that holds the given local optimizer.
-            optimizer (LocalOptimizer): The tf (local) optimizer object to
-                calculate the gradients with.
-            grads (ModelGradients): The gradient tensor to be applied.
-
-        Returns:
-            "tf.Operation": TF operation that applies supplied gradients.
-        """
-        return None
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    def action_sampler_fn(
-        self,
-        model: ModelV2,
-        *,
-        obs_batch: TensorType,
-        state_batches: TensorType,
-        **kwargs,
-    ) -> Tuple[TensorType, TensorType, TensorType, List[TensorType]]:
-        """Custom function for sampling new actions given policy.
-
-        Args:
-            model: Underlying model.
-            obs_batch: Observation tensor batch.
-            state_batches: Action sampling state batch.
-
-        Returns:
-            Sampled action
-            Log-likelihood
-            Action distribution inputs
-            Updated state
-        """
-        return None, None, None, None
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    def action_distribution_fn(
-        self,
-        model: ModelV2,
-        *,
-        obs_batch: TensorType,
-        state_batches: TensorType,
-        **kwargs,
-    ) -> Tuple[TensorType, type, List[TensorType]]:
-        """Action distribution function for this Policy.
-
-        Args:
-            model: Underlying model.
-            obs_batch: Observation tensor batch.
-            state_batches: Action sampling state batch.
-
-        Returns:
-            Distribution input.
-            ActionDistribution class.
-            State outs.
-        """
-        return None, None, None
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    def get_batch_divisibility_req(self) -> int:
-        """Get batch divisibility request.
-
-        Returns:
-            Size N. A sample batch must be of size K*N.
-        """
-        # By default, any sized batch is ok, so simply return 1.
-        return 1
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic_CallToSuperRecommended
-    def extra_action_out_fn(self) -> Dict[str, TensorType]:
-        """Extra values to fetch and return from compute_actions().
-
-        Returns:
-             Dict[str, TensorType]: An extra fetch-dict to be passed to and
-                returned from the compute_actions() call.
-        """
-        return {}
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic_CallToSuperRecommended
-    def extra_learn_fetches_fn(self) -> Dict[str, TensorType]:
-        """Extra stats to be reported after gradient computation.
-
-        Returns:
-             Dict[str, TensorType]: An extra fetch-dict.
-        """
-        return {}
-
     @override(Policy)
-    @OverrideToImplementCustomLogic_CallToSuperRecommended
-    def postprocess_trajectory(
+    def compute_actions(
         self,
-        sample_batch: SampleBatch,
-        other_agent_batches: Optional[SampleBatch] = None,
-        episode: Optional["Episode"] = None,
-    ):
-        """Post process trajectory in the format of a SampleBatch.
-
-        Args:
-            sample_batch: sample_batch: batch of experiences for the policy,
-                which will contain at most one episode trajectory.
-            other_agent_batches: In a multi-agent env, this contains a
-                mapping of agent ids to (policy, agent_batch) tuples
-                containing the policy and experiences of the other agents.
-            episode: An optional multi-agent episode object to provide
-                access to all of the internal episode state, which may
-                be useful for model-based or multi-agent algorithms.
-
-        Returns:
-            The postprocessed sample batch.
-        """
-        assert tf.executing_eagerly()
-        return Policy.postprocess_trajectory(self, sample_batch)
-
-    @OverrideToImplementCustomLogic
-    def optimizer(
-        self,
-    ) -> Union["tf.keras.optimizers.Optimizer", List["tf.keras.optimizers.Optimizer"]]:
-        """TF optimizer to use for policy optimization.
-
-        Returns:
-            A local optimizer or a list of local optimizers to use for this
-                Policy's Model.
-        """
-        return tf.keras.optimizers.Adam(self.config["lr"])
-
-    def _init_dist_class(self):
-        if is_overridden(self.action_sampler_fn) or is_overridden(
-            self.action_distribution_fn
-        ):
-            if not is_overridden(self.make_model):
-                raise ValueError(
-                    "`make_model` is required if `action_sampler_fn` OR "
-                    "`action_distribution_fn` is given"
-                )
-        else:
-            dist_class, _ = ModelCatalog.get_action_dist(
-                self.action_space, self.config["model"]
-            )
-        return dist_class
-
-    def _init_view_requirements(self):
-        # Auto-update model's inference view requirements, if recurrent.
-        self._update_model_view_requirements_from_init_state()
-        # Combine view_requirements for Model and Policy.
-        # TODO(jungong) : models will not carry view_requirements once they
-        # are migrated to be organic Keras models.
-        self.view_requirements.update(self.model.view_requirements)
-        # Disable env-info placeholder.
-        if SampleBatch.INFOS in self.view_requirements:
-            self.view_requirements[SampleBatch.INFOS].used_for_training = False
-
-    def maybe_initialize_optimizer_and_loss(self):
-        optimizers = force_list(self.optimizer())
-        if getattr(self, "exploration", None):
-            optimizers = self.exploration.get_exploration_optimizer(optimizers)
-
-        # The list of local (tf) optimizers (one per loss term).
-        self._optimizers: List[LocalOptimizer] = optimizers
-        # Backward compatibility: A user's policy may only support a single
-        # loss term and optimizer (no lists).
-        self._optimizer: LocalOptimizer = optimizers[0] if optimizers else None
-
-        self._initialize_loss_from_dummy_batch(
-            auto_remove_unneeded_view_reqs=True,
-        )
-        self._loss_initialized = True
-
-    @override(Policy)
-    def compute_actions_from_input_dict(
-        self,
-        input_dict: Dict[str, TensorType],
-        explore: bool = None,
+        *,
+        input_dict: Optional[Union[SampleBatch, Dict[str, TensorStructType]]] = None,
+        explore: Optional[bool] = None,
         timestep: Optional[int] = None,
-        episodes: Optional[List[Episode]] = None,
+        episodes: Optional[List["Episode"]] = None,
+        is_training: bool = False,
+        # Deprecated args.
+        obs_batch=None,
+        state_batches=None,
+        prev_action_batch=None,
+        prev_reward_batch=None,
+        info_batch=None,
+        # Kwargs for forward compatibility.
         **kwargs,
     ) -> Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
+
+        # If old signature used -> Warning and move everything into `input_dict`.
+        if input_dict is None:
+            assert obs_batch is not None,\
+                "ERROR: `compute_actions` either takes `input_dict` OR `obs_batch` as" \
+                " arg! You didn't provide either."
+            if log_once("old_compute_actions_signature"):
+                deprecation_warning(
+                    old="compute_actions(obs_batch=[..])",
+                    new="compute_actions(input_dict=[..])",
+                    error=False,
+                )
+            # Create `input_dict` to continue with.
+            input_dict = SampleBatch(
+                {
+                    SampleBatch.CUR_OBS: obs_batch,
+                },
+                _is_training=tf.constant(False),
+            )
+            if state_batches is not None:
+                for i, s in enumerate(state_batches):
+                    input_dict[f"state_in_{i}"] = s
+            if prev_action_batch is not None:
+                input_dict[SampleBatch.PREV_ACTIONS] = prev_action_batch
+            if prev_reward_batch is not None:
+                input_dict[SampleBatch.PREV_REWARDS] = prev_reward_batch
+            if info_batch is not None:
+                input_dict[SampleBatch.INFOS] = info_batch
+        else:
+            # Pack internal state inputs into (separate) list.
+            state_key = "state_in_0"
+            state_batches = []
+            i = 0
+            while state_key in input_dict:
+                i += 1
+                state_batches.append(input_dict[state_key])
+                state_key = f"state_in_{i}"
+
+        #self._state_in = state_batches
+        self._is_recurrent = state_batches != []
         self._is_training = False
 
         explore = explore if explore is not None else self.explore
@@ -441,13 +239,6 @@ class EagerTFPolicyV2(Policy):
         # Pass lazy (eager) tensor dict to Model as `input_dict`.
         input_dict = self._lazy_tensor_dict(input_dict)
         input_dict.set_training(False)
-
-        # Pack internal state inputs into (separate) list.
-        state_batches = [
-            input_dict[k] for k in input_dict.keys() if "state_in" in k[:8]
-        ]
-        self._state_in = state_batches
-        self._is_recurrent = state_batches != []
 
         # Call the exploration before_compute_actions hook.
         self.exploration.before_compute_actions(
@@ -462,50 +253,7 @@ class EagerTFPolicyV2(Policy):
             explore,
             timestep,
         )
-        # Update our global timestep by the batch size.
-        self.global_timestep.assign_add(tree.flatten(ret[0])[0].shape.as_list()[0])
-        return convert_to_numpy(ret)
-
-    # TODO(jungong) : deprecate this API and make compute_actions_from_input_dict the
-    # only canonical entry point for inference.
-    @override(Policy)
-    def compute_actions(
-        self,
-        obs_batch,
-        state_batches=None,
-        prev_action_batch=None,
-        prev_reward_batch=None,
-        info_batch=None,
-        episodes=None,
-        explore=None,
-        timestep=None,
-        **kwargs,
-    ):
-        # Create input dict to simply pass the entire call to
-        # self.compute_actions_from_input_dict().
-        input_dict = SampleBatch(
-            {
-                SampleBatch.CUR_OBS: obs_batch,
-            },
-            _is_training=tf.constant(False),
-        )
-        if state_batches is not None:
-            for s in enumerate(state_batches):
-                input_dict["state_in_{i}"] = s
-        if prev_action_batch is not None:
-            input_dict[SampleBatch.PREV_ACTIONS] = prev_action_batch
-        if prev_reward_batch is not None:
-            input_dict[SampleBatch.PREV_REWARDS] = prev_reward_batch
-        if info_batch is not None:
-            input_dict[SampleBatch.INFOS] = info_batch
-
-        return self.compute_actions_from_input_dict(
-            input_dict=input_dict,
-            explore=explore,
-            timestep=timestep,
-            episodes=episodes,
-            **kwargs,
-        )
+        return ret
 
     @with_lock
     @override(Policy)
@@ -563,6 +311,260 @@ class EagerTFPolicyV2(Policy):
         log_likelihoods = action_dist.logp(actions)
 
         return log_likelihoods
+
+    def initialize_optimizer_and_loss_if_necessary(self):
+        optimizers = force_list(self.optimizer())
+        if getattr(self, "exploration", None):
+            optimizers = self.exploration.get_exploration_optimizer(optimizers)
+
+        # The list of local (tf) optimizers (one per loss term).
+        self._optimizers: List[LocalOptimizer] = optimizers
+        # Backward compatibility: A user's policy may only support a single
+        # loss term and optimizer (no lists).
+        self._optimizer: LocalOptimizer = optimizers[0] if optimizers else None
+
+        self._initialize_loss_from_dummy_batch(
+            auto_remove_unneeded_view_reqs=True,
+        )
+        self._loss_initialized = True
+
+    @DeveloperAPI
+    @OverrideToImplementCustomLogic
+    @override(Policy)
+    def loss(
+        self,
+        model: Union[ModelV2, "tf.keras.Model"],
+        dist_class: Type[TFActionDistribution],
+        train_batch: SampleBatch,
+    ) -> Union[TensorType, List[TensorType]]:
+        """Compute loss for this policy using model, dist_class and a train_batch.
+
+        Args:
+            model: The Model to calculate the loss for.
+            dist_class: The action distr. class.
+            train_batch: The training data.
+
+        Returns:
+            A single loss tensor or a list of loss tensors.
+        """
+        raise NotImplementedError
+
+    @DeveloperAPI
+    @OverrideToImplementCustomLogic
+    def stats_fn(self, train_batch: SampleBatch) -> Dict[str, TensorType]:
+        """Stats function. Returns a dict of statistics.
+
+        Args:
+            train_batch: The SampleBatch (already) used for training.
+
+        Returns:
+            The stats dict.
+        """
+        return {}
+
+    @DeveloperAPI
+    @OverrideToImplementCustomLogic
+    def grad_stats_fn(
+        self, train_batch: SampleBatch, grads: ModelGradients
+    ) -> Dict[str, TensorType]:
+        """Gradient stats function. Returns a dict of statistics.
+
+        Args:
+            train_batch: The SampleBatch (already) used for training.
+
+        Returns:
+            The stats dict.
+        """
+        return {}
+
+    @DeveloperAPI
+    @OverrideToImplementCustomLogic
+    def compute_gradients_fn(
+        self, policy: Policy, optimizer: LocalOptimizer, loss: TensorType
+    ) -> ModelGradients:
+        """Gradients computing function (from loss tensor, using local optimizer).
+
+        Args:
+            policy (Policy): The Policy object that generated the loss tensor and
+                that holds the given local optimizer.
+            optimizer (LocalOptimizer): The tf (local) optimizer object to
+                calculate the gradients with.
+            loss (TensorType): The loss tensor for which gradients should be
+                calculated.
+
+        Returns:
+            ModelGradients: List of the possibly clipped gradients- and variable
+                tuples.
+        """
+        return None
+
+    @DeveloperAPI
+    @OverrideToImplementCustomLogic
+    def apply_gradients_fn(
+        self,
+        policy: Policy,
+        optimizer: "tf.keras.optimizers.Optimizer",
+        grads: ModelGradients,
+    ) -> "tf.Operation":
+        """Gradients computing function (from loss tensor, using local optimizer).
+
+        Args:
+            policy (Policy): The Policy object that generated the loss tensor and
+                that holds the given local optimizer.
+            optimizer (LocalOptimizer): The tf (local) optimizer object to
+                calculate the gradients with.
+            grads (ModelGradients): The gradient tensor to be applied.
+
+        Returns:
+            "tf.Operation": TF operation that applies supplied gradients.
+        """
+        return None
+
+    #@DeveloperAPI
+    #@OverrideToImplementCustomLogic
+    #def action_sampler_fn(
+    #    self,
+    #    model: ModelV2,
+    #    *,
+    #    obs_batch: TensorType,
+    #    state_batches: TensorType,
+    #    **kwargs,
+    #) -> Tuple[TensorType, TensorType, TensorType, List[TensorType]]:
+    #    """Custom function for sampling new actions given policy.
+
+    #    Args:
+    #        model: Underlying model.
+    #        obs_batch: Observation tensor batch.
+    #        state_batches: Action sampling state batch.
+
+    #    Returns:
+    #        Sampled action
+    #        Log-likelihood
+    #        Action distribution inputs
+    #        Updated state
+    #    """
+    #    return None, None, None, None
+
+    #@DeveloperAPI
+    #@OverrideToImplementCustomLogic
+    #def action_distribution_fn(
+    #    self,
+    #    model: ModelV2,
+    #    *,
+    #    obs_batch: TensorType,
+    #    state_batches: TensorType,
+    #    **kwargs,
+    #) -> Tuple[TensorType, type, List[TensorType]]:
+    #    """Action distribution function for this Policy.
+
+    #    Args:
+    #        model: Underlying model.
+    #        obs_batch: Observation tensor batch.
+    #        state_batches: Action sampling state batch.
+
+    #    Returns:
+    #        Distribution input.
+    #        ActionDistribution class.
+    #        State outs.
+    #    """
+    #    return None, None, None
+
+    @DeveloperAPI
+    @OverrideToImplementCustomLogic
+    def get_batch_divisibility_req(self) -> int:
+        """Get batch divisibility request.
+
+        Returns:
+            Size N. A sample batch must be of size K*N.
+        """
+        # By default, any sized batch is ok, so simply return 1.
+        return 1
+
+    #@DeveloperAPI
+    #@OverrideToImplementCustomLogic_CallToSuperRecommended
+    #def extra_action_out_fn(self) -> Dict[str, TensorType]:
+    #    """Extra values to fetch and return from compute_actions().
+
+    #    Returns:
+    #         Dict[str, TensorType]: An extra fetch-dict to be passed to and
+    #            returned from the compute_actions() call.
+    #    """
+    #    return {}
+
+    @DeveloperAPI
+    @OverrideToImplementCustomLogic_CallToSuperRecommended
+    def extra_learn_fetches_fn(self) -> Dict[str, TensorType]:
+        """Extra stats to be reported after gradient computation.
+
+        Returns:
+             Dict[str, TensorType]: An extra fetch-dict.
+        """
+        return {}
+
+    @override(Policy)
+    @OverrideToImplementCustomLogic_CallToSuperRecommended
+    def postprocess_trajectory(
+        self,
+        sample_batch: SampleBatch,
+        other_agent_batches: Optional[SampleBatch] = None,
+        episode: Optional["Episode"] = None,
+    ):
+        """Post process trajectory in the format of a SampleBatch.
+
+        Args:
+            sample_batch: sample_batch: batch of experiences for the policy,
+                which will contain at most one episode trajectory.
+            other_agent_batches: In a multi-agent env, this contains a
+                mapping of agent ids to (policy, agent_batch) tuples
+                containing the policy and experiences of the other agents.
+            episode: An optional multi-agent episode object to provide
+                access to all of the internal episode state, which may
+                be useful for model-based or multi-agent algorithms.
+
+        Returns:
+            The postprocessed sample batch.
+        """
+        assert tf.executing_eagerly()
+        return Policy.postprocess_trajectory(self, sample_batch)
+
+    @OverrideToImplementCustomLogic
+    def optimizer(
+        self,
+    ) -> Union["tf.keras.optimizers.Optimizer", List["tf.keras.optimizers.Optimizer"]]:
+        """TF optimizer to use for policy optimization.
+
+        Returns:
+            A local optimizer or a list of local optimizers to use for this
+                Policy's Model.
+        """
+        return tf.keras.optimizers.Adam(self.config["lr"])
+
+    def _init_dist_class(self):
+        #dist_class = None
+        #if is_overridden(self.action_sampler_fn) or is_overridden(
+        #    self.action_distribution_fn
+        #):
+        #    if not is_overridden(self.make_model):
+        #        raise ValueError(
+        #            "`make_model` is required if `action_sampler_fn` OR "
+        #            "`action_distribution_fn` is given"
+        #        )
+        #else:
+        dist_class, _ = ModelCatalog.get_action_dist(
+            self.action_space, self.config["model"]
+        )
+        return dist_class
+
+    def _init_view_requirements(self):
+        # Auto-update model's inference view requirements, if recurrent.
+        self._update_model_view_requirements_from_init_state()
+        # Combine view_requirements for Model and Policy.
+        # TODO(jungong) : models will not carry view_requirements once they
+        # are migrated to be organic Keras models.
+        self.view_requirements.update(self.model.view_requirements)
+        # Disable env-info placeholder.
+        if SampleBatch.INFOS in self.view_requirements:
+            self.view_requirements[SampleBatch.INFOS].used_for_training = False
 
     @with_lock
     @override(Policy)
@@ -737,54 +739,26 @@ class EagerTFPolicyV2(Policy):
 
         # Use Exploration object.
         with tf.variable_creator_scope(_disallow_var_creation):
-            if is_overridden(self.action_sampler_fn):
-                dist_inputs = None
-                state_out = []
-                actions, logp, dist_inputs, state_out = self.action_sampler_fn(
-                    self.model,
-                    input_dict[SampleBatch.CUR_OBS],
-                    explore=explore,
-                    timestep=timestep,
-                    episodes=episodes,
-                )
+            if isinstance(self.model, tf.keras.Model):
+                input_dict = SampleBatch(input_dict, seq_lens=seq_lens)
+                if state_batches and "state_in_0" not in input_dict:
+                    for i, s in enumerate(state_batches):
+                        input_dict[f"state_in_{i}"] = s
+                self._lazy_tensor_dict(input_dict)
+                dist_inputs, state_out, extra_fetches = self.model(input_dict)
             else:
-                if is_overridden(self.action_distribution_fn):
-
-                    # Try new action_distribution_fn signature, supporting
-                    # state_batches and seq_lens.
-                    (
-                        dist_inputs,
-                        self.dist_class,
-                        state_out,
-                    ) = self.action_distribution_fn(
-                        self.model,
-                        input_dict=input_dict,
-                        state_batches=state_batches,
-                        seq_lens=seq_lens,
-                        explore=explore,
-                        timestep=timestep,
-                        is_training=False,
-                    )
-                elif isinstance(self.model, tf.keras.Model):
-                    input_dict = SampleBatch(input_dict, seq_lens=seq_lens)
-                    if state_batches and "state_in_0" not in input_dict:
-                        for i, s in enumerate(state_batches):
-                            input_dict[f"state_in_{i}"] = s
-                    self._lazy_tensor_dict(input_dict)
-                    dist_inputs, state_out, extra_fetches = self.model(input_dict)
-                else:
-                    dist_inputs, state_out = self.model(
-                        input_dict, state_batches, seq_lens
-                    )
-
-                action_dist = self.dist_class(dist_inputs, self.model)
-
-                # Get the exploration action from the forward results.
-                actions, logp = self.exploration.get_exploration_action(
-                    action_distribution=action_dist,
-                    timestep=timestep,
-                    explore=explore,
+                dist_inputs, state_out = self.model(
+                    input_dict, state_batches, seq_lens
                 )
+
+            action_dist = self.dist_class(dist_inputs, self.model)
+
+            # Get the exploration action from the forward results.
+            actions, logp = self.exploration.get_exploration_action(
+                action_distribution=action_dist,
+                timestep=timestep,
+                explore=explore,
+            )
 
         # Action-logp and action-prob.
         if logp is not None:
@@ -793,8 +767,8 @@ class EagerTFPolicyV2(Policy):
         # Action-dist inputs.
         if dist_inputs is not None:
             extra_fetches[SampleBatch.ACTION_DIST_INPUTS] = dist_inputs
-        # Custom extra fetches.
-        extra_fetches.update(self.extra_action_out_fn())
+        ## Custom extra fetches.
+        #extra_fetches.update(self.extra_action_out_fn())
 
         return actions, state_out, extra_fetches
 

--- a/rllib/policy/eager_tf_policy_v2.py
+++ b/rllib/policy/eager_tf_policy_v2.py
@@ -150,6 +150,7 @@ class EagerTFPolicyV2(Policy):
         return {}
 
     @override(Policy)
+    @OverrideToImplementCustomLogic
     def compute_actions(
         self,
         *,
@@ -166,7 +167,7 @@ class EagerTFPolicyV2(Policy):
         info_batch=None,
         # Kwargs for forward compatibility.
         **kwargs,
-    ) -> Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
+    ) -> Tuple[TensorStructType, List[TensorType], Dict[str, TensorStructType]]:
 
         # If old signature used -> Warning and move everything into `input_dict`.
         if input_dict is None:
@@ -235,6 +236,7 @@ class EagerTFPolicyV2(Policy):
 
     @with_lock
     @override(Policy)
+    @OverrideToImplementCustomLogic
     def compute_log_likelihoods(
         self,
         actions,
@@ -385,6 +387,7 @@ class EagerTFPolicyV2(Policy):
         """
         return {}
 
+    @DeveloperAPI
     @OverrideToImplementCustomLogic
     def make_optimizer(
         self,
@@ -414,8 +417,10 @@ class EagerTFPolicyV2(Policy):
         if SampleBatch.INFOS in self.view_requirements:
             self.view_requirements[SampleBatch.INFOS].used_for_training = False
 
+    @DeveloperAPI
     @with_lock
     @override(Policy)
+    @OverrideToImplementCustomLogic
     def learn_on_batch(self, postprocessed_batch):
         # Callback handling.
         learn_stats = {}

--- a/rllib/policy/eager_tf_policy_v2.py
+++ b/rllib/policy/eager_tf_policy_v2.py
@@ -310,27 +310,6 @@ class EagerTFPolicyV2(Policy):
 
     @DeveloperAPI
     @OverrideToImplementCustomLogic
-    @override(Policy)
-    def loss(
-        self,
-        model: Union[ModelV2, "tf.keras.Model"],
-        dist_class: Type[TFActionDistribution],
-        train_batch: SampleBatch,
-    ) -> Union[TensorType, List[TensorType]]:
-        """Compute loss for this policy using model, dist_class and a train_batch.
-
-        Args:
-            model: The Model to calculate the loss for.
-            dist_class: The action distr. class.
-            train_batch: The training data.
-
-        Returns:
-            A single loss tensor or a list of loss tensors.
-        """
-        raise NotImplementedError
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
     def compute_gradients_fn(
         self, policy: Policy, optimizer: LocalOptimizer, loss: TensorType
     ) -> ModelGradients:

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -501,31 +501,36 @@ class Policy(metaclass=ABCMeta):
     ) -> Tuple[ModelGradients, Dict[str, TensorType]]:
         """Computes gradients given a batch of experiences.
 
-        Either this in combination with `apply_gradients()` or
+        Either this - in combination with `apply_gradients()` - or
         `learn_on_batch()` must be implemented by subclasses.
+        The default implementation of `learn_on_batch()` calls `compute_gradients()`
+        and `apply_gradients()` in sequence.
 
         Args:
             postprocessed_batch: The SampleBatch object to use
                 for calculating gradients.
 
         Returns:
-            grads: List of gradient output values.
-            grad_info: Extra policy-specific info values.
+            Tuple, consisting of 1) List of gradient output values and 2)
+            Extra policy-specific info values.
         """
-        raise NotImplementedError
+        # By default, do nothing.
+        return [], {}
 
     @DeveloperAPI
     def apply_gradients(self, gradients: ModelGradients) -> None:
-        """Applies the (previously) computed gradients.
+        """Applies `gradients` to the Policy's model(s) using its local optimizer(s).
 
-        Either this in combination with `compute_gradients()` or
+        Either this - in combination with `compute_gradients()` - or
         `learn_on_batch()` must be implemented by subclasses.
+        The default implementation of `learn_on_batch()` calls `compute_gradients()`
+        and `apply_gradients()` in sequence.
 
         Args:
             gradients: The already calculated gradients to apply to this
                 Policy.
         """
-        raise NotImplementedError
+        pass
 
     @DeveloperAPI
     def get_weights(self) -> ModelWeights:

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -212,6 +212,7 @@ class Policy(metaclass=ABCMeta):
 
     @abstractmethod
     @DeveloperAPI
+    @OverrideToImplementCustomLogic
     def compute_actions(
         self,
         *,
@@ -228,7 +229,7 @@ class Policy(metaclass=ABCMeta):
         info_batch=None,
         # Kwargs for forward compatibility.
         **kwargs,
-    ) -> Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
+    ) -> Tuple[TensorStructType, List[TensorType], Dict[str, TensorStructType]]:
         """Computes actions for the current policy.
 
         Args:

--- a/rllib/policy/policy_template.py
+++ b/rllib/policy/policy_template.py
@@ -1,30 +1,17 @@
-import gym
 from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
     TYPE_CHECKING,
-    Union,
 )
 
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.jax.jax_modelv2 import JAXModelV2
-from ray.rllib.models.modelv2 import ModelV2
-from ray.rllib.models.torch.torch_action_dist import TorchDistributionWrapper
 from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.torch_policy import TorchPolicy
 from ray.rllib.utils import add_mixins, NullContextManager
-from ray.rllib.utils.annotations import override, DeveloperAPI
+from ray.rllib.utils.annotations import Deprecated, override
 from ray.rllib.utils.framework import try_import_torch, try_import_jax
 from ray.rllib.utils.metrics.learner_info import LEARNER_STATS_KEY
 from ray.rllib.utils.numpy import convert_to_numpy
-from ray.rllib.utils.typing import ModelGradients, TensorType, TrainerConfigDict
 
 if TYPE_CHECKING:
     from ray.rllib.evaluation.episode import Episode  # noqa
@@ -33,213 +20,37 @@ jax, _ = try_import_jax()
 torch, _ = try_import_torch()
 
 
-# TODO: Deprecate in favor of directly sub-classing from TorchPolicy.
-@DeveloperAPI
+@Deprecated(
+    new="sub-class directly from `ray.rllib.policy.torch_policy_v2::TorchPolicyV2` "
+        "and override needed methods",
+    error=False,
+)
 def build_policy_class(
     name: str,
     framework: str,
     *,
-    loss_fn: Optional[
-        Callable[
-            [Policy, ModelV2, Type[TorchDistributionWrapper], SampleBatch],
-            Union[TensorType, List[TensorType]],
-        ]
-    ],
-    get_default_config: Optional[Callable[[], TrainerConfigDict]] = None,
-    stats_fn: Optional[Callable[[Policy, SampleBatch], Dict[str, TensorType]]] = None,
-    postprocess_fn: Optional[
-        Callable[
-            [
-                Policy,
-                SampleBatch,
-                Optional[Dict[Any, SampleBatch]],
-                Optional["Episode"],
-            ],
-            SampleBatch,
-        ]
-    ] = None,
-    extra_action_out_fn: Optional[
-        Callable[
-            [
-                Policy,
-                Dict[str, TensorType],
-                List[TensorType],
-                ModelV2,
-                TorchDistributionWrapper,
-            ],
-            Dict[str, TensorType],
-        ]
-    ] = None,
-    extra_grad_process_fn: Optional[
-        Callable[[Policy, "torch.optim.Optimizer", TensorType], Dict[str, TensorType]]
-    ] = None,
-    # TODO: (sven) Replace "fetches" with "process".
-    extra_learn_fetches_fn: Optional[Callable[[Policy], Dict[str, TensorType]]] = None,
-    optimizer_fn: Optional[
-        Callable[[Policy, TrainerConfigDict], "torch.optim.Optimizer"]
-    ] = None,
-    validate_spaces: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    before_init: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    before_loss_init: Optional[
-        Callable[[Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], None]
-    ] = None,
-    after_init: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    _after_loss_init: Optional[
-        Callable[[Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], None]
-    ] = None,
-    action_sampler_fn: Optional[
-        Callable[[TensorType, List[TensorType]], Tuple[TensorType, TensorType]]
-    ] = None,
-    action_distribution_fn: Optional[
-        Callable[
-            [Policy, ModelV2, TensorType, TensorType, TensorType],
-            Tuple[TensorType, type, List[TensorType]],
-        ]
-    ] = None,
-    make_model: Optional[
-        Callable[
-            [Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], ModelV2
-        ]
-    ] = None,
-    make_model_and_action_dist: Optional[
-        Callable[
-            [Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict],
-            Tuple[ModelV2, Type[TorchDistributionWrapper]],
-        ]
-    ] = None,
-    compute_gradients_fn: Optional[
-        Callable[[Policy, SampleBatch], Tuple[ModelGradients, dict]]
-    ] = None,
-    apply_gradients_fn: Optional[
-        Callable[[Policy, "torch.optim.Optimizer"], None]
-    ] = None,
-    mixins: Optional[List[type]] = None,
-    get_batch_divisibility_req: Optional[Callable[[Policy], int]] = None
-) -> Type[TorchPolicy]:
-    """Helper function for creating a new Policy class at runtime.
-
-    Supports frameworks JAX and PyTorch.
-
-    Args:
-        name (str): name of the policy (e.g., "PPOTorchPolicy")
-        framework (str): Either "jax" or "torch".
-        loss_fn (Optional[Callable[[Policy, ModelV2,
-            Type[TorchDistributionWrapper], SampleBatch], Union[TensorType,
-            List[TensorType]]]]): Callable that returns a loss tensor.
-        get_default_config (Optional[Callable[[None], TrainerConfigDict]]):
-            Optional callable that returns the default config to merge with any
-            overrides. If None, uses only(!) the user-provided
-            PartialTrainerConfigDict as dict for this Policy.
-        postprocess_fn (Optional[Callable[[Policy, SampleBatch,
-            Optional[Dict[Any, SampleBatch]], Optional["Episode"]],
-            SampleBatch]]): Optional callable for post-processing experience
-            batches (called after the super's `postprocess_trajectory` method).
-        stats_fn (Optional[Callable[[Policy, SampleBatch],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            values given the policy and training batch. If None,
-            will use `TorchPolicy.extra_grad_info()` instead. The stats dict is
-            used for logging (e.g. in TensorBoard).
-        extra_action_out_fn (Optional[Callable[[Policy, Dict[str, TensorType],
-            List[TensorType], ModelV2, TorchDistributionWrapper]], Dict[str,
-            TensorType]]]): Optional callable that returns a dict of extra
-            values to include in experiences. If None, no extra computations
-            will be performed.
-        extra_grad_process_fn (Optional[Callable[[Policy,
-            "torch.optim.Optimizer", TensorType], Dict[str, TensorType]]]):
-            Optional callable that is called after gradients are computed and
-            returns a processing info dict. If None, will call the
-            `TorchPolicy.extra_grad_process()` method instead.
-        # TODO: (sven) dissolve naming mismatch between "learn" and "compute.."
-        extra_learn_fetches_fn (Optional[Callable[[Policy],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            extra tensors from the policy after loss evaluation. If None,
-            will call the `TorchPolicy.extra_compute_grad_fetches()` method
-            instead.
-        optimizer_fn (Optional[Callable[[Policy, TrainerConfigDict],
-            "torch.optim.Optimizer"]]): Optional callable that returns a
-            torch optimizer given the policy and config. If None, will call
-            the `TorchPolicy.optimizer()` method instead (which returns a
-            torch Adam optimizer).
-        validate_spaces (Optional[Callable[[Policy, gym.Space, gym.Space,
-            TrainerConfigDict], None]]): Optional callable that takes the
-            Policy, observation_space, action_space, and config to check for
-            correctness. If None, no spaces checking will be done.
-        before_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            TrainerConfigDict], None]]): Optional callable to run at the
-            beginning of `Policy.__init__` that takes the same arguments as
-            the Policy constructor. If None, this step will be skipped.
-        before_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, TrainerConfigDict], None]]): Optional callable to
-            run prior to loss init. If None, this step will be skipped.
-        after_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            TrainerConfigDict], None]]): DEPRECATED: Use `before_loss_init`
-            instead.
-        _after_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, TrainerConfigDict], None]]): Optional callable to
-            run after the loss init. If None, this step will be skipped.
-            This will be deprecated at some point and renamed into `after_init`
-            to match `build_tf_policy()` behavior.
-        action_sampler_fn (Optional[Callable[[TensorType, List[TensorType]],
-            Tuple[TensorType, TensorType]]]): Optional callable returning a
-            sampled action and its log-likelihood given some (obs and state)
-            inputs. If None, will either use `action_distribution_fn` or
-            compute actions by calling self.model, then sampling from the
-            so parameterized action distribution.
-        action_distribution_fn (Optional[Callable[[Policy, ModelV2, TensorType,
-            TensorType, TensorType], Tuple[TensorType,
-            Type[TorchDistributionWrapper], List[TensorType]]]]): A callable
-            that takes the Policy, Model, the observation batch, an
-            explore-flag, a timestep, and an is_training flag and returns a
-            tuple of a) distribution inputs (parameters), b) a dist-class to
-            generate an action distribution object from, and c) internal-state
-            outputs (empty list if not applicable). If None, will either use
-            `action_sampler_fn` or compute actions by calling self.model,
-            then sampling from the parameterized action distribution.
-        make_model (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, TrainerConfigDict], ModelV2]]): Optional callable
-            that takes the same arguments as Policy.__init__ and returns a
-            model instance. The distribution class will be determined
-            automatically. Note: Only one of `make_model` or
-            `make_model_and_action_dist` should be provided. If both are None,
-            a default Model will be created.
-        make_model_and_action_dist (Optional[Callable[[Policy,
-            gym.spaces.Space, gym.spaces.Space, TrainerConfigDict],
-            Tuple[ModelV2, Type[TorchDistributionWrapper]]]]): Optional
-            callable that takes the same arguments as Policy.__init__ and
-            returns a tuple of model instance and torch action distribution
-            class.
-            Note: Only one of `make_model` or `make_model_and_action_dist`
-            should be provided. If both are None, a default Model will be
-            created.
-        compute_gradients_fn (Optional[Callable[
-            [Policy, SampleBatch], Tuple[ModelGradients, dict]]]): Optional
-            callable that the sampled batch an computes the gradients w.r.
-            to the loss function.
-            If None, will call the `TorchPolicy.compute_gradients()` method
-            instead.
-        apply_gradients_fn (Optional[Callable[[Policy,
-            "torch.optim.Optimizer"], None]]): Optional callable that
-            takes a grads list and applies these to the Model's parameters.
-            If None, will call the `TorchPolicy.apply_gradients()` method
-            instead.
-        mixins (Optional[List[type]]): Optional list of any class mixins for
-            the returned policy class. These mixins will be applied in order
-            and will have higher precedence than the TorchPolicy class.
-        get_batch_divisibility_req (Optional[Callable[[Policy], int]]):
-            Optional callable that returns the divisibility requirement for
-            sample batches. If None, will assume a value of 1.
-
-    Returns:
-        Type[TorchPolicy]: TorchPolicy child class constructed from the
-            specified args.
-    """
-
+    loss_fn=None,
+    get_default_config=None,
+    stats_fn=None,
+    postprocess_fn=None,
+    extra_action_out_fn=None,
+    extra_grad_process_fn=None,
+    extra_learn_fetches_fn=None,
+    optimizer_fn=None,
+    validate_spaces=None,
+    before_init=None,
+    before_loss_init=None,
+    after_init=None,
+    _after_loss_init=None,
+    action_sampler_fn=None,
+    action_distribution_fn=None,
+    make_model=None,
+    make_model_and_action_dist=None,
+    compute_gradients_fn=None,
+    apply_gradients_fn=None,
+    mixins=None,
+    get_batch_divisibility_req=None,
+):
     original_kwargs = locals().copy()
     parent_cls = TorchPolicy
     base = add_mixins(parent_cls, mixins)

--- a/rllib/policy/policy_template.py
+++ b/rllib/policy/policy_template.py
@@ -22,7 +22,7 @@ torch, _ = try_import_torch()
 
 @Deprecated(
     new="sub-class directly from `ray.rllib.policy.torch_policy_v2::TorchPolicyV2` "
-        "and override needed methods",
+    "and override needed methods",
     error=False,
 )
 def build_policy_class(

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -17,7 +17,7 @@ from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.utils import force_list
 from ray.rllib.utils.annotations import DeveloperAPI, override
 from ray.rllib.utils.debug import summarize
-from ray.rllib.utils.deprecation import Deprecated, deprecation_warning
+from ray.rllib.utils.deprecation import Deprecated
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.metrics import NUM_AGENT_STEPS_TRAINED
 from ray.rllib.utils.metrics.learner_info import LEARNER_STATS_KEY

--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -27,6 +27,7 @@ from ray.rllib.utils.tf_run_builder import _TFRunBuilder
 from ray.rllib.utils.typing import (
     LocalOptimizer,
     ModelGradients,
+    TensorStructType,
     TensorType,
     TrainerConfigDict,
 )
@@ -340,14 +341,19 @@ class TFPolicy(Policy):
     @override(Policy)
     def compute_actions(
         self,
-        obs_batch: Union[List[TensorType], TensorType],
+        *,
+        input_dict: Optional[Union[SampleBatch, Dict[str, TensorStructType]]] = None,
+        explore: Optional[bool] = None,
+        timestep: Optional[int] = None,
+        episodes: Optional[List["Episode"]] = None,
+        is_training: bool = False,
+        # Deprecated args.
+        obs_batch: Optional[Union[List[TensorType], TensorType]] = None,
         state_batches: Optional[List[TensorType]] = None,
         prev_action_batch: Union[List[TensorType], TensorType] = None,
         prev_reward_batch: Union[List[TensorType], TensorType] = None,
         info_batch: Optional[Dict[str, list]] = None,
-        episodes: Optional[List["Episode"]] = None,
-        explore: Optional[bool] = None,
-        timestep: Optional[int] = None,
+        # Kwargs for forward compatibility.
         **kwargs,
     ):
 
@@ -356,7 +362,7 @@ class TFPolicy(Policy):
 
         builder = _TFRunBuilder(self.get_session(), "compute_actions")
 
-        input_dict = {SampleBatch.OBS: obs_batch, "is_training": False}
+        input_dict = {SampleBatch.OBS: obs_batch}
         if state_batches:
             for i, s in enumerate(state_batches):
                 input_dict[f"state_in_{i}"] = s
@@ -366,7 +372,11 @@ class TFPolicy(Policy):
             input_dict[SampleBatch.PREV_REWARDS] = prev_reward_batch
 
         to_fetch = self._build_compute_actions(
-            builder, input_dict=input_dict, explore=explore, timestep=timestep
+            builder=builder,
+            input_dict=input_dict,
+            explore=explore,
+            timestep=timestep,
+            is_training=is_training,
         )
 
         # Execute session run to get action (and other fetches).
@@ -1023,14 +1033,12 @@ class TFPolicy(Policy):
         self,
         builder,
         *,
-        input_dict=None,
-        obs_batch=None,
-        state_batches=None,
-        prev_action_batch=None,
-        prev_reward_batch=None,
+        input_dict,
         episodes=None,
         explore=None,
         timestep=None,
+        is_training=False,
+        extra_action_fetches=None,
     ):
         explore = explore if explore is not None else self.config["explore"]
         timestep = timestep if timestep is not None else self.global_timestep
@@ -1043,70 +1051,39 @@ class TFPolicy(Policy):
         builder.add_feed_dict(self.extra_compute_action_feed_dict())
 
         # `input_dict` given: Simply build what's in that dict.
-        if input_dict is not None:
-            if hasattr(self, "_input_dict"):
-                for key, value in input_dict.items():
-                    if key in self._input_dict:
-                        # Handle complex/nested spaces as well.
-                        tree.map_structure(
-                            lambda k, v: builder.add_feed_dict({k: v}),
-                            self._input_dict[key],
-                            value,
-                        )
-            # For policies that inherit directly from TFPolicy.
-            else:
-                builder.add_feed_dict({self._obs_input: input_dict[SampleBatch.OBS]})
-                if SampleBatch.PREV_ACTIONS in input_dict:
-                    builder.add_feed_dict(
-                        {self._prev_action_input: input_dict[SampleBatch.PREV_ACTIONS]}
+        if hasattr(self, "_input_dict"):
+            for key, value in input_dict.items():
+                if key in self._input_dict:
+                    # Handle complex/nested spaces as well.
+                    tree.map_structure(
+                        lambda k, v: builder.add_feed_dict({k: v}),
+                        self._input_dict[key],
+                        value,
                     )
-                if SampleBatch.PREV_REWARDS in input_dict:
-                    builder.add_feed_dict(
-                        {self._prev_reward_input: input_dict[SampleBatch.PREV_REWARDS]}
-                    )
-                state_batches = []
-                i = 0
-                while "state_in_{}".format(i) in input_dict:
-                    state_batches.append(input_dict["state_in_{}".format(i)])
-                    i += 1
-                builder.add_feed_dict(dict(zip(self._state_inputs, state_batches)))
-
-            if "state_in_0" in input_dict and SampleBatch.SEQ_LENS not in input_dict:
-                builder.add_feed_dict(
-                    {self._seq_lens: np.ones(len(input_dict["state_in_0"]))}
-                )
-
-        # Hardcoded old way: Build fixed fields, if provided.
-        # TODO: (sven) This can be deprecated after trajectory view API flag is
-        #  removed and always True.
+        # For policies that inherit directly from TFPolicy.
         else:
-            if log_once("_build_compute_actions_input_dict"):
-                deprecation_warning(
-                    old="_build_compute_actions(.., obs_batch=.., ..)",
-                    new="_build_compute_actions(.., input_dict=..)",
-                    error=False,
+            builder.add_feed_dict({self._obs_input: input_dict[SampleBatch.OBS]})
+            if SampleBatch.PREV_ACTIONS in input_dict:
+                builder.add_feed_dict(
+                    {self._prev_action_input: input_dict[SampleBatch.PREV_ACTIONS]}
                 )
-            state_batches = state_batches or []
-            if len(self._state_inputs) != len(state_batches):
-                raise ValueError(
-                    "Must pass in RNN state batches for placeholders {}, "
-                    "got {}".format(self._state_inputs, state_batches)
+            if SampleBatch.PREV_REWARDS in input_dict:
+                builder.add_feed_dict(
+                    {self._prev_reward_input: input_dict[SampleBatch.PREV_REWARDS]}
                 )
-
-            tree.map_structure(
-                lambda k, v: builder.add_feed_dict({k: v}),
-                self._obs_input,
-                obs_batch,
-            )
-            if state_batches:
-                builder.add_feed_dict({self._seq_lens: np.ones(len(obs_batch))})
-            if self._prev_action_input is not None and prev_action_batch is not None:
-                builder.add_feed_dict({self._prev_action_input: prev_action_batch})
-            if self._prev_reward_input is not None and prev_reward_batch is not None:
-                builder.add_feed_dict({self._prev_reward_input: prev_reward_batch})
+            state_batches = []
+            i = 0
+            while "state_in_{}".format(i) in input_dict:
+                state_batches.append(input_dict["state_in_{}".format(i)])
+                i += 1
             builder.add_feed_dict(dict(zip(self._state_inputs, state_batches)))
 
-        builder.add_feed_dict({self._is_training: False})
+        if "state_in_0" in input_dict and SampleBatch.SEQ_LENS not in input_dict:
+            builder.add_feed_dict(
+                {self._seq_lens: np.ones(len(input_dict["state_in_0"]))}
+            )
+
+        builder.add_feed_dict({self._is_training: is_training})
         builder.add_feed_dict({self._is_exploring: explore})
         if timestep is not None:
             builder.add_feed_dict({self._timestep: timestep})
@@ -1115,10 +1092,10 @@ class TFPolicy(Policy):
         to_fetch = (
             [self._sampled_action]
             + self._state_outputs
-            + [self.extra_compute_action_fetches()]
+            + [extra_action_fetches or self.extra_compute_action_fetches()]
         )
 
-        # Perform the session call.
+        # Add the ops to fetch for the upcoming session call.
         fetches = builder.add_fetches(to_fetch)
         return fetches[0], fetches[1:-1], fetches[-1]
 

--- a/rllib/policy/tf_policy_template.py
+++ b/rllib/policy/tf_policy_template.py
@@ -1,210 +1,54 @@
-import gym
-from typing import Callable, Dict, List, Optional, Tuple, Type, Union, TYPE_CHECKING
-
-from ray.rllib.models.tf.tf_action_dist import TFActionDistribution
-from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.policy.dynamic_tf_policy import DynamicTFPolicy
 from ray.rllib.policy import eager_tf_policy
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.tf_policy import TFPolicy
 from ray.rllib.utils import add_mixins, force_list
-from ray.rllib.utils.annotations import override, DeveloperAPI
-from ray.rllib.utils.deprecation import deprecation_warning, DEPRECATED_VALUE
+from ray.rllib.utils.annotations import override
+from ray.rllib.utils.deprecation import (
+    deprecation_warning,
+    Deprecated,
+    DEPRECATED_VALUE,
+)
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.metrics.learner_info import LEARNER_STATS_KEY
-from ray.rllib.utils.typing import (
-    AgentID,
-    ModelGradients,
-    TensorType,
-    TrainerConfigDict,
-)
-
-if TYPE_CHECKING:
-    from ray.rllib.evaluation import Episode
 
 tf1, tf, tfv = try_import_tf()
 
 
-@DeveloperAPI
+@Deprecated(
+    new="create sub-classes from ray.rllib.policy.dynamic_tf_policy_v2::"
+        "DynamicTFPolicyV2 and ray.rllib.policy.eager_tf_policy_v2::EagerTFPolicyV2 "
+        "(see ray.rllib.agents.ppo.ppo_tf_policy.py for an example) and override "
+        "needed methods",
+    error=False,
+)
 def build_tf_policy(
     name: str,
     *,
-    loss_fn: Callable[
-        [Policy, ModelV2, Type[TFActionDistribution], SampleBatch],
-        Union[TensorType, List[TensorType]],
-    ],
-    get_default_config: Optional[Callable[[None], TrainerConfigDict]] = None,
-    postprocess_fn: Optional[
-        Callable[
-            [
-                Policy,
-                SampleBatch,
-                Optional[Dict[AgentID, SampleBatch]],
-                Optional["Episode"],
-            ],
-            SampleBatch,
-        ]
-    ] = None,
-    stats_fn: Optional[Callable[[Policy, SampleBatch], Dict[str, TensorType]]] = None,
-    optimizer_fn: Optional[
-        Callable[[Policy, TrainerConfigDict], "tf.keras.optimizers.Optimizer"]
-    ] = None,
-    compute_gradients_fn: Optional[
-        Callable[[Policy, "tf.keras.optimizers.Optimizer", TensorType], ModelGradients]
-    ] = None,
-    apply_gradients_fn: Optional[
-        Callable[
-            [Policy, "tf.keras.optimizers.Optimizer", ModelGradients], "tf.Operation"
-        ]
-    ] = None,
-    grad_stats_fn: Optional[
-        Callable[[Policy, SampleBatch, ModelGradients], Dict[str, TensorType]]
-    ] = None,
-    extra_action_out_fn: Optional[Callable[[Policy], Dict[str, TensorType]]] = None,
-    extra_learn_fetches_fn: Optional[Callable[[Policy], Dict[str, TensorType]]] = None,
-    validate_spaces: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    before_init: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    before_loss_init: Optional[
-        Callable[[Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], None]
-    ] = None,
-    after_init: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    make_model: Optional[
-        Callable[
-            [Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], ModelV2
-        ]
-    ] = None,
-    action_sampler_fn: Optional[
-        Callable[[TensorType, List[TensorType]], Tuple[TensorType, TensorType]]
-    ] = None,
-    action_distribution_fn: Optional[
-        Callable[
-            [Policy, ModelV2, TensorType, TensorType, TensorType],
-            Tuple[TensorType, type, List[TensorType]],
-        ]
-    ] = None,
-    mixins: Optional[List[type]] = None,
-    get_batch_divisibility_req: Optional[Callable[[Policy], int]] = None,
+    loss_fn=None,
+    get_default_config=None,
+    postprocess_fn=None,
+    stats_fn=None,
+    optimizer_fn=None,
+    compute_gradients_fn=None,
+    apply_gradients_fn=None,
+    grad_stats_fn=None,
+    extra_action_out_fn=None,
+    extra_learn_fetches_fn=None,
+    validate_spaces=None,
+    before_init=None,
+    before_loss_init=None,
+    after_init=None,
+    make_model=None,
+    action_sampler_fn=None,
+    action_distribution_fn=None,
+    mixins=None,
+    get_batch_divisibility_req=None,
     # Deprecated args.
     obs_include_prev_action_reward=DEPRECATED_VALUE,
     extra_action_fetches_fn=None,  # Use `extra_action_out_fn`.
     gradients_fn=None,  # Use `compute_gradients_fn`.
-) -> Type[DynamicTFPolicy]:
-    """Helper function for creating a dynamic tf policy at runtime.
-
-    Functions will be run in this order to initialize the policy:
-        1. Placeholder setup: postprocess_fn
-        2. Loss init: loss_fn, stats_fn
-        3. Optimizer init: optimizer_fn, gradients_fn, apply_gradients_fn,
-                           grad_stats_fn
-
-    This means that you can e.g., depend on any policy attributes created in
-    the running of `loss_fn` in later functions such as `stats_fn`.
-
-    In eager mode, the following functions will be run repeatedly on each
-    eager execution: loss_fn, stats_fn, gradients_fn, apply_gradients_fn,
-    and grad_stats_fn.
-
-    This means that these functions should not define any variables internally,
-    otherwise they will fail in eager mode execution. Variable should only
-    be created in make_model (if defined).
-
-    Args:
-        name (str): Name of the policy (e.g., "PPOTFPolicy").
-        loss_fn (Callable[[
-            Policy, ModelV2, Type[TFActionDistribution], SampleBatch],
-            Union[TensorType, List[TensorType]]]): Callable for calculating a
-            loss tensor.
-        get_default_config (Optional[Callable[[None], TrainerConfigDict]]):
-            Optional callable that returns the default config to merge with any
-            overrides. If None, uses only(!) the user-provided
-            PartialTrainerConfigDict as dict for this Policy.
-        postprocess_fn (Optional[Callable[[Policy, SampleBatch,
-            Optional[Dict[AgentID, SampleBatch]], Episode], None]]):
-            Optional callable for post-processing experience batches (called
-            after the parent class' `postprocess_trajectory` method).
-        stats_fn (Optional[Callable[[Policy, SampleBatch],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            TF tensors to fetch given the policy and batch input tensors. If
-            None, will not compute any stats.
-        optimizer_fn (Optional[Callable[[Policy, TrainerConfigDict],
-            "tf.keras.optimizers.Optimizer"]]): Optional callable that returns
-            a tf.Optimizer given the policy and config. If None, will call
-            the base class' `optimizer()` method instead (which returns a
-            tf1.train.AdamOptimizer).
-        compute_gradients_fn (Optional[Callable[[Policy,
-            "tf.keras.optimizers.Optimizer", TensorType], ModelGradients]]):
-            Optional callable that returns a list of gradients. If None,
-            this defaults to optimizer.compute_gradients([loss]).
-        apply_gradients_fn (Optional[Callable[[Policy,
-            "tf.keras.optimizers.Optimizer", ModelGradients],
-            "tf.Operation"]]): Optional callable that returns an apply
-            gradients op given policy, tf-optimizer, and grads_and_vars. If
-            None, will call the base class' `build_apply_op()` method instead.
-        grad_stats_fn (Optional[Callable[[Policy, SampleBatch, ModelGradients],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            TF fetches given the policy, batch input, and gradient tensors. If
-            None, will not collect any gradient stats.
-        extra_action_out_fn (Optional[Callable[[Policy],
-            Dict[str, TensorType]]]): Optional callable that returns
-            a dict of TF fetches given the policy object. If None, will not
-            perform any extra fetches.
-        extra_learn_fetches_fn (Optional[Callable[[Policy],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            extra values to fetch and return when learning on a batch. If None,
-            will call the base class' `extra_compute_grad_fetches()` method
-            instead.
-        validate_spaces (Optional[Callable[[Policy, gym.Space, gym.Space,
-            TrainerConfigDict], None]]): Optional callable that takes the
-            Policy, observation_space, action_space, and config to check
-            the spaces for correctness. If None, no spaces checking will be
-            done.
-        before_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            TrainerConfigDict], None]]): Optional callable to run at the
-            beginning of policy init that takes the same arguments as the
-            policy constructor. If None, this step will be skipped.
-        before_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, TrainerConfigDict], None]]): Optional callable to
-            run prior to loss init. If None, this step will be skipped.
-        after_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            TrainerConfigDict], None]]): Optional callable to run at the end of
-            policy init. If None, this step will be skipped.
-        make_model (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, TrainerConfigDict], ModelV2]]): Optional callable
-            that returns a ModelV2 object.
-            All policy variables should be created in this function. If None,
-            a default ModelV2 object will be created.
-        action_sampler_fn (Optional[Callable[[TensorType, List[TensorType]],
-            Tuple[TensorType, TensorType]]]): A callable returning a sampled
-            action and its log-likelihood given observation and state inputs.
-            If None, will either use `action_distribution_fn` or
-            compute actions by calling self.model, then sampling from the
-            so parameterized action distribution.
-        action_distribution_fn (Optional[Callable[[Policy, ModelV2, TensorType,
-            TensorType, TensorType],
-            Tuple[TensorType, type, List[TensorType]]]]): Optional callable
-            returning distribution inputs (parameters), a dist-class to
-            generate an action distribution object from, and internal-state
-            outputs (or an empty list if not applicable). If None, will either
-            use `action_sampler_fn` or compute actions by calling self.model,
-            then sampling from the so parameterized action distribution.
-        mixins (Optional[List[type]]): Optional list of any class mixins for
-            the returned policy class. These mixins will be applied in order
-            and will have higher precedence than the DynamicTFPolicy class.
-        get_batch_divisibility_req (Optional[Callable[[Policy], int]]):
-            Optional callable that returns the divisibility requirement for
-            sample batches. If None, will assume a value of 1.
-
-    Returns:
-        Type[DynamicTFPolicy]: A child class of DynamicTFPolicy based on the
-            specified args.
-    """
+):
     original_kwargs = locals().copy()
     base = add_mixins(DynamicTFPolicy, mixins)
 

--- a/rllib/policy/tf_policy_template.py
+++ b/rllib/policy/tf_policy_template.py
@@ -17,9 +17,9 @@ tf1, tf, tfv = try_import_tf()
 
 @Deprecated(
     new="create sub-classes from ray.rllib.policy.dynamic_tf_policy_v2::"
-        "DynamicTFPolicyV2 and ray.rllib.policy.eager_tf_policy_v2::EagerTFPolicyV2 "
-        "(see ray.rllib.agents.ppo.ppo_tf_policy.py for an example) and override "
-        "needed methods",
+    "DynamicTFPolicyV2 and ray.rllib.policy.eager_tf_policy_v2::EagerTFPolicyV2 "
+    "(see ray.rllib.agents.ppo.ppo_tf_policy.py for an example) and override "
+    "needed methods",
     error=False,
 )
 def build_tf_policy(

--- a/rllib/policy/torch_mixins.py
+++ b/rllib/policy/torch_mixins.py
@@ -161,16 +161,18 @@ class ValueNetworkMixin:
         is_training=False,
         **kwargs,
     ):
-        # Return value function outputs. VF estimates will hence be added to
-        # the SampleBatches produced by the sampler(s) to generate the train
-        # batches going into the loss function.
-        actions, state_outs, extra_outs = super().compute_actions(
+        # Call super()'s `compute_actions()` method to get standard extra_outs ...
+        actions, state_outs, extra_outs = super(
+            ValueNetworkMixin, self
+        ).compute_actions(
             input_dict=input_dict,
             explore=explore,
             timestep=timestep,
             episodes=episodes,
             is_training=is_training,
         )
+        # Add VF estimates to extra_outs in order for the SampleBatches produced by
+        # the sampler(s) to generate the train batches going into the loss function.
         extra_outs.update({SampleBatch.VF_PREDS: self.model.value_function()})
         return actions, state_outs, extra_outs
 

--- a/rllib/policy/torch_mixins.py
+++ b/rllib/policy/torch_mixins.py
@@ -3,10 +3,8 @@ from typing import Dict, List, Union
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.torch_policy import TorchPolicy
-from ray.rllib.policy.torch_policy_v2 import TorchPolicyV2
 from ray.rllib.utils.annotations import DeveloperAPI, override
 from ray.rllib.utils.framework import try_import_torch
-from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.schedules import PiecewiseSchedule
 from ray.rllib.utils.threading import with_lock
 from ray.rllib.utils.typing import (

--- a/rllib/policy/torch_policy_template.py
+++ b/rllib/policy/torch_policy_template.py
@@ -6,7 +6,7 @@ torch, _ = try_import_torch()
 
 @Deprecated(
     new="sub-class directly from `ray.rllib.policy.torch_policy_v2::TorchPolicyV2` "
-        "and override needed methods",
+    "and override needed methods",
     error=True,
 )
 def build_torch_policy(*args, **kwargs):

--- a/rllib/policy/torch_policy_template.py
+++ b/rllib/policy/torch_policy_template.py
@@ -1,97 +1,13 @@
-import gym
-from typing import Callable, Dict, List, Optional, Tuple, Type, Union
-
-from ray.rllib.models.modelv2 import ModelV2
-from ray.rllib.models.torch.torch_action_dist import TorchDistributionWrapper
-from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.policy_template import build_policy_class
-from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.policy.torch_policy import TorchPolicy
 from ray.rllib.utils.deprecation import Deprecated
 from ray.rllib.utils.framework import try_import_torch
-from ray.rllib.utils.typing import ModelGradients, TensorType, TrainerConfigDict
 
 torch, _ = try_import_torch()
 
 
-@Deprecated(new="build_policy_class(framework='torch')", error=False)
-def build_torch_policy(
-    name: str,
-    *,
-    loss_fn: Optional[
-        Callable[
-            [Policy, ModelV2, Type[TorchDistributionWrapper], SampleBatch],
-            Union[TensorType, List[TensorType]],
-        ]
-    ],
-    get_default_config: Optional[Callable[[], TrainerConfigDict]] = None,
-    stats_fn: Optional[Callable[[Policy, SampleBatch], Dict[str, TensorType]]] = None,
-    postprocess_fn=None,
-    extra_action_out_fn: Optional[
-        Callable[
-            [
-                Policy,
-                Dict[str, TensorType],
-                List[TensorType],
-                ModelV2,
-                TorchDistributionWrapper,
-            ],
-            Dict[str, TensorType],
-        ]
-    ] = None,
-    extra_grad_process_fn: Optional[
-        Callable[[Policy, "torch.optim.Optimizer", TensorType], Dict[str, TensorType]]
-    ] = None,
-    extra_learn_fetches_fn: Optional[Callable[[Policy], Dict[str, TensorType]]] = None,
-    optimizer_fn: Optional[
-        Callable[[Policy, TrainerConfigDict], "torch.optim.Optimizer"]
-    ] = None,
-    validate_spaces: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    before_init: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    before_loss_init: Optional[
-        Callable[[Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], None]
-    ] = None,
-    after_init: Optional[
-        Callable[[Policy, gym.Space, gym.Space, TrainerConfigDict], None]
-    ] = None,
-    _after_loss_init: Optional[
-        Callable[[Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], None]
-    ] = None,
-    action_sampler_fn: Optional[
-        Callable[[TensorType, List[TensorType]], Tuple[TensorType, TensorType]]
-    ] = None,
-    action_distribution_fn: Optional[
-        Callable[
-            [Policy, ModelV2, TensorType, TensorType, TensorType],
-            Tuple[TensorType, type, List[TensorType]],
-        ]
-    ] = None,
-    make_model: Optional[
-        Callable[
-            [Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict], ModelV2
-        ]
-    ] = None,
-    make_model_and_action_dist: Optional[
-        Callable[
-            [Policy, gym.spaces.Space, gym.spaces.Space, TrainerConfigDict],
-            Tuple[ModelV2, Type[TorchDistributionWrapper]],
-        ]
-    ] = None,
-    compute_gradients_fn: Optional[
-        Callable[[Policy, SampleBatch], Tuple[ModelGradients, dict]]
-    ] = None,
-    apply_gradients_fn: Optional[
-        Callable[[Policy, "torch.optim.Optimizer"], None]
-    ] = None,
-    mixins: Optional[List[type]] = None,
-    get_batch_divisibility_req: Optional[Callable[[Policy], int]] = None
-) -> Type[TorchPolicy]:
-
-    kwargs = locals().copy()
-    # Set to torch and call new function.
-    kwargs["framework"] = "torch"
-    return build_policy_class(**kwargs)
+@Deprecated(
+    new="sub-class directly from `ray.rllib.policy.torch_policy_v2::TorchPolicyV2` "
+        "and override needed methods",
+    error=True,
+)
+def build_torch_policy(*args, **kwargs):
+    pass

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -15,7 +15,6 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    Type,
     Union,
     TYPE_CHECKING,
 )
@@ -23,7 +22,6 @@ from typing import (
 import ray
 from ray.util import log_once
 from ray.rllib.models.catalog import ModelCatalog
-from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.torch.torch_action_dist import TorchDistributionWrapper
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.torch_policy import _directStepOptimizerSingleton

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -223,6 +223,7 @@ class TorchPolicyV2(Policy):
     @with_lock
     @override(Policy)
     @DeveloperAPI
+    @OverrideToImplementCustomLogic
     def compute_actions(
         self,
         *,
@@ -239,7 +240,7 @@ class TorchPolicyV2(Policy):
         info_batch=None,
         # Kwargs for forward compatibility.
         **kwargs,
-    ) -> Tuple[TensorStructType, List[TensorType], Dict[str, TensorType]]:
+    ) -> Tuple[TensorStructType, List[TensorType], Dict[str, TensorStructType]]:
 
         # If old signature used -> Warning and move everything into `input_dict`.
         if input_dict is None:
@@ -306,6 +307,7 @@ class TorchPolicyV2(Policy):
     @with_lock
     @override(Policy)
     @DeveloperAPI
+    @OverrideToImplementCustomLogic
     def compute_log_likelihoods(
         self,
         actions: Union[List[TensorStructType], TensorStructType],
@@ -455,6 +457,7 @@ class TorchPolicyV2(Policy):
     @with_lock
     @override(Policy)
     @DeveloperAPI
+    @OverrideToImplementCustomLogic
     def learn_on_batch(self, postprocessed_batch: SampleBatch) -> Dict[str, TensorType]:
 
         # Set Model to train mode.

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -44,7 +44,7 @@ from ray.rllib.utils.metrics.learner_info import LEARNER_STATS_KEY
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.spaces.space_utils import normalize_action
 from ray.rllib.utils.threading import with_lock
-from ray.rllib.utils.torch_utils import apply_grad_clipping, convert_to_torch_tensor
+from ray.rllib.utils.torch_utils import convert_to_torch_tensor
 from ray.rllib.utils.typing import (
     GradInfoDict,
     ModelGradients,
@@ -372,27 +372,6 @@ class TorchPolicyV2(Policy):
             log_likelihoods = action_dist.logp(actions)
 
             return log_likelihoods
-
-    @DeveloperAPI
-    @OverrideToImplementCustomLogic
-    @override(Policy)
-    def loss(
-        self,
-        model: ModelV2,
-        dist_class: Type[TorchDistributionWrapper],
-        train_batch: SampleBatch,
-    ) -> Union[TensorType, List[TensorType]]:
-        """Constructs the loss function.
-
-        Args:
-            model: The Model to calculate the loss for.
-            dist_class: The action distr. class.
-            train_batch: The training data.
-
-        Returns:
-            Loss tensor given the input batch.
-        """
-        raise NotImplementedError
 
     @DeveloperAPI
     @OverrideToImplementCustomLogic

--- a/rllib/utils/threading.py
+++ b/rllib/utils/threading.py
@@ -19,6 +19,12 @@ def with_lock(func: Callable) -> Callable:
     """
 
     def wrapper(self, *a, **k):
+        # Early-out for tf static graph policies (no need to lock).
+        from ray.rllib.policy.dynamic_tf_policy_v2 import DynamicTFPolicyV2
+
+        if isinstance(self, DynamicTFPolicyV2):
+            return func(self, *a, **k)
+
         try:
             with self._lock:
                 return func(self, *a, **k)

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -3,7 +3,7 @@ from gym.spaces import Discrete, MultiDiscrete
 import numpy as np
 import os
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, TYPE_CHECKING, Union
+from typing import Dict, List, Optional, TYPE_CHECKING
 import warnings
 
 from ray.rllib.models.repeated_values import RepeatedValues
@@ -19,7 +19,6 @@ from ray.rllib.utils.typing import (
 
 if TYPE_CHECKING:
     from ray.rllib.policy.torch_policy import TorchPolicy
-    from ray.rllib.policy.torch_policy_v2 import TorchPolicyV2
 
 torch, nn = try_import_torch()
 
@@ -31,9 +30,7 @@ FLOAT_MAX = 3.4e38
 
 @PublicAPI
 def apply_grad_clipping(
-    policy: Union["TorchPolicy", "TorchPolicyV2"],
-    optimizer: LocalOptimizer,
-    loss: TensorType,
+    policy: "TorchPolicy", optimizer: LocalOptimizer, loss: TensorType
 ) -> Dict[str, TensorType]:
     """Applies gradient clipping to already computed grads inside `optimizer`.
 
@@ -47,7 +44,7 @@ def apply_grad_clipping(
         gradients.
     """
     info = {}
-    if policy.config.get("grad_clip") is not None:
+    if policy.config["grad_clip"]:
         for param_group in optimizer.param_groups:
             # Make sure we only pass params with grad != None into torch
             # clip_grad_norm_. Would fail otherwise.
@@ -73,9 +70,7 @@ def atanh(x: TensorType) -> TensorType:
 
 
 @PublicAPI
-def concat_multi_gpu_td_errors(
-    policy: Union["TorchPolicy", "TorchPolicyV2"]
-) -> Dict[str, TensorType]:
+def concat_multi_gpu_td_errors(policy: "TorchPolicy") -> Dict[str, TensorType]:
     """Concatenates multi-GPU (per-tower) TD error tensors given TorchPolicy.
 
     TD-errors are extracted from the TorchPolicy via its tower_stats property.

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -3,7 +3,7 @@ from gym.spaces import Discrete, MultiDiscrete
 import numpy as np
 import os
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional, TYPE_CHECKING, Union
 import warnings
 
 from ray.rllib.models.repeated_values import RepeatedValues
@@ -19,6 +19,7 @@ from ray.rllib.utils.typing import (
 
 if TYPE_CHECKING:
     from ray.rllib.policy.torch_policy import TorchPolicy
+    from ray.rllib.policy.torch_policy_v2 import TorchPolicyV2
 
 torch, nn = try_import_torch()
 
@@ -30,7 +31,9 @@ FLOAT_MAX = 3.4e38
 
 @PublicAPI
 def apply_grad_clipping(
-    policy: "TorchPolicy", optimizer: LocalOptimizer, loss: TensorType
+    policy: Union["TorchPolicy", "TorchPolicyV2"],
+    optimizer: LocalOptimizer,
+    loss: TensorType,
 ) -> Dict[str, TensorType]:
     """Applies gradient clipping to already computed grads inside `optimizer`.
 
@@ -44,7 +47,7 @@ def apply_grad_clipping(
         gradients.
     """
     info = {}
-    if policy.config["grad_clip"]:
+    if policy.config.get("grad_clip") is not None:
         for param_group in optimizer.param_groups:
             # Make sure we only pass params with grad != None into torch
             # clip_grad_norm_. Would fail otherwise.
@@ -70,7 +73,9 @@ def atanh(x: TensorType) -> TensorType:
 
 
 @PublicAPI
-def concat_multi_gpu_td_errors(policy: "TorchPolicy") -> Dict[str, TensorType]:
+def concat_multi_gpu_td_errors(
+    policy: Union["TorchPolicy", "TorchPolicyV2"]
+) -> Dict[str, TensorType]:
     """Concatenates multi-GPU (per-tower) TD error tensors given TorchPolicy.
 
     TD-errors are extracted from the TorchPolicy via its tower_stats property.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR addresses the need to unify the different new Policy classes: TorchPolicyV2, EagerTFPolicyV2, and DynamicTFPolicyV2 to (mostly) use the same top-level API (inherited from Policy). Moving toward Ray 2.0, we should tie up this project in a timely fashion via these PRs here. A few more cleanup PRs will follow this one. The changes in here are:
* Establish `compute_actions` as the only way to customize action computations (including exploration!).
* Retire `extra_action_out_(fn)?`. In order to add extra action out fetches or computations to each action computing forward pass, simply override `compute_actions`, call super() therein (to get the "normal" behavior), and then add extra data to the returned extra_out dict. Then return that. See PPO's value-function handling (in this very PR) as an example on how to do this.
* Retire `action_sampler_fn` and `action_distribution_fn` (see above: Use `compute_actions()` instead).
* Soft-deprecate `compute_actions_from_input_dict()` and `compute_single_action()`. Again - only `compute_actions` should be used from here on.
* Establish Policy sub-classing as the only way to customize a policy. Deprecate `build_tf_policy` and `build_policy_class` utility methods.
* Establish `make_model` as the only way to custom-create models. Retire the torch-specific `make_model_and_action_dist`. Custom action distributions should either be specified via the `config.model.custom_action_dist` key OR inside an overridden `compute_actions` method.
* Establish `make_optimizer` as the only way to custom-create local optimizers for a policy. Retire/soft-deprecate the existing `optimizer()` methods. Their naming is confusing and hints toward a property (self.optimizer, similar to self.model), which they are not.
* Establish `stats_fn()` as the only way to create custom stats after the loss(es) have been calculated.
* Rename `maybe_initialize_optimizer_and_loss` into `initialize_optimizer_and_loss_if_necessary` to abide to RLlib-wide naming convention (`..._if_necessary()`).



TODO: In a follow up PR, we need to unify and cleanup all gradient-computing/stats related methods in TF- and TorchPolicies. There currently exists a zoo of different names and methods, which leads to a ton of confusion:
* compute_gradients, compute_gradients_fn, apply_gradients_fn, and apply_gradients
* TF-world: `grad_stats_fn()`, `extra_learn_fetches_fn()`, `extra_compute_grad_fetches()`, `extra_compute_grad_feed_dict()`, `gradients()`, `build_apply_op()`.
* TorchWorld: `extra_grad_process()`, `extra_compute_grad_fetches`(), 


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
