### PR TITLE
[Datasets] [Hotfix] Update `ds.to_pandas()` limit error to reflect current limit API

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2890,10 +2890,13 @@ class Dataset(Generic[T]):
             number of records.
         """
 
-        if self.count() > limit:
+        count = self.count()
+        if count > limit:
             raise ValueError(
-                "The dataset has more than the given limit of {} records. "
-                "Use ds.limit(N).to_pandas().".format(limit)
+                f"The dataset has more than the default limit of {limit} "
+                f"records: {count}. If you are sure that a DataFrame with "
+                f"{count} rows will fit in local memory, use "
+                f"ds.to_pandas(limit={count})."
             )
         blocks = self.get_internal_block_refs()
         output = DelegatingBlockBuilder()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2893,7 +2893,7 @@ class Dataset(Generic[T]):
         count = self.count()
         if count > limit:
             raise ValueError(
-                f"The dataset has more than the default limit of {limit} "
+                f"The dataset has more than the given limit of {limit} "
                 f"records: {count}. If you are sure that a DataFrame with "
                 f"{count} rows will fit in local memory, use "
                 f"ds.to_pandas(limit={count})."


### PR DESCRIPTION
This PR is a hotfix updating the `ds.to_pandas()` limit error to reflect the current limit API in `to_pandas()`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
