### PR TITLE
[Serve] Improve logs for new Serve REST API

### DIFF
--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -614,5 +614,6 @@ def run_graph(
         serve.start(_override_controller_namespace="serve")
         serve.run(app)
     except KeyboardInterrupt:
+        # Error is raised when this task is canceled with ray.cancel(), which
+        # happens when deploy_app() is called.
         logger.debug("Existing config deployment request terminated.")
-        pass

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -443,7 +443,10 @@ class ServeController:
 
         if self.config_deployment_request_ref is not None:
             ray.cancel(self.config_deployment_request_ref)
-            logger.debug("Canceled existing config deployment request.")
+            logger.info(
+                "Received new config deployment request. Cancelling "
+                "previous request."
+            )
 
         self.config_deployment_request_ref = run_graph.options(
             runtime_env=runtime_env
@@ -575,35 +578,41 @@ def run_graph(
     import_path: str, graph_env: dict, deployment_override_options: List[Dict]
 ):
     """Deploys a Serve application to the controller's Ray cluster."""
-    from ray import serve
-    from ray.serve.api import build
+    try:
+        from ray import serve
+        from ray.serve.api import build
 
-    # Import and build the graph
-    graph = import_attr(import_path)
-    app = build(graph)
+        # Import and build the graph
+        graph = import_attr(import_path)
+        app = build(graph)
 
-    # Override options for each deployment
-    for options in deployment_override_options:
-        name = options["name"]
+        # Override options for each deployment
+        for options in deployment_override_options:
+            name = options["name"]
 
-        # Merge graph-level and deployment-level runtime_envs
-        if "ray_actor_options" in options:
-            # If specified, get ray_actor_options from config
-            ray_actor_options = options["ray_actor_options"]
-        else:
-            # Otherwise, get options from graph code (and default to {} if code
-            # sets options to None)
-            ray_actor_options = app.deployments[name].ray_actor_options or {}
+            # Merge graph-level and deployment-level runtime_envs
+            if "ray_actor_options" in options:
+                # If specified, get ray_actor_options from config
+                ray_actor_options = options["ray_actor_options"]
+            else:
+                # Otherwise, get options from graph code (and default to {} if code
+                # sets options to None)
+                ray_actor_options = app.deployments[name].ray_actor_options or {}
 
-        deployment_env = ray_actor_options.get("runtime_env", {})
-        merged_env = override_runtime_envs_except_env_vars(graph_env, deployment_env)
+            deployment_env = ray_actor_options.get("runtime_env", {})
+            merged_env = override_runtime_envs_except_env_vars(
+                graph_env, deployment_env
+            )
 
-        ray_actor_options.update({"runtime_env": merged_env})
-        options["ray_actor_options"] = ray_actor_options
+            ray_actor_options.update({"runtime_env": merged_env})
+            options["ray_actor_options"] = ray_actor_options
 
-        # Update the deployment's options
-        app.deployments[name].set_options(**options)
+            # Update the deployment's options
+            app.deployments[name].set_options(**options)
 
-    # Run the graph locally on the cluster
-    serve.start(_override_controller_namespace="serve")
-    serve.run(app)
+        # Run the graph locally on the cluster
+        serve.start(_override_controller_namespace="serve")
+        serve.run(app)
+    except KeyboardInterrupt:
+        logger.debug("Existing config deployment request terminated.")
+        pass

--- a/python/ray/serve/endpoint_state.py
+++ b/python/ray/serve/endpoint_state.py
@@ -64,7 +64,7 @@ class EndpointState:
 
         existing_route_endpoint = self._get_endpoint_for_route(endpoint_info.route)
         if existing_route_endpoint is not None and existing_route_endpoint != endpoint:
-            logger.warn(
+            logger.debug(
                 f'route_prefix "{endpoint_info.route}" is currently '
                 f'registered to deployment "{existing_route_endpoint}". '
                 f'Re-registering route_prefix "{endpoint_info.route}" to '


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Serve REST API logs scary messages when Serve is operating normally. For example, [this is in the traceback](https://buildkite.com/ray-project/ray-builders-branch/builds/8031#01814430-10da-4cff-88a0-b9758e5dd296) when a new deployment graph is deployed:

```powershell
(ServeController pid=7252) 2022-06-08 17:21:55,088	ERROR worker.py:289 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::run_graph() (pid=8036, ip=127.0.0.1)
--
  | (ServeController pid=7252)   File "c:\install\ray\python\ray\serve\controller.py", line 589, in run_graph
  | (ServeController pid=7252)     serve.run(app)
  | (ServeController pid=7252)   File "c:\install\ray\python\ray\serve\api.py", line 634, in run
  | (ServeController pid=7252)     client.deploy_group(
  | (ServeController pid=7252)   File "c:\install\ray\python\ray\serve\client.py", line 58, in check
  | (ServeController pid=7252)     return f(self, *args, **kwargs)
  | (ServeController pid=7252)   File "c:\install\ray\python\ray\serve\client.py", line 314, in deploy_group
  | (ServeController pid=7252)     self._wait_for_deployment_healthy(name)
  | (ServeController pid=7252)   File "c:\install\ray\python\ray\serve\client.py", line 216, in _wait_for_deployment_healthy
  | (ServeController pid=7252)     time.sleep(CLIENT_POLLING_INTERVAL_S)
  | (ServeController pid=7252) KeyboardInterrupt
  | (ServeController pid=7252)
  | (ServeController pid=7252) During handling of the above exception, another exception occurred:
  | (ServeController pid=7252)
  | (ServeController pid=7252) ray::run_graph() (pid=8036, ip=127.0.0.1)
  | (ServeController pid=7252)   File "python\ray\_raylet.pyx", line 660, in ray._raylet.execute_task
  | (ServeController pid=7252)   File "python\ray\_raylet.pyx", line 692, in ray._raylet.execute_task
  | (ServeController pid=7252) ray.exceptions.TaskCancelledError: Task: TaskID(8394b964f7a642cdffffffffffffffffffffffff06000000) was cancelled

...

(ServeController pid=7252) WARNING 2022-06-08 17:21:57,146 controller 7252 endpoint_state.py:67 - route_prefix "/" is currently registered to deployment "BasicDriver". Re-registering route_prefix "/" to deployment "DAGDriver".
```

However, Serve is working normally in this traceback.

This change improves the logging by:
* Silently swallowing the `KeyboardInterrupt` exception.
* Changing the `route_prefix` re-registration message to a debug message instead of a warning.
* Always logging a message when a new REST API deploy request is received.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.