### PR TITLE
[State Observability] Return list instead of dict

### DIFF
--- a/dashboard/modules/state/state_head.py
+++ b/dashboard/modules/state/state_head.py
@@ -1,25 +1,20 @@
 import logging
+from typing import Callable
 
 import aiohttp.web
 
-import dataclasses
-
-from typing import Callable
-
-from ray.dashboard.datacenter import DataSource
-from ray.dashboard.utils import Change
-import ray.dashboard.utils as dashboard_utils
 import ray.dashboard.optional_utils as dashboard_optional_utils
+import ray.dashboard.utils as dashboard_utils
+from ray.dashboard.datacenter import DataSource
+from ray.dashboard.modules.log.log_manager import LogsManager
 from ray.dashboard.optional_utils import rest_response
-from ray.dashboard.modules.log.log_manager import (
-    LogsManager,
-)
 from ray.dashboard.state_aggregator import StateAPIManager
+from ray.dashboard.utils import Change
 from ray.experimental.state.common import (
-    ListApiOptions,
-    GetLogOptions,
-    DEFAULT_RPC_TIMEOUT,
     DEFAULT_LIMIT,
+    DEFAULT_RPC_TIMEOUT,
+    GetLogOptions,
+    ListApiOptions,
 )
 from ray.experimental.state.exception import DataSourceUnavailable
 from ray.experimental.state.state_manager import StateDataSourceClient
@@ -133,10 +128,7 @@ class StateHead(dashboard_utils.DashboardHeadModule):
             return self._reply(
                 success=True,
                 error_message="",
-                result={
-                    job_id: dataclasses.asdict(job_info)
-                    for job_id, job_info in result.result.items()
-                },
+                result=result.result,
                 partial_failure_warning=result.partial_failure_warning,
             )
         except DataSourceUnavailable as e:

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -1,34 +1,32 @@
 import asyncio
 import logging
-
-from dataclasses import fields
+from dataclasses import asdict, fields
 from itertools import islice
 from typing import List, Tuple
 
-from ray.core.generated.common_pb2 import TaskStatus
-import ray.dashboard.utils as dashboard_utils
 import ray.dashboard.memory_utils as memory_utils
-
+import ray.dashboard.utils as dashboard_utils
+from ray._private.utils import binary_to_hex
+from ray.core.generated.common_pb2 import TaskStatus
 from ray.experimental.state.common import (
-    filter_fields,
-    StateSchema,
-    SupportedFilterType,
     ActorState,
-    PlacementGroupState,
-    NodeState,
-    WorkerState,
-    TaskState,
-    ObjectState,
-    RuntimeEnvState,
     ListApiOptions,
     ListApiResponse,
+    NodeState,
+    ObjectState,
+    PlacementGroupState,
+    RuntimeEnvState,
+    StateSchema,
+    SupportedFilterType,
+    TaskState,
+    WorkerState,
+    filter_fields,
 )
 from ray.experimental.state.state_manager import (
-    StateDataSourceClient,
     DataSourceUnavailable,
+    StateDataSourceClient,
 )
 from ray.runtime_env import RuntimeEnv
-from ray._private.utils import binary_to_hex
 
 logger = logging.getLogger(__name__)
 
@@ -183,9 +181,7 @@ class StateAPIManager:
         result = self._filter(result, option.filters, ActorState)
         # Sort to make the output deterministic.
         result.sort(key=lambda entry: entry["actor_id"])
-        return ListApiResponse(
-            result={d["actor_id"]: d for d in islice(result, option.limit)}
-        )
+        return ListApiResponse(result=list(islice(result, option.limit)))
 
     async def list_placement_groups(self, *, option: ListApiOptions) -> ListApiResponse:
         """List all placement group information from the cluster.
@@ -213,9 +209,7 @@ class StateAPIManager:
         result = self._filter(result, option.filters, PlacementGroupState)
         # Sort to make the output deterministic.
         result.sort(key=lambda entry: entry["placement_group_id"])
-        return ListApiResponse(
-            result={d["placement_group_id"]: d for d in islice(result, option.limit)}
-        )
+        return ListApiResponse(result=list(islice(result, option.limit)))
 
     async def list_nodes(self, *, option: ListApiOptions) -> ListApiResponse:
         """List all node information from the cluster.
@@ -239,9 +233,7 @@ class StateAPIManager:
         result = self._filter(result, option.filters, NodeState)
         # Sort to make the output deterministic.
         result.sort(key=lambda entry: entry["node_id"])
