### PR TITLE
[Datasets] Add UDF passthrough args to map_batches().

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -35,11 +35,6 @@ from ray.data.read_api import (  # noqa: F401
     read_text,
 )
 
-# Module-level cached global functions (for impl/compute). It cannot be defined
-# in impl/compute since it has to be process-global across cloudpickled funcs.
-_cached_fn = None
-_cached_cls = None
-
 # Register custom Arrow JSON ReadOptions serializer after worker has initialized.
 if ray.is_initialized():
     _register_arrow_json_readoptions_serializer()

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import ray
 from ray.data._internal.block_list import BlockList
@@ -8,11 +8,14 @@ from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data.block import (
+    BatchUDF,
     Block,
     BlockAccessor,
     BlockExecStats,
     BlockMetadata,
     BlockPartition,
+    CallableClass,
+    RowUDF,
 )
 from ray.data.context import DEFAULT_SCHEDULING_STRATEGY, DatasetContext
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -22,13 +25,30 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 U = TypeVar("U")
 
-# A class type that implements __call__.
-CallableClass = type
+# Block transform function applied by task and actor pools.
+BlockTransform = Union[
+    # TODO(Clark): Once Ray only supports Python 3.8+, use protocol to constrain block
+    # transform type.
+    # Callable[[Block, ...], Iterable[Block]]
+    # Callable[[Block, BatchUDF, ...], Iterable[Block]],
+    Callable[[Block], Iterable[Block]],
+    Callable[[Block, Union[BatchUDF, RowUDF]], Iterable[Block]],
+    Callable[..., Iterable[Block]],
+]
+
+# UDF on a batch or row.
+UDF = Union[BatchUDF, RowUDF]
 
 
 @DeveloperAPI
 class ComputeStrategy:
-    def _apply(self, fn: Any, blocks: BlockList, clear_input_blocks: bool) -> BlockList:
+    def _apply(
+        self,
+        block_fn: BlockTransform,
+        remote_args: dict,
+        blocks: BlockList,
+        clear_input_blocks: bool,
+    ) -> BlockList:
         raise NotImplementedError
 
 
@@ -36,12 +56,23 @@ class ComputeStrategy:
 class TaskPoolStrategy(ComputeStrategy):
     def _apply(
         self,
-        fn: Any,
+        block_fn: BlockTransform,
         remote_args: dict,
         block_list: BlockList,
         clear_input_blocks: bool,
         name: Optional[str] = None,
+        fn: Optional[UDF] = None,
+        fn_args: Optional[List[Any]] = None,
+        fn_kwargs: Optional[Dict[str, Any]] = None,
+        fn_constructor_args: Optional[List[Any]] = None,
+        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
     ) -> BlockList:
+        assert fn_constructor_args is None and fn_constructor_kwargs is None
+        if fn_args is None:
+            fn_args = tuple()
+        if fn_kwargs is None:
+            fn_kwargs = {}
+
         context = DatasetContext.get_current()
 
         # Handle empty datasets.
@@ -56,12 +87,18 @@ class TaskPoolStrategy(ComputeStrategy):
 
         if context.block_splitting_enabled:
             map_block = cached_remote_fn(_map_block_split).options(**remote_args)
-            refs = [map_block.remote(b, fn, m.input_files) for b, m in blocks]
+            refs = [
+                map_block.remote(b, block_fn, m.input_files, fn, *fn_args, **fn_kwargs)
+                for b, m in blocks
+            ]
         else:
             map_block = cached_remote_fn(_map_block_nosplit).options(
                 **dict(remote_args, num_returns=2)
             )
-            all_refs = [map_block.remote(b, fn, m.input_files) for b, m in blocks]
+            all_refs = [
+                map_block.remote(b, block_fn, m.input_files, fn, *fn_args, **fn_kwargs)
+                for b, m in blocks
+            ]
             data_refs = [r[0] for r in all_refs]
             refs = [r[1] for r in all_refs]
 
