### PR TITLE
[C++ API] Hide other symbols in libray_api.so only keep ray*

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -6,11 +6,24 @@ load("//bazel:ray.bzl", "COPTS")
 cc_binary(
     name = "libray_api.so",
     copts = COPTS,
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": [
+            "-Wl,-exported_symbols_list,$(location :symbols/ray_api_exported_symbols_mac.lds)",
+        ],
+        "@bazel_tools//src/conditions:windows": [
+            #TODO(larry): Hide the symbols when we make it work on Windows.
+        ],
+        "//conditions:default": [
+            "-Wl,--version-script,$(location :symbols/ray_api_exported_symbols_linux.lds)",
+        ],
+    }),
     linkshared = 1,
     linkstatic = 1,
     visibility = ["//visibility:public"],
     deps = [
         ":ray_api",
+        ":symbols/ray_api_exported_symbols_linux.lds",
+        ":symbols/ray_api_exported_symbols_mac.lds",
     ],
 )
 

--- a/cpp/symbols/ray_api_exported_symbols_linux.lds
+++ b/cpp/symbols/ray_api_exported_symbols_linux.lds
@@ -1,0 +1,15 @@
+# This file defines the C++ symbols that need to be exported (aka ABI, application binary interface).
+# These symbols will be used by other libraries.
+# Note: This file is used for linux only, and should be kept in sync with `ray_api_exported_symbols.lds`.
+# Ray ABI is not finalized, the exact set of exported (C/C++) APIs is subject to change.
+VERSION_1.0 {
+    global:
+        # common
+        *[0-9]ray[0-9]*;
+        TaskExecutionHandler;
+        GetFunctionManager;
+        GetRemoteFunctions;
+        InitRayRuntime;
+    local: 
+        *;
+};

--- a/cpp/symbols/ray_api_exported_symbols_mac.lds
+++ b/cpp/symbols/ray_api_exported_symbols_mac.lds
@@ -1,0 +1,10 @@
+# This file defines the C++ symbols that need to be exported (aka ABI, application binary interface).
+# These symbols will be used by other libraries.
+# Note: This file is used for macOS only, and should be kept in sync with `ray_api_version_script.lds`.
+# Ray ABI is not finalized, the exact set of exported (C/C++) APIs is subject to change.
+# common
+*[0-9]ray[0-9]*;
+TaskExecutionHandler;
+GetFunctionManager;
+GetRemoteFunctions;
+InitRayRuntime;


### PR DESCRIPTION
## Why are these changes needed?

Users may rely on other libraries such as boost/bssl, and then the symbols of these libraries are exposed in libray_api.so, which will eventually lead to double symbols, which will lead to some problems.
So hide other symbols in libray_api.so only keep ray-related symbols.


## Related issue number
#25304 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
