### PR TITLE
[AIR][Serve] Add support for multi-modal array input

### DIFF
--- a/doc/source/serve/http-adapters.md
+++ b/doc/source/serve/http-adapters.md
@@ -141,6 +141,6 @@ Here is a list of adapters and please feel free to [contribute more](https://git
 
 ```{eval-rst}
 .. automodule:: ray.serve.http_adapters
-    :members: json_to_ndarray, image_to_ndarray, starlette_request, json_request, pandas_read_json
+    :members: json_to_ndarray, image_to_ndarray, starlette_request, json_request, pandas_read_json, json_to_multi_ndarray
 
 ```

--- a/python/ray/serve/http_adapters.py
+++ b/python/ray/serve/http_adapters.py
@@ -53,6 +53,12 @@ def json_to_ndarray(payload: NdArray) -> np.ndarray:
 
 
 @PublicAPI(stability="beta")
+def json_to_multi_ndarray(payload: Dict[str, NdArray]) -> Dict[str, np.ndarray]:
+    """Accepts a JSON of shape {str_key: NdArray} and converts it to dict of arrays."""
+    return {key: json_to_ndarray(arr_obj) for key, arr_obj in payload.items()}
+
+
+@PublicAPI(stability="beta")
 def starlette_request(
     request: starlette.requests.Request,
 ) -> starlette.requests.Request:

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -127,7 +127,8 @@ def collate_dataframe(
             return output_df
         if not isinstance(output_df, pd.DataFrame):
             raise TypeError(
-                f"The output should be a Pandas DataFrame but Serve got {type(output_df)}"
+                "The output should be a Pandas DataFrame but Serve got "
+                f"{type(output_df)}"
             )
         if len(output_df) % batch_size != 0:
             raise ValueError(

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -46,13 +46,15 @@ def collate_array(
     def unpack(output_arr):
         if isinstance(output_arr, list):
             return output_arr
-        assert isinstance(
-            output_arr, np.ndarray
-        ), f"The output should be np.ndarray but Serve got {type(output_arr)}."
-        assert len(output_arr) == batch_size, (
-            f"The output array should have shape of ({batch_size}, ...) "
-            f"but Serve got {output_arr.shape}"
-        )
+        if not isinstance(output_arr, np.ndarray):
+            raise TypeError(
+                f"The output should be np.ndarray but Serve got {type(output_arr)}."
+            )
+        if len(output_arr) != batch_size:
+            raise ValueError(
+                f"The output array should have shape of ({batch_size}, ...) "
+                f"but Serve got {output_arr.shape}"
+            )
         return [arr.squeeze(axis=0) for arr in np.split(output_arr, batch_size, axis=0)]
 
     return batched, unpack
@@ -93,9 +95,10 @@ def collate_dict_array(
         if isinstance(output_dict, list):
             return output_dict
 
-        assert isinstance(
-            output_dict, Dict
-        ), f"The output should be a dicitonary but Serve got {type(output_dict)}."
+        if not isinstance(output_dict, Dict):
+            raise TypeError(
+                f"The output should be a dictionary but Serve got {type(output_dict)}."
+            )
 
         split_list_of_dict = [{} for _ in range(batch_size)]
         for key, arr_unpack_func in unpack_dict.items():
@@ -121,13 +124,15 @@ def collate_dataframe(
     def unpack(output_df):
         if isinstance(output_df, list):
             return output_df
-        assert isinstance(
-            output_df, pd.DataFrame
-        ), f"The output should be a Pandas DataFrame but Serve got {type(output_df)}"
-        assert len(output_df) % batch_size == 0, (
-            f"The output dataframe should have length divisible by {batch_size}, "
-            f"but Serve got length {len(output_df)}."
-        )
+        if not isinstance(output_df, pd.DataFrame):
+            raise TypeError(
+                f"The output should be a Pandas DataFrame but Serve got {type(output_df)}"
+            )
+        if len(output_df) % batch_size != 0:
+            raise ValueError(
+                f"The output dataframe should have length divisible by {batch_size}, "
+                f"but Serve got length {len(output_df)}."
+            )
         return [df.reset_index(drop=True) for df in np.split(output_df, batch_size)]
 
     return batched, unpack

--- a/python/ray/serve/model_wrappers.py
+++ b/python/ray/serve/model_wrappers.py
@@ -53,6 +53,7 @@ def collate_array(
         if len(output_arr) != batch_size:
             raise ValueError(
                 f"The output array should have shape of ({batch_size}, ...) "
+                f"because the input has {batch_size} entries "
                 f"but Serve got {output_arr.shape}"
             )
         return [arr.squeeze(axis=0) for arr in np.split(output_arr, batch_size, axis=0)]
@@ -91,7 +92,7 @@ def collate_dict_array(
         unpack_dict[key] = unpack_func
 
     def unpack(output_dict: Dict[str, np.ndarray]):
-        # short circuit behavior, assume users know what they are doing.
+        # short circuit behavior, assume users already unpacked the output for us.
         if isinstance(output_dict, list):
             return output_dict
 
@@ -131,6 +132,7 @@ def collate_dataframe(
         if len(output_df) % batch_size != 0:
             raise ValueError(
                 f"The output dataframe should have length divisible by {batch_size}, "
+                f"because the input from {batch_size} different requests "
                 f"but Serve got length {len(output_df)}."
             )
         return [df.reset_index(drop=True) for df in np.split(output_df, batch_size)]

--- a/python/ray/serve/tests/test_http_adapters.py
+++ b/python/ray/serve/tests/test_http_adapters.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from ray.serve.http_adapters import (
     NdArray,
+    json_to_multi_ndarray,
     json_to_ndarray,
     image_to_ndarray,
     pandas_read_json,
@@ -49,6 +50,12 @@ def test_json_to_ndarray():
         json_to_ndarray(NdArray(array=[[1.9], [2.1]], shape=[1, 2], dtype="int")),
         np.array([[1.9, 2.1]]).astype("int"),
     )
+
+
+def test_json_to_multi_ndarray():
+    assert json_to_multi_ndarray(
+        {"a": NdArray(array=[1]), "b": NdArray(array=[3])}
+    ) == {"a": np.array(1), "b": np.array(3)}
 
 
 def test_image_to_ndarray():

--- a/python/ray/serve/tests/test_model_wrappers.py
+++ b/python/ray/serve/tests/test_model_wrappers.py
@@ -35,9 +35,9 @@ class TestCollationFunctions:
     def test_array_error(self):
         list_of_arr = [np.array([i]) for i in range(4)]
         _, unpack = collate_array(list_of_arr)
-        with pytest.raises(AssertionError, match="output array should have shape of"):
+        with pytest.raises(ValueError, match="output array should have shape of"):
             unpack(np.arange(2))
-        with pytest.raises(AssertionError, match="output should be np.ndarray but"):
+        with pytest.raises(TypeError, match="output should be np.ndarray but"):
             unpack("string")
 
     def test_dict_array(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray AIR's data batch type accepts no just simple array or dataframe, but also a dictionary of array. This PR adds support for that in Serve's model wrapper, as well as a new http adapter accepting that. Most code re-uses existing array implementation.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
