### PR TITLE
[CI] upgrade to go 1.18

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -322,7 +322,7 @@ install_cython_examples() {
 
 install_go() {
   local gimme_url="https://raw.githubusercontent.com/travis-ci/gimme/master/gimme"
-  suppress_xtrace eval "$(curl -f -s -L "${gimme_url}" | GIMME_GO_VERSION=1.14.2 bash)"
+  suppress_xtrace eval "$(curl -f -s -L "${gimme_url}" | GIMME_GO_VERSION=1.18.3 bash)"
 
   if [ -z "${GOPATH-}" ]; then
     GOPATH="${GOPATH:-${HOME}/go_dir}"

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -520,7 +520,7 @@ lint_bazel() {
     export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
 
     # Build buildifier
-    go get github.com/bazelbuild/buildtools/buildifier
+    go install github.com/bazelbuild/buildtools/buildifier@latest
 
     # Now run buildifier
     "${ROOT_DIR}"/lint/bazel-format.sh


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Lint job is failing with:

```
++ go get github.com/bazelbuild/buildtools/buildifier
# google.golang.org/protobuf/proto
/root/go_dir/src/google.golang.org/protobuf/proto/equal.go:36:33: undefined: reflect.Pointer
🚨 Error: The command exited with status 1
```


Go 1.18 made the following changes:
1. Renamed `reflect.Ptr` to `reflect.Pointer`
2. `go get` functionality was modified.

`protobuf-go` uses an unpinned version of Go and pulled in 1.8.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
