### PR TITLE
[air] Convert `_TrackedCheckpoint` to `ray.air.Checkpoint`

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -218,7 +218,7 @@ py_test(
 
 py_test(
     name = "test_result_grid",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_result_grid.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive", "tests_dir_R"],

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -2,14 +2,13 @@ import os
 from typing import Optional, Union
 
 import pandas as pd
+
+from ray.air.result import Result
 from ray.cloudpickle import cloudpickle
 from ray.exceptions import RayTaskError
-from ray.air.checkpoint import Checkpoint
-from ray.air.result import Result
 from ray.tune import ExperimentAnalysis
 from ray.tune.error import TuneError
 from ray.tune.trial import Trial
-from ray.tune.utils.trainable import TrainableUtil
 from ray.util import PublicAPI
 
 
@@ -165,13 +164,7 @@ class ResultGrid:
         return None
 
     def _trial_to_result(self, trial: Trial) -> Result:
-        if trial.checkpoint.dir_or_data:
-            checkpoint_dir = TrainableUtil.find_checkpoint_dir(
-                trial.checkpoint.dir_or_data
-            )
-            checkpoint = Checkpoint.from_directory(checkpoint_dir)
-        else:
-            checkpoint = None
+        checkpoint = trial.checkpoint.to_air_checkpoint()
 
         result = Result(
             checkpoint=checkpoint,

--- a/python/ray/tune/tests/test_result_grid.py
+++ b/python/ray/tune/tests/test_result_grid.py
@@ -21,7 +21,7 @@ def ray_start_2_cpus():
     ray.shutdown()
 
 
-def test_result_grid():
+def test_result_grid(ray_start_2_cpus):
     def f(config):
         # simulating the case that no report is called in train.
         with tune.checkpoint_dir(step=0) as checkpoint_dir:
@@ -40,7 +40,7 @@ def test_result_grid():
     assert result.metrics["config"] == result.config
 
 
-def test_result_grid_no_checkpoint():
+def test_result_grid_no_checkpoint(ray_start_2_cpus):
     def f(config):
         pass
 
@@ -83,7 +83,7 @@ def test_result_grid_future_checkpoint(ray_start_2_cpus):
             assert info["info"] == 4
 
 
-def test_best_result():
+def test_best_result(ray_start_2_cpus):
     def f(config):
         for _ in range(2):
             tune.report(x=config["x"])
@@ -95,7 +95,7 @@ def test_best_result():
     assert best_result.metrics["x"] == 2
 
 
-def test_best_result_no_report():
+def test_best_result_no_report(ray_start_2_cpus):
     def f(config):
         pass
 
@@ -105,7 +105,7 @@ def test_best_result_no_report():
         result_grid.get_best_result(metric="x", mode="max")
 
 
-def test_no_metric_mode():
+def test_no_metric_mode(ray_start_2_cpus):
     def f(config):
         tune.report(x=1)
 
@@ -121,7 +121,7 @@ def test_no_metric_mode():
         result_grid.get_best_result(mode="max")
 
 
-def test_result_grid_df():
+def test_result_grid_df(ray_start_2_cpus):
     def f(config):
         tune.report(metric=config["nested"]["param"] * 1)
         tune.report(metric=config["nested"]["param"] * 4)

--- a/python/ray/util/ml_utils/checkpoint_manager.py
+++ b/python/ray/util/ml_utils/checkpoint_manager.py
@@ -6,6 +6,7 @@ import logging
 import numbers
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -131,7 +132,13 @@ class _TrackedCheckpoint:
             checkpoint_dir = TrainableUtil.find_checkpoint_dir(checkpoint_data)
             checkpoint = Checkpoint.from_directory(checkpoint_dir)
         elif isinstance(checkpoint_data, bytes):
-            checkpoint = Checkpoint.from_bytes(checkpoint_data)
+            with tempfile.mkdtemp() as tmpdir:
+                TrainableUtil.create_from_pickle(checkpoint_data, tmpdir)
+                # Double wrap in checkpoint so we hold the data in memory and
+                # can remove the temp directory
+                checkpoint = Checkpoint.from_dict(
+                    Checkpoint.from_directory(tmpdir).to_dict()
+                )
         elif isinstance(checkpoint_data, dict):
             checkpoint = Checkpoint.from_dict(checkpoint_data)
         else:

--- a/python/ray/util/ml_utils/checkpoint_manager.py
+++ b/python/ray/util/ml_utils/checkpoint_manager.py
@@ -6,14 +6,14 @@ import logging
 import numbers
 import os
 import shutil
-
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Dict, Union, Callable, Tuple, List, Any
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import ray
 from ray.air import Checkpoint
 from ray.tune.result import NODE_IP
+from ray.tune.utils.trainable import TrainableUtil
 from ray.util import PublicAPI
 from ray.util.annotations import DeveloperAPI
 from ray.util.ml_utils.util import is_nan
@@ -117,6 +117,27 @@ class _TrackedCheckpoint:
             delete_fn(self)
         except Exception as e:
             logger.warning(f"Checkpoint deletion failed: {e}")
+
+    def to_air_checkpoint(self) -> Optional[Checkpoint]:
+        checkpoint_data = self.dir_or_data
+
+        if not checkpoint_data:
+            return None
+
+        if isinstance(checkpoint_data, ray.ObjectRef):
+            checkpoint_data = ray.get(checkpoint_data)
+
+        if isinstance(checkpoint_data, str):
+            checkpoint_dir = TrainableUtil.find_checkpoint_dir(checkpoint_data)
+            checkpoint = Checkpoint.from_directory(checkpoint_dir)
+        elif isinstance(checkpoint_data, bytes):
+            checkpoint = Checkpoint.from_bytes(checkpoint_data)
+        elif isinstance(checkpoint_data, dict):
+            checkpoint = Checkpoint.from_dict(checkpoint_data)
+        else:
+            raise RuntimeError(f"Unknown checkpoint data type: {type(checkpoint_data)}")
+
+        return checkpoint
 
     def __repr__(self):
         if self.storage_mode == CheckpointStorage.MEMORY:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We often need to convert our internal `_TrackedCheckpoint` objects to `ray.air.Checkpoint`s - we should do this in a utility method in the `_TrackedCheckpoint` class.
This PR also fixes cases where we haven't resolved the saved checkpoint futures, yet.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
