### PR TITLE
[Serve] Remove extraneous `serve.start()` in `run_graph()` task

### DIFF
--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -585,7 +585,6 @@ def run_graph(
             app.deployments[name].set_options(**options)
 
         # Run the graph locally on the cluster
-        serve.start()
         serve.run(app)
     except KeyboardInterrupt:
         # Error is raised when this task is canceled with ray.cancel(), which


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `run_graph()` task has been manually starting Serve with `serve.start()` to forcibly select the `"serve"` namespace. However, #25575 made all Serve actors start in the `"serve"` namespace, meaning this call is extraneous. `serve.run()` will call `serve.start()` anyways. This change removes `serve.start()` from the `run_graph()` task.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
