### PR TITLE
[Docs] Document Ray downscaling behavior

### DIFF
--- a/doc/source/cluster/guide.rst
+++ b/doc/source/cluster/guide.rst
@@ -71,15 +71,23 @@ How does it work?
 The Ray Cluster Launcher will automatically enable a load-based autoscaler. The
 autoscaler resource demand scheduler will look at the pending tasks, actors,
 and placement groups resource demands from the cluster, and try to add the
-minimum list of nodes that can fulfill these demands. When worker nodes are
-idle for more than :ref:`idle_timeout_minutes
-<cluster-configuration-idle-timeout-minutes>`, they will be removed (the head
-node is never removed unless the cluster is torn down).
-
-Autoscaler uses a simple binpacking algorithm to binpack the user demands into
+minimum list of nodes that can fulfill these demands. Autoscaler uses a simple 
+binpacking algorithm to binpack the user demands into
 the available cluster resources. The remaining unfulfilled demands are placed
 on the smallest list of nodes that satisfies the demand while maximizing
 utilization (starting from the smallest node).
+
+**Downcaling**: When worker nodes are
+idle (without active Tasks or Actors running on it) 
+for more than :ref:`idle_timeout_minutes
+<cluster-configuration-idle-timeout-minutes>`, they are subject to
+removal from the cluster. But there are two important additional conditions
+to note: 
+
+* The head node is never removed unless the cluster is torn down.
+* If Ray Object Store is used, and a Worker node still holds objects, it won't be removed
+
+
 
 **Here is "A Glimpse into the Ray Autoscaler" and how to debug/monitor your cluster:**
 

--- a/doc/source/cluster/guide.rst
+++ b/doc/source/cluster/guide.rst
@@ -85,7 +85,7 @@ removal from the cluster. But there are two important additional conditions
 to note: 
 
 * The head node is never removed unless the cluster is torn down.
-* If Ray Object Store is used, and a Worker node still holds objects, it won't be removed
+* If the Ray Object Store is used, and a Worker node still holds objects (including spilled objects on disk), it won't be removed.
 
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There's currently a common misconception that Ray can downscale whenever running Tasks / Actors finish. But actually, downscaling is fundamentally difficult if the Worker node still holds objects in object store. We should add documentation about this expected behavior.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/25462
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :( (Docs-only change)
