### PR TITLE
[Serve] Deprecate outdated REST API settings

### DIFF
--- a/dashboard/modules/serve/serve_head.py
+++ b/dashboard/modules/serve/serve_head.py
@@ -56,20 +56,11 @@ class ServeHead(dashboard_utils.DashboardHeadModule):
     @routes.put("/api/serve/deployments/")
     @optional_utils.init_ray_and_catch_exceptions(connect_to_serve=True)
     async def put_all_deployments(self, req: Request) -> Response:
-        from ray import serve
-        from ray.serve.application import Application
         from ray.serve.context import get_global_client
         from ray.serve.schema import ServeApplicationSchema
 
         config = ServeApplicationSchema.parse_obj(await req.json())
-
-        if config.import_path is not None:
-            client = get_global_client()
-            client.deploy_app(config)
-        else:
-            # TODO (shrekris-anyscale): Remove this conditional path
-            app = Application.from_dict(await req.json())
-            serve.run(app, _blocking=False)
+        get_global_client().deploy_app(config)
 
         return Response()
 

--- a/python/ray/serve/application.py
+++ b/python/ray/serve/application.py
@@ -4,14 +4,7 @@ from typing import (
     List,
 )
 
-from ray.serve.deployment import (
-    Deployment,
-    schema_to_deployment,
-    deployment_to_schema,
-)
-from ray.serve.schema import (
-    ServeApplicationSchema,
-)
+from ray.serve.deployment import Deployment
 
 
 class ImmutableDeploymentDict(dict):
@@ -80,35 +73,3 @@ class Application:
                     return None
 
         return ingress
-
-    def to_dict(self) -> Dict:
-        """Returns this Application's deployments as a dictionary.
-
-        This dictionary adheres to the Serve REST API schema. It can be deployed
-        via the Serve REST API.
-
-        Returns:
-            Dict: The Application's deployments formatted in a dictionary.
-        """
-
-        return ServeApplicationSchema(
-            deployments=[deployment_to_schema(d) for d in self._deployments.values()]
-        ).dict()
-
-    @classmethod
-    def from_dict(cls, d: Dict) -> "Application":
-        """Converts a dictionary of deployment data to an application.
-
-        Takes in a dictionary matching the Serve REST API schema and converts
-        it to an application containing those deployments.
-
-        Args:
-            d: A dictionary containing the deployments' data that matches
-                the Serve REST API schema.
-
-        Returns:
-            Application: a new application object containing the deployments.
-        """
-
-        schema = ServeApplicationSchema.parse_obj(d)
-        return cls([schema_to_deployment(s) for s in schema.deployments])

--- a/python/ray/serve/application.py
+++ b/python/ray/serve/application.py
@@ -1,9 +1,6 @@
-import yaml
 from typing import (
     Dict,
     Optional,
-    TextIO,
-    Union,
     List,
 )
 
@@ -115,54 +112,3 @@ class Application:
 
         schema = ServeApplicationSchema.parse_obj(d)
         return cls([schema_to_deployment(s) for s in schema.deployments])
