### PR TITLE
[Docs][Clusters] Use bold font consistently on landing page "Where to go from here"

### DIFF
--- a/doc/source/cluster/index.rst
+++ b/doc/source/cluster/index.rst
@@ -29,7 +29,7 @@ Where to go from here?
     :column: col-lg-6 px-2 py-2
     :card:
 
-    Quick Start
+    **Quick Start** 
     ^^^
 
     In this quick start tutorial you will take a sample application designed to
@@ -42,7 +42,7 @@ Where to go from here?
         :classes: btn-outline-info btn-block
     ---
 
-    Key Concepts
+    **Key Concepts**
     ^^^
 
     Understand the key concepts behind Ray Clusters. Learn about the main
@@ -55,7 +55,7 @@ Where to go from here?
         :classes: btn-outline-info btn-block
     ---
 
-    Deployment Guide
+    **Deployment Guide**
     ^^^
 
     Learn how to set up a distributed Ray cluster and run your workloads on it.
@@ -67,7 +67,7 @@ Where to go from here?
         :classes: btn-outline-info btn-block
     ---
 
-    API
+    **API**
     ^^^
 
     Get more in-depth information about the various APIs to interact with Ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
<img width="962" alt="Screen Shot 2022-05-31 at 10 14 19 AM" src="https://user-images.githubusercontent.com/10713559/171234173-6fffbf08-96ca-4730-94b5-be56c98fb226.png">

## Why are these changes needed?
In the "Where to go from here" block, we should use bold font consistently across Ray components.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( (It's a docs only change)
