### PR TITLE
[Datasets] Fix` __array__` protocol on `TensorArrayElement` and `TensorArray`.

### DIFF
--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -342,8 +342,8 @@ class TensorArrayElement(TensorOpsMixin):
         """
         return np.asarray(self._tensor)
 
-    def __array__(self):
-        return np.asarray(self._tensor)
+    def __array__(self, dtype: np.dtype = None):
+        return np.asarray(self._tensor, dtype=dtype)
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -342,8 +342,8 @@ class TensorArrayElement(TensorOpsMixin):
         """
         return np.asarray(self._tensor)
 
-    def __array__(self, dtype: np.dtype = None):
-        return np.asarray(self._tensor, dtype=dtype)
+    def __array__(self, dtype: np.dtype = None, **kwargs) -> np.ndarray:
+        return np.asarray(self._tensor, dtype=dtype, **kwargs)
 
 
 @PublicAPI(stability="beta")
@@ -891,8 +891,8 @@ class TensorArray(pd.api.extensions.ExtensionArray, TensorOpsMixin):
         except KeyError:
             raise NotImplementedError(f"'{name}' aggregate not implemented.") from None
 
-    def __array__(self, dtype: np.dtype = None):
-        return np.asarray(self._tensor, dtype=dtype)
+    def __array__(self, dtype: np.dtype = None, **kwargs) -> np.ndarray:
+        return np.asarray(self._tensor, dtype=dtype, **kwargs)
 
     def __array_ufunc__(self, ufunc: Callable, method: str, *inputs, **kwargs):
         """

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -624,6 +624,23 @@ def test_tensor_array_array_protocol(ray_start_regular_shared):
     )
 
 
+def test_tensor_array_scalar_cast(ray_start_regular_shared):
+    outer_dim = 3
+    inner_shape = (1,)
+    shape = (outer_dim,) + inner_shape
+    num_items = np.prod(np.array(shape))
+    arr = np.arange(num_items).reshape(shape)
+
+    t_arr = TensorArray(arr)
+
+    for t_arr_elem, arr_elem in zip(t_arr, arr):
+        assert float(t_arr_elem) == float(arr_elem)
+
+    arr = np.arange(1).reshape((1, 1, 1))
+    t_arr = TensorArray(arr)
+    assert float(t_arr) == float(arr)
+
+
 def test_tensor_array_reductions(ray_start_regular_shared):
     outer_dim = 3
     inner_shape = (2, 2, 2)

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -604,6 +604,26 @@ def test_tensor_array_ops(ray_start_regular_shared):
     np.testing.assert_equal(apply_logical_ops(arr), apply_logical_ops(df["two"]))
 
 
+def test_tensor_array_array_protocol(ray_start_regular_shared):
+    outer_dim = 3
+    inner_shape = (2, 2, 2)
+    shape = (outer_dim,) + inner_shape
+    num_items = np.prod(np.array(shape))
+    arr = np.arange(num_items).reshape(shape)
+
+    t_arr = TensorArray(arr)
+
+    np.testing.assert_array_equal(
+        np.asarray(t_arr, dtype=np.float32), arr.astype(np.float32)
+    )
+
+    t_arr_elem = t_arr[0]
+
+    np.testing.assert_array_equal(
+        np.asarray(t_arr_elem, dtype=np.float32), arr[0].astype(np.float32)
+    )
+
+
 def test_tensor_array_reductions(ray_start_regular_shared):
     outer_dim = 3
     inner_shape = (2, 2, 2)


### PR DESCRIPTION
This PR fixes two issues with the `__array__` protocol on the tensor extension:
1. The `__array__` protocol on `TensorArrayElement` was missing the `dtype` parameter, causing `np.asarray(tae, dtype=some_dtype)` calls to fail. This PR adds support for the `dtype` argument.
2. `TensorArray` and `TensorArrayElement` didn't support NumPy's scalar casting semantics for single-element tensors. This PR adds support for these scalar casting semantics.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
