### PR TITLE
[RLlib] Fix ModelCatalog for nested complex inputs

### DIFF
--- a/rllib/algorithms/sac/tests/test_sac.py
+++ b/rllib/algorithms/sac/tests/test_sac.py
@@ -101,7 +101,12 @@ class TestSAC(unittest.TestCase):
                         {
                             "a": simple_space,
                             "b": Discrete(2),
-                            "c": image_space,
+                            "c": Dict(
+                                {
+                                    "c1": image_space,
+                                    "c2": image_space,
+                                }
+                            ),
                         }
                     ),
                     "action_space": Box(-1.0, 1.0, shape=(1,)),

--- a/rllib/algorithms/sac/tests/test_sac.py
+++ b/rllib/algorithms/sac/tests/test_sac.py
@@ -101,12 +101,7 @@ class TestSAC(unittest.TestCase):
                         {
                             "a": simple_space,
                             "b": Discrete(2),
-                            "c": Dict(
-                                {
-                                    "c1": image_space,
-                                    "c2": image_space,
-                                }
-                            ),
+                            "c": image_space,
                         }
                     ),
                     "action_space": Box(-1.0, 1.0, shape=(1,)),

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -948,7 +948,7 @@ class ModelCatalog:
                 not isinstance(orig_space, (Dict, Tuple))
                 or not any(
                     isinstance(s, Box) and len(s.shape) >= 2
-                    for s in tree.flatten(orig_space.spaces)
+                    for s in flatten_space(orig_space)
                 )
             )
         ):

--- a/rllib/tests/test_catalog.py
+++ b/rllib/tests/test_catalog.py
@@ -89,30 +89,30 @@ class TestModelCatalog(unittest.TestCase):
 
         # Build test cases
         flat_input_case = {
-            "input_space": Box(0, 1, shape=(3,), dtype=np.float32),
-            "output_space": Box(0, 1, shape=(4,)),
+            "obs_space": Box(0, 1, shape=(3,), dtype=np.float32),
+            "action_space": Box(0, 1, shape=(4,)),
             "num_outputs": 4,
             "expected_model": "FullyConnectedNetwork",
         }
         img_input_case = {
-            "input_space": Box(0, 1, shape=(84, 84, 3), dtype=np.float32),
-            "output_space": Discrete(5),
+            "obs_space": Box(0, 1, shape=(84, 84, 3), dtype=np.float32),
+            "action_space": Discrete(5),
             "num_outputs": 5,
             "expected_model": "VisionNetwork",
         }
         flat_complex_input_case = {
-            "input_space": Box(0, 1, shape=(10,), dtype=np.float32),
-            "output_space": Box(0, 1, shape=(5,)),
+            "obs_space": Box(0, 1, shape=(10,), dtype=np.float32),
+            "action_space": Box(0, 1, shape=(5,)),
             "num_outputs": 5,
             "expected_model": "FullyConnectedNetwork",
         }