-        return ListApiResponse(
-            result={d["node_id"]: d for d in islice(result, option.limit)}
-        )
+        return ListApiResponse(result=list(islice(result, option.limit)))
 
     async def list_workers(self, *, option: ListApiOptions) -> ListApiResponse:
         """List all worker information from the cluster.
@@ -266,14 +258,17 @@ class StateAPIManager:
         result = self._filter(result, option.filters, WorkerState)
         # Sort to make the output deterministic.
         result.sort(key=lambda entry: entry["worker_id"])
-        return ListApiResponse(
-            result={d["worker_id"]: d for d in islice(result, option.limit)}
-        )
+        return ListApiResponse(result=list(islice(result, option.limit)))
 
     def list_jobs(self, *, option: ListApiOptions) -> ListApiResponse:
         # TODO(sang): Support limit & timeout & async calls.
         try:
-            result = self._client.get_job_info()
+            result = []
+            job_info = self._client.get_job_info()
+            for job_id, data in job_info.items():
+                data = asdict(data)
+                data["job_id"] = job_id
+                result.append(data)
         except DataSourceUnavailable:
             raise DataSourceUnavailable(GCS_QUERY_FAILURE_WARNING)
         return ListApiResponse(result=result)
@@ -341,7 +336,7 @@ class StateAPIManager:
         # Sort to make the output deterministic.
         result.sort(key=lambda entry: entry["task_id"])
         return ListApiResponse(
-            result={d["task_id"]: d for d in islice(result, option.limit)},
+            result=list(islice(result, option.limit)),
             partial_failure_warning=partial_failure_warning,
         )
 
@@ -412,7 +407,7 @@ class StateAPIManager:
         # Sort to make the output deterministic.
         result.sort(key=lambda entry: entry["object_id"])
         return ListApiResponse(
-            result={d["object_id"]: d for d in islice(result, option.limit)},
+            result=list(islice(result, option.limit)),
             partial_failure_warning=partial_failure_warning,
         )
 

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -1,9 +1,8 @@
 import logging
-
 from abc import ABC
 from dataclasses import dataclass, fields
 from enum import Enum, unique
-from typing import List, Dict, Union, Tuple, Set, Optional
+from typing import List, Optional, Set, Tuple, Union
 
 from ray.dashboard.modules.job.common import JobInfo
 
@@ -141,7 +140,7 @@ class ActorState(StateSchema):
 
     @classmethod
     def filterable_columns(cls) -> Set[str]:
-        return {"actor_id", "state", "class_name"}
+        return {"actor_id", "state", "class_name", "name", "pid"}
 
 
 @dataclass(init=True)
@@ -155,7 +154,7 @@ class PlacementGroupState(StateSchema):
 
     @classmethod
     def filterable_columns(cls) -> Set[str]:
-        return {"placement_group_id", "state"}
+        return {"placement_group_id", "state", "name"}
 
 
 @dataclass(init=True)
@@ -168,7 +167,7 @@ class NodeState(StateSchema):
 
     @classmethod
     def filterable_columns(cls) -> Set[str]:
-        return {"node_id", "state"}
+        return {"node_id", "state", "node_ip", "node_name"}
 
 
 class JobState(JobInfo, StateSchema):
@@ -205,11 +204,7 @@ class TaskState(StateSchema):
 
     @classmethod
     def filterable_columns(cls) -> Set[str]:
-        return {
-            "task_id",
-            "name",
-            "scheduling_state",
-        }
+        return {"task_id", "name", "scheduling_state", "type", "func_or_class_name"}
 
 
 @dataclass(init=True)
@@ -236,6 +231,7 @@ class ObjectState(StateSchema):
             "task_status",
             "type",
             "pid",
+            "call_site",
         }
 
 
@@ -260,20 +256,17 @@ class RuntimeEnvState(StateSchema):
 @dataclass(init=True)
 class ListApiResponse:
     # Returned data. None if no data is returned.
-    result: Union[
-        Dict[
-            str,
-            Union[
-                ActorState,
-                PlacementGroupState,
-                NodeState,
-                JobInfo,
-                WorkerState,
-                TaskState,
-                ObjectState,
-            ],
-        ],
-        List[RuntimeEnvState],
+    result: List[
+        Union[
+            ActorState,
+            PlacementGroupState,
+            NodeState,
+            JobInfo,
+            WorkerState,
+            TaskState,
+            ObjectState,
+            RuntimeEnvState,
+        ]
     ] = None
     # List API can have a partial failure if queries to
     # all sources fail. For example, getting object states

--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -1,18 +1,17 @@
 import os
-import sys
 import signal
-
-import ray
+import sys
 
 import pytest
 
+import ray
+from ray._private.test_utils import run_string_as_driver, wait_for_condition
 from ray.experimental.state.api import list_workers
-from ray._private.test_utils import wait_for_condition, run_string_as_driver
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
 def get_worker_by_pid(pid):
-    for w in list_workers().values():
+    for w in list_workers():
         if w["pid"] == pid:
             return w
     assert False

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1,92 +1,88 @@
 import json
 import sys
+from dataclasses import fields
+from typing import List, Tuple
+from unittest.mock import MagicMock
+
 import pytest
 import yaml
+from click.testing import CliRunner
 
-from typing import List, Tuple
-from dataclasses import fields
-
-from unittest.mock import MagicMock
+import ray
+import ray.dashboard.consts as dashboard_consts
+import ray.ray_constants as ray_constants
+from ray._private.test_utils import wait_for_condition
+from ray.cluster_utils import cluster_not_supported
+from ray.core.generated.common_pb2 import (
+    Address,
+    CoreWorkerStats,
+    ObjectRefInfo,
+    TaskInfoEntry,
+    TaskStatus,
+    WorkerType,
+)
+from ray.core.generated.gcs_pb2 import (
+    ActorTableData,
+    GcsNodeInfo,
+    PlacementGroupTableData,
+    WorkerTableData,
+)
+from ray.core.generated.gcs_service_pb2 import (
+    GetAllActorInfoReply,
+    GetAllNodeInfoReply,
+    GetAllPlacementGroupReply,
+    GetAllWorkerInfoReply,
+)
+from ray.core.generated.node_manager_pb2 import GetNodeStatsReply, GetTasksInfoReply
+from ray.core.generated.reporter_pb2 import ListLogsReply, StreamLogReply
+from ray.core.generated.runtime_env_agent_pb2 import GetRuntimeEnvsInfoReply
+from ray.core.generated.runtime_env_common_pb2 import (
+    RuntimeEnvState as RuntimeEnvStateProto,
+)
+from ray.dashboard.state_aggregator import (
+    GCS_QUERY_FAILURE_WARNING,
+    NODE_QUERY_FAILURE_WARNING,
+    StateAPIManager,
+    _convert_filters_type,
+)
+from ray.experimental.state.api import (
+    list_actors,
+    list_jobs,
+    list_nodes,
+    list_objects,
+    list_placement_groups,
+    list_runtime_envs,
+    list_tasks,
+    list_workers,
+)
+from ray.experimental.state.common import (
+    DEFAULT_LIMIT,
+    DEFAULT_RPC_TIMEOUT,
+    ActorState,
+    ListApiOptions,
+    NodeState,
+    ObjectState,
+    PlacementGroupState,
+    RuntimeEnvState,
+    SupportedFilterType,
+    TaskState,
+    WorkerState,
+)
+from ray.experimental.state.exception import DataSourceUnavailable, RayStateApiException
+from ray.experimental.state.state_cli import (
+    AvailableFormat,
+    get_state_api_output_to_print,
+)
+from ray.experimental.state.state_cli import list as cli_list
+from ray.experimental.state.state_manager import IdToIpMap, StateDataSourceClient
+from ray.job_submission import JobSubmissionClient
+from ray.runtime_env import RuntimeEnv
 
 if sys.version_info > (3, 7, 0):
     from unittest.mock import AsyncMock
 else:
     from asyncmock import AsyncMock
 
-import ray
-import ray.ray_constants as ray_constants
-
-from click.testing import CliRunner
-from ray.cluster_utils import cluster_not_supported
-from ray.core.generated.common_pb2 import (
-    Address,
-    WorkerType,
-    TaskStatus,
-    TaskInfoEntry,
-    CoreWorkerStats,
-    ObjectRefInfo,
-)
-from ray.core.generated.node_manager_pb2 import GetTasksInfoReply, GetNodeStatsReply
-from ray.core.generated.gcs_pb2 import (
-    ActorTableData,
-    PlacementGroupTableData,
-    GcsNodeInfo,
-    WorkerTableData,
-)
-from ray.core.generated.gcs_service_pb2 import (
-    GetAllActorInfoReply,
-    GetAllPlacementGroupReply,
-    GetAllNodeInfoReply,
-    GetAllWorkerInfoReply,
-)
-from ray.core.generated.reporter_pb2 import (
-    ListLogsReply,
-    StreamLogReply,
-)
-from ray.core.generated.runtime_env_common_pb2 import (
-    RuntimeEnvState as RuntimeEnvStateProto,
-)
-from ray.core.generated.runtime_env_agent_pb2 import GetRuntimeEnvsInfoReply
-import ray.dashboard.consts as dashboard_consts
-from ray.dashboard.state_aggregator import (
-    StateAPIManager,
-    GCS_QUERY_FAILURE_WARNING,
-    NODE_QUERY_FAILURE_WARNING,
-    _convert_filters_type,
-)
-from ray.experimental.state.api import (
-    list_actors,
-    list_placement_groups,
-    list_nodes,
-    list_jobs,
-    list_workers,
-    list_tasks,
-    list_objects,
-    list_runtime_envs,
-)
-from ray.experimental.state.common import (
-    SupportedFilterType,
-    ActorState,
-    PlacementGroupState,
-    NodeState,
-    WorkerState,
-    TaskState,
-    ObjectState,
-    RuntimeEnvState,
-    ListApiOptions,
-    DEFAULT_RPC_TIMEOUT,
-    DEFAULT_LIMIT,
-)
-from ray.experimental.state.exception import DataSourceUnavailable, RayStateApiException
-from ray.experimental.state.state_manager import StateDataSourceClient, IdToIpMap
-from ray.experimental.state.state_cli import (
-    list as cli_list,
-    get_state_api_output_to_print,
-    AvailableFormat,
-)
-from ray.runtime_env import RuntimeEnv
-from ray._private.test_utils import wait_for_condition
-from ray.job_submission import JobSubmissionClient
 
 """
 Unit tests
