### PR TITLE
[runtime env] plugin refactor[1/n]

### DIFF
--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -1,2 +1,5 @@
 # Env var set by job manager to pass runtime env and metadata to subprocess
 RAY_JOB_CONFIG_JSON_ENV_VAR = "RAY_JOB_CONFIG_JSON_ENV_VAR"
+
+# The plugins which should be loaded when ray cluster starts.
+RAY_RUNTIME_ENV_PLUGINS_ENV_VAR = "RAY_RUNTIME_ENV_PLUGINS"

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -1,10 +1,13 @@
 import logging
+import os
 from abc import ABC
 from typing import List
 
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.uri_cache import URICache
+from ray._private.runtime_env.constants import RAY_RUNTIME_ENV_PLUGINS_ENV_VAR
 from ray.util.annotations import DeveloperAPI
+from ray._private.utils import import_attr
 
 default_logger = logging.getLogger(__name__)
 
@@ -13,7 +16,7 @@ default_logger = logging.getLogger(__name__)
 class RuntimeEnvPlugin(ABC):
     """Abstract base class for runtime environment plugins."""
 
-    name: str
+    name: str = None
 
     @staticmethod
     def validate(runtime_env_dict: dict) -> str:
@@ -86,6 +89,45 @@ class RuntimeEnvPlugin(ABC):
             the amount of space reclaimed by the deletion.
         """
         return 0
+
+
+class RuntimeEnvPluginManager:
+    """This mananger is used to load plugins in runtime env agent."""
+
+    def __init__(self):
+        self.plugins = {}
+        plugins_config = os.environ.get(RAY_RUNTIME_ENV_PLUGINS_ENV_VAR)
+        if plugins_config:
+            self.load_plugins(plugins_config.split(","))
+
+    def load_plugins(self, plugin_classes: List[str]):
+        """Load runtime env plugins"""
+        for plugin_class_path in plugin_classes:
+            plugin_class = import_attr(plugin_class_path)
+            if not issubclass(plugin_class, RuntimeEnvPlugin):
+                default_logger.warning(
+                    "Invalid runtime env plugin class %s. "
+                    "The plugin class must inherit "
+                    "ray._private.runtime_env.plugin.RuntimeEnvPlugin.",
+                    plugin_class,
+                )
+                continue
+            if not plugin_class.name:
+                default_logger.warning(
+                    "No valid name in runtime env plugin %s", plugin_class
+                )
+                continue
+            if plugin_class.name in self.plugins:
+                default_logger.warning(
+                    "The name of runtime env plugin %s conflicts with %s",
+                    plugin_class,
+                    self.plugins[plugin_class.name],
+                )
+                continue
+            self.plugins[plugin_class.name] = plugin_class()
+
+    def get_plugin(self, name: str):
+        return self.plugins.get(name)
 
 
 @DeveloperAPI

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -923,3 +923,13 @@ def start_http_proxy(request):
         if proxy:
             proxy.terminate()
             proxy.wait()
+
+
+@pytest.fixture
+def set_runtime_env_plugins(request):
+    runtime_env_plugins = getattr(request, "param", "0")
+    try:
+        os.environ["RAY_RUNTIME_ENV_PLUGINS"] = runtime_env_plugins
+        yield runtime_env_plugins
+    finally:
+        del os.environ["RAY_RUNTIME_ENV_PLUGINS"]

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -13,14 +13,16 @@ from ray._private.test_utils import test_external_redis, wait_for_condition
 from ray.exceptions import RuntimeEnvSetupError
 
 MY_PLUGIN_CLASS_PATH = "ray.tests.test_runtime_env_plugin.MyPlugin"
+MY_PLUGIN_NAME = "MyPlugin"
 
 
 class MyPlugin(RuntimeEnvPlugin):
+    name = MY_PLUGIN_NAME
     env_key = "MY_PLUGIN_TEST_ENVIRONMENT_KEY"
 
     @staticmethod
     def validate(runtime_env_dict: dict) -> str:
-        value = runtime_env_dict["plugins"][MY_PLUGIN_CLASS_PATH]
+        value = runtime_env_dict[MY_PLUGIN_NAME]
         if value == "fail":
             raise ValueError("not allowed")
         return value
@@ -42,7 +44,14 @@ class MyPlugin(RuntimeEnvPlugin):
         )
 
 
-def test_simple_env_modification_plugin(ray_start_regular):
+@pytest.mark.parametrize(
+    "set_runtime_env_plugins",
+    [
+        MY_PLUGIN_CLASS_PATH,
+    ],
+    indirect=True,
+)
+def test_simple_env_modification_plugin(set_runtime_env_plugins, ray_start_regular):
     _, tmp_file_path = tempfile.mkstemp()
 
     @ray.remote
@@ -57,21 +66,19 @@ def test_simple_env_modification_plugin(ray_start_regular):
             "nice": psutil.Process().nice(),
         }
 
-    with pytest.raises(ValueError, match="not allowed"):
-        f.options(runtime_env={"plugins": {MY_PLUGIN_CLASS_PATH: "fail"}}).remote()
+    with pytest.raises(RuntimeEnvSetupError, match="not allowed"):
+        ray.get(f.options(runtime_env={MY_PLUGIN_NAME: "fail"}).remote())
 
     if os.name != "nt":
         output = ray.get(
             f.options(
                 runtime_env={
-                    "plugins": {
-                        MY_PLUGIN_CLASS_PATH: {
-                            "env_value": 42,
-                            "tmp_file": tmp_file_path,
-                            "tmp_content": "hello",
-                            # See https://en.wikipedia.org/wiki/Nice_(Unix)
-                            "prefix_command": "nice -n 19",
-                        }
+                    MY_PLUGIN_NAME: {
+                        "env_value": 42,
+                        "tmp_file": tmp_file_path,
+                        "tmp_content": "hello",
+                        # See https://en.wikipedia.org/wiki/Nice_(Unix)
+                        "prefix_command": "nice -n 19",
                     }
                 }
             ).remote()
@@ -81,11 +88,13 @@ def test_simple_env_modification_plugin(ray_start_regular):
 
 
 MY_PLUGIN_FOR_HANG_CLASS_PATH = "ray.tests.test_runtime_env_plugin.MyPluginForHang"
+MY_PLUGIN_FOR_HANG_NAME = "MyPluginForHang"
 my_plugin_setup_times = 0
 
 
 # This plugin will hang when first setup, second setup will ok
 class MyPluginForHang(RuntimeEnvPlugin):
+    name = MY_PLUGIN_FOR_HANG_NAME
     env_key = "MY_PLUGIN_FOR_HANG_TEST_ENVIRONMENT_KEY"
 
     @staticmethod
@@ -112,7 +121,14 @@ class MyPluginForHang(RuntimeEnvPlugin):
         ctx.env_vars[MyPluginForHang.env_key] = str(my_plugin_setup_times)
 
 
-def test_plugin_hang(ray_start_regular):
+@pytest.mark.parametrize(
+    "set_runtime_env_plugins",
+    [
+        MY_PLUGIN_FOR_HANG_CLASS_PATH,
+    ],
+    indirect=True,
+)
+def test_plugin_hang(set_runtime_env_plugins, ray_start_regular):
     env_key = MyPluginForHang.env_key
 
     @ray.remote(num_cpus=0.1)
@@ -122,11 +138,9 @@ def test_plugin_hang(ray_start_regular):
     refs = [
         f.options(
             # Avoid hitting the cache of runtime_env
-            runtime_env={"plugins": {MY_PLUGIN_FOR_HANG_CLASS_PATH: {"name": "f1"}}}
+            runtime_env={MY_PLUGIN_FOR_HANG_NAME: {"name": "f1"}}
         ).remote(),
-        f.options(
-            runtime_env={"plugins": {MY_PLUGIN_FOR_HANG_CLASS_PATH: {"name": "f2"}}}
-        ).remote(),
+        f.options(runtime_env={MY_PLUGIN_FOR_HANG_NAME: {"name": "f2"}}).remote(),
     ]
 
     def condition():
@@ -145,19 +159,26 @@ def test_plugin_hang(ray_start_regular):
 
 
 DUMMY_PLUGIN_CLASS_PATH = "ray.tests.test_runtime_env_plugin.DummyPlugin"
+DUMMY_PLUGIN_NAME = "DummyPlugin"
 HANG_PLUGIN_CLASS_PATH = "ray.tests.test_runtime_env_plugin.HangPlugin"
+HANG_PLUGIN_NAME = "HangPlugin"
 DISABLE_TIMEOUT_PLUGIN_CLASS_PATH = (
     "ray.tests.test_runtime_env_plugin.DiasbleTimeoutPlugin"
 )
+DISABLE_TIMEOUT_PLUGIN_NAME = "test_plugin_timeout"
 
 
 class DummyPlugin(RuntimeEnvPlugin):
+    name = DUMMY_PLUGIN_NAME
+
     @staticmethod
     def validate(runtime_env_dict: dict) -> str:
         return 1
 
 
 class HangPlugin(DummyPlugin):
+    name = HANG_PLUGIN_NAME
+
     def create(
         self, uri: str, runtime_env: "RuntimeEnv", ctx: RuntimeEnvContext  # noqa: F821
     ) -> float:
@@ -165,14 +186,25 @@ class HangPlugin(DummyPlugin):
 
 
 class DiasbleTimeoutPlugin(DummyPlugin):
+    name = DISABLE_TIMEOUT_PLUGIN_NAME
+
     def create(
         self, uri: str, runtime_env: "RuntimeEnv", ctx: RuntimeEnvContext  # noqa: F821
     ) -> float:
         sleep(10)
 
 
+@pytest.mark.parametrize(
+    "set_runtime_env_plugins",
+    [
+        f"{DUMMY_PLUGIN_CLASS_PATH},"
+        f"{HANG_PLUGIN_CLASS_PATH},"
+        f"{DISABLE_TIMEOUT_PLUGIN_CLASS_PATH}",
+    ],
+    indirect=True,
+)
 @pytest.mark.skipif(test_external_redis(), reason="Failing in redis mode.")
-def test_plugin_timeout(start_cluster):
+def test_plugin_timeout(set_runtime_env_plugins, start_cluster):
     @ray.remote(num_cpus=0.1)
     def f():
         return True
@@ -180,20 +212,14 @@ def test_plugin_timeout(start_cluster):
     refs = [
         f.options(
             runtime_env={
-                "plugins": {
-                    HANG_PLUGIN_CLASS_PATH: {"name": "f1"},
-                },
+                HANG_PLUGIN_NAME: {"name": "f1"},
                 "config": {"setup_timeout_seconds": 10},
             }
         ).remote(),
-        f.options(
-            runtime_env={"plugins": {DUMMY_PLUGIN_CLASS_PATH: {"name": "f2"}}}
-        ).remote(),
+        f.options(runtime_env={DUMMY_PLUGIN_NAME: {"name": "f2"}}).remote(),
         f.options(
             runtime_env={
-                "plugins": {
-                    HANG_PLUGIN_CLASS_PATH: {"name": "f3"},
-                },
+                HANG_PLUGIN_NAME: {"name": "f3"},
                 "config": {"setup_timeout_seconds": -1},
             }
         ).remote(),


### PR DESCRIPTION
## Why are these changes needed?

The first PR of runtime env plugin refactor. The prototype is https://github.com/ray-project/ray/pull/25387.
- Add a RuntimeEnvPluginManager which is used to load all the runtime env plugins when ray starts.
- Move the plugin field from nested "plugins" to outside.
- Use name of plugins in the user API, instead of class paths.

Before:
```
runtime_env={
    "plugins": {{"ray.tests.test_runtime_env_plugin.MyPlugin": "key": "value"}}
}
```
After:
```
runtime_env={
    "MyPlugin": {"key": "value"}
}
```