### PR TITLE
[runtime env] move 'eager_intall' to 'config'

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -134,7 +134,7 @@ This will install the dependencies to the remote cluster.  Any tasks and actors 
     1. As soon as the job starts (i.e., as soon as ``ray.init()`` is called), the dependencies are eagerly downloaded and installed.
     2. The dependencies are installed only when a task is invoked or an actor is created.
 
-  The default is option 1. To change the behavior to option 2, add ``"eager_install": False`` to the ``runtime_env``.
+  The default is option 1. To change the behavior to option 2, add ``"eager_install": False`` to the ``config`` of ``runtime_env``.
 
 .. _rte-per-task-actor:
 
@@ -363,17 +363,21 @@ The ``runtime_env`` is a Python dictionary or a python class :class:`ray.runtime
 
   Note: ``container`` is experimental now. If you have some requirements or run into any problems, raise issues in `github <https://github.com/ray-project/ray/issues>`__.
 
-- ``eager_install`` (bool): Indicates whether to install the runtime environment on the cluster at ``ray.init()`` time, before the workers are leased. This flag is set to ``True`` by default.
+- ``config`` (dict | :class:`ray.runtime_env.RuntimeEnvConfig <ray.runtime_env.RuntimeEnvConfig>`): config for runtime environment. Either a dict or a RuntimeEnvConfig.
+  Fields:
+  (1) setup_timeout_seconds, the timeout of runtime environment creation, timeout is in seconds.
+
+  - Example: ``{"setup_timeout_seconds": 10}``
+
+  - Example: ``RuntimeEnvConfig(setup_timeout_seconds=10)``
+
+  (2) ``eager_install`` (bool): Indicates whether to install the runtime environment on the cluster at ``ray.init()`` time, before the workers are leased. This flag is set to ``True`` by default.
   If set to ``False``, the runtime environment will be only installed when the first task is invoked or when the first actor is created.
   Currently, specifying this option per-actor or per-task is not supported.
 
   - Example: ``{"eager_install": False}``
 
-- ``config`` (dict | :class:`ray.runtime_env.RuntimeEnvConfig <ray.runtime_env.RuntimeEnvConfig>`): config for runtime environment. Either a dict or a RuntimeEnvConfig. Field: (1) setup_timeout_seconds, the timeout of runtime environment creation, timeout is in seconds.
-
-  - Example: ``{"setup_timeout_seconds": 10}``
-
-  - Example: ``RuntimeEnvConfig(setup_timeout_seconds=10)``
+  - Example: ``RuntimeEnvConfig(eager_install=False)``
 
 Caching and Garbage Collection
 """"""""""""""""""""""""""""""
