### PR TITLE
add retry logic for parquet file reading

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -54,6 +54,49 @@ def _deregister_parquet_file_fragment_serialization():
     ray.util.deregister_serializer(ParquetFileFragment)
 
 
+# this retry helps when HA hdfs service not able to handle overloaded read request.
+# even with HA configed, hdfs service might be overloaded with parquet file read request
+# expecially when simutaneously running many hyper parameter tuning jobs
+# with ray.data parallelism setting at high value like the default 200 
+def deserialize_pieces(serialized_pieces):
+    from ray import cloudpickle
+    import random
+    # to make retries of different process hit hdfs server
+    # at slightly different time
+    min_interval = 1 + random.random()
+    final_exception = None
+    # retry at most 8 times
+    for i in range(8):
+        try:
+            pieces: List[
+                "pyarrow._dataset.ParquetFileFragment"
+            ] = cloudpickle.loads(serialized_pieces)
+            return pieces
+        except Exception as e:
+            import traceback
+            import time
+            tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+            err_msg_str = f'{type(e)}:{str(e)}'
+            retry_timing = "" if i == 7 else (f'Will retry after {min_interval} sec. ')
+            log_only_show_in_1st_retry = "" if i else (
+                f"If earlier hdfsBuilderConnect threw java.net.UnknownHostException, "
+                f"it may or may not be an issue depends on these retries succeed or not. "
+                f"serialized_pieces:{serialized_pieces}"
+            )
+            logger.error(
+                f"{i + 1}th attempt to deserialize ParquetFileFragment pieces failed "
+                f"with:{err_msg_str} traceback:{tb_str}. "
+                f"{retry_timing}"
+                f"{log_only_show_in_1st_retry}"
+            )
+            # exponential backoff at
+            # 1, 2, 4, 8, 16, 32, 64
+            time.sleep(min_interval)
+            min_interval = min_interval * 2
+            final_exception = e
+    raise final_exception
+
+
 class ParquetDatasource(FileBasedDatasource):
     """Parquet datasource, for reading and writing Parquet files.
 
@@ -107,9 +150,7 @@ class ParquetDatasource(FileBasedDatasource):
             # Deserialize after loading the filesystem class.
             try:
                 _register_parquet_file_fragment_serialization()
-                pieces: List[
-                    "pyarrow._dataset.ParquetFileFragment"
-                ] = cloudpickle.loads(serialized_pieces)
+                pieces = deserialize_pieces(serialized_pieces)
             finally:
                 _deregister_parquet_file_fragment_serialization()
 
@@ -238,12 +279,11 @@ def _fetch_metadata_serialization_wrapper(
     # Implicitly trigger S3 subsystem initialization by importing
     # pyarrow.fs.
     import pyarrow.fs  # noqa: F401
-    from ray import cloudpickle
 
     # Deserialize after loading the filesystem class.
     try:
         _register_parquet_file_fragment_serialization()
-        pieces: List["pyarrow._dataset.ParquetFileFragment"] = cloudpickle.loads(pieces)
+        pieces = deserialize_pieces(pieces)
     finally:
         _deregister_parquet_file_fragment_serialization()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
when reading parquet file from a hdfs server with high parallelism, the hdfs server might be overloaded and causing hdfs connection failure issue.  retry with exponential backoff help with such case and avoid failing the ray.data reading job.

## Related issue number
MA-14867

Checks
E2E uber internal test:
peloton job id 1a82064e-28f7-449d-9951-9f3934ac326d
job log: P320509

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [] This PR is not tested :(
