### PR TITLE
[Datasets] [Docs] Fix a broken link in Ray Dataset doc

### DIFF
--- a/doc/source/data/key-concepts.rst
+++ b/doc/source/data/key-concepts.rst
@@ -46,7 +46,7 @@ Dataset Pipelines
 -----------------
 
 
-Datasets execute their transformations synchronously in blocking calls. However, it can be useful to overlap dataset computations with output. This can be done with a `DatasetPipeline <data-pipelines-quick-start>`__.
+Datasets execute their transformations synchronously in blocking calls. However, it can be useful to overlap dataset computations with output. This can be done with a `DatasetPipeline <package-ref.html#datasetpipeline-api>`__.
 
 A DatasetPipeline is an unified iterator over a (potentially infinite) sequence of Ray Datasets, each of which represents a *window* over the original data. Conceptually it is similar to a `Spark DStream <https://spark.apache.org/docs/latest/streaming-programming-guide.html#discretized-streams-dstreams>`__, but manages execution over a bounded amount of source data instead of an unbounded stream. Ray computes each dataset window on-demand and stitches their output together into a single logical data iterator. DatasetPipeline implements most of the same transformation and output methods as Datasets (e.g., map, filter, split, iter_rows, to_torch, etc.).
 


### PR DESCRIPTION
## Why are these changes needed?

In [Ray Data Key Concepts doc](https://docs.ray.io/en/latest/data/key-concepts.html),  DatasetPipeline link is not working
> This can be done with a [DatasetPipeline](https://docs.ray.io/en/latest/data/data-pipelines-quick-start).

This change rollbacks to the previous link which is referred correctly. 

## Related issue number

Previous PR: https://github.com/ray-project/ray/pull/22067

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
