### PR TITLE
[AIR] Delayed type checking for Preprocessors

### DIFF
--- a/python/ray/air/_internal/checkpointing.py
+++ b/python/ray/air/_internal/checkpointing.py
@@ -1,14 +1,16 @@
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 import ray.cloudpickle as cpickle
-from ray.air.preprocessor import Preprocessor
 from ray.air.constants import PREPROCESSOR_KEY
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 def save_preprocessor_to_dir(
-    preprocessor: Preprocessor,
+    preprocessor: "Preprocessor",
     parent_dir: Union[os.PathLike, str],
 ) -> None:
     """Save preprocessor to file. Returns path saved to."""
@@ -19,7 +21,7 @@ def save_preprocessor_to_dir(
 
 def load_preprocessor_from_dir(
     parent_dir: os.PathLike,
-) -> Optional[Preprocessor]:
+) -> Optional["Preprocessor"]:
     """Loads preprocessor from directory, if file exists."""
     parent_dir = Path(parent_dir)
     preprocessor_path = parent_dir.joinpath(PREPROCESSOR_KEY)

--- a/python/ray/air/predictors/integrations/huggingface/huggingface_predictor.py
+++ b/python/ray/air/predictors/integrations/huggingface/huggingface_predictor.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, Union, List
+from typing import Optional, Type, Union, List, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -9,9 +9,11 @@ from transformers.pipelines.table_question_answering import (
 )
 
 from ray.air.predictor import DataBatchType, Predictor
-from ray.air.preprocessor import Preprocessor
 from ray.air.checkpoint import Checkpoint
 from ray.air._internal.checkpointing import load_preprocessor_from_dir
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class HuggingFacePredictor(Predictor):
@@ -28,7 +30,7 @@ class HuggingFacePredictor(Predictor):
     def __init__(
         self,
         pipeline: Optional[Pipeline] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
     ):
         self.pipeline = pipeline
         self.preprocessor = preprocessor

--- a/python/ray/air/predictors/integrations/lightgbm/lightgbm_predictor.py
+++ b/python/ray/air/predictors/integrations/lightgbm/lightgbm_predictor.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, List, Union, TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
@@ -6,8 +6,10 @@ import lightgbm
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.predictor import Predictor, DataBatchType
-from ray.air.preprocessor import Preprocessor
 from ray.air.train.integrations.lightgbm import load_checkpoint
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class LightGBMPredictor(Predictor):
@@ -20,7 +22,7 @@ class LightGBMPredictor(Predictor):
     """
 
     def __init__(
-        self, model: lightgbm.Booster, preprocessor: Optional[Preprocessor] = None
+        self, model: lightgbm.Booster, preprocessor: Optional["Preprocessor"] = None
     ):
         self.model = model
         self.preprocessor = preprocessor

--- a/python/ray/air/predictors/integrations/lightgbm/utils.py
+++ b/python/ray/air/predictors/integrations/lightgbm/utils.py
@@ -1,20 +1,22 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import os
 import lightgbm
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY
-from ray.air.preprocessor import Preprocessor
 from ray.air._internal.checkpointing import (
     save_preprocessor_to_dir,
 )
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 def to_air_checkpoint(
     path: str,
     booster: lightgbm.Booster,
-    preprocessor: Optional[Preprocessor] = None,
+    preprocessor: Optional["Preprocessor"] = None,
 ) -> Checkpoint:
     """Convert a pretrained model to AIR checkpoint for serve or inference.
 

--- a/python/ray/air/predictors/integrations/rl/rl_predictor.py
+++ b/python/ray/air/predictors/integrations/rl/rl_predictor.py
@@ -1,13 +1,15 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
-import numpy
 import numpy as np
 import pandas as pd
-from ray.air import Preprocessor, Checkpoint
+from ray.air.checkpoint import Checkpoint
 from ray.air.predictor import Predictor, DataBatchType
 from ray.air.train.integrations.rl import load_checkpoint
 from ray.rllib.policy.policy import Policy
 from ray.rllib.utils.typing import EnvType
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class RLPredictor(Predictor):
@@ -22,7 +24,7 @@ class RLPredictor(Predictor):
     def __init__(
         self,
         policy: Policy,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
     ):
         self.policy = policy
         self.preprocessor = preprocessor