@@ -150,13 +187,27 @@ class ActorPoolStrategy(ComputeStrategy):
 
     def _apply(
         self,
-        fn: Any,
+        block_fn: BlockTransform,
         remote_args: dict,
         block_list: BlockList,
         clear_input_blocks: bool,
         name: Optional[str] = None,
+        fn: Optional[UDF] = None,
+        fn_args: Optional[List[Any]] = None,
+        fn_kwargs: Optional[Dict[str, Any]] = None,
+        fn_constructor_args: Optional[List[Any]] = None,
+        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
     ) -> BlockList:
         """Note: this is not part of the Dataset public API."""
+        if fn_args is None:
+            fn_args = tuple()
+        if fn_kwargs is None:
+            fn_kwargs = {}
+        if fn_constructor_args is None:
+            fn_constructor_args = tuple()
+        if fn_constructor_kwargs is None:
+            fn_constructor_kwargs = {}
+
         context = DatasetContext.get_current()
 
         blocks_in = block_list.get_blocks_with_metadata()
@@ -173,19 +224,46 @@ class ActorPoolStrategy(ComputeStrategy):
         map_bar = ProgressBar(name, total=orig_num_blocks)
 
         class BlockWorker:
+            def __init__(
+                self,
+                *fn_constructor_args: Any,
+                **fn_constructor_kwargs: Any,
+            ):
+                if not isinstance(fn, CallableClass):
+                    if fn_constructor_args or fn_constructor_kwargs:
+                        raise ValueError(
+                            "fn_constructor_{kw}args only valid for CallableClass "
+                            f"UDFs, but got: {fn}"
+                        )
+                    self.fn = fn
+                else:
+                    self.fn = fn(*fn_constructor_args, **fn_constructor_kwargs)
+
             def ready(self):
                 return "ok"
 
             def map_block_split(
-                self, block: Block, input_files: List[str]
+                self,
+                block: Block,
+                input_files: List[str],
+                *fn_args,
+                **fn_kwargs,
             ) -> BlockPartition:
-                return _map_block_split(block, fn, input_files)
+                return _map_block_split(
+                    block, block_fn, input_files, self.fn, *fn_args, **fn_kwargs
+                )
 
             @ray.method(num_returns=2)
             def map_block_nosplit(
-                self, block: Block, input_files: List[str]
+                self,
+                block: Block,
+                input_files: List[str],
+                *fn_args,
+                **fn_kwargs,
             ) -> Tuple[Block, BlockMetadata]:
-                return _map_block_nosplit(block, fn, input_files)
+                return _map_block_nosplit(
+                    block, block_fn, input_files, self.fn, *fn_args, **fn_kwargs
+                )
 
         if not remote_args:
             remote_args["num_cpus"] = 1
@@ -199,7 +277,10 @@ class ActorPoolStrategy(ComputeStrategy):
 
         BlockWorker = ray.remote(**remote_args)(BlockWorker)
 
-        workers = [BlockWorker.remote() for _ in range(self.min_size)]
+        workers = [
+            BlockWorker.remote(*fn_constructor_args, **fn_constructor_kwargs)
+            for _ in range(self.min_size)
+        ]
         tasks = {w.ready.remote(): w for w in workers}
         tasks_in_flight = collections.defaultdict(int)
         metadata_mapping = {}
@@ -216,7 +297,9 @@ class ActorPoolStrategy(ComputeStrategy):
                         len(workers) < self.max_size
                         and len(ready_workers) / len(workers) > 0.8
                     ):
-                        w = BlockWorker.remote()
+                        w = BlockWorker.remote(
+                            *fn_constructor_args, **fn_constructor_kwargs
+                        )
                         workers.append(w)
                         tasks[w.ready.remote()] = w
                         map_bar.set_description(
@@ -249,10 +332,18 @@ class ActorPoolStrategy(ComputeStrategy):
                 ):
                     block, meta = blocks_in.pop()
                     if context.block_splitting_enabled:
-                        ref = worker.map_block_split.remote(block, meta.input_files)
+                        ref = worker.map_block_split.remote(
+                            block,
+                            meta.input_files,
+                            *fn_args,
+                            **fn_kwargs,
+                        )
                     else:
                         ref, meta_ref = worker.map_block_nosplit.remote(
-                            block, meta.input_files
+                            block,
+                            meta.input_files,
+                            *fn_args,
+                            **fn_kwargs,
                         )
                         metadata_mapping[ref] = meta_ref
                     tasks[ref] = worker
