### PR TITLE
[runtime env] remove unused runtime env uris from protobuf

### DIFF
--- a/python/ray/runtime_env.py
+++ b/python/ray/runtime_env.py
@@ -490,16 +490,6 @@ class RuntimeEnv(dict):
             # set py_modules uris
             proto_runtime_env.uris.py_modules_uris.extend(py_modules_uris)
 
-        # set conda uri
-        conda_uri = self.conda_uri()
-        if conda_uri is not None:
-            proto_runtime_env.uris.conda_uri = conda_uri
-
-        # set pip uri
-        pip_uri = self.pip_uri()
-        if pip_uri is not None:
-            proto_runtime_env.uris.pip_uri = pip_uri
-
         # set env_vars
         env_vars = self.env_vars()
         proto_runtime_env.env_vars.update(env_vars.items())

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1497,17 +1497,6 @@ static std::vector<std::string> GetUrisFromRuntimeEnv(
   for (const auto &uri : runtime_env->uris().py_modules_uris()) {
     result.emplace_back(uri);
   }
-  if (!runtime_env->uris().conda_uri().empty()) {
-    const auto &uri = runtime_env->uris().conda_uri();
-    result.emplace_back(uri);
-  }
-  if (!runtime_env->uris().pip_uri().empty()) {
-    const auto &uri = runtime_env->uris().pip_uri();
-    result.emplace_back(uri);
-  }
-  for (const auto &uri : runtime_env->uris().plugin_uris()) {
-    result.emplace_back(uri);
-  }
   return result;
 }
 

--- a/src/ray/protobuf/runtime_env_common.proto
+++ b/src/ray/protobuf/runtime_env_common.proto
@@ -152,12 +152,6 @@ message RuntimeEnvUris {
   string working_dir_uri = 1;
   /// python modules uris
   repeated string py_modules_uris = 2;
-  /// conda uri
-  string conda_uri = 3;
-  /// pip uri
-  string pip_uri = 4;
-  /// plugin uris
-  repeated string plugin_uris = 5;
 }
 
 /// The runtime environment describes all the runtime packages needed to


### PR DESCRIPTION
## Why are these changes needed?

We only need working_dir_uri and py_modules_uris which are used for reference counting in GCS. Raylet and agent don't need the uris absolutely.