-        flat_complex_input_case["input_space"].original_space = Tuple([
+        flat_complex_input_case["obs_space"].original_space = Tuple([
             Box(0, 1, shape=(3,), dtype=np.float32),
             Box(0, 1, shape=(4,), dtype=np.float32),
             Discrete(3),
         ])
         nested_complex_input_case = {
-            "input_space": Tuple([
+            "obs_space": Tuple([
                 Box(0, 1, shape=(3,), dtype=np.float32),
                 Discrete(3),
                 Tuple([
@@ -120,7 +120,7 @@ class TestModelCatalog(unittest.TestCase):
                     Box(0, 1, shape=(84, 84, 3), dtype=np.float32),
                 ]),
             ]),
-            "output_space": Box(0, 1, shape=(7,)),
+            "action_space": Box(0, 1, shape=(7,)),
             "num_outputs": 7,
             "expected_model": "ComplexInputNetwork",
         }
@@ -156,16 +156,16 @@ class TestModelCatalog(unittest.TestCase):
                 if test["expected_model"] == "ComplexInputNetwork":
                     model_config["fcnet_hiddens"] = [256, 256]
                 m = ModelCatalog.get_model_v2(
-                    obs_space=test["input_space"],
-                    action_space=test["output_space"],
+                    obs_space=test["obs_space"],
+                    action_space=test["action_space"],
                     num_outputs=test["num_outputs"],
                     model_config=model_config,
                     framework=fw,
                 )
                 self.assertTrue(test["expected_model"] in type(m).__name__)
-                if isinstance(test["input_space"], Box):
+                if isinstance(test["obs_space"], Box):
                     # Do a test forward pass.
-                    obs = np.array([test["input_space"].sample()])
+                    obs = np.array([test["obs_space"].sample()])
                     if fw == "torch":
                         obs = torch.from_numpy(obs)
                     out, state_outs = m({"obs": obs})

--- a/rllib/tests/test_catalog.py
+++ b/rllib/tests/test_catalog.py
@@ -6,7 +6,11 @@ import unittest
 
 import ray
 from ray.rllib.models import ActionDistribution, ModelCatalog, MODEL_DEFAULTS
-from ray.rllib.models.preprocessors import NoPreprocessor, Preprocessor
+from ray.rllib.models.preprocessors import (
+    NoPreprocessor,
+    Preprocessor,
+    TupleFlatteningPreprocessor,
+)
 from ray.rllib.models.tf.tf_action_dist import (
     MultiActionDistribution,
     TFActionDistribution,
@@ -100,17 +104,18 @@ class TestModelCatalog(unittest.TestCase):
             "num_outputs": 5,
             "expected_model": "VisionNetwork",
         }
-        flat_complex_input_case = {
-            "obs_space": Box(0, 1, shape=(10,), dtype=np.float32),
-            "action_space": Box(0, 1, shape=(5,)),
-            "num_outputs": 5,
-            "expected_model": "FullyConnectedNetwork",
-        }
-        flat_complex_input_case["obs_space"].original_space = Tuple([
+        complex_obs_space = Tuple([
             Box(0, 1, shape=(3,), dtype=np.float32),
             Box(0, 1, shape=(4,), dtype=np.float32),
             Discrete(3),
         ])
+        obs_prep = TupleFlatteningPreprocessor(complex_obs_space)
+        flat_complex_input_case = {
+            "obs_space": obs_prep.observation_space,
+            "action_space": Box(0, 1, shape=(5,)),
+            "num_outputs": 5,
+            "expected_model": "FullyConnectedNetwork",
+        }
         nested_complex_input_case = {
             "obs_space": Tuple([
                 Box(0, 1, shape=(3,), dtype=np.float32),

--- a/rllib/tests/test_catalog.py
+++ b/rllib/tests/test_catalog.py
@@ -101,8 +101,10 @@ class TestModelCatalog(unittest.TestCase):
         input_configs.append((img_space, "VisionNetwork", ["jax"]))
         flat_complex_space = Box(0, 1, shape=(9,), dtype=np.float32)
         flat_complex_space.original_space = Tuple([flat_space, flat_space, Discrete(3)])
-        input_configs.append((flat_complex_space, "FullyConnectedNetwork", []))
-        nested_complex_space = Tuple([flat_space, Discrete(3), Tuple([img_space, img_space])])
+        input_configs.append((flat_complex_space, "FullyConnectedNetwork", ["jax"]))
+        nested_complex_space = Tuple(
+            [flat_space, Discrete(3), Tuple([img_space, img_space])]
+        )
         input_configs.append((nested_complex_space, "ComplexInputNetwork", ["jax"]))
 
         for obs_space, network_name, skip_fw in input_configs:

--- a/rllib/tests/test_catalog.py
+++ b/rllib/tests/test_catalog.py
@@ -111,11 +111,14 @@ class TestModelCatalog(unittest.TestCase):
             for action_space in action_spaces:
                 for fw in framework_iterator(frameworks=("jax", "tf", "tf2", "torch")):
                     if fw not in skip_fw:
+                        model_config = {}
+                        if network_name == "ComplexInputNetwork":
+                            model_config["fcnet_hiddens"] = [256, 256]
                         m = ModelCatalog.get_model_v2(
                             obs_space=obs_space,
                             action_space=action_space,
                             num_outputs=num_outputs,
-                            model_config={},
+                            model_config=model_config,
                             framework=fw,
                         )
                         self.assertTrue(network_name in type(m).__name__)

--- a/rllib/tests/test_catalog.py
+++ b/rllib/tests/test_catalog.py
@@ -106,11 +106,13 @@ class TestModelCatalog(unittest.TestCase):
             "num_outputs": 5,
             "expected_model": "VisionNetwork",
         }
-        complex_obs_space = Tuple([
-            Box(0, 1, shape=(3,), dtype=np.float32),
-            Box(0, 1, shape=(4,), dtype=np.float32),
-            Discrete(3),
-        ])
+        complex_obs_space = Tuple(
+            [
+                Box(0, 1, shape=(3,), dtype=np.float32),
+                Box(0, 1, shape=(4,), dtype=np.float32),
+                Discrete(3),
+            ]
+        )
         obs_prep = TupleFlatteningPreprocessor(complex_obs_space)
         flat_complex_input_case = {
             "obs_space": obs_prep.observation_space,
@@ -119,14 +121,18 @@ class TestModelCatalog(unittest.TestCase):
             "expected_model": "FullyConnectedNetwork",
         }
         nested_complex_input_case = {
-            "obs_space": Tuple([
-                Box(0, 1, shape=(3,), dtype=np.float32),
-                Discrete(3),
-                Tuple([
-                    Box(0, 1, shape=(84, 84, 3), dtype=np.float32),
-                    Box(0, 1, shape=(84, 84, 3), dtype=np.float32),
-                ]),
-            ]),
+            "obs_space": Tuple(
+                [
+                    Box(0, 1, shape=(3,), dtype=np.float32),
+                    Discrete(3),
+                    Tuple(
+                        [
+                            Box(0, 1, shape=(84, 84, 3), dtype=np.float32),
+                            Box(0, 1, shape=(84, 84, 3), dtype=np.float32),
+                        ]
+                    ),
+                ]
+            ),
             "action_space": Box(0, 1, shape=(7,)),
             "num_outputs": 7,
             "expected_model": "ComplexInputNetwork",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ModelCatalog.get_model_v2` returns a `FullyConnectedNetwork` instead of a `ComplexInputNetwork` for nested complex inputs, which leads to an error during forward pass.

## Related issue number

Solves #25619

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