@@ -285,43 +376,6 @@ class ActorPoolStrategy(ComputeStrategy):
                 raise e
 
 
-def cache_wrapper(
-    fn: Union[CallableClass, Callable[[Any], Any]],
-    compute: Optional[Union[str, ComputeStrategy]],
-) -> Callable[[Any], Any]:
-    """Implements caching of stateful callables.
-
-    Args:
-        fn: Either a plain function or class of a stateful callable.
-
-    Returns:
-        A plain function with per-process initialization cached as needed.
-    """
-    if isinstance(fn, CallableClass):
-
-        if (
-            compute is None
-            or compute == "tasks"
-            or isinstance(compute, TaskPoolStrategy)
-        ):
-            raise ValueError(
-                "``compute`` must be specified when using a callable class, and must "
-                "specify the actor compute strategy. "
-                'For example, use ``compute="actors"`` or '
-                "``compute=ActorPoolStrategy(min, max)``."
-            )
-
-        def _fn(item: Any) -> Any:
-            if ray.data._cached_fn is None or ray.data._cached_cls != fn:
-                ray.data._cached_cls = fn
-                ray.data._cached_fn = fn()
-            return ray.data._cached_fn(item)
-
-        return _fn
-    else:
-        return fn
-
-
 def get_compute(compute_spec: Union[str, ComputeStrategy]) -> ComputeStrategy:
     if not compute_spec or compute_spec == "tasks":
         return TaskPoolStrategy()
@@ -341,10 +395,19 @@ def is_task_compute(compute_spec: Union[str, ComputeStrategy]) -> bool:
     )
 
 
-def _map_block_split(block: Block, fn: Any, input_files: List[str]) -> BlockPartition:
+def _map_block_split(
+    block: Block,
+    block_fn: BlockTransform,
+    input_files: List[str],
+    fn: Optional[UDF],
+    *fn_args,
+    **fn_kwargs,
+) -> BlockPartition:
     output = []
     stats = BlockExecStats.builder()
-    for new_block in fn(block):
+    if fn is not None:
+        fn_args = (fn,) + fn_args
+    for new_block in block_fn(block, *fn_args, **fn_kwargs):
         accessor = BlockAccessor.for_block(new_block)
         new_meta = BlockMetadata(
             num_rows=accessor.num_rows(),
@@ -360,11 +423,18 @@ def _map_block_split(block: Block, fn: Any, input_files: List[str]) -> BlockPart
 
 
 def _map_block_nosplit(
-    block: Block, fn: Any, input_files: List[str]
+    block: Block,
+    block_fn: BlockTransform,
+    input_files: List[str],
+    fn: Optional[UDF],
+    *fn_args,
+    **fn_kwargs,
 ) -> Tuple[Block, BlockMetadata]:
     stats = BlockExecStats.builder()
     builder = DelegatingBlockBuilder()
-    for new_block in fn(block):
+    if fn is not None:
+        fn_args = (fn,) + fn_args
+    for new_block in block_fn(block, *fn_args, **fn_kwargs):
         builder.add_block(new_block)
     new_block = builder.build()
     accessor = BlockAccessor.for_block(new_block)

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -62,9 +62,9 @@ class TaskPoolStrategy(ComputeStrategy):
         clear_input_blocks: bool,
         name: Optional[str] = None,
         fn: Optional[UDF] = None,
-        fn_args: Optional[List[Any]] = None,
+        fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[List[Any]] = None,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
         fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
     ) -> BlockList:
         assert fn_constructor_args is None and fn_constructor_kwargs is None
@@ -193,9 +193,9 @@ class ActorPoolStrategy(ComputeStrategy):
         clear_input_blocks: bool,
         name: Optional[str] = None,
         fn: Optional[UDF] = None,
-        fn_args: Optional[List[Any]] = None,
+        fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[List[Any]] = None,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
         fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
     ) -> BlockList:
         """Note: this is not part of the Dataset public API."""

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1,35 +1,36 @@
 import copy
