### PR TITLE
[air] Add streaming BatchPredictor support

### DIFF
--- a/doc/source/ray-air/doc_code/air_key_concepts.py
+++ b/doc/source/ray-air/doc_code/air_key_concepts.py
@@ -73,11 +73,18 @@ from ray.air.predictors.integrations.xgboost import XGBoostPredictor
 
 batch_predictor = BatchPredictor.from_checkpoint(result.checkpoint, XGBoostPredictor)
 
+# Bulk batch prediction.
 predicted_labels = (
     batch_predictor.predict(test_dataset)
     .map_batches(lambda df: (df > 0.5).astype(int), batch_format="pandas")
     .to_pandas(limit=float("inf"))
 )
+
+# Pipelined batch prediction: instead of processing the data in bulk, process it
+# incrementally in windows of the given size.
+pipeline = batch_predictor.predict_pipelined(test_dataset, bytes_per_window=1048576)
+for batch in pipeline.iter_batches():
+    print("Pipeline result", batch)
 
 # __air_batch_predictor_end__
 

--- a/python/ray/air/batch_predictor.py
+++ b/python/ray/air/batch_predictor.py
@@ -130,7 +130,7 @@ class BatchPredictor:
         blocks_per_window: Optional[int] = None,
         bytes_per_window: Optional[int] = None,
         **kwargs,
-    ) -> ray.data.Dataset:
+    ) -> ray.data.DatasetPipeline:
         """Setup a prediction pipeline for batch scoring.
 
         Unlike `predict()`, this generates a DatasetPipeline object and does not

--- a/python/ray/air/batch_predictor.py
+++ b/python/ray/air/batch_predictor.py
@@ -68,12 +68,12 @@ class BatchPredictor:
             ...     def predict(self, data, **kwargs):
             ...         return pd.DataFrame({"a": [42] * len(data)})
             >>> # Create a batch predictor for this dummy predictor.
-            >>> batch_pred = BatchPredictor(
+            >>> batch_pred = BatchPredictor( # doctest: +SKIP
             ...     Checkpoint.from_dict({"x": 0}), DummyPredictor)
             >>> # Create a dummy dataset.
-            >>> ds = ray.data.range_tensor(1000, parallelism=4)
+            >>> ds = ray.data.range_tensor(1000, parallelism=4) # doctest: +SKIP
             >>> # Execute batch prediction using this predictor.
-            >>> print(batch_pred.predict(ds))
+            >>> print(batch_pred.predict(ds)) # doctest: +SKIP
             Dataset(num_blocks=4, num_rows=1000, schema={a: int64})
 
         Args:
@@ -151,12 +151,13 @@ class BatchPredictor:
             ...     def predict(self, data, **kwargs):
             ...         return pd.DataFrame({"a": [42] * len(data)})
             >>> # Create a batch predictor for this dummy predictor.
-            >>> batch_pred = BatchPredictor(
+            >>> batch_pred = BatchPredictor( # doctest: +SKIP
             ...     Checkpoint.from_dict({"x": 0}), DummyPredictor)
             >>> # Create a dummy dataset.
-            >>> ds = ray.data.range_tensor(1000, parallelism=4)
+            >>> ds = ray.data.range_tensor(1000, parallelism=4) # doctest: +SKIP
             >>> # Setup a prediction pipeline.
-            >>> print(batch_pred.predict_pipelined(ds, blocks_per_window=1))
+            >>> print(batch_pred.predict_pipelined( # doctest: +SKIP
+            ...     ds, blocks_per_window=1))
             DatasetPipeline(num_windows=4, num_stages=3)
 
         Args:

--- a/python/ray/air/tests/test_batch_predictor.py
+++ b/python/ray/air/tests/test_batch_predictor.py
@@ -56,6 +56,16 @@ def test_batch_prediction():
         16.0,
     ]
 
+    test_dataset = ray.data.from_items([1.0, 2.0, 3.0, 4.0])
+    assert next(
+        batch_predictor.predict_pipelined(
+            test_dataset, blocks_per_window=2
+        ).iter_datasets()
+    ).to_pandas().to_numpy().squeeze().tolist() == [
+        4.0,
+        8.0,
+    ]
+
 
 def test_batch_prediction_fs():
     batch_predictor = BatchPredictor.from_checkpoint(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add pipelined batch prediction support. This technically isn't required, but I think it is a bit discoverability improvement to surface it as a top-level API instead of relying on the user to know how to generate pipelines.