### PR TITLE
[docs] Move the workflows (alpha) library to the more libraries section for now

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -197,6 +197,15 @@ parts:
       - file: ray-more-libs/index
         title: More Libraries
         sections:
+          - file: ray-more-libs/joblib
+          - file: ray-more-libs/lightgbm-ray
+          - file: ray-more-libs/multiprocessing
+          - file: ray-more-libs/ray-collective
+          - file: ray-more-libs/ray-lightning
+          - file: ray-core/examples/using-ray-with-pytorch-lightning
+          - file: ray-more-libs/xgboost-ray
+          - file: ray-core/examples/dask_xgboost/dask_xgboost
+          - file: ray-core/examples/modin_xgboost/modin_xgboost
           - file: workflows/concepts
             title: Ray Workflows
             sections:
@@ -207,15 +216,6 @@ parts:
               - file: workflows/comparison
               - file: workflows/advanced
               - file: workflows/package-ref
-          - file: ray-more-libs/joblib
-          - file: ray-more-libs/lightgbm-ray
-          - file: ray-more-libs/multiprocessing
-          - file: ray-more-libs/ray-collective
-          - file: ray-more-libs/ray-lightning
-          - file: ray-core/examples/using-ray-with-pytorch-lightning
-          - file: ray-more-libs/xgboost-ray
-          - file: ray-core/examples/dask_xgboost/dask_xgboost
-          - file: ray-core/examples/modin_xgboost/modin_xgboost
 
   - caption: Ray Core
     chapters:

--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -194,20 +194,19 @@ parts:
           - file: rllib/rllib-examples
           - file: rllib/package_ref/index
 
-      - file: workflows/concepts
-        title: Ray Workflows
-        sections:
-          - file: workflows/basics
-          - file: workflows/management
-          - file: workflows/metadata
-          - file: workflows/events
-          - file: workflows/comparison
-          - file: workflows/advanced
-          - file: workflows/package-ref
-
       - file: ray-more-libs/index
         title: More Libraries
         sections:
+          - file: workflows/concepts
+            title: Ray Workflows
+            sections:
+              - file: workflows/basics
+              - file: workflows/management
+              - file: workflows/metadata
+              - file: workflows/events
+              - file: workflows/comparison
+              - file: workflows/advanced
+              - file: workflows/package-ref
           - file: ray-more-libs/joblib
           - file: ray-more-libs/lightgbm-ray
           - file: ray-more-libs/multiprocessing

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -40,7 +40,7 @@ It provides libraries for distributed
 [tuning](tune/index.rst), 
 [reinforcement learning](rllib/index.rst), 
 [model serving](serve/index.rst), 
-and [more](workflows/concepts.rst). 
+and [more](ray-more-libs/index.rst). 
 +++
 ```{link-button} ray-overview/index
 :type: ref


### PR DESCRIPTION
Move the workflows lib into more libraries, as it isn't something we can push into beta in the near future.