### PR TITLE
[RuntimeEnv] Fixes spaces in paths causing failures on Windows

### DIFF
--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import subprocess
 import sys
 from typing import Any, Dict, List, Optional
 
@@ -46,7 +47,7 @@ class RuntimeEnvContext:
         os.environ.update(self.env_vars)
 
         if language == Language.PYTHON and sys.platform == "win32":
-            executable = f'"{self.py_executable}"'  # Path may contain spaces
+            executable = self.py_executable
         elif language == Language.PYTHON:
             executable = f"exec {self.py_executable}"
         elif language == Language.JAVA:
@@ -69,7 +70,7 @@ class RuntimeEnvContext:
         command_str = " && ".join(self.command_prefix + [exec_command])
         logger.debug(f"Exec'ing worker with command: {command_str}")
         if sys.platform == "win32":
-            os.system(command_str)
+            subprocess.run([executable, *passthrough_args])
         else:
             # PyCharm will monkey patch the os.execvp at
             # .pycharm_helpers/pydev/_pydev_bundle/pydev_monkey.py


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a follow-up to the previous PR (GitHub did some funky things when I did a rebase, so I had to create a new one)

On Windows systems, the `exec_worker` method may fail due to spaces being present in arguments that are file paths. This addresses said issue.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #24574

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

cc @mattip @architkulkarni  @SJ-L