### PR TITLE
[RLlib] Fix sample batch concat samples

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1237,6 +1237,7 @@ class MultiAgentBatch:
         policy_batches: Dict[PolicyID, SampleBatch], env_steps: int
     ) -> Union[SampleBatch, "MultiAgentBatch"]:
         """Returns SampleBatch or MultiAgentBatch, depending on given policies.
+        If policy_batches is empty (i.e. {}) it returns an empty SampleBatch.
 
         Args:
             policy_batches: Mapping from policy ids to SampleBatch.
@@ -1246,6 +1247,10 @@ class MultiAgentBatch:
             The single default policy's SampleBatch or a MultiAgentBatch
             (more than one policy).
         """
+        # handle the empty case
+        if not policy_batches:
+            return SampleBatch(policy_batches, env_steps=env_steps)
+
         if len(policy_batches) == 1 and DEFAULT_POLICY_ID in policy_batches:
             return policy_batches[DEFAULT_POLICY_ID]
         return MultiAgentBatch(policy_batches=policy_batches, env_steps=env_steps)

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -16,7 +16,7 @@ from ray.rllib.utils.typing import (
     PolicyID,
     TensorType,
     SampleBatchType,
-    ViewRequirementsDict
+    ViewRequirementsDict,
 )
 
 tf1, tf, tfv = try_import_tf()
@@ -188,8 +188,7 @@ class SampleBatch(dict):
         return len(self)
 
     @Deprecated(
-        new='calling concat_samples() from rllib.policy.sample_batch',
-        error=False
+        new="calling concat_samples() from rllib.policy.sample_batch", error=False
     )
     @staticmethod
     @PublicAPI
@@ -1177,8 +1176,7 @@ class MultiAgentBatch:
         return MultiAgentBatch(policy_batches=policy_batches, env_steps=env_steps)
 
     @Deprecated(
-        new='calling concat_samples() from rllib.policy.sample_batch',
-        error=False
+        new="calling concat_samples() from rllib.policy.sample_batch", error=False
     )
     @staticmethod
     @PublicAPI
@@ -1306,8 +1304,7 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
                 s.max_seq_len is None or max_seq_len is None
             ) and s.max_seq_len != max_seq_len:
                 raise ValueError(
-                    "Samples must consistently either provide or omit "
-                    "`max_seq_len`!"
+                    "Samples must consistently either provide or omit " "`max_seq_len`!"
                 )
             elif zero_padded and s.max_seq_len != max_seq_len:
                 raise ValueError(

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -187,11 +187,11 @@ class SampleBatch(dict):
         """
         return len(self)
 
-    @Deprecated(
-        new="calling concat_samples() from rllib.policy.sample_batch", error=False
-    )
     @staticmethod
     @PublicAPI
+    @Deprecated(
+        new="concat_samples() from rllib.policy.sample_batch", error=False
+    )
     def concat_samples(
         samples: Union[List["SampleBatch"], List["MultiAgentBatch"]],
     ) -> Union["SampleBatch", "MultiAgentBatch"]:
@@ -1175,11 +1175,11 @@ class MultiAgentBatch:
             return policy_batches[DEFAULT_POLICY_ID]
         return MultiAgentBatch(policy_batches=policy_batches, env_steps=env_steps)
 
-    @Deprecated(
-        new="calling concat_samples() from rllib.policy.sample_batch", error=False
-    )
     @staticmethod
     @PublicAPI
+    @Deprecated(
+        new="concat_samples() from rllib.policy.sample_batch", error=False
+    )
     def concat_samples(samples: List["MultiAgentBatch"]) -> "MultiAgentBatch":
         return concat_samples(samples)
 

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1153,7 +1153,7 @@ class MultiAgentBatch:
         policy_batches: Dict[PolicyID, SampleBatch], env_steps: int
     ) -> Union[SampleBatch, "MultiAgentBatch"]:
         """Returns SampleBatch or MultiAgentBatch, depending on given policies.
-        If policy_batches is empty (i.e. {}) it returns an empty SampleBatch.
+        If policy_batches is empty (i.e. {}) it returns an empty MultiAgentBatch.
 
         Args:
             policy_batches: Mapping from policy ids to SampleBatch.
@@ -1163,14 +1163,6 @@ class MultiAgentBatch:
             The single default policy's SampleBatch or a MultiAgentBatch
             (more than one policy).
         """
-        # # handle the empty case
-        # if not policy_batches:
-        #     foo = SampleBatch(policy_batches, env_steps=env_steps)
-        #     bar = MultiAgentBatch(policy_batches, env_steps=env_steps)
-        #     print('sample_batch = ', foo.count)
-        #     print('ma_batch = ', bar.count)
-        #     return SampleBatch(policy_batches, env_steps=env_steps)
-
         if len(policy_batches) == 1 and DEFAULT_POLICY_ID in policy_batches:
             return policy_batches[DEFAULT_POLICY_ID]
         return MultiAgentBatch(policy_batches=policy_batches, env_steps=env_steps)

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1169,7 +1169,7 @@ class MultiAgentBatch:
     @PublicAPI
     @Deprecated(new="concat_samples() from rllib.policy.sample_batch", error=False)
     def concat_samples(samples: List["MultiAgentBatch"]) -> "MultiAgentBatch":
-        return concat_samples(samples)
+        return _concat_samples_into_ma_batch(samples)
 
     @PublicAPI
     def copy(self) -> "MultiAgentBatch":

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1318,6 +1318,9 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
     # Collect the concat'd data.
     concatd_data = {}
 
+    def concat_key(*values):
+        return concat_aligned(values, time_major)
+
     for k in concated_samples[0].keys():
         try:
             if k == "infos":
@@ -1326,7 +1329,7 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
                 )
             else:
                 concatd_data[k] = tree.map_structure(
-                    _concat_key, *[c[k] for c in concated_samples]
+                    concat_key, *[c[k] for c in concated_samples]
                 )
         except Exception:
             raise ValueError(

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1240,7 +1240,7 @@ class MultiAgentBatch:
             str(self.policy_batches), self.count
         )
 
-
+@PublicAPI
 def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
     """
     Concatenates n SampleBatches or MultiAgentBatches.
@@ -1340,7 +1340,7 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
         _max_seq_len=max_seq_len,
     )
 
