### PR TITLE
[Core] Add retry exception allowlist for user-defined filtering of retryable application-level errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,8 @@ venv
 # Vim
 .*.swp
 *.swp
+.*.swo
+*.swo
 tags
 tags.lock
 tags.temp

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -133,7 +133,7 @@ Status TaskExecutor::ExecuteTask(
     const std::vector<rpc::ObjectReference> &arg_refs,
     const std::vector<ObjectID> &return_ids,
     const std::string &debugger_breakpoint,
-    const std::string &serialized_retry_exception_predicate,
+    const std::string &serialized_retry_exception_allowlist,
     std::vector<std::shared_ptr<ray::RayObject>> *results,
     std::shared_ptr<ray::LocalMemoryBuffer> &creation_task_exception_pb_bytes,
     bool *is_retryable_error,
@@ -149,7 +149,7 @@ Status TaskExecutor::ExecuteTask(
   std::string func_name = typed_descriptor->FunctionName();
   bool cross_lang = !typed_descriptor->Caller().empty();
   // TODO(Clark): Support retrying application-level errors for C++.
-  // TODO(Clark): Support exception predicates for retrying application-level
+  // TODO(Clark): Support exception allowlist for retrying application-level
   // errors for C++.
   *is_retryable_error = false;
 

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -133,9 +133,10 @@ Status TaskExecutor::ExecuteTask(
     const std::vector<rpc::ObjectReference> &arg_refs,
     const std::vector<ObjectID> &return_ids,
     const std::string &debugger_breakpoint,
+    const std::string &serialized_retry_exception_predicate,
     std::vector<std::shared_ptr<ray::RayObject>> *results,
     std::shared_ptr<ray::LocalMemoryBuffer> &creation_task_exception_pb_bytes,
-    bool *is_application_level_error,
+    bool *is_retryable_error,
     const std::vector<ConcurrencyGroup> &defined_concurrency_groups,
     const std::string name_of_concurrency_group_to_execute) {
   RAY_LOG(DEBUG) << "Execute task type: " << TaskType_Name(task_type)
@@ -147,6 +148,10 @@ Status TaskExecutor::ExecuteTask(
   auto typed_descriptor = function_descriptor->As<ray::CppFunctionDescriptor>();
   std::string func_name = typed_descriptor->FunctionName();
   bool cross_lang = !typed_descriptor->Caller().empty();
+  // TODO(Clark): Support retrying application-level errors for C++.
+  // TODO(Clark): Support exception predicates for retrying application-level
+  // errors for C++.
+  *is_retryable_error = false;
 
   Status status{};
   std::shared_ptr<msgpack::sbuffer> data = nullptr;

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -86,7 +86,7 @@ class TaskExecutor {
       const std::vector<rpc::ObjectReference> &arg_refs,
       const std::vector<ObjectID> &return_ids,
       const std::string &debugger_breakpoint,
-      const std::string &serialized_retry_exception_predicate,
+      const std::string &serialized_retry_exception_allowlist,
       std::vector<std::shared_ptr<ray::RayObject>> *results,
       std::shared_ptr<ray::LocalMemoryBuffer> &creation_task_exception_pb_bytes,
       bool *is_retryable_error,

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -86,9 +86,10 @@ class TaskExecutor {
       const std::vector<rpc::ObjectReference> &arg_refs,
       const std::vector<ObjectID> &return_ids,
       const std::string &debugger_breakpoint,
+      const std::string &serialized_retry_exception_predicate,
       std::vector<std::shared_ptr<ray::RayObject>> *results,
       std::shared_ptr<ray::LocalMemoryBuffer> &creation_task_exception_pb_bytes,
-      bool *is_application_level_error,
+      bool *is_retryable_error,
       const std::vector<ConcurrencyGroup> &defined_concurrency_groups,
       const std::string name_of_concurrency_group_to_execute);
 

--- a/doc/source/ray-core/doc_code/tasks_fault_tolerance.py
+++ b/doc/source/ray-core/doc_code/tasks_fault_tolerance.py
@@ -1,0 +1,91 @@
+# flake8: noqa
+
+# fmt: off
+# __tasks_fault_tolerance_retries_begin__
+import numpy as np
+import os
+import ray
+import time
+
+ray.init(ignore_reinit_error=True)
+
+@ray.remote(max_retries=1)
+def potentially_fail(failure_probability):
+    time.sleep(0.2)
+    if np.random.random() < failure_probability:
+        os._exit(0)
+    return 0
+
+for _ in range(3):
+    try:
+        # If this task crashes, Ray will retry it up to one additional
+        # time. If either of the attempts succeeds, the call to ray.get
+        # below will return normally. Otherwise, it will raise an
+        # exception.
+        ray.get(potentially_fail.remote(0.5))
+        print('SUCCESS')
+    except ray.exceptions.WorkerCrashedError:
+        print('FAILURE')
+# __tasks_fault_tolerance_retries_end__
+# fmt: on
+
+# fmt: off
+# __tasks_fault_tolerance_retries_exception_begin__
+import numpy as np
+import os
+import ray
+import time
+
+ray.init(ignore_reinit_error=True)
+
+class RandomError(Exception):
+    pass
+
+@ray.remote(max_retries=1, retry_exceptions=True)
+def potentially_fail(failure_probability):
+    if failure_probability < 0 or failure_probability > 1:
+        raise ValueError(
+            "failure_probability must be between 0 and 1, but got: "
+            f"{failure_probability}"
+        )
+    time.sleep(0.2)
+    if np.random.random() < failure_probability:
+        raise RandomError("Failed!")
+    return 0
+
+for _ in range(3):
+    try:
+        # If this task crashes, Ray will retry it up to one additional
+        # time. If either of the attempts succeeds, the call to ray.get
+        # below will return normally. Otherwise, it will raise an
+        # exception.
+        ray.get(potentially_fail.remote(0.5))
+        print('SUCCESS')
+    except RandomError:
+        print('FAILURE')
+
+# Provide the exceptions that we want to retry as an allowlist.
+retry_on_exception = potentially_fail.options(retry_exceptions=[RandomError])
+try:
+    # This will fail since we're passing in -1 for the failure_probability,
+    # which will raise a ValueError in the task and does not match the RandomError
+    # exception that we provided.
+    ray.get(retry_on_exception.remote(-1))
+except ValueError:
+    print("FAILED AS EXPECTED")
+else:
+    raise RuntimeError("An exception should be raised so this shouldn't be reached.")
+
+# These will retry on the RandomError exception.
+for _ in range(3):
+    try:
+        # If this task crashes, Ray will retry it up to one additional
+        # time. If either of the attempts succeeds, the call to ray.get
+        # below will return normally. Otherwise, it will raise an
+        # exception.
+        ray.get(retry_on_exception.remote(0.5))
+        print('SUCCESS')
+    except RandomError:
+        print('FAILURE AFTER RETRIES')
+# __tasks_fault_tolerance_retries_exception_end__
+# fmt: on

--- a/doc/source/ray-core/tasks/fault-tolerance.rst
+++ b/doc/source/ray-core/tasks/fault-tolerance.rst
@@ -21,32 +21,10 @@ using :ref:`runtime environments<runtime-environments>`.
 
 You can experiment with this behavior by running the following code.
 
-.. code-block:: python
-
-    import numpy as np
-    import os
-    import ray
-    import time
-
-    ray.init(ignore_reinit_error=True)
-
-    @ray.remote(max_retries=1)
-    def potentially_fail(failure_probability):
-        time.sleep(0.2)
-        if np.random.random() < failure_probability:
-            os._exit(0)
-        return 0
-
-    for _ in range(3):
-        try:
-            # If this task crashes, Ray will retry it up to one additional
-            # time. If either of the attempts succeeds, the call to ray.get
-            # below will return normally. Otherwise, it will raise an
-            # exception.
-            ray.get(potentially_fail.remote(0.5))
-            print('SUCCESS')
-        except ray.exceptions.WorkerCrashedError:
-            print('FAILURE')
+.. literalinclude:: ../doc_code/tasks_fault_tolerance.py
+  :language: python
+  :start-after: __tasks_fault_tolerance_retries_begin__
+  :end-before: __tasks_fault_tolerance_retries_end__
 
 You can also control whether application-level errors are retried, and even **which**
 application-level errors are retried, via the ``retry_exceptions`` argument. This is
@@ -58,64 +36,10 @@ retries with ``retry_exceptions=True``, or even retry a specific set of
 application-level errors (such as a class of exception types that you know to be
 transient) by providing an allowlist of exceptions:
 
-.. code-block:: python
-
-    import numpy as np
-    import os
-    import ray
-    import time
-
-    ray.init(ignore_reinit_error=True)
-
-    class RandomError(Exception):
-        pass
-
-    @ray.remote(max_retries=1, retry_exceptions=True)
-    def potentially_fail(failure_probability):
-        if failure_probability < 0 or failure_probability > 1:
-            raise ValueError(
-                "failure_probability must be between 0 and 1, but got: "
-                f"{failure_probability}"
-            )
-        time.sleep(0.2)
-        if np.random.random() < failure_probability:
-            raise RandomError("Failed!")
-        return 0
-
-    for _ in range(3):
-        try:
-            # If this task crashes, Ray will retry it up to one additional
-            # time. If either of the attempts succeeds, the call to ray.get
-            # below will return normally. Otherwise, it will raise an
-            # exception.
-            ray.get(potentially_fail.remote(0.5))
-            print('SUCCESS')
-        except RandomError:
-            print('FAILURE')
-
-    # Provide the exceptions that we want to retry as an allowlis.
-    retry_on_exception = potentially_fail.options(retry_exceptions=[RandomError])
-    try:
-        # This will fail since we're passing in -1 for the failure_probability,
-        # which will raise a ValueError in the task and does not match the RandomError
-        # exception that we provided.
-        ray.get(retry_on_exception.remote(-1))
-    except ValueError:
-        print("FAILED AS EXPECTED")
-    else:
-        raise RuntimeError("An exception should be raised so this shouldn't be reached.")
-
-    # These will retry on the RandomError exception.
-    for _ in range(3):
-        try:
-            # If this task crashes, Ray will retry it up to one additional
-            # time. If either of the attempts succeeds, the call to ray.get
-            # below will return normally. Otherwise, it will raise an
-            # exception.
-            ray.get(retry_on_exception.remote(0.5))
-            print('SUCCESS')
-        except RandomError:
-            print('FAILURE AFTER RETRIES')
+.. literalinclude:: ../doc_code/tasks_fault_tolerance.py
+  :language: python
+  :start-after: __tasks_fault_tolerance_retries_exception_begin__
+  :end-before: __tasks_fault_tolerance_retries_exception_end__
 
 The semantics for each of the potential ``retry_exceptions`` values are as follows:
 

--- a/doc/source/ray-core/tasks/fault-tolerance.rst
+++ b/doc/source/ray-core/tasks/fault-tolerance.rst
@@ -56,8 +56,7 @@ retrying non-idempotent tasks when they have partially executed.
 However, if your tasks are idempotent, then you can enable application-level error
 retries with ``retry_exceptions=True``, or even retry a specific set of
 application-level errors (such as a class of exception types that you know to be
-transient) by providing an allowlist of exceptions, or an exception predicate that
-returns ``True`` when an exception should be retried:
+transient) by providing an allowlist of exceptions:
 
 .. code-block:: python
 
@@ -94,9 +93,7 @@ returns ``True`` when an exception should be retried:
         except RandomError:
             print('FAILURE')
 
-    # Provide the exceptions that we want to retry. This can be a list of exceptions
-    # or a function that takes an exception and returns whether we should retry on
-    # that exception.
+    # Provide the exceptions that we want to retry as an allowlis.
     retry_on_exception = potentially_fail.options(retry_exceptions=[RandomError])
     try:
         # This will fail since we're passing in -1 for the failure_probability,
@@ -128,9 +125,6 @@ The semantics for each of the potential ``retry_exceptions`` values are as follo
 
 * ``retry_exceptions=[Exc1, Exc2]``: Application-level errors that are instances of
   either ``Exc1`` or ``Exc2`` are retried.
-
-* ``retry_exceptions=lambda e: isinstance(e, SomeException)``: Application-level errors
-  for which ``predicate_fn(e)`` returns ``True`` are retried.
 
 .. _object-reconstruction:
 

--- a/doc/source/ray-core/tasks/fault-tolerance.rst
+++ b/doc/source/ray-core/tasks/fault-tolerance.rst
@@ -1,7 +1,13 @@
 .. _task-fault-tolerance:
 
+===============
 Fault Tolerance
 ===============
+
+.. _task-retries:
+
+Retries
+=======
 
 When a worker is executing a task, if the worker dies unexpectedly, either
 because the process crashed or because the machine failed, Ray will rerun
@@ -42,7 +48,91 @@ You can experiment with this behavior by running the following code.
         except ray.exceptions.WorkerCrashedError:
             print('FAILURE')
 
+You can also control whether application-level errors are retried, and even **which**
+application-level errors are retried, via the ``retry_exceptions`` argument. This is
+``False`` by default, so if your application code within the Ray task raises an
+exception, this failure will **not** be retried. This is to ensure that Ray is not
+retrying non-idempotent tasks when they have partially executed.
+However, if your tasks are idempotent, then you can enable application-level error
+retries with ``retry_exceptions=True``, or even retry a specific set of
+application-level errors (such as a class of exception types that you know to be
+transient) by providing an exception predicate:
+``retry_exceptions=lambda e: isinstance(e, ConnectionError)``.
+
+.. code-block:: python
+
+    import numpy as np
+    import os
+    import ray
+    import time
+
+    ray.init(ignore_reinit_error=True)
+
+    class RandomError(Exception):
+        pass
+
+    @ray.remote(max_retries=1, retry_exceptions=True)
+    def potentially_fail(failure_probability):
+        if failure_probability < 0 or failure_probability > 1:
+            raise ValueError(
+                "failure_probability must be between 0 and 1, but got: "
+                f"{failure_probability}"
+            )
+        time.sleep(0.2)
+        if np.random.random() < failure_probability:
+            raise RandomError("Failed!")
+        return 0
+
+    for _ in range(3):
+        try:
+            # If this task crashes, Ray will retry it up to one additional
+            # time. If either of the attempts succeeds, the call to ray.get
+            # below will return normally. Otherwise, it will raise an
+            # exception.
+            ray.get(potentially_fail.remote(0.5))
+            print('SUCCESS')
+        except RandomError:
+            print('FAILURE')
+
+    # Use an exception predicate to only retry RandomError exceptions.
+    potentially_fail_with_predicate = potentially_fail.options(
+        retry_exceptions=lambda e: isinstance(e, RandomError)
+    )
+    try:
+        # This will fail since we're passing in -1 for the failure_probability,
+        # which will raise a ValueError in the task and will therefore NOT satisfy
+        # our exception predicate.
+        ray.get(potentially_fail_with_predicate.remote(-1))
+    except ValueError:
+        print("FAILED AS EXPECTED")
+    else:
+        raise RuntimeError("An exception should be raised so this shouldn't be reached.")
+
+    # These will retry on the RandomError exceptions.
+    for _ in range(3):
+        try:
+            # If this task crashes, Ray will retry it up to one additional
+            # time. If either of the attempts succeeds, the call to ray.get
+            # below will return normally. Otherwise, it will raise an
+            # exception.
+            ray.get(potentially_fail_with_predicate.remote(0.5))
+            print('SUCCESS')
+        except RandomError:
+            print('FAILURE AFTER RETRIES')
+
+The semantics for each of the potential ``retry_exceptions`` values are as follows:
+
+* ``retry_exceptions=False`` (default): Application-level errors are not retried.
+
+* ``retry_exceptions=True``: All application-level errors are retried.
+
+* ``retry_exceptions=predicate_fn``: All application-level errors for which
+  ``predicate_fn(e)`` returns ``True`` will be retried.
+
 .. _object-reconstruction:
+
+Lineage-based Object Reconstruction
+===================================
 
 Ray also implements *lineage reconstruction* to recover task outputs that are
 lost from the distributed object store. This can occur during node failures.

--- a/doc/source/ray-core/tasks/fault-tolerance.rst
+++ b/doc/source/ray-core/tasks/fault-tolerance.rst
@@ -94,11 +94,10 @@ returns ``True`` when an exception should be retried:
         except RandomError:
             print('FAILURE')
 
-    # Use an exception predicate to only retry RandomError exceptions.
-    # Provide which exception we want to retry. This can be a single exception, a list
-    # of exceptions, or a function that takes an exception and returns whether we should
-    # retry on that exception.
-    retry_on_exception = potentially_fail.options(retry_exceptions=RandomError)
+    # Provide the exceptions that we want to retry. This can be a list of exceptions
+    # or a function that takes an exception and returns whether we should retry on
+    # that exception.
+    retry_on_exception = potentially_fail.options(retry_exceptions=[RandomError])
     try:
         # This will fail since we're passing in -1 for the failure_probability,
         # which will raise a ValueError in the task and does not match the RandomError
@@ -126,9 +125,6 @@ The semantics for each of the potential ``retry_exceptions`` values are as follo
 * ``retry_exceptions=False`` (default): Application-level errors are not retried.
 
 * ``retry_exceptions=True``: All application-level errors are retried.
-
-* ``retry_exceptions=SomeException``: Application-level errors that are instances of
-  ``SomeException`` are retried.
 
 * ``retry_exceptions=[Exc1, Exc2]``: Application-level errors that are instances of
   either ``Exc1`` or ``Exc2`` are retried.

--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -125,10 +125,13 @@ _task_only_options = {
         "Setting 'object_store_memory' is not implemented for tasks",
     ),
     "retry_exceptions": Option(
-        (bool, list),
+        (bool, list, tuple),
         lambda x: (
             isinstance(x, bool)
-            or (isinstance(x, list) and all(issubclass_safe(x_, Exception) for x_ in x))
+            or (
+                isinstance(x, (list, tuple))
+                and all(issubclass_safe(x_, Exception) for x_ in x)
+            )
         ),
         "retry_exceptions must be either a boolean or a list of exceptions",
         default_value=False,

--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -26,7 +26,6 @@ class Option:
         """Validate the option."""
         if self.type_constraint is not None:
             if inspect.isfunction(self.type_constraint):
-                print(value)
                 satisfies_type_constraint = self.type_constraint(value)
             else:
                 satisfies_type_constraint = isinstance(value, self.type_constraint)
@@ -112,7 +111,6 @@ def issubclass_safe(obj: Any, cls_: type) -> bool:
     try:
         return issubclass(obj, cls_)
     except TypeError:
-        print(obj, cls_)
         return False
 
 

--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -132,16 +132,14 @@ _task_only_options = {
     "retry_exceptions": Option(
         lambda x: (
             isinstance(x, bool)
-            or issubclass_safe(x, Exception)
             or (isinstance(x, list) and all(issubclass_safe(x_, Exception) for x_ in x))
             or inspect.isfunction(x)
         ),
         lambda x: (
             not inspect.isfunction(x) or len(inspect.signature(x).parameters) == 1
         ),
-        "retry_exceptions must be either a boolean, an exception, a list of "
-        "exceptions, or a predicate function that takes an exception and returns a "
-        "boolean.",
+        "retry_exceptions must be either a boolean, a list of exceptions, or a "
+        "predicate function that takes an exception and returns a boolean.",
         default_value=False,
     ),
 }

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2775,9 +2775,9 @@ def remote(*args, **kwargs):
             in beta and may change before becoming stable.
         retry_exceptions: Only for *remote functions*. This specifies whether
             application-level errors should be retried up to max_retries times.
-            This can be a boolean, an exception or list of exceptions that should be
-            retried, or a predicate function that takes an exception and returns whether
-            that particular exception should be retried.
+            This can be a boolean, a list of exceptions that should be retried, or a
+            predicate function that takes an exception and returns whether that
+            particular exception should be retried.
         scheduling_strategy: Strategy about how to
             schedule a remote function or actor. Possible values are
             None: ray will figure out the scheduling strategy to use, it

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2773,9 +2773,10 @@ def remote(*args, **kwargs):
             this actor or task and its children. See
             :ref:`runtime-environments` for detailed documentation. This API is
             in beta and may change before becoming stable.
-        retry_exceptions: Only for *remote functions*. This specifies
-            whether application-level errors should be retried
-            up to max_retries times.
+        retry_exceptions: Only for *remote functions*. This specifies whether
+            application-level errors should be retried up to max_retries times.
+            This can be a boolean or a predicate function that takes an exception and
+            returns whether that particular exception should be retried.
         scheduling_strategy: Strategy about how to
             schedule a remote function or actor. Possible values are
             None: ray will figure out the scheduling strategy to use, it

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2775,8 +2775,9 @@ def remote(*args, **kwargs):
             in beta and may change before becoming stable.
         retry_exceptions: Only for *remote functions*. This specifies whether
             application-level errors should be retried up to max_retries times.
-            This can be a boolean or a predicate function that takes an exception and
-            returns whether that particular exception should be retried.
+            This can be a boolean, an exception or list of exceptions that should be
+            retried, or a predicate function that takes an exception and returns whether
+            that particular exception should be retried.
         scheduling_strategy: Strategy about how to
             schedule a remote function or actor. Possible values are
             None: ray will figure out the scheduling strategy to use, it

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2775,9 +2775,7 @@ def remote(*args, **kwargs):
             in beta and may change before becoming stable.
         retry_exceptions: Only for *remote functions*. This specifies whether
             application-level errors should be retried up to max_retries times.
-            This can be a boolean, a list of exceptions that should be retried, or a
-            predicate function that takes an exception and returns whether that
-            particular exception should be retried.
+            This can be a boolean or a list of exceptions that should be retried.
         scheduling_strategy: Strategy about how to
             schedule a remote function or actor. Possible values are
             None: ray will figure out the scheduling strategy to use, it

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -132,6 +132,7 @@ from ray.util.scheduling_strategies import (
     NodeAffinitySchedulingStrategy,
 )
 import ray._private.ray_constants as ray_constants
+import ray.cloudpickle as ray_pickle
 from ray._private.async_compat import sync_to_async, get_new_event_loop
 from ray._private.client_mode_hook import disable_client_hook
 import ray._private.gcs_utils as gcs_utils
@@ -484,6 +485,78 @@ cdef raise_if_dependency_failed(arg):
         raise arg
 
 
+cdef c_bool determine_if_retryable(
+    Exception e,
+    const c_string serialized_retry_exception_predicate,
+    FunctionDescriptor function_descriptor,
+):
+    """Determine if the provided exception is retryable, according to the
+    (possibly null) serialized predicate function.
+
+    If the serialized predicate function is an empty string or is None once
+    deserialized, the exception is considered retryable and we return True.
+
+    This method can raise exceptions in several cases:
+        - Deserialization fails (TypeError)
+        - Deserialized predicate function is not a function (TypeError)
+        - Predicate function raises an error (RuntimeError)
+        - Predicate function output is not a boolean (TypeError)
+    """
+    if len(serialized_retry_exception_predicate) == 0:
+        # No exception predicate specified, default to all retryable.
+        return True
+
+    # Deserialize exception predicate and apply it to exception e.
+    try:
+        exception_predicate = ray_pickle.loads(
+            serialized_retry_exception_predicate,
+        )
+    except TypeError as inner_e:
+        # Exception predicate deserialization failed.
+        msg = (
+            "Could not deserialize the retry exception predicate "
+            f"function {exception_predicate} for task "
+            f"{function_descriptor.repr}. "
+            "Check "
+            "https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting " # noqa
+            "for more information.")
+        raise TypeError(msg) from inner_e
+
+    if exception_predicate is None:
+        # No exception predicate specified, default to all retryable.
+        return True
+
+    if not inspect.isfunction(exception_predicate):
+        # Exception predicate is not a function.
+        raise TypeError(
+            "Exception predicate provided via retry_exceptions "
+            "must be a Callabe[[Exception], bool], but got: "
+            f"{type(exception_predicate)}, {exception_predicate}"
+        )
+
+    try:
+        predicate_result = exception_predicate(e)
+    except Exception as inner_e:
+        # Exception predicate invocation failed.
+        raise RuntimeError(
+            "Calling exception predicate provided via "
+            "retry_exceptions failed for predicate "
+            f"{exception_predicate}"
+        ) from inner_e
+
+    if not isinstance(predicate_result, bool):
+        # Exception predicate returned wrong type.
+        raise TypeError(
+            "Exception predicate provided via retry_exceptions "
+            "must be a function that takes an exception and "
+            "returns a boolean whether the exception is retryable, "
+            f"but instead returned: {type(predicate_result)}, "
+            f"{predicate_result}\nPredicate: {exception_predicate}"
+        )
+
+    return predicate_result
+
+
 cdef execute_task(
         CTaskType task_type,
         const c_string name,
@@ -493,14 +566,15 @@ cdef execute_task(
         const c_vector[CObjectReference] &c_arg_refs,
         const c_vector[CObjectID] &c_return_ids,
         const c_string debugger_breakpoint,
+        const c_string serialized_retry_exception_predicate,
         c_vector[shared_ptr[CRayObject]] *returns,
-        c_bool *is_application_level_error,
+        c_bool *is_retryable_error,
         # This parameter is only used for actor creation task to define
         # the concurrency groups of this actor.
         const c_vector[CConcurrencyGroup] &c_defined_concurrency_groups,
         const c_string c_name_of_concurrency_group_to_execute):
 
-    is_application_level_error[0] = False
+    is_retryable_error[0] = False
 
     worker = ray._private.worker.global_worker
     manager = worker.function_actor_manager
@@ -695,9 +769,21 @@ cdef execute_task(
                     raise TaskCancelledError(
                             core_worker.get_current_task_id())
                 except Exception as e:
-                    is_application_level_error[0] = True
-                    if core_worker.get_current_task_retry_exceptions():
+                    is_retryable_error[0] = determine_if_retryable(
+                        e,
+                        serialized_retry_exception_predicate,
+                        function_descriptor,
+                    )
+                    if (
+                        is_retryable_error[0]
+                        and core_worker.get_current_task_retry_exceptions()
+                    ):
                         logger.info("Task failed with retryable exception:"
+                                    " {}.".format(
+                                        core_worker.get_current_task_id()),
+                                    exc_info=True)
+                    else:
+                        logger.info("Task failed with unretryable exception:"
                                     " {}.".format(
                                         core_worker.get_current_task_id()),
                                     exc_info=True)
@@ -799,9 +885,10 @@ cdef CRayStatus task_execution_handler(
         const c_vector[CObjectReference] &c_arg_refs,
         const c_vector[CObjectID] &c_return_ids,
         const c_string debugger_breakpoint,
+        const c_string serialized_retry_exception_predicate,
         c_vector[shared_ptr[CRayObject]] *returns,
         shared_ptr[LocalMemoryBuffer] &creation_task_exception_pb_bytes,
-        c_bool *is_application_level_error,
+        c_bool *is_retryable_error,
         const c_vector[CConcurrencyGroup] &defined_concurrency_groups,
         const c_string name_of_concurrency_group_to_execute) nogil:
     with gil, disable_client_hook():
@@ -811,8 +898,10 @@ cdef CRayStatus task_execution_handler(
                 # it does, that indicates that there was an internal error.
                 execute_task(task_type, task_name, ray_function, c_resources,
                              c_args, c_arg_refs, c_return_ids,
-                             debugger_breakpoint, returns,
-                             is_application_level_error,
+                             debugger_breakpoint,
+                             serialized_retry_exception_predicate,
+                             returns,
+                             is_retryable_error,
                              defined_concurrency_groups,
                              name_of_concurrency_group_to_execute)
             except Exception as e:
@@ -1525,6 +1614,7 @@ cdef class CoreWorker:
                     resources,
                     int max_retries,
                     c_bool retry_exceptions,
+                    retry_exception_predicate,
                     scheduling_strategy,
                     c_string debugger_breakpoint,
                     c_string serialized_runtime_env_info,
@@ -1539,6 +1629,19 @@ cdef class CoreWorker:
 
         self.python_scheduling_strategy_to_c(
             scheduling_strategy, &c_scheduling_strategy)
+
+        try:
+            serialized_retry_exception_predicate = ray_pickle.dumps(
+                retry_exception_predicate,
+            )
+        except TypeError as e:
+            msg = (
+                "Could not serialize the retry exception predicate function "
+                f"{retry_exception_predicate} for task {function_descriptor.repr}. "
+                "Check "
+                "https://docs.ray.io/en/master/ray-core/objects/serialization.html#troubleshooting " # noqa
+                "for more information.")
+            raise TypeError(msg) from e
 
         with self.profile_event(b"submit_task"):
             prepare_resources(resources, &c_resources)
@@ -1558,7 +1661,9 @@ cdef class CoreWorker:
                     serialized_runtime_env_info),
                 max_retries, retry_exceptions,
                 c_scheduling_strategy,
-                debugger_breakpoint)
+                debugger_breakpoint,
+                serialized_retry_exception_predicate,
+            )
 
             # These arguments were serialized and put into the local object
             # store during task submission. The backend increments their local

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -111,7 +111,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             int max_retries,
             c_bool retry_exceptions,
             const CSchedulingStrategy &scheduling_strategy,
-            c_string debugger_breakpoint)
+            c_string debugger_breakpoint,
+            c_string serialized_retry_exception_predicate)
         CRayStatus CreateActor(
             const CRayFunction &function,
             const c_vector[unique_ptr[CTaskArg]] &args,
@@ -287,10 +288,11 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const c_vector[CObjectReference] &arg_refs,
             const c_vector[CObjectID] &return_ids,
             const c_string debugger_breakpoint,
+            const c_string serialized_retry_exception_predicate,
             c_vector[shared_ptr[CRayObject]] *returns,
             shared_ptr[LocalMemoryBuffer]
             &creation_task_exception_pb_bytes,
-            c_bool *is_application_level_error,
+            c_bool *is_retryable_error,
             const c_vector[CConcurrencyGroup] &defined_concurrency_groups,
             const c_string name_of_concurrency_group_to_execute) nogil
          ) task_execution_callback

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -112,7 +112,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             c_bool retry_exceptions,
             const CSchedulingStrategy &scheduling_strategy,
             c_string debugger_breakpoint,
-            c_string serialized_retry_exception_predicate)
+            c_string serialized_retry_exception_allowlist)
         CRayStatus CreateActor(
             const CRayFunction &function,
             const c_vector[unique_ptr[CTaskArg]] &args,
@@ -288,7 +288,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const c_vector[CObjectReference] &arg_refs,
             const c_vector[CObjectID] &return_ids,
             const c_string debugger_breakpoint,
-            const c_string serialized_retry_exception_predicate,
+            const c_string serialized_retry_exception_allowlist,
             c_vector[shared_ptr[CRayObject]] *returns,
             shared_ptr[LocalMemoryBuffer]
             &creation_task_exception_pb_bytes,

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -59,9 +59,9 @@ class RemoteFunction:
         _max_retries: The number of times this task may be retried
             on worker failure.
         _retry_exceptions: Whether application-level errors should be retried.
-            This can be a boolean, an exception or list of exceptions that should be
-            retried, or a predicate function that takes an exception and returns whether
-            that particular exception should be retried.
+            This can be a boolean, a list of exceptions that should be retried, or a
+            predicate function that takes an exception and returns whether that
+            particular exception should be retried.
         _runtime_env: The runtime environment for this task.
         _decorator: An optional decorator that should be applied to the remote
             function invocation (as opposed to the function execution) before
@@ -255,10 +255,8 @@ class RemoteFunction:
         num_returns = task_options["num_returns"]
         max_retries = task_options["max_retries"]
         retry_exceptions = task_options["retry_exceptions"]
-        if isinstance(retry_exceptions, Exception):
-            retry_exceptions = [retry_exceptions]
         if isinstance(retry_exceptions, list):
-            # Convert implicit allowlist of exceptions to an exception predicate.
+            # Convert allowlist of exceptions to an exception predicate.
             retry_exceptions_ = retry_exceptions
             retry_exceptions = lambda e: isinstance(  # noqa: E731
                 e, tuple(retry_exceptions_)

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -59,7 +59,7 @@ class RemoteFunction:
         _max_retries: The number of times this task may be retried
             on worker failure.
         _retry_exceptions: Whether application-level errors should be retried.
-            This can be a boolean or a list of exceptions that should be retried.
+            This can be a boolean or a list/tuple of exceptions that should be retried.
         _runtime_env: The runtime environment for this task.
         _decorator: An optional decorator that should be applied to the remote
             function invocation (as opposed to the function execution) before
@@ -253,7 +253,7 @@ class RemoteFunction:
         num_returns = task_options["num_returns"]
         max_retries = task_options["max_retries"]
         retry_exceptions = task_options["retry_exceptions"]
-        if not isinstance(retry_exceptions, bool):
+        if isinstance(retry_exceptions, (list, tuple)):
             retry_exception_allowlist = tuple(retry_exceptions)
             retry_exceptions = True
         else:

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -59,8 +59,9 @@ class RemoteFunction:
         _max_retries: The number of times this task may be retried
             on worker failure.
         _retry_exceptions: Whether application-level errors should be retried.
-            This can be a boolean or a predicate function that takes an exception and
-            returns whether that particular exception should be retried.
+            This can be a boolean, an exception or list of exceptions that should be
+            retried, or a predicate function that takes an exception and returns whether
+            that particular exception should be retried.
         _runtime_env: The runtime environment for this task.
         _decorator: An optional decorator that should be applied to the remote
             function invocation (as opposed to the function execution) before
@@ -254,6 +255,14 @@ class RemoteFunction:
         num_returns = task_options["num_returns"]
         max_retries = task_options["max_retries"]
         retry_exceptions = task_options["retry_exceptions"]
+        if isinstance(retry_exceptions, Exception):
+            retry_exceptions = [retry_exceptions]
+        if isinstance(retry_exceptions, list):
+            # Convert implicit allowlist of exceptions to an exception predicate.
+            retry_exceptions_ = retry_exceptions
+            retry_exceptions = lambda e: isinstance(  # noqa: E731
+                e, tuple(retry_exceptions_)
+            )
         if inspect.isfunction(retry_exceptions):
             retry_exception_predicate = retry_exceptions
             retry_exceptions = True

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -110,14 +110,7 @@ class CountError(Exception):
     pass
 
 
-@pytest.mark.parametrize(
-    "retry_exceptions",
-    [[CountError], lambda e: isinstance(e, CountError)],
-)
-def test_retry_application_level_error_exception_filter(
-    ray_start_regular,
-    retry_exceptions,
-):
+def test_retry_application_level_error_exception_filter(ray_start_regular):
     @ray.remote
     class Counter:
         def __init__(self):
@@ -127,7 +120,7 @@ def test_retry_application_level_error_exception_filter(
             self.value += 1
             return self.value
 
-    @ray.remote(max_retries=1, retry_exceptions=retry_exceptions)
+    @ray.remote(max_retries=1, retry_exceptions=[CountError])
     def func(counter):
         if counter is None:
             raise ValueError()

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -106,6 +106,51 @@ def test_retry_application_level_error(ray_start_regular):
         ray.get(r3)
 
 
+def test_retry_application_level_error_predicate(ray_start_regular):
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.value = 0
+
+        def increment(self):
+            self.value += 1
+            return self.value
+
+    class CountError(Exception):
+        pass
+
+    @ray.remote(max_retries=1, retry_exceptions=lambda e: isinstance(e, CountError))
+    def func(counter):
+        if counter is None:
+            raise ValueError()
+        count = counter.increment.remote()
+        if ray.get(count) == 1:
+            raise CountError()
+        else:
+            return 2
+
+    # Exception that doesn't satisfy the predicate should cause the task to immediately
+    # fail.
+    r0 = func.remote(None)
+    with pytest.raises(ValueError):
+        ray.get(r0)
+
+    # Test against exceptions (CountError) that do satisfy the predicate.
+    counter1 = Counter.remote()
+    r1 = func.remote(counter1)
+    assert ray.get(r1) == 2
+
+    counter2 = Counter.remote()
+    r2 = func.options(max_retries=0).remote(counter2)
+    with pytest.raises(CountError):
+        ray.get(r2)
+
+    counter3 = Counter.remote()
+    r3 = func.options(retry_exceptions=False).remote(counter3)
+    with pytest.raises(CountError):
+        ray.get(r3)
+
+
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
 def test_connect_with_disconnected_node(shutdown_only):
     config = {

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -112,7 +112,7 @@ class CountError(Exception):
 
 @pytest.mark.parametrize(
     "retry_exceptions",
-    [CountError, [CountError], lambda e: isinstance(e, CountError)],
+    [[CountError], lambda e: isinstance(e, CountError)],
 )
 def test_retry_application_level_error_exception_filter(
     ray_start_regular,

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -324,6 +324,10 @@ bool TaskSpecification::IsSpreadSchedulingStrategy() const {
          rpc::SchedulingStrategy::SchedulingStrategyCase::kSpreadSchedulingStrategy;
 }
 
+const std::string TaskSpecification::GetSerializedRetryExceptionPredicate() const {
+  return message_->serialized_retry_exception_predicate();
+}
+
 // === Below are getter methods specific to actor creation tasks.
 
 ActorID TaskSpecification::ActorCreationId() const {

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -324,8 +324,8 @@ bool TaskSpecification::IsSpreadSchedulingStrategy() const {
          rpc::SchedulingStrategy::SchedulingStrategyCase::kSpreadSchedulingStrategy;
 }
 
-const std::string TaskSpecification::GetSerializedRetryExceptionPredicate() const {
-  return message_->serialized_retry_exception_predicate();
+const std::string TaskSpecification::GetSerializedRetryExceptionAllowlist() const {
+  return message_->serialized_retry_exception_allowlist();
 }
 
 // === Below are getter methods specific to actor creation tasks.

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -302,6 +302,9 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// Whether this task is an actor task.
   bool IsActorTask() const;
 
+  // Returns the serialized exception predicate for this task.
+  const std::string GetSerializedRetryExceptionPredicate() const;
+
   // Methods specific to actor creation tasks.
 
   ActorID ActorCreationId() const;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -302,8 +302,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// Whether this task is an actor task.
   bool IsActorTask() const;
 
-  // Returns the serialized exception predicate for this task.
-  const std::string GetSerializedRetryExceptionPredicate() const;
+  // Returns the serialized exception allowlist for this task.
+  const std::string GetSerializedRetryExceptionAllowlist() const;
 
   // Methods specific to actor creation tasks.
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -141,12 +141,12 @@ class TaskSpecBuilder {
   TaskSpecBuilder &SetNormalTaskSpec(
       int max_retries,
       bool retry_exceptions,
-      const std::string &serialized_retry_exception_predicate,
+      const std::string &serialized_retry_exception_allowlist,
       const rpc::SchedulingStrategy &scheduling_strategy) {
     message_->set_max_retries(max_retries);
     message_->set_retry_exceptions(retry_exceptions);
-    message_->set_serialized_retry_exception_predicate(
-        serialized_retry_exception_predicate);
+    message_->set_serialized_retry_exception_allowlist(
+        serialized_retry_exception_allowlist);
     message_->mutable_scheduling_strategy()->CopyFrom(scheduling_strategy);
     return *this;
   }

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -138,11 +138,15 @@ class TaskSpecBuilder {
     return *this;
   }
 
-  TaskSpecBuilder &SetNormalTaskSpec(int max_retries,
-                                     bool retry_exceptions,
-                                     const rpc::SchedulingStrategy &scheduling_strategy) {
+  TaskSpecBuilder &SetNormalTaskSpec(
+      int max_retries,
+      bool retry_exceptions,
+      const std::string &serialized_retry_exception_predicate,
+      const rpc::SchedulingStrategy &scheduling_strategy) {
     message_->set_max_retries(max_retries);
     message_->set_retry_exceptions(retry_exceptions);
+    message_->set_serialized_retry_exception_predicate(
+        serialized_retry_exception_predicate);
     message_->mutable_scheduling_strategy()->CopyFrom(scheduling_strategy);
     return *this;
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1620,7 +1620,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
     bool retry_exceptions,
     const rpc::SchedulingStrategy &scheduling_strategy,
     const std::string &debugger_breakpoint,
-    const std::string &serialized_retry_exception_predicate) {
+    const std::string &serialized_retry_exception_allowlist) {
   RAY_CHECK(scheduling_strategy.scheduling_strategy_case() !=
             rpc::SchedulingStrategy::SchedulingStrategyCase::SCHEDULING_STRATEGY_NOT_SET);
 
@@ -1656,7 +1656,7 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
                       task_options.serialized_runtime_env_info);
   builder.SetNormalTaskSpec(max_retries,
                             retry_exceptions,
-                            serialized_retry_exception_predicate,
+                            serialized_retry_exception_allowlist,
                             scheduling_strategy);
   TaskSpecification task_spec = builder.Build();
   RAY_LOG(DEBUG) << "Submitting normal task " << task_spec.DebugString();
@@ -2312,7 +2312,7 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
       arg_refs,
       return_ids,
       task_spec.GetDebuggerBreakpoint(),
-      task_spec.GetSerializedRetryExceptionPredicate(),
+      task_spec.GetSerializedRetryExceptionAllowlist(),
       return_objects,
       creation_task_exception_pb_bytes,
       is_retryable_error,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1619,7 +1619,8 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
     int max_retries,
     bool retry_exceptions,
     const rpc::SchedulingStrategy &scheduling_strategy,
-    const std::string &debugger_breakpoint) {
+    const std::string &debugger_breakpoint,
+    const std::string &serialized_retry_exception_predicate) {
   RAY_CHECK(scheduling_strategy.scheduling_strategy_case() !=
             rpc::SchedulingStrategy::SchedulingStrategyCase::SCHEDULING_STRATEGY_NOT_SET);
 
@@ -1653,7 +1654,10 @@ std::vector<rpc::ObjectReference> CoreWorker::SubmitTask(
                       debugger_breakpoint,
                       depth,
                       task_options.serialized_runtime_env_info);
-  builder.SetNormalTaskSpec(max_retries, retry_exceptions, scheduling_strategy);
+  builder.SetNormalTaskSpec(max_retries,
+                            retry_exceptions,
+                            serialized_retry_exception_predicate,
+                            scheduling_strategy);
   TaskSpecification task_spec = builder.Build();
   RAY_LOG(DEBUG) << "Submitting normal task " << task_spec.DebugString();
   std::vector<rpc::ObjectReference> returned_refs;
@@ -2224,7 +2228,7 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
                                const std::shared_ptr<ResourceMappingType> &resource_ids,
                                std::vector<std::shared_ptr<RayObject>> *return_objects,
                                ReferenceCounter::ReferenceTableProto *borrowed_refs,
-                               bool *is_application_level_error) {
+                               bool *is_retryable_error) {
   RAY_LOG(DEBUG) << "Executing task, task info = " << task_spec.DebugString();
   task_queue_length_ -= 1;
   num_executed_tasks_ += 1;
@@ -2308,9 +2312,10 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
       arg_refs,
       return_ids,
       task_spec.GetDebuggerBreakpoint(),
+      task_spec.GetSerializedRetryExceptionPredicate(),
       return_objects,
       creation_task_exception_pb_bytes,
-      is_application_level_error,
+      is_retryable_error,
       defined_concurrency_groups,
       name_of_concurrency_group_to_execute);
 
@@ -2481,12 +2486,9 @@ std::vector<rpc::ObjectReference> CoreWorker::ExecuteTaskLocalMode(
   }
   auto old_id = GetActorId();
   SetActorId(actor_id);
-  bool is_application_level_error;
-  RAY_UNUSED(ExecuteTask(task_spec,
-                         resource_ids,
-                         &return_objects,
-                         &borrowed_refs,
-                         &is_application_level_error));
+  bool is_retryable_error;
+  RAY_UNUSED(ExecuteTask(
+      task_spec, resource_ids, &return_objects, &borrowed_refs, &is_retryable_error));
   SetActorId(old_id);
   return returned_refs;
 }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -458,6 +458,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] debugger_breakpoint breakpoint to drop into for the debugger after this
   /// task starts executing, or "" if we do not want to drop into the debugger.
   /// should capture parent's placement group implicilty.
+  /// \param[in] serialized_retry_exception_predicate An serialized exception predicate
+  /// function that takes a frontend-language exception/error and returns whether the
+  /// exception should be retried. Default is an empty string, which will be treated as
+  /// a null predicate function in the language worker.
   /// \return ObjectRefs returned by this task.
   std::vector<rpc::ObjectReference> SubmitTask(
       const RayFunction &function,
@@ -466,7 +470,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
       int max_retries,
       bool retry_exceptions,
       const rpc::SchedulingStrategy &scheduling_strategy,
-      const std::string &debugger_breakpoint);
+      const std::string &debugger_breakpoint,
+      const std::string &serialized_retry_exception_predicate = "");
 
   /// Create an actor.
   ///
@@ -934,7 +939,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                      const std::shared_ptr<ResourceMappingType> &resource_ids,
                      std::vector<std::shared_ptr<RayObject>> *return_objects,
                      ReferenceCounter::ReferenceTableProto *borrowed_refs,
-                     bool *is_application_level_error);
+                     bool *is_retryable_error);
 
   /// Put an object in the local plasma store.
   Status PutInLocalPlasmaStore(const RayObject &object,

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -458,10 +458,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] debugger_breakpoint breakpoint to drop into for the debugger after this
   /// task starts executing, or "" if we do not want to drop into the debugger.
   /// should capture parent's placement group implicilty.
-  /// \param[in] serialized_retry_exception_allowlist An serialized exception predicate
-  /// function that takes a frontend-language exception/error and returns whether the
-  /// exception should be retried. Default is an empty string, which will be treated as
-  /// a null predicate function in the language worker.
+  /// \param[in] serialized_retry_exception_allowlist A serialized exception list
+  /// that serves as an allowlist of frontend-language exceptions/errors that should be
+  /// retried. Default is an empty string, which will be treated as an allow-all in the
+  /// language worker.
   /// \return ObjectRefs returned by this task.
   std::vector<rpc::ObjectReference> SubmitTask(
       const RayFunction &function,

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -458,7 +458,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] debugger_breakpoint breakpoint to drop into for the debugger after this
   /// task starts executing, or "" if we do not want to drop into the debugger.
   /// should capture parent's placement group implicilty.
-  /// \param[in] serialized_retry_exception_predicate An serialized exception predicate
+  /// \param[in] serialized_retry_exception_allowlist An serialized exception predicate
   /// function that takes a frontend-language exception/error and returns whether the
   /// exception should be retried. Default is an empty string, which will be treated as
   /// a null predicate function in the language worker.
@@ -471,7 +471,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
       bool retry_exceptions,
       const rpc::SchedulingStrategy &scheduling_strategy,
       const std::string &debugger_breakpoint,
-      const std::string &serialized_retry_exception_predicate = "");
+      const std::string &serialized_retry_exception_allowlist = "");
 
   /// Create an actor.
   ///

--- a/src/ray/core_worker/core_worker_options.h
+++ b/src/ray/core_worker/core_worker_options.h
@@ -41,9 +41,10 @@ struct CoreWorkerOptions {
       const std::vector<rpc::ObjectReference> &arg_refs,
       const std::vector<ObjectID> &return_ids,
       const std::string &debugger_breakpoint,
+      const std::string &serialized_retry_exception_predicate,
       std::vector<std::shared_ptr<RayObject>> *results,
       std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb_bytes,
-      bool *is_application_level_error,
+      bool *is_retryable_error,
       // The following 2 parameters `defined_concurrency_groups` and
       // `name_of_concurrency_group_to_execute` are used for Python
       // asyncio actor only.

--- a/src/ray/core_worker/core_worker_options.h
+++ b/src/ray/core_worker/core_worker_options.h
@@ -41,7 +41,7 @@ struct CoreWorkerOptions {
       const std::vector<rpc::ObjectReference> &arg_refs,
       const std::vector<ObjectID> &return_ids,
       const std::string &debugger_breakpoint,
-      const std::string &serialized_retry_exception_predicate,
+      const std::string &serialized_retry_exception_allowlist,
       std::vector<std::shared_ptr<RayObject>> *results,
       std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb_bytes,
       bool *is_retryable_error,

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -116,9 +116,10 @@ Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(JNIEnv *env,
          const std::vector<rpc::ObjectReference> &arg_refs,
          const std::vector<ObjectID> &return_ids,
          const std::string &debugger_breakpoint,
+         const std::string &serialized_retry_exception_predicate,
          std::vector<std::shared_ptr<RayObject>> *results,
          std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb,
-         bool *is_application_level_error,
+         bool *is_retryable_error,
          const std::vector<ConcurrencyGroup> &defined_concurrency_groups,
          const std::string name_of_concurrency_group_to_execute) {
         // These 2 parameters are used for Python only, and Java worker
@@ -126,7 +127,9 @@ Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(JNIEnv *env,
         RAY_UNUSED(defined_concurrency_groups);
         RAY_UNUSED(name_of_concurrency_group_to_execute);
         // TODO(jjyao): Support retrying application-level errors for Java
-        *is_application_level_error = false;
+        // TODO(Clark): Support exception predicates for retrying application-level
+        // errors for Java.
+        *is_retryable_error = false;
 
         JNIEnv *env = GetJNIEnv();
         RAY_CHECK(java_task_executor);

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -116,7 +116,7 @@ Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(JNIEnv *env,
          const std::vector<rpc::ObjectReference> &arg_refs,
          const std::vector<ObjectID> &return_ids,
          const std::string &debugger_breakpoint,
-         const std::string &serialized_retry_exception_predicate,
+         const std::string &serialized_retry_exception_allowlist,
          std::vector<std::shared_ptr<RayObject>> *results,
          std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb,
          bool *is_retryable_error,
@@ -127,7 +127,7 @@ Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(JNIEnv *env,
         RAY_UNUSED(defined_concurrency_groups);
         RAY_UNUSED(name_of_concurrency_group_to_execute);
         // TODO(jjyao): Support retrying application-level errors for Java
-        // TODO(Clark): Support exception predicates for retrying application-level
+        // TODO(Clark): Support exception allowlist for retrying application-level
         // errors for Java.
         *is_retryable_error = false;
 

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -64,7 +64,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
 
   bool ReplyPushTask(Status status = Status::OK(),
                      bool exit = false,
-                     bool is_application_level_error = false) {
+                     bool is_retryable_error = false) {
     if (callbacks.size() == 0) {
       return false;
     }
@@ -73,8 +73,8 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     if (exit) {
       reply.set_worker_exiting(true);
     }
-    if (is_application_level_error) {
-      reply.set_is_application_level_error(true);
+    if (is_retryable_error) {
+      reply.set_is_retryable_error(true);
     }
     callback(status, reply);
     callbacks.pop_front();

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -92,13 +92,13 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
     RAY_CHECK(num_returns >= 0);
 
     std::vector<std::shared_ptr<RayObject>> return_objects;
-    bool is_application_level_error = false;
+    bool is_retryable_error = false;
     auto status = task_handler_(task_spec,
                                 resource_ids,
                                 &return_objects,
                                 reply->mutable_borrowed_refs(),
-                                &is_application_level_error);
-    reply->set_is_application_level_error(is_application_level_error);
+                                &is_retryable_error);
+    reply->set_is_retryable_error(is_retryable_error);
 
     bool objects_valid = return_objects.size() == num_returns;
     if (objects_valid) {

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -54,7 +54,7 @@ class CoreWorkerDirectTaskReceiver {
                            const std::shared_ptr<ResourceMappingType> resource_ids,
                            std::vector<std::shared_ptr<RayObject>> *return_objects,
                            ReferenceCounter::ReferenceTableProto *borrower_refs,
-                           bool *is_application_level_error)>;
+                           bool *is_retryable_error)>;
 
   using OnTaskDone = std::function<Status()>;
 

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -585,8 +585,7 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
               is_actor ? rpc::ErrorType::ACTOR_DIED : rpc::ErrorType::WORKER_DIED,
               &status));
         } else {
-          if (!task_spec.GetMessage().retry_exceptions() ||
-              !reply.is_application_level_error() ||
+          if (!task_spec.GetMessage().retry_exceptions() || !reply.is_retryable_error() ||
               !task_finisher_->RetryTaskIfPossible(task_id)) {
             task_finisher_->CompletePendingTask(task_id, reply, addr.ToProto());
           }

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -312,14 +312,17 @@ message TaskSpec {
   string concurrency_group_name = 24;
   // Whether application-level errors (exceptions) should be retried.
   bool retry_exceptions = 25;
+  // A serialized exception predicate function that takes a frontend-language
+  // exception/error and returns whether the exception should be retried.
+  bytes serialized_retry_exception_predicate = 26;
   // The depth of the task. The driver has depth 0, anything it calls has depth
   // 1, etc.
-  int64 depth = 26;
+  int64 depth = 27;
   // Strategy about how to schedule this task.
-  SchedulingStrategy scheduling_strategy = 27;
+  SchedulingStrategy scheduling_strategy = 28;
   // A count of the number of times this task has been attempted so far. 0
   // means this is the first execution.
-  uint64 attempt_number = 28;
+  uint64 attempt_number = 29;
 }
 
 message TaskInfoEntry {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -312,8 +312,8 @@ message TaskSpec {
   string concurrency_group_name = 24;
   // Whether application-level errors (exceptions) should be retried.
   bool retry_exceptions = 25;
-  // A serialized exception allowlist that takes a frontend-language
-  // exception/error and returns whether the exception should be retried.
+  // A serialized exception list that serves as an allowlist of frontend-language
+  // exceptions/errors that should be retried.
   bytes serialized_retry_exception_allowlist = 26;
   // The depth of the task. The driver has depth 0, anything it calls has depth
   // 1, etc.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -312,9 +312,9 @@ message TaskSpec {
   string concurrency_group_name = 24;
   // Whether application-level errors (exceptions) should be retried.
   bool retry_exceptions = 25;
-  // A serialized exception predicate function that takes a frontend-language
+  // A serialized exception allowlist that takes a frontend-language
   // exception/error and returns whether the exception should be retried.
-  bytes serialized_retry_exception_predicate = 26;
+  bytes serialized_retry_exception_allowlist = 26;
   // The depth of the task. The driver has depth 0, anything it calls has depth
   // 1, etc.
   int64 depth = 27;

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -125,8 +125,8 @@ message PushTaskReply {
   // may now be borrowing. The reference counts also include any new borrowers
   // that the worker created by passing a borrowed ID into a nested task.
   repeated ObjectReferenceCount borrowed_refs = 4;
-  // Whether the result contains an application-level error (exception).
-  bool is_application_level_error = 5;
+  // Whether the result contains a retryable application-level error.
+  bool is_retryable_error = 5;
 }
 
 message DirectActorCallArgWaitCompleteRequest {
@@ -137,8 +137,7 @@ message DirectActorCallArgWaitCompleteRequest {
   int64 tag = 2;
 }
 
-message DirectActorCallArgWaitCompleteReply {
-}
+message DirectActorCallArgWaitCompleteReply {}
 
 message GetObjectStatusRequest {
   // The ID of the worker that owns this object. This is also
@@ -180,8 +179,7 @@ message WaitForActorOutOfScopeRequest {
   bytes actor_id = 2;
 }
 
-message WaitForActorOutOfScopeReply {
-}
+message WaitForActorOutOfScopeReply {}
 
 message UpdateObjectLocationBatchRequest {
   bytes intended_worker_id = 1;
@@ -189,8 +187,7 @@ message UpdateObjectLocationBatchRequest {
   repeated ObjectLocationUpdate object_location_updates = 3;
 }
 
-message UpdateObjectLocationBatchReply {
-}
+message UpdateObjectLocationBatchReply {}
 
 enum ObjectPlasmaLocationUpdate {
   // Object is added to plasma store.
@@ -234,8 +231,7 @@ message KillActorRequest {
   ActorDeathCause death_cause = 4;
 }
 
-message KillActorReply {
-}
+message KillActorReply {}
 
 message CancelTaskRequest {
   // ID of task that should be killed.
@@ -262,8 +258,7 @@ message RemoteCancelTaskRequest {
   bool recursive = 3;
 }
 
-message RemoteCancelTaskReply {
-}
+message RemoteCancelTaskReply {}
 
 message GetCoreWorkerStatsRequest {
   // The ID of the worker this message is intended for.
@@ -304,15 +299,13 @@ message LocalGCRequest {
   bool triggered_by_global_gc = 1;
 }
 
-message LocalGCReply {
-}
+message LocalGCReply {}
 
 message PlasmaObjectReadyRequest {
   bytes object_id = 1;
 }
 
-message PlasmaObjectReadyReply {
-}
+message PlasmaObjectReadyReply {}
 
 message SpillObjectsRequest {
   repeated ObjectReference object_refs_to_spill = 1;
@@ -340,11 +333,9 @@ message DeleteSpilledObjectsRequest {
   repeated string spilled_objects_url = 1;
 }
 
-message DeleteSpilledObjectsReply {
-}
+message DeleteSpilledObjectsReply {}
 
-message ExitRequest {
-}
+message ExitRequest {}
 
 message ExitReply {
   /// Whether or not exit succeeds. If the core worker owns any object, the request fails.

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -179,7 +179,7 @@ RayTask CreateTask(
     }
   }
 
-  spec_builder.SetNormalTaskSpec(0, false, scheduling_strategy);
+  spec_builder.SetNormalTaskSpec(0, false, "", scheduling_strategy);
 
   return RayTask(spec_builder.Build());
 }


### PR DESCRIPTION
Both Ray libraries (Workflows, Datasets, etc.) and end-users need to be able to retry application-level errors; this is currently supported via the `retry_exceptions` argument. However, not all application-level errors are transient, and therefore not all application-level errors should be retried.

This PR adds supported for specifying an exception allowlist (`List[Exception]`) as the `retry_exceptions` argument, such that an application-level exception will only be retried if it is in the allowlist.

## Exception Allowlist

```python
@ray.remote(
    retry_exceptions=ConnectionError,
    max_retries=3,
)
def f(a):
    if a < 0:
        raise ValueError("invalid input")
    else:
        # connect_and_add might transiently raise a ConnectionError
        return connect_and_add(a)

# Fails without retrying the non-transient error.
ray.get(f.remote(-1))

# Retries up to 3 times.
ray.get(f.remote(5))
```

See the RFC for more motivation and API design discussion: https://github.com/ray-project/ray/issues/25743

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/25743

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
