### PR TITLE
[hotfix] Revert "Exclude Bazel build files from Ray wheels (#25679)"

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,5 +1,3 @@
 include ray/autoscaler/ray-schema.json
 include ray/py.typed
 recursive-include ray *.pyi
-global-exclude *BUILD
-global-exclude *BUILD.bazel


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Nightly wheels are stuck at 736c7b13c4dcfb3f1b748124184e293ffab14bf8.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(