### PR TITLE
[Core] Fix node affinity strategy when resource is empty

### DIFF
--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -380,6 +380,22 @@ def test_node_affinity_scheduling_strategy(
         ).remote()
         assert head_node_id == ray.get(actor.get_node_id.remote())
 
+        actor = Actor.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                worker_node_id, soft=False
+            ),
+            num_cpus=0,
+        ).remote()
+        assert worker_node_id == ray.get(actor.get_node_id.remote())
+
+        actor = Actor.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                head_node_id, soft=False
+            ),
+            num_cpus=0,
+        ).remote()
+        assert head_node_id == ray.get(actor.get_node_id.remote())
+
         # Wait until the target node becomes available.
         worker_actor = Actor.options(resources={"worker": 1}).remote()
         assert worker_node_id == ray.get(worker_actor.get_node_id.remote())

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -107,7 +107,10 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
     bool *is_infeasible) {
   // The zero cpu actor is a special case that must be handled the same way by all
   // scheduling policies.
-  if (actor_creation && resource_request.IsEmpty()) {
+  if (actor_creation && resource_request.IsEmpty() &&
+      scheduling_strategy.scheduling_strategy_case() !=
+          rpc::SchedulingStrategy::SchedulingStrategyCase::
+              kNodeAffinitySchedulingStrategy) {
     return scheduling_policy_->Schedule(resource_request, SchedulingOptions::Random());
   }
 

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -106,7 +106,7 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
     int64_t *total_violations,
     bool *is_infeasible) {
   // The zero cpu actor is a special case that must be handled the same way by all
-  // scheduling policies.
+  // scheduling policies, except for node affnity scheduling policy.
   if (actor_creation && resource_request.IsEmpty() &&
       scheduling_strategy.scheduling_strategy_case() !=
           rpc::SchedulingStrategy::SchedulingStrategyCase::

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -98,6 +98,16 @@ bool ClusterResourceScheduler::IsSchedulable(const ResourceRequest &resource_req
       /*ignore_object_store_memory_requirement*/ node_id == local_node_id_);
 }
 
+namespace {
+bool IsHardNodeAffinitySchedulingStrategy(
+    const rpc::SchedulingStrategy &scheduling_strategy) {
+  return scheduling_strategy.scheduling_strategy_case() ==
+             rpc::SchedulingStrategy::SchedulingStrategyCase::
+                 kNodeAffinitySchedulingStrategy &&
+         !scheduling_strategy.node_affinity_scheduling_strategy().soft();
+}
+}  // namespace
+
 scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
     const ResourceRequest &resource_request,
     const rpc::SchedulingStrategy &scheduling_strategy,
@@ -106,11 +116,9 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
     int64_t *total_violations,
     bool *is_infeasible) {
   // The zero cpu actor is a special case that must be handled the same way by all
-  // scheduling policies, except for node affnity scheduling policy.
+  // scheduling policies, except for HARD node affnity scheduling policy.
   if (actor_creation && resource_request.IsEmpty() &&
-      scheduling_strategy.scheduling_strategy_case() !=
-          rpc::SchedulingStrategy::SchedulingStrategyCase::
-              kNodeAffinitySchedulingStrategy) {
+      !IsHardNodeAffinitySchedulingStrategy(scheduling_strategy)) {
     return scheduling_policy_->Schedule(resource_request, SchedulingOptions::Random());
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Today, Ray scheduler always pick a random node if the resource requirement is empty, regardless of scheduling policy/strategy.

However, for node affinity scheduling policy, we should not pick random policy but try to stick to the node affinity constraints. 


## Related issue number

closes #25323

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
