### PR TITLE
[AIR] Add `_predict_arrow` interface for Predictor

### DIFF
--- a/python/ray/air/predictor.py
+++ b/python/ray/air/predictor.py
@@ -50,8 +50,9 @@ class Predictor(abc.ABC):
     To implement a new Predictor for your particular framework, you should subclass
     the base ``Predictor`` and implement the following two methods:
 
-        1. ``_predict_pandas``: Given a pandas.DataFrame input, return a
-           pandas.DataFrame containing predictions.
+        1. ``_predict_pandas`` or ``_predict_arrow``: Given a
+            pandas.DataFrame/pyarrow.Table input, return a
+            pandas.DataFrame/pyarrow.Table containing predictions.
         2. ``from_checkpoint``: Logic for creating a Predictor from an
            :ref:`AIR Checkpoint <air-checkpoint-ref>`.
     """

--- a/python/ray/air/predictor.py
+++ b/python/ray/air/predictor.py
@@ -111,6 +111,24 @@ class Predictor(abc.ABC):
         """
         raise NotImplementedError
 
+    @DeveloperAPI
+    def _predict_arrow(self, data: "pyarrow.Table", **kwargs) -> "pyarrow.Table":
+        """Perform inference on an Arrow Table.
+
+        Predictors can implement this method instead of ``_predict_pandas``
+        for better performance when the input batch type is a Numpy array, dict of
+        numpy arrays, or an Arrow Table as conversion from these types are zero copy.
+
+        Args:
+            data: An Arrow Table to perform predictions on.
+            kwargs: Arguments specific to the predictor implementation.
+
+        Returns:
+            An Arrow Table containing the prediction result.
+        """
+
+        raise NotImplementedError
+
     def __reduce__(self):
         raise PredictorNotSerializableException(
             "Predictor instances are not serializable. Instead, you may want "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Adds `_predict_arrow` Developer API to Predictors for better performance when working with numpy arrays or arrow tables.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
