### PR TITLE
[rfc][doc] Add clarity to stability guidelines

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -48,7 +48,7 @@ sphinxemoji==0.2.0
 sphinx-jsonschema==1.17.2
 sphinx-panels==0.6.0
 sphinx-version-warning==1.1.2
-sphinx-book-theme==0.1.7
+sphinx-book-theme==0.3.2
 sphinx-external-toc==0.2.3
 sphinxcontrib.yt==0.2.2
 sphinx-sitemap==2.2.0

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -48,7 +48,7 @@ sphinxemoji==0.2.0
 sphinx-jsonschema==1.17.2
 sphinx-panels==0.6.0
 sphinx-version-warning==1.1.2
-sphinx-book-theme==0.3.2
+sphinx-book-theme==0.1.7
 sphinx-external-toc==0.2.3
 sphinxcontrib.yt==0.2.2
 sphinx-sitemap==2.2.0

--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -249,6 +249,7 @@ parts:
 
   - caption: Developer Guides
     chapters:
+      - file: ray-contribute/stability
       - file: ray-contribute/getting-involved
         sections:
           - file: ray-contribute/development

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -246,13 +246,67 @@ check recent tests known to be flaky.
 
 .. _`CI`: https://github.com/ray-project/ray/tree/master/ci
 
+.. _api-stability:
+
 API stability
 -------------
 
-Ray provides stability guarantees for its public APIs in Ray core and libraries. The level of stability provided depends on how the API is annotated.
+Ray provides stability guarantees for its public APIs in Ray core and libraries, which are decorated/labeled accordingly.
+
+An API can be labeled:
+
+* :ref:`PublicAPI <public-api-def>`, which means the API is exposed to end users. PublicAPI has three sub-levels (alpha, beta, stable), as described below.
+* :ref:`DeveloperAPI <developer-api-def>`, which means the API is explicitly exposed to *advanced* Ray users and library developers
+* :ref:`Deprecated <deprecated-api-def>`, which may be removed in future releases of Ray.
+
+Ray's PublicAPI stability definitions are based off the `Google stability level guidelines <https://google.aip.dev/181>`_, with minor differences:
+
+Alpha
+~~~~~
+
+An *alpha* component undergoes rapid iteration with a known set of users who
+**must** be tolerant of change. The number of users **should** be a
+curated, manageable set, such that it is feasible to communicate with all
+of them individually.
+
+Breaking changes **must** be both allowed and expected in alpha components, and
+users **must** have no expectation of stability.
+
+Beta
+~~~~
+
+A *beta* component **must** be considered complete and ready to be declared
+stable, subject to public testing.
+
+Because users of beta components tend to have a lower tolerance of change, beta
+components **should** be as stable as possible; however, the beta component
+**must** be permitted to change over time. These changes **should** be minimal
+but **may** include backwards-incompatible changes to beta components.
+
+Backwards-incompatible changes **must** be made only after a reasonable
+deprecation period to provide users with an opportunity to migrate their code.
+
+Stable
+~~~~~~
+
+A *stable* component **must** be fully-supported over the lifetime of the major
+API version. Because users expect such stability from components marked stable,
+there **must** be no breaking changes to these components within a major version
+(excluding extraordinary circumstances).
+
+Docstrings
+~~~~~~~~~~
+
+.. _public-api-def:
 
 .. autofunction:: ray.util.annotations.PublicAPI
+
+.. _developer-api-def:
+
 .. autofunction:: ray.util.annotations.DeveloperAPI
+
+.. _deprecated-api-def:
+
 .. autofunction:: ray.util.annotations.Deprecated
 
 Undecorated functions can be generally assumed to not be part of the Ray public API.
@@ -272,7 +326,7 @@ In Python APIs, consider forcing the use of kwargs instead of positional argumen
         pass
 
 For callback APIs, consider adding a ``**kwargs`` placeholder as a "forward compatibility placeholder" in case more args need to be passed to the callback in the future, e.g.:
- 
+
 .. code-block:: python
 
     def tune_user_callback(model, score, **future_kwargs):

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -246,73 +246,11 @@ check recent tests known to be flaky.
 
 .. _`CI`: https://github.com/ray-project/ray/tree/master/ci
 
