### PR TITLE
Make isort compatible with black

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,6 +2,7 @@
 # This is to make isort compatible with Black. See
 # https://black.readthedocs.io/en/stable/the_black_code_style.html#how-black-wraps-lines.
 line_length=88
+profile = black
 multi_line_output=3
 include_trailing_comma=True
 use_parentheses=True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,7 +2,7 @@
 # This is to make isort compatible with Black. See
 # https://black.readthedocs.io/en/stable/the_black_code_style.html#how-black-wraps-lines.
 line_length=88
-profile = black
+profile=black
 multi_line_output=3
 include_trailing_comma=True
 use_parentheses=True


### PR DESCRIPTION
## Why are these changes needed?

We should make isort play nicely with black

Before this fix:

./scripts/format.sh --files /Users/clarence/github/oss/ray/python/ray/autoscaler/_private/gcp/node_provider.py
```
Fixing /Users/clarence/github/oss/ray/python/ray/autoscaler/_private/gcp/node_provider.py
reformatted /Users/clarence/github/oss/ray/python/ray/autoscaler/_private/gcp/node_provider.py
All done! ✨ 🍰 ✨
1 file reformatted.
```
After the fix:

./scripts/format.sh --files /Users/clarence/github/oss/ray/python/ray/autoscaler/_private/gcp/node_provider.py
```
All done! ✨ 🍰 ✨
1 file left unchanged.
```
Follow up from https://github.com/ray-project/ray/pull/25678

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
