### PR TITLE
[data] add retry logic to ray.data parquet file reading

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -64,7 +64,6 @@ def deserialize_pieces(
     serialized_pieces: str,
 ) -> List["pyarrow._dataset.ParquetFileFragment"]:
     from ray import cloudpickle
-    import random
 
     min_interval = 0
     final_exception = None
@@ -78,6 +77,7 @@ def deserialize_pieces(
         except Exception as e:
             import traceback
             import time
+            import random
 
             tb_str = traceback.format_exception(
                 etype=type(e), value=e, tb=e.__traceback__

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -187,7 +187,6 @@ class ParquetDatasource(ParquetBaseDatasource):
             try:
                 _register_parquet_file_fragment_serialization()
                 pieces = _deserialize_pieces_with_retry(serialized_pieces)
-                logger.error(f"serialized_pieces:{serialized_pieces}")
             finally:
                 _deregister_parquet_file_fragment_serialization()
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -79,8 +79,6 @@ def _deserialize_pieces(
 def _deserialize_pieces_with_retry(
     serialized_pieces: str,
 ) -> List["pyarrow._dataset.ParquetFileFragment"]:
-    from ray import cloudpickle
-
     min_interval = 0
     final_exception = None
     for i in range(FILE_READING_RETRY):

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -60,7 +60,7 @@ def _deregister_parquet_file_fragment_serialization():
 # even with HA configed, hdfs service might be overloaded with parquet file read
 # request expecially when simutaneously running many hyper parameter tuning jobs
 # with ray.data parallelism setting at high value like the default 200
-def deserialize_pieces(
+def _deserialize_pieces(
     serialized_pieces: str,
 ) -> List["pyarrow._dataset.ParquetFileFragment"]:
     from ray import cloudpickle
@@ -174,7 +174,7 @@ class ParquetDatasource(ParquetBaseDatasource):
             # Deserialize after loading the filesystem class.
             try:
                 _register_parquet_file_fragment_serialization()
-                pieces = deserialize_pieces(serialized_pieces)
+                pieces = _deserialize_pieces(serialized_pieces)
             finally:
                 _deregister_parquet_file_fragment_serialization()
 
@@ -290,7 +290,7 @@ def _fetch_metadata_serialization_wrapper(
     # Deserialize after loading the filesystem class.
     try:
         _register_parquet_file_fragment_serialization()
-        pieces = deserialize_pieces(pieces)
+        pieces = _deserialize_pieces(pieces)
     finally:
         _deregister_parquet_file_fragment_serialization()
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -183,7 +183,9 @@ class ParquetDatasource(ParquetBaseDatasource):
             # Deserialize after loading the filesystem class.
             try:
                 _register_parquet_file_fragment_serialization()
-                pieces: List["pyarrow._dataset.ParquetFileFragment"] = _deserialize_pieces_with_retry(serialized_pieces)
+                pieces: List[
+                    "pyarrow._dataset.ParquetFileFragment"
+                ] = _deserialize_pieces_with_retry(serialized_pieces)
             finally:
                 _deregister_parquet_file_fragment_serialization()
 
@@ -299,7 +301,9 @@ def _fetch_metadata_serialization_wrapper(
     # Deserialize after loading the filesystem class.
     try:
         _register_parquet_file_fragment_serialization()
-        pieces: List["pyarrow._dataset.ParquetFileFragment"] = _deserialize_pieces_with_retry(pieces)
+        pieces: List[
+            "pyarrow._dataset.ParquetFileFragment"
+        ] = _deserialize_pieces_with_retry(pieces)
     finally:
         _deregister_parquet_file_fragment_serialization()
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -57,8 +57,8 @@ def _deregister_parquet_file_fragment_serialization():
 
 
 # this retry helps when HA hdfs service not able to handle overloaded read request.
-# even with HA configed, hdfs service might be overloaded with parquet file read request
-# expecially when simutaneously running many hyper parameter tuning jobs
+# even with HA configed, hdfs service might be overloaded with parquet file read
+# request expecially when simutaneously running many hyper parameter tuning jobs
 # with ray.data parallelism setting at high value like the default 200
 def deserialize_pieces(
     serialized_pieces: str
@@ -79,16 +79,18 @@ def deserialize_pieces(
         except Exception as e:
             import traceback
             import time
-            tb_str = traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+            tb_str = traceback.format_exception(
+                etype=type(e), value=e, tb=e.__traceback__
+            )
             err_msg_str = f'{type(e)}:{str(e)}'
-            retry_timing = "" if i == 7 else (f'Will retry after {min_interval} sec. ')
+            retry_timing = "" if i == 7 else (f' Retry after {min_interval} sec. ')
             log_only_show_in_1st_retry = "" if i else (
-                f"If earlier hdfsBuilderConnect threw java.net.UnknownHostException, "
-                f"it may or may not be an issue depends on these retries succeed or not. "
-                f"serialized_pieces:{serialized_pieces}"
+                f"If earlier hdfsBuilderConnect threw java.net.UnknownHostException"
+                f", It may or may not be an issue depends on these retries "
+                f"succeed or not. serialized_pieces:{serialized_pieces}"
             )
             logger.error(
-                f"{i + 1}th attempt to deserialize ParquetFileFragment pieces failed "
+                f"{i + 1}th attempt to deserialize ParquetFileFragment failed "
                 f"with:{err_msg_str} traceback:{tb_str}. "
                 f"{retry_timing}"
                 f"{log_only_show_in_1st_retry}"

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -85,27 +85,21 @@ def _deserialize_pieces_with_retry(
         try:
             return _deserialize_pieces(serialized_pieces)
         except Exception as e:
-            import traceback
             import time
             import random
 
-            tb_str = traceback.format_exception(
-                etype=type(e), value=e, tb=e.__traceback__
-            )
-            err_msg_str = f"{type(e)}:{str(e)}"
-            retry_timing = "" if i == 7 else (f" Retry after {min_interval} sec. ")
+            retry_timing = "" if i == FILE_READING_RETRY - 1 else (f"Retry after {min_interval} sec. ")
             log_only_show_in_1st_retry = (
                 ""
                 if i
-                else (
+                else ( 
                     f"If earlier read attempt threw certain Exception"
-                    f", It may or may not be an issue depends on these retries "
+                    f", it may or may not be an issue depends on these retries "
                     f"succeed or not. serialized_pieces:{serialized_pieces}"
                 )
             )
-            logger.error(
-                f"{i + 1}th attempt to deserialize ParquetFileFragment failed "
-                f"with:{err_msg_str} traceback:{tb_str}. "
+            logger.exception(
+                f"{i + 1}th attempt to deserialize ParquetFileFragment failed. "
                 f"{retry_timing}"
                 f"{log_only_show_in_1st_retry}"
             )

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -12,6 +12,7 @@ from fsspec.implementations.local import LocalFileSystem
 from pytest_lazyfixture import lazy_fixture
 from io import BytesIO
 from functools import partial
+from unittest.mock import patch
 
 import ray
 
@@ -35,6 +36,7 @@ from ray.data.datasource import (
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import PARALLELIZE_META_FETCH_THRESHOLD
+from ray.data.datasource.parquet_datasource import _deserialize_pieces_with_retry
 from ray.data.tests.conftest import *  # noqa
 
 
@@ -332,6 +334,68 @@ def test_read_example_data(ray_start_regular_shared, tmp_path):
 @pytest.mark.parametrize(
     "fs,data_path",
     [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+    ],
+)
+def test_parquet_deserialize_pieces_with_retry(
+    ray_start_regular_shared, fs, data_path, monkeypatch
+):
+    from ray import cloudpickle
+
+    setup_data_path = _unwrap_protocol(data_path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    table = pa.Table.from_pandas(df1)
+    path1 = os.path.join(setup_data_path, "test1.parquet")
+    pq.write_table(table, path1, filesystem=fs)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    table = pa.Table.from_pandas(df2)
+    path2 = os.path.join(setup_data_path, "test2.parquet")
+    pq.write_table(table, path2, filesystem=fs)
+
+    dataset_kwargs = {}
+    pq_ds = pq.ParquetDataset(
+        data_path, **dataset_kwargs, filesystem=fs, use_legacy_dataset=False
+    )
+    serialized_pieces = cloudpickle.dumps(pq_ds.pieces)
+
+    # test 1st attempt succeed
+    pieces = _deserialize_pieces_with_retry(serialized_pieces)
+    assert "test1.parquet" in pieces[0].path
+    assert "test2.parquet" in pieces[1].path
+
+    # test the 3rd attempt succeed with a mock function constructed
+    # to throw in the first two attempts
+    class MockDeserializer:
+        def __init__(self, planned_exp_or_return):
+            self.planned_exp_or_return = planned_exp_or_return
+            self.cur_index = 0
+
+        def __call__(self, *args: Any, **kwds: Any) -> Any:
+            exp_or_ret = self.planned_exp_or_return[self.cur_index]
+            self.cur_index += 1
+            if type(exp_or_ret) == Exception:
+                raise exp_or_ret
+            else:
+                return exp_or_ret
+
+    mock_deserializer = MockDeserializer(
+        [
+            Exception("1st mock failed attempt"),
+            Exception("2nd mock failed attempt"),
+            pieces,
+        ]
+    )
+    monkeypatch.setattr(
+        ray.data.datasource.parquet_datasource, "_deserialize_pieces", mock_deserializer
+    )
+    retried_pieces = _deserialize_pieces_with_retry(serialized_pieces)
+    assert "test1.parquet" in retried_pieces[0].path
+    assert "test2.parquet" in retried_pieces[1].path
+
+
+@pytest.mark.parametrize(
+    "fs,data_path",
+    [
         (None, lazy_fixture("local_path")),
         (lazy_fixture("local_fs"), lazy_fixture("local_path")),
         (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
@@ -347,6 +411,7 @@ def test_parquet_read_basic(ray_start_regular_shared, fs, data_path):
     setup_data_path = _unwrap_protocol(data_path)
     path1 = os.path.join(setup_data_path, "test1.parquet")
     pq.write_table(table, path1, filesystem=fs)
+
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     table = pa.Table.from_pandas(df2)
     path2 = os.path.join(setup_data_path, "test2.parquet")

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -12,7 +12,6 @@ from fsspec.implementations.local import LocalFileSystem
 from pytest_lazyfixture import lazy_fixture
 from io import BytesIO
 from functools import partial
-from unittest.mock import patch
 
 import ray
 
@@ -411,7 +410,6 @@ def test_parquet_read_basic(ray_start_regular_shared, fs, data_path):
     setup_data_path = _unwrap_protocol(data_path)
     path1 = os.path.join(setup_data_path, "test1.parquet")
     pq.write_table(table, path1, filesystem=fs)
-
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     table = pa.Table.from_pandas(df2)
     path2 = os.path.join(setup_data_path, "test2.parquet")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
when reading parquet file from a datasource, the reading process of deserializing the parquet file may run into transient issue.  For example reading from hdfs server with high parallelism, the hdfs server might be overloaded and causing hdfs connection failure issue.  Retry with exponential backoff help with such transient failure and avoid failing the entire ray.data reading job.

## Related issue number
MA-14867

## Checks
E2E uber internal test:
peloton job id 1a82064e-28f7-449d-9951-9f3934ac326d
job log: P320509
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [] This PR is not tested :(
