### PR TITLE
[RLlib] added better error messages for multi-agent failure of sampler

### DIFF
--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -949,8 +949,21 @@ class SimpleListCollector(SampleCollector):
 
         if is_done:
             del self.episode_steps[episode_id]
-            del self.agent_steps[episode_id]
             del self.episodes[episode_id]
+
+            if episode_id in self.agent_steps:
+                del self.agent_steps[episode_id]
+            else:
+                assert len(pre_batches) == 0, \
+                    'Expected the batch to be empty since the episode_id is missing.'
+                # if the key does not exist it means that throughout the episode all
+                # observations were empty (i.e. there was no agent in the env)
+                msg = (
+                    f"Data from episode {episode_id} does not show any agent "
+                    f"interactions. Hint: Make sure for at least one timestep in the "
+                    f"episode, env.step() returns non-empty values."
+                )
+                raise ValueError(msg)
 
             # Make PolicyCollectorGroup available for more agent batches in
             # other episodes. Do not reset count to 0.

--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -954,8 +954,9 @@ class SimpleListCollector(SampleCollector):
             if episode_id in self.agent_steps:
                 del self.agent_steps[episode_id]
             else:
-                assert len(pre_batches) == 0, \
-                    'Expected the batch to be empty since the episode_id is missing.'
+                assert (
+                    len(pre_batches) == 0
+                ), "Expected the batch to be empty since the episode_id is missing."
                 # if the key does not exist it means that throughout the episode all
                 # observations were empty (i.e. there was no agent in the env)
                 msg = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses #24470 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