-.. _api-stability:
-
-API stability
--------------
-
-Ray provides stability guarantees for its public APIs in Ray core and libraries, which are decorated/labeled accordingly.
-
-An API can be labeled:
-
-* :ref:`PublicAPI <public-api-def>`, which means the API is exposed to end users. PublicAPI has three sub-levels (alpha, beta, stable), as described below.
-* :ref:`DeveloperAPI <developer-api-def>`, which means the API is explicitly exposed to *advanced* Ray users and library developers
-* :ref:`Deprecated <deprecated-api-def>`, which may be removed in future releases of Ray.
-
-Ray's PublicAPI stability definitions are based off the `Google stability level guidelines <https://google.aip.dev/181>`_, with minor differences:
-
-Alpha
-~~~~~
-
-An *alpha* component undergoes rapid iteration with a known set of users who
-**must** be tolerant of change. The number of users **should** be a
-curated, manageable set, such that it is feasible to communicate with all
-of them individually.
-
-Breaking changes **must** be both allowed and expected in alpha components, and
-users **must** have no expectation of stability.
-
-Beta
-~~~~
-
-A *beta* component **must** be considered complete and ready to be declared
-stable, subject to public testing.
-
-Because users of beta components tend to have a lower tolerance of change, beta
-components **should** be as stable as possible; however, the beta component
-**must** be permitted to change over time. These changes **should** be minimal
-but **may** include backwards-incompatible changes to beta components.
-
-Backwards-incompatible changes **must** be made only after a reasonable
-deprecation period to provide users with an opportunity to migrate their code.
-
-Stable
-~~~~~~
-
-A *stable* component **must** be fully-supported over the lifetime of the major
-API version. Because users expect such stability from components marked stable,
-there **must** be no breaking changes to these components within a major version
-(excluding extraordinary circumstances).
-
-Docstrings
-~~~~~~~~~~
-
-.. _public-api-def:
-
-.. autofunction:: ray.util.annotations.PublicAPI
-
-.. _developer-api-def:
-
-.. autofunction:: ray.util.annotations.DeveloperAPI
-
-.. _deprecated-api-def:
-
-.. autofunction:: ray.util.annotations.Deprecated
-
-Undecorated functions can be generally assumed to not be part of the Ray public API.
 
 API compatibility style guide
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
+
+Ray provides stability guarantees for its public APIs in Ray core and libraries, which are described in the :ref:`API Stability guide <api-stability>`.
 
 It's hard to fully capture the semantics of API compatibility into a single annotation (for example, public APIs may have "experimental" arguments). For more granular stability contracts, those can be noted in the pydoc (e.g., "the ``random_shuffle`` option is experimental"). When possible, experimental arguments should also be prefixed by underscores in Python (e.g., `_owner=`).
 
@@ -331,6 +269,8 @@ For callback APIs, consider adding a ``**kwargs`` placeholder as a "forward comp
 
     def tune_user_callback(model, score, **future_kwargs):
         pass
+
+
 
 Becoming a Reviewer
 -------------------

--- a/doc/source/ray-contribute/stability.rst
+++ b/doc/source/ray-contribute/stability.rst
@@ -1,0 +1,64 @@
+.. _api-stability:
+
+API stability
+-------------
+
+Ray provides stability guarantees for its public APIs in Ray core and libraries, which are decorated/labeled accordingly.
+
+An API can be labeled:
+
+* :ref:`PublicAPI <public-api-def>`, which means the API is exposed to end users. PublicAPI has three sub-levels (alpha, beta, stable), as described below.
+* :ref:`DeveloperAPI <developer-api-def>`, which means the API is explicitly exposed to *advanced* Ray users and library developers
+* :ref:`Deprecated <deprecated-api-def>`, which may be removed in future releases of Ray.
+
+Ray's PublicAPI stability definitions are based off the `Google stability level guidelines <https://google.aip.dev/181>`_, with minor differences:
+
+Alpha
+~~~~~
+
+An *alpha* component undergoes rapid iteration with a known set of users who
+**must** be tolerant of change. The number of users **should** be a
+curated, manageable set, such that it is feasible to communicate with all
+of them individually.
+
+Breaking changes **must** be both allowed and expected in alpha components, and
+users **must** have no expectation of stability.
+
+Beta
+~~~~
+
+A *beta* component **must** be considered complete and ready to be declared
+stable, subject to public testing.
+
+Because users of beta components tend to have a lower tolerance of change, beta
+components **should** be as stable as possible; however, the beta component
+**must** be permitted to change over time. These changes **should** be minimal
+but **may** include backwards-incompatible changes to beta components.
+
+Backwards-incompatible changes **must** be made only after a reasonable
+deprecation period to provide users with an opportunity to migrate their code.
+
+Stable
+~~~~~~
+
+A *stable* component **must** be fully-supported over the lifetime of the major
+API version. Because users expect such stability from components marked stable,
+there **must** be no breaking changes to these components within a major version
+(excluding extraordinary circumstances).
+
+Docstrings
+----------
+
+.. _public-api-def:
+
+.. autofunction:: ray.util.annotations.PublicAPI
+
+.. _developer-api-def:
+
+.. autofunction:: ray.util.annotations.DeveloperAPI
+
+.. _deprecated-api-def:
+
+.. autofunction:: ray.util.annotations.Deprecated
+
+Undecorated functions can be generally assumed to not be part of the Ray public API.