@@ -239,7 +235,7 @@ async def test_api_manager_list_actors(state_api_manager):
     )
     result = await state_api_manager.list_actors(option=create_api_options())
     data = result.result
-    actor_data = list(data.values())[0]
+    actor_data = data[0]
     verify_schema(ActorState, actor_data)
 
     """
@@ -286,7 +282,7 @@ async def test_api_manager_list_pgs(state_api_manager):
     )
     result = await state_api_manager.list_placement_groups(option=create_api_options())
     data = result.result
-    data = list(data.values())[0]
+    data = data[0]
     verify_schema(PlacementGroupState, data)
 
     """
@@ -334,7 +330,7 @@ async def test_api_manager_list_nodes(state_api_manager):
     )
     result = await state_api_manager.list_nodes(option=create_api_options())
     data = result.result
-    data = list(data.values())[0]
+    data = data[0]
     verify_schema(NodeState, data)
 
     """
@@ -379,7 +375,7 @@ async def test_api_manager_list_workers(state_api_manager):
     )
     result = await state_api_manager.list_workers(option=create_api_options())
     data = result.result
-    data = list(data.values())[0]
+    data = data[0]
     verify_schema(WorkerState, data)
 
     """
@@ -441,7 +437,7 @@ async def test_api_manager_list_tasks(state_api_manager):
     data_source_client.get_task_info.assert_any_await("1", timeout=DEFAULT_RPC_TIMEOUT)
     data_source_client.get_task_info.assert_any_await("2", timeout=DEFAULT_RPC_TIMEOUT)
     data = result.result
