### PR TITLE
[Core] fix raylet stuck when forking worker

### DIFF
--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -203,9 +203,9 @@ class ProcessFD {
       if (decouple) {
         int s;
         (void)waitpid(pid, &s, 0);  // can't do much if this fails, so ignore return value
+        int r = read(pipefds[0], &pid, sizeof(pid));
+        (void)r;  // can't do much if this fails, so ignore return value
       }
-      int r = read(pipefds[0], &pid, sizeof(pid));
-      (void)r;  // can't do much if this fails, so ignore return value
     }
     // Use pipe to track process lifetime. (The pipe closes when process terminates.)
     fd = pipefds[0];


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The raylet may stuck when forking worker  because of the reading of fd, which is similar to this issue (https://github.com/gperftools/gperftools/issues/178).

At present, the decouple field is only set when running the CI test, so we can make the read function execute only when decouple is set, so it will not affect the production job. 

Child process(worker):
![image](https://user-images.githubusercontent.com/2016670/171430414-a0ebaed4-1aef-4faa-9e00-5e4d993a9db0.png)

Parent process(raylet):
![image](https://user-images.githubusercontent.com/2016670/171430507-2266b88d-2ad3-4493-b6a8-358c1613a561.png)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
