### PR TITLE
[Rllib] Add timeout to filter synchronization

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1604,7 +1604,9 @@ class Algorithm(Trainable):
                 '(e.g., YourEnvCls) or a registered env id (e.g., "your_env").'
             )
 
-    def _sync_filters_if_needed(self, workers: WorkerSet, timeout_seconds: int = None):
+    def _sync_filters_if_needed(
+        self, workers: WorkerSet, timeout_seconds: Optional[float] = None
+    ):
         if self.config.get("observation_filter", "NoFilter") != "NoFilter":
             FilterManager.synchronize(
                 workers.local_worker().filters,

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -679,7 +679,9 @@ class Algorithm(Trainable):
             )
             self._sync_filters_if_needed(
                 self.evaluation_workers,
-                timeout_seconds=self.config["sync_filters_on_rollout_workers_timeout_s"],
+                timeout_seconds=self.config[
+                    "sync_filters_on_rollout_workers_timeout_s"
+                ],
             )
 
         if self.config["custom_eval_function"]:

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -679,7 +679,7 @@ class Algorithm(Trainable):
             )
             self._sync_filters_if_needed(
                 self.evaluation_workers,
-                timeout=self.config["sync_filters_on_rollout_workers_timeout_s"],
+                timeout_seconds=self.config["sync_filters_on_rollout_workers_timeout_s"],
             )
 
         if self.config["custom_eval_function"]:

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -189,6 +189,7 @@ class AlgorithmConfig:
         # TODO: Set this flag still in the config or - much better - in the
         #  RolloutWorker as a property.
         self.in_evaluation = False
+        self.sync_filters_on_rollout_workers_timeout_s = 60
 
         # `self.reporting()`
         self.keep_per_episode_custom_metrics = False

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -189,7 +189,7 @@ class AlgorithmConfig:
         # TODO: Set this flag still in the config or - much better - in the
         #  RolloutWorker as a property.
         self.in_evaluation = False
-        self.sync_filters_on_rollout_workers_timeout_s = 60
+        self.sync_filters_on_rollout_workers_timeout_s = 60.0
 
         # `self.reporting()`
         self.keep_per_episode_custom_metrics = False

--- a/rllib/evaluation/tests/test_trajectory_view_api.py
+++ b/rllib/evaluation/tests/test_trajectory_view_api.py
@@ -64,9 +64,6 @@ class TestTrajectoryViewAPI(unittest.TestCase):
             policy = algo.get_policy()
             view_req_model = policy.model.view_requirements
             view_req_policy = policy.view_requirements
-            print(_)
-            print(view_req_policy)
-            print(view_req_model)
             assert len(view_req_model) == 1, view_req_model
             assert len(view_req_policy) == 11, view_req_policy
             for key in [
@@ -321,8 +318,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
             normalize_actions=False,
             num_envs=1,
         )
-        batch = rollout_worker_w_api.sample()
-        print(batch)
+        batch = rollout_worker_w_api.sample()  # noqa: F841
 
     def test_counting_by_agent_steps(self):
         config = copy.deepcopy(ppo.DEFAULT_CONFIG)

--- a/rllib/utils/filter_manager.py
+++ b/rllib/utils/filter_manager.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import ray
 from ray.rllib.utils.annotations import DeveloperAPI
@@ -16,7 +17,10 @@ class FilterManager:
     @staticmethod
     @DeveloperAPI
     def synchronize(
-        local_filters, remotes, update_remote=True, timeout_seconds: int = None
+        local_filters,
+        remotes,
+        update_remote=True,
+        timeout_seconds: Optional[float] = None,
     ):
         """Aggregates all filters from remote evaluators.
 

--- a/rllib/utils/filter_manager.py
+++ b/rllib/utils/filter_manager.py
@@ -1,5 +1,10 @@
+import logging
+
 import ray
 from ray.rllib.utils.annotations import DeveloperAPI
+from ray.exceptions import GetTimeoutError
+
+logger = logging.getLogger(__name__)
 
 
 @DeveloperAPI
@@ -10,7 +15,9 @@ class FilterManager:
 
     @staticmethod
     @DeveloperAPI
-    def synchronize(local_filters, remotes, update_remote=True):
+    def synchronize(
+        local_filters, remotes, update_remote=True, timeout_seconds: int = None
+    ):
         """Aggregates all filters from remote evaluators.
 
         Local copy is updated and then broadcasted to all remote evaluators.
@@ -19,14 +26,37 @@ class FilterManager:
             local_filters: Filters to be synchronized.
             remotes: Remote evaluators with filters.
             update_remote: Whether to push updates to remote filters.
+            timeout_seconds: How long to wait for filter to get or set filters
         """
-        remote_filters = ray.get(
-            [r.get_filters.remote(flush_after=True) for r in remotes]
-        )
+        try:
+            remote_filters = ray.get(
+                [r.get_filters.remote(flush_after=True) for r in remotes],
+                timeout=timeout_seconds,
+            )
+        except GetTimeoutError:
+            logger.error(
+                "Failed to get remote filters from a rollout worker in "
+                "FilterManager. "
+                "Filtered "
+                "metrics may be computed, but filtered wrong."
+            )
+
         for rf in remote_filters:
             for k in local_filters:
                 local_filters[k].apply_changes(rf[k], with_buffer=False)
         if update_remote:
             copies = {k: v.as_serializable() for k, v in local_filters.items()}
             remote_copy = ray.put(copies)
-            [r.sync_filters.remote(remote_copy) for r in remotes]
+
+            try:
+                ray.get(
+                    [r.sync_filters.remote(remote_copy) for r in remotes],
+                    timeout=timeout_seconds,
+                )
+            except GetTimeoutError:
+                logger.error(
+                    "Failed to set remote filters to a rollout worker in "
+                    "FilterManager. "
+                    "Filtered "
+                    "metrics may be computed, but filtered wrong."
+                )


### PR DESCRIPTION
## Why are these changes needed?

The filters that Rollout Workers apply to metrics are updated regularely as part of the training_step().
This operation includes a ray.get() that is lacking a timeout.
Without knowing the specifics of why this times out on my local machine when running IMPALA, I propose to set a timeout here so that we do not get stuck on this unnoticed.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
