### PR TITLE
[Core] fix gRPC handlers' unlimited active calls configuration

### DIFF
--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -108,8 +108,10 @@ void GrpcServer::Run() {
   for (auto &entry : server_call_factories_) {
     for (int i = 0; i < num_threads_; i++) {
       // When there is no max active RPC limit, a call will be added to the completetion
-      // queue before processing starts, so adding only 1 call is enough.
-      int buffer_size = 1;
+      // queue before RPC processing starts. In this case, the buffer size only
+      // determines the number of tags in the completion queue, instead of the number of
+      // inflight RPCs being processed.
+      int buffer_size = 128;
       if (entry->GetMaxActiveRPCs() != -1) {
         buffer_size = entry->GetMaxActiveRPCs();
       }

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -107,10 +107,9 @@ void GrpcServer::Run() {
   // Create calls for all the server call factories.
   for (auto &entry : server_call_factories_) {
     for (int i = 0; i < num_threads_; i++) {
-      // Create a buffer of 100 calls for each RPC handler.
-      // TODO(edoakes): a small buffer should be fine and seems to have better
-      // performance, but we don't currently handle backpressure on the client.
-      int buffer_size = 100;
+      // When there is no max active RPC limit, a call will be added to the completetion
+      // queue before processing starts, so adding only 1 call is enough.
+      int buffer_size = 1;
       if (entry->GetMaxActiveRPCs() != -1) {
         buffer_size = entry->GetMaxActiveRPCs();
       }

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -377,7 +377,7 @@ class ServerCallFactoryImpl : public ServerCallFactory {
 
   /// Maximum request number to handle at the same time.
   /// -1 means no limit.
-  uint64_t max_active_rpcs_;
+  int64_t max_active_rpcs_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -162,6 +162,12 @@ class ServerCallImpl : public ServerCall {
     start_time_ = absl::GetCurrentTimeNanos();
     ray::stats::STATS_grpc_server_req_handling.Record(1.0, call_name_);
     if (!io_service_.stopped()) {
+      if (factory_.GetMaxActiveRPCs() == -1) {
+        // Create a new `ServerCall` as completion queue tag before handling the request
+        // when no back pressure limit is set, so that new requests can continue to be
+        // pulled from the completion queue before this request is done.
+        factory_.CreateCall();
+      }
       io_service_.post([this] { HandleRequestImpl(); }, call_name_);
     } else {
       // Handle service for rpc call has stopped, we must handle the call here
@@ -173,16 +179,6 @@ class ServerCallImpl : public ServerCall {
 
   void HandleRequestImpl() {
     state_ = ServerCallState::PROCESSING;
-    // NOTE(hchen): This `factory` local variable is needed. Because `SendReply` runs in
-    // a different thread, and will cause `this` to be deleted.
-    const auto &factory = factory_;
-    if (factory.GetMaxActiveRPCs() == -1) {
-      // Create a new `ServerCall` to accept the next incoming request.
-      // We create this before handling the request only when no back pressure limit is
-      // set. So that the it can be populated by the completion queue in the background if
-      // a new request comes in.
-      factory.CreateCall();
-    }
     (service_handler_.*handle_request_function_)(
         request_,
         reply_,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray's gRPC server wrapper configures a max active call setting for each handler. When the max active call is `-1`, the handler is supposed to allow handling unlimited number of requests concurrently. However in practice it is often observed that handlers configured with unlimited active calls are still handling at most 100 requests concurrently. 

This is a result of the existing logic: 
1. At a high level, each gRPC method is associated with a number of ServerCall objects (acting as "tags") in the gRPC completion queue. When there is no tag for a method, gRPC server thread will not be able to poll requests from the method call from the completion queue. After a request is polled from the completion queue, it is processed by the polling gRPC server thread, then queued to an eventloop. 
2. When a handler is in the "unlimited" mode, it creates when a new `ServerCall` object (tag) before actual processing. The problem is that new ServerCalls are created on the eventloop instead of the gRPC server thread. When the event loop runs a callback from the gRPC server, the callback creates a new ServerCall object, and can run the gRPC handler to completion if the handler does not have any async step. So overall, the event loop will not run more callbacks than the initial number of `ServerCall`s, which is 100 in the "unlimited" mode.

The solution is to create a new `ServerCall` in the gRPC server thread, before sending the `ServerCall` to the eventloop.

Running some night tests to verify the fix does not introduce instabilities: https://buildkite.com/ray-project/release-tests-branch/builds/652

Also, looking into adding gRPC server / client stress tests with large number of concurrent requests.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
