### PR TITLE
[air] update checkpoint.py to deal with metadata in conversion.

### DIFF
--- a/python/ray/air/checkpoint.py
+++ b/python/ray/air/checkpoint.py
@@ -30,7 +30,7 @@ _CHECKPOINT_DIR_PREFIX = "checkpoint_tmp_"
 logger = logging.getLogger(__name__)
 
 
-@PublicAPI(stability="alpha")
+@PublicAPI
 class Checkpoint:
     """Ray ML Checkpoint.
 

--- a/python/ray/air/tests/test_checkpoints.py
+++ b/python/ray/air/tests/test_checkpoints.py
@@ -194,6 +194,33 @@ class CheckpointsConversionTest(unittest.TestCase):
 
         self._assert_fs_checkpoint(checkpoint)
 
+    def test_metadata(self):
+        """Test conversion with metadata involved.
+
+        a. from fs to dict checkpoint;
+        b. drop some marker to dict checkpoint;
+        c. convert back to fs checkpoint;
+        d. convert back to dict checkpoint.
+
+        Assert that the marker should still be there."""
+        checkpoint = self._prepare_fs_checkpoint()
+
+        # Convert into dict checkpoint
+        data_dict = checkpoint.to_dict()
+        self.assertIsInstance(data_dict, dict)
+
+        data_dict["my_marker"] = "marked"
+
+        # Create from dict
+        checkpoint = Checkpoint.from_dict(data_dict)
+        self.assertTrue(checkpoint._data_dict)
+
+        self._assert_fs_checkpoint(checkpoint)
+
+        # Convert back to dict
+        data_dict_2 = Checkpoint.from_directory(checkpoint.to_directory()).to_dict()
+        assert data_dict_2["my_marker"] == "marked"
+
     def test_fs_checkpoint_fs(self):
         """Test conversion from fs to fs checkpoint and back."""
         checkpoint = self._prepare_fs_checkpoint()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is carved out from https://github.com/ray-project/ray/pull/25558. 
tlrd: checkpoint.py current doesn't support the following
```
a. from fs to dict checkpoint;
b. drop some marker to dict checkpoint;
c. convert back to fs checkpoint;
d. convert back to dict checkpoint.
Assert that the marker should still be there
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
