### PR TITLE
[Serve] Add queue handle metrics into the autoscaling decision

### DIFF
--- a/python/ray/serve/autoscaling_metrics.py
+++ b/python/ray/serve/autoscaling_metrics.py
@@ -97,11 +97,11 @@ class InMemoryMetricsStore:
     def __init__(self):
         self.data: DefaultDict[str, List[TimeStampedValue]] = defaultdict(list)
 
-    def add_metrics_point(self, key: str, data: dict):
+    def add_metrics_point(self, key: str, data: TimeStampedValue):
         """Push new data points to the store.
 
         Args:
-            data_points(dict): dictionary containing the metrics values. The
+            data_points(TimeStampedValue): dictionary containing the metrics values. The
               key should be a string that uniquely identifies this time series
               and to be used to perform aggregation.
             timestamp(float): the unix epoch timestamp the metrics are
@@ -115,6 +115,7 @@ class InMemoryMetricsStore:
         """Get all data points given key after window_start_timestamp_s"""
 
         datapoints = self.data[key]
+        print("get points: ", datapoints)
 
         idx = bisect.bisect(
             a=datapoints,
@@ -157,7 +158,8 @@ class InMemoryMetricsStore:
         do_compact: bool = True,
         tag: Any = None,
     ):
-        """Perform a latest operation for metric `key`. The function will return latest value given the key.
+        """Perform a latest operation for metric `key`. The function will return
+            latest value given the key.
 
         Args:
             key(str): the metric name.
@@ -171,9 +173,9 @@ class InMemoryMetricsStore:
         Returns:
             Latest value of the data points for the key on and after time
             window_start_timestamp_s. if tag is provided, the return value will be
-            a list, each elemt of the list represents each tag. (Currently we don't
-            need the tag information. If needed in the future, the function can
-            directly return dict)
+            a list, each element of the list represents each tag value. (Currently
+            we don't need the tag information. If needed in the future, the function
+            can directly return dict)
         """
         points_after_idx = self._get_datapoints(key, window_start_timestamp_s)
 
@@ -186,7 +188,8 @@ class InMemoryMetricsStore:
             for point in points_after_idx[::-1]:
                 if tag in point.tags and point.tags[tag] not in datapoints_per_tags:
                     datapoints_per_tags[point.tags[tag]] = point
-            points_after_idx = list(datapoints_per_tags.values())
-            return [point.value for point in points_after_idx]
+            datapoints = list(datapoints_per_tags.values())
+            print(self.data[key])
+            return [point.value for point in datapoints]
         else:
             return [points_after_idx[-1].value] if points_after_idx else []

--- a/python/ray/serve/autoscaling_metrics.py
+++ b/python/ray/serve/autoscaling_metrics.py
@@ -188,7 +188,6 @@ class InMemoryMetricsStore:
                 if tag in point.tags and point.tags[tag] not in datapoints_per_tags:
                     datapoints_per_tags[point.tags[tag]] = point
             datapoints = list(datapoints_per_tags.values())
-            print(self.data[key])
             return [point.value for point in datapoints]
         else:
             return [points_after_idx[-1].value] if points_after_idx else []

--- a/python/ray/serve/autoscaling_metrics.py
+++ b/python/ray/serve/autoscaling_metrics.py
@@ -115,7 +115,6 @@ class InMemoryMetricsStore:
         """Get all data points given key after window_start_timestamp_s"""
 
         datapoints = self.data[key]
