### PR TITLE
[1/2][serve] Use GcsClient to replace the kv client to use timeout.

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -191,6 +191,15 @@ class RuntimeContext(object):
         worker.check_connected()
         return worker.core_worker.get_actor_handle(self.actor_id)
 
+    @property
+    def gcs_address(self):
+        """Get the GCS address of the ray cluster.
+        Returns:
+            The GCS address of the cluster.
+        """
+        self.worker.check_connected()
+        return self.worker.gcs_client.address
+
     def _get_actor_call_stats(self):
         """Get the current worker's task counters.
 

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -102,7 +102,7 @@ ANONYMOUS_NAMESPACE_PATTERN = re.compile(
 HANDLE_METRIC_PUSH_INTERVAL_S = 10
 
 # Timeout for GCS internal KV service
-RAY_SERVE_KV_TIMEOUT = int(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "0")) or None
+RAY_SERVE_KV_TIMEOUT = float(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "0")) or None
 
 
 class ServeHandleType(str, Enum):

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -102,7 +102,7 @@ ANONYMOUS_NAMESPACE_PATTERN = re.compile(
 HANDLE_METRIC_PUSH_INTERVAL_S = 10
 
 # Timeout for GCS internal KV service
-SERVE_KV_TIMEOUT = int(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "5"))
+RAY_SERVE_KV_TIMEOUT = int(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "5"))
 
 
 class ServeHandleType(str, Enum):

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -1,3 +1,5 @@
+import os
+
 from enum import Enum
 import re
 
@@ -98,6 +100,9 @@ ANONYMOUS_NAMESPACE_PATTERN = re.compile(
 
 # Handle metric push interval. (This interval will affect the cold start time period)
 HANDLE_METRIC_PUSH_INTERVAL_S = 10
+
+# Timeout for GCS internal KV service
+SERVE_KV_TIMEOUT = int(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "5"))
 
 
 class ServeHandleType(str, Enum):

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -102,7 +102,7 @@ ANONYMOUS_NAMESPACE_PATTERN = re.compile(
 HANDLE_METRIC_PUSH_INTERVAL_S = 10
 
 # Timeout for GCS internal KV service
-RAY_SERVE_KV_TIMEOUT = float(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "0")) or None
+RAY_SERVE_KV_TIMEOUT_S = float(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "0")) or None
 
 
 class ServeHandleType(str, Enum):

--- a/python/ray/serve/constants.py
+++ b/python/ray/serve/constants.py
@@ -102,7 +102,7 @@ ANONYMOUS_NAMESPACE_PATTERN = re.compile(
 HANDLE_METRIC_PUSH_INTERVAL_S = 10
 
 # Timeout for GCS internal KV service
-RAY_SERVE_KV_TIMEOUT = int(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "5"))
+RAY_SERVE_KV_TIMEOUT = int(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "0")) or None
 
 
 class ServeHandleType(str, Enum):

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -79,7 +79,7 @@ class RayInternalKVStore(KVStoreBase):
         if not isinstance(key, str):
             raise TypeError("key must be a string, got: {}.".format(type(key)))
 
-        return self.gcs_aio_client.internal_kv_get(
+        return self.gcs_client.internal_kv_get(
             self.get_storage_key(key).encode(),
             namespace=ray_constants.KV_NAMESPACE_SERVE,
             timeout=self.timeout,
@@ -95,7 +95,7 @@ class RayInternalKVStore(KVStoreBase):
         if not isinstance(key, str):
             raise TypeError("key must be a string, got: {}.".format(type(key)))
 
-        return self.gcs_aio_client.internal_kv_del(
+        return self.gcs_client.internal_kv_del(
             self.get_storage_key(key).encode(),
             False,
             namespace=ray_constants.KV_NAMESPACE_SERVE,

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -13,7 +13,7 @@ import ray
 from ray import ray_constants
 from ray._private.gcs_utils import GcsClient
 
-from ray.serve.constants import SERVE_LOGGER_NAME
+from ray.serve.constants import SERVE_LOGGER_NAME, RAY_SERVE_KV_TIMEOUT
 from ray.serve.storage.kv_store_base import KVStoreBase
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -33,14 +33,13 @@ class RayInternalKVStore(KVStoreBase):
     def __init__(
         self,
         namespace: str = None,
-        timeout: Optional[float] = None,
     ):
         if namespace is not None and not isinstance(namespace, str):
             raise TypeError("namespace must a string, got: {}.".format(type(namespace)))
 
         self.gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
 
-        self.timeout = timeout
+        self.timeout = RAY_SERVE_KV_TIMEOUT
         self.namespace = namespace or ""
 
     def get_storage_key(self, key: str) -> str:

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     boto3 = None
 
+import ray
 from ray import ray_constants
 from ray._private.gcs_utils import GcsClient
 
@@ -36,8 +37,6 @@ class RayInternalKVStore(KVStoreBase):
     ):
         if namespace is not None and not isinstance(namespace, str):
             raise TypeError("namespace must a string, got: {}.".format(type(namespace)))
-
-        import ray
 
         self.gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
 

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -215,6 +215,7 @@ class RayS3KVStore(KVStoreBase):
         aws_access_key_id=None,
         aws_secret_access_key=None,
         aws_session_token=None,
+        endpoint_url=None,
     ):
         self._namespace = namespace
         self._bucket = bucket
@@ -230,6 +231,7 @@ class RayS3KVStore(KVStoreBase):
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
+            endpoint_url=endpoint_url,
         )
 
     def get_storage_key(self, key: str) -> str:

--- a/python/ray/serve/storage/kv_store.py
+++ b/python/ray/serve/storage/kv_store.py
@@ -13,7 +13,7 @@ import ray
 from ray import ray_constants
 from ray._private.gcs_utils import GcsClient
 
-from ray.serve.constants import SERVE_LOGGER_NAME, RAY_SERVE_KV_TIMEOUT
+from ray.serve.constants import SERVE_LOGGER_NAME, RAY_SERVE_KV_TIMEOUT_S
 from ray.serve.storage.kv_store_base import KVStoreBase
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -39,7 +39,7 @@ class RayInternalKVStore(KVStoreBase):
 
         self.gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
 
-        self.timeout = RAY_SERVE_KV_TIMEOUT
+        self.timeout = RAY_SERVE_KV_TIMEOUT_S
         self.namespace = namespace or ""
 
     def get_storage_key(self, key: str) -> str:

--- a/python/ray/serve/tests/storage_tests/test_kv_store.py
+++ b/python/ray/serve/tests/storage_tests/test_kv_store.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import pytest
 from ray.serve.constants import DEFAULT_CHECKPOINT_PATH
+from ray._private.test_utils import simulate_storage
 from ray.serve.storage.checkpoint_path import make_kv_store
 from ray.serve.storage.kv_store import RayInternalKVStore, RayLocalKVStore, RayS3KVStore
 from ray.serve.storage.kv_store_base import KVStoreBase
@@ -80,18 +81,36 @@ def test_external_kv_local_disk():
     _test_operations(kv_store)
 
 
-@pytest.mark.skip(reason="Need to figure out credentials for testing")
 def test_external_kv_aws_s3():
-    kv_store = RayS3KVStore(
-        "namespace",
-        bucket="jiao-test",
-        s3_path="/checkpoint",
-        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", None),
-        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", None),
-        aws_session_token=os.environ.get("AWS_SESSION_TOKEN", None),
-    )
+    with simulate_storage("s3", "serve-test") as uri:
+        from urllib.parse import urlparse, parse_qs
 
-    _test_operations(kv_store)
+        o = urlparse(uri)
+        qs = parse_qs(o.query)
+        region_name = qs["region"][0]
+        endpoint_url = qs["endpoint_override"][0]
+
+        import boto3
+
+        s3 = boto3.client(
+            "s3",
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+        )
+        s3.create_bucket(
+            Bucket="serve-test",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+
+        kv_store = RayS3KVStore(
+            "namespace",
+            bucket="serve-test",
+            prefix="checkpoint",
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+        )
+
+        _test_operations(kv_store)
 
 
 @pytest.mark.skip(reason="Need to figure out credentials for testing")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Timeout is only introduced in GcsClient due to the reason that ray client is not defining the timeout well for their API and it's a lot of effort to make it work e2e.  For built-in component, we should use GcsClient directly.

This PR use GcsClient to replace the old one to integrate GCS HA with Ray Serve.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
