### PR TITLE
[runtime env] Make all plugins return a `List` of URIs

### DIFF
--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -236,7 +236,7 @@ class RuntimeEnvAgent(
 
     def unused_uris_processor(self, unused_uris: List[Tuple[str, UriType]]) -> None:
         for uri, uri_type in unused_uris:
-            self._uri_caches[uri_type.name].mark_unused(uri)
+            self._uri_caches[uri_type.value].mark_unused(uri)
 
     def unused_runtime_env_processor(self, unused_runtime_env: str) -> None:
         def delete_runtime_env():

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -1,40 +1,42 @@
 import asyncio
-import traceback
-from dataclasses import dataclass
 import json
 import logging
 import os
 import time
-from typing import Dict, Set, List, Tuple, Callable
-from enum import Enum
+import traceback
 from collections import defaultdict
-from ray._private.runtime_env.plugin import PluginCacheManager
-from ray._private.runtime_env.uri_cache import URICache
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict, List, Set, Tuple
 
-from ray._private.utils import import_attr
-from ray.core.generated import runtime_env_agent_pb2
-from ray.core.generated import runtime_env_agent_pb2_grpc
-from ray.core.generated import agent_manager_pb2
-import ray.dashboard.utils as dashboard_utils
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.modules.runtime_env.runtime_env_consts as runtime_env_consts
-from ray.experimental.internal_kv import (
-    _internal_kv_initialized,
-    _initialize_internal_kv,
-)
-from ray._private.ray_logging import setup_component_logger
+import ray.dashboard.utils as dashboard_utils
 from ray._private.async_compat import create_task
-from ray._private.runtime_env.pip import PipPlugin
+from ray._private.ray_logging import setup_component_logger
 from ray._private.runtime_env.conda import CondaPlugin
-from ray._private.runtime_env.context import RuntimeEnvContext
-from ray._private.runtime_env.py_modules import PyModulesPlugin
-from ray._private.runtime_env.java_jars import JavaJarsPlugin
-from ray._private.runtime_env.working_dir import WorkingDirPlugin
 from ray._private.runtime_env.container import ContainerManager
-from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.java_jars import JavaJarsPlugin
+from ray._private.runtime_env.pip import PipPlugin
+from ray._private.runtime_env.plugin import PluginCacheManager
+from ray._private.runtime_env.py_modules import PyModulesPlugin
+from ray._private.runtime_env.uri_cache import URICache
+from ray._private.runtime_env.working_dir import WorkingDirPlugin
+from ray._private.utils import import_attr
+from ray.core.generated import (
+    agent_manager_pb2,
+    runtime_env_agent_pb2,
+    runtime_env_agent_pb2_grpc,
+)
 from ray.core.generated.runtime_env_common_pb2 import (
     RuntimeEnvState as ProtoRuntimeEnvState,
 )
+from ray.experimental.internal_kv import (
+    _initialize_internal_kv,
+    _internal_kv_initialized,
+)
+from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
 
 default_logger = logging.getLogger(__name__)
 
@@ -55,11 +57,11 @@ class CreatedEnvResult:
 
 
 class UriType(Enum):
-    WORKING_DIR = 1
-    PY_MODULES = 2
-    PIP = 3
-    CONDA = 4
-    JAVA_JARS = 5
+    WORKING_DIR = "working_dir"
+    PY_MODULES = "py_modules"
+    PIP = "pip"
+    CONDA = "conda"
+    JAVA_JARS = "java_jars"
 
 
 class ReferenceTable:
@@ -226,35 +228,15 @@ class RuntimeEnvAgent(
 
     def uris_parser(self, runtime_env):
         result = list()
-        uri = self._working_dir_plugin.get_uri(runtime_env)
-        if uri:
-            result.append((uri, UriType.WORKING_DIR))
-        uris = self._py_modules_plugin.get_uris(runtime_env)
-        for uri in uris:
-            result.append((uri, UriType.PY_MODULES))
-        uri = self._pip_plugin.get_uri(runtime_env)
-        if uri:
-            result.append((uri, UriType.PIP))
-        uri = self._conda_plugin.get_uri(runtime_env)
-        if uri:
-            result.append((uri, UriType.CONDA))
-        uris = self._java_jars_plugin.get_uris(runtime_env)
-        for uri in uris:
-            result.append((uri, UriType.JAVA_JARS))
+        for plugin in self._base_plugins:
+            uris = plugin.get_uris(runtime_env)
+            for uri in uris:
+                result.append((uri, UriType(plugin.name)))
         return result
 
     def unused_uris_processor(self, unused_uris: List[Tuple[str, UriType]]) -> None:
         for uri, uri_type in unused_uris:
-            if uri_type == UriType.WORKING_DIR:
-                self._uri_caches["working_dir"].mark_unused(uri)
-            elif uri_type == UriType.PY_MODULES:
-                self._uri_caches["py_modules"].mark_unused(uri)
-            elif uri_type == UriType.JAVA_JARS:
-                self._uri_caches["java_jars"].mark_unused(uri)
-            elif uri_type == UriType.CONDA:
-                self._uri_caches["conda"].mark_unused(uri)
-            elif uri_type == UriType.PIP:
-                self._uri_caches["pip"].mark_unused(uri)
+            self._uri_caches[uri_type.name].mark_unused(uri)
 
     def unused_runtime_env_processor(self, unused_runtime_env: str) -> None:
         def delete_runtime_env():

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -1,36 +1,35 @@
-import os
-import sys
+import asyncio
+import hashlib
 import json
 import logging
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-import yaml
-import hashlib
-import subprocess
+import os
 import platform
 import runpy
 import shutil
-import asyncio
-
-from filelock import FileLock
-from typing import Optional, List, Dict, Any
+import subprocess
+import sys
 from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+from filelock import FileLock
 
 import ray
-
 from ray._private.runtime_env.conda_utils import (
-    get_conda_activate_commands,
     create_conda_env_if_needed,
     delete_conda_env,
+    get_conda_activate_commands,
 )
 from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.packaging import Protocol, parse_uri
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.utils import (
     get_directory_size_bytes,
-    get_wheel_filename,
     get_master_wheel_url,
     get_release_wheel_url,
+    get_wheel_filename,
     try_to_create_directory,
 )
-from ray._private.runtime_env.packaging import Protocol, parse_uri
 
 default_logger = logging.getLogger(__name__)
 
@@ -279,12 +278,12 @@ class CondaPlugin(RuntimeEnvPlugin):
         """
         return os.path.join(self._resources_dir, hash)
 
-    def get_uri(self, runtime_env: "RuntimeEnv") -> Optional[str]:  # noqa: F821
-        """Return the conda URI from the RuntimeEnv if it exists, else None."""
+    def get_uris(self, runtime_env: "RuntimeEnv") -> List[str]:  # noqa: F821
+        """Return the conda URI from the RuntimeEnv if it exists, else return []."""
         conda_uri = runtime_env.conda_uri()
         if conda_uri != "":
-            return conda_uri
-        return None
+            return [conda_uri]
+        return []
 
     def delete_uri(
         self, uri: str, logger: Optional[logging.Logger] = default_logger

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -281,7 +281,7 @@ class CondaPlugin(RuntimeEnvPlugin):
     def get_uris(self, runtime_env: "RuntimeEnv") -> List[str]:  # noqa: F821
         """Return the conda URI from the RuntimeEnv if it exists, else return []."""
         conda_uri = runtime_env.conda_uri()
-        if conda_uri != "":
+        if conda_uri:
             return [conda_uri]
         return []
 

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -352,7 +352,7 @@ class CondaPlugin(RuntimeEnvPlugin):
 
     def modify_context(
         self,
-        uri: str,
+        uris: List[str],
         runtime_env: "RuntimeEnv",  # noqa: F821
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,

--- a/python/ray/_private/runtime_env/java_jars.py
+++ b/python/ray/_private/runtime_env/java_jars.py
@@ -1,19 +1,18 @@
+import asyncio
 import logging
 import os
 from typing import Dict, List, Optional
-import asyncio
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 
-from ray.experimental.internal_kv import _internal_kv_initialized
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.packaging import (
-    download_and_unpack_package,
     delete_package,
+    download_and_unpack_package,
     get_local_dir_from_uri,
     is_jar_uri,
 )
-from ray._private.utils import get_directory_size_bytes
-from ray._private.utils import try_to_create_directory
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.utils import get_directory_size_bytes, try_to_create_directory
+from ray.experimental.internal_kv import _internal_kv_initialized
 
 default_logger = logging.getLogger(__name__)
 
@@ -44,7 +43,7 @@ class JavaJarsPlugin(RuntimeEnvPlugin):
 
         return local_dir_size
 
-    def get_uris(self, runtime_env: dict) -> Optional[List[str]]:
+    def get_uris(self, runtime_env: dict) -> List[str]:
         return runtime_env.java_jars()
 
     def _download_jars(

--- a/python/ray/_private/runtime_env/java_jars.py
+++ b/python/ray/_private/runtime_env/java_jars.py
@@ -77,13 +77,11 @@ class JavaJarsPlugin(RuntimeEnvPlugin):
 
     def modify_context(
         self,
-        uris: Optional[List[str]],
+        uris: List[str],
         runtime_env_dict: Dict,
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ):
-        if uris is None:
-            return
         for uri in uris:
             module_dir = self._get_local_dir_from_uri(uri)
             if not module_dir.exists():

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -201,10 +201,10 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
     uri = urlparse(pkg_uri)
     try:
         protocol = Protocol(uri.scheme)
-    except ValueError:
+    except ValueError as e:
         raise ValueError(
-            f"Invalid protocol for runtime_env URI: {pkg_uri}. "
-            f"Supported protocols: {Protocol._member_names_}."
+            f"Invalid protocol for runtime_env URI {pkg_uri}. "
+            f"Supported protocols: {Protocol._member_names_}. Original error: {e}"
         )
     if protocol == Protocol.S3 or protocol == Protocol.GS:
         return (protocol, f"{protocol.value}_{uri.netloc}{uri.path.replace('/', '_')}")

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -1,21 +1,23 @@
-from enum import Enum
-from tempfile import TemporaryDirectory
-from filelock import FileLock
 import hashlib
 import logging
 import os
-from pathlib import Path
 import shutil
+from enum import Enum
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Callable, List, Optional, Tuple
 from urllib.parse import urlparse
 from zipfile import ZipFile
+
+from filelock import FileLock
+
+from ray._private.thirdparty.pathspec import PathSpec
 from ray.experimental.internal_kv import (
-    _internal_kv_put,
-    _internal_kv_get,
     _internal_kv_exists,
+    _internal_kv_get,
+    _internal_kv_put,
     _pin_runtime_env_uri,
 )
-from ray._private.thirdparty.pathspec import PathSpec
 from ray.ray_constants import (
     RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT,
     RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_ENV_VAR,
@@ -197,7 +199,13 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
             -> ("file", "file__path_to_test_module.zip")
     """
     uri = urlparse(pkg_uri)
-    protocol = Protocol(uri.scheme)
+    try:
+        protocol = Protocol(uri.scheme)
+    except ValueError:
+        raise ValueError(
+            f"Invalid protocol for runtime_env URI: {pkg_uri}. "
+            f"Supported protocols: {Protocol._member_names_}."
+        )
     if protocol == Protocol.S3 or protocol == Protocol.GS:
         return (protocol, f"{protocol.value}_{uri.netloc}{uri.path.replace('/', '_')}")
     elif protocol == Protocol.HTTPS:
@@ -601,8 +609,8 @@ def download_and_unpack_package(
 
                 if protocol == Protocol.S3:
                     try:
-                        from smart_open import open as open_file
                         import boto3
+                        from smart_open import open as open_file
                     except ImportError:
                         raise ImportError(
                             "You must `pip install smart_open` and "
@@ -612,8 +620,8 @@ def download_and_unpack_package(
                     tp = {"client": boto3.client("s3")}
                 elif protocol == Protocol.GS:
                     try:
-                        from smart_open import open as open_file
                         from google.cloud import storage  # noqa: F401
+                        from smart_open import open as open_file
                     except ImportError:
                         raise ImportError(
                             "You must `pip install smart_open` and "

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 from ray._private.async_compat import asynccontextmanager, create_task, get_running_loop
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.packaging import Protocol, parse_uri
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.runtime_env.utils import check_output_cmd
 from ray._private.utils import get_directory_size_bytes, try_to_create_directory
 
@@ -362,7 +363,8 @@ class PipProcessor:
         return self._run().__await__()
 
 
-class PipManager:
+class PipPlugin(RuntimeEnvPlugin):
+    name = "pip"    
     def __init__(self, resources_dir: str):
         self._pip_resources_dir = os.path.join(resources_dir, "pip")
         self._creating_task = {}
@@ -395,7 +397,7 @@ class PipManager:
         protocol, hash = parse_uri(uri)
         if protocol != Protocol.PIP:
             raise ValueError(
-                "PipManager can only delete URIs with protocol "
+                "PipPlugin can only delete URIs with protocol "
                 f"pip. Received protocol {protocol}, URI {uri}"
             )
 

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -454,13 +454,15 @@ class PipPlugin(RuntimeEnvPlugin):
 
     def modify_context(
         self,
-        uri: str,
+        uris: List[str],
         runtime_env: "RuntimeEnv",  # noqa: F821
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ):
         if not runtime_env.has_pip():
             return
+        # PipPlugin only uses a single URI.
+        uri = uris[0]
         # Update py_executable.
         protocol, hash = parse_uri(uri)
         target_dir = self._get_path_from_hash(hash)

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -364,7 +364,8 @@ class PipProcessor:
 
 
 class PipPlugin(RuntimeEnvPlugin):
-    name = "pip"    
+    name = "pip"
+
     def __init__(self, resources_dir: str):
         self._pip_resources_dir = os.path.join(resources_dir, "pip")
         self._creating_task = {}

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -386,7 +386,7 @@ class PipPlugin(RuntimeEnvPlugin):
     def get_uris(self, runtime_env: "RuntimeEnv") -> List[str]:  # noqa: F821
         """Return the pip URI from the RuntimeEnv if it exists, else return []."""
         pip_uri = runtime_env.pip_uri()
-        if pip_uri != "":
+        if pip_uri:
             return [pip_uri]
         return []
 

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -103,17 +103,15 @@ class PluginCacheManager:
         logger: logging.Logger = default_logger,
     ):
         uris = self._plugin.get_uris(runtime_env)
-
-        if uris is not None:
-            for uri in uris:
-                if uri not in self._uri_cache:
-                    logger.debug(f"Cache miss for URI {uri}.")
-                    size_bytes = await self._plugin.create(
-                        uri, runtime_env, context, logger=logger
-                    )
-                    self._uri_cache.add(uri, size_bytes, logger=logger)
-                else:
-                    logger.debug(f"Cache hit for URI {uri}.")
-                    self._uri_cache.mark_used(uri, logger=logger)
+        for uri in uris:
+            if uri not in self._uri_cache:
+                logger.debug(f"Cache miss for URI {uri}.")
+                size_bytes = await self._plugin.create(
+                    uri, runtime_env, context, logger=logger
+                )
+                self._uri_cache.add(uri, size_bytes, logger=logger)
+            else:
+                logger.debug(f"Cache hit for URI {uri}.")
+                self._uri_cache.mark_used(uri, logger=logger)
 
         self._plugin.modify_context(uris, runtime_env, context)

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -58,7 +58,7 @@ class RuntimeEnvPlugin(ABC):
 
     def modify_context(
         self,
-        uri: Optional[str],
+        uris: List[str],
         runtime_env: "RuntimeEnv",  # noqa: F821
         context: RuntimeEnvContext,
         logger: logging.Logger,
@@ -69,7 +69,7 @@ class RuntimeEnvPlugin(ABC):
         startup, or add new environment variables.
 
         Args:
-            uri(str): a URI uniquely describing this resource.
+            uris(List[str]): a URIs used by this resource.
             runtime_env(RuntimeEnv): the runtime env protobuf.
             ctx(RuntimeEnvContext): auxiliary information supplied by Ray.
         """

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC
-from typing import List, Optional
+from typing import List
 
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.uri_cache import URICache

--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -1,30 +1,29 @@
+import asyncio
 import logging
 import os
+from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, List, Optional
-from pathlib import Path
-import asyncio
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 
-from ray.experimental.internal_kv import _internal_kv_initialized
 from ray._private.runtime_env.conda_utils import exec_cmd_stream_to_logger
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.packaging import (
-    download_and_unpack_package,
+    Protocol,
     delete_package,
+    download_and_unpack_package,
     get_local_dir_from_uri,
     get_uri_for_directory,
     get_uri_for_package,
+    is_whl_uri,
     package_exists,
     parse_uri,
-    is_whl_uri,
-    Protocol,
     upload_package_if_needed,
     upload_package_to_gcs,
 )
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.runtime_env.working_dir import set_pythonpath_in_context
-from ray._private.utils import get_directory_size_bytes
-from ray._private.utils import try_to_create_directory
+from ray._private.utils import get_directory_size_bytes, try_to_create_directory
+from ray.experimental.internal_kv import _internal_kv_initialized
 
 default_logger = logging.getLogger(__name__)
 
@@ -152,7 +151,7 @@ class PyModulesPlugin(RuntimeEnvPlugin):
 
         return local_dir_size
 
-    def get_uris(self, runtime_env: dict) -> Optional[List[str]]:
+    def get_uris(self, runtime_env: dict) -> List[str]:
         return runtime_env.py_modules()
 
     def _download_and_install_wheel(

--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -214,13 +214,11 @@ class PyModulesPlugin(RuntimeEnvPlugin):
 
     def modify_context(
         self,
-        uris: Optional[List[str]],
+        uris: List[str],
         runtime_env_dict: Dict,
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ):
-        if uris is None:
-            return
         module_dirs = []
         for uri in uris:
             module_dir = self._get_local_dir_from_uri(uri)

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -1,24 +1,24 @@
+import asyncio
 import logging
 import os
-from typing import Any, Dict, Optional
 from pathlib import Path
-import asyncio
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from typing import Any, Dict, List, Optional
 
-from ray.experimental.internal_kv import _internal_kv_initialized
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.packaging import (
-    download_and_unpack_package,
+    Protocol,
     delete_package,
+    download_and_unpack_package,
     get_local_dir_from_uri,
     get_uri_for_directory,
     get_uri_for_package,
-    upload_package_to_gcs,
     parse_uri,
-    Protocol,
     upload_package_if_needed,
+    upload_package_to_gcs,
 )
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.utils import get_directory_size_bytes, try_to_create_directory
+from ray.experimental.internal_kv import _internal_kv_initialized
 
 default_logger = logging.getLogger(__name__)
 
@@ -127,11 +127,11 @@ class WorkingDirPlugin(RuntimeEnvPlugin):
 
         return local_dir_size
 
-    def get_uri(self, runtime_env: "RuntimeEnv") -> Optional[str]:  # noqa: F821
+    def get_uris(self, runtime_env: "RuntimeEnv") -> List[str]:  # noqa: F821
         working_dir_uri = runtime_env.working_dir()
         if working_dir_uri != "":
-            return working_dir_uri
-        return None
+            return [working_dir_uri]
+        return []
 
     async def create(
         self,

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -154,11 +154,13 @@ class WorkingDirPlugin(RuntimeEnvPlugin):
         return await loop.run_in_executor(None, _create)
 
     def modify_context(
-        self, uri: Optional[str], runtime_env_dict: Dict, context: RuntimeEnvContext
+        self, uris: List[str], runtime_env_dict: Dict, context: RuntimeEnvContext
     ):
-        if uri is None:
+        if not uris:
             return
 
+        # WorkingDirPlugin uses a single URI.
+        uri = uris[0]
         local_dir = get_local_dir_from_uri(uri, self._resources_dir)
         if not local_dir.exists():
             raise ValueError(

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -1,35 +1,37 @@
+import json
 import logging
 import os
-import pytest
-import sys
 import subprocess
-import time
-import requests
-from pathlib import Path
-from unittest import mock
-import json
+import sys
 import tempfile
+import time
+from pathlib import Path
+from typing import List
+from unittest import mock
+
+import pytest
+import requests
 
 import ray
-from ray.exceptions import RuntimeEnvSetupError
-from ray._private.test_utils import (
-    wait_for_condition,
-    get_error_message,
-    get_log_sources,
-    chdir,
-)
-from ray._private.utils import (
-    get_wheel_filename,
-    get_master_wheel_url,
-    get_release_wheel_url,
-)
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.runtime_env.uri_cache import URICache
 from ray._private.runtime_env.utils import (
     SubprocessCalledProcessError,
     check_output_cmd,
 )
-from ray._private.runtime_env.uri_cache import URICache
-from ray._private.runtime_env.context import RuntimeEnvContext
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.test_utils import (
+    chdir,
+    get_error_message,
+    get_log_sources,
+    wait_for_condition,
+)
+from ray._private.utils import (
+    get_master_wheel_url,
+    get_release_wheel_url,
+    get_wheel_filename,
+)
+from ray.exceptions import RuntimeEnvSetupError
 from ray.runtime_env import RuntimeEnv
 
 
@@ -570,7 +572,10 @@ class MyPlugin(RuntimeEnvPlugin):
 
     @staticmethod
     def modify_context(
-        uri: str, runtime_env: dict, ctx: RuntimeEnvContext, logger: logging.Logger
+        uris: List[str],
+        runtime_env: dict,
+        ctx: RuntimeEnvContext,
+        logger: logging.Logger,
     ) -> None:
         global runtime_env_retry_times
         runtime_env_retry_times += 1

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -1,14 +1,16 @@
+import logging
 import os
 import tempfile
 from time import sleep
-import logging
+from typing import List
+
 import pytest
-from ray._private.runtime_env.context import RuntimeEnvContext
-from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-from ray._private.test_utils import wait_for_condition, test_external_redis
-from ray.exceptions import RuntimeEnvSetupError
 
 import ray
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.test_utils import test_external_redis, wait_for_condition
+from ray.exceptions import RuntimeEnvSetupError
 
 MY_PLUGIN_CLASS_PATH = "ray.tests.test_runtime_env_plugin.MyPlugin"
 
@@ -25,7 +27,7 @@ class MyPlugin(RuntimeEnvPlugin):
 
     def modify_context(
         self,
-        uri: str,
+        uris: List[str],
         plugin_config_dict: dict,
         ctx: RuntimeEnvContext,
         logger: logging.Logger,
@@ -101,7 +103,7 @@ class MyPluginForHang(RuntimeEnvPlugin):
 
     def modify_context(
         self,
-        uri: str,
+        uris: List[str],
         plugin_config_dict: dict,
         ctx: RuntimeEnvContext,
         logger: logging.Logger,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Followup from #24622.  This is another step towards pluggability for runtime_env.  Previously some plugin classes had `get_uri` which returned a single URI, while others had `get_uris` which returned a list.  This PR makes all plugins use `get_uris`, which simplifies the code overall.

Most of the lines in the diff just come from the new `format.sh` which sorts the imports.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
