### PR TITLE
[docs] Try to clarify some advantages of bulk ingest in the AIR ingest docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 
 # ==== Documentation ====
 
-/doc/ @maxpumperla @pcmoritz @richardliaw @edoakes @simon-mo
+/doc/ @maxpumperla @pcmoritz @richardliaw @edoakes @simon-mo @ericl
 
 # ==== Ray core ====
 


### PR DESCRIPTION
Clarify the caching behavior of preprocessors with bulk vs streaming ingest.