-    data = list(data.values())
+    data = data
     assert len(data) == 2
     verify_schema(TaskState, data[0])
     verify_schema(TaskState, data[1])
@@ -520,7 +516,7 @@ async def test_api_manager_list_objects(state_api_manager):
     data_source_client.get_object_info.assert_any_await(
         "2", timeout=DEFAULT_RPC_TIMEOUT
     )
-    data = list(data.values())
+    data = data
     assert len(data) == 2
     verify_schema(ObjectState, data[0])
     verify_schema(ObjectState, data[1])
@@ -967,7 +963,7 @@ def test_list_actors(shutdown_only):
     a = A.remote()  # noqa
 
     def verify():
-        actor_data = list(list_actors().values())[0]
+        actor_data = list_actors()[0]
         correct_state = actor_data["state"] == "ALIVE"
         is_id_hex = is_hex(actor_data["actor_id"])
         correct_id = a._actor_id.hex() == actor_data["actor_id"]
@@ -986,7 +982,7 @@ def test_list_pgs(shutdown_only):
     pg = ray.util.placement_group(bundles=[{"CPU": 1}])  # noqa
 
     def verify():
-        pg_data = list(list_placement_groups().values())[0]
+        pg_data = list_placement_groups()[0]
         correct_state = pg_data["state"] == "CREATED"
         is_id_hex = is_hex(pg_data["placement_group_id"])
         correct_id = pg.id.hex() == pg_data["placement_group_id"]
