### PR TITLE
[data] Make ActorPoolStrategy kill pool of actors if exception is raised

### DIFF
--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -272,9 +272,10 @@ class ActorPoolStrategy(ComputeStrategy):
                 new_metadata = ray.get(new_metadata)
             return BlockList(new_blocks, new_metadata)
 
-        finally:
+        except Exception:
             for worker in workers:
                 ray.kill(worker)
+            raise
 
 
 def cache_wrapper(

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -11,7 +11,6 @@ import pyarrow.parquet as pq
 import pytest
 
 import ray
-import ray.data.tests.util as util
 from ray._private.test_utils import wait_for_condition
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data._internal.block_builder import BlockBuilder


### PR DESCRIPTION
## Why are these changes needed?

This PR makes `ray.data.ActorPoolStrategy` gracefully handle exceptions by terminating any running actors.

## Related issue number

Closes #24948.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR. **Looks like `format.sh` rearranged some imports too. If this isn't what we want, I can revert this.**
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

The linting CI failure seems to be unrelated.