-        print("get points: ", datapoints)
 
         idx = bisect.bisect(
             a=datapoints,

--- a/python/ray/serve/client.py
+++ b/python/ray/serve/client.py
@@ -181,7 +181,7 @@ class ServeControllerClient:
                 # Guard against new unhandled statuses being added.
                 assert status.status == DeploymentStatus.UPDATING
 
-            logger.debug(
+            logger.info(
                 f"Waiting for {name} to be healthy, current status: "
                 f"{status.status}."
             )

--- a/python/ray/serve/client.py
+++ b/python/ray/serve/client.py
@@ -181,7 +181,7 @@ class ServeControllerClient:
                 # Guard against new unhandled statuses being added.
                 assert status.status == DeploymentStatus.UPDATING
 
-            logger.info(
+            logger.debug(
                 f"Waiting for {name} to be healthy, current status: "
                 f"{status.status}."
             )

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -207,17 +207,17 @@ class ServeController:
                 try:
                     self.http_state.update()
                 except Exception:
-                    print("Exception updating HTTP state.")
+                    logger.exception("Exception updating HTTP state.")
 
                 try:
                     self.deployment_state_manager.update()
                 except Exception:
-                    print("Exception updating deployment state.")
+                    logger.exception("Exception updating deployment state.")
 
             try:
                 self._put_serve_snapshot()
             except Exception:
-                print("Exception putting serve snapshot.")
+                logger.exception("Exception putting serve snapshot.")
             await asyncio.sleep(CONTROL_LOOP_PERIOD_S)
 
     def _put_serve_snapshot(self) -> None:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -200,7 +200,6 @@ class ServeController:
         # NOTE(edoakes): we catch all exceptions here and simply log them,
         # because an unhandled exception would cause the main control loop to
         # halt, which should *never* happen.
-        print("run_control_loop")
         while True:
 
             async with self.write_lock:

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -13,8 +13,12 @@ from ray.serve.constants import (
     SERVE_PROXY_NAME,
 )
 from ray.serve.http_proxy import HTTPProxyActor
-from ray.serve.utils import format_actor_name, get_all_node_ids
-
+from ray.serve.common import EndpointTag, NodeId
+from ray.serve.utils import (
+    format_actor_name,
+    get_all_node_ids,
+    get_current_node_resource_key,
+)
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -9,16 +9,12 @@ from ray.serve.config import HTTPOptions, DeploymentMode
 from ray.serve.constants import (
     ASYNC_CONCURRENCY,
     SERVE_LOGGER_NAME,
-    SERVE_PROXY_NAME,
     SERVE_NAMESPACE,
+    SERVE_PROXY_NAME,
 )
 from ray.serve.http_proxy import HTTPProxyActor
-from ray.serve.utils import (
-    format_actor_name,
-    get_all_node_ids,
-    get_current_node_resource_key,
-)
-from ray.serve.common import EndpointTag, NodeId
+from ray.serve.utils import format_actor_name, get_all_node_ids
+
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -109,7 +105,7 @@ class HTTPState:
             try:
                 proxy = ray.get_actor(name, namespace=SERVE_NAMESPACE)
             except ValueError:
-                logger.info(
+                print(
                     "Starting HTTP proxy with name '{}' on node '{}' "
                     "listening on '{}:{}'".format(
                         name, node_id, self._config.host, self._config.port

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -105,7 +105,7 @@ class HTTPState:
             try:
                 proxy = ray.get_actor(name, namespace=SERVE_NAMESPACE)
             except ValueError:
-                logger.info((
+                logger.info(
                     "Starting HTTP proxy with name '{}' on node '{}' "
                     "listening on '{}:{}'".format(
                         name, node_id, self._config.host, self._config.port

--- a/python/ray/serve/http_state.py
+++ b/python/ray/serve/http_state.py
@@ -105,7 +105,7 @@ class HTTPState:
             try:
                 proxy = ray.get_actor(name, namespace=SERVE_NAMESPACE)
             except ValueError:
-                print(
+                logger.info((
                     "Starting HTTP proxy with name '{}' on node '{}' "
                     "listening on '{}:{}'".format(
                         name, node_id, self._config.host, self._config.port

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -698,9 +698,6 @@ def test_e2e_intermediate_downscaling(serve_instance):
     handle = A.get_handle()
     [handle.remote() for _ in range(50)]
 
-    print(
-        "test_e2e_intermediate_downscaling: ", get_num_running_replicas(controller, A)
-    )
     wait_for_condition(
         lambda: get_num_running_replicas(controller, A) >= 20, timeout=30
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Add "tag" into the InMemoryMetricsStore
- Remove raw datatype passing the data, instead use TimeStampedValue
- Add queue handle metrics into the calculate_desired_num_replicas function

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
