### PR TITLE
[data] Mark randomize_block_order() as experimental since it breaks stage fusion

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -793,7 +793,7 @@ class Dataset(Generic[T]):
         *,
         seed: Optional[int] = None,
     ) -> "Dataset[T]":
-        """Randomly shuffle the blocks of this dataset.
+        """Randomly shuffle the blocks of this dataset (EXPERIMENTAL).
 
         Examples:
             >>> import ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The randomize_block_order() command has issues with breaking stage fusion, per https://github.com/ray-project/ray/pull/25870

Tracking issue: https://github.com/ray-project/ray/issues/26057