### PR TITLE
[Serve] Use node affinity for HTTPProxy actors to allow scaledown by Ray Autoscaler

### DIFF
--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -5,12 +5,13 @@ from typing import Dict, List, Tuple
 
 import ray
 from ray.actor import ActorHandle
-from ray.serve.config import HTTPOptions, DeploymentMode
+from ray.serve.common import EndpointTag, NodeId
+from ray.serve.config import DeploymentMode, HTTPOptions
 from ray.serve.constants import (
     ASYNC_CONCURRENCY,
     SERVE_LOGGER_NAME,
-    SERVE_PROXY_NAME,
     SERVE_NAMESPACE,
+    SERVE_PROXY_NAME,
 )
 from ray.serve.http_proxy import HTTPProxyActor
 from ray.serve.utils import (
@@ -18,7 +19,7 @@ from ray.serve.utils import (
     get_all_node_ids,
     get_current_node_resource_key,
 )
-from ray.serve.common import EndpointTag, NodeId
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -123,7 +124,9 @@ class HTTPState:
                     max_concurrency=ASYNC_CONCURRENCY,
                     max_restarts=-1,
                     max_task_retries=-1,
-                    resources={node_resource: 0.01},
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id, soft=False
+                    ),
                 ).remote(
                     self._config.host,
                     self._config.port,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
TODO: 
- [ ] Figure out why the existing unit test for the downscale behavior https://github.com/ray-project/ray/blob/master/python/ray/serve/tests/test_standalone2.py#L650-L696 was spuriously passing, and fix it.
## Why are these changes needed?
Uses node affinity to allow the Ray Autoscaler to shut down a node when the HTTPproxy actor is the only actor on the node.  Previously, the autoscaler would never shut down the node because it used `0.01` of a custom resource to enforce that there be only one HTTPproxy per node, but any amount of any resource being used would prevent scaledown.  This PR uses the node affinity API instead to enforce the placement constraint.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/25414
Closes https://github.com/ray-project/ray/issues/22734
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
