### PR TITLE
[Datasets] Workaround for unserializable Arrow JSON ReadOptions.

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,40 +1,50 @@
-from ray.data.read_api import (  # noqa: F401
-    from_items,
-    range,
-    range_table,
-    range_arrow,
-    range_tensor,
-    read_parquet,
-    read_parquet_bulk,
-    read_json,
-    read_csv,
-    read_binary_files,
-    from_dask,
-    from_modin,
-    from_mars,
-    from_pandas,
-    from_pandas_refs,
-    from_numpy,
-    from_numpy_refs,
-    from_arrow,
-    from_arrow_refs,
-    from_spark,
-    from_huggingface,
-    read_datasource,
-    read_numpy,
-    read_text,
+import ray
+from ray.data._internal.arrow_serialization import (
+    _register_arrow_json_readoptions_serializer,
 )
-from ray.data.datasource import Datasource, ReadTask
+from ray.data._internal.compute import ActorPoolStrategy
+from ray.data._internal.progress_bar import set_progress_bars
 from ray.data.dataset import Dataset
 from ray.data.dataset_pipeline import DatasetPipeline
-from ray.data._internal.progress_bar import set_progress_bars
-from ray.data._internal.compute import ActorPoolStrategy
+from ray.data.datasource import Datasource, ReadTask
 from ray.data.preprocessor import Preprocessor
+from ray.data.read_api import (  # noqa: F401
+    from_arrow,
+    from_arrow_refs,
+    from_dask,
+    from_huggingface,
+    from_items,
+    from_mars,
+    from_modin,
+    from_numpy,
+    from_numpy_refs,
+    from_pandas,
+    from_pandas_refs,
+    from_spark,
+    range,
+    range_arrow,
+    range_table,
+    range_tensor,
+    read_binary_files,
+    read_csv,
+    read_datasource,
+    read_json,
+    read_numpy,
+    read_parquet,
+    read_parquet_bulk,
+    read_text,
+)
 
 # Module-level cached global functions (for impl/compute). It cannot be defined
 # in impl/compute since it has to be process-global across cloudpickled funcs.
 _cached_fn = None
 _cached_cls = None
+
+# Register custom Arrow JSON ReadOptions serializer after worker has initialized.
+if ray.is_initialized():
+    _register_arrow_json_readoptions_serializer()
+else:
+    ray.worker._post_init_hooks.append(_register_arrow_json_readoptions_serializer)
 
 __all__ = [
     "ActorPoolStrategy",

--- a/python/ray/data/_internal/arrow_serialization.py
+++ b/python/ray/data/_internal/arrow_serialization.py
@@ -1,0 +1,29 @@
+import os
+
+
+def _register_arrow_json_readoptions_serializer():
+    import ray
+
+    if (
+        os.environ.get(
+            "RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION",
+            "0",
+        )
+        == "1"
+    ):
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.info("Disabling custom Arrow JSON ReadOptions serialization.")
+        return
+
+    try:
+        import pyarrow.json as pajson
+    except ModuleNotFoundError:
+        return
+
+    ray.util.register_serializer(
+        pajson.ReadOptions,
+        serializer=lambda opts: (opts.use_threads, opts.block_size),
+        deserializer=lambda args: pajson.ReadOptions(*args),
+    )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -67,7 +67,7 @@ from ray.data.datasource import (
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
-    _wrap_arrow_serialization_workaround,
+    _wrap_and_register_arrow_serialization_workaround,
 )
 from ray.data.random_access_dataset import RandomAccessDataset
 from ray.data.row import TableRow
@@ -2215,7 +2215,7 @@ class Dataset(Generic[T]):
                     blocks,
                     metadata,
                     ray_remote_args,
-                    _wrap_arrow_serialization_workaround(write_args),
+                    _wrap_and_register_arrow_serialization_workaround(write_args),
                 )
             )
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -35,7 +35,7 @@ from ray.data.datasource import (
 )
 from ray.data.datasource.file_based_datasource import (
     _unwrap_arrow_serialization_workaround,
-    _wrap_arrow_serialization_workaround,
+    _wrap_and_register_arrow_serialization_workaround,
 )
 from ray.types import ObjectRef
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
@@ -250,7 +250,7 @@ def read_datasource(
                 datasource,
                 ctx,
                 parallelism,
-                _wrap_arrow_serialization_workaround(read_args),
+                _wrap_and_register_arrow_serialization_workaround(read_args),
             )
         )
 


### PR DESCRIPTION
`pyarrow.json.ReadOptions` are not picklable until Arrow 8.0.0, which we do not yet support. This PR adds a custom serializer for this type and ensures that said serializer is registered before each Ray task submission.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #24966 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