-
+@PublicAPI
 def concat_samples_into_ma_batch(samples: List[SampleBatchType]) -> "MultiAgentBatch":
     """
     Concatenates a list of SampleBatchTypes to a single MultiAgentBatch type.

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1244,6 +1244,7 @@ class MultiAgentBatch:
 @PublicAPI
 def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
     """Concatenates a list of  SampleBatches or MultiAgentBatches.
+
     If all items in the list are or SampleBatch typ4, the output will be
     a SampleBatch type. Otherwise, the output will be a MultiAgentBatch type.
     If input is a mixture of SampleBatch and MultiAgentBatch types, it will treat

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1356,6 +1356,7 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
 @PublicAPI
 def concat_samples_into_ma_batch(samples: List[SampleBatchType]) -> "MultiAgentBatch":
     """Concatenates a list of SampleBatchTypes to a single MultiAgentBatch type.
+
     This function, as opposed to concat_samples() forces the output to always be
     MultiAgentBatch which is more generic than SampleBatch.
 

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1169,7 +1169,7 @@ class MultiAgentBatch:
     @PublicAPI
     @Deprecated(new="concat_samples() from rllib.policy.sample_batch", error=False)
     def concat_samples(samples: List["MultiAgentBatch"]) -> "MultiAgentBatch":
-        return _concat_samples_into_ma_batch(samples)
+        return concat_samples_into_ma_batch(samples)
 
     @PublicAPI
     def copy(self) -> "MultiAgentBatch":
@@ -1249,26 +1249,26 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
     The output will still be a MultiAgentBatch object even if all
     MultiAgentBatches are empty. Empty samples are simply ignored.
 
-        Args:
-            samples: List of SampleBatches or MultiAgentBatches to be
-                concatenated.
+    Args:
+        samples: List of SampleBatches or MultiAgentBatches to be
+            concatenated.
 
-        Returns:
-            A new (concatenated) SampleBatch or MultiAgentBatch.
+    Returns:
+        A new (concatenated) SampleBatch or MultiAgentBatch.
 
-        Examples:
-            >>> import numpy as np
-            >>> from ray.rllib.policy.sample_batch import SampleBatch
-            >>> b1 = SampleBatch({"a": np.array([1, 2]), # doctest: +SKIP
-            ...                   "b": np.array([10, 11])})
-            >>> b2 = SampleBatch({"a": np.array([3]), # doctest: +SKIP
-            ...                   "b": np.array([12])})
-            >>> print(concat_samples([b1, b2])) # doctest: +SKIP
-            {"a": np.array([1, 2, 3]), "b": np.array([10, 11, 12])}
+    Examples:
+        >>> import numpy as np
+        >>> from ray.rllib.policy.sample_batch import SampleBatch
+        >>> b1 = SampleBatch({"a": np.array([1, 2]), # doctest: +SKIP
+        ...                   "b": np.array([10, 11])})
+        >>> b2 = SampleBatch({"a": np.array([3]), # doctest: +SKIP
+        ...                   "b": np.array([12])})
+        >>> print(concat_samples([b1, b2])) # doctest: +SKIP
+        {"a": np.array([1, 2, 3]), "b": np.array([10, 11, 12])}
     """
 
     if any([isinstance(s, MultiAgentBatch) for s in samples]):
