### PR TITLE
[CI] Use BUILDKITE_JOB_ID for better navigation for flaky tracker

### DIFF
--- a/ci/build/get_build_info.py
+++ b/ci/build/get_build_info.py
@@ -50,7 +50,7 @@ def get_build_env():
             "TRAVIS_JOB_WEB_URL": (
                 os.environ["BUILDKITE_BUILD_URL"]
                 + "#"
-                + os.environ["BUILDKITE_BUILD_ID"]
+                + os.environ["BUILDKITE_JOB_ID"]
             ),
             "TRAVIS_OS_NAME": {  # The map is used to stay consistent with Travis
                 "linux": "linux",

--- a/ci/build/get_build_info.py
+++ b/ci/build/get_build_info.py
@@ -48,9 +48,7 @@ def get_build_env():
         return {
             "TRAVIS_COMMIT": os.environ["BUILDKITE_COMMIT"],
             "TRAVIS_JOB_WEB_URL": (
-                os.environ["BUILDKITE_BUILD_URL"]
-                + "#"
-                + os.environ["BUILDKITE_JOB_ID"]
+                os.environ["BUILDKITE_BUILD_URL"] + "#" + os.environ["BUILDKITE_JOB_ID"]
             ),
             "TRAVIS_OS_NAME": {  # The map is used to stay consistent with Travis
                 "linux": "linux",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This change helps to take flaky test tracker directly to the failed step
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
