### PR TITLE
[Serve] Stop Ray in `test_serve_head.py` fixture

### DIFF
--- a/dashboard/modules/serve/tests/test_serve_head.py
+++ b/dashboard/modules/serve/tests/test_serve_head.py
@@ -16,6 +16,7 @@ STATUS_URL = "http://localhost:8265/api/serve/deployments/status"
 
 @pytest.fixture
 def ray_start_stop():
+    subprocess.check_output(["ray", "stop", "--force"])
     subprocess.check_output(["ray", "start", "--head"])
     yield
     subprocess.check_output(["ray", "stop", "--force"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_serve_head.py`'s `ray_start_stop()` fixture uses the Ray CLI to start and stop Ray between tests. However, sometimes Ray is already started before the test suite begins ([ex. 1](https://buildkite.com/ray-project/ray-builders-branch/builds/8210#01816f71-fcb8-4067-a29a-194b7700b301/1577-2647), [ex. 2](https://buildkite.com/ray-project/ray-builders-pr/builds/35820#01816e16-200a-4b24-9286-f74d0f8afd5c/3104-4173)– thanks @architkulkarni for finding these!). This causes the test to timeout since the fixture fails.

This change stops Ray using the CLI _before_ any of the unit tests start in order to prevent any state sharing.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - `test_serve_head.py`'s new behavior should test this change.
