### PR TITLE
don't sort imports for init file

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -1,3 +1,5 @@
+# isort: skip_file
+
 import logging
 import os
 


### PR DESCRIPTION
## Why are these changes needed?

The init file has some special import ordering that it must preserve, and therefore should not be automatically sorted by the formatter script.

## Related issue number

https://github.com/ray-project/ray/pull/25678

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
