### PR TITLE
[AIR] Fix trainer allowed scaling config keys

### DIFF
--- a/python/ray/ml/train/data_parallel_trainer.py
+++ b/python/ray/ml/train/data_parallel_trainer.py
@@ -228,6 +228,7 @@ class DataParallelTrainer(Trainer):
         "num_workers",
         "num_cpus_per_worker",
         "num_gpus_per_worker",
+        "resources_per_worker",
         "additional_resources_per_worker",
         "use_gpu",
     ]

--- a/python/ray/ml/train/gbdt_trainer.py
+++ b/python/ray/ml/train/gbdt_trainer.py
@@ -69,6 +69,7 @@ class GBDTTrainer(Trainer):
         "num_workers",
         "num_cpus_per_worker",
         "num_gpus_per_worker",
+        "resources_per_worker",
         "additional_resources_per_worker",
         "use_gpu",
     ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds `resources_per_worker` to allowed scaling config keys in `DataParallelTrainer` and `GBDTTrainer`.

This is a short term fix that should be followed-up. See below for details.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/25328

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
