### PR TITLE
[tune/ci] Multinode support killing nodes in Ray client mode

### DIFF
--- a/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
@@ -374,11 +374,6 @@ class DockerCluster:
         container = self._get_docker_container(node_id=node_id)
         subprocess.check_output(f"docker kill {container}", shell=True)
 
-    def __getstate__(self):
-        state = self.__dict__
-        state.pop("_execution_process", None)
-        state.pop("_execution_event", None)
-
 
 class RemoteAPI:
     """Remote API to control cluster state from within cluster tasks.

--- a/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
@@ -56,7 +56,7 @@ class DockerCluster:
         )
         self._monitor_process = None
 
-        self._execution_process = None
+        self._execution_thread = None
         self._execution_event = threading.Event()
         self._execution_queue = None
 
@@ -137,8 +137,8 @@ class DockerCluster:
                 if cmd == "kill_node":
                     self.kill_node(**kwargs)
 
-        self._execution_process = threading.Thread(target=entrypoint)
-        self._execution_process.start()
+        self._execution_thread = threading.Thread(target=entrypoint)
+        self._execution_thread.start()
 
         return RemoteAPI(self._execution_queue)
 
@@ -374,6 +374,9 @@ class RemoteAPI:
 
     This API uses a Ray queue to interact with an execution thread on the
     host machine that will execute commands passed to the queue.
+
+    Instances of this class can be serialized and passed to Ray remote actors
+    to interact with cluster state (but they can also be used outside actors).
 
     The API subset is limited to specific commands.
 

--- a/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/test_utils.py
@@ -348,12 +348,6 @@ class DockerCluster:
 
         return node_status["Name"]
 
-    def _execute_docker_cmd(self, cmd: str):
-        if self._execution_process:
-            self._execution_queue.put(cmd)
-        else:
-            subprocess.check_output(cmd, shell=True)
-
     def kill_node(
         self,
         node_id: Optional[str] = None,

--- a/python/ray/tune/tests/test_multinode_sync.py
+++ b/python/ray/tune/tests/test_multinode_sync.py
@@ -134,6 +134,7 @@ class MultiNodeSyncTest(unittest.TestCase):
         )
         self.cluster.start()
         self.cluster.connect(client=True, timeout=120)
+        remote_api = self.cluster.remote_execution_api()
 
         def train(config):
             time.sleep(120)
@@ -150,7 +151,7 @@ class MultiNodeSyncTest(unittest.TestCase):
                     and len(trials) == 3
                     and all(trial.status == Trial.RUNNING for trial in trials)
                 ):
-                    self._cluster.kill_node(num=2, _use_queue=True)
+                    remote_api.kill_node(num=2)
                     self._killed = True
 
         tune.run(

--- a/python/ray/tune/tests/test_multinode_sync.py
+++ b/python/ray/tune/tests/test_multinode_sync.py
@@ -115,7 +115,6 @@ class MultiNodeSyncTest(unittest.TestCase):
 
         When `max_failures` is set to larger than zero.
         """
-
         self.cluster.update_config(
             {
                 "provider": {"head_resources": {"CPU": 4, "GPU": 0}},
@@ -141,8 +140,7 @@ class MultiNodeSyncTest(unittest.TestCase):
             tune.report(1.0)
 
         class FailureInjectionCallback(Callback):
-            def __init__(self, cluster):
-                self._cluster = cluster
+            def __init__(self):
                 self._killed = False
 
             def on_step_begin(self, iteration, trials, **info):
@@ -159,7 +157,7 @@ class MultiNodeSyncTest(unittest.TestCase):
             num_samples=3,
             resources_per_trial={"cpu": 4},
             max_failures=1,
-            callbacks=[FailureInjectionCallback(self.cluster)],
+            callbacks=[FailureInjectionCallback()],
         )
 
     def testCheckpointSync(self):

--- a/python/ray/tune/tests/test_multinode_sync.py
+++ b/python/ray/tune/tests/test_multinode_sync.py
@@ -150,7 +150,7 @@ class MultiNodeSyncTest(unittest.TestCase):
                     and len(trials) == 3
                     and all(trial.status == Trial.RUNNING for trial in trials)
                 ):
-                    self._cluster.kill_node(num=2)
+                    self._cluster.kill_node(num=2, _use_queue=True)
                     self._killed = True
 
         tune.run(
@@ -159,10 +159,6 @@ class MultiNodeSyncTest(unittest.TestCase):
             resources_per_trial={"cpu": 4},
             max_failures=1,
             callbacks=[FailureInjectionCallback(self.cluster)],
-            # The following two are to be removed once we have proper setup
-            # for killing nodes while in ray client mode.
-            _remote=False,
-            local_dir="/tmp/ray_results/",
         )
 
     def testCheckpointSync(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The multi node testing utility currently does not support controlling cluster state from within Ray tasks or actors., but it currently requires Ray client. This makes it impossible to properly test e.g. fault tolerance, as the driver has to be executed on the client machine in order to control cluster state. However, this client machine is not part of the Ray cluster and can't schedule tasks on the local node - which is required by some utilities, e.g. checkpoint to driver syncing.

This PR introduces a remote control API for the multi node cluster utility that utilizes a Ray queue to communicate with an execution thread. That way we can instruct cluster commands from within the Ray cluster.

## Related issue number

Closes #21654

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
