### PR TITLE
[Serve] Fix release test

### DIFF
--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -13,6 +13,8 @@ worker_node_types:
     - name: worker_node
       # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
       instance_type: m5.2xlarge
+      # smaller min workers will make the head node cpu usage very high, and crash the head node.
+      # issue: https://github.com/ray-project/ray/issues/18908
       min_workers: 5
       # 1k max replicas
       max_workers: 130

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -6,14 +6,14 @@ max_workers: 130
 
 head_node_type:
     name: head_node
-    # 16 cpus, x86, 64G mem, 10Gb NIC
-    instance_type: m5.4xlarge
+    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
+    instance_type: m5.2xlarge
 
 worker_node_types:
     - name: worker_node
       # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
       instance_type: m5.2xlarge
-      min_workers: 1
+      min_workers: 5
       # 1k max replicas
       max_workers: 130
       use_spot: false

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -6,8 +6,8 @@ max_workers: 130
 
 head_node_type:
     name: head_node
-    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-    instance_type: m5.2xlarge
+    # 16 cpus, x86, 64G mem, 10Gb NIC
+    instance_type: m5.4xlarge
 
 worker_node_types:
     - name: worker_node


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

the tests serve_autoscaling_multi_deployment is not stable. bump the init of number nodes for scaling up.

During the failure case, observed the head node cpu can reach to 100%.

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
