### PR TITLE
[RLlib] Issue 25401: Faulty usage of get_filter_config in ComplexInputNetworks

### DIFF
--- a/rllib/models/tf/complex_input_net.py
+++ b/rllib/models/tf/complex_input_net.py
@@ -61,7 +61,7 @@ class ComplexInputNetwork(TFModelV2):
                 config = {
                     "conv_filters": model_config["conv_filters"]
                     if "conv_filters" in model_config
-                    else get_filter_config(obs_space.shape),
+                    else get_filter_config(component.shape),
                     "conv_activation": model_config.get("conv_activation"),
                     "post_fcnet_hiddens": [],
                 }

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -71,7 +71,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 config = {
                     "conv_filters": model_config["conv_filters"]
                     if "conv_filters" in model_config
-                    else get_filter_config(obs_space.shape),
+                    else get_filter_config(component.shape),
                     "conv_activation": model_config.get("conv_activation"),
                     "post_fcnet_hiddens": [],
                 }

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -131,8 +131,11 @@ def get_filter_config(shape):
         raise ValueError(
             "No default configuration for obs shape {}".format(shape)
             + ", you must specify `conv_filters` manually as a model option. "
-            "Default configurations are only available for inputs of shape "
-            "[42, 42, K] and [84, 84, K]. You may alternatively want "
+            "Default configurations are only available for inputs of the following "
+              "shapes: [42, 42, K], [84, 84, K], [10, 10, K], [240, 320, K] and "
+              " [480, 640, K]. You may "
+              "alternatively "
+              "want "
             "to use a custom model or preprocessor."
         )
 

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -132,10 +132,10 @@ def get_filter_config(shape):
             "No default configuration for obs shape {}".format(shape)
             + ", you must specify `conv_filters` manually as a model option. "
             "Default configurations are only available for inputs of the following "
-              "shapes: [42, 42, K], [84, 84, K], [10, 10, K], [240, 320, K] and "
-              " [480, 640, K]. You may "
-              "alternatively "
-              "want "
+            "shapes: [42, 42, K], [84, 84, K], [10, 10, K], [240, 320, K] and "
+            " [480, 640, K]. You may "
+            "alternatively "
+            "want "
             "to use a custom model or preprocessor."
         )
 


### PR DESCRIPTION
## Why are these changes needed?

ComplexInputNetworks tries to pass obs_space.shape to get_filter_config, even though obs_space might be a gym.spaces.Dict.

## Related issue number

Closes #25401

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
