### PR TITLE
[RLlib] Small Ape-X deflake

### DIFF
--- a/rllib/algorithms/apex_dqn/tests/test_apex_dqn.py
+++ b/rllib/algorithms/apex_dqn/tests/test_apex_dqn.py
@@ -123,7 +123,7 @@ class TestApexDQN(unittest.TestCase):
                 lr_schedule=[[0, 0.2], [100, 0.001]],
             )
             .reporting(
-                min_sample_timesteps_per_iteration=10,
+                min_train_timesteps_per_iteration=10,
                 # 0 metrics reporting delay, this makes sure timestep,
                 # which lr depends on, is updated after each worker rollout.
                 min_time_s_per_iteration=0,

--- a/rllib/algorithms/apex_dqn/tests/test_apex_dqn.py
+++ b/rllib/algorithms/apex_dqn/tests/test_apex_dqn.py
@@ -130,21 +130,14 @@ class TestApexDQN(unittest.TestCase):
             )
         )
 
-        def _train_n_ts(trainer, n: int):
+        def _step_n_times(trainer, n: int):
             """Step trainer n times.
 
             Returns:
                 learning rate at the end of the execution.
             """
-            ts = 0
-            while ts < n:
+            for _ in range(n):
                 results = trainer.train()
-                ts += (
-                    results["info"][LEARNER_INFO]
-                    .get(DEFAULT_POLICY_ID, {})
-                    .get("num_agent_steps_trained", 0)
-                )
-
             return results["info"][LEARNER_INFO][DEFAULT_POLICY_ID][LEARNER_STATS_KEY][
                 "cur_lr"
             ]
@@ -152,11 +145,11 @@ class TestApexDQN(unittest.TestCase):
         for _ in framework_iterator(config):
             trainer = config.build(env="CartPole-v0")
 
-            lr = _train_n_ts(trainer, 50)
+            lr = _step_n_times(trainer, 3)  # 50 timesteps
             # Close to 0.2
             self.assertGreaterEqual(lr, 0.1)
 
-            lr = _train_n_ts(trainer, 200)
+            lr = _step_n_times(trainer, 20)  # 200 timesteps
             # LR Annealed to 0.001
             self.assertLessEqual(lr, 0.0011)
 


### PR DESCRIPTION
## Why are these changes needed?

The Ape-X LR unit test was [flakey on my latest (unrelated) PR](https://buildkite.com/ray-project/ray-builders-pr/builds/36541#018194bf-ecb8-4c52-a4e3-88db77810501).
This is because a training step may include only sample collection, but no training in this case. 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
