### PR TITLE
[tests] Deflake test_reconstruction.py::test_basic_reconstruction_actor_task[False]

### DIFF
--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -268,12 +268,12 @@ def test_basic_reconstruction_actor_task(ray_start_cluster, reconstruction_enabl
     cluster.add_node(num_cpus=1, resources={"node2": 1}, object_store_memory=10 ** 8)
     cluster.wait_for_nodes()
 
-    # Set max retries to 1 because Ray fails actor tasks if the actor is
-    # restarting when the task is submitted.
+    # Always set max retries to -1 because Ray fails actor tasks if the actor
+    # is restarting when the task is submitted.
     # See #22818 for details.
     @ray.remote(
         max_restarts=-1,
-        max_task_retries=-1 if reconstruction_enabled else -1,
+        max_task_retries=-1,
         resources={"node1": 1},
         num_cpus=0,
     )

--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -268,9 +268,12 @@ def test_basic_reconstruction_actor_task(ray_start_cluster, reconstruction_enabl
     cluster.add_node(num_cpus=1, resources={"node2": 1}, object_store_memory=10 ** 8)
     cluster.wait_for_nodes()
 
+    # Set max retries to 1 because Ray fails actor tasks if the actor is
+    # restarting when the task is submitted.
+    # See #22818 for details.
     @ray.remote(
         max_restarts=-1,
-        max_task_retries=-1 if reconstruction_enabled else 0,
+        max_task_retries=-1 if reconstruction_enabled else -1,
         resources={"node1": 1},
         num_cpus=0,
     )
@@ -293,25 +296,30 @@ def test_basic_reconstruction_actor_task(ray_start_cluster, reconstruction_enabl
     obj = a.large_object.remote()
     ray.get(dependent_task.options(resources={"node1": 1}).remote(obj))
 
-    # Workaround to kill the actor process too since there is a bug where the
-    # actor's plasma client hangs after the plasma store has exited.
-    os.kill(pid, SIGKILL)
+    for i in range(10):
+        # Workaround to kill the actor process too since there is a bug where the
+        # actor's plasma client hangs after the plasma store has exited.
+        os.kill(pid, SIGKILL)
 
-    cluster.remove_node(node_to_kill, allow_graceful=False)
-    cluster.add_node(num_cpus=1, resources={"node1": 2}, object_store_memory=10 ** 8)
+        cluster.remove_node(node_to_kill, allow_graceful=False)
+        node_to_kill = cluster.add_node(
+            num_cpus=1, resources={"node1": 2}, object_store_memory=10 ** 8
+        )
 
-    wait_for_pid_to_exit(pid)
+        wait_for_pid_to_exit(pid)
 
-    if reconstruction_enabled:
-        ray.get(dependent_task.remote(obj))
-    else:
-        with pytest.raises(ray.exceptions.RayTaskError):
+        if reconstruction_enabled:
             ray.get(dependent_task.remote(obj))
-        with pytest.raises(ray.exceptions.ObjectLostError):
-            ray.get(obj)
+        else:
+            with pytest.raises(ray.exceptions.RayTaskError):
+                ray.get(dependent_task.remote(obj))
+            with pytest.raises(ray.exceptions.ObjectLostError):
+                ray.get(obj)
 
-    # Make sure the actor handle is still usable.
-    pid = ray.get(a.pid.remote())
+        # Make sure the actor handle is still usable.
+        pid_ref = a.pid.remote()
+        print(i, "pid", pid_ref)
+        pid = ray.get(pid_ref)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Very flaky on Windows.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test was flaky because actor tasks can fail if submitted when the actor process is failed or restarting. This PR changes the test to be more stressful so that the error is easier to reproduce and changes the max_retries parameter to -1 so that the actor task will succeed.

## Related issue number

Closes #24942.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
