### PR TITLE
[WIP] Prompt to enable usage stats if Ray is initialized from the main file of an application 

### DIFF
--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -184,10 +184,7 @@ def record_library_usage(library_usage: str):
         # This happens if the library is imported before ray.init
         return
 
-    # Only report library usage from driver to reduce
-    # the load to kv store.
-    if ray.worker.global_worker.mode == ray.SCRIPT_MODE:
-        _put_library_usage(library_usage)
+    _put_library_usage(library_usage)
 
 
 def _put_pre_init_library_usages():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This enables usage stats if Ray is initialized from the main file of an application (ray.init() is called by the __main__ file). This means that we only prompt if Ray is directly used by a user, and not indirectly via a library. Stats collection is always disabled when Ray is used as a library in another application.