### PR TITLE
[RLlib] `evaluation_config` as a TrainerConfig (TrainerConfig may include another TrainerConfig for evaluation).

### DIFF
--- a/rllib/agents/tests/test_trainer.py
+++ b/rllib/agents/tests/test_trainer.py
@@ -340,9 +340,9 @@ class TestTrainer(unittest.TestCase):
         # Configure the evaluation workers (use env samplers).
         evaluation_config = config.copy()
         # Test, whether spaces are inferred.
-        evaluation_config\
-            .offline_data(input_="sampler")\
-            .environment(env="CartPole-v0", observation_space=None, action_space=None)
+        evaluation_config.offline_data(input_="sampler").environment(
+            env="CartPole-v0", observation_space=None, action_space=None
+        )
         # Add evaluation config to main config and switch on evaluation.
         config.evaluation(
             evaluation_interval=1,

--- a/rllib/agents/trainer_config.py
+++ b/rllib/agents/trainer_config.py
@@ -883,7 +883,8 @@ class TrainerConfig:
                 raise ValueError(
                     "When specifying your `evaluation_config`, make sure it does not "
                     "contain yet another `evaluatio_config` inside of it (this "
-                    "property must be None)!")
+                    "property must be None)!"
+                )
             self.evaluation_config = evaluation_config
         if evaluation_num_workers is not None:
             self.evaluation_num_workers = evaluation_num_workers

--- a/rllib/algorithms/marwil/tests/test_bc.py
+++ b/rllib/algorithms/marwil/tests/test_bc.py
@@ -34,17 +34,20 @@ class TestBC(unittest.TestCase):
         data_file = os.path.join(rllib_dir, "tests/data/cartpole/large.json")
         print("data_file={} exists={}".format(data_file, os.path.isfile(data_file)))
 
-        config = (
-            marwil.BCConfig()
-            .evaluation(
-                evaluation_interval=3,
-                evaluation_num_workers=1,
-                evaluation_duration=5,
-                evaluation_parallel_to_training=True,
-                evaluation_config={"input": "sampler"},
-            )
-            .offline_data(input_=[data_file])
+        # Main configuration: Read from offline file.
+        config = marwil.BCConfig().offline_data(input_=[data_file])
+        # Configure the evaluation workers (use env samplers).
+        evaluation_config = config.copy()
+        evaluation_config.offline_data(input_="sampler")
+        # Add evaluation config to main config and switch on evaluation.
+        config.evaluation(
+            evaluation_interval=3,
+            evaluation_num_workers=1,
+            evaluation_duration=5,
+            evaluation_parallel_to_training=True,
+            evaluation_config=evaluation_config,
         )
+
         num_iterations = 350
         min_reward = 75.0
 

--- a/rllib/algorithms/marwil/tests/test_marwil.py
+++ b/rllib/algorithms/marwil/tests/test_marwil.py
@@ -44,18 +44,23 @@ class TestMARWIL(unittest.TestCase):
         data_file = os.path.join(rllib_dir, "tests/data/cartpole/large.json")
         print("data_file={} exists={}".format(data_file, os.path.isfile(data_file)))
 
+        # Main configuration: Read from offline file.
         config = (
             marwil.MARWILConfig()
             .rollouts(num_rollout_workers=2)
             .environment(env="CartPole-v0")
-            .evaluation(
-                evaluation_interval=3,
-                evaluation_num_workers=1,
-                evaluation_duration=5,
-                evaluation_parallel_to_training=True,
-                evaluation_config={"input": "sampler"},
-            )
             .offline_data(input_=[data_file])
+        )
+        # Configure the evaluation workers (use env samplers).
+        evaluation_confg = config.copy()
+        evaluation_confg.offline_data(input_="sampler")
+        # Add evaluation config to main config and switch on evaluation.
+        config.evaluation(
+            evaluation_interval=3,
+            evaluation_num_workers=1,
+            evaluation_duration=5,
+            evaluation_parallel_to_training=True,
+            evaluation_config=evaluation_confg,
         )
 
         num_iterations = 350

--- a/rllib/algorithms/qmix/qmix.py
+++ b/rllib/algorithms/qmix/qmix.py
@@ -129,9 +129,7 @@ class QMixConfig(SimpleQConfig):
         # metrics are already only reported for the lowest epsilon workers.
         self.evaluation_interval = None
         self.evaluation_duration = 10
-        self.evaluation_config = {
-            "explore": False,
-        }
+        self.evaluation_config = {"explore": False}
         # __sphinx_doc_end__
         # fmt: on
 

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -81,7 +81,8 @@ class WorkerSet:
                 in the returned set as well (default: True). If `num_workers`
                 is 0, always create a local worker.
             logdir: Optional logging directory for workers.
-            _setup: Whether to setup workers. This is only for testing.
+            _setup: Whether to setup workers. A value of False here is only for
+                testing purposes.
         """
 
         if not trainer_config:
@@ -342,7 +343,8 @@ class WorkerSet:
     def stop(self) -> None:
         """Calls `stop` on all rollout workers (including the local one)."""
         try:
-            self.local_worker().stop()
+            if self.local_worker() is not None:
+                self.local_worker().stop()
             tids = [w.stop.remote() for w in self.remote_workers()]
             ray.get(tids)
         except Exception:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

`evaluation_config` as a TrainerConfig (TrainerConfig may include another TrainerConfig for evaluation).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
