### PR TITLE
[RLlib] Fix multi agent environment checks for observations that contain only partial information each step

### DIFF
--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -142,7 +142,7 @@ class MultiAgentEnv(gym.Env):
                         f"MultiAgentDicts with incomplete information. "
                         f"Meaning that they only contain information on a subset of"
                         f" participating agents. Ignore this warning if this is "
-                        f"intended, for example if your environment is turn-based "
+                        f"intended, for example if your environment is a turn-based "
                         f"simulation."
                     )
             return True

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -136,8 +136,8 @@ class MultiAgentEnv(gym.Env):
             )
         if self._spaces_in_preferred_format:
             if allow_partial_multi_agent_obs:
-                # If we allow partial observations, only check if observations of
-                # agents present in x fit
+                # If we allow partial observations, only check whether observations of
+                # agents present in x are contained
                 return any(
                     self.observation_space[key].contains(agent_obs)
                     for key, agent_obs in x.items()

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -138,12 +138,12 @@ class MultiAgentEnv(gym.Env):
             if not all(k in self.observation_space for k in x):
                 if log_once("possibly_bad_multi_agent_dict_missing_agent_observations"):
                     logger.warning(
-                        f"You environment returns observations that that are "
-                        f"MultiAgentDicts with incomplete information. "
-                        f"Meaning that they only contain information on a subset of"
-                        f" participating agents. Ignore this warning if this is "
-                        f"intended, for example if your environment is a turn-based "
-                        f"simulation."
+                        "You environment returns observations that that are "
+                        "MultiAgentDicts with incomplete information. "
+                        "Meaning that they only contain information on a subset of"
+                        " participating agents. Ignore this warning if this is "
+                        "intended, for example if your environment is a turn-based "
+                        "simulation."
                     )
             return True
 

--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -138,7 +138,7 @@ class MultiAgentEnv(gym.Env):
             if not all(k in self.observation_space for k in x):
                 if log_once("possibly_bad_multi_agent_dict_missing_agent_observations"):
                     logger.warning(
-                        "You environment returns observations that that are "
+                        "You environment returns observations that are "
                         "MultiAgentDicts with incomplete information. "
                         "Meaning that they only contain information on a subset of"
                         " participating agents. Ignore this warning if this is "

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -285,22 +285,15 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
         raise ValueError(error)
 
     next_obs, reward, done, info = env.step(sampled_action)
-    allow_partial_multi_agent_obs = (
-        allow_partial_multi_agent_obs
-        or _check_if_element_multi_agent_dict(env, next_obs, "step, next_obs")
-    )
-    allow_partial_multi_agent_obs = (
-        allow_partial_multi_agent_obs
-        or _check_if_element_multi_agent_dict(env, reward, "step, reward")
-    )
-    allow_partial_multi_agent_obs = (
-        allow_partial_multi_agent_obs
-        or _check_if_element_multi_agent_dict(env, done, "step, done")
-    )
-    allow_partial_multi_agent_obs = (
-        allow_partial_multi_agent_obs
-        or _check_if_element_multi_agent_dict(env, info, "step, info")
-    )
+
+    # If
+    allow_partial_multi_agent_obs = any([
+        _check_if_element_multi_agent_dict(env, next_obs, "step, next_obs"),
+        _check_if_element_multi_agent_dict(env, reward, "step, reward"),
+        _check_if_element_multi_agent_dict(env, done, "step, done"),
+        _check_if_element_multi_agent_dict(env, info, "step, info")
+    ])
+
     _check_reward(
         {"dummy_env_id": reward}, base_env=True, agent_ids=env.get_agent_ids()
     )
@@ -549,12 +542,13 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
         if all(k in element for k in agent_ids):
             return False
         else:
-            logger.warning(
-                f"The element returned by {function_string} contains values "
-                f"that are MultiAgentDicts with incomplete information. "
-                f"Meaning that they only contain information on a subset of"
-                f" participating agents. Ignore this warning if this is "
-                f"intended, for example if your environment is turn-based "
-                f"simulation."
-            )
+            if log_once("possibly_bad_multi_agent_dict_missing_agent_observations"):
+                logger.warning(
+                    f"The element returned by {function_string} contains values "
+                    f"that are MultiAgentDicts with incomplete information. "
+                    f"Meaning that they only contain information on a subset of"
+                    f" participating agents. Ignore this warning if this is "
+                    f"intended, for example if your environment is turn-based "
+                    f"simulation."
+                )
         return True

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -230,26 +230,19 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
 
     reset_obs = env.reset()
     sampled_obs = env.observation_space_sample()
-    # If any of the following two checks contains only partial information on an
-    # agent, we warn user and keep going
-    allow_partial_multi_agent_obs = _check_if_element_multi_agent_dict(
-        env, reset_obs, "reset()"
-    )
-    allow_partial_multi_agent_obs = (
-        allow_partial_multi_agent_obs
-        or _check_if_element_multi_agent_dict(
-            env, sampled_obs, "env.observation_space_sample()"
-        )
+    _check_if_element_multi_agent_dict(env, reset_obs, "reset()")
+    _check_if_element_multi_agent_dict(
+        env, sampled_obs, "env.observation_space_sample()"
     )
 
     try:
-        env.observation_space_contains(reset_obs, allow_partial_multi_agent_obs)
+        env.observation_space_contains(reset_obs)
     except Exception as e:
         raise ValueError(
             "Your observation_space_contains function has some error "
         ) from e
 
-    if not env.observation_space_contains(reset_obs, allow_partial_multi_agent_obs):
+    if not env.observation_space_contains(reset_obs):
         error = (
             _not_contained_error("env.reset", "observation")
             + f"\n\n reset_obs: {reset_obs}\n\n env.observation_space_sample():"
@@ -257,7 +250,7 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
         )
         raise ValueError(error)
 
-    if not env.observation_space_contains(sampled_obs, allow_partial_multi_agent_obs):
+    if not env.observation_space_contains(sampled_obs):
         error = (
             _not_contained_error("observation_space_sample", "observation")
             + f"\n\n env.observation_space_sample():"
@@ -266,12 +259,7 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
         raise ValueError(error)
 
     sampled_action = env.action_space_sample()
-    allow_partial_multi_agent_obs = (
-        allow_partial_multi_agent_obs
-        or _check_if_element_multi_agent_dict(
-            env, sampled_action, "action_space_sample"
-        )
-    )
+    _check_if_element_multi_agent_dict(env, sampled_action, "action_space_sample")
     try:
         env.action_space_contains(sampled_action)
     except Exception as e:
@@ -285,21 +273,16 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
         raise ValueError(error)
 
     next_obs, reward, done, info = env.step(sampled_action)
-
-    # If
-    allow_partial_multi_agent_obs = any([
-        _check_if_element_multi_agent_dict(env, next_obs, "step, next_obs"),
-        _check_if_element_multi_agent_dict(env, reward, "step, reward"),
-        _check_if_element_multi_agent_dict(env, done, "step, done"),
-        _check_if_element_multi_agent_dict(env, info, "step, info")
-    ])
-
+    _check_if_element_multi_agent_dict(env, next_obs, "step, next_obs")
+    _check_if_element_multi_agent_dict(env, reward, "step, reward")
+    _check_if_element_multi_agent_dict(env, done, "step, done")
+    _check_if_element_multi_agent_dict(env, info, "step, info")
     _check_reward(
         {"dummy_env_id": reward}, base_env=True, agent_ids=env.get_agent_ids()
     )
     _check_done({"dummy_env_id": done}, base_env=True, agent_ids=env.get_agent_ids())
     _check_info({"dummy_env_id": info}, base_env=True, agent_ids=env.get_agent_ids())
-    if not env.observation_space_contains(next_obs, allow_partial_multi_agent_obs):
+    if not env.observation_space_contains(next_obs):
         error = (
             _not_contained_error("env.step(sampled_action)", "observation")
             + f":\n\n next_obs: {next_obs} \n\n sampled_obs: {sampled_obs}"
@@ -500,7 +483,6 @@ def _check_if_multi_env_dict(env, element, function_string):
 
 
 def _check_if_element_multi_agent_dict(env, element, function_string, base_env=False):
-    """Checks whether an element is a valid"""
     if not isinstance(element, dict):
         if base_env:
             error = (
@@ -518,7 +500,17 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
     agent_ids: Set = copy(env.get_agent_ids())
     agent_ids.add("__all__")
 
-    if not any(k in agent_ids for k in element):
+    if not all(k in agent_ids for k in element):
+        if any(k in agent_ids for k in element):
+            logger.warning(
+                f"The element returned by {function_string} contains values "
+                f"that are MultiAgentDicts with incomplete information. "
+                f"Meaning that they only contain information on a subset of"
+                f" participating agents. Ignore this warning if this is "
+                f"intended, for example if your environment is turn-based "
+                f"simulation."
+            )
+            return
         if base_env:
             error = (
                 f"The element returned by {function_string} has agent_ids"
@@ -538,17 +530,3 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
                 f"ids of agents supported by your env."
             )
         raise ValueError(error)
-    else:
-        if all(k in element for k in agent_ids):
-            return False
-        else:
-            if log_once("possibly_bad_multi_agent_dict_missing_agent_observations"):
-                logger.warning(
-                    f"The element returned by {function_string} contains values "
-                    f"that are MultiAgentDicts with incomplete information. "
-                    f"Meaning that they only contain information on a subset of"
-                    f" participating agents. Ignore this warning if this is "
-                    f"intended, for example if your environment is turn-based "
-                    f"simulation."
-                )
-        return True

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -501,16 +501,6 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
     agent_ids.add("__all__")
 
     if not all(k in agent_ids for k in element):
-        if any(k in agent_ids for k in element):
-            logger.warning(
-                f"The element returned by {function_string} contains values "
-                f"that are MultiAgentDicts with incomplete information. "
-                f"Meaning that they only contain information on a subset of"
-                f" participating agents. Ignore this warning if this is "
-                f"intended, for example if your environment is turn-based "
-                f"simulation."
-            )
-            return
         if base_env:
             error = (
                 f"The element returned by {function_string} has agent_ids"

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -60,7 +60,8 @@ def check_env(env: EnvType) -> None:
             ),
         ):
             raise ValueError(
-                "Env must of one of the following supported types: BaseEnv, gym.Env, "
+                "Env must be of one of the following supported types: BaseEnv, "
+                "gym.Env, "
                 "MultiAgentEnv, VectorEnv, RemoteBaseEnv, ExternalMultiAgentEnv, "
                 f"ExternalEnv, but instead is of type {type(env)}."
             )

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -60,9 +60,9 @@ def check_env(env: EnvType) -> None:
             ),
         ):
             raise ValueError(
-                "Env must be one of the supported types: BaseEnv, gym.Env, "
+                "Env must of one of the following supported types: BaseEnv, gym.Env, "
                 "MultiAgentEnv, VectorEnv, RemoteBaseEnv, ExternalMultiAgentEnv, "
-                f"ExternalEnv, but instead was a {type(env)}"
+                f"ExternalEnv, but instead is of type {type(env)}."
             )
         if isinstance(env, MultiAgentEnv):
             check_multiagent_environments(env)
@@ -73,8 +73,8 @@ def check_env(env: EnvType) -> None:
         else:
             logger.warning(
                 "Env checking isn't implemented for VectorEnvs, RemoteBaseEnvs, "
-                "ExternalMultiAgentEnv,or ExternalEnvs or Environments that are "
-                "Ray actors"
+                "ExternalMultiAgentEnv, ExternalEnvs or environments that are "
+                "Ray actors."
             )
     except Exception:
         actual_error = traceback.format_exc()
@@ -84,7 +84,7 @@ def check_env(env: EnvType) -> None:
             "We've added a module for checking your custom environments. It "
             "may cause your experiment to fail if your environment is not set up"
             "correctly. You can disable this behavior by setting "
-            "`disable_env_checking=True` in your config "
+            "`disable_env_checking=True` in your environment config "
             "dictionary. You can run the environment checking module "
             "standalone by calling ray.rllib.utils.check_env([env])."
         )
@@ -485,7 +485,7 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
     if not isinstance(element, dict):
         if base_env:
             error = (
-                f"The element returned by {function_string} has values "
+                f"The element returned by {function_string} contains values "
                 f"that are not MultiAgentDicts. Instead, they are of "
                 f"type: {type(element)}"
             )
@@ -500,6 +500,16 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
     agent_ids.add("__all__")
 
     if not all(k in agent_ids for k in element):
+        if any(k in agent_ids for k in element):
+            logger.warning(
+                f"The element returned by {function_string} contains values "
+                f"that are MultiAgentDicts with incomplete information. "
+                f"Meaning that they only contain information on a subset of"
+                f" participating agents. Ignore this warning if this is "
+                f"intended, for example if your environment is turn-based "
+                f"simulation."
+            )
+            return
         if base_env:
             error = (
                 f"The element returned by {function_string} has agent_ids"
@@ -514,7 +524,7 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
                 f" that are not the names of the agents in the env. "
                 f"\nAgent_ids in this MultiAgentDict: "
                 f"{list(element.keys())}\nAgent_ids in this env:"
-                f"{list(env.get_agent_ids())}. You likley need to add the private "
+                f"{list(env.get_agent_ids())}. You likely need to add the private "
                 f"attribute `_agent_ids` to your env, which is a set containing the "
                 f"ids of agents supported by your env."
             )


### PR DESCRIPTION
## Why are these changes needed?

Our current env checks do not permit integration of multi-agent environments that return partial information.
This PR makes it so that, if only some agent's information is detected (as opposed to none), we warn the user but continue.

## Related issue number

Closes #25359 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