--- a/python/ray/air/predictors/integrations/sklearn/sklearn_predictor.py
+++ b/python/ray/air/predictors/integrations/sklearn/sklearn_predictor.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, List, Union, TYPE_CHECKING
 
 import pandas as pd
 import numpy as np
@@ -6,12 +6,14 @@ from joblib import parallel_backend
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.predictor import Predictor, DataBatchType
-from ray.air.preprocessor import Preprocessor
 from ray.air.train.integrations.sklearn import load_checkpoint
 from ray.air._internal.sklearn_utils import set_cpu_params
 from ray.util.joblib import register_ray
 
 from sklearn.base import BaseEstimator
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class SklearnPredictor(Predictor):
@@ -25,7 +27,7 @@ class SklearnPredictor(Predictor):
     """
 
     def __init__(
-        self, estimator: BaseEstimator, preprocessor: Optional[Preprocessor] = None
+        self, estimator: BaseEstimator, preprocessor: Optional["Preprocessor"] = None
     ):
         self.estimator = estimator
         self.preprocessor = preprocessor

--- a/python/ray/air/predictors/integrations/sklearn/utils.py
+++ b/python/ray/air/predictors/integrations/sklearn/utils.py
@@ -1,21 +1,23 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import os
 from sklearn.base import BaseEstimator
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY
-from ray.air.preprocessor import Preprocessor
 from ray.air._internal.checkpointing import (
     save_preprocessor_to_dir,
 )
 import ray.cloudpickle as cpickle
 
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
+
 
 def to_air_checkpoint(
     path: str,
     estimator: BaseEstimator,
-    preprocessor: Optional[Preprocessor] = None,
+    preprocessor: Optional["Preprocessor"] = None,
 ) -> Checkpoint:
     """Convert a pretrained model to AIR checkpoint for serve or inference.
 

--- a/python/ray/air/predictors/integrations/tensorflow/tensorflow_predictor.py
+++ b/python/ray/air/predictors/integrations/tensorflow/tensorflow_predictor.py
@@ -1,13 +1,15 @@
-from typing import Callable, Optional, Union, List, Type
+from typing import Callable, Optional, Union, List, Type, TYPE_CHECKING
 
 import pandas as pd
 import tensorflow as tf
 
 from ray.air.predictor import Predictor, DataBatchType
-from ray.air.preprocessor import Preprocessor
 from ray.air.checkpoint import Checkpoint
 from ray.air.train.data_parallel_trainer import _load_checkpoint
 from ray.air._internal.tensorflow_utils import convert_pandas_to_tf_tensor
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class TensorflowPredictor(Predictor):
@@ -24,7 +26,7 @@ class TensorflowPredictor(Predictor):
     def __init__(
         self,
         model_definition: Union[Callable[[], tf.keras.Model], Type[tf.keras.Model]],
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         model_weights: Optional[list] = None,
     ):
         self.model_definition = model_definition

--- a/python/ray/air/predictors/integrations/tensorflow/utils.py
+++ b/python/ray/air/predictors/integrations/tensorflow/utils.py
@@ -1,14 +1,16 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from tensorflow import keras
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY, PREPROCESSOR_KEY
-from ray.air.preprocessor import Preprocessor
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 def to_air_checkpoint(
-    model: keras.Model, preprocessor: Optional[Preprocessor] = None
+    model: keras.Model, preprocessor: Optional["Preprocessor"] = None
 ) -> Checkpoint:
     """Convert a pretrained model to AIR checkpoint for serve or inference.
 

--- a/python/ray/air/predictors/integrations/torch/torch_predictor.py
+++ b/python/ray/air/predictors/integrations/torch/torch_predictor.py
@@ -1,14 +1,16 @@
-from typing import Optional, Union, List
+from typing import Optional, Union, List, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import torch
 
 from ray.air.predictor import Predictor, DataBatchType
-from ray.air.preprocessor import Preprocessor
 from ray.air.checkpoint import Checkpoint
 from ray.air.train.integrations.torch import load_checkpoint
 from ray.air._internal.torch_utils import convert_pandas_to_torch_tensor
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class TorchPredictor(Predictor):
@@ -21,7 +23,7 @@ class TorchPredictor(Predictor):
     """
 
     def __init__(
-        self, model: torch.nn.Module, preprocessor: Optional[Preprocessor] = None
+        self, model: torch.nn.Module, preprocessor: Optional["Preprocessor"] = None
     ):
         self.model = model
         self.preprocessor = preprocessor

