### PR TITLE
replace os.execvp with subprocess.run

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -143,7 +143,7 @@ class Node:
             ),
             setup_worker_path=os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
-                f"workers/{ray_constants.SETUP_WORKER_FILENAME}",
+                "workers", f"{ray_constants.SETUP_WORKER_FILENAME}",
             ),
         )
 

--- a/python/ray/tests/mock_setup_worker.py
+++ b/python/ray/tests/mock_setup_worker.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 import sys
 
 parser = argparse.ArgumentParser(
@@ -37,10 +38,9 @@ parser.add_argument("--language", type=str, help="the language type of the worke
 
 args, remaining_args = parser.parse_known_args()
 
-py_executable: str = sys.executable
-command_str = " ".join([f"exec {py_executable}"] + remaining_args)
+command_args = [sys.executable] + remaining_args
 child_pid = os.fork()
 if child_pid == 0:
     # child process
-    os.execvp("bash", ["bash", "-c", command_str])
+    subprocess.run(command_args)
 os.waitpid(child_pid, 0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The call to `os.execvp` for starting a worker process is complicated and can be replaced with `subprocess.run`. This will also solve the problem of paths with spaces in them, since subprocess properly handles them.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24574

Replaces #25151
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
