### PR TITLE
[AWS] Cleanup Naming/Typing of Boto3 resources/clients

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -6,6 +6,7 @@ from collections import OrderedDict, defaultdict
 from typing import Any, Dict, List
 
 import botocore
+from boto3.resources.base import ServiceResource
 
 import ray.ray_constants as ray_constants
 from ray.autoscaler._private.aws.cloudwatch.cloudwatch_helper import (
@@ -54,7 +55,7 @@ def from_aws_format(tags):
     return tags
 
 
-def make_ec2_client(region, max_retries, aws_credentials=None):
+def make_ec2_resource(region, max_retries, aws_credentials=None) -> ServiceResource:
     """Make client, retrying requests up to `max_retries`."""
     aws_credentials = aws_credentials or {}
     return resource_cache("ec2", region, max_retries, **aws_credentials)
@@ -99,12 +100,12 @@ class AWSNodeProvider(NodeProvider):
         self.cache_stopped_nodes = provider_config.get("cache_stopped_nodes", True)
         aws_credentials = provider_config.get("aws_credentials")
 
-        self.ec2 = make_ec2_client(
+        self.ec2 = make_ec2_resource(
             region=provider_config["region"],
             max_retries=BOTO_MAX_RETRIES,
             aws_credentials=aws_credentials,
         )
-        self.ec2_fail_fast = make_ec2_client(
+        self.ec2_fail_fast = make_ec2_resource(
             region=provider_config["region"],
             max_retries=0,
             aws_credentials=aws_credentials,

--- a/python/ray/autoscaler/_private/aws/utils.py
+++ b/python/ray/autoscaler/_private/aws/utils.py
@@ -3,6 +3,8 @@ from functools import lru_cache
 
 import boto3
 from boto3.exceptions import ResourceNotExistsError
+from boto3.resources.base import ServiceResource
+from botocore.client import BaseClient
 from botocore.config import Config
 
 from ray.autoscaler._private.cli_logger import cf, cli_logger
@@ -141,7 +143,9 @@ def boto_exception_handler(msg, *args, **kwargs):
 
 
 @lru_cache()
-def resource_cache(name, region, max_retries=BOTO_MAX_RETRIES, **kwargs):
+def resource_cache(
+    name, region, max_retries=BOTO_MAX_RETRIES, **kwargs
+) -> ServiceResource:
     cli_logger.verbose(
         "Creating AWS resource `{}` in `{}`", cf.bold(name), cf.bold(region)
     )
@@ -157,7 +161,7 @@ def resource_cache(name, region, max_retries=BOTO_MAX_RETRIES, **kwargs):
 
 
 @lru_cache()
-def client_cache(name, region, max_retries=BOTO_MAX_RETRIES, **kwargs):
+def client_cache(name, region, max_retries=BOTO_MAX_RETRIES, **kwargs) -> BaseClient:
     try:
         # try to re-use a client from the resource cache first
         return resource_cache(name, region, max_retries, **kwargs).meta.client

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -727,7 +727,7 @@ def test_terminate_nodes(num_on_demand_nodes, num_spot_nodes, stop):
     }
     node_ids = list(on_demand_nodes.union(spot_nodes))
 
-    with patch("ray.autoscaler._private.aws.node_provider.make_ec2_client"):
+    with patch("ray.autoscaler._private.aws.node_provider.make_ec2_resource"):
         provider = AWSNodeProvider(
             provider_config={"region": "nowhere", "cache_stopped_nodes": stop},
             cluster_name="default",

--- a/python/ray/tests/aws/test_aws_batch_tag_update.py
+++ b/python/ray/tests/aws/test_aws_batch_tag_update.py
@@ -24,7 +24,7 @@ def batch_test(num_threads, delay):
     updated.
     """
     with mock.patch(
-        "ray.autoscaler._private.aws.node_provider.make_ec2_client"
+        "ray.autoscaler._private.aws.node_provider.make_ec2_resource"
     ), mock.patch.object(AWSNodeProvider, "_create_tags", mock_create_tags):
         provider = AWSNodeProvider(
             provider_config={"region": "nowhere"}, cluster_name="default"


### PR DESCRIPTION
## Why are these changes needed?
* It's a bit hard to follow if these are `clients` or `resources` so add typing + rename a mis-named function.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
