### PR TITLE
Respect import order for psutil and setproctitle

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,4 +9,6 @@ use_parentheses=True
 float_to_top=True
 
 
-known_first_party=ray
+known_local_folder=ray
+known_afterray=psutil,setproctitle
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER,AFTERRAY

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -1,32 +1,33 @@
 import argparse
 import asyncio
 import io
+import json
 import logging
 import logging.handlers
 import os
 import sys
-import json
+
+import ray
+import ray._private.services
+import ray._private.utils
+import ray.dashboard.consts as dashboard_consts
+import ray.dashboard.utils as dashboard_utils
+import ray.experimental.internal_kv as internal_kv
+import ray.ray_constants as ray_constants
+from ray._private.gcs_pubsub import GcsAioPublisher, GcsPublisher
+from ray._private.gcs_utils import GcsClient
+from ray._private.ray_logging import setup_component_logger
+from ray.core.generated import agent_manager_pb2, agent_manager_pb2_grpc
+
+# Import psutil after ray so the packaged version is used.
+import psutil
 
 try:
     from grpc import aio as aiogrpc
 except ImportError:
     from grpc.experimental import aio as aiogrpc
 
-import ray
-import ray.experimental.internal_kv as internal_kv
-import ray.dashboard.consts as dashboard_consts
-import ray.dashboard.utils as dashboard_utils
-import ray.ray_constants as ray_constants
-import ray._private.services
-import ray._private.utils
-from ray._private.gcs_utils import GcsClient
-from ray._private.gcs_pubsub import GcsPublisher, GcsAioPublisher
-from ray.core.generated import agent_manager_pb2
-from ray.core.generated import agent_manager_pb2_grpc
-from ray._private.ray_logging import setup_component_logger
 
-# Import psutil after ray so the packaged version is used.
-import psutil
 
 # Publishes at most this number of lines of Raylet logs, when the Raylet dies
 # unexpectedly.

--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -28,7 +28,6 @@ except ImportError:
     from grpc.experimental import aio as aiogrpc
 
 
-
 # Publishes at most this number of lines of Raylet logs, when the Raylet dies
 # unexpectedly.
 _RAYLET_LOG_MAX_PUBLISH_LINES = 20

--- a/python/ray/autoscaler/_private/cluster_dump.py
+++ b/python/ray/autoscaler/_private/cluster_dump.py
@@ -9,14 +9,15 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import List, Optional, Sequence, Tuple
 
-# Import psutil after ray so the packaged version is used.
-import psutil
 import yaml
 
 import ray  # noqa: F401
 from ray.autoscaler._private.cli_logger import cli_logger
 from ray.autoscaler._private.providers import _get_node_provider
 from ray.autoscaler.tags import NODE_KIND_HEAD, NODE_KIND_WORKER, TAG_RAY_NODE_KIND
+
+# Import psutil after ray so the packaged version is used.
+import psutil
 
 MAX_PARALLEL_SSH_WORKERS = 8
 DEFAULT_SSH_USER = "ubuntu"


### PR DESCRIPTION
## Why are these changes needed?

Sort imports in a way that preserves the ordering requirements. This PR is needed for any file changes that imports psutil or setproctitle

Before:
```
isort dashboard/agent.py 
python -m ci.lint.check_import_order dashboard/agent.py

```
```
dashboard/agent.py:11 import psutil without explicitly import ray before it.
check import ordering failed

```
With fix it doesn't print the error

## Related issue number

https://github.com/ray-project/ray/pull/25678

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
