### PR TITLE
[core] Allow setting object spill config from RAY_object_spilling_config env var

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -1467,6 +1467,9 @@ class Node:
         if not automatic_spilling_enabled:
             return
 
+        if not object_spilling_config:
+            object_spilling_config = os.environ.get("RAY_object_spilling_config", "")
+
         # If the config is not specified, we fill up the default.
         if not object_spilling_config:
             object_spilling_config = json.dumps(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously it was not possible to set the object spill config from the `RAY_xxx` environment variable, unlike other system configs. This is because the config is initialized in Python first, before the C++ config is parsed.