### PR TITLE
🎨 Update type annotations to include options in `ray.remote()`

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -33,6 +33,7 @@ from typing import (
 
 import colorama
 import setproctitle
+from typing_extensions import Literal, Protocol
 
 import ray
 import ray._private.gcs_utils as gcs_utils
@@ -77,6 +78,7 @@ from ray.experimental.internal_kv import (
 )
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 from ray.util.debug import log_once
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray.util.tracing.tracing_helper import _import_from_string
 
 SCRIPT_MODE = 0
@@ -2494,71 +2496,143 @@ def _make_remote(function_or_class, options):
     )
 
 
+class RemoteDecorator(Protocol):
+    @overload
+    def __call__(self, __function: Callable[[], R]) -> RemoteFunctionNoArgs[R]:
+        ...
+
+    @overload
+    def __call__(self, __function: Callable[[T0], R]) -> RemoteFunction0[R, T0]:
+        ...
+
+    @overload
+    def __call__(self, __function: Callable[[T0, T1], R]) -> RemoteFunction1[R, T0, T1]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2], R]
+    ) -> RemoteFunction2[R, T0, T1, T2]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2, T3], R]
+    ) -> RemoteFunction3[R, T0, T1, T2, T3]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2, T3, T4], R]
+    ) -> RemoteFunction4[R, T0, T1, T2, T3, T4]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2, T3, T4, T5], R]
+    ) -> RemoteFunction5[R, T0, T1, T2, T3, T4, T5]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6], R]
+    ) -> RemoteFunction6[R, T0, T1, T2, T3, T4, T5, T6]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7], R]
+    ) -> RemoteFunction7[R, T0, T1, T2, T3, T4, T5, T6, T7]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8], R]
+    ) -> RemoteFunction8[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]:
+        ...
+
+    @overload
+    def __call__(
+        self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9], R]
+    ) -> RemoteFunction9[R, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]:
+        ...
+
+    # Pass on typing actors for now. The following makes it so no type errors
+    # are generated for actors.
+    @overload
+    def __call__(self, __t: type) -> Any:
+        ...
+
+
+# Only used for type annotations as a placeholder
+Undefined: Any = object()
+
+
 @overload
-def remote(function: Callable[[], R]) -> RemoteFunctionNoArgs[R]:
+def remote(__function: Callable[[], R]) -> RemoteFunctionNoArgs[R]:
     ...
 
 
 @overload
-def remote(function: Callable[[T0], R]) -> RemoteFunction0[R, T0]:
+def remote(__function: Callable[[T0], R]) -> RemoteFunction0[R, T0]:
     ...
 
 
 @overload
-def remote(function: Callable[[T0, T1], R]) -> RemoteFunction1[R, T0, T1]:
+def remote(__function: Callable[[T0, T1], R]) -> RemoteFunction1[R, T0, T1]:
     ...
 
 
 @overload
-def remote(function: Callable[[T0, T1, T2], R]) -> RemoteFunction2[R, T0, T1, T2]:
+def remote(__function: Callable[[T0, T1, T2], R]) -> RemoteFunction2[R, T0, T1, T2]:
     ...
 
 
 @overload
 def remote(
-    function: Callable[[T0, T1, T2, T3], R]
+    __function: Callable[[T0, T1, T2, T3], R]
 ) -> RemoteFunction3[R, T0, T1, T2, T3]:
     ...
 
 
 @overload
 def remote(
-    function: Callable[[T0, T1, T2, T3, T4], R]
+    __function: Callable[[T0, T1, T2, T3, T4], R]
 ) -> RemoteFunction4[R, T0, T1, T2, T3, T4]:
     ...
 
 
 @overload
 def remote(
-    function: Callable[[T0, T1, T2, T3, T4, T5], R]
+    __function: Callable[[T0, T1, T2, T3, T4, T5], R]
 ) -> RemoteFunction5[R, T0, T1, T2, T3, T4, T5]:
     ...
 
 
 @overload
 def remote(
-    function: Callable[[T0, T1, T2, T3, T4, T5, T6], R]
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6], R]
 ) -> RemoteFunction6[R, T0, T1, T2, T3, T4, T5, T6]:
     ...
 
 
 @overload
 def remote(
-    function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7], R]
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7], R]
 ) -> RemoteFunction7[R, T0, T1, T2, T3, T4, T5, T6, T7]:
     ...
 
 
 @overload
 def remote(
-    function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8], R]
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8], R]
 ) -> RemoteFunction8[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]:
     ...
 
 
 @overload
 def remote(
-    function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9], R]
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9], R]
 ) -> RemoteFunction9[R, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]:
     ...
 
@@ -2566,7 +2640,31 @@ def remote(
 # Pass on typing actors for now. The following makes it so no type errors
 # are generated for actors.
 @overload
-def remote(t: type) -> Any:
+def remote(__t: type) -> Any:
+    ...
+
+
+# Passing options
+@overload
+def remote(
+    *,
+    num_returns: Union[int, float] = Undefined,
+    num_cpus: Union[int, float] = Undefined,
+    num_gpus: Union[int, float] = Undefined,
+    resources: Dict[str, float] = Undefined,
+    accelerator_type: str = Undefined,
+    memory: Union[int, float] = Undefined,
+    object_store_memory: int = Undefined,
+    max_calls: int = Undefined,
+    max_restarts: int = Undefined,
+    max_task_retries: int = Undefined,
+    max_retries: int = Undefined,
+    runtime_env: Dict[str, Any] = Undefined,
+    retry_exceptions: bool = Undefined,
+    scheduling_strategy: Union[
+        None, Literal["DEFAULT"], Literal["SPREAD"], PlacementGroupSchedulingStrategy
+    ] = Undefined,
+) -> RemoteDecorator:
     ...
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Closes https://github.com/ray-project/ray/issues/25657.

🎨 Update type annotations to include options in `ray.remote()`

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current type annotations expect and support using:

```Python
@ray.remote
def do_things(x: int, y: float):
    return x * y
```

...without options.

This PR adds type annotations for passing options, as in:

```Python
@ray.remote(num_cpus=3)
def do_more_things(name: str, value: float):
    return f"{name}: {value}"
```

Before:

<img width="687" alt="Screenshot 2022-06-22 at 04 49 11" src="https://user-images.githubusercontent.com/1326112/174999689-80bdc3ce-b437-464f-b05c-7613b3f8f89b.png">

After (autocompletion):

<img width="687" alt="Screenshot 2022-06-22 at 04 50 34" src="https://user-images.githubusercontent.com/1326112/174999899-5062335a-17ee-44a8-ad5c-97335e201e7b.png">

...and no errors:

<img width="687" alt="Screenshot 2022-06-22 at 04 51 15" src="https://user-images.githubusercontent.com/1326112/175000001-0a978871-8835-426f-9e09-5848194639fd.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Related to: https://github.com/ray-project/ray/issues/25657

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