--- a/doc/source/ray-contribute/stability.rst
+++ b/doc/source/ray-contribute/stability.rst
@@ -1,7 +1,7 @@
 .. _api-stability:
 
 API stability
--------------
+=============
 
 Ray provides stability guarantees for its public APIs in Ray core and libraries, which are decorated/labeled accordingly.
 

--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -45,7 +45,7 @@ def PublicAPI(*args, **kwargs):
         if stability in ["alpha", "beta"]:
             obj.__doc__ += (
                 f"\n    PublicAPI ({stability}): This API is in {stability} "
-                "and may change before becoming stable. "
+                "and may change before becoming stable."
             )
         else:
             obj.__doc__ += "\n    PublicAPI: This API is stable across Ray releases."

--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -1,18 +1,19 @@
 def PublicAPI(*args, **kwargs):
     """Annotation for documenting public APIs.
 
-    Public APIs are classes and methods exposed to end users of Ray. You
-    can expect these APIs to remain backwards compatible across minor Ray
-    releases (e.g., Ray 1.4 -> 1.8).
+    Public APIs are classes and methods exposed to end users of Ray.
 
-    If "stability" is beta, the API is still public and can be used by early
-    users, but are subject to change.
-
-    If "stability" is alpha, the API can be used by advanced users who are
+    If ``stability="alpha"``, the API can be used by advanced users who are
     tolerant to and expect breaking changes.
 
+    If ``stability="beta"``, the API is still public and can be used by early
+    users, but are subject to change.
+
+    If ``stability="stable"``, the APIs will remain backwards compatible across
+    minor Ray releases (e.g., Ray 1.4 -> 1.8).
+
     For a full definition of the stability levels, please refer to the
-    `Google stability level guidelines <https://google.aip.dev/181>`_
+    `Ray API Stability definitions <api-stability>`_.
 
     Args:
         stability: One of {"stable", "beta", "alpha"}.
@@ -44,10 +45,15 @@ def PublicAPI(*args, **kwargs):
         if stability in ["alpha", "beta"]:
             obj.__doc__ += (
                 f"\n    PublicAPI ({stability}): This API is in {stability} "
-                "and may change before becoming stable."
+                "and may change before becoming stable. "
             )
         else:
             obj.__doc__ += "\n    PublicAPI: This API is stable across Ray releases."
+
+        obj.__doc__ += (
+            "(`Definitions <https://docs.ray.io/en/latest/"
+            "ray-contribute/getting-involved.html#api-stability>`_)"
+        )
         _mark_annotated(obj)
         return obj
 

--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -50,10 +50,6 @@ def PublicAPI(*args, **kwargs):
         else:
             obj.__doc__ += "\n    PublicAPI: This API is stable across Ray releases."
 
-        obj.__doc__ += (
-            "(`Definitions <https://docs.ray.io/en/latest/"
-            "ray-contribute/getting-involved.html#api-stability>`_)"
-        )
         _mark_annotated(obj)
         return obj
 

--- a/python/ray/util/annotations.py
+++ b/python/ray/util/annotations.py
@@ -13,7 +13,7 @@ def PublicAPI(*args, **kwargs):
     minor Ray releases (e.g., Ray 1.4 -> 1.8).
 
     For a full definition of the stability levels, please refer to the
-    `Ray API Stability definitions <api-stability>`_.
+    :ref:`Ray API Stability definitions <api-stability>`.
 
     Args:
         stability: One of {"stable", "beta", "alpha"}.


### PR DESCRIPTION
## Why are these changes needed?

Google guidelines were 1. not indexable and 2. not precisely relevant for our project.

This PR aims to make the stability guidelines much more clear.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(