### PR TITLE
[Deployment Graph] Remove _execute_impl and json serde code for DeploymentNode IR

### DIFF
--- a/python/ray/serve/pipeline/deployment_function_node.py
+++ b/python/ray/serve/pipeline/deployment_function_node.py
@@ -4,12 +4,10 @@ from ray import ObjectRef
 
 from ray.experimental.dag.dag_node import DAGNode
 from ray.experimental.dag.format_utils import get_dag_node_str
-from ray.experimental.dag.constants import DAGNODE_TYPE_KEY
 from ray.serve.deployment import Deployment, schema_to_deployment
 from ray.serve.config import DeploymentConfig
 from ray.serve.handle import RayServeLazySyncHandle
 from ray.serve.schema import DeploymentSchema
-from ray.serve.utils import get_deployment_import_path
 
 
 class DeploymentFunctionNode(DAGNode):
@@ -105,35 +103,3 @@ class DeploymentFunctionNode(DAGNode):
 
     def get_deployment_name(self):
         return self._deployment_name
-
-    def get_import_path(self):
-        if (
-            "is_from_serve_deployment" in self._bound_other_args_to_resolve
-        ):  # built by serve top level api, this is ignored for serve.run
-            return "dummy"
-        return get_deployment_import_path(self._deployment)
-
-    def to_json(self) -> Dict[str, Any]:
-        return {
-            DAGNODE_TYPE_KEY: DeploymentFunctionNode.__name__,
-            "deployment_name": self.get_deployment_name(),
-            # Will be overriden by build()
-            "import_path": self.get_import_path(),
-            "args": self.get_args(),
-            "kwargs": self.get_kwargs(),
-            # .options() should not contain any DAGNode type
-            "options": self.get_options(),
-            "other_args_to_resolve": self.get_other_args_to_resolve(),
-        }
-
-    @classmethod
-    def from_json(cls, input_json):
-        assert input_json[DAGNODE_TYPE_KEY] == DeploymentFunctionNode.__name__
-        return cls(
-            input_json["import_path"],
-            input_json["deployment_name"],
-            input_json["args"],
-            input_json["kwargs"],
-            input_json["options"],
-            other_args_to_resolve=input_json["other_args_to_resolve"],
-        )

--- a/python/ray/serve/pipeline/deployment_function_node.py
+++ b/python/ray/serve/pipeline/deployment_function_node.py
@@ -1,6 +1,5 @@
 import inspect
 from typing import Any, Callable, Dict, List, Union
-from ray import ObjectRef
 
 from ray.experimental.dag.dag_node import DAGNode
 from ray.experimental.dag.format_utils import get_dag_node_str
@@ -89,14 +88,6 @@ class DeploymentFunctionNode(DAGNode):
             new_options,
             other_args_to_resolve=new_other_args_to_resolve,
         )
-
-    def _execute_impl(self, *args, **kwargs) -> ObjectRef:
-        """Executor of DeploymentFunctionNode by calling .remote() on the
-        deployment handle.
-
-        Deployment method always default to __call__.
-        """
-        return self._deployment_handle.remote(*self._bound_args, **self._bound_kwargs)
 
     def __str__(self) -> str:
         return get_dag_node_str(self, str(self._body))

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -44,15 +44,6 @@ class DeploymentMethodNode(DAGNode):
             other_args_to_resolve=new_other_args_to_resolve,
         )
 
