### PR TITLE
[Tune] Raise error when Integration Callbacks are used outside of Tune Session

### DIFF
--- a/python/ray/tune/integration/keras.py
+++ b/python/ray/tune/integration/keras.py
@@ -42,72 +42,84 @@ class TuneCallback(Callback):
             )
         self._on = on
 
+    def _handle_with_tune_check(self, logs: Dict, when: str):
+        if not tune.is_session_enabled():
+            raise RuntimeError(
+                "No Tune session identified. Make sure you are running "
+                "Keras training inside a Tune run. "
+                "If you are using the Ray Train library for "
+                "distributed training, "
+                "these callbacks will not work, and you should instead "
+                "manually call ``train.report()``."
+            )
+        return self._handle(logs, when)
+
     def _handle(self, logs: Dict, when: str):
         raise NotImplementedError
 
     def on_batch_begin(self, batch, logs=None):
         if "batch_begin" in self._on:
-            self._handle(logs, "batch_begin")
+            self._handle_with_tune_check(logs, "batch_begin")
 
     def on_batch_end(self, batch, logs=None):
         if "batch_end" in self._on:
-            self._handle(logs, "batch_end")
+            self._handle_with_tune_check(logs, "batch_end")
 
     def on_epoch_begin(self, epoch, logs=None):
         if "epoch_begin" in self._on:
-            self._handle(logs, "epoch_begin")
+            self._handle_with_tune_check(logs, "epoch_begin")
 
     def on_epoch_end(self, epoch, logs=None):
         if "epoch_end" in self._on:
-            self._handle(logs, "epoch_end")
+            self._handle_with_tune_check(logs, "epoch_end")
 
     def on_train_batch_begin(self, batch, logs=None):
         if "train_batch_begin" in self._on:
-            self._handle(logs, "train_batch_begin")
+            self._handle_with_tune_check(logs, "train_batch_begin")
 
     def on_train_batch_end(self, batch, logs=None):
         if "train_batch_end" in self._on:
-            self._handle(logs, "train_batch_end")
+            self._handle_with_tune_check(logs, "train_batch_end")
 
     def on_test_batch_begin(self, batch, logs=None):
         if "test_batch_begin" in self._on:
-            self._handle(logs, "test_batch_begin")
+            self._handle_with_tune_check(logs, "test_batch_begin")
 
     def on_test_batch_end(self, batch, logs=None):
         if "test_batch_end" in self._on:
-            self._handle(logs, "test_batch_end")
+            self._handle_with_tune_check(logs, "test_batch_end")
 
     def on_predict_batch_begin(self, batch, logs=None):
         if "predict_batch_begin" in self._on:
-            self._handle(logs, "predict_batch_begin")
+            self._handle_with_tune_check(logs, "predict_batch_begin")
 
     def on_predict_batch_end(self, batch, logs=None):
         if "predict_batch_end" in self._on:
-            self._handle(logs, "predict_batch_end")
+            self._handle_with_tune_check(logs, "predict_batch_end")
 
     def on_train_begin(self, logs=None):
         if "train_begin" in self._on:
-            self._handle(logs, "train_begin")
+            self._handle_with_tune_check(logs, "train_begin")
 
     def on_train_end(self, logs=None):
         if "train_end" in self._on:
-            self._handle(logs, "train_end")
+            self._handle_with_tune_check(logs, "train_end")
 
     def on_test_begin(self, logs=None):
         if "test_begin" in self._on:
-            self._handle(logs, "test_begin")
+            self._handle_with_tune_check(logs, "test_begin")
 
     def on_test_end(self, logs=None):
         if "test_end" in self._on:
-            self._handle(logs, "test_end")
+            self._handle_with_tune_check(logs, "test_end")
 
     def on_predict_begin(self, logs=None):
         if "predict_begin" in self._on:
-            self._handle(logs, "predict_begin")
+            self._handle_with_tune_check(logs, "predict_begin")
 
     def on_predict_end(self, logs=None):
         if "predict_end" in self._on:
-            self._handle(logs, "predict_end")
+            self._handle_with_tune_check(logs, "predict_end")
 
 
 class TuneReportCallback(TuneCallback):

--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -47,46 +47,59 @@ class TuneCallback(Callback):
             )
         self._on = on
 
