### PR TITLE
[Core] use jemalloc for shuffle nightly tests

### DIFF
--- a/release/nightly_tests/shuffle/shuffle_app_config.yaml
+++ b/release/nightly_tests/shuffle/shuffle_app_config.yaml
@@ -1,5 +1,8 @@
 base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py37") }}
-debian_packages: []
+env_vars: {"LD_PRELOAD": "/usr/lib/x86_64-linux-gnu/libjemalloc.so"}
+
+debian_packages:
+- libjemalloc-dev
 
 python:
   pip_packages: []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Switching to `jemalloc` makes `scheduling_test_many_0s_tasks_many_nodes` pass consistently: https://buildkite.com/ray-project/release-tests-branch/builds/723
 Some shuffle tests see similar symptoms where one Raylet among all has unexpected memory usage growth. Test out using `jemalloc` for shuffle nightly tests to see if stability can be improved.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#25163
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
