### PR TITLE
[core] Add weekly test for 100TB random shuffle

### DIFF
--- a/release/nightly_tests/shuffle/100tb_shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_app_config.yaml
@@ -1,0 +1,18 @@
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
+debian_packages: []
+env_vars: {"RAY_object_spilling_config": "{\"type\":\"filesystem\",\"params\":{\"directory_path\":[\"/tmp/data0\",\"/tmp/data1\"]}}"}
+
+python:
+  pip_packages: []
+  conda_packages: []
+
+post_build_cmds:
+  - pip3 uninstall -y ray && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
+  - pip3 install -U ray[default]
+  - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
+  - echo "yes N | sudo mkfs -t ext4 /dev/nvme1n1 || true" >> ~/.bashrc
+  - echo "mkdir -p /tmp/data0" >> ~/.bashrc
+  - echo "mkdir -p /tmp/data1" >> ~/.bashrc
+  - echo "sudo chmod 0777 /tmp/data0" >> ~/.bashrc
+  - echo "sudo chmod 0777 /tmp/data1" >> ~/.bashrc
+  - echo "sudo mount /dev/nvme1n1 /tmp/data1 || true" >> ~/.bashrc

--- a/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
+++ b/release/nightly_tests/shuffle/100tb_shuffle_compute.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+aws:
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 2000
+        - DeviceName: /dev/sda2
+          Ebs:
+            VolumeSize: 2000
+
+head_node_type:
+    name: head_node
+    instance_type:  m5.8xlarge
+    resources: {"cpu": 0}
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.4xlarge
+      min_workers: 99
+      max_workers: 99
+      use_spot: false
+      resources: {"cpu": 8}

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3527,6 +3527,29 @@
     type: sdk_command
     file_manager: sdk
 
+- name: dataset_shuffle_push_based_random_shuffle_100tb
+  group: core-dataset-tests
+  working_dir: nightly_tests
+  legacy:
+    test_name: dataset_shuffle_push_based_random_shuffle_100tb
+    test_suite: dataset_test
+
+  stable: false
+
+  frequency: weekly
+  team: core
+  cluster:
+    cluster_env: shuffle/100tb_shuffle_app_config.yaml
+    cluster_compute: shuffle/100tb_shuffle_compute.yaml
+
+  run:
+    timeout: 28800
+    script: RAY_DATASET_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=100000 --partition-size=1e9 --shuffle
+    wait_for_nodes:
+      num_nodes: 100
+    type: sdk_command
+    file_manager: sdk
+
 ##################
 # Core Chaos tests
 ##################


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a CI test for 100TB shuffle.

There is a custom config for this nightly test to: (1) make sure each node gets 4TB of storage, (2) head node has 0 CPUs, (3) worker nodes have half their actual vCPU count.

## Related issue number

Closes #24480.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
