### PR TITLE
[CI][minor] Disallow filters if command isn't specified.

### DIFF
--- a/ci/repro-ci.py
+++ b/ci/repro-ci.py
@@ -586,6 +586,10 @@ def main(
     commands: bool = False,
     filters: Optional[List[str]] = None,
 ):
+    if filters and not commands:
+        raise ValueError(
+            "Must specify the command flag '-c' to use filter options '-f'."
+        )
     random.seed(1235)
 
     logger = logging.getLogger("main")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Trivial "developer experience" tweak to the ci repro script:
disallow filtering commands if we're not running the commands.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
