### PR TITLE
[flakey] Fix test_modin.py

### DIFF
--- a/python/ray/tests/modin/BUILD
+++ b/python/ray/tests/modin/BUILD
@@ -1,6 +1,6 @@
 py_test(
  name = "test_modin",
- size = "small",
+ size = "large",
  srcs = ["test_modin.py"],
  deps = ["//:ray_lib"],
  tags = ["team:core", "exclusive"],

--- a/python/ray/tests/modin/test_modin.py
+++ b/python/ray/tests/modin/test_modin.py
@@ -22,7 +22,7 @@ import pandas
 import numpy as np
 from numpy.testing import assert_array_equal
 import ray
-from ray.util.client.ray_client_helpers import ray_start_client_server
+from ray.tests.conftest import start_cluster
 
 modin_compatible_version = sys.version_info >= (3, 7, 0)
 modin_installed = True
@@ -45,16 +45,10 @@ if not skip:
 
 # Module scoped fixture. Will first run all tests without ray
 # client, then rerun all tests with a single ray client session.
-@pytest.fixture(params=[False, True], autouse=True, scope="module")
-def run_ray_client(request):
-    if request.param:
-        with ray_start_client_server() as client:
-            yield client
-    else:
-        # Run without ray client (do nothing)
-        yield
-        # Cleanup state before rerunning tests with client
-        ray.shutdown()
+@pytest.fixture(autouse=True)
+def run_ray_client(start_cluster):
+    ray.init(start_cluster[1])
+    yield
 
 
 random_state = np.random.RandomState(seed=42)

--- a/python/ray/tests/modin/test_modin.py
+++ b/python/ray/tests/modin/test_modin.py
@@ -22,7 +22,7 @@ import pandas
 import numpy as np
 from numpy.testing import assert_array_equal
 import ray
-from ray.tests.conftest import start_cluster
+from ray.tests.conftest import start_cluster  # noqa F401
 
 modin_compatible_version = sys.version_info >= (3, 7, 0)
 modin_installed = True
@@ -46,7 +46,7 @@ if not skip:
 # Module scoped fixture. Will first run all tests without ray
 # client, then rerun all tests with a single ray client session.
 @pytest.fixture(autouse=True)
-def run_ray_client(start_cluster):
+def run_ray_client(start_cluster):  # noqa F811
     ray.init(start_cluster[1])
     yield
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
test_modin.py is flakey right now. It complains about some modules can't be imported. This seems like a init issue where client mode and non-client mode are mixed. This test closes the cluster for each run. It slows the test a little bit, but it's more stable.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
