### PR TITLE
[Java] Support starting named actors in different namespace.

### DIFF
--- a/java/api/src/main/java/io/ray/api/call/ActorCreator.java
+++ b/java/api/src/main/java/io/ray/api/call/ActorCreator.java
@@ -61,9 +61,4 @@ public class ActorCreator<A> extends BaseActorCreator<ActorCreator<A>> {
     return this;
   }
 
-  /** Set the namespace that this actor uses. */
-  public ActorCreator<A> setNamespace(String namespace) {
-    builder.setNamespace(namespace);
-    return this;
-  }
 }

--- a/java/api/src/main/java/io/ray/api/call/ActorCreator.java
+++ b/java/api/src/main/java/io/ray/api/call/ActorCreator.java
@@ -60,4 +60,10 @@ public class ActorCreator<A> extends BaseActorCreator<ActorCreator<A>> {
     builder.setRuntimeEnv(runtimeEnv);
     return this;
   }
+
+  /** Set the namespace that this actor uses. */
+  public ActorCreator<A> setNamespace(String namespace) {
+    builder.setNamespace(namespace);
+    return this;
+  }
 }

--- a/java/api/src/main/java/io/ray/api/call/ActorCreator.java
+++ b/java/api/src/main/java/io/ray/api/call/ActorCreator.java
@@ -60,5 +60,4 @@ public class ActorCreator<A> extends BaseActorCreator<ActorCreator<A>> {
     builder.setRuntimeEnv(runtimeEnv);
     return this;
   }
-
 }

