### PR TITLE
[CI] Print linkcheck summary only in linkcheck

### DIFF
--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -275,9 +275,11 @@ class _BrokenLinksQueue(Queue):
 
     def __init__(self, maxsize: int = 0) -> None:
         self._last_line_no = None
+        self.used = False
         super().__init__(maxsize)
 
     def put(self, item: logging.LogRecord, block=True, timeout=None):
+        self.used = True
         message = item.getMessage()
         # line nos are separate records
         if ": line" in message:
@@ -318,6 +320,9 @@ class LinkcheckSummarizer:
 
     def summarize(self, *args, **kwargs):
         """Summarizes broken links."""
+        if not self.log_queue.used:
+            return
+
         self.logger.logger.removeHandler(self.queue_handler)
 
         self.logger.info("\nBROKEN LINKS SUMMARY:\n")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Small tweak to ensure that the "BROKEN LINKS SUMMARY" message is only printed in the LinkCheck job and not Lint.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
