### PR TITLE
[Java] Allow to specify zero CPU as resource.

### DIFF
--- a/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
@@ -13,10 +13,10 @@ public abstract class BaseTaskOptions implements Serializable {
 
   public BaseTaskOptions(Map<String, Double> resources) {
     for (Map.Entry<String, Double> entry : resources.entrySet()) {
-      if (entry.getValue() == null || entry.getValue().compareTo(0.0) <= 0) {
+      if (entry.getValue() == null || entry.getValue().compareTo(0.0) < 0) {
         throw new IllegalArgumentException(
             String.format(
-                "Resource values should be " + "positive. Specified resource: %s = %s.",
+                "Resource values should be " + "non negative. Specified resource: %s = %s.",
                 entry.getKey(), entry.getValue()));
       }
       // Note: A resource value should be an integer if it is greater than 1.0.

--- a/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
+++ b/java/api/src/main/java/io/ray/api/options/BaseTaskOptions.java
@@ -30,6 +30,12 @@ public abstract class BaseTaskOptions implements Serializable {
                 entry.getKey(), entry.getValue()));
       }
     }
-    this.resources.putAll(resources);
+    /// Filter 0 resources
+    resources.forEach(
+        (key, value) -> {
+          if (value != 0) {
+            this.resources.put(key, value);
+          }
+        });
   }
 }

--- a/java/test/src/main/java/io/ray/test/BaseTaskOptionsTest.java
+++ b/java/test/src/main/java/io/ray/test/BaseTaskOptionsTest.java
@@ -28,7 +28,7 @@ public class BaseTaskOptionsTest {
     new MockActorCreationOptions(resources);
   }
 
-  @Test(expectedExceptions = {IllegalArgumentException.class})
+  @Test
   public void testIllegalResourcesWithZeroValue() {
     Map<String, Double> resources = ImmutableMap.of("CPU", 0.0);
     new MockActorCreationOptions(resources);

--- a/java/test/src/main/java/io/ray/test/ResourcesManagementTest.java
+++ b/java/test/src/main/java/io/ray/test/ResourcesManagementTest.java
@@ -1,12 +1,10 @@
 package io.ray.test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.ray.api.ActorHandle;
 import io.ray.api.ObjectRef;
 import io.ray.api.Ray;
 import io.ray.api.WaitResult;
-import io.ray.api.options.CallOptions;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,15 +45,6 @@ public class ResourcesManagementTest extends BaseTest {
 
     Assert.assertEquals(1, waitResult.getReady().size());
     Assert.assertEquals(0, waitResult.getUnready().size());
-
-    try {
-      CallOptions callOptions3 =
-          new CallOptions.Builder().setResources(ImmutableMap.of("CPU", 0.0)).build();
-      Assert.fail();
-    } catch (RuntimeException e) {
-      // We should receive a RuntimeException indicates that we should not
-      // pass a zero capacity resource.
-    }
   }
 
   public void testActors() {
@@ -77,6 +66,12 @@ public class ResourcesManagementTest extends BaseTest {
 
   public void testSpecifyZeroCPU() {
     ActorHandle<Echo> echo = Ray.actor(Echo::new).setResource("CPU", 0.0).remote();
+    final ObjectRef<Integer> result1 = echo.task(Echo::echo, 100).remote();
+    Assert.assertEquals(100, (int) result1.get());
+  }
+
+  public void testSpecifyZeroCustomResource() {
+    ActorHandle<Echo> echo = Ray.actor(Echo::new).setResource("A", 0.0).remote();
     final ObjectRef<Integer> result1 = echo.task(Echo::echo, 100).remote();
     Assert.assertEquals(100, (int) result1.get());
   }

--- a/java/test/src/main/java/io/ray/test/ResourcesManagementTest.java
+++ b/java/test/src/main/java/io/ray/test/ResourcesManagementTest.java
@@ -74,4 +74,10 @@ public class ResourcesManagementTest extends BaseTest {
     Assert.assertEquals(0, waitResult.getReady().size());
     Assert.assertEquals(1, waitResult.getUnready().size());
   }
+
+  public void testSpecifyZeroCPU() {
+    ActorHandle<Echo> echo = Ray.actor(Echo::new).setResource("CPU", 0.0).remote();
+    final ObjectRef<Integer> result1 = echo.task(Echo::echo, 100).remote();
+    Assert.assertEquals(100, (int) result1.get());
+  }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is aligned to the behavior of Python resources validation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