@@ -1004,7 +1000,7 @@ def test_list_nodes(shutdown_only):
     ray.init()
 
     def verify():
-        node_data = list(list_nodes().values())[0]
+        node_data = list_nodes()[0]
         correct_state = node_data["state"] == "ALIVE"
         is_id_hex = is_hex(node_data["node_id"])
         correct_id = ray.nodes()[0]["NodeID"] == node_data["node_id"]
@@ -1029,9 +1025,9 @@ def test_list_jobs(shutdown_only):
     )
 
     def verify():
-        job_data = list(list_jobs().values())[0]
+        job_data = list_jobs()[0]
         print(job_data)
-        job_id_from_api = list(list_jobs().keys())[0]
+        job_id_from_api = job_data["job_id"]
         correct_state = job_data["status"] == "SUCCEEDED"
         correct_id = job_id == job_id_from_api
         return correct_state and correct_id
@@ -1048,7 +1044,7 @@ def test_list_workers(shutdown_only):
     ray.init()
 
     def verify():
-        worker_data = list(list_workers().values())[0]
+        worker_data = list_workers()[0]
         is_id_hex = is_hex(worker_data["worker_id"])
         # +1 to take into account of drivers.
         correct_num_workers = len(list_workers()) == ray.cluster_resources()["CPU"] + 1
@@ -1082,7 +1078,7 @@ def test_list_tasks(shutdown_only):
     im = impossible.remote()  # noqa
 
     def verify():
