### PR TITLE
[Java] Add entry to run custom test using bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ java/**/.settings
 java/**/.classpath
 java/**/.project
 java/runtime/native_dependencies/
+java/testng_custom.xml
 
 dependency-reduced-pom.xml
 

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -177,16 +177,46 @@ define_java_module(
     ],
 )
 
-java_binary(
-    name = "all_tests",
-    args = ["java/testng.xml"],
-    data = ["testng.xml"],
-    main_class = "org.testng.TestNG",
+java_library(
+    name = "all_tests_lib",
     runtime_deps = [
         ":io_ray_ray_performance_test",
         ":io_ray_ray_runtime_test",
         ":io_ray_ray_serve_test",
         ":io_ray_ray_test",
+    ],
+)
+
+java_test(
+    name = "all_tests",
+    args = ["java/testng.xml"],
+    data = [
+        "testng.xml",
+        ":ray_java_pkg",
+        "//:ray_pkg",
+    ],
+    main_class = "org.testng.TestNG",
+    tags = ["local"],
+    runtime_deps = [
+        ":all_tests_lib",
+    ],
+)
+
+# 0. `cp testng_custom_template.xml testng_custom.xml`
+# 1. Specify test class/method in `testng_custom.xml`
+# 2. `bazel test //java:custom_test --test_output=streamed`
+java_test(
+    name = "custom_test",
+    args = ["java/testng_custom.xml"],
+    data = [
+        "testng_custom.xml",
+        ":ray_java_pkg",
+        "//:ray_pkg",
+    ],
+    main_class = "org.testng.TestNG",
+    tags = ["local"],
+    runtime_deps = [
+        ":all_tests_lib",
     ],
 )
 

--- a/java/testng_custom_template.xml
+++ b/java/testng_custom_template.xml
@@ -14,11 +14,5 @@
         <listener class-name="io.ray.test.RayAlterSuiteListener" />
         <listener class-name="io.ray.test.TestProgressListener" />
         <listener class-name="io.ray.test.SystemPropertyListener" />
-        <listener class-name="io.ray.test.AnnotationTransformer" />
     </listeners>
 </suite>
-
-
-
-
-

--- a/java/testng_custom_template.xml
+++ b/java/testng_custom_template.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="RAY suite" verbose="2" configfailurepolicy="continue">
+    <test name = "RAY test">
+        <classes>
+            <class name="io.ray.test.CrossLanguageInvocationTest">
+                <methods>
+                    <include name="testPythonCallJavaFunction" />
+                </methods>
+            </class>
+        </classes>
+    </test>
+    <listeners>
+        <listener class-name="io.ray.test.RayAlterSuiteListener" />
+        <listener class-name="io.ray.test.TestProgressListener" />
+        <listener class-name="io.ray.test.SystemPropertyListener" />
+        <listener class-name="io.ray.test.AnnotationTransformer" />
+    </listeners>
+</suite>
+
+
+
+
+


### PR DESCRIPTION
## Why are these changes needed?

Now we can run custom java tests by:

0. `cp testng_custom_template.xml testng_custom.xml`
1. Specify test class/method in `testng_custom.xml`
2. `bazel test //java:custom_test --test_output=streamed`