### PR TITLE
[rfc] [data] SPREAD actor pool actors evenly across the cluster by default

### DIFF
--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -10,7 +10,7 @@ from ray.data.block import (
     BlockPartition,
     BlockExecStats,
 )
-from ray.data.context import DatasetContext
+from ray.data.context import DatasetContext, DEFAULT_SCHEDULING_STRATEGY
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.block_list import BlockList
 from ray.data._internal.progress_bar import ProgressBar
@@ -187,6 +187,7 @@ class ActorPoolStrategy(ComputeStrategy):
         if not remote_args:
             remote_args["num_cpus"] = 1
 
+        ctx = DatasetContext.get_current()
         if (
             "scheduling_strategy" not in remote_args
             and ctx.scheduling_strategy == DEFAULT_SCHEDULING_STRATEGY

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -187,12 +187,12 @@ class ActorPoolStrategy(ComputeStrategy):
         if not remote_args:
             remote_args["num_cpus"] = 1
 
-        ctx = DatasetContext.get_current()
-        if (
-            "scheduling_strategy" not in remote_args
-            and ctx.scheduling_strategy == DEFAULT_SCHEDULING_STRATEGY
-        ):
-            remote_args["scheduling_strategy"] = "SPREAD"
+        if "scheduling_strategy" not in remote_args:
+            ctx = DatasetContext.get_current()
+            if ctx.scheduling_strategy == DEFAULT_SCHEDULING_STRATEGY:
+                remote_args["scheduling_strategy"] = "SPREAD"
+            else:
+                remote_args["scheduling_strategy"] = ctx.scheduling_strategy
 
         BlockWorker = ray.remote(**remote_args)(BlockWorker)
 

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -187,7 +187,11 @@ class ActorPoolStrategy(ComputeStrategy):
         if not remote_args:
             remote_args["num_cpus"] = 1
 
-        remote_args["scheduling_strategy"] = context.scheduling_strategy
+        if (
+            "scheduling_strategy" not in remote_args
+            and ctx.scheduling_strategy == DEFAULT_SCHEDULING_STRATEGY
+        ):
+            remote_args["scheduling_strategy"] = "SPREAD"
 
         BlockWorker = ray.remote(**remote_args)(BlockWorker)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I think that we should spread actors by default, since we don't optimize for locality here. This should provide better load balancing of actors during pipelined execution by default.