### PR TITLE
[core] Clear backlogged deletions for spilled objects

### DIFF
--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -142,7 +142,6 @@ void LocalObjectManager::FlushFreeObjects() {
     on_objects_freed_(objects_to_free_);
     objects_to_free_.clear();
   }
-  // Deletion wouldn't work when the object pinning is not enabled.
   ProcessSpilledObjectsDeleteQueue(free_objects_batch_size_);
   last_free_objects_at_ms_ = current_time_ms();
 }
@@ -301,11 +300,13 @@ void LocalObjectManager::SpillObjectsInternal(
         rpc::SpillObjectsRequest request;
         std::vector<ObjectID> requested_objects_to_spill;
         for (const auto &object_id : objects_to_spill) {
-          RAY_CHECK(objects_pending_spill_.count(object_id));
+          auto it = objects_pending_spill_.find(object_id);
+          RAY_CHECK(it != objects_pending_spill_.end());
           auto freed_it = local_objects_.find(object_id);
           // If the object hasn't already been freed, spill it.
           if (freed_it == local_objects_.end() || freed_it->second.second) {
-            objects_pending_spill_.erase(object_id);
+            num_bytes_pending_spill_ -= it->second->GetSize();
+            objects_pending_spill_.erase(it);
           } else {
             auto ref = request.add_object_refs_to_spill();
             ref->set_object_id(object_id.Binary());
@@ -314,6 +315,12 @@ void LocalObjectManager::SpillObjectsInternal(
             requested_objects_to_spill.push_back(object_id);
           }
         }
+
+        if (request.object_refs_to_spill_size() == 0) {
+          callback(Status::OK());
+          return;
+        }
+
         io_worker->rpc_client()->SpillObjects(
             request,
             [this, requested_objects_to_spill, callback, io_worker](
@@ -350,6 +357,13 @@ void LocalObjectManager::SpillObjectsInternal(
               }
             });
       });
