### PR TITLE
[RLlib] fix broken link replay buffer docs

### DIFF
--- a/doc/source/rllib/rllib-replay-buffers.rst
+++ b/doc/source/rllib/rllib-replay-buffers.rst
@@ -115,7 +115,7 @@ Here is an example of how to implement your own toy example of a ReplayBuffer cl
     :end-before: __sphinx_doc_replay_buffer_own_buffer__end__
 
 For a full implementation, you should consider other methods like ``get_state()`` and ``set_state()``.
-A more extensive example is `our implementation <replay-buffers.html#ray-rllib-utils-replay-buffers-reservoir-replay-buffer>`__ of `reservoir sampling <https://www.cs.umd.edu/~samir/498/vitter.pdf>`__, the :py:class:`~ray.rllib.utils.replay_buffers.reservoir_replay_buffer.ReservoirReplayBuffer`.
+A more extensive example is our implementation of `reservoir sampling <https://www.cs.umd.edu/~samir/498/vitter.pdf>`__, the :py:class:`~ray.rllib.utils.replay_buffers.reservoir_replay_buffer.ReservoirReplayBuffer`.
 
 
 Advanced Usage

--- a/doc/source/rllib/rllib-replay-buffers.rst
+++ b/doc/source/rllib/rllib-replay-buffers.rst
@@ -115,7 +115,7 @@ Here is an example of how to implement your own toy example of a ReplayBuffer cl
     :end-before: __sphinx_doc_replay_buffer_own_buffer__end__
 
 For a full implementation, you should consider other methods like ``get_state()`` and ``set_state()``.
-A more extensive example is `our implementation <https://github.com/ray-project/ray/blob/master/rllib/utils/replay_buffers/reservoir_buffer.py>`__ of `reservoir sampling <https://www.cs.umd.edu/~samir/498/vitter.pdf>`__, the :py:class:`~ray.rllib.utils.replay_buffers.reservoir_replay_buffer.ReservoirReplayBuffer`.
+A more extensive example is `our implementation <replay-buffers.html#ray-rllib-utils-replay-buffers-reservoir-replay-buffer>`__ of `reservoir sampling <https://www.cs.umd.edu/~samir/498/vitter.pdf>`__, the :py:class:`~ray.rllib.utils.replay_buffers.reservoir_replay_buffer.ReservoirReplayBuffer`.
 
 
 Advanced Usage


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

fixes lintcheck

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
