### PR TITLE
[air] add `CustomStatefulPreprocessor`

### DIFF
--- a/doc/source/ray-air/doc_code/preprocessors.py
+++ b/doc/source/ray-air/doc_code/preprocessors.py
@@ -140,7 +140,7 @@ print(dataset_transformed.take())
 from typing import Dict
 import ray
 from pandas import DataFrame
-from ray.air.preprocessors import StatefulPreprocessor
+from ray.air.preprocessors import CustomStatefulPreprocessor
 from ray.data import Dataset
 from ray.data.aggregate import Max
 
@@ -159,7 +159,7 @@ print(dataset.take())
 # [{'value': 0}, {'value': 1}, {'value': 2}, {'value': 3}]
 
 # Create a stateful preprocessor that finds the max value and scales each value by it.
-preprocessor = StatefulPreprocessor(get_max, scale_by_max)
+preprocessor = CustomStatefulPreprocessor(get_max, scale_by_max)
 dataset_transformed = preprocessor.fit_transform(dataset)
 print(dataset_transformed.take())
 # [{'value': 0}, {'value': 3}, {'value': 6}, {'value': 9}]

--- a/doc/source/ray-air/preprocessors.rst
+++ b/doc/source/ray-air/preprocessors.rst
@@ -128,8 +128,9 @@ Ray AIR provides a handful of ``Preprocessor``\s that you can use out of the box
 .. tabbed:: Common APIs
 
     #. :class:`Preprocessor <ray.air.preprocessor.Preprocessor>`
-    #. :class:`BatchMapper <ray.air.preprocessors.BatchMapper>`
     #. :class:`Chain <ray.air.preprocessors.Chain>`
+    #. :class:`BatchMapper <ray.air.preprocessors.BatchMapper>`
+    #. :class:`StatefulPreprocessor <ray.air.preprocessors.StatefulPreprocessor>`
 
 .. tabbed:: Tabular
 
@@ -188,5 +189,9 @@ Custom Preprocessors
     :start-after: __custom_stateless_start__
     :end-before: __custom_stateless_end__
 
-**Stateful Preprocessors:** Coming soon!
+**Stateful Preprocessors:** Stateful preprocessors can be implemented with the ``StatefulPreprocessor``.
 
+.. literalinclude:: doc_code/preprocessors.py
+    :language: python
+    :start-after: __custom_stateful_start__
+    :end-before: __custom_stateful_end__

--- a/doc/source/ray-air/preprocessors.rst
+++ b/doc/source/ray-air/preprocessors.rst
@@ -130,7 +130,7 @@ Ray AIR provides a handful of ``Preprocessor``\s that you can use out of the box
     #. :class:`Preprocessor <ray.air.preprocessor.Preprocessor>`
     #. :class:`Chain <ray.air.preprocessors.Chain>`
     #. :class:`BatchMapper <ray.air.preprocessors.BatchMapper>`
-    #. :class:`StatefulPreprocessor <ray.air.preprocessors.StatefulPreprocessor>`
+    #. :class:`CustomStatefulPreprocessor <ray.air.preprocessors.CustomStatefulPreprocessor>`
 
 .. tabbed:: Tabular
 
@@ -189,7 +189,7 @@ Custom Preprocessors
     :start-after: __custom_stateless_start__
     :end-before: __custom_stateless_end__
 
-**Stateful Preprocessors:** Stateful preprocessors can be implemented with the ``StatefulPreprocessor``.
+**Stateful Preprocessors:** Stateful preprocessors can be implemented with the ``CustomStatefulPreprocessor``.
 
 .. literalinclude:: doc_code/preprocessors.py
     :language: python

--- a/python/ray/air/preprocessor.py
+++ b/python/ray/air/preprocessor.py
@@ -23,6 +23,10 @@ class Preprocessor(abc.ABC):
     to transform both local data batches and distributed datasets. For example, a
     Normalization preprocessor may calculate the mean and stdev of a field during
     fitting, and uses these attributes to implement its normalization transform.
