### PR TITLE
[Tune] Integrate BigDL-Nano into Ray Tune to accelerate distributed hyperparameter tuning for deep learning

### DIFF
--- a/python/ray/tune/integration/trainable.py
+++ b/python/ray/tune/integration/trainable.py
@@ -1,0 +1,136 @@
+import ray
+from ray import tune
+
+
+class LightningTrainable(tune.Trainable):
+    '''
+    This is an abstract class for trainable PyTorch Lightning models.
+    This creator will internally use an accelerated Pytorch Lightning
+    Trainer (`bigdl.nano.pytorch.Trainer`) when running on CPU, and the
+    standard Pytorch Lightning Trainer when running on GPU.
+
+    Generally you only need to implement `create_model` when subclassing
+    LightningTrainable.
+
+    Other implementation methods that may be helpful to override are
+    `configure_trainer`
+
+    A typical usage is:
+    >>> class MyTrainable(LightningTrainable):
+    >>>     def create_model(self, config):
+    >>>         return PL_MODEL(config)
+    >>> 
+    >>> analysis = tune.run(MyTrainable, ...)
+
+    :param cpu_binding: Users can set this class variable to enable or
+           disable cpu core binding for each trial. Your Trainable without
+           binding will totally rely on the OS scheduler, which is
+           inefficient in most cases. With this variable set to True,
+           trails will be binded to a fixed set of cpu id. It's highly
+           recommeneded that users set `reuse_actor` to True as well if cpu
+           binding is enabled. This technique is defaultly disabled.
+
+    A typical usage for cpu_binding is:
+    >>> class MyTrainable(LightningTrainable):
+    >>>     cpu_binding = True
+    >>>     ...
+
+    '''
+
+    _cpu_procs = None
+    cpu_binding = False
+
+    def create_model(self, config):
+        '''
+        Subclasses should override this method to return a PyTorch Lightning model
+
+        `create_model` takes a config dictionary and returns a pytorch lightning module.
+        '''
+        raise NotImplementedError("Users need to implement this method")
+
+    def configure_trainer(self):
+        '''
+        Subclasses should override this method to returns a dictionary to configure Trainer;
+        please refer to
+        https://pytorch-lightning.readthedocs.io/en/latest/common/trainer.html#trainer-class-api
+        Users can also set parameters to configure some bigdl-nano pytorch-lightning parameters;
+        please refer to
+        https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/pytorch_train.html
+
+        A default trainer setting will be {"max_epochs": 1}
+        '''
+        return {"max_epochs": 1}
+
+    def setup(self, config):
+        '''
+        Subclasses should not override this method
+
+        It creates an accelerated Pytorch Lightning Trainer (bigdl.nano.pytorch.Trainer)
+        when running on CPU, and a standard Pytorch Lightning Trainer when running on GPU.
+        '''
+        self.model = self.create_model(config=config)
+        trainer_config = self.configure_trainer()
+        # TODO: change to an error raise method in ray if needed
+        assert isinstance(trainer_config, dict),\
+            f"`configure_trainer` should return a dict while get a {type(trainer_config)}"
+
+        trial_required_resources = self.trial_resources.required_resources
+        if "GPU" not in trial_required_resources:
+            from bigdl.nano.pytorch import Trainer
+            nano_config = {"use_ipex": True}
+            nano_config.update(trainer_config)
+            self.trainer = Trainer(**nano_config)
+        else:
+            from pytorch_lightning import Trainer
+            self.trainer = Trainer(**trainer_config)
+
+    def step(self):
+        '''
+        Subclasses should not override this method
+        '''
+        self.trainer.fit(self.model)
+        valid_result = self.trainer.validate(self.model)
+        return valid_result[0]
+
+    def reset_config(self, config):
+        '''
+        Subclasses should not override this method
+        '''
+        self.setup(config)
+        return True
+
+    @classmethod
+    def get_runtime_env(cls, placement_group_factory):
+        '''
+        Subclasses should not override this method.
+
+        Set CPU specific tunings/optimizations in runtime_env
+        when running on CPU.
+        '''
+        from bigdl.nano.common import get_nano_env_var
+        # set CPU specific optimizations when running on CPU
+        required_resources = placement_group_factory.required_resources
+        if "GPU" in required_resources:
+            return {}
+
+        cpu_num = placement_group_factory.head_cpus
+        nano_env = get_nano_env_var()
+        # reset OMP_NUM_THREADS to be CPU required for each trial.
+        nano_env["OMP_NUM_THREADS"] = str(int(cpu_num))
+        # remove KMP_AFFINITY since it might not fit all cases
+        nano_env.pop("KMP_AFFINITY", None)
+        runtime_env = {"env_vars": nano_env}
+
+        # cpu binding
+        if cls.cpu_binding:
+            from bigdl.nano.common.cpu_schedule import schedule_workers
+            actor_num = int(ray.cluster_resources()["CPU"] // cpu_num)
+            if cls._cpu_procs is None:
+                cls._cpu_procs = iter(schedule_workers(actor_num))
+            cpu_proc = next(cls._cpu_procs, None)
+            if cpu_proc is not None:
+                runtime_env["env_vars"]["KMP_AFFINITY"] =\
+                                f"granularity=fine,proclist"\
+                                f"=[{','.join([str(i) for i in cpu_proc])}],explicit"
+
+        return runtime_env

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -358,7 +358,8 @@ class RayTrialExecutor:
         if not self._pg_manager.has_ready(trial):
             return None
 
-        full_actor_class = self._pg_manager.get_full_actor_cls(trial, _actor_cls)
+        runtime_env = trainable_cls.get_runtime_env(trial.placement_group_factory)
+        full_actor_class = self._pg_manager.get_full_actor_cls(trial, _actor_cls, runtime_env)
         # Clear the Trial's location (to be updated later on result)
         # since we don't know where the remote runner is placed.
         trial.set_location(_Location())

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -228,6 +228,27 @@ class Trainable:
         """
         return ""
 
+    @classmethod
+    def get_runtime_env(cls, placement_group_factory):
+        """Provides users' customize runtime environment.
+
+        This can be overridden by sub-classes for users
+        to customize runtime environment.
+
+        .. code-block:: python
+
+            @classmethod
+            def default_resource_request(cls, placement_group_factory):
+                return {"env_vars":{"MY_ENV": "MY_VALUE"}}
+
+        Args:
+            placement_group_factory: The Trainable's placement_group_factory.
+
+        Returns:
+            Dict: A runtime env dictionary
+        """
+        return {}
+
     def get_current_ip(self):
         self._local_ip = ray.util.get_node_ip_address()
         return self._local_ip

--- a/python/ray/tune/utils/placement_groups.py
+++ b/python/ray/tune/utils/placement_groups.py
@@ -471,7 +471,7 @@ class _PlacementGroupManager:
         return list(self._staging_futures.keys())
 
     def get_full_actor_cls(
-        self, trial: "Trial", actor_cls: ActorClass
+        self, trial: "Trial", actor_cls: ActorClass, runtime_env: Dict
     ) -> Optional[ActorClass]:
         """Get a fully configured actor class.
 
@@ -482,6 +482,7 @@ class _PlacementGroupManager:
         Args:
             trial: "Trial" object to start
             actor_cls: Ray actor class.
+            runtime_env: Runtime environment dictionary.
 
         Returns:
             Configured ActorClass or None
@@ -518,6 +519,7 @@ class _PlacementGroupManager:
                 memory=memory,
                 object_store_memory=object_store_memory,
                 resources=resources,
+                runtime_env=runtime_env,
             )
         else:
             return actor_cls.options(
@@ -526,6 +528,7 @@ class _PlacementGroupManager:
                 num_cpus=0,
                 num_gpus=0,
                 resources={},
+                runtime_env=runtime_env,
             )
 
     def has_ready(self, trial: "Trial", update: bool = False) -> bool:


