### PR TITLE
[Docs] Remove `$` from pip install instructions

### DIFF
--- a/doc/source/rllib/index.rst
+++ b/doc/source/rllib/index.rst
@@ -52,9 +52,9 @@ PyTorch (or both as shown below):
 
 .. code-block:: bash
 
-    $ conda create -n rllib python=3.8
-    $ conda activate rllib
-    $ pip install "ray[rllib]" tensorflow torch
+    conda create -n rllib python=3.8
+    conda activate rllib
+    pip install "ray[rllib]" tensorflow torch
 
 Note, for installation on computers running Apple Silicon (such as M1), please follow instructions
 `here <https://docs.ray.io/en/latest/installation.html#m1-mac-apple-silicon-support>`_
@@ -63,7 +63,7 @@ To be able to run our Atari examples, you should also install:
 
 .. code-block:: bash
 
-    $ pip install "gym[atari]" "gym[accept-rom-license]" atari_py
+    pip install "gym[atari]" "gym[accept-rom-license]" atari_py
 
 After these quick pip installs, you can start coding against RLlib.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
![Screen Shot 2022-06-01 at 10 18 40 AM](https://user-images.githubusercontent.com/10713559/171464598-e68e5c42-4c80-4195-8266-83550dab1801.png)

The purpose of the bash code block is so that people can click the "copy" button and paste. With `$` it won't work

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Simple docs change, skipping the creation of an issue

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( (Docs-only change)
