### PR TITLE
Enable isort for base directory

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,11 +10,11 @@ float_to_top=True
 filter_files=True
 
 # Skip docs/* as these are carefully crafted and aren't strictly code.
-# Skip python/ray/*.py to avoid touching python/ray/__init__.py, which
-# is also carefully crafted.
+# Skip python/ray/__init__.py and python/ray/setup-dev.py, which
+# are also carefully crafted.
 # For the rest we will gradually remove them from the blacklist as we
 # reformat the code to follow the style guide.
-skip_glob=python/ray/*.py,doc/*,ci/*,python/ray/_raylet*,python/ray/_private/*,python/ray/air/*,python/ray/cloudpickle/*,python/ray/core/*,dashboard/*,python/ray/data/*,python/ray/experimental/*,python/ray/includes/*,python/ray/internal/*,python/ray/ray_operator/*,python/ray/scripts/*,python/ray/serve/*,python/ray/sgd/*,python/ray/streaming/*,python/ray/tests/*,python/ray/tests/*,python/ray/train/*,python/ray/tune/*,python/ray/util/*,python/ray/workers/*,python/ray/workflow/*,rllib/*,release/*,
+skip_glob=python/ray/__init__.py,python/ray/setup-dev.py,python/ray/dag/*.py,doc/*,ci/*,python/ray/_raylet*,python/ray/_private/*,python/ray/air/*,python/ray/cloudpickle/*,python/ray/core/*,dashboard/*,python/ray/data/*,python/ray/experimental/*,python/ray/includes/*,python/ray/internal/*,python/ray/ray_operator/*,python/ray/scripts/*,python/ray/serve/*,python/ray/sgd/*,python/ray/streaming/*,python/ray/tests/*,python/ray/tests/*,python/ray/train/*,python/ray/tune/*,python/ray/util/*,python/ray/workers/*,python/ray/workflow/*,rllib/*,release/*,
 
 known_local_folder=ray
 known_afterray=psutil,setproctitle

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -3,7 +3,6 @@ from traceback import format_exception
 from typing import Optional, Union
 
 import colorama
-import setproctitle
 
 import ray._private.ray_constants as ray_constants
 import ray.cloudpickle as pickle
@@ -16,6 +15,8 @@ from ray.core.generated.common_pb2 import (
     RayException,
 )
 from ray.util.annotations import DeveloperAPI, PublicAPI
+
+import setproctitle
 
 
 @PublicAPI

--- a/python/ray/job_submission/__init__.py
+++ b/python/ray/job_submission/__init__.py
@@ -1,4 +1,4 @@
+from ray.dashboard.modules.job.common import JobInfo, JobStatus
 from ray.dashboard.modules.job.sdk import JobSubmissionClient
-from ray.dashboard.modules.job.common import JobStatus, JobInfo
 
 __all__ = ["JobSubmissionClient", "JobStatus", "JobInfo"]


### PR DESCRIPTION
## Why are these changes needed?

Remove  base dir : 'python/ray/*.py' from the isort blacklist. This is needed so it will run isort on subdirectories under python/ray, and allow us to start enabling isort for subdirectories 

## Related issue number

https://github.com/ray-project/ray/pull/25678

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [] Release tests
   - [] This PR is not tested :(