### PR DESCRIPTION
### General Motivation
Many users use Ray Tune to perform large-scale, distributed HPO (hyperparameter optimization) of deep learning models (TensorFlow, Keras, PyTorch Lightning, etc.). In these cases, Tune can easily launch 1000s of experiments on a large cluster, and use all the CPU cores and GPUs for scalable hyperparameter tuning.

However, while Tune has good out-of-box GPU support, today it does not efficiently leverage the aggregate compute power of the large number of CPU cores in a cluster to tune these deep learning models. E.g., the [benchmarking result](#benchmark-result) below shows more than 5.74x speedup can be obtainable by applying a variety of modern CPU optimizations.

[BigDL-Nano](https://arxiv.org/abs/2204.01715) is a library that allows the users to transparently accelerate their deep learning models on model CPU; it automatically integrating many optimized libraries, best-known tunings, and software optimizations; please see one of our CVPR 2022 demos [here](https://huggingface.co/spaces/CVPR/BigDL-Nano_inference). 

We propose to integrate BigDL-Nano into Ray Tune, so as to transparently accelerate distributed hyperparameter tuning for deep learning models when running on a CPU cluster. This PR shows a prototype for accelerating the tuning of PyTorch Lightning models in Tune, and we plan to support other frameworks including TensorFlow and PyTorch.

### Design and Architecture
We propose to extend the _Trainable Class API_ to provide a `LightningTrainable` class that reduces boilerplate codes when tuning PyTorch Lightning, and at the same time automatically accelerates PyTorch Lightning models using BigDL-Nano.

#### LightningTrainable API

```python
class LightningTrainable(tune.Trainable):
    '''
    This is an abstract class for trainable PyTorch Lightning models.
    This creator will internally use an accelerated Pytorch Lightning
    Trainer (`bigdl.nano.pytorch.Trainer`) when running on CPU, and the
    standard Pytorch Lightning Trainer when running on GPU.

    Generally you only need to implement `create_model` when subclassing
    LightningTrainable.

    Other implementation methods that may be helpful to override are
    `configure_trainer`

    A typical usage is:
    >>> class MyTrainable(LightningTrainable):
    >>>     def create_model(self, config):
    >>>         return PL_MODEL(config)
    >>> 
    >>> analysis = tune.run(MyTrainable, ...)

    :param cpu_binding: Users can set this class variable to enable or
           disable cpu core binding for each trial. Your Trainable without
           binding will totally rely on the OS scheduler, which is
           inefficient in most cases. With this variable set to True,
           trails will be binded to a fixed set of cpu id. It's highly
           recommeneded that users set `reuse_actor` to True as well if cpu
           binding is enabled. This technique is defaultly disabled.

    A typical usage for cpu_binding is:
    >>> class MyTrainable(LightningTrainable):
    >>>     cpu_binding = True
    >>>     ...
    '''
```

This `LightningTrainable` can be used by customers easily through

```python
class MyTrainable(LightningTrainable):

    cpu_binding = True

    def create_model(self, config):
        return PL_MODEL(config)

    def configrate_trainer(self):
        return {"max_epochs": 2, ...}

analysis = tune.run(MyTrainable, ...)
```

#### runtime_env for trainable
Users' customized runtime_env is important for training performance improvement and, to be more generally, requested by some users https://github.com/ray-project/ray/issues/23234 . In our proposal, we proposed an interface in `tune.trainable` for users to set runtime env customizedly.

```python
# trainable.py
@classmethod
def get_runtime_env(cls, placement_group_factory):
    """Provides users' customize runtime environment.

    This can be overridden by sub-classes for users
    to customize runtime environment.

    .. code-block:: python

        @classmethod
        def default_resource_request(cls, placement_group_factory):
            return {"env_vars":{"MY_ENV": "MY_VALUE"}}

    Args:
        placement_group_factory: The Trainable's placement_group_factory.

    Returns:
        Dict: A runtime env dictionary
    """
    return {}
```
Users can override this method to set their own customized variables. In `LightningTrainable`, this method is overrided by default.

### Benchmark Result
We did some initial performance benchmarking on a 48-core CPU server, tuning the [example model](https://github.com/Lightning-AI/lightning/blob/master/examples/pl_domain_templates/computer_vision_fine_tuning.py). Four different scenarios are tested:
1. **Ray Tune default**: the default behavior of Ray Tune when tuning the PyTorch Lightning model
2. **Ray Tune multi-core**: manually add configurations (e.g. `torch.set_num_threads`) in Ray Tune to use multiple CPU cores when tuning PyTorch Lightning 
3. **Ray Tune + BigDL-Nano**: use the default `LightningTrainable` implementation when tuning PyTorch Lightning 
4. **Ray Tune + BigDL-Nano + core binding**: enable _core binding_ in  `LightningTrainable` when tuning PyTorch Lightning

The table below shows that **"Ray Tune + BigDL-Nano"** is 4.34x faster than **"Ray Tune default"**, and **"Ray Tune + BigDL-Nano + core binding"** is 5.74x faster than **"Ray Tune default"**.

Speedup of BigDL-Nano|Ray Tune default|Ray Tune multi-core|
----|-----------|-----|
**Ray Tune + BigDL-Nano** |4.34x|1.20x|
**Ray Tune + BigDL-Nano + core binding** |5.74x|1.59x|

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
