### PR TITLE
[air] RunConfig.`failure` --> `failure_config`

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -298,7 +298,7 @@ class RunConfig:
             Currently only stateless callbacks are supported for resumed runs.
             (any state of the callback will not be checkpointed by Tune
             and thus will not take effect in resumed runs).
-        failure: The failure mode configuration.
+        failure_config: The failure mode configuration.
         sync_config: Configuration object for syncing. See tune.SyncConfig.
         verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
@@ -310,6 +310,6 @@ class RunConfig:
     local_dir: Optional[str] = None
     callbacks: Optional[List["Callback"]] = None
     stop: Optional[Union[Mapping, "Stopper", Callable[[str, Mapping], bool]]] = None
-    failure: Optional[FailureConfig] = None
+    failure_config: Optional[FailureConfig] = None
     sync_config: Optional[SyncConfig] = None
     verbose: Union[int, Verbosity] = Verbosity.V3_TRIAL_DETAILS

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -164,7 +164,9 @@ class TunerInternal:
             sync_config=self._run_config.sync_config,
             stop=self._run_config.stop,
             max_failures=(
-                self._run_config.failure.max_failures if self._run_config.failure else 0
+                self._run_config.failure_config.max_failures
+                if self._run_config.failure_config
+                else 0
             ),
             _experiment_checkpoint_dir=self._experiment_checkpoint_dir,
             raise_on_failed_trial=False,
@@ -184,7 +186,9 @@ class TunerInternal:
             sync_config=self._run_config.sync_config,
             stop=self._run_config.stop,
             max_failures=(
-                self._run_config.failure.max_failures if self._run_config.failure else 0
+                self._run_config.failure_config.max_failures
+                if self._run_config.failure_config
+                else 0
             ),
             _experiment_checkpoint_dir=self._experiment_checkpoint_dir,
             raise_on_failed_trial=False,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Use consistent naming convention inside of `RunConfig`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
