### PR TITLE
[Core] install jemalloc in Ray docker and use jemalloc in `benchmark` release tests

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -30,6 +30,7 @@ ENV HOME=/home/ray
 RUN sudo apt-get update -y && sudo apt-get upgrade -y \
     && sudo apt-get install -y \
         git \
+        libjemalloc-dev \
         wget \
         cmake \
         g++ \ 

--- a/release/benchmarks/app_config.yaml
+++ b/release/benchmarks/app_config.yaml
@@ -1,5 +1,5 @@
 base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
-env_vars: {}
+env_vars: {"LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so"}
 
 python:
   pip_packages: []

--- a/release/benchmarks/app_config.yaml
+++ b/release/benchmarks/app_config.yaml
@@ -1,6 +1,9 @@
 base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_GPU"] | default("anyscale/ray-ml:nightly-py37-gpu") }}
 env_vars: {"LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so"}
 
+debian_packages:
+- libjemalloc-dev
+
 python:
   pip_packages: []
   conda_packages: []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are mysterious memory usage growth in Ray clusters that disappear when running with `jemalloc`. Before we are able to figure out the root cause, it seems using `jemalloc` by default can be a good walkaround. Because of its efficiency, using `jemalloc` by default can be beneficial, but we need to run more benchmarks to verify.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
