### PR TITLE
[Core] Fix check failure from incorrect death cause

### DIFF
--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -198,9 +198,11 @@ inline std::string GenErrorMessageFromDeathCause(
     return death_cause.runtime_env_failed_context().error_message();
   } else if (death_cause.context_case() == ContextCase::kActorUnschedulableContext) {
     return death_cause.actor_unschedulable_context().error_message();
-  } else {
-    RAY_CHECK(death_cause.context_case() == ContextCase::kActorDiedErrorContext);
+  } else if death_cause.context_case() == ContextCase::kActorDiedErrorContext) {
     return death_cause.actor_died_error_context().error_message();
+  } else {
+    RAY_CHECK(death_cause.context_case() == ContextCase::CONTEXT_NOT_SET);
+    return "Death cause not recorded.";
   }
 }
 

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -198,7 +198,7 @@ inline std::string GenErrorMessageFromDeathCause(
     return death_cause.runtime_env_failed_context().error_message();
   } else if (death_cause.context_case() == ContextCase::kActorUnschedulableContext) {
     return death_cause.actor_unschedulable_context().error_message();
-  } else if death_cause.context_case() == ContextCase::kActorDiedErrorContext) {
+  } else if (death_cause.context_case() == ContextCase::kActorDiedErrorContext) {
     return death_cause.actor_died_error_context().error_message();
   } else {
     RAY_CHECK(death_cause.context_case() == ContextCase::CONTEXT_NOT_SET);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes the check failure;

```
  | 2022-06-21 19:14:10,718	WARNING worker.py:1737 -- A worker died or was killed while executing a task by an unexpected system error. To troubleshoot the problem, check the logs for the dead worker. RayTask ID: ffffffffffffffff7cc1d49b6d4812ea954ca19a01000000 Worker ID: 9fb0f63d84689c6a9e5257309a6346170c827aa7f970c0ee45e79a8b Node ID: 2d493b4f39f0c382a5dc28137ba73af78b0327696117e9981bd2425c Worker IP address: 172.18.0.3 Worker port: 35883 Worker PID: 31945 Worker exit type: SYSTEM_ERROR Worker exit detail: Worker unexpectedly exits with a connection error code 2. End of file. There are some potential root causes. (1) The process is killed by SIGKILL by OOM killer due to high memory usage. (2) ray stop --force is called. (3) The worker is crashed unexpectedly due to SIGSEGV or other unexpected errors.
  | (HTTPProxyActor pid=31945) [2022-06-21 19:14:10,710 C 31945 31971] pb_util.h:202:  Check failed: death_cause.context_case() == ContextCase::kActorDiedErrorContext
  | (HTTPProxyActor pid=31945) *** StackTrace Information ***
  | (HTTPProxyActor pid=31945)     ray::SpdLogMessage::Flush()
  | (HTTPProxyActor pid=31945)     ray::RayLog::~RayLog()
  | (HTTPProxyActor pid=31945)     ray::core::CoreWorker::HandleKillActor()
  | (HTTPProxyActor pid=31945)     std::_Function_handler<>::_M_invoke()
  | (HTTPProxyActor pid=31945)     EventTracker::RecordExecution()
  | (HTTPProxyActor pid=31945)     std::_Function_handler<>::_M_invoke()
  | (HTTPProxyActor pid=31945)     boost::asio::detail::completion_handler<>::do_complete()
  | (HTTPProxyActor pid=31945)     boost::asio::detail::scheduler::do_run_one()
  | (HTTPProxyActor pid=31945)     boost::asio::detail::scheduler::run()
  | (HTTPProxyActor pid=31945)     boost::asio::io_context::run()
  | (HTTPProxyActor pid=31945)     ray::core::CoreWorker::RunIOService()
  | (HTTPProxyActor pid=31945)     execute_native_thread_routine
  | (HTTPProxyActor pid=31945)
  | (HTTPProxyActor pid=31982) INFO:     Started server process [31982]
```

NOTE: This is a temporary fix. The root cause is that there's a path that doesn't properly report the death cause (when this RPC is triggered by `gcs_actor_scheduler`). This should be addressed separately to improve exit observability.

Since this is intended to be picked for 1.13.1, I only added the minimal fix. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/25985

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
