### PR TITLE
[datasets] Avoid unnecessary metadata serialization in Datasets shuffle

### DIFF
--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -181,7 +181,7 @@ class PushBasedShufflePlan(ShuffleOp):
                 stage.merge_schedule,
                 *self._map_args,
             )
-            metadata_ref = map_result.pop(0)
+            metadata_ref = map_result.pop(-1)
             return metadata_ref, map_result
 
         def submit_merge_task(arg):
@@ -338,7 +338,7 @@ class PushBasedShufflePlan(ShuffleOp):
         *map_args: List[Any],
     ) -> List[Union[BlockMetadata, Block]]:
         mapper_outputs = map_fn(idx, block, output_num_blocks, *map_args)
-        meta = mapper_outputs.pop(0)
+        meta = mapper_outputs.pop(-1)
 
         parts = []
         merge_idx = 0
@@ -351,7 +351,7 @@ class PushBasedShufflePlan(ShuffleOp):
             len(parts),
             schedule.num_merge_tasks_per_round,
         )
-        return [meta] + parts
+        return parts + [meta]
 
     @staticmethod
     def _merge(
@@ -375,7 +375,7 @@ class PushBasedShufflePlan(ShuffleOp):
         meta = BlockAccessor.for_block(block).get_metadata(
             input_files=None, exec_stats=stats.build()
         )
-        return [meta] + merged_outputs
+        return merged_outputs + [meta]
 
     @staticmethod
     def _compute_shuffle_schedule(

--- a/python/ray/data/_internal/shuffle.py
+++ b/python/ray/data/_internal/shuffle.py
@@ -77,8 +77,8 @@ class SimpleShufflePlan(ShuffleOp):
         # The first item returned is the BlockMetadata.
         shuffle_map_metadata = []
         for i, refs in enumerate(shuffle_map_out):
-            shuffle_map_metadata.append(refs[0])
-            shuffle_map_out[i] = refs[1:]
+            shuffle_map_metadata.append(refs[-1])
+            shuffle_map_out[i] = refs[:-1]
 
         # Eagerly delete the input block references in order to eagerly release
         # the blocks' memory.

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -67,7 +67,7 @@ class _ShufflePartitionOp(ShuffleOp):
         num_rows = sum(BlockAccessor.for_block(s).num_rows() for s in slices)
         assert num_rows == block.num_rows(), (num_rows, block.num_rows())
         metadata = block.get_metadata(input_files=None, exec_stats=stats.build())
-        return [metadata] + slices
+        return slices + [metadata]
 
     @staticmethod
     def reduce(

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -54,7 +54,7 @@ class _SortOp(ShuffleOp):
         meta = BlockAccessor.for_block(block).get_metadata(
             input_files=None, exec_stats=stats.build()
         )
-        return [meta] + out
+        return out + [meta]
 
     @staticmethod
     def reduce(

--- a/python/ray/data/grouped_dataset.py
+++ b/python/ray/data/grouped_dataset.py
@@ -35,7 +35,7 @@ class _GroupbyOp(ShuffleOp):
         meta = BlockAccessor.for_block(block).get_metadata(
             input_files=None, exec_stats=stats.build()
         )
-        return [meta] + parts
+        return parts + [meta]
 
     @staticmethod
     def reduce(

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -188,22 +188,38 @@ def test_push_based_shuffle_schedule():
             next_highest_merge_factor = schedule.num_map_tasks_per_round // (
                 schedule.num_merge_tasks_per_round + 1
             )
-            assert next_highest_merge_factor <= merge_factor <= actual_merge_factor
+            assert next_highest_merge_factor <= merge_factor <= actual_merge_factor, (
+                next_highest_merge_factor,
+                merge_factor,
+                actual_merge_factor,
+            )
         else:
-            assert schedule.num_merge_tasks_per_round == 1
+            assert schedule.num_merge_tasks_per_round == 1, (
+                schedule.num_map_tasks_per_round,
+                merge_factor,
+            )
 
         # Tasks are evenly distributed.
         tasks_per_node = defaultdict(int)
-        for node_id in schedule.merge_task_placement:
+        for i in range(schedule.num_merge_tasks_per_round):
+            task_options = schedule.get_merge_task_options(i)
+            node_id = task_options["scheduling_strategy"].node_id
             tasks_per_node[node_id] += 1
         low = min(tasks_per_node.values())
         high = low + 1
         assert low <= max(tasks_per_node.values()) <= high
 
         # Reducers are evenly distributed across mergers.
-        low = min(schedule.num_reducers_per_merge_idx)
-        high = low + 1
-        assert low <= max(schedule.num_reducers_per_merge_idx) <= high
+        num_reducers_per_merge_idx = [
+            schedule.merge_schedule.get_num_reducers_per_merge_idx(i)
+            for i in range(schedule.num_merge_tasks_per_round)
+        ]
+        high = max(num_reducers_per_merge_idx)
+        num_imbalanced = 0
+        for num_reducers in num_reducers_per_merge_idx:
+            if num_reducers < high:
+                num_imbalanced += 1
+        assert num_imbalanced <= 1
 
     for num_cpus in range(1, 20):
         _test(20, 3, {"node1": num_cpus})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Push-based shuffle has some extra metadata involving merge and reduce tasks. Previously we were serializing an O(n) (n = reduce tasks) metadata and sending this to tasks, which caused a lot of unnecessary plasma usage on the head node. This PR splits up the metadata into parts that can be kept on the driver and a relatively cheap part that is sent to all tasks.

## Related issue number

One of the issues needed for #24480.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
