### PR TITLE
Fixing kuberntes example in doc.

### DIFF
--- a/doc/source/cluster/kubernetes.rst
+++ b/doc/source/cluster/kubernetes.rst
@@ -165,7 +165,7 @@ Then in a new shell, you can run a job using the CLI:
 
   $ export RAY_ADDRESS="http://127.0.0.1:8265"
 
-  $ ray job submit --runtime-env-json='{"working_dir": "./", "pip": ["requests==2.26.0"]}' -- "python script.py"
+  $ ray job submit --runtime-env-json='{"working_dir": "./", "pip": ["requests==2.26.0"]}' -- python script.py
   2021-12-01 23:04:52,672 INFO cli.py:25 -- Creating JobSubmissionClient at address: http://127.0.0.1:8265
   2021-12-01 23:04:52,809 INFO sdk.py:144 -- Uploading package gcs://_ray_pkg_bbcc8ca7e83b4dc0.zip.
   2021-12-01 23:04:52,810 INFO packaging.py:352 -- Creating a file package for local directory './'.


### PR DESCRIPTION
The double quotes are not needed in example see [this](https://github.com/ray-project/kuberay/issues/283)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. --> 
@architkulkarni @DmitriGekhtman 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#283

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
