### PR TITLE
[tune] catch pyarrow 8.0.0 error

### DIFF
--- a/python/ray/air/_internal/remote_storage.py
+++ b/python/ray/air/_internal/remote_storage.py
@@ -97,7 +97,7 @@ def get_fs_and_path(
         fs, path = pyarrow.fs.FileSystem.from_uri(uri)
         _cached_fs[cache_key] = fs
         return fs, path
-    except pyarrow.lib.ArrowInvalid:
+    except (pyarrow.lib.ArrowInvalid, pyarrow.lib.ArrowNotImplementedError):
         # Raised when URI not recognized
         if not fsspec:
             # Only return if fsspec is not installed


### PR DESCRIPTION

## Why are these changes needed?

`pyarrow 8.0.0` raises `ArrowNotImplementedError` instead of `pyarrow.lib.ArrowInvalid` for unrecognized URI.

**Repro:**
```python
from ray import tune

def trainable(config):
     pass

tune.run(trainable, sync_config=tune.SyncConfig(upload_dir="gs://<BUCKET>/experiments"))
```

**Before:**
```
  File "/Users/matt/workspace/ray/python/ray/tune/tune.py", line 430, in run
    _validate_upload_dir(sync_config)
  File "/Users/matt/workspace/ray/python/ray/tune/syncer.py", line 48, in _validate_upload_dir
    if not is_non_local_path_uri(sync_config.upload_dir):
  File "/Users/matt/workspace/ray/python/ray/air/_internal/remote_storage.py", line 71, in is_non_local_path_uri
    if bool(get_fs_and_path(uri)[0]):
  File "/Users/matt/workspace/ray/python/ray/air/_internal/remote_storage.py", line 97, in get_fs_and_path
    fs, path = pyarrow.fs.FileSystem.from_uri(uri)
  File "pyarrow/_fs.pyx", line 350, in pyarrow._fs.FileSystem.from_uri
  File "pyarrow/error.pxi", line 144, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 121, in pyarrow.lib.check_status
pyarrow.lib.ArrowNotImplementedError: Got GCS URI but Arrow compiled without GCS support
```

This is not unit tested because `pyarrow` is pinned to `pyarrow >= 6.0.1, < 7.0.0` for Datasets.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