+    def _handle_with_tune_check(
+        self, trainer: Trainer, pl_module: Optional[LightningModule]
+    ):
+        if not tune.is_session_enabled():
+            raise RuntimeError(
+                "No Tune session identified. Make sure you are running "
+                "PyTorch Lightning training inside a Tune run. "
+                "If you are using the Ray Lightning library, use the "
+                "callbacks in the ``ray_lightning.tune`` package "
+                "instead of these ones."
+            )
+        return self._handle(trainer, pl_module)
+
     def _handle(self, trainer: Trainer, pl_module: Optional[LightningModule]):
         raise NotImplementedError
 
     def on_init_start(self, trainer: Trainer):
         if "init_start" in self._on:
-            self._handle(trainer, None)
+            self._handle_with_tune_check(trainer, None)
 
     def on_init_end(self, trainer: Trainer):
         if "init_end" in self._on:
-            self._handle(trainer, None)
+            self._handle_with_tune_check(trainer, None)
 
     def on_fit_start(
         self, trainer: Trainer, pl_module: Optional[LightningModule] = None
     ):
         if "fit_start" in self._on:
-            self._handle(trainer, None)
+            self._handle_with_tune_check(trainer, None)
 
     def on_fit_end(self, trainer: Trainer, pl_module: Optional[LightningModule] = None):
         if "fit_end" in self._on:
-            self._handle(trainer, None)
+            self._handle_with_tune_check(trainer, None)
 
     def on_sanity_check_start(self, trainer: Trainer, pl_module: LightningModule):
         if "sanity_check_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_sanity_check_end(self, trainer: Trainer, pl_module: LightningModule):
         if "sanity_check_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_epoch_start(self, trainer: Trainer, pl_module: LightningModule):
         if "epoch_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
         if "epoch_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_batch_start(self, trainer: Trainer, pl_module: LightningModule):
         if "batch_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_validation_batch_start(
         self,
@@ -97,7 +110,7 @@ class TuneCallback(Callback):
         dataloader_idx,
     ):
         if "validation_batch_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_validation_batch_end(
         self,
@@ -109,7 +122,7 @@ class TuneCallback(Callback):
         dataloader_idx,
     ):
         if "validation_batch_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_test_batch_start(
         self,
@@ -120,7 +133,7 @@ class TuneCallback(Callback):
         dataloader_idx,
     ):
         if "test_batch_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_test_batch_end(
         self,
@@ -132,39 +145,39 @@ class TuneCallback(Callback):
         dataloader_idx,
     ):
         if "test_batch_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_batch_end(self, trainer: Trainer, pl_module: LightningModule):
         if "batch_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule):
         if "train_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_train_end(self, trainer: Trainer, pl_module: LightningModule):
         if "train_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_validation_start(self, trainer: Trainer, pl_module: LightningModule):
         if "validation_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_validation_end(self, trainer: Trainer, pl_module: LightningModule):
         if "validation_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_test_start(self, trainer: Trainer, pl_module: LightningModule):
         if "test_start" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_test_end(self, trainer: Trainer, pl_module: LightningModule):
         if "test_end" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
     def on_keyboard_interrupt(self, trainer: Trainer, pl_module: LightningModule):
         if "keyboard_interrupt" in self._on:
-            self._handle(trainer, pl_module)
+            self._handle_with_tune_check(trainer, pl_module)
 
 
 class TuneReportCallback(TuneCallback):

--- a/python/ray/tune/tests/test_integration_pytorch_lightning.py
+++ b/python/ray/tune/tests/test_integration_pytorch_lightning.py
@@ -69,6 +69,17 @@ class PyTorchLightningIntegrationTest(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def testFailsOutsideTune(self):
+        def train():
+            module = _MockModule(10.0, 20.0)
+            trainer = pl.Trainer(
+                max_epochs=1, callbacks=[TuneReportCallback(on="validation_end")]
+            )
+            trainer.fit(module)
+
+        with self.assertRaises(RuntimeError):
+            train()
+
     def testReportCallbackUnnamed(self):
         def train(config):
             module = _MockModule(10.0, 20.0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Raise a good error message when integration callbacks are used outside of a Tune session.

This is in response to https://github.com/ray-project/ray/issues/25482.

Added a test for PTL Callbacks, but it does not look like we have existing tests for the other callback integrations.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
