### PR TITLE
[air] Use `predict_pandas` in xgboost, lightgbm, rl, huggingface, sklearn

### DIFF
--- a/python/ray/air/predictors/integrations/huggingface/huggingface_predictor.py
+++ b/python/ray/air/predictors/integrations/huggingface/huggingface_predictor.py
@@ -1,16 +1,16 @@
-from typing import Optional, Type, Union, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional, Type, Union
 
-import numpy as np
 import pandas as pd
-
-from transformers.pipelines import Pipeline, pipeline as pipeline_factory
+from transformers.pipelines import Pipeline
+from transformers.pipelines import pipeline as pipeline_factory
 from transformers.pipelines.table_question_answering import (
     TableQuestionAnsweringPipeline,
 )
 
-from ray.air.predictor import DataBatchType, Predictor
-from ray.air.checkpoint import Checkpoint
 from ray.air._internal.checkpointing import load_preprocessor_from_dir
+from ray.air.checkpoint import Checkpoint
+from ray.air.constants import TENSOR_COLUMN_NAME
+from ray.air.predictor import Predictor
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
@@ -101,12 +101,12 @@ class HuggingFacePredictor(Predictor):
             columns = columns[0]
         return columns
 
-    def predict(
+    def _predict_pandas(
         self,
-        data: DataBatchType,
+        data: "pd.DataFrame",
         feature_columns: Optional[List[str]] = None,
         **pipeline_call_kwargs,
-    ) -> DataBatchType:
+    ) -> "pd.DataFrame":
         """Run inference on data batch.
 
         The data is converted into a list (unless ``pipeline`` is a
@@ -150,14 +150,14 @@ class HuggingFacePredictor(Predictor):
 
 
         Returns:
-            DataBatchType: Prediction result.
+            Prediction result.
         """
-        if self.preprocessor:
-            data = self.preprocessor.transform_batch(data)
-
-        if isinstance(data, np.ndarray):
-            # If numpy array, then convert to pandas dataframe.
-            data = pd.DataFrame(data)
+        if TENSOR_COLUMN_NAME in data:
+            arr = data[TENSOR_COLUMN_NAME].to_numpy()
+            if feature_columns:
+                data = pd.DataFrame(arr[:, feature_columns])
+        elif feature_columns:
+            data = data[feature_columns]
 
         data = data[feature_columns] if feature_columns else data
 

--- a/python/ray/air/predictors/integrations/lightgbm/lightgbm_predictor.py
+++ b/python/ray/air/predictors/integrations/lightgbm/lightgbm_predictor.py
@@ -101,7 +101,7 @@ class LightGBMPredictor(Predictor):
 
 
         Returns:
-            pd.DataFrame: Prediction result.
+            Prediction result.
 
         """
         if TENSOR_COLUMN_NAME in data:

--- a/python/ray/air/predictors/integrations/sklearn/sklearn_predictor.py
+++ b/python/ray/air/predictors/integrations/sklearn/sklearn_predictor.py
@@ -1,16 +1,15 @@
-from typing import Optional, List, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import pandas as pd
-import numpy as np
 from joblib import parallel_backend
-
-from ray.air.checkpoint import Checkpoint
-from ray.air.predictor import Predictor, DataBatchType
-from ray.train.sklearn import load_checkpoint
-from ray.air._internal.sklearn_utils import set_cpu_params
-from ray.util.joblib import register_ray
-
 from sklearn.base import BaseEstimator
+
+from ray.air._internal.sklearn_utils import set_cpu_params
+from ray.air.checkpoint import Checkpoint
+from ray.air.constants import TENSOR_COLUMN_NAME
+from ray.air.predictor import Predictor
+from ray.train.sklearn import load_checkpoint
+from ray.util.joblib import register_ray
 
 if TYPE_CHECKING:
     from ray.data.preprocessor import Preprocessor
@@ -47,13 +46,13 @@ class SklearnPredictor(Predictor):
         estimator, preprocessor = load_checkpoint(checkpoint)
         return SklearnPredictor(estimator=estimator, preprocessor=preprocessor)
 
-    def predict(
+    def _predict_pandas(
         self,
-        data: DataBatchType,
+        data: "pd.DataFrame",
         feature_columns: Optional[Union[List[str], List[int]]] = None,
         num_estimator_cpus: Optional[int] = 1,
         **predict_kwargs,
-    ) -> pd.DataFrame:
+    ) -> "pd.DataFrame":
         """Run inference on data batch.
 
         Args:
