### PR TITLE
[Serve] Disable background thread of handle when autoscale config is …

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Coroutine, Dict, Optional, Union
 import threading
 
+import ray
 from ray.actor import ActorHandle
 
 from ray import serve
@@ -17,7 +18,9 @@ from ray.serve.utils import (
     DEFAULT,
 )
 from ray.serve.autoscaling_metrics import start_metrics_pusher
+from ray.serve.common import DeploymentInfo
 from ray.serve.constants import HANDLE_METRIC_PUSH_INTERVAL_S
+from ray.serve.generated.serve_pb2 import DeploymentRoute
 from ray.serve.router import Router, RequestMetadata
 from ray.util import metrics
 
@@ -106,13 +109,23 @@ class RayServeHandle:
 
         self.router: Router = _router or self._make_router()
 
-        self._stop_event = threading.Event()
-        self._pusher = start_metrics_pusher(
-            interval_s=HANDLE_METRIC_PUSH_INTERVAL_S,
-            collection_callback=self._collect_handle_queue_metrics,
-            metrics_process_func=self.controller_handle.record_handle_metrics.remote,
-            stop_event=self._stop_event,
+        deployment_route = DeploymentRoute.FromString(
+            ray.get(
+                self.controller_handle.get_deployment_info.remote(self.deployment_name)
+            )
         )
+        deployment_info = DeploymentInfo.from_proto(deployment_route.deployment_info)
+
+        self._stop_event = None
+        self._pusher = None
+        if deployment_info.deployment_config.autoscaling_config:
+            self._stop_event = threading.Event()
+            self._pusher = start_metrics_pusher(
+                interval_s=HANDLE_METRIC_PUSH_INTERVAL_S,
+                collection_callback=self._collect_handle_queue_metrics,
+                metrics_process_func=self.controller_handle.record_handle_metrics.remote,
+                stop_event=self._stop_event,
+            )
 
     def _collect_handle_queue_metrics(self) -> Dict[str, int]:
         return {self.deployment_name: self.router.get_num_queued_queries()}
@@ -125,8 +138,9 @@ class RayServeHandle:
         )
 
     def stop_metrics_pusher(self):
-        self._stop_event.set()
-        self._pusher.join()
+        if self._stop_event and self._pusher:
+            self._stop_event.set()
+            self._pusher.join()
 
     @property
     def is_polling(self) -> bool:

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -116,14 +116,15 @@ class RayServeHandle:
         )
         deployment_info = DeploymentInfo.from_proto(deployment_route.deployment_info)
 
-        self._stop_event = None
-        self._pusher = None
+        self._stop_event: Optional[threading.Event] = None
+        self._pusher: Optional[threading.Thread] = None
+        remote_func = self.controller_handle.record_handle_metrics.remote
         if deployment_info.deployment_config.autoscaling_config:
             self._stop_event = threading.Event()
             self._pusher = start_metrics_pusher(
                 interval_s=HANDLE_METRIC_PUSH_INTERVAL_S,
                 collection_callback=self._collect_handle_queue_metrics,
-                metrics_process_func=self.controller_handle.record_handle_metrics.remote,
+                metrics_process_func=remote_func,
                 stop_event=self._stop_event,
             )
 


### PR DESCRIPTION
…not set

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

No background thread needed when no autoscale config is set

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