+import uuid
 from typing import (
+    TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
-    List,
-    Tuple,
-    Optional,
-    Union,
-    Any,
-    Iterator,
     Iterable,
-    TYPE_CHECKING,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
 )
-import uuid
+
+import ray
+from ray.data._internal.block_list import BlockList
+from ray.data._internal.compute import (
+    UDF,
+    ActorPoolStrategy,
+    BlockTransform,
+    ComputeStrategy,
+    get_compute,
+    is_task_compute,
+)
+from ray.data._internal.lazy_block_list import LazyBlockList
+from ray.data._internal.stats import DatasetStats
+from ray.data.block import Block
+from ray.data.context import DatasetContext
 
 if TYPE_CHECKING:
     import pyarrow
 
-import ray
-from ray.data.context import DatasetContext
-from ray.data.block import Block
-from ray.data._internal.block_list import BlockList
-from ray.data._internal.compute import (
-    get_compute,
-    is_task_compute,
-    ComputeStrategy,
-    ActorPoolStrategy,
-    BlockTransform,
-    UDF,
-)
-from ray.data._internal.stats import DatasetStats
-from ray.data._internal.lazy_block_list import LazyBlockList
 
 # Scheduling strategy can be inherited from prev stage if not specified.
 INHERITABLE_REMOTE_ARGS = ["scheduling_strategy"]

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -98,6 +98,29 @@ Block = Union[List[T], "pyarrow.Table", "pandas.DataFrame", bytes]
 # returned from batch UDFs.
 DataBatch = Union[Block, np.ndarray, Dict[str, np.ndarray]]
 
+# A class type that implements __call__.
+CallableClass = type
+
+# A UDF on data batches.
+BatchUDF = Union[
+    # TODO(Clark): Once Ray only supports Python 3.8+, use protocol to constraint batch
+    # UDF type.
+    # Callable[[DataBatch, ...], DataBatch]
+    Callable[[DataBatch], DataBatch],
+    Callable[..., DataBatch],
+    CallableClass,
+]
+
+# A UDF on data rows.
+RowUDF = Union[
+    # TODO(Clark): Once Ray only supports Python 3.8+, use protocol to constraint batch
+    # UDF type.
+    # Callable[[T, ...], U]
+    Callable[[T], U],
+    Callable[..., U],
+    CallableClass,
+]
+
 # A list of block references pending computation by a single task. For example,
 # this may be the output of a task reading a file.
 BlockPartition = List[Tuple[ObjectRef[Block], "BlockMetadata"]]

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3333,26 +3333,14 @@ class Dataset(Generic[T]):
             state["_last_export_session_and_job"] = None
             return reconstructor, args, state
 
-        def _reduce_object_ref(object_ref: ray.ObjectRef):
-            raise ValueError(
-                "Lineage-based serialization is not supported for this dataset since "
-                "it contains an object ref in its lineage, which "
-                "means that it cannot be used as a tunable hyperparameter."
-                "Note this includes calling map_batches() on a UDF that closes over "
-                "object refs or with extra args via fn_{constructor_}_{kw}args that "
-                "contain object refs."
-            )
-
         context = ray._private.worker.global_worker.get_serialization_context()
         try:
             context._register_cloudpickle_reducer(
                 ray.remote_function.RemoteFunction, _reduce_remote_fn
             )
-            context._register_cloudpickle_reducer(ray.ObjectRef, _reduce_object_ref)
             serialized = pickle.dumps(ds)
         finally:
             context._unregister_cloudpickle_reducer(ray.remote_function.RemoteFunction)
-            context._unregister_cloudpickle_reducer(ray.ObjectRef)
         return serialized
 
     @staticmethod

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -288,9 +288,9 @@ class Dataset(Generic[T]):
         batch_size: Optional[int] = 4096,
         compute: Union[str, ComputeStrategy] = None,
         batch_format: str = "native",
