### PR TITLE
[RLlib] Fixes logging of all Algorithm names as error message

### DIFF
--- a/rllib/__init__.py
+++ b/rllib/__init__.py
@@ -37,7 +37,6 @@ def _register_all():
         + list(CONTRIBUTED_ALGORITHMS.keys())
         + ["__fake", "__sigmoid_fake_data", "__parameter_tuning"]
     ):
-        logging.warning(key)
         register_trainable(key, get_algorithm_class(key))
 
     def _see_contrib(name):

--- a/rllib/__init__.py
+++ b/rllib/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from ray._private.usage import usage_lib
+
 # Note: do not introduce unnecessary library dependencies here, e.g. gym.
 # This file is imported from the tune module in order to register RLlib agents.
 from ray.rllib.env.base_env import BaseEnv
@@ -12,7 +14,6 @@ from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.policy.tf_policy import TFPolicy
 from ray.rllib.policy.torch_policy import TorchPolicy
 from ray.tune.registry import register_trainable
-from ray._private.usage import usage_lib
 
 
 def _setup_logger():

--- a/rllib/algorithms/registry.py
+++ b/rllib/algorithms/registry.py
@@ -277,7 +277,7 @@ def _get_algorithm_class(alg: str, return_config=False) -> type:
             _ParameterTuningTrainer.get_default_config(),
         )
     else:
-        raise Exception(("Unknown algorithm {}.").format(alg))
+        raise Exception("Unknown algorithm {}.".format(alg))
 
     if return_config:
         return class_, config


### PR DESCRIPTION
## Why are these changes needed?

Currently, all algorithms (that we register) are logged as an error message.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