@@ -110,22 +109,21 @@ class SklearnPredictor(Predictor):
 
 
         Returns:
-            pd.DataFrame: Prediction result.
+            Prediction result.
 
         """
         register_ray()
 
-        if self.preprocessor:
-            data = self.preprocessor.transform_batch(data)
-
         if num_estimator_cpus:
             set_cpu_params(self.estimator, num_estimator_cpus)
 
-        if feature_columns:
-            if isinstance(data, np.ndarray):
+        if TENSOR_COLUMN_NAME in data:
+            data = data[TENSOR_COLUMN_NAME].to_numpy()
+            if feature_columns:
                 data = data[:, feature_columns]
-            else:
-                data = data[feature_columns]
+        elif feature_columns:
+            data = data[feature_columns]
+
         with parallel_backend("ray", n_jobs=num_estimator_cpus):
             df = pd.DataFrame(self.estimator.predict(data, **predict_kwargs))
         df.columns = (

--- a/python/ray/air/predictors/integrations/xgboost/xgboost_predictor.py
+++ b/python/ray/air/predictors/integrations/xgboost/xgboost_predictor.py
@@ -105,7 +105,7 @@ class XGBoostPredictor(Predictor):
 
 
         Returns:
-            pd.DataFrame: Prediction result.
+            Prediction result.
 
         """
         dmatrix_kwargs = dmatrix_kwargs or {}

--- a/python/ray/air/predictors/integrations/xgboost/xgboost_predictor.py
+++ b/python/ray/air/predictors/integrations/xgboost/xgboost_predictor.py
@@ -1,11 +1,11 @@
-from typing import Optional, List, Union, Dict, Any, TYPE_CHECKING
-import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import pandas as pd
 import xgboost
 
 from ray.air.checkpoint import Checkpoint
-from ray.air.predictor import Predictor, DataBatchType
+from ray.air.constants import TENSOR_COLUMN_NAME
+from ray.air.predictor import Predictor
 from ray.train.xgboost import load_checkpoint
 
 if TYPE_CHECKING:
@@ -42,21 +42,20 @@ class XGBoostPredictor(Predictor):
         bst, preprocessor = load_checkpoint(checkpoint)
         return XGBoostPredictor(model=bst, preprocessor=preprocessor)
 
-    def predict(
+    def _predict_pandas(
         self,
-        data: DataBatchType,
+        data: "pd.DataFrame",
         feature_columns: Optional[Union[List[str], List[int]]] = None,
         dmatrix_kwargs: Optional[Dict[str, Any]] = None,
         **predict_kwargs,
-    ) -> pd.DataFrame:
+    ) -> "pd.DataFrame":
         """Run inference on data batch.
 
         The data is converted into an XGBoost DMatrix before being inputted to
         the model.
 
         Args:
-            data: A batch of input data. Either a pandas DataFrame or numpy
-                array.
+            data: A batch of input data.
             feature_columns: The names or indices of the columns in the
                 data to use as features to predict on. If None, then use
                 all columns in ``data``.
@@ -111,14 +110,13 @@ class XGBoostPredictor(Predictor):
         """
         dmatrix_kwargs = dmatrix_kwargs or {}
 
-        if self.preprocessor:
-            data = self.preprocessor.transform_batch(data)
-
-        if feature_columns:
-            if isinstance(data, np.ndarray):
+        if TENSOR_COLUMN_NAME in data:
+            data = data[TENSOR_COLUMN_NAME].to_numpy()
+            if feature_columns:
                 data = data[:, feature_columns]
-            else:
-                data = data[feature_columns]
+        elif feature_columns:
+            data = data[feature_columns]
+
         matrix = xgboost.DMatrix(data, **dmatrix_kwargs)
         df = pd.DataFrame(self.model.predict(matrix, **predict_kwargs))
         df.columns = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Switching to the `_predict_pandas` API implementation for xgboost, lightgbm, rl, huggingface, and sklearn predictors.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
