### PR TITLE
Benchmark the object spilling performance

### DIFF
--- a/python/ray/data/tests/test_object_spilling.py
+++ b/python/ray/data/tests/test_object_spilling.py
@@ -30,8 +30,8 @@ def create_dataset():
         assert args.data_type == 1
         # Parquet data
         files = [
-            f"s3://ursa-labs-taxi-data/{year}/{month}/data.parquet"
-            for year in range(2009, 2018) for month in range(1, 12)
+            f"s3://ursa-labs-taxi-data/{year}/{str(month).zfill(2)}/data.parquet"
+            for year in range(2017, 2019) for month in range(1, 13)
         ]
         ds = ray.data.read_parquet(files)
     return ds

--- a/python/ray/data/tests/test_object_spilling.py
+++ b/python/ray/data/tests/test_object_spilling.py
@@ -30,9 +30,8 @@ def create_dataset():
         assert args.data_type == 1
         # Parquet data
         files = [
-            f"s3://shuffling-data-loader-benchmarks/data/r10_000_000_000-f1000"
-            f"/input_data_{i}.parquet.snappy"
-            for i in range(args.num_files)
+            f"s3://ursa-labs-taxi-data/{year}/{month}/data.parquet"
+            for year in range(2009, 2018) for month in range(1, 12)
         ]
         ds = ray.data.read_parquet(files)
     return ds
@@ -45,7 +44,8 @@ num_batches, num_bytes = 0, 0
 batch_delays = []
 
 ds = create_dataset()
-for batch in ds.iter_batches(batch_size=args.batch_size):
+print("ds:", ds)
+for batch in ds.iter_batches():
     num_batches += 1
     batch_delay = time.perf_counter() - batch_start
     batch_delays.append(batch_delay)

--- a/python/ray/data/tests/test_object_spilling.py
+++ b/python/ray/data/tests/test_object_spilling.py
@@ -1,0 +1,40 @@
+import ray
+import time
+
+import numpy as np
+
+# Create a dataset with 30 GiB, and 512 MiB/block
+NUM_GB = 30
+BLOCK_SIZE_GB = 0.5
+
+# 80*80*4*8*5000 = 1 GiB
+ds = ray.data.range_tensor(
+    5000 * NUM_GB, shape=(80, 80, 4), parallelism=int(NUM_GB / BLOCK_SIZE_GB)
+)
+
+print("Starting consume the dataset")
+start = time.perf_counter()
+batch_start = start
+num_batches, num_bytes = 0, 0
+batch_delays = []
+
+for batch in ds.iter_batches():
+    num_batches += 1
+    batch_delay = time.perf_counter() - batch_start
+    batch_delays.append(batch_delay)
+    assert isinstance(batch, np.ndarray)
+    num_bytes += batch.nbytes
+    batch_start = time.perf_counter()
+
+duration = time.perf_counter() - start
+
+print("Total time to iterate all data:", duration)
+print("Total number of batches:", num_batches)
+print(
+    "P50/P95/Max batch delay (s)",
+    np.quantile(batch_delays, 0.5),
+    np.quantile(batch_delays, 0.95),
+    np.max(batch_delays),
+)
+print("Total number of bytes read:", round(num_bytes / (1024 * 1024), 2), "MiB")
+print("Mean throughput", round(num_bytes / (1024 * 1024) / duration, 2), "MiB/s")

--- a/python/ray/data/tests/test_object_spilling.py
+++ b/python/ray/data/tests/test_object_spilling.py
@@ -1,16 +1,42 @@
+import argparse
 import ray
 import time
+import sys
 
+import pandas as pd
 import numpy as np
 
-# Create a dataset with 30 GiB, and 512 MiB/block
-NUM_GB = 30
-BLOCK_SIZE_GB = 0.5
-
-# 80*80*4*8*5000 = 1 GiB
-ds = ray.data.range_tensor(
-    5000 * NUM_GB, shape=(80, 80, 4), parallelism=int(NUM_GB / BLOCK_SIZE_GB)
+parser = argparse.ArgumentParser("Benchmarking spilling performance")
+parser.add_argument("--data-type", type=int, default=0)  # 0: tensor 1: parquet
+parser.add_argument(
+    "--batch-size",
+    type=int,
+    default=2500,
 )
+parser.add_argument("--num-files", type=int, default=30)
+args = parser.parse_args()
+
+
+def create_dataset():
+    if args.data_type == 0:
+        # Tensor data: create a dataset with 30 GiB, and 512 MiB/block
+        NUM_GB = 30
+        BLOCK_SIZE_GB = 0.5
+        # 80*80*4*8*5000 = 1 GiB
+        ds = ray.data.range_tensor(
+            5000 * NUM_GB, shape=(80, 80, 4), parallelism=int(NUM_GB / BLOCK_SIZE_GB)
+        )
+    else:
+        assert args.data_type == 1
+        # Parquet data
+        files = [
+            f"s3://shuffling-data-loader-benchmarks/data/r10_000_000_000-f1000"
+            f"/input_data_{i}.parquet.snappy"
+            for i in range(args.num_files)
+        ]
+        ds = ray.data.read_parquet(files)
+    return ds
+
 
 print("Starting consume the dataset")
 start = time.perf_counter()
@@ -18,12 +44,21 @@ batch_start = start
 num_batches, num_bytes = 0, 0
 batch_delays = []
 
-for batch in ds.iter_batches():
+ds = create_dataset()
+for batch in ds.iter_batches(batch_size=args.batch_size):
     num_batches += 1
     batch_delay = time.perf_counter() - batch_start
     batch_delays.append(batch_delay)
-    assert isinstance(batch, np.ndarray)
-    num_bytes += batch.nbytes
+
+    if isinstance(batch, pd.DataFrame):
+        num_bytes += int(batch.memory_usage(index=True, deep=True).sum())
+    elif isinstance(batch, np.ndarray):
+        num_bytes += batch.nbytes
+    else:
+        # NOTE: This isn't recursive and will just return the size of
+        # the object pointers if list of non-primitive types.
+        num_bytes += sys.getsizeof(batch)
+
     batch_start = time.perf_counter()
 
 duration = time.perf_counter() - start


### PR DESCRIPTION
## Why are these changes needed?
Benchmark the object spilling performance for spilling compression.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
