### PR TITLE
[Doc] [Job Submission] Add warning about entrypoint command in quotes

### DIFF
--- a/doc/source/cluster/job-submission.rst
+++ b/doc/source/cluster/job-submission.rst
@@ -167,6 +167,11 @@ Here are some examples of CLI commands from the Quick Start example and their ou
     {'raysubmit_AYhLMgDJ6XBQFvFP': JobInfo(status='SUCCEEDED', message='Job finished successfully.', error_type=None, start_time=1645908622, end_time=1645908623, metadata={}, runtime_env={}),
     'raysubmit_su9UcdUviUZ86b1t': JobInfo(status='SUCCEEDED', message='Job finished successfully.', error_type=None, start_time=1645908669, end_time=1645908670, metadata={}, runtime_env={})}
 
+.. warning::
+
+    When using the CLI, do not wrap the entrypoint command in quotes.  For example, use 
+    ``ray job submit --working_dir="." -- python script.py`` instead of ``ray job submit --working_dir="." -- "python script.py"``.
+    Otherwise you may encounter the error ``/bin/sh: 1: python script.py: not found``.
 
 Using the CLI on a remote cluster
 """""""""""""""""""""""""""""""""

--- a/doc/source/cluster/jobs-package-ref.rst
+++ b/doc/source/cluster/jobs-package-ref.rst
@@ -15,6 +15,12 @@ Job Submission CLI
 .. click:: ray.dashboard.modules.job.cli:submit
    :prog: ray job submit
 
+.. warning::
+
+    When using the CLI, do not wrap the entrypoint command in quotes.  For example, use 
+    ``ray job submit --working_dir="." -- python script.py`` instead of ``ray job submit --working_dir="." -- "python script.py"``.
+    Otherwise you may encounter the error ``/bin/sh: 1: python script.py: not found``.
+
 .. _ray-job-status-doc:
 
 .. click:: ray.dashboard.modules.job.cli:status


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A common error is to wrap the entrypoint command in quotes.  However this leads to errors because bash interprets it as a single command. 

Example:
`ray job submit --working_dir="." -- "python script.py"`
yields
`/bin/sh: 1: python script.py: not found`

This PR adds a warning about this to the docs.

In the future we should consider making this work by removing the quotes internally or by some other solution.  Not sure if there are edge cases we need to think about.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
