### PR TITLE
[serve][docs] Replaced term 'actor_init_options' with 'ray_actor_options' in documentation

### DIFF
--- a/doc/source/serve/performance.md
+++ b/doc/source/serve/performance.md
@@ -39,7 +39,7 @@ Given the symptom, there are several ways to fix it.
 ### Choosing the right hardware
 
 Make sure you are using the right hardware and resources.
-Are you using GPUs (`actor_init_options={“num_gpus”: 1}`) or 1+ cores (`actor_init_options={“num_cpus”: 2}`, and setting `OMP_NUM_THREADS`)
+Are you using GPUs (`ray_actor_options={“num_gpus”: 1}`) or 1+ cores (`ray_actor_options={“num_cpus”: 2}`, and setting `OMP_NUM_THREADS`)
 to increase the performance of your deep learning framework?
 
 ### Async functions


### PR DESCRIPTION
## Why are these changes needed?

Replaced the term `actor_init_options` with `ray_actor_options` in [this documentation section](https://docs.ray.io/en/releases-1.13.0/serve/performance.html#choosing-the-right-hardware) because `actor_init_options` is an outdated variable name. It's been changed to `ray_actor_options` in the [code](https://github.com/ray-project/ray/blob/2546fbf99de4fdc892807eeb56dbc076df389365/python/ray/serve/deployment.py#L45).

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - N/A this is a change made to documentation

