### PR TITLE
Windows gpu detection workaround with GPUtil

### DIFF
--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -273,8 +273,7 @@ class ResourceSpec(
 def _autodetect_num_gpus():
     """Attempt to detect the number of GPUs on this machine.
 
-    TODO(rkn): This currently assumes NVIDIA GPUs on Linux.
-    TODO(mehrdadn): Use a better mechanism for Windows.
+    TODO(rkn): Only detects NVidia GPUs (except when using WMIC on windows)
 
     Returns:
         The number of GPUs if any were detected, otherwise 0.
@@ -341,8 +340,7 @@ def _constraints_from_gpu_info(info_str: str):
 def _get_gpu_info_string():
     """Get the gpu type for this machine.
 
-    TODO(Alex): All the caveats of _autodetect_num_gpus and we assume only one
-    gpu type.
+    TODO: Detects maximum one NVidia gpu type on linux
 
     Returns:
         (str) The gpu's model name.

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -183,10 +183,7 @@ class ResourceSpec(
                 num_gpus = min(num_gpus, len(gpu_ids))
 
         try:
-            if (
-                sys.platform.startswith("linux")
-                and importlib.util.find_spec("GPUtil") is not None
-            ):
+            if importlib.util.find_spec("GPUtil") is not None:
                 gpu_types = _get_gpu_types_gputil()
             else:
                 info_string = _get_gpu_info_string()
@@ -283,14 +280,13 @@ def _autodetect_num_gpus():
         The number of GPUs if any were detected, otherwise 0.
     """
     result = 0
-    if sys.platform.startswith("linux"):
-        if importlib.util.find_spec("GPUtil"):
-            gpu_list = GPUtil.getGPUs()
-            result = len(gpu_list)
-        else:
-            proc_gpus_path = "/proc/driver/nvidia/gpus"
-            if os.path.isdir(proc_gpus_path):
-                result = len(os.listdir(proc_gpus_path))
+    if importlib.util.find_spec("GPUtil"):
+        gpu_list = GPUtil.getGPUs()
+        result = len(gpu_list)
+    elif sys.platform.startswith("linux"):
+        proc_gpus_path = "/proc/driver/nvidia/gpus"
+        if os.path.isdir(proc_gpus_path):
+            result = len(os.listdir(proc_gpus_path))
     elif sys.platform == "win32":
         props = "AdapterCompatibility"
         cmdargs = ["WMIC", "PATH", "Win32_VideoController", "GET", props]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Because [WMIC is now deprecated](https://docs.microsoft.com/en-us/windows/deployment/planning/windows-10-deprecated-features), #9300 may stop working on recent Windows systems. As a workaround this PR extends GPUtil to do GPU detection when installed on Windows systems.

## Related issue number

<!-- For example: "Closes #1234" -->
Workaround for #9166

This builds on #18938

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