-        fn_args: Optional[List[Any]] = None,
+        fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[List[Any]] = None,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
         fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
         **ray_remote_args,
     ) -> "Dataset[Any]":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -234,7 +234,12 @@ class Dataset(Generic[T]):
                 that can be instantiated to create such a callable. Callable classes are
                 only supported for the actor compute strategy.
             compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
+                tasks, or "actors" to use an autoscaling actor pool. If wanting to
+                configure the min or max size of the autoscaling actor pool, you can
+                provide an
+                :class:`ActorPoolStrategy(min, max) <ray.data.ActorPoolStrategy>`
+                instance. If using callable classes for fn, the actor compute strategy
+                must be used.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
@@ -339,7 +344,12 @@ class Dataset(Generic[T]):
             batch_size: Request a specific batch size, or None to use entire
                 blocks as batches. Defaults to a system-chosen batch size.
             compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
+                tasks, or "actors" to use an autoscaling actor pool. If wanting to
+                configure the min or max size of the autoscaling actor pool, you can
+                provide an
+                :class:`ActorPoolStrategy(min, max) <ray.data.ActorPoolStrategy>`
+                instance. If using callable classes for fn, the actor compute strategy
+                must be used.
             batch_format: Specify "native" to use the native block format (promotes
                 tables to Pandas and tensors to NumPy), "pandas" to select
                 ``pandas.DataFrame``, "pyarrow" to select ``pyarrow.Table``, or "numpy"
@@ -539,7 +549,12 @@ class Dataset(Generic[T]):
                 that can be instantiated to create such a callable. Callable classes are
                 only supported for the actor compute strategy.
             compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
+                tasks, or "actors" to use an autoscaling actor pool. If wanting to
+                configure the min or max size of the autoscaling actor pool, you can
+                provide an
+                :class:`ActorPoolStrategy(min, max) <ray.data.ActorPoolStrategy>`
+                instance. If using callable classes for fn, the actor compute strategy
+                must be used.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
@@ -600,7 +615,12 @@ class Dataset(Generic[T]):
                 that can be instantiated to create such a callable. Callable classes are
                 only supported for the actor compute strategy.
             compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, or ActorPoolStrategy(min, max) to use an autoscaling actor pool.
+                tasks, or "actors" to use an autoscaling actor pool. If wanting to
+                configure the min or max size of the autoscaling actor pool, you can
+                provide an
+                :class:`ActorPoolStrategy(min, max) <ray.data.ActorPoolStrategy>`
+                instance. If using callable classes for fn, the actor compute strategy
+                must be used.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -316,49 +316,6 @@ def test_dataset_lineage_serialization_unsupported(shutdown_only, lazy):
     with pytest.raises(ValueError):
         ds2.serialize_lineage()
 
-    # Object refs captured in UDF.
-    # TODO(Clark): Enable this test case after Ray Core hang on closed ref fetch is
-    # fixed.
-    # obj = ray.put(1)
-    # ds = ray.data.range(10)
-    # ds = maybe_lazy(ds, lazy)
-    # ds = ds.map_batches(
-    #     lambda x: [x_ + ray.get(obj) for x_ in x], batch_size=2,
-    # )
-
-    # with pytest.raises(ValueError):
-    #     ds.serialize_lineage()
-
-    # Object refs captured in stage.
-    obj = ray.put(1)
-    ds = ray.data.range(10)
-    ds = maybe_lazy(ds, lazy)
-    ds = ds.map_batches(lambda x, v: [x_ + v for x_ in x], batch_size=2, fn_args=(obj,))
-
-    with pytest.raises(ValueError):
-        ds.serialize_lineage()
-
-    obj = ray.put(1)
-    ds = ray.data.range(10)
-    ds = maybe_lazy(ds, lazy)
-
-    class CallableClass:
-        def __init__(self, v):
-            self.v = v
-
-        def __call__(self, x):
-            return [x_ + self.v for x_ in x]
-
-    ds = ds.map_batches(
-        CallableClass,
-        batch_size=2,
-        compute="actors",
-        fn_constructor_args=(obj,),
-    )
-
-    with pytest.raises(ValueError):
-        ds.serialize_lineage()
-
 
 @pytest.mark.parametrize("pipelined", [False, True])
 def test_basic(ray_start_regular_shared, pipelined):

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -3,6 +3,8 @@ from typing import List
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 import ray
@@ -424,6 +426,100 @@ def test_optimize_incompatible_stages(ray_start_regular_shared):
             "map_batches",
             "random_shuffle_map",
             "random_shuffle_reduce",