+
+  // Deleting spilled objects can fall behind when there is a lot
+  // of concurrent spilling and object frees. Clear the queue here
+  // if needed.
+  if (spilled_object_pending_delete_.size() >= free_objects_batch_size_) {
+    ProcessSpilledObjectsDeleteQueue(free_objects_batch_size_);
+  }
 }
 
 void LocalObjectManager::OnObjectSpilled(const std::vector<ObjectID> &object_ids,
@@ -604,6 +618,7 @@ std::string LocalObjectManager::DebugString() const {
   result << "- num bytes pending spill: " << num_bytes_pending_spill_ << "\n";
   result << "- cumulative spill requests: " << spilled_objects_total_ << "\n";
   result << "- cumulative restore requests: " << restored_objects_total_ << "\n";
+  result << "- spilled objects pending delete: " << spilled_object_pending_delete_.size() << "\n";
   return result.str();
 }
 

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -340,6 +340,10 @@ class LocalObjectManagerTestWithMinSpillingSize {
     RayConfig::instance().initialize(R"({"object_spilling_config": "dummy"})");
   }
 
+  int64_t NumBytesPendingSpill() {
+    return manager.num_bytes_pending_spill_;
+  }
+
   void AssertNoLeaks() {
     // TODO(swang): Assert this for all tests.
     ASSERT_TRUE(manager.pinned_objects_size_ == 0);
@@ -1280,7 +1284,7 @@ TEST_F(LocalObjectManagerTest, TestDuplicatePinAndSpill) {
 
   // Should only spill the objects once.
   ASSERT_TRUE(worker_pool.FlushPopSpillWorkerCallbacks());
-  ASSERT_TRUE(worker_pool.io_worker_client->ReplySpillObjects({}));
+  ASSERT_FALSE(worker_pool.io_worker_client->ReplySpillObjects({}));
   ASSERT_FALSE(worker_pool.FlushPopSpillWorkerCallbacks());
 
   manager.FlushFreeObjects();
@@ -1453,6 +1457,128 @@ TEST_F(LocalObjectManagerTest, TestPinBytes) {
 
   // With no pinned or spilled object, the pinned bytes should be 0.
   ASSERT_EQ(manager.GetPinnedBytes(), 0);
+
+  AssertNoLeaks();
+}
+
+TEST_F(LocalObjectManagerTest, TestConcurrentSpillAndDelete1) {
+  rpc::Address owner_address;
+  owner_address.set_worker_id(WorkerID::FromRandom().Binary());
+
+  std::vector<ObjectID> object_ids;
+  // Prepare data for objects.
+  for (size_t i = 0; i < free_objects_batch_size; i++) {
+    ObjectID object_id = ObjectID::FromRandom();
+    object_ids.push_back(object_id);
+  }
+
+  std::vector<std::unique_ptr<RayObject>> objects;
+  for (size_t i = 0; i < free_objects_batch_size; i++) {
+    std::string meta = std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
+    auto metadata = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+    auto meta_buffer = std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
+    auto object = std::make_unique<RayObject>(
+        nullptr, meta_buffer, std::vector<rpc::ObjectReference>());
+    objects.push_back(std::move(object));
+  }
+
+  // There is no pinned object yet.
+  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+
+  // Pin objects.
+  manager.PinObjectsAndWaitForFree(object_ids, std::move(objects), owner_address);
+
+  // Pinned object memory should be reported.
+  ASSERT_GT(manager.GetPinnedBytes(), 0);
+
+  // Spill all objects.
+  bool spilled = false;
+  manager.SpillObjects(object_ids, [&](const Status &status) {
+    RAY_CHECK(status.ok());
+    spilled = true;
+  });
+  ASSERT_FALSE(spilled);
+  ASSERT_TRUE(worker_pool.FlushPopSpillWorkerCallbacks());
+
+  // Delete all objects while they're being spilled.
+  for (size_t i = 0; i < free_objects_batch_size; i++) {
+    EXPECT_CALL(*subscriber_, Unsubscribe(_, _, object_ids[i].Binary()));
+    ASSERT_TRUE(subscriber_->PublishObjectEviction());
+  }
+
+  // Spill finishes, they should get deleted now.
+  std::vector<std::string> urls;
+  for (size_t i = 0; i < object_ids.size(); i++) {
+    urls.push_back(BuildURL("url" + std::to_string(i)));
+  }
+  ASSERT_TRUE(worker_pool.io_worker_client->ReplySpillObjects(urls));
+  ASSERT_FALSE(owner_client->ReplyUpdateObjectLocationBatch());
+  ASSERT_TRUE(spilled);
+
+  manager.ProcessSpilledObjectsDeleteQueue(free_objects_batch_size);
+  int deleted_urls_size = worker_pool.io_worker_client->ReplyDeleteSpilledObjects();
+  ASSERT_EQ(deleted_urls_size, object_ids.size());
+  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(NumBytesPendingSpill(), 0);
+
+  AssertNoLeaks();
+}
+
+TEST_F(LocalObjectManagerTest, TestConcurrentSpillAndDelete2) {
+  rpc::Address owner_address;
+  owner_address.set_worker_id(WorkerID::FromRandom().Binary());
+
+  std::vector<ObjectID> object_ids;
+  // Prepare data for objects.
+  for (size_t i = 0; i < free_objects_batch_size; i++) {
+    ObjectID object_id = ObjectID::FromRandom();
+    object_ids.push_back(object_id);
+  }
+
+  std::vector<std::unique_ptr<RayObject>> objects;
+  for (size_t i = 0; i < free_objects_batch_size; i++) {
+    std::string meta = std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
+    auto metadata = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+    auto meta_buffer = std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
+    auto object = std::make_unique<RayObject>(
+        nullptr, meta_buffer, std::vector<rpc::ObjectReference>());
+    objects.push_back(std::move(object));
+  }
+
+  // There is no pinned object yet.
+  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+
+  // Pin objects.
+  manager.PinObjectsAndWaitForFree(object_ids, std::move(objects), owner_address);
+
+  // Pinned object memory should be reported.
+  ASSERT_GT(manager.GetPinnedBytes(), 0);
+
+  // Spill all objects.
+  bool spilled = false;
+  manager.SpillObjects(object_ids, [&](const Status &status) {
+    RAY_CHECK(status.ok());
+    spilled = true;
+  });
+  ASSERT_FALSE(spilled);
+
+  // Delete all objects while they're being spilled.
+  for (size_t i = 0; i < free_objects_batch_size; i++) {
+    EXPECT_CALL(*subscriber_, Unsubscribe(_, _, object_ids[i].Binary()));
+    ASSERT_TRUE(subscriber_->PublishObjectEviction());
+  }
+
+  ASSERT_TRUE(worker_pool.FlushPopSpillWorkerCallbacks());
+  std::vector<std::string> urls;
+  ASSERT_FALSE(worker_pool.io_worker_client->ReplySpillObjects(urls));
+  ASSERT_FALSE(owner_client->ReplyUpdateObjectLocationBatch());
+  ASSERT_TRUE(spilled);
+
+  manager.ProcessSpilledObjectsDeleteQueue(free_objects_batch_size);
+  int deleted_urls_size = worker_pool.io_worker_client->ReplyDeleteSpilledObjects();
+  ASSERT_EQ(deleted_urls_size, 0);
+  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(NumBytesPendingSpill(), 0);
 
   AssertNoLeaks();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When objects that are spilled or being spilled are freed, we queue a request to delete them. We only clear this queue when additional objects get freed, so GC for spilled objects can fall behind when there is a lot of concurrent spilling and deletion (as in Datasets push-based shuffle). This PR fixes this to clear the deletion queue if the backlog is greater than the configured batch size. Also fixes some accounting bugs for how many bytes are pinned vs pending spill.

## Related issue number

Closes #25467.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