-
-    def to_yaml(self, f: Optional[TextIO] = None) -> Optional[str]:
-        """Returns this application's deployments as a YAML string.
-
-        Optionally writes the YAML string to a file as well. To write to a
-        file, use this pattern:
-
-        with open("file_name.txt", "w") as f:
-            app.to_yaml(f=f)
-
-        This file is formatted as a Serve YAML config file. It can be deployed
-        via the Serve CLI.
-
-        Args:
-            f (Optional[TextIO]): A pointer to the file where the YAML should
-                be written.
-
-        Returns:
-            Optional[String]: The deployments' YAML string. The output is from
-                yaml.safe_dump(). Returned only if no file pointer is passed in.
-        """
-
-        return yaml.safe_dump(
-            self.to_dict(), stream=f, default_flow_style=False, sort_keys=False
-        )
-
-    @classmethod
-    def from_yaml(cls, str_or_file: Union[str, TextIO]) -> "Application":
-        """Converts YAML data to deployments for an application.
-
-        Takes in a string or a file pointer to a file containing deployment
-        definitions in YAML. These definitions are converted to a new
-        application object containing the deployments.
-
-        To read from a file, use the following pattern:
-
-        with open("file_name.txt", "w") as f:
-            app = app.from_yaml(str_or_file)
-
-        Args:
-            str_or_file (Union[String, TextIO]): Either a string containing
-                YAML deployment definitions or a pointer to a file containing
-                YAML deployment definitions. The YAML format must adhere to the
-                ServeApplicationSchema JSON Schema defined in
-                ray.serve.schema. This function works with
-                Serve YAML config files.
-
-        Returns:
-            Application: a new Application object containing the deployments.
-        """
-        return cls.from_dict(yaml.safe_load(str_or_file))

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, Extra, root_validator, validator
-from typing import Union, Tuple, List, Dict
+from typing import Union, List, Dict
 from ray._private.runtime_env.packaging import parse_uri
 from ray.serve.common import (
     DeploymentStatusInfo,
@@ -83,29 +83,6 @@ class DeploymentSchema(
 ):
     name: str = Field(
         ..., description=("Globally-unique name identifying this deployment.")
-    )
-    import_path: str = Field(
-        default=None,
-        description=(
-            "The application's full import path. Should be of the "
-            'form "module.submodule_1...submodule_n.'
-            'MyClassOrFunction." This is equivalent to '
-            '"from module.submodule_1...submodule_n import '
-            'MyClassOrFunction". Only works with Python '
-            "applications."
-        ),
-    )
-    init_args: Union[Tuple, List] = Field(
-        default=None,
-        description=(
-            "The application's init_args. Only works with Python applications."
-        ),
-    )
-    init_kwargs: Dict = Field(
-        default=None,
-        description=(
-            "The application's init_args. Only works with Python applications."
-        ),
     )
     num_replicas: int = Field(
         default=None,
@@ -244,35 +221,6 @@ class DeploymentSchema(
                 'contain "{" or "}".'
             )
 
-        return v
-
-    @validator("import_path")
-    def import_path_format_valid(cls, v: str):
-        if ":" in v:
-            if v.count(":") > 1:
-                raise ValueError(
-                    f'Got invalid import path "{v}". An '
-                    "import path may have at most one colon."
-                )
-            if v.rfind(":") == 0 or v.rfind(":") == len(v) - 1:
-                raise ValueError(
-                    f'Got invalid import path "{v}". An '
-                    "import path may not start or end with a colon."
-                )
-            return v
-        else:
-            if v.count(".") == 0:
-                raise ValueError(
-                    f'Got invalid import path "{v}". An '
-                    "import path must contain at least one dot or colon "
-                    "separating the module (and potentially submodules) from "
-                    'the deployment graph. E.g.: "module.deployment_graph".'
-                )
-            if v.rfind(".") == 0 or v.rfind(".") == len(v) - 1:
-                raise ValueError(
-                    f'Got invalid import path "{v}". An '
-                    "import path may not start or end with a dot."
-                )
         return v
 
 

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -22,6 +22,7 @@ from ray.serve.constants import (
     DEFAULT_HTTP_PORT,
     SERVE_NAMESPACE,
 )
+from ray.serve.deployment import deployment_to_schema
 from ray.serve.deployment_graph import ClassNode, FunctionNode
 from ray.serve.schema import ServeApplicationSchema
 
@@ -388,14 +389,11 @@ def build(import_path: str, app_dir: str, output_path: Optional[str]):
         )
 
     app = build_app(node)
-    config = app.to_dict()
-    config["import_path"] = import_path
 
-    deprecated_config_properties = {"init_args", "init_kwargs", "import_path"}
-    for deployment in config["deployments"]:
-        for property in deprecated_config_properties:
-            if property in deployment:
-                del deployment[property]
+    config = ServeApplicationSchema(
+        deployments=[deployment_to_schema(d) for d in app.deployments.values()]
+    ).dict()
+    config["import_path"] = import_path
 
     if output_path is not None:
         if not output_path.endswith(".yaml"):

--- a/python/ray/serve/tests/test_application.py
+++ b/python/ray/serve/tests/test_application.py
@@ -1,14 +1,9 @@
-from typing import Dict
 import pytest
 import sys
-import os
-import yaml
-import requests
 
 import ray
 from ray import serve
 from ray.serve.application import Application
-from ray.serve.api import build as build_app
 from ray._private.test_utils import wait_for_condition
 
 
@@ -270,68 +265,6 @@ def decorated_func(req=None):
 class DecoratedClass:
     def __call__(self, req=None):
         return "got decorated class"
-
-
-class TestServeBuild:
-    @serve.deployment
-    class A:
-        pass
-
-    def test_build_non_importable(self, serve_instance):
-        def gen_deployment():
-            @serve.deployment
-            def f():
-                pass
-
-            return f
-
-        with pytest.raises(RuntimeError, match="must be importable"):
-            build_app(gen_deployment().bind()).to_dict()
-
-
-def compare_specified_options(deployments1: Dict, deployments2: Dict):
-    """
-    Helper method that takes 2 deployment dictionaries in the REST API
-    format and compares their specified settings. Assumes deployments2 may
-    have default values that deployments1 lacks. Does not compare
-    ray_actor_options.
-    """
-
-    deployments1 = deployments1["deployments"]
-    deployments2 = deployments2["deployments"]
-
-    for deployments in [deployments1, deployments2]:
-        deployments.sort(key=lambda d: d["name"])
-
-    for deployment1, deployment2 in zip(deployments1, deployments2):
-        for key, val in deployment1.items():
-            if val and key != "ray_actor_options":
-                assert deployment1[key] == deployment2[key]
-
-
-class TestDictTranslation:
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="File path incorrect on Windows."
-    )
-    def test_deploy_from_dict(self, serve_instance):
-        config_file_name = os.path.join(
-            os.path.dirname(__file__), "test_config_files", "two_deployments.yaml"
-        )
-
-        with open(config_file_name, "r") as config_file:
-            config_dict = yaml.safe_load(config_file)
-
-        app = Application.from_dict(config_dict)
-        app_dict = app.to_dict()
-
-        compare_specified_options(config_dict, app_dict)
-
-        serve.run(app.from_dict(app_dict))
-
-        assert (
-            requests.get("http://localhost:8000/shallow").text == "Hello shallow world!"
-        )
-        assert requests.get("http://localhost:8000/one").text == "2"
 
 
 def test_immutable_deployment_list(serve_instance):

