### PR TITLE
[minor] Add a job submission hook by env var

### DIFF
--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -141,7 +141,7 @@ def submit(
 
     if ray_constants.RAY_JOB_SUBMIT_HOOK in os.environ:
         # Submit all args as **kwargs per the JOB_SUBMIT_HOOK contract.
-        return _load_class(os.environ[ray_constants.RAY_JOB_SUBMIT_HOOK])(
+        _load_class(os.environ[ray_constants.RAY_JOB_SUBMIT_HOOK])(
             address=address,
             job_id=job_id,
             runtime_env=runtime_env,

--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -7,8 +7,10 @@ from typing import Optional, Tuple
 
 import click
 
+import ray.ray_constants as ray_constants
 from ray.autoscaler._private.cli_logger import add_click_logging_options, cli_logger, cf
 from ray.job_submission import JobStatus, JobSubmissionClient
+from ray.internal.storage import _load_class
 from ray.util.annotations import PublicAPI
 from ray.dashboard.modules.dashboard_sdk import parse_runtime_env_args
 
@@ -136,6 +138,19 @@ def submit(
     Example:
         ray job submit -- python my_script.py --arg=val
     """
+
+    if ray_constants.RAY_JOB_SUBMIT_HOOK in os.environ:
+        # Submit all args as **kwargs per the JOB_SUBMIT_HOOK contract.
+        return _load_class(os.environ[ray_constants.RAY_JOB_SUBMIT_HOOK])(
+            address=address,
+            job_id=job_id,
+            runtime_env=runtime_env,
+            runtime_env_json=runtime_env_json,
+            working_dir=working_dir,
+            entrypoint=entrypoint,
+            no_wait=no_wait,
+        )
+
     client = _get_sdk_client(address, create_cluster_if_needed=True)
 
     final_runtime_env = parse_runtime_env_args(

--- a/dashboard/modules/job/tests/test_cli_integration.py
+++ b/dashboard/modules/job/tests/test_cli_integration.py
@@ -78,6 +78,15 @@ def _run_cmd(cmd: str, should_fail=False) -> Tuple[str, str]:
     return p.stdout.decode("utf-8"), p.stderr.decode("utf-8")
 
 
+class TestJobSubmitHook:
+    """Tests the RAY_JOB_SUBMIT_HOOK env var."""
+
+    def test_hook(self, ray_start_stop):
+        with set_env_var("RAY_JOB_SUBMIT_HOOK", "ray._private.test_utils.job_hook"):
+            stdout, _ = _run_cmd("ray job submit -- echo hello")
+            assert "hook intercepted: echo hello" in stdout
+
+
 class TestRayAddress:
     """
     Integration version of job CLI test that ensures interaction with the

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1287,3 +1287,10 @@ def simulate_storage(storage_type, root=None):
             yield url
     else:
         raise ValueError(f"Unknown storage type: {storage_type}")
+
+
+def job_hook(**kwargs):
+    """Function called by reflection by test_cli_integration."""
+    cmd = " ".join(kwargs["entrypoint"])
+    print(f"hook intercepted: {cmd}")
+    sys.exit(0)

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -82,8 +82,7 @@ RAY_RUNTIME_ENV_HOOK = "RAY_RUNTIME_ENV_HOOK"
 # but otherwise returns void. Example: "your.module.ray_start_hook".
 RAY_START_HOOK = "RAY_START_HOOK"
 # Hook that is invoked on `ray job submit`. It will be given all the same args as the
-# job.cli.submit() function gets, passed as kwargs to this function. If defined, this
-# fully replaces the usual execution of submit().
+# job.cli.submit() function gets, passed as kwargs to this function.
 RAY_JOB_SUBMIT_HOOK = "RAY_JOB_SUBMIT_HOOK"
 
 DEFAULT_DASHBOARD_IP = "127.0.0.1"

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -81,6 +81,10 @@ RAY_RUNTIME_ENV_HOOK = "RAY_RUNTIME_ENV_HOOK"
 # whether we are the head node as arguments. The function can modify the params class,
 # but otherwise returns void. Example: "your.module.ray_start_hook".
 RAY_START_HOOK = "RAY_START_HOOK"
+# Hook that is invoked on `ray job submit`. It will be given all the same args as the
+# job.cli.submit() function gets, passed as kwargs to this function. If defined, this
+# fully replaces the usual execution of submit().
+RAY_JOB_SUBMIT_HOOK = "RAY_JOB_SUBMIT_HOOK"
 
 DEFAULT_DASHBOARD_IP = "127.0.0.1"
 DEFAULT_DASHBOARD_PORT = 8265


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Similar to RAY_RUNTIME_ENV_HOOK and RAY_START_HOOK, add a job submit hook that can be used for printing advisory messages / intercepting job submit calls.