-        return _concat_samples_into_ma_batch(samples)
+        return concat_samples_into_ma_batch(samples)
 
     # the output is a SampleBatch type
     concatd_seq_lens = []
@@ -1341,7 +1341,31 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
     )
 
 
-def _concat_samples_into_ma_batch(samples: List[SampleBatchType]) -> "MultiAgentBatch":
+def concat_samples_into_ma_batch(samples: List[SampleBatchType]) -> "MultiAgentBatch":
+    """
+    Concatenates a list of SampleBatchTypes to a single MultiAgentBatch type.
+    This function, as opposed to concat_samples() forces the output to always be
+    MultiAgentBatch which is more generic than SampleBatch.
+
+    Args:
+        samples: List of SampleBatches or MultiAgentBatches to be
+            concatenated.
+
+    Returns:
+        A new (concatenated) MultiAgentBatch.
+
+    Examples:
+        >>> import numpy as np
+        >>> from ray.rllib.policy.sample_batch import SampleBatch
+        >>> b1 = MultiAgentBatch({"a": np.array([1, 2]), # doctest: +SKIP
+        ...                       "b": np.array([10, 11])}, env_steps=2)
+        >>> b2 = SampleBatch({"a": np.array([3]), # doctest: +SKIP
+        ...                   "b": np.array([12])})
+        >>> print(concat_samples([b1, b2])) # doctest: +SKIP
+        MultiAgentBatch = {'default_policy': {"a": np.array([1, 2, 3]),
+                                              "b": np.array([10, 11, 12])}}
+
+    """
 
     policy_batches = collections.defaultdict(list)
     env_steps = 0

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -189,9 +189,7 @@ class SampleBatch(dict):
 
     @staticmethod
     @PublicAPI
-    @Deprecated(
-        new="concat_samples() from rllib.policy.sample_batch", error=False
-    )
+    @Deprecated(new="concat_samples() from rllib.policy.sample_batch", error=False)
     def concat_samples(
         samples: Union[List["SampleBatch"], List["MultiAgentBatch"]],
     ) -> Union["SampleBatch", "MultiAgentBatch"]:
@@ -1169,9 +1167,7 @@ class MultiAgentBatch:
 
     @staticmethod
     @PublicAPI
-    @Deprecated(
-        new="concat_samples() from rllib.policy.sample_batch", error=False
-    )
+    @Deprecated(new="concat_samples() from rllib.policy.sample_batch", error=False)
     def concat_samples(samples: List["MultiAgentBatch"]) -> "MultiAgentBatch":
         return concat_samples(samples)
 
@@ -1318,9 +1314,6 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
     # Collect the concat'd data.
     concatd_data = {}
 
-    def concat_key(*values):
-        return concat_aligned(values, time_major)
-
     for k in concated_samples[0].keys():
         try:
             if k == "infos":
@@ -1329,7 +1322,7 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
                 )
             else:
                 concatd_data[k] = tree.map_structure(
-                    concat_key, *[c[k] for c in concated_samples]
+                    _concat_key, *[c[k] for c in concated_samples]
                 )
         except Exception:
             raise ValueError(
@@ -1372,11 +1365,11 @@ def _concat_samples_into_ma_batch(samples: List[SampleBatchType]) -> "MultiAgent
             policy_batches[key].append(batch)
         env_steps += s.env_steps()
 
-        out = {}
-        for key, batches in policy_batches.items():
-            out[key] = concat_samples(batches)
+    out = {}
+    for key, batches in policy_batches.items():
+        out[key] = concat_samples(batches)
 
-        return MultiAgentBatch(out, env_steps)
+    return MultiAgentBatch(out, env_steps)
 
 
 def _concat_key(*values, time_major=None):

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -1240,6 +1240,7 @@ class MultiAgentBatch:
             str(self.policy_batches), self.count
         )
 
+
 @PublicAPI
 def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
     """
@@ -1339,6 +1340,7 @@ def concat_samples(samples: List[SampleBatchType]) -> SampleBatchType:
         _zero_padded=zero_padded,
         _max_seq_len=max_seq_len,
     )
+
 
 @PublicAPI
 def concat_samples_into_ma_batch(samples: List[SampleBatchType]) -> "MultiAgentBatch":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When we invalidate some episodes within the environment by setting training_enabled = False in the info dict, the empty returned episode becomes a MABatch which cannot be concatenated with the other SampleBatches and leads to error. This PR resolves this by letting the user to concat MABatch and SampleBatches into a single MABatch object (even if the objects are empty themselves). 

At the same time it makes sense to make this method a function inside `sample_batch.py` instead of attributing it to the class with `static_method` decorator, deprecating the old `static_method`'s. 

Solves #25150 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
