### PR TITLE
[Datasets] [GitHub] Adds GitHub Action for adding Datasets-labeled issues to Data Team project

### DIFF
--- a/.github/workflows/data_team_project.yml
+++ b/.github/workflows/data_team_project.yml
@@ -1,0 +1,20 @@
+name: Adds issues with "datasets" label to Data Team GitHub project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add Datasets issues to Data Team project
+    runs-on: ubuntu-latest
+    permissions:
+      repository-projects: write
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/ray-project/projects/31
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          labeled: datasets


### PR DESCRIPTION
This PR adds a [GitHub Action](https://github.com/marketplace/actions/add-to-github-projects-beta) that adds `datasets`-labeled issues (upon opening/labeling) to the Data Team's GitHub project. This should obviate the need for manual issue adding to the project before the start of each sprint.
