### PR TITLE
[Docs] Remove RL Summit announcement from RLlib docs

### DIFF
--- a/doc/source/_includes/rllib/announcement_bottom.rst
+++ b/doc/source/_includes/rllib/announcement_bottom.rst
@@ -1,15 +1,1 @@
-.. admonition:: `Production RL Summit - March 29`_
 
-    Join us at Production RL Summit — a free virtual reinforcement learning event showcasing how companies like
-    JP Morgan, Riot Games, Dow, and Siemens are apply RL to real business problems. Connect with peers and experts
-    from the RL community, and sharpen your RL skills with hands-on workshop.
-
-    .. link-button:: https://hopin.com/events/production-rl-summit?utm_source=ray-docs&utm_medium=info-box&utm_campaign=rl_summit
-        :text: Register Now
-        :classes: btn-outline-primary
-
-.. _`Production RL Summit - March 29`: https://www.anyscale.com/production-rl-summit?utm_source=ray-docs&utm_medium=info-box&utm_campaign=rl_summit
-
-.. image:: https://ray-docs-promo.netlify.app/assets/img/rllib/bottom.png
-    :alt:
-    :target: https://ray-docs-promo.netlify.app/rllib


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
RL Summit was already held in March. We should remove the announcement now. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Simple change, skipping the creation of an issue
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( (Docs-only change)