--- a/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
+++ b/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
@@ -26,10 +26,10 @@ public class BaseActorCreator<T extends BaseActorCreator> {
   }
 
   /**
-   * Set the actor name of a named actor.
+   * Set the actor name along with a different namespace.
    *
    * @param name The name of the named actor.
-   * @param namespace The namespace that this actor will live.
+   * @param namespace The namespace that this actor will live in.
    * @return self
    */
   public T setName(String name, String namespace) {

--- a/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
+++ b/java/api/src/main/java/io/ray/api/call/BaseActorCreator.java
@@ -25,6 +25,19 @@ public class BaseActorCreator<T extends BaseActorCreator> {
     return self();
   }
 
+  /**
+   * Set the actor name of a named actor.
+   *
+   * @param name The name of the named actor.
+   * @param namespace The namespace that this actor will live.
+   * @return self
+   */
+  public T setName(String name, String namespace) {
+    builder.setName(name);
+    builder.setNamespace(namespace);
+    return self();
+  }
+
   public T setLifetime(ActorLifetime lifetime) {
     builder.setLifetime(lifetime);
     return self();

--- a/java/api/src/main/java/io/ray/api/options/ActorCreationOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/ActorCreationOptions.java
@@ -23,6 +23,7 @@ public class ActorCreationOptions extends BaseTaskOptions {
   public final int bundleIndex;
   public final List<ConcurrencyGroup> concurrencyGroups;
   public final String serializedRuntimeEnv;
+  public final String namespace;
   public final int maxPendingCalls;
 
   private ActorCreationOptions(
@@ -36,6 +37,7 @@ public class ActorCreationOptions extends BaseTaskOptions {
       int bundleIndex,
       List<ConcurrencyGroup> concurrencyGroups,
       String serializedRuntimeEnv,
+      String namespace,
       int maxPendingCalls) {
     super(resources);
     this.name = name;
@@ -47,6 +49,7 @@ public class ActorCreationOptions extends BaseTaskOptions {
     this.bundleIndex = bundleIndex;
     this.concurrencyGroups = concurrencyGroups;
     this.serializedRuntimeEnv = serializedRuntimeEnv;
+    this.namespace = namespace;
     this.maxPendingCalls = maxPendingCalls;
   }
 
@@ -62,6 +65,7 @@ public class ActorCreationOptions extends BaseTaskOptions {
     private int bundleIndex;
     private List<ConcurrencyGroup> concurrencyGroups = new ArrayList<>();
     private RuntimeEnv runtimeEnv = null;
+    private String namespace = null;
     private int maxPendingCalls = -1;
 
     /**
@@ -197,6 +201,7 @@ public class ActorCreationOptions extends BaseTaskOptions {
           bundleIndex,
           concurrencyGroups,
           runtimeEnv != null ? runtimeEnv.toJsonBytes() : "",
+          namespace,
           maxPendingCalls);
     }
 
@@ -208,6 +213,11 @@ public class ActorCreationOptions extends BaseTaskOptions {
 
     public Builder setRuntimeEnv(RuntimeEnv runtimeEnv) {
       this.runtimeEnv = runtimeEnv;
+      return this;
+    }
+
+    public Builder setNamespace(String namespace) {
+      this.namespace = namespace;
       return this;
     }
   }

--- a/java/test/src/main/java/io/ray/test/NamespaceTest.java
+++ b/java/test/src/main/java/io/ray/test/NamespaceTest.java
@@ -125,7 +125,7 @@ public class NamespaceTest {
     try {
       Ray.init();
       ActorHandle<GetNamespaceActor> actor =
-          Ray.actor(GetNamespaceActor::new).setName("a").setNamespace("namespace2").remote();
+          Ray.actor(GetNamespaceActor::new).setName("a", "namespace2").remote();
       Assert.assertFalse(Ray.getActor("a").isPresent());
     } finally {
       Ray.shutdown();

--- a/java/test/src/main/java/io/ray/test/NamespaceTest.java
+++ b/java/test/src/main/java/io/ray/test/NamespaceTest.java
@@ -119,4 +119,16 @@ public class NamespaceTest {
       Ray.shutdown();
     }
   }
+
+  public void testSpecifyNamespaceForActor() {
+    System.setProperty("ray.job.namespace", "namespace1");
+    try {
+      Ray.init();
+      ActorHandle<GetNamespaceActor> actor =
+          Ray.actor(GetNamespaceActor::new).setName("a").setNamespace("namespace2").remote();
+      Assert.assertFalse(Ray.getActor("a").isPresent());
+    } finally {
+      Ray.shutdown();
+    }
+  }
 }

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
@@ -166,6 +166,7 @@ inline ActorCreationOptions ToActorCreationOptions(JNIEnv *env,
   auto placement_options = std::make_pair(PlacementGroupID::Nil(), -1);
   std::vector<ConcurrencyGroup> concurrency_groups;
   std::string serialized_runtime_env = "";
+  std::string ray_namespace = "";
   int32_t max_pending_calls = -1;
 
   if (actorCreationOptions) {
@@ -249,13 +250,16 @@ inline ActorCreationOptions ToActorCreationOptions(JNIEnv *env,
       serialized_runtime_env = JavaStringToNativeString(env, java_serialized_runtime_env);
     }
 
+    auto java_namespace = (jstring)env->GetObjectField(actorCreationOptions,
+                                                  java_actor_creation_options_namespace);
+    if (java_namespace) {
+      ray_namespace = JavaStringToNativeString(env, java_namespace);
+    }
+
     max_pending_calls = static_cast<int32_t>(env->GetIntField(
         actorCreationOptions, java_actor_creation_options_max_pending_calls));
   }
 
-  // TODO(suquark): support passing namespace for Java. Currently
-  // there is no use case.
-  std::string ray_namespace = "";
   rpc::SchedulingStrategy scheduling_strategy;
   scheduling_strategy.mutable_default_scheduling_strategy();
   if (!placement_options.first.IsNil()) {

--- a/src/ray/core_worker/lib/java/jni_init.cc
+++ b/src/ray/core_worker/lib/java/jni_init.cc
@@ -112,6 +112,7 @@ jfieldID java_actor_creation_options_group;
 jfieldID java_actor_creation_options_bundle_index;
 jfieldID java_actor_creation_options_concurrency_groups;
 jfieldID java_actor_creation_options_serialized_runtime_env;
+jfieldID java_actor_creation_options_namespace;
 jfieldID java_actor_creation_options_max_pending_calls;
 
 jclass java_actor_lifetime_class;
@@ -362,6 +363,8 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
       java_actor_creation_options_class, "concurrencyGroups", "Ljava/util/List;");
   java_actor_creation_options_serialized_runtime_env = env->GetFieldID(
       java_actor_creation_options_class, "serializedRuntimeEnv", "Ljava/lang/String;");
+  java_actor_creation_options_namespace = env->GetFieldID(
+      java_actor_creation_options_class, "namespace", "Ljava/lang/String;"); 
   java_actor_creation_options_max_pending_calls =
       env->GetFieldID(java_actor_creation_options_class, "maxPendingCalls", "I");
 

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -201,6 +201,8 @@ extern jfieldID java_actor_creation_options_bundle_index;
 extern jfieldID java_actor_creation_options_concurrency_groups;
 /// serializedRuntimeEnv field of ActorCreatrionOptions class
 extern jfieldID java_actor_creation_options_serialized_runtime_env;
+/// namespace field of ActorCreatrionOptions class
+extern jfieldID java_actor_creation_options_namespace;
 /// maxPendingCalls field of ActorCreationOptions class
 extern jfieldID java_actor_creation_options_max_pending_calls;
 /// ActorLifetime enum class


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Allow you start actors in different namespace instead of the driver namespace.
Usage is simple:
```java
Ray.init(namespace="a");
/// Named actor a will starts in namespace `b`
ActorHandle<A> a = Ray.actor(A::new).setName("myActor", "b").remote();
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#22563 #25665
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
