### PR TITLE
[RLlib] fix_bug: empty episode now becomes a SampleBatch not a MABatch

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1237,6 +1237,7 @@ class MultiAgentBatch:
         policy_batches: Dict[PolicyID, SampleBatch], env_steps: int
     ) -> Union[SampleBatch, "MultiAgentBatch"]:
         """Returns SampleBatch or MultiAgentBatch, depending on given policies.
+        If policy_batches is empty (i.e. {}) it returns an empty SampleBatch.
 
         Args:
             policy_batches: Mapping from policy ids to SampleBatch.
@@ -1246,6 +1247,10 @@ class MultiAgentBatch:
             The single default policy's SampleBatch or a MultiAgentBatch
             (more than one policy).
         """
+        # handle the empty case
+        if not policy_batches:
+            return SampleBatch(policy_batches, env_steps=env_steps)
+
         if len(policy_batches) == 1 and DEFAULT_POLICY_ID in policy_batches:
             return policy_batches[DEFAULT_POLICY_ID]
         return MultiAgentBatch(policy_batches=policy_batches, env_steps=env_steps)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When we invalidate some episodes within the environment by setting `training_enabled = False` in the info dict, the empty returned episode becomes a MASampleBatch which cannot be concatenated with the other SampleBatches and leads to error. This PR resolves this by converting the empty episode to an empty SampleBatch by default. 
During concatenation, MultiAgentBatch types can be concatenated with empty SampleBatches but not the other way around. So our approach would still work in multi-agent case if we invalidate some worker env episodes. 

Solves #25150 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
