### PR TITLE
[runtime env] [CI] Hard-code agent port in runtime env tests

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -361,7 +361,8 @@ def start_cluster(ray_start_cluster_enabled, request):
     assert request.param in {"ray_client", "no_ray_client"}
     use_ray_client: bool = request.param == "ray_client"
     cluster = ray_start_cluster_enabled
-    cluster.add_node(num_cpus=4)
+    # Use a hard-coded agent port to prevent failures due to port conflicts.
+    cluster.add_node(num_cpus=4, metrics_agent_port="10031")
     if use_ray_client:
         cluster.head_node._ray_params.ray_client_server_port = "10004"
         cluster.head_node.start_ray_client_server()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After investigating the flaky `osx::test_runtime_env_working_dir_3.py`, 5/6 failures were due to 


> Failed to create runtime environment {"pythonRuntimeEnv": {"pyModules": ["s3://runtime-env-test/test_runtime_env.zip"]}, "uris": {"pyModulesUris": ["s3://runtime-env-test/test_runtime_env.zip"]}} because the Ray agent couldn't be started due to the port conflict. See `dashboard_agent.log` for more details. To solve the problem, start Ray with a hard-coded agent port. `ray start --dashboard-agent-grpc-port [port]` and make sure the port is not used by other processes.


Following the instruction in the error message, this PR hardcodes the agent port for these tests.  The change is made in the `start_cluster` fixture which sets up Ray for these tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
