### PR TITLE
[data] add retry logic to ray.data parquet file reading (#25673)

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -31,6 +31,7 @@ PARALLELIZE_META_FETCH_THRESHOLD = 24
 # The number of rows to read per batch. This is sized to generate 10MiB batches
 # for rows about 1KiB in size.
 PARQUET_READER_ROW_BATCH_SIZE = 100000
+FILE_READING_RETRY = 8
 
 
 def _register_parquet_file_fragment_serialization():
@@ -52,6 +53,69 @@ def _deregister_parquet_file_fragment_serialization():
     from pyarrow.dataset import ParquetFileFragment
 
     ray.util.deregister_serializer(ParquetFileFragment)
+
+
+# This is the bare bone deserializing function with no retry
+# easier to mock its behavior for testing when isolated from retry logic
+def _deserialize_pieces(
+    serialized_pieces: str,
+) -> List["pyarrow._dataset.ParquetFileFragment"]:
+    from ray import cloudpickle
+
+    pieces: List["pyarrow._dataset.ParquetFileFragment"] = cloudpickle.loads(
+        serialized_pieces
+    )
+    return pieces
+
+
+# This retry helps when the upstream datasource is not able to handle
+# overloaded read request or failed with some retriable failures.
+# For example when reading data from HA hdfs service, hdfs might
+# lose connection for some unknown reason expecially when
+# simutaneously running many hyper parameter tuning jobs
+# with ray.data parallelism setting at high value like the default 200
+# Such connection failure can be restored with some waiting and retry.
+def _deserialize_pieces_with_retry(
+    serialized_pieces: str,
+) -> List["pyarrow._dataset.ParquetFileFragment"]:
+    min_interval = 0
+    final_exception = None
+    for i in range(FILE_READING_RETRY):
+        try:
+            return _deserialize_pieces(serialized_pieces)
+        except Exception as e:
+            import time
+            import random
+
+            retry_timing = (
+                ""
+                if i == FILE_READING_RETRY - 1
+                else (f"Retry after {min_interval} sec. ")
+            )
+            log_only_show_in_1st_retry = (
+                ""
+                if i
+                else (
+                    f"If earlier read attempt threw certain Exception"
+                    f", it may or may not be an issue depends on these retries "
+                    f"succeed or not. serialized_pieces:{serialized_pieces}"
+                )
+            )
+            logger.exception(
+                f"{i + 1}th attempt to deserialize ParquetFileFragment failed. "
+                f"{retry_timing}"
+                f"{log_only_show_in_1st_retry}"
+            )
+            if not min_interval:
+                # to make retries of different process hit hdfs server
+                # at slightly different time
+                min_interval = 1 + random.random()
+            # exponential backoff at
+            # 1, 2, 4, 8, 16, 32, 64
+            time.sleep(min_interval)
+            min_interval = min_interval * 2
+            final_exception = e
+    raise final_exception
 
 
 class ParquetDatasource(FileBasedDatasource):
@@ -109,7 +173,7 @@ class ParquetDatasource(FileBasedDatasource):
                 _register_parquet_file_fragment_serialization()
                 pieces: List[
                     "pyarrow._dataset.ParquetFileFragment"
-                ] = cloudpickle.loads(serialized_pieces)
+                ] = _deserialize_pieces_with_retry(serialized_pieces)
             finally:
                 _deregister_parquet_file_fragment_serialization()
 
@@ -238,12 +302,13 @@ def _fetch_metadata_serialization_wrapper(
     # Implicitly trigger S3 subsystem initialization by importing
     # pyarrow.fs.
     import pyarrow.fs  # noqa: F401
-    from ray import cloudpickle
 
     # Deserialize after loading the filesystem class.
     try:
         _register_parquet_file_fragment_serialization()
-        pieces: List["pyarrow._dataset.ParquetFileFragment"] = cloudpickle.loads(pieces)
+        pieces: List[
+            "pyarrow._dataset.ParquetFileFragment"
+        ] = _deserialize_pieces_with_retry(pieces)
     finally:
         _deregister_parquet_file_fragment_serialization()
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -16,6 +16,7 @@ from ray.data.datasource import DummyOutputDatasource
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import _unwrap_protocol
 from ray.data.datasource.parquet_datasource import PARALLELIZE_META_FETCH_THRESHOLD
+from ray.data.datasource.parquet_datasource import _deserialize_pieces_with_retry
 from ray.data.tests.conftest import *  # noqa
 
 
@@ -228,6 +229,68 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     ds_df = pd.concat([ds_df1, ds_df2])
     df = pd.concat([df1, df2])
     assert ds_df.equals(df)
+
+
+@pytest.mark.parametrize(
+    "fs,data_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+    ],
+)
+def test_parquet_deserialize_pieces_with_retry(
+    ray_start_regular_shared, fs, data_path, monkeypatch
+):
+    from ray import cloudpickle
+
+    setup_data_path = _unwrap_protocol(data_path)
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    table = pa.Table.from_pandas(df1)
+    path1 = os.path.join(setup_data_path, "test1.parquet")
+    pq.write_table(table, path1, filesystem=fs)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    table = pa.Table.from_pandas(df2)
+    path2 = os.path.join(setup_data_path, "test2.parquet")
+    pq.write_table(table, path2, filesystem=fs)
+
+    dataset_kwargs = {}
+    pq_ds = pq.ParquetDataset(
+        data_path, **dataset_kwargs, filesystem=fs, use_legacy_dataset=False
+    )
+    serialized_pieces = cloudpickle.dumps(pq_ds.pieces)
+
+    # test 1st attempt succeed
+    pieces = _deserialize_pieces_with_retry(serialized_pieces)
+    assert "test1.parquet" in pieces[0].path
+    assert "test2.parquet" in pieces[1].path
+
+    # test the 3rd attempt succeed with a mock function constructed
+    # to throw in the first two attempts
+    class MockDeserializer:
+        def __init__(self, planned_exp_or_return):
+            self.planned_exp_or_return = planned_exp_or_return
+            self.cur_index = 0
+
+        def __call__(self, *args: Any, **kwds: Any) -> Any:
+            exp_or_ret = self.planned_exp_or_return[self.cur_index]
+            self.cur_index += 1
+            if type(exp_or_ret) == Exception:
+                raise exp_or_ret
+            else:
+                return exp_or_ret
+
+    mock_deserializer = MockDeserializer(
+        [
+            Exception("1st mock failed attempt"),
+            Exception("2nd mock failed attempt"),
+            pieces,
+        ]
+    )
+    monkeypatch.setattr(
+        ray.data.datasource.parquet_datasource, "_deserialize_pieces", mock_deserializer
+    )
+    retried_pieces = _deserialize_pieces_with_retry(serialized_pieces)
+    assert "test1.parquet" in retried_pieces[0].path
+    assert "test2.parquet" in retried_pieces[1].path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is cherry picking the https://github.com/ray-project/ray/pull/25673 to our ubranch-1.11.0 to fixhdfs connection issue with retry.
when reading parquet file from a datasource, the reading process of deserializing the parquet file may run into transient issue.  For example reading from hdfs server with high parallelism, the hdfs server might be overloaded and causing hdfs connection failure issue.  Retry with exponential backoff help with such transient failure and avoid failing the entire ray.data reading job.

## Related issue number
MA-14867

## Checks
E2E uber internal test:
peloton job id 1a82064e-28f7-449d-9951-9f3934ac326d
job log: P320509
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [] This PR is not tested :(
