### PR TITLE
[core] Make ray able to connect to redis without pip redis.

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -754,13 +754,23 @@ test_minimal() {
   # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic
   # shellcheck disable=SC2086
+  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 --test_env=TEST_EXTERNAL_REDIS=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic
+  # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_2
+  # shellcheck disable=SC2086
+  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 --test_env=TEST_EXTERNAL_REDIS=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_2
   # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_3
   # shellcheck disable=SC2086
+  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 --test_env=TEST_EXTERNAL_REDIS=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_3
+  # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_4
   # shellcheck disable=SC2086
+  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 --test_env=TEST_EXTERNAL_REDIS=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_4
+  # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_5
+  # shellcheck disable=SC2086
+  bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 --test_env=TEST_EXTERNAL_REDIS=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_basic_5
   # shellcheck disable=SC2086
   bazel test --test_output=streamed --config=ci --test_env=RAY_MINIMAL=1 ${BAZEL_EXPORT_OPTIONS} python/ray/tests/test_output
   # shellcheck disable=SC2086

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -192,11 +192,6 @@ RESOURCES_ENVIRONMENT_VARIABLE = "RAY_OVERRIDE_RESOURCES"
 # The reporter will report its statistics this often (milliseconds).
 REPORTER_UPDATE_INTERVAL_MS = env_integer("REPORTER_UPDATE_INTERVAL_MS", 2500)
 
-# Number of attempts to ping the Redis server. See
-# `services.py::wait_for_redis_to_start()` and
-# `services.py::create_redis_client()`
-START_REDIS_WAIT_RETRIES = env_integer("RAY_START_REDIS_WAIT_RETRIES", 60)
-
 # Temporary flag to disable log processing in the dashboard.  This is useful
 # if the dashboard is overloaded by logs and failing to process other
 # dashboard API requests (e.g. Job Submission).

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -683,46 +683,23 @@ def start(
                 cf.bold("RAY_REDIS_ADDRESS"),
                 address,
             )
-            cli_logger.print(
-                "Will use `{}` as external Redis server address(es). "
-                "If the primary one is not reachable, we starts new one(s) "
-                "with `{}` in local.",
-                cf.bold(address),
-                cf.bold("--port"),
-            )
             external_addresses = address.split(",")
 
             # We reuse primary redis as sharding when there's only one
             # instance provided.
             if len(external_addresses) == 1:
                 external_addresses.append(external_addresses[0])
-            reachable = False
-            try:
-                [primary_redis_ip, port] = external_addresses[0].split(":")
-                ray._private.services.wait_for_redis_to_start(
-                    primary_redis_ip, port, password=redis_password
+
+            ray_params.update_if_absent(external_addresses=external_addresses)
+            num_redis_shards = len(external_addresses) - 1
+            if redis_password == ray_constants.REDIS_DEFAULT_PASSWORD:
+                cli_logger.warning(
+                    "`{}` should not be specified as empty string if "
+                    "external redis server(s) `{}` points to requires "
+                    "password.",
+                    cf.bold("--redis-password"),
+                    cf.bold("--address"),
                 )
-                reachable = True
-            # We catch a generic Exception here in case someone later changes
-            # the type of the exception.
-            except Exception:
-                cli_logger.print(
-                    "The primary external redis server `{}` is not reachable. "
-                    "Will starts new one(s) with `{}` in local.",
-                    cf.bold(external_addresses[0]),
-                    cf.bold("--port"),
-                )
-            if reachable:
-                ray_params.update_if_absent(external_addresses=external_addresses)
-                num_redis_shards = len(external_addresses) - 1
-                if redis_password == ray_constants.REDIS_DEFAULT_PASSWORD:
-                    cli_logger.warning(
-                        "`{}` should not be specified as empty string if "
-                        "external redis server(s) `{}` points to requires "
-                        "password.",
-                        cf.bold("--redis-password"),
-                        cf.bold("--address"),
-                    )
 
         # Get the node IP address if one is not provided.
         ray_params.update_if_absent(node_ip_address=services.get_node_ip_address())

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -366,35 +366,10 @@ def test_ray_init_using_hostname(ray_start_cluster):
     assert node_table[0].get("NodeManagerHostname", "") == hostname
 
 
-def test_redis_connect_backoff():
-    import time
-
-    from ray._private import ray_constants
-
-    unreachable_address = "127.0.0.1:65535"
-    redis_ip, redis_port = unreachable_address.split(":")
-    wait_retries = ray_constants.START_REDIS_WAIT_RETRIES
-    ray_constants.START_REDIS_WAIT_RETRIES = 12
-    try:
-        start = time.time()
-        with pytest.raises(RuntimeError):
-            ray._private.services.wait_for_redis_to_start(redis_ip, int(redis_port))
-        end = time.time()
-        duration = end - start
-        assert duration > 2
-
-        start = time.time()
-        with pytest.raises(RuntimeError):
-            ray._private.services.create_redis_client(redis_address=unreachable_address)
-        end = time.time()
-        duration = end - start
-        assert duration > 2
-    finally:
-        ray_constants.START_REDIS_WAIT_RETRIES = wait_retries
-
-
 if __name__ == "__main__":
     import sys
+
+    import pytest
 
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -26,6 +26,12 @@ def unix_socket_delete(unix_socket):
 
 def test_tempdir(shutdown_only):
     shutil.rmtree(ray._private.utils.get_ray_temp_dir(), ignore_errors=True)
+    if os.path.exists(ray._private.utils.get_ray_temp_dir()):
+        # sometimes even after delete, it's still there.
+        # delete it again to make sure it's cleaned up
+        shutil.rmtree(ray._private.utils.get_ray_temp_dir(), ignore_errors=True)
+        assert not os.path.exists(ray._private.utils.get_ray_temp_dir())
+
     ray.init(
         _temp_dir=os.path.join(
             ray._private.utils.get_user_temp_dir(), "i_am_a_temp_dir"

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -48,7 +48,7 @@ struct GcsServerConfig {
   std::string redis_address;
   uint16_t redis_port = 6379;
   bool retry_redis = true;
-  bool enable_sharding_conn = true;
+  bool enable_sharding_conn = false;
   std::string node_ip_address;
   std::string log_dir;
   // This includes the config list of raylet.

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -130,7 +130,7 @@ Status RedisClient::Connect(std::vector<instrumented_io_context *> io_services) 
 
   RAY_CHECK_OK(primary_context_->Connect(options_.server_ip_,
                                          options_.server_port_,
-                                         /*sharding=*/true,
+                                         /*sharding=*/options_.enable_sharding_conn_,
                                          /*password=*/options_.password_));
 
   if (options_.enable_sharding_conn_) {

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -33,7 +33,7 @@ class RedisClientOptions {
   RedisClientOptions(const std::string &ip,
                      int port,
                      const std::string &password,
-                     bool enable_sharding_conn = true)
+                     bool enable_sharding_conn = false)
       : server_ip_(ip),
         server_port_(port),
         password_(password),
@@ -47,7 +47,7 @@ class RedisClientOptions {
   std::string password_;
 
   // Whether we enable sharding for accessing data.
-  bool enable_sharding_conn_{true};
+  bool enable_sharding_conn_ = false;
 };
 
 /// \class RedisClient

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -344,7 +344,8 @@ Status ConnectWithRetries(const std::string &address,
   while (!status.ok()) {
     if (connection_attempts >= RayConfig::instance().redis_db_connect_retries()) {
       RAY_LOG(FATAL) << RayConfig::instance().redis_db_connect_retries() << " attempts "
-                     << "to connect have all failed. The last error message was: "
+                     << "to connect have all failed. Please check whether the"
+                     << " redis storage is alive or not. The last error message was: "
                      << errorMessage;
       break;
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Right now, only cpp layer in ray is connecting to redis which means we don't need pip redis to connect to a redis db.

The blocking part is that we are doing some sharding in redis right now. But this feature is not actually used and the shard is always 1. So to make things simple, this feature is just disabled.

Test is added to make sure we can start ray with a redis db without pip redis. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