@@ -419,7 +423,7 @@ Are environments installed on every node?
 """""""""""""""""""""""""""""""""""""""""
 
 If a runtime environment is specified in ``ray.init(runtime_env=...)``, then the environment will be installed on every node.  See :ref:`Per-Job <rte-per-job>` for more details.
-(Note, by default the runtime environment will be installed eagerly on every node in the cluster. If you want to lazily install the runtime environment on demand, set the ``eager_install`` option to false: ``ray.init(runtime_env={..., "eager_install": False}``.)
+(Note, by default the runtime environment will be installed eagerly on every node in the cluster. If you want to lazily install the runtime environment on demand, set the ``eager_install`` option to false: ``ray.init(runtime_env={..., "config": {"eager_install": False}}``.)
 
 When is the environment installed?
 """"""""""""""""""""""""""""""""""

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -247,13 +247,6 @@ def parse_and_validate_env_vars(env_vars: Dict[str, str]) -> Optional[Dict[str, 
     return env_vars
 
 
-def parse_and_validate_eager_install(eager_install: bool) -> bool:
-    assert eager_install is not None
-    if not isinstance(eager_install, bool):
-        raise TypeError(f"eager_install must be a boolean. got {type(eager_install)}")
-    return eager_install
-
-
 # Dictionary mapping runtime_env options with the function to parse and
 # validate them.
 OPTION_TO_VALIDATION_FN = {
@@ -264,5 +257,4 @@ OPTION_TO_VALIDATION_FN = {
     "pip": parse_and_validate_pip,
     "env_vars": parse_and_validate_env_vars,
     "container": parse_and_validate_container,
-    "eager_install": parse_and_validate_eager_install,
 }

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1378,21 +1378,8 @@ def get_runtime_env_info(
 
     proto_runtime_env_info.uris[:] = runtime_env.get_uris()
 
-    # Normally, `RuntimeEnv` should guarantee the accuracy of field eager_install,
-    # but so far, the internal code has not completely prohibited direct
-    # modification of fields in RuntimeEnv, so we should check it for insurance.
     # TODO(Catch-Bull): overload `__setitem__` for `RuntimeEnv`, change the
     # runtime_env of all internal code from dict to RuntimeEnv.
-
-    eager_install = runtime_env.get("eager_install")
-    if is_job_runtime_env or eager_install is not None:
-        if eager_install is None:
-            eager_install = True
-        elif not isinstance(eager_install, bool):
-            raise TypeError(
-                f"eager_install must be a boolean. got {type(eager_install)}"
-            )
-        proto_runtime_env_info.runtime_env_eager_install = eager_install
 
     runtime_env_config = runtime_env.get("config")
     if runtime_env_config is None:
@@ -1405,6 +1392,23 @@ def get_runtime_env_info(
     proto_runtime_env_info.runtime_env_config.CopyFrom(
         runtime_env_config.build_proto_runtime_env_config()
     )
+
+    # Normally, `RuntimeEnv` should guarantee the accuracy of field eager_install,
+    # but so far, the internal code has not completely prohibited direct
+    # modification of fields in RuntimeEnv, so we should check it for insurance.
+    eager_install = (
+        runtime_env_config.get("eager_install")
+        if runtime_env_config is not None
+        else None
+    )
+    if is_job_runtime_env or eager_install is not None:
+        if eager_install is None:
+            eager_install = True
+        elif not isinstance(eager_install, bool):
+            raise TypeError(
+                f"eager_install must be a boolean. got {type(eager_install)}"
+            )
+        proto_runtime_env_info.runtime_env_config.eager_install = eager_install
 
     proto_runtime_env_info.serialized_runtime_env = runtime_env.serialize()
 

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -243,7 +243,10 @@ def test_job_eager_install(shutdown_only, runtime_env_class):
     wait_for_condition(lambda: len(get_conda_env_list()) == env_count + 1, timeout=60)
     ray.shutdown()
     # Test disable eager install
-    runtime_env = {"conda": {"dependencies": ["toolz"]}, "eager_install": False}
+    runtime_env = {
+        "conda": {"dependencies": ["toolz"]},
+        "config": {"eager_install": False},
+    }
     ray.init(runtime_env=runtime_env_class(**runtime_env))
     with pytest.raises(RuntimeError):
         wait_for_condition(
@@ -251,7 +254,10 @@ def test_job_eager_install(shutdown_only, runtime_env_class):
         )
     ray.shutdown()
     # Test unavailable type
-    runtime_env = {"conda": {"dependencies": ["toolz"]}, "eager_install": 123}
+    runtime_env = {
+        "conda": {"dependencies": ["toolz"]},
+        "config": {"eager_install": 123},
+    }
     with pytest.raises(TypeError):
         ray.init(runtime_env=runtime_env_class(**runtime_env))
     ray.shutdown()

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -458,8 +458,12 @@ std::string TaskSpecification::DebugString() const {
       // Erase the last ":"
       stream.seekp(-1, std::ios_base::end);
     }
-    stream << ", runtime_env_eager_install="
-           << runtime_env_info.runtime_env_eager_install();
+    if (runtime_env_info.has_runtime_env_config()) {
+      stream << ", eager_install="
+             << runtime_env_info.runtime_env_config().eager_install();
+      stream << ", setup_timeout_seconds="
+             << runtime_env_info.runtime_env_config().setup_timeout_seconds();
+    }
   }
 
   return stream.str();

--- a/src/ray/protobuf/runtime_env_common.proto
+++ b/src/ray/protobuf/runtime_env_common.proto
@@ -186,6 +186,8 @@ message RuntimeEnv {
 message RuntimeEnvConfig {
   /// The timeout of runtime env creation.
   int32 setup_timeout_seconds = 1;
+  /// Indicates whether to install runtime env eagerly before the workers are leased.
+  bool eager_install = 2;
 }
 
 /// The runtime env information which is transfered between ray core processes.
@@ -194,10 +196,8 @@ message RuntimeEnvInfo {
   string serialized_runtime_env = 1;
   /// URIs used in this runtime env. These will be used for reference counting.
   repeated string uris = 2;
-  /// Indicates whether to install runtime env eagerly before the workers are leased.
-  bool runtime_env_eager_install = 3;
   /// The serialized runtime env config passed from the user.
-  RuntimeEnvConfig runtime_env_config = 4;
+  RuntimeEnvConfig runtime_env_config = 3;
 }
 
 message RuntimeEnvState {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -621,7 +621,8 @@ void WorkerPool::MarkPortAsFree(int port) {
 
 static bool NeedToEagerInstallRuntimeEnv(const rpc::JobConfig &job_config) {
   if (job_config.has_runtime_env_info() &&
-      job_config.runtime_env_info().runtime_env_eager_install()) {
+      job_config.runtime_env_info().has_runtime_env_config() &&
+      job_config.runtime_env_info().runtime_env_config().eager_install()) {
     auto const &runtime_env = job_config.runtime_env_info().serialized_runtime_env();
     return !IsRuntimeEnvEmpty(runtime_env);
   }

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -535,7 +535,7 @@ static inline rpc::RuntimeEnvInfo ExampleRuntimeEnvInfo(
   for (auto &uri : uris) {
     runtime_env_info.mutable_uris()->Add(std::string(uri));
   }
-  runtime_env_info.set_runtime_env_eager_install(eager_install);
+  runtime_env_info.mutable_runtime_env_config()->set_eager_install(eager_install);
   return runtime_env_info;
 }
 


### PR DESCRIPTION
## Why are these changes needed?

The `eager_intall` should be a config field.

before:
    runtime_env = {
      "conda": {"dependencies": ["toolz"]}, 
      "eager_install": False
     }

after:
    runtime_env = {
        "conda": {"dependencies": ["toolz"]},
        "config": {"eager_install": False},
    }