### PR TITLE
[macOS] Only cleanup directory after upload

### DIFF
--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -9,6 +9,7 @@ RAY_DIR=$(cd "${ROOT_DIR}/../../"; pwd)
 cd "${RAY_DIR}"
 
 cleanup() {
+  # Cleanup the directory because macOS file system is shared between builds.
   rm -rf /tmp/bazel_event_logs
 }
 trap cleanup EXIT

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -8,13 +8,11 @@ RAY_DIR=$(cd "${ROOT_DIR}/../../"; pwd)
 
 cd "${RAY_DIR}"
 
-# Cleanup old entries, this is needed in macOS shared environment.
-if [[ "${OSTYPE}" = darwin* ]]; then
-  if [[ -n "${BUILDKITE-}" ]]; then
-    echo "Cleanup old entries in macOS"
-    rm -rf /tmp/bazel_event_logs
-  fi
-fi
+cleanup() {
+  rm -rf /tmp/bazel_event_logs
+}
+trap cleanup EXIT
+
 mkdir -p /tmp/bazel_event_logs
 
 ./ci/build/get_build_info.py > /tmp/bazel_event_logs/metadata.json


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Missed it in previous enablement of uploading bazel log, we should no longer clean the directory anymore. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