--- a/python/ray/air/predictors/integrations/torch/utils.py
+++ b/python/ray/air/predictors/integrations/torch/utils.py
@@ -1,14 +1,16 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import torch
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY, PREPROCESSOR_KEY
-from ray.air.preprocessor import Preprocessor
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 def to_air_checkpoint(
-    model: torch.nn.Module, preprocessor: Optional[Preprocessor] = None
+    model: torch.nn.Module, preprocessor: Optional["Preprocessor"] = None
 ) -> Checkpoint:
     """Convert a pretrained model to AIR checkpoint for serve or inference.
 

--- a/python/ray/air/predictors/integrations/xgboost/utils.py
+++ b/python/ray/air/predictors/integrations/xgboost/utils.py
@@ -1,20 +1,22 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import os
 import xgboost
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY
-from ray.air.preprocessor import Preprocessor
 from ray.air._internal.checkpointing import (
     save_preprocessor_to_dir,
 )
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 def to_air_checkpoint(
     path: str,
     booster: xgboost.Booster,
-    preprocessor: Optional[Preprocessor] = None,
+    preprocessor: Optional["Preprocessor"] = None,
 ) -> Checkpoint:
     """Convert a pretrained model to AIR checkpoint for serve or inference.
 

--- a/python/ray/air/predictors/integrations/xgboost/xgboost_predictor.py
+++ b/python/ray/air/predictors/integrations/xgboost/xgboost_predictor.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union, Dict, Any
+from typing import Optional, List, Union, Dict, Any, TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
@@ -6,8 +6,10 @@ import xgboost
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.predictor import Predictor, DataBatchType
-from ray.air.preprocessor import Preprocessor
 from ray.air.train.integrations.xgboost import load_checkpoint
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class XGBoostPredictor(Predictor):
@@ -20,7 +22,7 @@ class XGBoostPredictor(Predictor):
     """
 
     def __init__(
-        self, model: xgboost.Booster, preprocessor: Optional[Preprocessor] = None
+        self, model: xgboost.Booster, preprocessor: Optional["Preprocessor"] = None
     ):
         self.model = model
         self.preprocessor = preprocessor

--- a/python/ray/air/train/data_parallel_ingest.py
+++ b/python/ray/air/train/data_parallel_ingest.py
@@ -2,10 +2,10 @@ from typing import Optional, Dict, List, Union, TYPE_CHECKING
 
 from ray.actor import ActorHandle
 from ray.air.config import DatasetConfig
-from ray.air.preprocessor import Preprocessor
 
 if TYPE_CHECKING:
     from ray.data import Dataset, DatasetPipeline
+    from ray.air.preprocessor import Preprocessor
 
 
 class _DataParallelIngestSpec:
@@ -20,10 +20,10 @@ class _DataParallelIngestSpec:
         """
         self.dataset_config = dataset_config
         self.preprocessed_datasets: Optional[Dict[str, "Dataset"]] = None
