### PR TITLE
[release/xgboost/lightgbm] Fix app config dependency install overwriting ray

### DIFF
--- a/release/golden_notebook_tests/dask_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/dask_xgboost_app_config.yaml
@@ -18,6 +18,5 @@ post_build_cmds:
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
-  - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
-  - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.
-  - pip install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
+  - pip install -U --force-reinstall --no-deps --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray xgboost
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/golden_notebook_tests/modin_xgboost_app_config.yaml
+++ b/release/golden_notebook_tests/modin_xgboost_app_config.yaml
@@ -16,10 +16,7 @@ python:
 
 post_build_cmds:
   - pip uninstall -y ray || true && pip install -U {{ env["RAY_WHEELS"] | default("ray") }}
-  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Upgrade the XGBoost-Ray version in post build commands, otherwise it will be cached in the Anyscale Docker image.
   - echo {{ env["TIMESTAMP"] }}
-  - pip install -U xgboost # Upgrade to latest xgboost version so cached version is not used.
-  - pip uninstall xgboost_ray -y # Uninstall first so pip does a reinstall.
-  - pip install -U --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray
-
+  - pip install -U --force-reinstall --no-deps --no-cache-dir git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray xgboost
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}

--- a/release/lightgbm_tests/app_config.yaml
+++ b/release/lightgbm_tests/app_config.yaml
@@ -14,8 +14,8 @@ python:
 post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install ray[default] # Needed for Ray Client to work.
+  - pip3 install -U --force-reinstall --no-deps xgboost xgboost_ray lightgbm_ray petastorm  # Avoid caching
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - pip3 install -U --force-reinstall xgboost xgboost_ray lightgbm_ray petastorm  # Install latest releases
   - sudo mkdir -p /data || true
   - sudo chown ray:1000 /data || true
   - rm -rf /data/classification.parquet || true

--- a/release/lightgbm_tests/app_config_gpu.yaml
+++ b/release/lightgbm_tests/app_config_gpu.yaml
@@ -12,8 +12,8 @@ python:
 
 post_build_cmds:
   - pip uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install -U --force-reinstall --no-deps xgboost xgboost_ray lightgbm_ray petastorm  # Avoid caching
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - pip install -U --force-reinstall xgboost xgboost_ray lightgbm_ray petastorm  # Install latest releases
   - sudo mkdir -p /data || true
   - sudo chown ray:1000 /data || true
   - rm -rf /data/classification.parquet || true

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -13,9 +13,9 @@ python:
 
 post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
-  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # TODO(jungong): remove once nightly image gets upgraded.
   - pip install -U pybullet==3.2.0
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Clone the rl-experiments repo for offline-RL files.
   - git clone https://github.com/ray-project/rl-experiments.git
   - cp rl-experiments/halfcheetah-sac/2021-09-06/halfcheetah_expert_sac.zip ~/.

--- a/release/xgboost_tests/app_config.yaml
+++ b/release/xgboost_tests/app_config.yaml
@@ -14,8 +14,8 @@ python:
 post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   - pip3 install ray[default] # Needed for Ray Client to work.
+  - pip3 install -U --force-reinstall --no-deps xgboost xgboost_ray petastorm  # Avoid caching
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - pip3 install -U --force-reinstall xgboost xgboost_ray petastorm  # Install latest releases
   - sudo mkdir -p /data || true
   - sudo chown ray:1000 /data || true
   - rm -rf /data/classification.parquet || true

--- a/release/xgboost_tests/app_config_gpu.yaml
+++ b/release/xgboost_tests/app_config_gpu.yaml
@@ -12,8 +12,8 @@ python:
 
 post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install -U --force-reinstall --no-deps xgboost xgboost_ray petastorm  # Avoid caching
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
-  - pip install -U --force-reinstall xgboost xgboost_ray petastorm  # Install latest releases
   - sudo mkdir -p /data || true
   - sudo chown ray:1000 /data || true
   - rm -rf /data/classification.parquet || true


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This line:

```
pip3 install -U --force-reinstall xgboost xgboost_ray lightgbm_ray petastorm
```

also re-installs the dependencies of these packages, and the `--force-reinstall` means we overwrite existing ones. This leads us to re-install the latest ray release, overwriting the wheels to be tested:

```
[INFO] 5/31/2022, 12:12:16 AM: Successfully installed ... ray-1.12.1 ...
[INFO] 5/31/2022, 12:12:17 AM: * Executed RUN pip3 install -U --force-reinstall xgboost xgboost_ray petastorm  (ff6ae9f9)
```

Instead, we should use `--no-deps` to avoid re-installing dependencies. Also, the wheels sanity check is moved to after installing additional packages in order to catch these errors earlier.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
