### PR TITLE
[data] Fix stage fusion between equivalent resource args (fixes BatchPredictor)

### DIFF
--- a/python/ray/air/tests/test_batch_predictor.py
+++ b/python/ray/air/tests/test_batch_predictor.py
@@ -46,14 +46,15 @@ def test_batch_prediction():
         Checkpoint.from_dict({"factor": 2.0}), DummyPredictor
     )
 
-    test_dataset = ray.data.from_items([1.0, 2.0, 3.0, 4.0])
-    assert batch_predictor.predict(
-        test_dataset
-    ).to_pandas().to_numpy().squeeze().tolist() == [
+    test_dataset = ray.data.range(4)
+    ds = batch_predictor.predict(test_dataset)
+    # Check fusion occurred.
+    assert "read->map_batches" in ds.stats(), ds.stats()
+    assert ds.to_pandas().to_numpy().squeeze().tolist() == [
+        0.0,
         4.0,
         8.0,
         12.0,
-        16.0,
     ]
 
 

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -315,6 +315,11 @@ def get_compute(compute_spec: Union[str, ComputeStrategy]) -> ComputeStrategy:
         raise ValueError("compute must be one of [`tasks`, `actors`, ComputeStrategy]")
 
 
+def is_task_compute(compute_spec: Union[str, ComputeStrategy]) -> bool:
+    return not compute_spec or compute_spec == "tasks" or \
+        isinstance(compute_spec, TaskPoolStrategy)
+
+
 def _map_block_split(block: Block, fn: Any, input_files: List[str]) -> BlockPartition:
     output = []
     stats = BlockExecStats.builder()

--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -316,8 +316,11 @@ def get_compute(compute_spec: Union[str, ComputeStrategy]) -> ComputeStrategy:
 
 
 def is_task_compute(compute_spec: Union[str, ComputeStrategy]) -> bool:
-    return not compute_spec or compute_spec == "tasks" or \
-        isinstance(compute_spec, TaskPoolStrategy)
+    return (
+        not compute_spec
+        or compute_spec == "tasks"
+        or isinstance(compute_spec, TaskPoolStrategy)
+    )
 
 
 def _map_block_split(block: Block, fn: Any, input_files: List[str]) -> BlockPartition:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -17,9 +17,8 @@ if TYPE_CHECKING:
 import ray
 from ray.data.context import DatasetContext
 from ray.data.block import Block
-from ray.data.compute import is_task_compute
 from ray.data._internal.block_list import BlockList
-from ray.data._internal.compute import get_compute
+from ray.data._internal.compute import get_compute, is_task_compute
 from ray.data._internal.stats import DatasetStats
 from ray.data._internal.lazy_block_list import LazyBlockList
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -594,6 +594,11 @@ def _canonicalize(remote_args: dict) -> dict:
         remote_args["num_cpus"] = 1
     if "num_gpus" not in remote_args or remote_args["num_gpus"] is None:
         remote_args["num_gpus"] = 0
+    resources = remote_args.get("resources", {})
+    for k, v in list(resources.items()):
+        if v is None or v == 0.0:
+            del resources[k]
+    remote_args["resources"] = resources
     return remote_args
 
 

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -364,6 +364,8 @@ def test_optimize_equivalent_remote_args(ray_start_regular_shared):
 
     equivalent_kwargs = [
         {},
+        {"resources": {"blah": 0}},
+        {"resources": {"blah": None}},
         {"num_cpus": None},
         {"num_cpus": 1},
         {"num_cpus": 1, "num_gpus": 0},

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -356,6 +356,36 @@ def test_optimize_fuse(ray_start_regular_shared):
     )
 
 
+def test_optimize_equivalent_remote_args(ray_start_regular_shared):
+    context = DatasetContext.get_current()
+    context.optimize_fuse_stages = True
+    context.optimize_fuse_read_stages = True
+    context.optimize_fuse_shuffle_stages = True
+
+    equivalent_kwargs = [
+        {},
+        {"num_cpus": None},
+        {"num_cpus": 1},
+        {"num_cpus": 1, "num_gpus": 0},
+        {"num_cpus": 1, "num_gpus": None},
+    ]
+
+    for kwa in equivalent_kwargs:
+        for kwb in equivalent_kwargs:
+            print("CHECKING", kwa, kwb)
+            pipe = ray.data.range(3).repeat(2)
+            pipe = pipe.map_batches(lambda x: x, compute="tasks", **kwa)
+            pipe = pipe.map_batches(lambda x: x, compute="tasks", **kwb)
+            pipe.take()
+            expect_stages(
+                pipe,
+                1,
+                [
+                    "read->map_batches->map_batches",
+                ],
+            )
+
+
 def test_optimize_incompatible_stages(ray_start_regular_shared):
     context = DatasetContext.get_current()
     context.optimize_fuse_stages = True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

BatchPredictor sets num_cpus and num_gpus explicitly, which was breaking the stage fusion optimization. Ensure that equivalent resource specifications are fused together.