### PR TITLE
[C++ API] add default_actor_lifetime param and add more exception info for cpp worker

### DIFF
--- a/cpp/include/ray/api/ray_config.h
+++ b/cpp/include/ray/api/ray_config.h
@@ -24,6 +24,11 @@
 
 namespace ray {
 
+enum class ActorLifetime {
+  NON_DETACHED,
+  DETACHED,
+};
+
 class RayConfig {
  public:
   // The address of the Ray cluster to connect to.
@@ -43,6 +48,9 @@ class RayConfig {
   // takes effect only if Ray head is started by a driver. Run `ray start --help` for
   // details.
   std::vector<std::string> head_args = {};
+
+  // The default actor lifetime type, `DETACHED` or `NON_DETACHED`.
+  ActorLifetime default_actor_lifetime = ActorLifetime::NON_DETACHED;
 
   /* The following are unstable parameters and their use is discouraged. */
 

--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -70,8 +70,29 @@ ABSL_FLAG(int64_t,
           -1,
           "The startup token assigned to this worker process by the raylet.");
 
+ABSL_FLAG(std::string,
+          ray_default_actor_lifetime,
+          "",
+          "The default actor lifetime type, `detached` or `non_detached`.");
+
 namespace ray {
 namespace internal {
+
+rpc::JobConfig_ActorLifetime ParseDefaultActorLifetimeType(
+    const std::string &default_actor_lifetime_origin) {
+  std::string default_actor_lifetime;
+  default_actor_lifetime.resize(default_actor_lifetime_origin.size());
+  transform(default_actor_lifetime_origin.begin(),
+            default_actor_lifetime_origin.end(),
+            default_actor_lifetime.begin(),
+            ::tolower);
+  RAY_CHECK(default_actor_lifetime == "non_detached" ||
+            default_actor_lifetime == "detached")
+      << "The default_actor_lifetime_string config must be `detached` or `non_detached`.";
+  return default_actor_lifetime == "non_detached"
+             ? rpc::JobConfig_ActorLifetime_NON_DETACHED
+             : rpc::JobConfig_ActorLifetime_DETACHED;
+}
 
 void ConfigInternal::Init(RayConfig &config, int argc, char **argv) {
   if (!config.address.empty()) {
@@ -87,6 +108,10 @@ void ConfigInternal::Init(RayConfig &config, int argc, char **argv) {
   if (!config.head_args.empty()) {
     head_args = config.head_args;
   }
+  if (config.default_actor_lifetime == ActorLifetime::DETACHED) {
+    default_actor_lifetime = rpc::JobConfig_ActorLifetime_DETACHED;
+  }
+
   if (argc != 0 && argv != nullptr) {
     // Parse config from command line.
     absl::ParseCommandLine(argc, argv);
@@ -129,6 +154,10 @@ void ConfigInternal::Init(RayConfig &config, int argc, char **argv) {
       head_args.insert(head_args.end(), args.begin(), args.end());
     }
     startup_token = absl::GetFlag<int64_t>(FLAGS_startup_token);
+    if (!FLAGS_ray_default_actor_lifetime.CurrentValue().empty()) {
+      default_actor_lifetime =
+          ParseDefaultActorLifetimeType(FLAGS_ray_default_actor_lifetime.CurrentValue());
+    }
   }
   worker_type = config.is_worker_ ? WorkerType::WORKER : WorkerType::DRIVER;
   if (worker_type == WorkerType::DRIVER && run_mode == RunMode::CLUSTER) {

--- a/cpp/src/ray/config_internal.h
+++ b/cpp/src/ray/config_internal.h
@@ -60,6 +60,10 @@ class ConfigInternal {
 
   std::vector<std::string> head_args = {};
 
+  // The default actor lifetime type.
+  rpc::JobConfig_ActorLifetime default_actor_lifetime =
+      rpc::JobConfig_ActorLifetime_NON_DETACHED;
+
   static ConfigInternal &Instance() {
     static ConfigInternal config;
     return config;

--- a/cpp/src/ray/runtime/task/native_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/native_task_submitter.cc
@@ -120,18 +120,17 @@ ActorID NativeTaskSubmitter::CreateActor(InvocationSpec &invocation,
         bundle_id.second);
     placement_group_scheduling_strategy->set_placement_group_capture_child_tasks(false);
   }
-  ray::core::ActorCreationOptions actor_options{
-      create_options.max_restarts,
-      /*max_task_retries=*/0,
-      create_options.max_concurrency,
-      create_options.resources,
-      resources,
-      /*dynamic_worker_options=*/{},
-      /*is_detached=*/std::make_optional<bool>(false),
-      name,
-      ray_namespace,
-      /*is_asyncio=*/false,
-      scheduling_strategy};
+  ray::core::ActorCreationOptions actor_options{create_options.max_restarts,
+                                                /*max_task_retries=*/0,
+                                                create_options.max_concurrency,
+                                                create_options.resources,
+                                                resources,
+                                                /*dynamic_worker_options=*/{},
+                                                /*is_detached=*/std::nullopt,
+                                                name,
+                                                ray_namespace,
+                                                /*is_asyncio=*/false,
+                                                scheduling_strategy};
   ActorID actor_id;
   auto status = core_worker.CreateActor(
       BuildRayFunction(invocation), invocation.args, actor_options, "", &actor_id);

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -37,6 +37,24 @@ TEST(RayClusterModeTest, Initialized) {
   EXPECT_TRUE(!ray::IsInitialized());
 }
 
+TEST(RayClusterModeTest, DefaultActorLifetimeTest) {
+  ray::RayConfig config;
+  config.default_actor_lifetime = ray::ActorLifetime::DETACHED;
+  ray::Init(config, cmd_argc, cmd_argv);
+  ray::ActorHandle<Counter> parent_actor =
+      ray::Actor(RAY_FUNC(Counter::FactoryCreate)).Remote();
+  std::string child_actor_name = "child_actor_name";
+  parent_actor.Task(&Counter::CreateChildActor).Remote(child_actor_name).Get();
+  auto child_actor_optional = ray::GetActor<Counter>(child_actor_name);
+  EXPECT_TRUE(child_actor_optional);
+  auto child_actor = *child_actor_optional;
+  EXPECT_EQ(1, *child_actor.Task(&Counter::Plus1).Remote().Get());
+  parent_actor.Kill();
+  sleep(4);
+  EXPECT_EQ(2, *child_actor.Task(&Counter::Plus1).Remote().Get());
+  ray::Shutdown();
+}
+
 struct Person {
   std::string name;
   int age;
@@ -293,6 +311,11 @@ TEST(RayClusterModeTest, ResourcesManagementTest) {
 
 TEST(RayClusterModeTest, ExceptionTest) {
   EXPECT_THROW(ray::Task(ThrowTask).Remote().Get(), ray::internal::RayTaskException);
+  try {
+    ray::Task(ThrowTask).Remote().Get();
+  } catch (ray::internal::RayTaskException &e) {
+    EXPECT_TRUE(std::string(e.what()).find("std::logic_error") != std::string::npos);
+  }
 
   auto actor1 = ray::Actor(RAY_FUNC(Counter::FactoryCreate, int)).Remote(1);
   auto object1 = actor1.Task(&Counter::ExceptionFunc).Remote();

--- a/cpp/src/ray/test/cluster/counter.cc
+++ b/cpp/src/ray/test/cluster/counter.cc
@@ -83,6 +83,12 @@ bool Counter::CheckRestartInActorCreationTask() { return is_restared; }
 
 bool Counter::CheckRestartInActorTask() { return ray::WasCurrentActorRestarted(); }
 
+ray::ActorHandle<Counter> Counter::CreateChildActor(std::string actor_name) {
+  auto child_actor =
+      ray::Actor(RAY_FUNC(Counter::FactoryCreate)).SetName(actor_name).Remote();
+  return child_actor;
+}
+
 RAY_REMOTE(RAY_FUNC(Counter::FactoryCreate),
            Counter::FactoryCreateException,
            RAY_FUNC(Counter::FactoryCreate, int),
@@ -96,6 +102,7 @@ RAY_REMOTE(RAY_FUNC(Counter::FactoryCreate),
            &Counter::CheckRestartInActorTask,
            &Counter::GetVal,
            &Counter::GetIntVal,
-           &Counter::Initialized);
+           &Counter::Initialized,
+           &Counter::CreateChildActor);
 
 RAY_REMOTE(ActorConcurrentCall::FactoryCreate, &ActorConcurrentCall::CountDown);

--- a/cpp/src/ray/test/cluster/counter.h
+++ b/cpp/src/ray/test/cluster/counter.h
@@ -37,6 +37,7 @@ class Counter {
 
   bool CheckRestartInActorCreationTask();
   bool CheckRestartInActorTask();
+  ray::ActorHandle<Counter> CreateChildActor(std::string actor_name);
 
   std::string GetVal(ray::ObjectRef<std::string> obj) { return *obj.Get(); }
 

--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -143,6 +143,9 @@ void ProcessHelper::RayStart(CoreWorkerOptions::TaskExecutionCallback callback) 
   options.task_execution_callback = callback;
   options.startup_token = ConfigInternal::Instance().startup_token;
   rpc::JobConfig job_config;
+  job_config.set_default_actor_lifetime(
+      ConfigInternal::Instance().default_actor_lifetime);
+
   for (const auto &path : ConfigInternal::Instance().code_search_path) {
     job_config.add_code_search_path(path);
   }


### PR DESCRIPTION
## Why are these changes needed?

add default_actor_lifetime param and add more exception info for cpp worker

## Related issue number


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
