### PR TITLE
WINDOWS: replace ':' with '$' for filename

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -27,14 +27,14 @@ from ray._private.services import (
     wait_for_redis_to_start,
 )
 from ray._private.test_utils import (
+    get_and_run_node_killer,
     init_error_pubsub,
     init_log_pubsub,
     setup_tls,
     teardown_tls,
-    get_and_run_node_killer,
     test_external_redis,
 )
-from ray.cluster_utils import Cluster, AutoscalingCluster, cluster_not_supported
+from ray.cluster_utils import AutoscalingCluster, Cluster, cluster_not_supported
 
 
 def get_default_fixure_system_config():
@@ -747,6 +747,10 @@ def append_short_test_summary(rep):
         os.makedirs(summary_dir, exist_ok=True)
 
     test_name = rep.nodeid.replace(os.sep, "::")
+
+    if os.name == "nt":
+        # ":" is not legal in filenames in windows
+        test_name.replace(":", "$")
 
     header_file = os.path.join(summary_dir, "000_header.txt")
     summary_file = os.path.join(summary_dir, test_name + ".txt")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On windows, creating a file with a ':' in the name will fail. However '$' is fine. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #25766 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
