### PR TITLE
[RLLib ] Better default parameters with training intensity for R2D2

### DIFF
--- a/rllib/algorithms/r2d2/r2d2.py
+++ b/rllib/algorithms/r2d2/r2d2.py
@@ -91,8 +91,8 @@ class R2D2Config(DQNConfig):
         self.lr = 1e-4
         self.gamma = 0.997
         self.train_batch_size = 1000
-        self.target_network_update_freq = 2500
-        self.training_intensity = 1000
+        self.target_network_update_freq = 1000
+        self.training_intensity = 150
         # R2D2 is using a buffer that stores sequences.
         self.replay_buffer_config = {
             "type": "MultiAgentReplayBuffer",

--- a/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2-fake-gpus.yaml
+++ b/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2-fake-gpus.yaml
@@ -2,12 +2,12 @@ stateless-cartpole-r2d2:
     env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
     run: R2D2
     stop:
-        episode_reward_mean: 100
-        timesteps_total: 50000
+        episode_reward_mean: 150
+        timesteps_total: 1000000
     config:
         # Works for both torch and tf.
         framework: tf
-        num_workers: 4
+        num_workers: 0
         # R2D2 settings.
         replay_buffer_config:
           type: MultiAgentReplayBuffer

--- a/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2.yaml
+++ b/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2.yaml
@@ -3,11 +3,11 @@ stateless-cartpole-r2d2:
     run: R2D2
     stop:
         episode_reward_mean: 100
-        timesteps_total: 50000
+        timesteps_total: 500000
     config:
         # Works for both torch and tf.
         framework: tf
-        num_workers: 4
+        num_workers: 0
         # R2D2 settings.
         replay_buffer_config:
           type: MultiAgentReplayBuffer

--- a/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2.yaml
+++ b/rllib/tuned_examples/r2d2/stateless-cartpole-r2d2.yaml
@@ -2,8 +2,8 @@ stateless-cartpole-r2d2:
     env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
     run: R2D2
     stop:
-        episode_reward_mean: 100
-        timesteps_total: 500000
+        episode_reward_mean: 150
+        timesteps_total: 1000000
     config:
         # Works for both torch and tf.
         framework: tf


### PR DESCRIPTION
## Why are these changes needed?

This PR deflakes R2D2 learning regression tests.
Since I introduced training intesity to R2D2 in #24923, the relevant parameters had not been tuned.


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
