### PR TITLE
Add back ray.state in deprecation wrapper; print stack trace on warning

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -191,7 +191,6 @@ class _DeprecationWrapper(object):
                 f"DeprecationWarning: `ray.{self._name}.{attr}` is a private "
                 "attribute and access will be removed in a future Ray version."
             )
-            assert False
         return value
 
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -198,6 +198,7 @@ class _DeprecationWrapper(object):
 worker = _DeprecationWrapper("worker", ray._private.worker)
 ray_constants = _DeprecationWrapper("ray_constants", ray._private.ray_constants)
 serialization = _DeprecationWrapper("serialization", ray._private.serialization)
+state = _DeprecationWrapper("state", ray._private.state)
 
 __all__ = [
     "__version__",

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -201,6 +201,7 @@ class _DeprecationWrapper(object):
 worker = _DeprecationWrapper("worker", ray._private.worker)
 ray_constants = _DeprecationWrapper("ray_constants", ray._private.ray_constants)
 serialization = _DeprecationWrapper("serialization", ray._private.serialization)
+state = _DeprecationWrapper("state", ray._private.state)
 
 __all__ = [
     "__version__",

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -191,6 +191,7 @@ class _DeprecationWrapper(object):
                 f"DeprecationWarning: `ray.{self._name}.{attr}` is a private "
                 "attribute and access will be removed in a future Ray version."
             )
+            assert False
         return value
 
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -184,14 +184,15 @@ class _DeprecationWrapper(object):
         self._warned = set()
 
     def __getattr__(self, attr):
-        import traceback
-
         value = getattr(self._real_worker, attr)
         if attr not in self._warned:
+            import traceback
+
             self._warned.add(attr)
             logger.warning(
                 f"DeprecationWarning: `ray.{self._name}.{attr}` is a private "
-                "attribute and access will be removed in a future Ray version.")
+                "attribute and access will be removed in a future Ray version."
+            )
             traceback.print_stack()
         return value
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -184,13 +184,15 @@ class _DeprecationWrapper(object):
         self._warned = set()
 
     def __getattr__(self, attr):
+        import traceback
+
         value = getattr(self._real_worker, attr)
         if attr not in self._warned:
             self._warned.add(attr)
             logger.warning(
                 f"DeprecationWarning: `ray.{self._name}.{attr}` is a private "
-                "attribute and access will be removed in a future Ray version."
-            )
+                "attribute and access will be removed in a future Ray version.")
+            traceback.print_stack()
         return value
 
 
@@ -198,7 +200,6 @@ class _DeprecationWrapper(object):
 worker = _DeprecationWrapper("worker", ray._private.worker)
 ray_constants = _DeprecationWrapper("ray_constants", ray._private.ray_constants)
 serialization = _DeprecationWrapper("serialization", ray._private.serialization)
-state = _DeprecationWrapper("state", ray._private.state)
 
 __all__ = [
     "__version__",

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -220,7 +220,7 @@ def _put_library_usage(library_usage: str):
     # Record the library usage to the temp (e.g., /tmp/ray) folder.
     # Note that although we always write this file, it is not
     # reported when the usage stats is disabled.
-    if ray.worker.global_worker.mode == ray.SCRIPT_MODE:
+    if ray._private.worker.global_worker.mode == ray.SCRIPT_MODE:
         try:
             lib_usage_recorder = LibUsageRecorder(ray._private.utils.get_ray_temp_dir())
             lib_usage_recorder.put_lib_usage(library_usage)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A couple users have complained about `ray.state` vanishing, so add it back as soft deprecated in 2.0.