### PR TITLE
[CI][Hotfix] Fix macOS kickoff job

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -12,7 +12,8 @@ import subprocess
 import sys
 
 
-def list_changed_files(commit_range: str):
+# NOTE(simon): do not add type hint here because it's ran using python2 in CI.
+def list_changed_files(commit_range):
     """Returns a list of names of files changed in the given commit range.
 
     The function works by opening a subprocess and running git. If an error


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/commit/905258dbc19753c81039f993477e7ab027960729 added type hints to determine-tests-to-run.py script.

macOS determine tests to run was running under Python 2 but the error was silently.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
