### PR TITLE
Fix file_system_monitor.cc message

### DIFF
--- a/src/ray/common/file_system_monitor.cc
+++ b/src/ray/common/file_system_monitor.cc
@@ -105,6 +105,7 @@ bool FileSystemMonitor::OverCapacityImpl(
   RAY_LOG_EVERY_MS(ERROR, 10 * 1000)
       << path << " is over " << capacity_threshold_ * 100
       << "\% full, available space: " << space_info->available
+      << "; capacity: " << space_info->capacity
       << ". Object creation will fail if spilling is required.";
   return true;
 }

--- a/src/ray/common/file_system_monitor.cc
+++ b/src/ray/common/file_system_monitor.cc
@@ -103,7 +103,7 @@ bool FileSystemMonitor::OverCapacityImpl(
   }
 
   RAY_LOG_EVERY_MS(ERROR, 10 * 1000)
-      << path << " is over " << capacity_threshold_
+      << path << " is over " << capacity_threshold_ * 100
       << "\% full, available space: " << space_info->available
       << ". Object creation will fail if spilling is required.";
   return true;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

I'm seeing these errors

```
(raylet, ip=172.31.58.175) [2022-06-28 03:48:42,324 E 702775 702805] (raylet) file_system_monitor.cc:105: /mnt/data0/ray is over 0.95% full, available space: 50637901824. Object creation will fail if spilling is required.
```

They should be `95%` instead of `0.95%`.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

@scv119