### PR TITLE
Create RAY_TMPDIR if it doesn't exist

### DIFF
--- a/python/ray/autoscaler/_private/local/node_provider.py
+++ b/python/ray/autoscaler/_private/local/node_provider.py
@@ -29,6 +29,7 @@ filelock_logger.setLevel(logging.WARNING)
 class ClusterState:
     def __init__(self, lock_path, save_path, provider_config):
         self.lock = RLock()
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
         self.file_lock = FileLock(lock_path)
         self.save_path = save_path
 

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -24,6 +24,7 @@ from ray.autoscaler.tags import (
     TAG_RAY_NODE_STATUS,
     STATUS_UP_TO_DATE,
 )
+from ray._private.utils import get_ray_temp_dir
 import pytest
 
 
@@ -53,6 +54,14 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
         local_node_provider = _NODE_PROVIDERS.get("local")({})
         assert local_node_provider is LocalNodeProvider
 
+    @pytest.fixture(autouse=True)
+    def _set_monkeypatch(self, monkeypatch):
+        self._monkeypatch = monkeypatch
+
+    @pytest.fixture(autouse=True)
+    def _set_tmpdir(self, tmpdir):
+        self._tmpdir = tmpdir
+
     def testClusterStateInit(self):
         """Check ClusterState __init__ func generates correct state file.
 
@@ -61,6 +70,9 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
         # Use a random head_ip so that the state file is regenerated each time
         # this test is run. (Otherwise the test will fail spuriously when run a
         # second time.)
+        self._monkeypatch.setenv("RAY_TMPDIR", self._tmpdir)
+        # ensure that a new cluster can start up if RAY_TMPDIR doesn't exist yet
+        assert not os.path.exists(get_ray_temp_dir())
         head_ip = ".".join(str(random.randint(0, 255)) for _ in range(4))
         cluster_config = {
             "cluster_name": "random_name",
@@ -77,6 +89,7 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
         node_provider = _get_node_provider(
             provider_config, cluster_config["cluster_name"], use_cache=False
         )
+        assert os.path.exists(get_ray_temp_dir())
         assert node_provider.external_ip(head_ip) == "0.0.0.0.3"
         assert isinstance(node_provider, LocalNodeProvider)
         expected_workers = {}


### PR DESCRIPTION
This will prevent `FileNotFoundError`s on fresh `ray up` installs.

## Why are these changes needed?

When starting a local ray cluster with `ray up cluster.yml` on a new machine, the temporary directory used by ray does not exist yet and may lead to errors that prevent the cluster from starting up. This issue would not be noticed if one has created a local cluster before, or if the `RAY_TMPDIR` is set to something that already exists.

For example in the linked issue below, the file `/tmp/ray/cluster-default.lock` could not be created by `Filelock` because `/tmp/ray` didn't exist yet.

## Related issue number

Closes #25326 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/. (None needed)
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