+
+    Preprocessors can also be stateless and transform data without needed to be fitted.
+    For example, a preprocessor may simply remove a column, which does not require
+    any state to be fitted.
     """
 
     class FitStatus(str, Enum):

--- a/python/ray/air/preprocessors/__init__.py
+++ b/python/ray/air/preprocessors/__init__.py
@@ -16,6 +16,7 @@ from ray.air.preprocessors.scaler import (
     MaxAbsScaler,
     RobustScaler,
 )
+from ray.air.preprocessors.stateful_preprocessor import StatefulPreprocessor
 from ray.air.preprocessors.tokenizer import Tokenizer
 from ray.air.preprocessors.transformer import PowerTransformer
 from ray.air.preprocessors.vectorizer import CountVectorizer, HashingVectorizer
@@ -38,5 +39,6 @@ __all__ = [
     "RobustScaler",
     "SimpleImputer",
     "StandardScaler",
+    "StatefulPreprocessor",
     "Tokenizer",
 ]

--- a/python/ray/air/preprocessors/__init__.py
+++ b/python/ray/air/preprocessors/__init__.py
@@ -16,7 +16,7 @@ from ray.air.preprocessors.scaler import (
     MaxAbsScaler,
     RobustScaler,
 )
-from ray.air.preprocessors.stateful_preprocessor import StatefulPreprocessor
+from ray.air.preprocessors.custom_stateful import CustomStatefulPreprocessor
 from ray.air.preprocessors.tokenizer import Tokenizer
 from ray.air.preprocessors.transformer import PowerTransformer
 from ray.air.preprocessors.vectorizer import CountVectorizer, HashingVectorizer
@@ -24,8 +24,9 @@ from ray.air.preprocessors.vectorizer import CountVectorizer, HashingVectorizer
 __all__ = [
     "BatchMapper",
     "Categorizer",
-    "CountVectorizer",
     "Chain",
+    "CountVectorizer",
+    "CustomStatefulPreprocessor",
     "FeatureHasher",
     "HashingVectorizer",
     "LabelEncoder",
@@ -39,6 +40,5 @@ __all__ = [
     "RobustScaler",
     "SimpleImputer",
     "StandardScaler",
-    "StatefulPreprocessor",
     "Tokenizer",
 ]

--- a/python/ray/air/preprocessors/custom_stateful.py
+++ b/python/ray/air/preprocessors/custom_stateful.py
@@ -7,24 +7,22 @@ if TYPE_CHECKING:
     import pandas
 
 
-class StatefulPreprocessor(Preprocessor):
-    """Implements a stateful preprocessor that fits on a Dataset.
+class CustomStatefulPreprocessor(Preprocessor):
+    """Implements a user-defined stateful preprocessor that fits on a Dataset.
 
     This is meant to be generic and can be used to perform arbitrary stateful
     preprocessing that cannot already be done through existing preprocessors.
     Logic must be defined to perform fitting on a Ray Dataset and transforming
-    Pandas DataFrames.
+    pandas DataFrames.
 
     Example:
 
     .. code-block:: python
 
-        from typing import Dict
-
         import pandas as pd
         import ray.data
         from pandas import DataFrame
-        from ray.air.preprocessors import StatefulPreprocessor
+        from ray.air.preprocessors import CustomStatefulPreprocessor
         from ray.data import Dataset
         from ray.data.aggregate import Max
 
@@ -44,7 +42,7 @@ class StatefulPreprocessor(Preprocessor):
             return max_a
 
 
-        def subtract_max_a_from_a_and_add_max_a_to_b(df: DataFrame, stats: Dict):
+        def subtract_max_a_from_a_and_add_max_a_to_b(df: DataFrame, stats: dict):
             # Subtract max A value from column A and subtract it from B.
             max_a = stats["max(A)"]
             df["A"] = df["A"] - max_a
@@ -52,7 +50,7 @@ class StatefulPreprocessor(Preprocessor):
             return df
 
 
-        preprocessor = StatefulPreprocessor(
+        preprocessor = CustomStatefulPreprocessor(
             get_max_a,
             subtract_max_a_from_a_and_add_max_a_to_b
         )
@@ -109,11 +107,13 @@ class StatefulPreprocessor(Preprocessor):
         return self.transform_fn(df, self.stats_)
 
     def __repr__(self):
-        fit_fn_name = getattr(self.fit_fn, "__name__", self.fit_fn)
-        transform_fn_name = getattr(self.transform_fn, "__name__", self.transform_fn)
+        fit_fn_name = getattr(self.fit_fn, "__name__", str(self.fit_fn))
+        transform_fn_name = getattr(
+            self.transform_fn, "__name__", str(self.transform_fn)
+        )
         stats = getattr(self, "stats_", None)
         return (
-            f"StatefulPreprocessor("
+            f"CustomStatefulPreprocessor("
             f"fit_fn={fit_fn_name}, "
             f"transform_fn={transform_fn_name}, "
             f"stats={stats})"

--- a/python/ray/air/preprocessors/stateful_preprocessor.py
+++ b/python/ray/air/preprocessors/stateful_preprocessor.py
@@ -1,0 +1,120 @@
+from typing import Callable, TYPE_CHECKING, Dict
+
+from ray.air.preprocessor import Preprocessor
+from ray.data import Dataset
+
+if TYPE_CHECKING:
+    import pandas
+
+
+class StatefulPreprocessor(Preprocessor):
+    """Implements a stateful preprocessor that fits on a Dataset.
+
+    This is meant to be generic and can be used to perform arbitrary stateful
+    preprocessing that cannot already be done through existing preprocessors.
+    Logic must be defined to perform fitting on a Ray Dataset and transforming
+    Pandas DataFrames.
+
+    Example:
+
+    .. code-block:: python
+
+        from typing import Dict
+
+        import pandas as pd
+        import ray.data
+        from pandas import DataFrame
+        from ray.air.preprocessors import StatefulPreprocessor
+        from ray.data import Dataset
+        from ray.data.aggregate import Max
+
+        items = [
+            {"A": 1, "B": 10},
+            {"A": 2, "B": 20},
+            {"A": 3, "B": 30},
+        ]
+
+        ds = ray.data.from_items(items)
+
+
+        def get_max_a(ds: Dataset):
+            # Calculate max value for column A.
+            max_a = ds.aggregate(Max("A"))
+            # {'max(A)': 3}
+            return max_a
+
+
+        def subtract_max_a_from_a_and_add_max_a_to_b(df: DataFrame, stats: Dict):
+            # Subtract max A value from column A and subtract it from B.
+            max_a = stats["max(A)"]
+            df["A"] = df["A"] - max_a
+            df["B"] = df["B"] + max_a
+            return df
+
+
+        preprocessor = StatefulPreprocessor(
+            get_max_a,
+            subtract_max_a_from_a_and_add_max_a_to_b
+        )
+        preprocessor.fit(ds)
+        transformed_ds = preprocessor.transform(ds)
+
+        expected_items = [
+            {"A": -2, "B": 13},
+            {"A": -1, "B": 23},
+            {"A": 0, "B": 33},
+        ]
+        expected_ds = ray.data.from_items(expected_items)
+        assert transformed_ds.take(3) == expected_ds.take(3)
+
+        batch = pd.DataFrame(
+            {
+                "A": [5, 6],
+                "B": [10, 10]
+            }
+        )
+        transformed_batch = preprocessor.transform_batch(batch)
+        expected_batch = pd.DataFrame(
+            {
+                "A": [2, 3],
+                "B": [13, 13],
+            }
+        )
+        assert transformed_batch.equals(expected_batch)
+
+
+    Args:
+        fit_fn: A user defined function that computes state information about
+            a :class:`ray.data.Dataset` and returns it in a :class:`dict`.
+        transform_fn: A user defined function that takes in a
+            :class:`pandas.DataFrame` and the :class:`dict` computed from
+            ``fit_fn``, and returns a transformed :class:`pandas.DataFrame`.
+    """
+
+    _is_fittable = True
+
+    def __init__(
+        self,
+        fit_fn: Callable[[Dataset], Dict],
+        transform_fn: Callable[["pandas.DataFrame", Dict], "pandas.DataFrame"],
+    ):
+        self.fit_fn = fit_fn
+        self.transform_fn = transform_fn
+
+    def _fit(self, dataset: Dataset) -> "Preprocessor":
+        self.stats_ = self.fit_fn(dataset)
+        return self
+
+    def _transform_pandas(self, df: "pandas.DataFrame") -> "pandas.DataFrame":
+        return self.transform_fn(df, self.stats_)
+
+    def __repr__(self):
+        fit_fn_name = getattr(self.fit_fn, "__name__", self.fit_fn)
+        transform_fn_name = getattr(self.transform_fn, "__name__", self.transform_fn)
+        stats = getattr(self, "stats_", None)
+        return (
+            f"StatefulPreprocessor("
+            f"fit_fn={fit_fn_name}, "
+            f"transform_fn={transform_fn_name}, "
+            f"stats={stats})"
+        )

--- a/python/ray/air/tests/test_preprocessors.py
+++ b/python/ray/air/tests/test_preprocessors.py
@@ -1,12 +1,13 @@
 import warnings
 from collections import Counter
+from typing import Dict
 from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pytest
-
 import ray
+from pandas import DataFrame
 from ray.air.preprocessor import PreprocessorNotFittedException
 from ray.air.preprocessors import (
     BatchMapper,
@@ -17,6 +18,7 @@ from ray.air.preprocessors import (
     LabelEncoder,
     SimpleImputer,
     Chain,
+    StatefulPreprocessor,
 )
 from ray.air.preprocessors.encoder import Categorizer, MultiHotEncoder
 from ray.air.preprocessors.hasher import FeatureHasher
@@ -26,6 +28,8 @@ from ray.air.preprocessors.tokenizer import Tokenizer
 from ray.air.preprocessors.transformer import PowerTransformer
 from ray.air.preprocessors.utils import simple_split_tokenizer, simple_hash
 from ray.air.preprocessors.vectorizer import CountVectorizer, HashingVectorizer
+from ray.data import Dataset
+from ray.data.aggregate import Max
 
 
 def test_standard_scaler():
@@ -1094,6 +1098,62 @@ def test_batch_mapper():
     )
 
     assert out_df.equals(expected_df)
+
+
+def test_stateful_preprocessor():
+    """Tests basic StatefulPreprocessor functionality."""
+
+    items = [
+        {"A": 1, "B": 10, "C": 1},
+        {"A": 2, "B": 20, "C": 2},
+        {"A": 3, "B": 30, "C": 3},
+    ]
+
+    ds = ray.data.from_items(items)
+
+    def get_max_a(ds: Dataset):
+        # Calculate max value for column A.
+        max_a = ds.aggregate(Max("A"))
+        return max_a
+
+    def subtract_max_a_from_a_and_add_max_a_to_b(df: DataFrame, stats: Dict):
+        # Subtract max A value from column A and subtract it from B.
+        max_a = stats["max(A)"]
+        df["A"] = df["A"] - max_a
+        df["B"] = df["B"] + max_a
+        return df
+
+    preprocessor = StatefulPreprocessor(
+        get_max_a, subtract_max_a_from_a_and_add_max_a_to_b
+    )
+    preprocessor.fit(ds)
+    transformed_ds = preprocessor.transform(ds)
+
+    expected_items = [
+        {"A": -2, "B": 13, "C": 1},
+        {"A": -1, "B": 23, "C": 2},
+        {"A": 0, "B": 33, "C": 3},
+    ]
+    expected_ds = ray.data.from_items(expected_items)
+
+    assert transformed_ds.take(3) == expected_ds.take(3)
+
+    batch = pd.DataFrame(
+        {
+            "A": [5, 6],
+            "B": [10, 10],
+            "C": [5, 10],
+        }
+    )
+    transformed_batch = preprocessor.transform_batch(batch)
+    expected_batch = pd.DataFrame(
+        {
+            "A": [2, 3],
+            "B": [13, 13],
+            "C": [5, 10],
+        }
+    )
+    assert transformed_batch.equals(expected_batch)
 
 
 def test_power_transformer():

--- a/python/ray/air/tests/test_preprocessors.py
+++ b/python/ray/air/tests/test_preprocessors.py
@@ -18,7 +18,7 @@ from ray.air.preprocessors import (
     LabelEncoder,
     SimpleImputer,
     Chain,
-    StatefulPreprocessor,
+    CustomStatefulPreprocessor,
 )
 from ray.air.preprocessors.encoder import Categorizer, MultiHotEncoder
 from ray.air.preprocessors.hasher import FeatureHasher
@@ -1100,8 +1100,8 @@ def test_batch_mapper():
     assert out_df.equals(expected_df)
 
 
-def test_stateful_preprocessor():
-    """Tests basic StatefulPreprocessor functionality."""
+def test_custom_stateful_preprocessor():
+    """Tests basic CustomStatefulPreprocessor functionality."""
 
     items = [
         {"A": 1, "B": 10, "C": 1},
@@ -1123,7 +1123,7 @@ def test_stateful_preprocessor():
         df["B"] = df["B"] + max_a
         return df
 
-    preprocessor = StatefulPreprocessor(
+    preprocessor = CustomStatefulPreprocessor(
         get_max_a, subtract_max_a_from_a_and_add_max_a_to_b
     )
     preprocessor.fit(ds)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Adding a `CustomStatefulPreprocessor` class to allow users to implement custom stateful preprocessing logic.

**Notes:**
1. I went with the API that matches our current implementation the most (fitting on a `Dataset`, transforming a `DataFrame`). This allows the user to implement the minimal amount of code themselves, but requires them to understand why transforming a `DataFrame` supports `Preprocessor.transform(Dataset)`. 
    1. Another alternative would be to allow them to pass in a `transform_fn(Dataset)` in addition to `transform_batch_fn(DataFrame)` for more customizability.
2. While existing Preprocessors can be implemented through this, I chose not to in this PR because it's possible that implementation diverges when we support Arrow format or other features. This class will remain targeted towards user-defined preprocessing logic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