-        self.preprocessor: Optional[Preprocessor] = None
+        self.preprocessor: Optional["Preprocessor"] = None
 
     def preprocess_datasets(
-        self, prep: Preprocessor, datasets: Dict[str, "Dataset"]
+        self, prep: "Preprocessor", datasets: Dict[str, "Dataset"]
     ) -> Dict[str, "Dataset"]:
         """Preprocess the given datasets.
 

--- a/python/ray/air/train/data_parallel_trainer.py
+++ b/python/ray/air/train/data_parallel_trainer.py
@@ -9,6 +9,7 @@ from typing import (
     Tuple,
     Union,
     Type,
+    TYPE_CHECKING,
 )
 
 import ray
@@ -22,7 +23,6 @@ from ray.air.constants import (
 from ray.air.trainer import Trainer
 from ray.air.config import ScalingConfig, RunConfig, DatasetConfig
 from ray.air.trainer import GenDataset
-from ray.air.preprocessor import Preprocessor
 from ray.air.checkpoint import Checkpoint
 from ray.air.train.data_parallel_ingest import _DataParallelIngestSpec
 from ray.train import BackendConfig, TrainingIterator
@@ -32,6 +32,8 @@ from ray.train.utils import construct_train_func
 from ray.util.annotations import DeveloperAPI
 from ray.util.ml_utils.checkpoint_manager import CheckpointStrategy, _TrackedCheckpoint
 
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +42,7 @@ logger = logging.getLogger(__name__)
 class _DataParallelCheckpointManager(TuneCheckpointManager):
     def __init__(
         self,
-        preprocessor: Preprocessor,
+        preprocessor: "Preprocessor",
         run_dir: Optional[Path] = None,
         checkpoint_strategy: Optional[CheckpointStrategy] = None,
     ):
@@ -249,7 +251,7 @@ class DataParallelTrainer(Trainer):
         dataset_config: Optional[Dict[str, DatasetConfig]] = None,
         run_config: Optional[RunConfig] = None,
         datasets: Optional[Dict[str, GenDataset]] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
         if not ray.is_initialized():
@@ -389,7 +391,7 @@ class DataParallelTrainer(Trainer):
 
 def _load_checkpoint(
     checkpoint: Checkpoint, trainer_name: str
-) -> Tuple[Any, Optional[Preprocessor]]:
+) -> Tuple[Any, Optional["Preprocessor"]]:
     """Load a Ray Train Checkpoint.
 
     This is a private API.

--- a/python/ray/air/train/gbdt_trainer.py
+++ b/python/ray/air/train/gbdt_trainer.py
@@ -3,7 +3,6 @@ import warnings
 
 from ray.air.trainer import GenDataset
 from ray.air.config import ScalingConfig, RunConfig, ScalingConfigDataClass
-from ray.air.preprocessor import Preprocessor
 from ray.air._internal.checkpointing import save_preprocessor_to_dir
 from ray.tune.utils.trainable import TrainableUtil
 from ray.util.annotations import DeveloperAPI
@@ -14,6 +13,7 @@ from ray.air.constants import MODEL_KEY, TRAIN_DATASET_KEY
 
 if TYPE_CHECKING:
     import xgboost_ray
+    from ray.air.preprocessor import Preprocessor
 
 
 def _convert_scaling_config_to_ray_params(
@@ -88,7 +88,7 @@ class GBDTTrainer(Trainer):
         dmatrix_params: Optional[Dict[str, Dict[str, Any]]] = None,
         scaling_config: Optional[ScalingConfig] = None,
         run_config: Optional[RunConfig] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
         **train_kwargs,
     ):
@@ -135,7 +135,7 @@ class GBDTTrainer(Trainer):
     def _load_checkpoint(
         self,
         checkpoint: Checkpoint,
-    ) -> Tuple[Any, Optional[Preprocessor]]:
+    ) -> Tuple[Any, Optional["Preprocessor"]]:
         raise NotImplementedError
 
     def _train(self, **kwargs):

--- a/python/ray/air/train/integrations/horovod/horovod_trainer.py
+++ b/python/ray/air/train/integrations/horovod/horovod_trainer.py
@@ -1,13 +1,15 @@
-from typing import Dict, Callable, Optional, Union
+from typing import Dict, Callable, Optional, Union, TYPE_CHECKING
 
 from ray.air.config import ScalingConfig, RunConfig, DatasetConfig
 from ray.air.trainer import GenDataset