--- a/python/ray/serve/tests/test_deployment_graph_classmethod.py
+++ b/python/ray/serve/tests/test_deployment_graph_classmethod.py
@@ -12,7 +12,7 @@ from ray.serve.deployment_graph import ClassNode, InputNode
 
 def maybe_build(node: ClassNode, use_build: bool) -> Union[Application, ClassNode]:
     if use_build:
-        return Application.from_dict(build_app(node).to_dict())
+        return build_app(node)
     else:
         return node
 

--- a/python/ray/serve/tests/test_pipeline_dag.py
+++ b/python/ray/serve/tests/test_pipeline_dag.py
@@ -23,7 +23,7 @@ NESTED_HANDLE_KEY = "nested_handle"
 
 def maybe_build(node: ClassNode, use_build: bool) -> Union[Application, ClassNode]:
     if use_build:
-        return Application.from_dict(build_app(node).to_dict())
+        return build_app(node)
     else:
         return node
 

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -206,7 +206,6 @@ class TestDeploymentSchema:
 
         return {
             "name": "deep",
-            "import_path": "my_module.MyClass",
             "num_replicas": None,
             "route_prefix": None,
             "max_concurrent_queries": None,
@@ -232,7 +231,6 @@ class TestDeploymentSchema:
 
         deployment_schema = {
             "name": "shallow",
-            "import_path": "test_env.shallow_import.ShallowClass",
             "num_replicas": 2,
             "route_prefix": "/shallow",
             "max_concurrent_queries": 32,
@@ -265,24 +263,6 @@ class TestDeploymentSchema:
         }
 
         DeploymentSchema.parse_obj(deployment_schema)
-
-    def test_invalid_python_attributes(self):
-        # Test setting invalid attributes for Python to ensure a validation or
-        # value error is raised.
-
-        # Python requires an import path
-        deployment_schema = self.get_minimal_deployment_schema()
-
-        # DeploymentSchema should be generated with valid import_paths
-        for path in get_valid_import_paths():
-            deployment_schema["import_path"] = path
-            DeploymentSchema.parse_obj(deployment_schema)
-
-        # Invalid import_path syntax should raise a ValidationError
-        for path in get_invalid_import_paths():
-            deployment_schema["import_path"] = path
-            with pytest.raises(ValidationError):
-                DeploymentSchema.parse_obj(deployment_schema)
 
     def test_gt_zero_deployment_schema(self):
         # Ensure ValidationError is raised when any fields that must be greater
@@ -391,7 +371,6 @@ class TestServeApplicationSchema:
             "deployments": [
                 {
                     "name": "shallow",
-                    "import_path": "test_env.shallow_import.ShallowClass",
                     "num_replicas": 2,
                     "route_prefix": "/shallow",
                     "max_concurrent_queries": 32,
@@ -424,7 +403,6 @@ class TestServeApplicationSchema:
                 },
                 {
                     "name": "deep",
-                    "import_path": ("test_env.subdir1.subdir2.deep_import.DeepClass"),
                     "num_replicas": None,
                     "route_prefix": None,
                     "max_concurrent_queries": None,

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -638,9 +638,8 @@ def test_deployment_to_schema_to_deployment():
         # decorator without converting global_f() into a Deployment object.
         pass
 
-    f._func_or_class = "ray.serve.tests.test_schema.global_f"
-
     deployment = schema_to_deployment(deployment_to_schema(f))
+    deployment.set_options(func_or_class="ray.serve.tests.test_schema.global_f")
 
     assert deployment.num_replicas == 3
     assert deployment.route_prefix == "/hello"
@@ -670,9 +669,8 @@ def test_unset_fields_schema_to_deployment_ray_actor_options():
     def f():
         pass
 
-    f._func_or_class = "ray.serve.tests.test_schema.global_f"
-
     deployment = schema_to_deployment(deployment_to_schema(f))
+    deployment.set_options(func_or_class="ray.serve.tests.test_schema.global_f")
 
     assert len(deployment.ray_actor_options) == 0
 
@@ -712,28 +710,6 @@ def test_status_schema_helpers():
     assert len(deployment_names) == 0
 
     serve.shutdown()
-
-
-@serve.deployment
-def decorated_f(*args):
-    return "reached decorated_f"
-
-
-def test_use_deployment_import_path():
-    """Ensure deployment func_or_class becomes import path when schematized."""
-
-    d = schema_to_deployment(deployment_to_schema(decorated_f))
-
-    assert isinstance(d.func_or_class, str)
-
-    # CI may change the parent path, so check only that the suffix matches.
-    assert d.func_or_class.endswith("ray.serve.tests.test_schema.decorated_f")
-
-    serve.start()
-    d.deploy()
-    assert (
-        requests.get("http://localhost:8000/decorated_f").text == "reached decorated_f"
-    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Since #25691 introduced end-to-end REST API and CLI support for the new Serve config format, the outdated format can be phased out. This change removes now-outdated fields from the config, including:

* (Deployment-level) `import_path`
* `init_args`
* `init_kwargs`

Note that these settings can still be configured through the Python API. This change affects only Serve's REST API and CLI.

To further support this change, outdated functionality from `Application` is also removed, including the following methods:

* `to_dict()`/`from_dict()`
* `to_yaml()`/`from_yaml()`

Their functionality is moved to the few dependent pieces of code, and their implementations are removed.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change relies on existing unit tests. Outdated tests are updated or removed.
