### PR TITLE
[RLlib] PPO automatic train batch size calculation fix

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -11,6 +11,7 @@ Detailed documentation: https://docs.ray.io/en/master/rllib-algorithms.html#ppo
 
 import logging
 from typing import List, Optional, Type, Union
+import math
 
 from ray.util.debug import log_once
 from ray.rllib.agents.trainer import Trainer
@@ -325,8 +326,9 @@ class PPO(Trainer):
             config["train_batch_size"] > 0
             and config["train_batch_size"] % calculated_min_rollout_size != 0
         ):
-            new_rollout_fragment_length = config["train_batch_size"] // (
-                num_workers * config["num_envs_per_worker"]
+            new_rollout_fragment_length = math.ceil(
+                config["train_batch_size"]
+                / (num_workers * config["num_envs_per_worker"])
             )
             logger.warning(
                 "`train_batch_size` ({}) cannot be achieved with your other "


### PR DESCRIPTION
## Why are these changes needed?

Our PPO config processing calculates rollouts lengths that accumulate to <= train_batch_size during algorithm execution, while they should be accumulating to >= train_batcH_size.

To cite a user from the forum:
"An example:
train_batch_size = 4000
rollout_fragment_length = 200
num_worker = 7
num_envs_per_worker = 1"
results in rollout_fragment_length of 571 and ends up collecting 7994 timesteps, which is almost 2x instead of 4004, which would be the sensible thing to do here.

## Related issue number

[Related forum discussion](https://discuss.ray.io/t/why-auto-adjust-rollout-fragment-length-by-a-floor-division-instead-of-ceiling-operation/6432)

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