-from ray.air.preprocessor import Preprocessor
 from ray.air.checkpoint import Checkpoint
 
 
 from ray.air.train.data_parallel_trainer import DataParallelTrainer
 from ray.train.horovod import HorovodConfig
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 class HorovodTrainer(DataParallelTrainer):
@@ -173,7 +175,7 @@ class HorovodTrainer(DataParallelTrainer):
         dataset_config: Optional[Dict[str, DatasetConfig]] = None,
         run_config: Optional[RunConfig] = None,
         datasets: Optional[Dict[str, GenDataset]] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
         super().__init__(

--- a/python/ray/air/train/integrations/huggingface/huggingface_trainer.py
+++ b/python/ray/air/train/integrations/huggingface/huggingface_trainer.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 from distutils.version import LooseVersion
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union, TYPE_CHECKING
 import warnings
 
 import torch
@@ -25,7 +25,6 @@ from ray.air.constants import (
     TRAIN_DATASET_KEY,
     PREPROCESSOR_KEY,
 )
-from ray.air.preprocessor import Preprocessor
 from ray.air.train.integrations.torch import TorchTrainer
 from ray.air.trainer import GenDataset
 from ray.air.train.data_parallel_trainer import _DataParallelCheckpointManager
@@ -45,6 +44,9 @@ from ray.train.constants import TUNE_CHECKPOINT_ID
 from ray.train.torch import TorchConfig
 from ray.tune.trainable import Trainable
 from ray.tune.utils.file_transfer import delete_on_node, sync_dir_between_nodes
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 # This trainer uses a special checkpoint syncing logic.
 # Because HF checkpoints are very large dirs (at least several GBs),
@@ -276,7 +278,7 @@ class HuggingFaceTrainer(TorchTrainer):
         scaling_config: Optional[ScalingConfig] = None,
         dataset_config: Optional[Dict[str, DatasetConfig]] = None,
         run_config: Optional[RunConfig] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
 
@@ -416,7 +418,7 @@ def load_checkpoint(
     Union[transformers.modeling_utils.PreTrainedModel, torch.nn.Module],
     transformers.training_args.TrainingArguments,
     Optional[transformers.PreTrainedTokenizer],
-    Optional[Preprocessor],
+    Optional["Preprocessor"],
 ]:
     """Load a Checkpoint from ``HuggingFaceTrainer``.
 

--- a/python/ray/air/train/integrations/lightgbm/lightgbm_trainer.py
+++ b/python/ray/air/train/integrations/lightgbm/lightgbm_trainer.py
@@ -1,8 +1,7 @@
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, TYPE_CHECKING
 import os
 
 from ray.air.checkpoint import Checkpoint
-from ray.air.preprocessor import Preprocessor
 from ray.air.train.gbdt_trainer import GBDTTrainer
 from ray.air._internal.checkpointing import load_preprocessor_from_dir
 from ray.util.annotations import PublicAPI
@@ -11,6 +10,9 @@ from ray.air.constants import MODEL_KEY
 import lightgbm
 import lightgbm_ray
 from lightgbm_ray.tune import TuneReportCheckpointCallback
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 @PublicAPI(stability="alpha")
@@ -81,13 +83,13 @@ class LightGBMTrainer(GBDTTrainer):
 
     def _load_checkpoint(
         self, checkpoint: Checkpoint
-    ) -> Tuple[lightgbm.Booster, Optional[Preprocessor]]:
+    ) -> Tuple[lightgbm.Booster, Optional["Preprocessor"]]:
         return load_checkpoint(checkpoint)
 
 
 def load_checkpoint(
     checkpoint: Checkpoint,
-) -> Tuple[lightgbm.Booster, Optional[Preprocessor]]:
+) -> Tuple[lightgbm.Booster, Optional["Preprocessor"]]:
     """Load a Checkpoint from ``LightGBMTrainer``.
 
     Args:

--- a/python/ray/air/train/integrations/rl/rl_trainer.py
+++ b/python/ray/air/train/integrations/rl/rl_trainer.py
@@ -1,11 +1,10 @@
 import inspect
 import os
-from typing import Optional, Dict, Tuple, Type, Union, Callable, Any
+from typing import Optional, Dict, Tuple, Type, Union, Callable, Any, TYPE_CHECKING
 
 import ray.cloudpickle as cpickle
 from ray.air.checkpoint import Checkpoint
 from ray.air.config import ScalingConfig, RunConfig
-from ray.air.preprocessor import Preprocessor
 from ray.air.trainer import Trainer, GenDataset
 from ray.air._internal.checkpointing import (
     load_preprocessor_from_dir,
@@ -21,6 +20,8 @@ from ray.tune.resources import Resources
 from ray.util.annotations import PublicAPI
 from ray.util.ml_utils.dict import merge_dicts
 
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 RL_TRAINER_CLASS_FILE = "trainer_class.pkl"
 RL_CONFIG_FILE = "config.pkl"
@@ -118,7 +119,7 @@ class RLTrainer(Trainer):
         scaling_config: Optional[ScalingConfig] = None,
         run_config: Optional[RunConfig] = None,
         datasets: Optional[Dict[str, GenDataset]] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
         self._algorithm = algorithm
@@ -257,7 +258,7 @@ class RLTrainer(Trainer):
 def load_checkpoint(
     checkpoint: Checkpoint,
     env: Optional[EnvType] = None,
-) -> Tuple[Policy, Optional[Preprocessor]]:
+) -> Tuple[Policy, Optional["Preprocessor"]]:
     """Load a Checkpoint from ``RLTrainer``.
 
     Args:

--- a/python/ray/air/train/integrations/sklearn/sklearn_trainer.py
+++ b/python/ray/air/train/integrations/sklearn/sklearn_trainer.py
@@ -4,7 +4,7 @@ import warnings
 from collections import defaultdict
 from time import time
 from traceback import format_exc
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,6 @@ import ray.cloudpickle as cpickle
 from ray.air.checkpoint import Checkpoint
 from ray.air.config import RunConfig, ScalingConfig
 from ray.air.constants import MODEL_KEY, TRAIN_DATASET_KEY
-from ray.air.preprocessor import Preprocessor
 from ray.air.trainer import GenDataset, Trainer
 from ray.air._internal.checkpointing import (
     load_preprocessor_from_dir,
@@ -32,6 +31,8 @@ from sklearn.model_selection import BaseCrossValidator, cross_validate
 # we are using a private API here, but it's consistent across versions
 from sklearn.model_selection._validation import _check_multimetric_scoring, _score
 
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +172,7 @@ class SklearnTrainer(Trainer):
         set_estimator_cpus: bool = True,
         scaling_config: Optional[ScalingConfig] = None,
         run_config: Optional[RunConfig] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         **fit_params,
     ):
         if fit_params.pop("resume_from_checkpoint", None):
@@ -439,7 +440,7 @@ class SklearnTrainer(Trainer):
 
 def load_checkpoint(
     checkpoint: Checkpoint,
-) -> Tuple[BaseEstimator, Optional[Preprocessor]]:
+) -> Tuple[BaseEstimator, Optional["Preprocessor"]]:
     """Load a Checkpoint from ``SklearnTrainer``.
 
     Args:

--- a/python/ray/air/train/integrations/tensorflow/tensorflow_trainer.py
+++ b/python/ray/air/train/integrations/tensorflow/tensorflow_trainer.py
@@ -1,13 +1,15 @@
-from typing import Callable, Optional, Dict, Tuple, Type, Union
+from typing import Callable, Optional, Dict, Tuple, Type, Union, TYPE_CHECKING
 import tensorflow as tf
 
 from ray.train.tensorflow import TensorflowConfig
 from ray.air.trainer import GenDataset
 from ray.air.train.data_parallel_trainer import DataParallelTrainer, _load_checkpoint
 from ray.air.config import ScalingConfig, RunConfig, DatasetConfig
-from ray.air.preprocessor import Preprocessor
 from ray.air.checkpoint import Checkpoint
 from ray.util import PublicAPI
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 @PublicAPI(stability="alpha")
@@ -166,7 +168,7 @@ class TensorflowTrainer(DataParallelTrainer):
         dataset_config: Optional[Dict[str, DatasetConfig]] = None,
         run_config: Optional[RunConfig] = None,
         datasets: Optional[Dict[str, GenDataset]] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
         if not tensorflow_config:
@@ -188,7 +190,7 @@ class TensorflowTrainer(DataParallelTrainer):
 def load_checkpoint(
     checkpoint: Checkpoint,
     model: Union[Callable[[], tf.keras.Model], Type[tf.keras.Model], tf.keras.Model],
-) -> Tuple[tf.keras.Model, Optional[Preprocessor]]:
+) -> Tuple[tf.keras.Model, Optional["Preprocessor"]]:
     """Load a Checkpoint from ``TensorflowTrainer``.
 
     Args:

--- a/python/ray/air/train/integrations/torch/torch_trainer.py
+++ b/python/ray/air/train/integrations/torch/torch_trainer.py
@@ -1,14 +1,16 @@
-from typing import Callable, Optional, Dict, Tuple, Union
+from typing import Callable, Optional, Dict, Tuple, Union, TYPE_CHECKING
 import torch
 
 from ray.train.torch import TorchConfig
 from ray.air.trainer import GenDataset
 from ray.air.train.data_parallel_trainer import DataParallelTrainer, _load_checkpoint
 from ray.air.config import ScalingConfig, RunConfig, DatasetConfig
-from ray.air.preprocessor import Preprocessor
 from ray.air.checkpoint import Checkpoint
 from ray.air._internal.torch_utils import load_torch_model
 from ray.util import PublicAPI
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 @PublicAPI(stability="alpha")
@@ -176,7 +178,7 @@ class TorchTrainer(DataParallelTrainer):
         dataset_config: Optional[Dict[str, DatasetConfig]] = None,
         run_config: Optional[RunConfig] = None,
         datasets: Optional[Dict[str, GenDataset]] = None,
-        preprocessor: Optional[Preprocessor] = None,
+        preprocessor: Optional["Preprocessor"] = None,
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
         if not torch_config:
@@ -197,7 +199,7 @@ class TorchTrainer(DataParallelTrainer):
 
 def load_checkpoint(
     checkpoint: Checkpoint, model: Optional[torch.nn.Module] = None
-) -> Tuple[torch.nn.Module, Optional[Preprocessor]]:
+) -> Tuple[torch.nn.Module, Optional["Preprocessor"]]:
     """Load a Checkpoint from ``TorchTrainer``.
 
     Args:

--- a/python/ray/air/train/integrations/xgboost/xgboost_trainer.py
+++ b/python/ray/air/train/integrations/xgboost/xgboost_trainer.py
@@ -1,8 +1,7 @@
 import os
-from typing import Optional, Tuple
+from typing import Optional, Tuple, TYPE_CHECKING
 
 from ray.air.checkpoint import Checkpoint
-from ray.air.preprocessor import Preprocessor
 from ray.air.train.gbdt_trainer import GBDTTrainer
 from ray.air._internal.checkpointing import load_preprocessor_from_dir
 from ray.util.annotations import PublicAPI
@@ -11,6 +10,9 @@ from ray.air.constants import MODEL_KEY
 import xgboost
 import xgboost_ray
 from xgboost_ray.tune import TuneReportCheckpointCallback
+
+if TYPE_CHECKING:
+    from ray.air.preprocessor import Preprocessor
 
 
 @PublicAPI(stability="alpha")
@@ -71,13 +73,13 @@ class XGBoostTrainer(GBDTTrainer):
 
     def _load_checkpoint(
         self, checkpoint: Checkpoint
-    ) -> Tuple[xgboost.Booster, Optional[Preprocessor]]:
+    ) -> Tuple[xgboost.Booster, Optional["Preprocessor"]]:
         return load_checkpoint(checkpoint)
 
 
 def load_checkpoint(
     checkpoint: Checkpoint,
-) -> Tuple[xgboost.Booster, Optional[Preprocessor]]:
+) -> Tuple[xgboost.Booster, Optional["Preprocessor"]]:
     """Load a Checkpoint from ``XGBoostTrainer``.
 
     Args:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Breaks the hard dependency on Preprocessor imports for type hints in AIR. Preparation for move of Preprocessors to `ray.data`.

Trainer still has a hard dependency due to an `isinstance` check.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
