### PR TITLE
Add tip to first uninstall the Python-only build before installing the Full build

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -9,7 +9,7 @@ For a majority of Ray users, installing Ray via the latest wheels or pip package
 
   If you are only editing Python files, follow instructions for :ref:`python-develop` to avoid long build times.
 
-  If you already followed the instructions in :ref:`python-develop` and want to switch to the Full build in this section, you will need to first delete the symlinks and uninstall Ray.
+  If you already followed the instructions in :ref:`python-develop` and want to switch to the Full build in this section, you will need to first uninstall.
 
 .. contents::
   :local:

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -5,7 +5,11 @@ Building Ray from Source
 
 For a majority of Ray users, installing Ray via the latest wheels or pip package is usually enough. However, you may want to build the latest master branch.
 
-.. tip:: If you are only editing Python files, follow instructions for :ref:`python-develop` to avoid long build times.
+.. tip::
+
+  If you are only editing Python files, follow instructions for :ref:`python-develop` to avoid long build times.
+
+  If you already followed the instructions in :ref:`python-develop` and want to switch to the Full build in this section, you will need to first delete the symlinks and uninstall Ray.
 
 .. contents::
   :local:


### PR DESCRIPTION
## Why are these changes needed?

It is not clear from the docs that one needs to first uninstall the setup in "Building Ray (Python Only)" if one wants to switch to "Building Ray on Linux & MacOS (full)". Because of the symlinks in Python-only setup one must first delete them and the pip package before doing pip install -e that is in the full build

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [] This PR is not tested :(

run make html and verify the content:

Tip

If you are only editing Python files, follow instructions for [Building Ray (Python Only)](https://github.com/ray-project/ray/compare/cl_fbd?expand=1#python-develop) to avoid long build times.

If you already followed the instructions in [Building Ray (Python Only)](https://github.com/ray-project/ray/compare/cl_fbd?expand=1#python-develop) and want to switch to the Full build in this section, you will need to first delete the symlinks and uninstall Ray.
