### PR TITLE
[RLlib] bug fix: conversion of float64 to float32 when on GPU

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -11,6 +11,7 @@ from ray.rllib.utils.compression import pack, unpack, is_compressed
 from ray.rllib.utils.deprecation import Deprecated, deprecation_warning
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.numpy import concat_aligned
+from ray.rllib.utils.torch_utils import convert_to_torch_tensor
 from ray.rllib.utils.typing import PolicyID, TensorType, ViewRequirementsDict
 
 tf1, tf, tfv = try_import_tf()
@@ -703,7 +704,7 @@ class SampleBatch(dict):
             assert torch is not None
             for k, v in self.items():
                 if isinstance(v, np.ndarray) and v.dtype != object:
-                    self[k] = torch.from_numpy(v).to(device)
+                    self[k] = convert_to_torch_tensor(v, device)
         else:
             raise NotImplementedError
         return self


### PR DESCRIPTION
when on GPU, sample_batch.to_device() only converts the device and does not convert float64 to float32.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
