### PR TITLE
[RLlib] Include SampleBatch.T column in all collected batches

### DIFF
--- a/rllib/evaluation/tests/test_trajectory_view_api.py
+++ b/rllib/evaluation/tests/test_trajectory_view_api.py
@@ -64,8 +64,11 @@ class TestTrajectoryViewAPI(unittest.TestCase):
             policy = algo.get_policy()
             view_req_model = policy.model.view_requirements
             view_req_policy = policy.view_requirements
+            print(_)
+            print(view_req_policy)
+            print(view_req_model)
             assert len(view_req_model) == 1, view_req_model
-            assert len(view_req_policy) == 10, view_req_policy
+            assert len(view_req_policy) == 11, view_req_policy
             for key in [
                 SampleBatch.OBS,
                 SampleBatch.ACTIONS,
@@ -110,7 +113,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
             view_req_policy = policy.view_requirements
             # 7=obs, prev-a + r, 2x state-in, 2x state-out.
             assert len(view_req_model) == 7, view_req_model
-            assert len(view_req_policy) == 20, (len(view_req_policy), view_req_policy)
+            assert len(view_req_policy) == 21, (len(view_req_policy), view_req_policy)
             for key in [
                 SampleBatch.OBS,
                 SampleBatch.ACTIONS,

--- a/rllib/policy/dynamic_tf_policy.py
+++ b/rllib/policy/dynamic_tf_policy.py
@@ -821,6 +821,7 @@ class DynamicTFPolicy(TFPolicy):
                         SampleBatch.DONES,
                         SampleBatch.REWARDS,
                         SampleBatch.INFOS,
+                        SampleBatch.T,
                         SampleBatch.OBS_EMBEDS,
                     ]
                 ):
@@ -842,6 +843,7 @@ class DynamicTFPolicy(TFPolicy):
                         SampleBatch.DONES,
                         SampleBatch.REWARDS,
                         SampleBatch.INFOS,
+                        SampleBatch.T,
                     ]
                     and key not in self.model.view_requirements
                 ):

--- a/rllib/policy/dynamic_tf_policy_v2.py
+++ b/rllib/policy/dynamic_tf_policy_v2.py
@@ -805,6 +805,7 @@ class DynamicTFPolicyV2(TFPolicy):
                         SampleBatch.DONES,
                         SampleBatch.REWARDS,
                         SampleBatch.INFOS,
+                        SampleBatch.T,
                         SampleBatch.OBS_EMBEDS,
                     ]
                 ):
@@ -826,6 +827,7 @@ class DynamicTFPolicyV2(TFPolicy):
                         SampleBatch.DONES,
                         SampleBatch.REWARDS,
                         SampleBatch.INFOS,
+                        SampleBatch.T,
                     ]
                     and key not in self.model.view_requirements
                 ):

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -1016,6 +1016,7 @@ class Policy(metaclass=ABCMeta):
                             SampleBatch.DONES,
                             SampleBatch.REWARDS,
                             SampleBatch.INFOS,
+                            SampleBatch.T,
                         ]
                     ):
                         self.view_requirements[key].used_for_training = False
@@ -1033,6 +1034,7 @@ class Policy(metaclass=ABCMeta):
                             SampleBatch.DONES,
                             SampleBatch.REWARDS,
                             SampleBatch.INFOS,
+                            SampleBatch.T,
                         ]
                         and key not in self.model.view_requirements
                     ):

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -877,10 +877,10 @@ class Policy(metaclass=ABCMeta):
             ),
             SampleBatch.DONES: ViewRequirement(),
             SampleBatch.INFOS: ViewRequirement(),
+            SampleBatch.T: ViewRequirement(),
             SampleBatch.EPS_ID: ViewRequirement(),
             SampleBatch.UNROLL_ID: ViewRequirement(),
             SampleBatch.AGENT_INDEX: ViewRequirement(),
-            "t": ViewRequirement(),
         }
 
     def _initialize_loss_from_dummy_batch(


### PR DESCRIPTION
## Why are these changes needed?

Most view requirements fall short of the SampleBatch.T='t' field, which is not accessed in dummy batch passes of models.
Therefore, this information is excluded from collected sample batches by default.
In most setups, this is not of interest. But it must be included when saving batches for offline learning purposes and for timeslicing of MultiAgentBatches. Our implementation of timeslice() build on availability of the column SampleBatch.T.

This small PR paves the way for my [other PR](https://github.com/ray-project/ray/pull/25661), which needs this information for the replay buffer lockstep mode.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
