### PR TITLE
[Test] Fixed the `test_state_api_log` failure in the master

### DIFF
--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -363,7 +363,7 @@ async def test_logs_manager_stream_log(logs_manager):
         keep_alive=True,
         lines=10,
         interval=0.5,
-        timeout=30,
+        timeout=None,
     )
 
     # Currently cannot test actor_id with AsyncMock.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes this (timeout should be None since we remove timeout when media_type==stream)

<img width="471" alt="Screen Shot 2022-06-28 at 8 44 13 AM" src="https://user-images.githubusercontent.com/18510752/176222880-b0bb053b-fa37-4e3d-af46-05cb4b66b85c.png">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
