### PR TITLE
[Serve] Checkpoint the `DeploymentState`'s `_deleting` attribute

### DIFF
--- a/python/ray/serve/deployment_state.py
+++ b/python/ray/serve/deployment_state.py
@@ -950,7 +950,12 @@ class DeploymentState:
         Return deployment's target state submitted by user's deployment call.
         Should be persisted and outlive current ray cluster.
         """
-        return (self._target_info, self._target_replicas, self._target_version)
+        return (
+            self._target_info,
+            self._target_replicas,
+            self._target_version,
+            self._deleting,
+        )
 
     def get_checkpoint_data(self):
         return self.get_target_state_checkpoint_data()
@@ -963,6 +968,7 @@ class DeploymentState:
             self._target_info,
             self._target_replicas,
             self._target_version,
+            self._deleting,
         ) = target_state_checkpoint
 
     def recover_current_state_from_replica_actor_names(

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -457,10 +457,13 @@ def test_controller_recover_and_delete():
 
     # All replicas should be removed once the controller revives
     wait_for_condition(
-        lambda: len(ray.util.list_named_actors(all_namespaces=True))
-        == len(actors) - 50,
-        timeout=50,
+        lambda: len(ray.util.list_named_actors(all_namespaces=True)) == len(actors) - 50
     )
+
+    # The deployment should be deleted, meaning its state should not be stored
+    # in the DeploymentStateManager. This can be checked by attempting to
+    # retrieve the deployment's status through the controller.
+    assert client.get_serve_status().get_deployment_status("f") is None
 
     serve.shutdown()
     ray.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Recently `linux://release:serve_failure_smoke_test` has become [flaky](https://flakey-tests.ray.io/#):

<img width="1304" alt="Screen Shot 2022-06-04 at 1 02 41 AM" src="https://user-images.githubusercontent.com/92341594/171990588-ef8e8039-f0e7-4a7f-b03f-13f5015d104b.png">

The traceback usually involved a deployment failing to be deleted ([see example traceback](https://buildkite.com/ray-project/ray-builders-branch/builds/7927#0181273d-b189-4b2f-ad2b-ed6b629c61ea)):

```
Traceback (most recent call last):
--
  | File "/root/.cache/bazel/_bazel_root/5fe90af4e7d1ed9fcf52f59e39e126f5/execroot/com_github_ray_project_ray/bazel-out/k8-opt/bin/release/serve_failure_smoke_test.runfiles/com_github_ray_project_ray/release/long_running_tests/workloads/serve_failure.py", line 163, in <module>
  | tester.run()
  | File "/root/.cache/bazel/_bazel_root/5fe90af4e7d1ed9fcf52f59e39e126f5/execroot/com_github_ray_project_ray/bazel-out/k8-opt/bin/release/serve_failure_smoke_test.runfiles/com_github_ray_project_ray/release/long_running_tests/workloads/serve_failure.py", line 134, in run
  | action_chosen()
  | File "/root/.cache/bazel/_bazel_root/5fe90af4e7d1ed9fcf52f59e39e126f5/execroot/com_github_ray_project_ray/bazel-out/k8-opt/bin/release/serve_failure_smoke_test.runfiles/com_github_ray_project_ray/release/long_running_tests/workloads/serve_failure.py", line 103, in create_deployment
  | serve.get_deployment(deployment_to_delete).delete()
  | File "/ray/python/ray/serve/deployment.py", line 252, in delete
  | return get_global_client().delete_deployments([self._name])
  | File "/ray/python/ray/serve/client.py", line 58, in check
  | return f(self, *args, **kwargs)
  | File "/ray/python/ray/serve/client.py", line 344, in delete_deployments
  | self._wait_for_deployment_deleted(name)
  | File "/ray/python/ray/serve/client.py", line 237, in _wait_for_deployment_deleted
  | raise TimeoutError(f"Deployment {name} wasn't deleted after {timeout_s}s.")
  | TimeoutError: Deployment sfTPdCfOyk wasn't deleted after 60s.
```

As mentioned in #25459, this is related to the controller being killed and recovered in the test.

This change fixes the issue: when the controller is killed, its [`deployment_state_manager`](https://github.com/ray-project/ray/blob/16bdfe6a3981a08a02a66984dadeac5b73c7cb1f/python/ray/serve/controller.py#L117-L124)'s [`deployment_states`](https://github.com/ray-project/ray/blob/b024a9543e5379c5695c50da577971a88bf699ef/python/ray/serve/deployment_state.py#L1561) all lose access to their [`_deleting`](https://github.com/ray-project/ray/blob/b024a9543e5379c5695c50da577971a88bf699ef/python/ray/serve/deployment_state.py#L946) flags, and recover with them automatically set to `False`. If a deployment was mid-deletion when the controller dies, its `_deleting` flag is reset to `False`, so even if the deployment's replicas are all deleted, the `deployment_state_manager` still tracks the deployment.

This change adds the `_deleting` flag to each `DeploymentState`'s checkpoint, so when the controller recovers it continues to track whether the deployment was deleting.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds `test_controller_recover_and_delete` to assess controller deletion behavior after recovery.