### PR TITLE
[docs] Mention the import ordering style for python 

### DIFF
--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -131,7 +131,7 @@ Alternatively, you can also run one specific C++ test. You can use:
 Code Style
 ----------
 
-In general, we follow the `Google style guide <https://google.github.io/styleguide/>`__ for C++ code and the `Black code style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`__ for Python code. However, it is more important for code to be in a locally consistent style than to strictly follow guidelines. Whenever in doubt, follow the local code style of the component.
+In general, we follow the `Google style guide <https://google.github.io/styleguide/>`__ for C++ code and the `Black code style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`__ for Python code. Python imports follow `PEP8 style <https://peps.python.org/pep-0008/#imports>`__. However, it is more important for code to be in a locally consistent style than to strictly follow guidelines. Whenever in doubt, follow the local code style of the component.
 
 For Python documentation, we follow a subset of the `Google pydoc format <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`__. The following code snippet demonstrates the canonical Ray pydoc formatting:
 


### PR DESCRIPTION
## Why are these changes needed?

We recently added support in format.sh to auto-sort imports of new files in https://github.com/ray-project/ray/pull/25678

This PR adds documentation to the code style section that explicitly calls out the import ordering / style

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Run make html and got the following in the doc, and verified new link works

```
Code Style[¶](https://github.com/ray-project/ray/pull/25755#code-style)
In general, we follow the [Google style guide](https://google.github.io/styleguide/) for C++ code and the [Black code style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) for Python code. Python imports follow [PEP8 style](https://peps.python.org/pep-0008/#imports). However, it is more important for code to be in a locally consistent style than to strictly follow guidelines. Whenever in doubt, follow the local code style of the component.

For Python documentation, we follow a subset of the [Google pydoc format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). The following code snippet demonstrates the canonical Ray pydoc formatting:
```