### PR TITLE
[air] Allow fusing task and actor stages if they have compatible resource types

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -411,8 +411,6 @@ class OneToOneStage(Stage):
     def can_fuse(self, prev: Stage):
         if not isinstance(prev, OneToOneStage):
             return False
-        if prev.compute != self.compute:
-            return False
         if not _are_remote_args_compatible(prev.ray_remote_args, self.ray_remote_args):
             return False
         return True

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -411,6 +411,10 @@ class OneToOneStage(Stage):
     def can_fuse(self, prev: Stage):
         if not isinstance(prev, OneToOneStage):
             return False
+        # Allow fusing tasks->actors if the resources are compatible (read->map), but
+        # not the other way around. The latter will be used as the compute if fused.
+        if self.compute == "tasks" and prev.compute != self.compute:
+            return False
         if not _are_remote_args_compatible(prev.ray_remote_args, self.ray_remote_args):
             return False
         return True
@@ -429,7 +433,7 @@ class OneToOneStage(Stage):
                 for tmp2 in fn2(tmp1):
                     yield tmp2
 
-        return OneToOneStage(name, block_fn, prev.compute, prev.ray_remote_args)
+        return OneToOneStage(name, block_fn, self.compute, prev.ray_remote_args)
 
     def __call__(
         self, blocks: BlockList, clear_input_blocks: bool

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -363,17 +363,16 @@ def test_optimize_incompatible_stages(ray_start_regular_shared):
     context.optimize_fuse_shuffle_stages = True
 
     pipe = ray.data.range(3).repeat(2)
+    # Should get fused as long as their resource types are compatible.
     pipe = pipe.map_batches(lambda x: x, compute="actors")
     pipe = pipe.map_batches(lambda x: x, compute="tasks")
     pipe = pipe.random_shuffle_each_window()
     pipe.take()
     expect_stages(
         pipe,
-        3,
+        1,
         [
-            "read",
-            "map_batches",
-            "map_batches->random_shuffle_map",
+            "read->map_batches->map_batches->random_shuffle_map",
             "random_shuffle_reduce",
         ],
     )

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -365,14 +365,16 @@ def test_optimize_incompatible_stages(ray_start_regular_shared):
     pipe = ray.data.range(3).repeat(2)
     # Should get fused as long as their resource types are compatible.
     pipe = pipe.map_batches(lambda x: x, compute="actors")
+    # Cannot fuse actors->tasks.
     pipe = pipe.map_batches(lambda x: x, compute="tasks")
     pipe = pipe.random_shuffle_each_window()
     pipe.take()
     expect_stages(
         pipe,
-        1,
+        2,
         [
-            "read->map_batches->map_batches->random_shuffle_map",
+            "read->map_batches",
+            "map_batches->random_shuffle_map",
             "random_shuffle_reduce",
         ],
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we cannot fuse task and actor stages, even if they're using the same resources (e.g., num_cpus=1). This greatly slows down BatchPredictor when using CPUs, since we cannot fuse with the read stage. This will incur extra disk spilling.

AFAIK, this doesn't really have any downside.