### PR TITLE
Revert "[Ray Dataset] fix the type infer of `pd.dataframe` (when dtype is `object`.) "

### DIFF
--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -47,13 +47,6 @@ def convert_pandas_to_tf_tensor(
             # them. If the columns contain different types (for example, `float32`s
             # and `int32`s), then `tf.concat` raises an error.
             dtype: np.dtype = np.find_common_type(df.dtypes, [])
-
-            # if the columns are `ray.data.extensions.tensor_extension.TensorArray`,
-            # the dtype will be `object`. In this case, we need to set the dtype to
-            # none, and use the automatic type casting of `tf.convert_to_tensor`.
-            if isinstance(dtype, object):
-                dtype = None
-
         except TypeError:
             # `find_common_type` fails if a series has `TensorDtype`. In this case,
             # don't cast any of the series and continue.


### PR DESCRIPTION
Reverts ray-project/ray#25563

looks it breaks the master:

<img width="540" alt="image" src="https://user-images.githubusercontent.com/837180/173719893-b08d9ded-8d11-4ccc-8adf-4ea01eaff89c.png">
