### PR TITLE
Remove `node.py` and `ray_constants.py` links from `setup-dev.py`

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -89,9 +89,7 @@ if __name__ == "__main__":
     do_link("util", force=args.yes)
     do_link("workflow", force=args.yes)
     do_link("_private", force=args.yes)
-    do_link("node.py", force=args.yes)
     do_link("cluster_utils.py", force=args.yes)
-    do_link("ray_constants.py", force=args.yes)
     # Link package's `dashboard` directly to local (repo's) dashboard.
     # The repo's `dashboard` is a file, soft-linking to which will not work
     # on Mac.


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/ray/pull/25695 moved these two files to `_private/` so they don't need to be individually linked anymore

## Related issue number

Closes #26017

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
