### PR TITLE
[Core][Nightly test] use smaller instance for scheduling tests

### DIFF
--- a/release/benchmarks/scheduling.yaml
+++ b/release/benchmarks/scheduling.yaml
@@ -5,15 +5,18 @@ max_workers: 999
 
 head_node_type:
     name: head_node
-    instance_type: m5.16xlarge
+    instance_type: m5.4xlarge
     resources:
+      # Assume the node has 64 CPU instead of 16.
+      # This should be fine since each task has little
+      # computation in scheduling tests.
       cpu: 64
       custom_resources:
         node: 1
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.16xlarge
+      instance_type: m5.4xlarge
       min_workers: 31
       max_workers: 31
       use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`m5.16xlarge` instances have 64 CPU and 256GB memory, which are overkill for scheduling tests that do not have a lot of computations. Use smaller instance `m5.4xlarge` to save cost and make allocating instances easier.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
