### PR TITLE
[Ray Dataset] fix the type infer of `pd.dataframe` (when dtype is `object`.) 

### DIFF
--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -51,6 +51,12 @@ def convert_pandas_to_tf_tensor(
             # don't cast any of the series and continue.
             pass
 
+    # if the columns are `ray.data.extensions.tensor_extension.TensorArray`, 
+    # the dtype will be `object`. In this case, we need to set the dtype to
+    # none, and use the automatic type casting of `tf.convert_to_tensor`.
+    if isinstance(dtype, object):
+        dtype = None
+
     def tensorize(series):
         try:
             return tf.convert_to_tensor(series, dtype=dtype)

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -51,7 +51,7 @@ def convert_pandas_to_tf_tensor(
             # don't cast any of the series and continue.
             pass
 
-    # if the columns are `ray.data.extensions.tensor_extension.TensorArray`, 
+    # if the columns are `ray.data.extensions.tensor_extension.TensorArray`,
     # the dtype will be `object`. In this case, we need to set the dtype to
     # none, and use the automatic type casting of `tf.convert_to_tensor`.
     if isinstance(dtype, object):

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -58,8 +58,6 @@ def convert_pandas_to_tf_tensor(
             # don't cast any of the series and continue.
             pass
 
-
-
     def tensorize(series):
         try:
             return tf.convert_to_tensor(series, dtype=dtype)

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -46,13 +46,13 @@ def convert_pandas_to_tf_tensor(
             # them. If the columns contain different types (for example, `float32`s
             # and `int32`s), then `tf.concat` raises an error.
             dtype: np.dtype = np.find_common_type(df.dtypes, [])
-            
+
             # if the columns are `ray.data.extensions.tensor_extension.TensorArray`,
             # the dtype will be `object`. In this case, we need to set the dtype to
             # none, and use the automatic type casting of `tf.convert_to_tensor`.
             if isinstance(dtype, object):
                 dtype = None
-                
+
         except TypeError:
             # `find_common_type` fails if a series has `TensorDtype`. In this case,
             # don't cast any of the series and continue.

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -46,16 +46,19 @@ def convert_pandas_to_tf_tensor(
             # them. If the columns contain different types (for example, `float32`s
             # and `int32`s), then `tf.concat` raises an error.
             dtype: np.dtype = np.find_common_type(df.dtypes, [])
+            
+            # if the columns are `ray.data.extensions.tensor_extension.TensorArray`,
+            # the dtype will be `object`. In this case, we need to set the dtype to
+            # none, and use the automatic type casting of `tf.convert_to_tensor`.
+            if isinstance(dtype, object):
+                dtype = None
+                
         except TypeError:
             # `find_common_type` fails if a series has `TensorDtype`. In this case,
             # don't cast any of the series and continue.
             pass
 
-        # if the columns are `ray.data.extensions.tensor_extension.TensorArray`,
-        # the dtype will be `object`. In this case, we need to set the dtype to
-        # none, and use the automatic type casting of `tf.convert_to_tensor`.
-        if isinstance(dtype, object):
-            dtype = None
+
 
     def tensorize(series):
         try:

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -51,11 +51,11 @@ def convert_pandas_to_tf_tensor(
             # don't cast any of the series and continue.
             pass
 
-    # if the columns are `ray.data.extensions.tensor_extension.TensorArray`,
-    # the dtype will be `object`. In this case, we need to set the dtype to
-    # none, and use the automatic type casting of `tf.convert_to_tensor`.
-    if isinstance(dtype, object):
-        dtype = None
+        # if the columns are `ray.data.extensions.tensor_extension.TensorArray`,
+        # the dtype will be `object`. In this case, we need to set the dtype to
+        # none, and use the automatic type casting of `tf.convert_to_tensor`.
+        if isinstance(dtype, object):
+            dtype = None
 
     def tensorize(series):
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

this is a temporal fix of #25556. When the `dtype` from the pandas dataframe gives `object`, we set the `dtype` to be `None` and make use of the auto-inferring of the type in the conversion. 

@bveeramani @clarkzinzow 

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
