### PR TITLE
[github] Codeowners for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,16 +72,16 @@
 /doc/source/rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke
 
 # Tune (docs)
-/doc/source/tune @richardliaw @krfricke @xwjiang @amogkam @matthewdeng @Yard1 @maxpumperla
+/doc/source/tune/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla
 
 # Train (docs)
-/doc/source/train @richardliaw @krfricke @xwjiang @amogkam @matthewdeng @Yard1 @maxpumperla
+/doc/source/train/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla
 
 # Serve (docs)
-/doc/source/serve @edoakes @simon-mo @jiaodong
+/doc/source/serve/ @edoakes @simon-mo @jiaodong
 
 # AIR (docs)
-/doc/source/air @richardliaw @gjoliver @krfricke @xwjiang @amogkam @matthewdeng @Yard1 @maxpumperla
+/doc/source/air/ @richardliaw @gjoliver @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla
 
 # ML Docker Dependencies
 /python/requirements/ml/requirements_dl.txt @amogkam @sven1977 @richardliaw @matthewdeng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,11 @@
 # It uses the same pattern rule for gitignore file,
 # see https://git-scm.com/docs/gitignore#_pattern_format.
 
+
+# ==== Documentation ====
+
+/doc/ @maxpumperla @pcmoritz @richardliaw @edoakes @simon-mo
+
 # ==== Ray core ====
 
 # API compatibility
@@ -64,6 +69,19 @@
 
 # RLlib.
 /rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke
+/doc/source/rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke
+
+# Tune (docs)
+/doc/source/tune @richardliaw @krfricke @xwjiang @amogkam @matthewdeng @Yard1 @maxpumperla
+
+# Train (docs)
+/doc/source/train @richardliaw @krfricke @xwjiang @amogkam @matthewdeng @Yard1 @maxpumperla
+
+# Serve (docs)
+/doc/source/serve @edoakes @simon-mo @jiaodong
+
+# AIR (docs)
+/doc/source/air @richardliaw @gjoliver @krfricke @xwjiang @amogkam @matthewdeng @Yard1 @maxpumperla
 
 # ML Docker Dependencies
 /python/requirements/ml/requirements_dl.txt @amogkam @sven1977 @richardliaw @matthewdeng
@@ -77,9 +95,6 @@
 /python/ray/_private/usage/ @ericl @richardliaw @rkooo567 @jjyao
 /dashboard/modules/usage_stats/ @ericl @richardliaw @rkooo567 @jjyao
 
-# ==== Documentation ====
-
-/doc/ @maxpumperla @pcmoritz @richardliaw @edoakes @simon-mo
 
 # ==== Build and CI ====
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#24910 prevents subteams from merging any changes that affect docs in the slightest without approval. The /doc rules also supersedes customs rules. This PR

- Move the rule to the top, so (hopefully) it will be superseded by custom local rules
- Adds docs codeowners for some of the libraries (train, tune, serve, AIR) to enable teams to approve and merge changes here
- This PR does not include other docs parts (e.g. workflows, observability, more-libs) as I lack context on who to give access here. 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