-    def _execute_impl(self, *args, **kwargs):
-        """Executor of DeploymentMethodNode by ray.remote()"""
-        # Execute with bound args.
-        method_body = getattr(self._deployment_handle, self._deployment_method_name)
-        return method_body.remote(
-            *self._bound_args,
-            **self._bound_kwargs,
-        )
-
     def __str__(self) -> str:
         return get_dag_node_str(
             self,

--- a/python/ray/serve/pipeline/deployment_method_node.py
+++ b/python/ray/serve/pipeline/deployment_method_node.py
@@ -2,9 +2,8 @@ from typing import Any, Dict, Optional, Tuple, List
 
 from ray.experimental.dag import DAGNode
 from ray.experimental.dag.format_utils import get_dag_node_str
-from ray.experimental.dag.constants import DAGNODE_TYPE_KEY, PARENT_CLASS_NODE_KEY
+from ray.experimental.dag.constants import PARENT_CLASS_NODE_KEY
 from ray.serve.deployment import Deployment
-from ray.serve.config import DeploymentConfig
 
 
 class DeploymentMethodNode(DAGNode):
@@ -65,55 +64,3 @@ class DeploymentMethodNode(DAGNode):
 
     def get_deployment_method_name(self) -> str:
         return self._deployment_method_name
-
-    def get_import_path(self) -> str:
-        if (
-            "is_from_serve_deployment"
-            in self._bound_other_args_to_resolve[
-                "parent_class_node"
-            ]._bound_other_args_to_resolve
-        ):  # built by serve top level api, this is ignored for serve.run
-            return "dummy"
-        elif isinstance(self._deployment._func_or_class, str):
-            # We're processing a deserilized JSON node where import_path
-            # is dag_node body.
-            return self._deployment._func_or_class
-        else:
-            body = self._deployment._func_or_class.__ray_actor_class__
-            return f"{body.__module__}.{body.__qualname__}"
-
-    def to_json(self) -> Dict[str, Any]:
-        return {
-            DAGNODE_TYPE_KEY: DeploymentMethodNode.__name__,
-            "deployment_name": self.get_deployment_name(),
-            "deployment_method_name": self.get_deployment_method_name(),
-            # Will be overriden by build()
-            "import_path": self.get_import_path(),
-            "args": self.get_args(),
-            "kwargs": self.get_kwargs(),
-            # .options() should not contain any DAGNode type
-            "options": self.get_options(),
-            "other_args_to_resolve": self.get_other_args_to_resolve(),
-            "uuid": self.get_stable_uuid(),
-        }
-
-    @classmethod
-    def from_json(cls, input_json, object_hook=None):
-        assert input_json[DAGNODE_TYPE_KEY] == DeploymentMethodNode.__name__
-        return cls(
-            Deployment(
-                input_json["import_path"],
-                input_json["deployment_name"],
-                # TODO: (jiaodong) Support deployment config from user input
-                DeploymentConfig(),
-                init_args=input_json["args"],
-                init_kwargs=input_json["kwargs"],
-                ray_actor_options=input_json["options"],
-                _internal=True,
-            ),
-            input_json["deployment_method_name"],
-            input_json["args"],
-            input_json["kwargs"],
-            input_json["options"],
-            other_args_to_resolve=input_json["other_args_to_resolve"],
-        )

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -17,7 +17,6 @@ from ray.experimental.dag.constants import PARENT_CLASS_NODE_KEY
 from ray.experimental.dag.format_utils import get_dag_node_str
 from ray.serve.deployment import Deployment, schema_to_deployment
 from ray.serve.config import DeploymentConfig
-from ray.serve.utils import get_deployment_import_path
 from ray.serve.schema import DeploymentSchema
 
 
@@ -162,10 +161,3 @@ class DeploymentNode(DAGNode):
 
     def get_deployment_name(self):
         return self._deployment.name
-
-    def get_import_path(self):
-        if (
-            "is_from_serve_deployment" in self._bound_other_args_to_resolve
-        ):  # built by serve top level api, this is ignored for serve.run
-            return "dummy"
-        return get_deployment_import_path(self._deployment)

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 from typing import Any, Callable, Dict, Optional, List, Tuple, Union
 
 from ray.experimental.dag import DAGNode
@@ -14,13 +13,9 @@ from ray.serve.handle import RayServeLazySyncHandle
 
 from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
 from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
-from ray.experimental.dag.constants import (
-    DAGNODE_TYPE_KEY,
-    PARENT_CLASS_NODE_KEY,
-)
+from ray.experimental.dag.constants import PARENT_CLASS_NODE_KEY
 from ray.experimental.dag.format_utils import get_dag_node_str
 from ray.serve.deployment import Deployment, schema_to_deployment
-from ray.serve.deployment_graph import RayServeDAGHandle
 from ray.serve.config import DeploymentConfig
 from ray.serve.utils import get_deployment_import_path
 from ray.serve.schema import DeploymentSchema
@@ -64,19 +59,6 @@ class DeploymentNode(DAGNode):
                 return RayServeLazySyncHandle(node._deployment.name)
             elif isinstance(node, DeploymentExecutorNode):
                 return node._deployment_handle
-            elif isinstance(
-                node,
-                (
-                    DeploymentMethodNode,
-                    DeploymentMethodExecutorNode,
-                    DeploymentFunctionNode,
-                    DeploymentFunctionExecutorNode,
-                ),
-            ):
-                from ray.serve.pipeline.json_serde import DAGNodeEncoder
-
-                serve_dag_root_json = json.dumps(node, cls=DAGNodeEncoder)
-                return RayServeDAGHandle(serve_dag_root_json)
 
         (
             replaced_deployment_init_args,
@@ -85,6 +67,9 @@ class DeploymentNode(DAGNode):
             [deployment_init_args, deployment_init_kwargs],
             predictate_fn=lambda node: isinstance(
                 node,
+                # We need to match and replace all DAGNodes even though they
+                # could be None, because no DAGNode replacement should run into
+                # re-resolved child DAGNodes, otherwise with KeyError
                 (
                     DeploymentNode,
                     DeploymentMethodNode,
@@ -184,28 +169,3 @@ class DeploymentNode(DAGNode):
         ):  # built by serve top level api, this is ignored for serve.run
             return "dummy"
         return get_deployment_import_path(self._deployment)
-
-    def to_json(self) -> Dict[str, Any]:
-        return {
-            DAGNODE_TYPE_KEY: DeploymentNode.__name__,
-            "deployment_name": self.get_deployment_name(),
-            # Will be overriden by build()
-            "import_path": self.get_import_path(),
-            "args": self.get_args(),
-            "kwargs": self.get_kwargs(),
-            # .options() should not contain any DAGNode type
-            "options": self.get_options(),
-            "other_args_to_resolve": self.get_other_args_to_resolve(),
-        }
-
-    @classmethod
-    def from_json(cls, input_json):
-        assert input_json[DAGNODE_TYPE_KEY] == DeploymentNode.__name__
-        return cls(
-            input_json["import_path"],
-            input_json["deployment_name"],
-            input_json["args"],
-            input_json["kwargs"],
-            input_json["options"],
-            other_args_to_resolve=input_json["other_args_to_resolve"],
-        )

--- a/python/ray/serve/pipeline/deployment_node.py
+++ b/python/ray/serve/pipeline/deployment_node.py
@@ -156,15 +156,6 @@ class DeploymentNode(DAGNode):
             other_args_to_resolve=new_other_args_to_resolve,
         )
 
-    def _execute_impl(self, *args, **kwargs):
-        """Executor of DeploymentNode getting called each time on dag.execute.
-
-        The execute implementation is recursive, that is, the method nodes will receive
-        whatever this method returns. We return a handle here so method node can
-        directly call upon.
-        """
-        return self._deployment_handle
-
     def __getattr__(self, method_name: str):
         # Raise an error if the method is invalid.
         getattr(self._deployment.func_or_class, method_name)

--- a/python/ray/serve/pipeline/json_serde.py
+++ b/python/ray/serve/pipeline/json_serde.py
@@ -6,15 +6,11 @@ import json
 from ray.experimental.dag import (
     DAGNode,
     ClassNode,
-    ClassMethodNode,
     FunctionNode,
     InputNode,
     InputAttributeNode,
     DAGNODE_TYPE_KEY,
 )
-from ray.serve.pipeline.deployment_node import DeploymentNode
-from ray.serve.pipeline.deployment_method_node import DeploymentMethodNode
-from ray.serve.pipeline.deployment_function_node import DeploymentFunctionNode
 from ray.serve.deployment_executor_node import DeploymentExecutorNode
 from ray.serve.deployment_method_executor_node import DeploymentMethodExecutorNode
 from ray.serve.deployment_function_executor_node import DeploymentFunctionExecutorNode
@@ -133,12 +129,6 @@ def dagnode_from_json(input_json: Any) -> Union[DAGNode, RayServeHandle, Any]:
         # Ray DAG Inputs
         InputNode.__name__: InputNode,
         InputAttributeNode.__name__: InputAttributeNode,
-        # Ray DAG Nodes
-        ClassMethodNode.__name__: ClassMethodNode,
-        # Deployment transformation nodes
-        DeploymentNode.__name__: DeploymentNode,
-        DeploymentMethodNode.__name__: DeploymentMethodNode,
-        DeploymentFunctionNode.__name__: DeploymentFunctionNode,
         # Deployment graph execution nodes
         DeploymentExecutorNode.__name__: DeploymentExecutorNode,
         DeploymentMethodExecutorNode.__name__: DeploymentMethodExecutorNode,

--- a/python/ray/serve/pipeline/tests/test_deployment_node.py
+++ b/python/ray/serve/pipeline/tests/test_deployment_node.py
@@ -63,27 +63,6 @@ async def test_simple_deployment_async(serve_instance):
     assert ray.get(await node.get.execute()) == ray.get(await handle.get.remote())
 
 
-def test_simple_deployment_sync(serve_instance):
-    """Internal testing only for simple creation and execution.
-
-    User should NOT directly create instances of Deployment or DeploymentNode.
-    """
-    node = DeploymentNode(
-        Actor,
-        "test",
-        (10,),
-        {},
-        {},
-    )
-    node._deployment.deploy()
-    handle = node._deployment_handle
-
-    assert ray.get(node.get.execute()) == 10
-    ray.get(node.inc.execute())
-    assert ray.get(node.get.execute()) == 11
-    assert ray.get(node.get.execute()) == ray.get(handle.get.remote())
-
-
 def test_mix_sync_async_handle(serve_instance):
     # TODO: (jiaodong) Add complex multi-deployment tests from ray DAG.
     pass

--- a/python/ray/serve/pipeline/tests/test_json_serde.py
+++ b/python/ray/serve/pipeline/tests/test_json_serde.py
@@ -22,7 +22,6 @@ from ray.serve.pipeline.tests.resources.test_modules import (
     combine,
     Counter,
     ClassHello,
-    fn,
     fn_hello,
     Combine,
     NESTED_HANDLE_KEY,
@@ -355,20 +354,6 @@ class TestHandleJSON:
         # Load the handle back from the dict.
         handle = serve_handle_from_json_dict(json.loads(serialized))
         assert await call(handle, "hi") == "hi"
-
-
-def test_chain_of_values():
-    with InputNode() as dag_input:
-        out = fn.bind(1)
-        out_2 = fn.bind(out, incr=2)
-        out_val = fn.bind(out_2, incr=3)
-        model = Model.bind(out_val)
-        ray_dag = model.forward.bind(dag_input)
-
-    json_serialized = json.dumps(ray_dag, cls=DAGNodeEncoder)
-    deserialized_dag_node = json.loads(json_serialized, object_hook=dagnode_from_json)
-
-    assert ray.get(deserialized_dag_node.execute(2)) == ray.get(ray_dag.execute(2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

After we have the final executor node in place, we've reached the final state for deployment graph outputs with runnable tests. Given ray core level dag as source, now we can clean up parts in between to reflect the latest stage.

Changes:

- DeploymentNode, DeploymentMethodNode and DeploymentFunctionNode removed `_executor_impl` because they're only used as IR and placeholder rather than actual execution
- Similarly, JSON serde related code are also removed as final json serde happens at executor dag level.
- Removed json_serde.py imports and code related to these nodes 
- DeploymentNode now has simplified handle replacement logic that still captures all node types, but no longer json serde the outer node into DAGHandle
- Test fixes 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
