### PR TITLE
[Tune] Remove docstring for private `_StatusReporter`

### DIFF
--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -123,15 +123,7 @@ class FuncCheckpointUtil:
 
 
 class _StatusReporter:
-    """Object passed into your function that you can report status through.
-
-    Example:
-        >>> from ray.tune.function_runner import _StatusReporter
-        >>> reporter = _StatusReporter(...) # doctest: +SKIP
-        >>> def trainable_function(config, reporter): # doctest: +SKIP
-        >>>     assert isinstance(reporter, _StatusReporter) # doctest: +SKIP
-        >>>     reporter(timesteps_this_iter=1) # doctest: +SKIP
-    """
+    """Object passed into your function that you can report status through."""
 
     def __init__(
         self,
@@ -169,14 +161,6 @@ class _StatusReporter:
 
         Args:
             kwargs: Latest training result status.
-
-        Example:
-            >>> from ray.tune.function_runner import _StatusReporter
-            >>> reporter = _StatusReporter(...) # doctest: +SKIP
-            >>> reporter(mean_accuracy=1, training_iteration=4) # doctest: +SKIP
-            >>> reporter( # doctest: +SKIP
-            ...     mean_accuracy=1, training_iteration=4, done=True
-            ... )
 
         Raises:
             StopIteration: A StopIteration exception is raised if the trial has


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Remove outdated docstrings for `_StatusReporter`.

In response to https://discuss.ray.io/t/how-to-use-ray-tune-function-runner-statusreporter-with-tune-with-parameters/6400/2

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
