### PR TITLE
[data] Fix bug in computing merge partitions in push-based shuffle

### DIFF
--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -1,15 +1,15 @@
 import logging
 import math
-from typing import Callable, List, Optional, Dict, Any, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 import ray
+from ray.data._internal.block_list import BlockList
+from ray.data._internal.progress_bar import ProgressBar
+from ray.data._internal.remote_fn import cached_remote_fn
+from ray.data._internal.shuffle import ShuffleOp
+from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
 from ray.types import ObjectRef
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-from ray.data.block import Block, BlockAccessor, BlockMetadata, BlockExecStats
-from ray.data._internal.shuffle import ShuffleOp
-from ray.data._internal.progress_bar import ProgressBar
-from ray.data._internal.block_list import BlockList
-from ray.data._internal.remote_fn import cached_remote_fn
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +40,13 @@ class _MergeTaskSchedule:
         if reducer_idx < self.merge_partition_size * self._partitions_with_extra_task:
             merge_idx = reducer_idx // (self.merge_partition_size + 1)
         else:
-            reducer_idx -= (self.merge_partition_size + 1) * self._partitions_with_extra_task
-            merge_idx = self._partitions_with_extra_task + reducer_idx // self.merge_partition_size
+            reducer_idx -= (
+                self.merge_partition_size + 1
+            ) * self._partitions_with_extra_task
+            merge_idx = (
+                self._partitions_with_extra_task
+                + reducer_idx // self.merge_partition_size
+            )
         assert merge_idx < self.num_merge_tasks_per_round
         return merge_idx
 

--- a/python/ray/data/_internal/push_based_shuffle.py
+++ b/python/ray/data/_internal/push_based_shuffle.py
@@ -21,12 +21,8 @@ U = TypeVar("U")
 class _MergeTaskSchedule:
     def __init__(self, output_num_blocks: int, num_merge_tasks_per_round: int):
         self.num_merge_tasks_per_round = num_merge_tasks_per_round
-        self.merge_partition_size = math.ceil(
-            output_num_blocks / num_merge_tasks_per_round
-        )
-        self.last_merge_partition_size = output_num_blocks - (
-            self.merge_partition_size * (self.num_merge_tasks_per_round - 1)
-        )
+        self.merge_partition_size = output_num_blocks // num_merge_tasks_per_round
+        self._partitions_with_extra_task = output_num_blocks % num_merge_tasks_per_round
 
     def get_num_reducers_per_merge_idx(self, merge_idx: int) -> int:
         """
@@ -34,12 +30,20 @@ class _MergeTaskSchedule:
         final reduce tasks. This helper function returns P based on the merge
         task index.
         """
-        if merge_idx == self.num_merge_tasks_per_round - 1:
-            return self.last_merge_partition_size
-        return self.merge_partition_size
+        assert merge_idx < self.num_merge_tasks_per_round
+        partition_size = self.merge_partition_size
+        if merge_idx < self._partitions_with_extra_task:
+            partition_size += 1
+        return partition_size
 
     def get_merge_idx_for_reducer_idx(self, reducer_idx: int) -> int:
-        return reducer_idx // self.merge_partition_size
+        if reducer_idx < self.merge_partition_size * self._partitions_with_extra_task:
+            merge_idx = reducer_idx // (self.merge_partition_size + 1)
+        else:
+            reducer_idx -= (self.merge_partition_size + 1) * self._partitions_with_extra_task
+            merge_idx = self._partitions_with_extra_task + reducer_idx // self.merge_partition_size
+        assert merge_idx < self.num_merge_tasks_per_round
+        return merge_idx
 
 
 class _PushBasedShuffleStage:
@@ -408,7 +412,7 @@ class PushBasedShufflePlan(ShuffleOp):
             # merge tasks, but we can spread the group across multiple distinct
             # nodes.
             leftover_cpus += node_parallelism % num_tasks_per_map_merge_group
-            if leftover_cpus > num_tasks_per_map_merge_group:
+            if num_merge_tasks == 0 and leftover_cpus > num_tasks_per_map_merge_group:
                 merge_task_placement.append(node)
                 num_merge_tasks_per_round += 1
                 leftover_cpus -= num_tasks_per_map_merge_group

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -7,11 +7,10 @@ import pyarrow as pa
 import pytest
 
 import ray
-
-from ray.tests.conftest import *  # noqa
+from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
 from ray.data.block import BlockAccessor
 from ray.data.tests.conftest import *  # noqa
-from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
+from ray.tests.conftest import *  # noqa
 
 
 @pytest.mark.parametrize("use_push_based_shuffle", [False, True])
@@ -215,17 +214,22 @@ def test_push_based_shuffle_schedule():
             for i in range(schedule.num_merge_tasks_per_round)
         ]
         high = max(num_reducers_per_merge_idx)
-        num_imbalanced = 0
         for num_reducers in num_reducers_per_merge_idx:
-            if num_reducers < high:
-                num_imbalanced += 1
-        assert num_imbalanced <= 1
+            assert num_reducers == high or num_reducers == high - 1
+
+        for merge_idx in range(schedule.num_merge_tasks_per_round):
+            assert isinstance(
+                schedule.merge_schedule.get_num_reducers_per_merge_idx(merge_idx), int
+            )
+            assert schedule.merge_schedule.get_num_reducers_per_merge_idx(merge_idx) > 0
 
     for num_cpus in range(1, 20):
         _test(20, 3, {"node1": num_cpus})
     _test(20, 3, {"node1": 100})
     _test(100, 3, {"node1": 10, "node2": 10, "node3": 10})
     _test(100, 10, {"node1": 10, "node2": 10, "node3": 10})
+    # Regression test for https://github.com/ray-project/ray/issues/25863.
+    _test(1000, 2, {f"node{i}": 16 for i in range(20)})
 
 
 def test_push_based_shuffle_stats(ray_start_cluster):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a bug in push-based shuffle in computing the merge task <> reduce tasks mapping when the number of reduce tasks does not divide evenly by the number of merge tasks. Previously, if there were N reduce tasks for one merge task, we would do:
[N + 1, N + 1, ..., N + 1, all left over tasks]
which could lead to negative many reduce tasks n the last merge partition.

This PR changes it to:
[N + 1, N + 1, ..., N + 1, N, N, N, ...]

## Related issue number

Closes #25863.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