-        tasks = list(list_tasks().values())
+        tasks = list_tasks()
         correct_num_tasks = len(tasks) == 5
         waiting_for_execution = len(
             list(
@@ -1138,7 +1134,7 @@ def test_list_actor_tasks(shutdown_only):
     calls = [a.call.remote() for _ in range(10)]  # noqa
 
     def verify():
-        tasks = list(list_tasks().values())
+        tasks = list_tasks()
         # Actor.__init__: 1 finished
         # Actor.call: 1 running, 9 waiting for execution (queued).
         correct_num_tasks = len(tasks) == 11
@@ -1196,7 +1192,7 @@ def test_list_objects(shutdown_only):
     ray.get(f.remote(plasma_obj))
 
     def verify():
-        obj = list(list_objects().values())[0]
+        obj = list_objects()[0]
         # For detailed output, the test is covered from `test_memstat.py`
         return obj["object_id"] == plasma_obj.hex()
 
@@ -1422,8 +1418,8 @@ def test_filter(shutdown_only):
     """
     Test CLI
     """
-    dead_actor_id = list(list_actors(filters=[("state", "DEAD")]))[0]
-    alive_actor_id = list(list_actors(filters=[("state", "ALIVE")]))[0]
+    dead_actor_id = list_actors(filters=[("state", "DEAD")])[0]["actor_id"]
+    alive_actor_id = list_actors(filters=[("state", "ALIVE")])[0]["actor_id"]
     runner = CliRunner()
     result = runner.invoke(cli_list, ["actors", "--filter", "state", "DEAD"])
     assert result.exit_code == 0
@@ -1432,8 +1428,8 @@ def test_filter(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
     import os
+    import sys
 
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -1,38 +1,38 @@
 import json
 import os
-import requests
-
-from unittest.mock import MagicMock
-from typing import List
-import pytest
 import sys
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from click.testing import CliRunner
+
+import ray
+import ray.scripts.scripts as scripts
+from ray._private.test_utils import (
+    format_web_url,
+    wait_for_condition,
+    wait_until_server_available,
+)
+from ray._raylet import ActorID, NodeID, TaskID, WorkerID
+from ray.core.generated.common_pb2 import Address
+from ray.core.generated.gcs_pb2 import ActorTableData
+from ray.core.generated.reporter_pb2 import ListLogsReply, StreamLogReply
+from ray.dashboard.modules.actor.actor_head import actor_table_data_to_dict
+from ray.dashboard.modules.log.log_agent import tail as tail_file
+from ray.dashboard.modules.log.log_manager import LogsManager
+from ray.dashboard.tests.conftest import *  # noqa
+from ray.experimental.state.api import get_log, list_logs, list_nodes, list_workers
+from ray.experimental.state.common import GetLogOptions
+from ray.experimental.state.exception import DataSourceUnavailable
+from ray.experimental.state.state_manager import StateDataSourceClient
 
 if sys.version_info > (3, 7, 0):
     from unittest.mock import AsyncMock
 else:
     from asyncmock import AsyncMock
 
-import ray
-
-from click.testing import CliRunner
-from ray._private.test_utils import (
-    format_web_url,
-    wait_until_server_available,
-)
-from ray._raylet import WorkerID, ActorID, TaskID, NodeID
-from ray.dashboard.modules.actor.actor_head import actor_table_data_to_dict
-from ray.dashboard.tests.conftest import *  # noqa
-from ray.core.generated.common_pb2 import Address
-from ray.core.generated.reporter_pb2 import StreamLogReply, ListLogsReply
-from ray.core.generated.gcs_pb2 import ActorTableData
-from ray.dashboard.modules.log.log_agent import tail as tail_file
-from ray.dashboard.modules.log.log_manager import LogsManager
-from ray.experimental.state.api import list_nodes, list_workers, list_logs, get_log
-from ray.experimental.state.common import GetLogOptions
-from ray.experimental.state.exception import DataSourceUnavailable
-from ray.experimental.state.state_manager import StateDataSourceClient
-import ray.scripts.scripts as scripts
-from ray._private.test_utils import wait_for_condition
 
 ASYNCMOCK_MIN_PYTHON_VER = (3, 8)
 
@@ -377,7 +377,7 @@ def test_logs_list(ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
-    node_id = list(list_nodes().keys())[0]
+    node_id = list_nodes()[0]["node_id"]
 
     def verify():
         response = requests.get(webui_url + f"/api/v0/logs?node_id={node_id}")
@@ -418,7 +418,7 @@ def test_logs_list(ray_start_with_dashboard):
         logs = result["data"]["result"]
         assert "gcs_server" in logs
         assert "internal" in logs
-        assert len(logs.keys()) == 2
+        assert len(logs) == 2
         assert "gcs_server.out" in logs["gcs_server"]
         assert "gcs_server.err" in logs["gcs_server"]
         assert "debug_state_gcs.txt" in logs["internal"]
@@ -441,9 +441,7 @@ def test_logs_list(ray_start_with_dashboard):
         ]
         assert all([cat in logs for cat in worker_log_categories])
         num_workers = len(
-            list(
-                filter(lambda w: w["worker_type"] == "WORKER", list_workers().values())
-            )
+            list(filter(lambda w: w["worker_type"] == "WORKER", list_workers()))
         )
         assert (
             len(logs["worker_out"])
@@ -461,7 +459,7 @@ def test_logs_stream_and_tail(ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
-    node_id = list(list_nodes().keys())[0]
+    node_id = list_nodes()[0]["node_id"]
 
     def verify_basic():
         stream_response = requests.get(
@@ -552,7 +550,7 @@ def test_log_list(ray_start_cluster):
     ray.init(address=cluster.address)
 
     def verify():
-        head_node = list(list_nodes().values())[0]
+        head_node = list_nodes()[0]
         # When glob filter is not provided, it should provide all logs
         logs = list_logs(node_id=head_node["node_id"])
         assert "raylet" in logs
@@ -575,7 +573,7 @@ def test_log_get(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=0)
     ray.init(address=cluster.address)
-    head_node = list(list_nodes().values())[0]
+    head_node = list_nodes()[0]
     cluster.add_node(num_cpus=1)
 
     @ray.remote(num_cpus=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

 I’d like to propose a bit changes to the API. Currently we are returning the dict of ID -> value mapping when the list API is returned. But I am thinking to change this to a list because the sort will become ineffective if we return the dictionary. So, it’s ideal we use the list to keep the order (it’s important for deterministic order)

Also, for some APIs, each entry doesn’t have a unique id. For example, list objects will have duplicated object IDs from their entries, which is not working with dict return type (e.g., there can be more than 1 Object ID entry if the object is locally referenced & borrowed by task/pinned in memory)
Also, users can easily build dict index on their own if it is necessary.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