+        ],
+    )
+
+
+def test_optimize_callable_classes(ray_start_regular_shared, tmp_path):
+    context = DatasetContext.get_current()
+    context.optimize_fuse_stages = True
+    context.optimize_fuse_read_stages = True
+    context.optimize_fuse_shuffle_stages = True
+
+    # Set up.
+    df = pd.DataFrame({"one": [1, 2, 3], "two": [2, 3, 4]})
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, os.path.join(tmp_path, "test1.parquet"))
+
+    class CallableFn:
+        def __init__(self, a, b=None):
+            assert a == 1
+            assert b == 2
+            self.a = a
+            self.b = b
+
+        def __call__(self, x):
+            return self.b * x + self.a
+
+    # Test callable chain.
+    fn_constructor_args = (ray.put(1),)
+    fn_constructor_kwargs = {"b": ray.put(2)}
+    pipe = (
+        ray.data.read_parquet(str(tmp_path))
+        .repeat(2)
+        .map_batches(
+            CallableFn,
+            batch_size=1,
+            batch_format="pandas",
+            compute="actors",
+            fn_constructor_args=fn_constructor_args,
+            fn_constructor_kwargs=fn_constructor_kwargs,
+        )
+        .map_batches(
+            CallableFn,
+            batch_size=1,
+            batch_format="pandas",
+            compute="actors",
+            fn_constructor_args=fn_constructor_args,
+            fn_constructor_kwargs=fn_constructor_kwargs,
+        )
+    )
+    ds_list = pipe.take()
+    values = [s["one"] for s in ds_list]
+    assert values == [7, 11, 15, 7, 11, 15]
+    values = [s["two"] for s in ds_list]
+    assert values == [11, 15, 19, 11, 15, 19]
+    expect_stages(
+        pipe,
+        1,
+        [
+            "read->map_batches->map_batches",
+        ],
+    )
+
+    # Test function + callable chain.
+    fn_constructor_args = (ray.put(1),)
+    fn_constructor_kwargs = {"b": ray.put(2)}
+    pipe = (
+        ray.data.read_parquet(str(tmp_path))
+        .repeat(2)
+        .map_batches(
+            lambda df, a, b=None: b * df + a,
+            batch_size=1,
+            batch_format="pandas",
+            compute="actors",
+            fn_args=(ray.put(1),),
+            fn_kwargs={"b": ray.put(2)},
+        )
+        .map_batches(
+            CallableFn,
+            batch_size=1,
+            batch_format="pandas",
+            compute="actors",
+            fn_constructor_args=fn_constructor_args,
+            fn_constructor_kwargs=fn_constructor_kwargs,
+        )
+    )
+    ds_list = pipe.take()
+    values = [s["one"] for s in ds_list]
+    assert values == [7, 11, 15, 7, 11, 15]
+    values = [s["two"] for s in ds_list]
+    assert values == [11, 15, 19, 11, 15, 19]
+    expect_stages(
+        pipe,
+        1,
+        [
+            "read->map_batches->map_batches",
         ],
     )
 


### PR DESCRIPTION
Users often have UDFs that require arguments only known at Dataset creation time, and sometimes these arguments may be large objects better suited for shared zero-copy access via the object store. One example is batch inference on a large on-CPU model using the actor pool strategy: without putting the large model into the object store and sharing across actors on the same node, each actor worker will need its own copy of the model.

Unfortunately, we can't rely on closing over these object refs, since the object ref will then be serialized in the exported function/class definition, causing the object to be indefinitely pinned and therefore leaked. It's much cleaner to instead link these object refs in as actor creation and task arguments. This PR adds support for threading such object refs through as actor creation and task arguments and supplying the concrete values to the UDFs.

## TODOs

- [x] Add docs/example to "Transforming Datasets" user guide

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
