### PR TITLE
[RLlib] fixes global timesteps being off by init sample batch size

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -910,6 +910,8 @@ class Policy(metaclass=ABCMeta):
         # in the dummy batch are accessed by the different function (e.g.
         # loss) such that we can then adjust our view requirements.
         self._no_tracing = True
+        # Save for later so that loss init does not change global timestep
+        global_ts_before_init = self.global_timestep
 
         sample_batch_size = max(self.batch_divisibility_req * 4, 32)
         self._dummy_batch = self._get_dummy_batch_from_view_requirements(
@@ -1048,6 +1050,8 @@ class Policy(metaclass=ABCMeta):
                         # this key to save space in the sample batch.
                         elif self.config["output"] is None:
                             del self.view_requirements[key]
+
+        self.global_timestep = global_ts_before_init
 
     def _get_dummy_batch_from_view_requirements(
         self, batch_size: int = 1

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -25,6 +25,7 @@ from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.view_requirement import ViewRequirement
+from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.annotations import (
     PublicAPI,
     DeveloperAPI,
@@ -911,7 +912,7 @@ class Policy(metaclass=ABCMeta):
         # loss) such that we can then adjust our view requirements.
         self._no_tracing = True
         # Save for later so that loss init does not change global timestep
-        global_ts_before_init = self.global_timestep
+        global_ts_before_init = int(convert_to_numpy(self.global_timestep))
 
         sample_batch_size = max(self.batch_divisibility_req * 4, 32)
         self._dummy_batch = self._get_dummy_batch_from_view_requirements(
@@ -1051,7 +1052,16 @@ class Policy(metaclass=ABCMeta):
                         elif self.config["output"] is None:
                             del self.view_requirements[key]
 
-        self.global_timestep = global_ts_before_init
+        if type(self.global_timestep) is int:
+            self.global_timestep = global_ts_before_init
+        elif isinstance(self.global_timestep, tf.Variable):
+            self.global_timestep.assign(global_ts_before_init)
+        else:
+            raise ValueError(
+                "Variable self.global_timestep of policy {} needs to be "
+                "either of type `int` or `tf.Variable`, "
+                "but is of type {}.".format(self, type(self.global_timestep))
+            )
 
     def _get_dummy_batch_from_view_requirements(
         self, batch_size: int = 1


### PR DESCRIPTION
## Why are these changes needed?

Since policies require a loss init pass, their global timesteps are off by the size of the init batch.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
