### PR TITLE
[Jobs] [Test] Add integration tests to cover runtime_env inheritance with working_dir and with Tune

### DIFF
--- a/dashboard/modules/job/tests/subprocess_driver_scripts/per_task_runtime_env.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/per_task_runtime_env.py
@@ -15,7 +15,10 @@ def run():
 
     driver_working_dir = ray.get_runtime_context().runtime_env.working_dir()
     task_working_dir = ray.get(get_task_working_dir.remote())
-    assert driver_working_dir == task_working_dir, (driver_working_dir, task_working_dir)
+    assert driver_working_dir == task_working_dir, (
+        driver_working_dir,
+        task_working_dir,
+    )
 
 
 if __name__ == "__main__":

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/per_task_runtime_env.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/per_task_runtime_env.py
@@ -1,0 +1,22 @@
+import os
+import ray
+
+
+def run():
+    ray.init()
+
+    @ray.remote(runtime_env={"env_vars": {"FOO": "bar"}})
+    def get_task_working_dir():
+        # Check behavior of working_dir: The cwd should contain the
+        # current file, which is being used as a job entrypoint script.
+        assert os.path.exists("per_task_runtime_env.py")
+
+        return ray.get_runtime_context().runtime_env.working_dir()
+
+    driver_working_dir = ray.get_runtime_context().runtime_env.working_dir()
+    task_working_dir = ray.get(get_task_working_dir.remote())
+    assert driver_working_dir == task_working_dir, (driver_working_dir, task_working_dir)
+
+
+if __name__ == "__main__":
+    run()

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_basic.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_basic.py
@@ -6,8 +6,9 @@ from jobs with an empty working_dir, this test will fail.  See #25484"""
 from ray_tune_dependency import foo
 from ray import tune
 
+
 def objective(*args):
     foo()
 
-tune.run(objective)
 
+tune.run(objective)

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_basic.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_basic.py
@@ -1,0 +1,13 @@
+"""Tests that Ray Tune works with the working_dir set in Jobs.
+
+Ray Tune internally sets environment variables using runtime_env.
+If the inherited internal runtime environment overwrites the working_dir
+from jobs with an empty working_dir, this test will fail.  See #25484"""
+from ray_tune_dependency import foo
+from ray import tune
+
+def objective(*args):
+    foo()
+
+tune.run(objective)
+

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_dependency.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_dependency.py
@@ -1,0 +1,4 @@
+"""A file dependency for testing working_dir behavior with Ray Tune."""
+
+def foo():
+   pass

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_dependency.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/ray_tune_dependency.py
@@ -1,4 +1,5 @@
 """A file dependency for testing working_dir behavior with Ray Tune."""
 
+
 def foo():
-   pass
+    pass

--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -29,6 +29,8 @@ from ray._private.test_utils import (
 
 logger = logging.getLogger(__name__)
 
+DRIVER_SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "subprocess_driver_scripts")
+
 
 @pytest.fixture(scope="module")
 def headers():
@@ -271,6 +273,27 @@ def test_submit_job(job_sdk_client, runtime_env_option, monkeypatch):
 
     logs = client.get_job_logs(job_id)
     assert runtime_env_option["expected_logs"] in logs
+
+
+def test_per_task_runtime_env(job_sdk_client: JobSubmissionClient):
+    run_cmd = "python per_task_runtime_env.py"
+    job_id = job_sdk_client.submit_job(
+        entrypoint=run_cmd,
+        runtime_env={"working_dir": DRIVER_SCRIPT_DIR},
+    )
+
+    wait_for_condition(_check_job_succeeded, client=job_sdk_client, job_id=job_id)
+
+
+def test_ray_tune_basic(job_sdk_client: JobSubmissionClient):
+    run_cmd = "python ray_tune_basic.py"
+    job_id = job_sdk_client.submit_job(
+        entrypoint=run_cmd,
+        runtime_env={"working_dir": DRIVER_SCRIPT_DIR},
+    )
+    wait_for_condition(
+        _check_job_succeeded, timeout=30, client=job_sdk_client, job_id=job_id
+    )
 
 
 def test_http_bad_request(job_sdk_client):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current inheritance behavior for runtime_envs enables the following workflow for Jobs:  A working_dir can be set in the Jobs API, and then inside the driver script, if a new per-task runtime_env is defined, it will automatically inherit the driver's working_dir.

There is an ongoing discussion about the best approach for runtime_env inheritance going forward: https://github.com/ray-project/ray/issues/25484, in which we noted that there were no tests covering this behavior.

This PR adds integration tests for the above behavior. If we ultimately decide to abandon the current inheritance behavior and instead have child runtime envs completely overwrite the parent runtime env, this test will fail, reminding us to do the following:

- Update the internal runtime_env usage in Ray Tune to use the `ray.get_runtime_context().runtime_env.update` API
- Update the documentation for Ray Jobs telling users to use `ray.get_runtime_context().runtime_env.update` and update this test
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
