### PR TITLE
[client] Fix ignore_reinit_error behavior in ray client

### DIFF
--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -840,6 +840,19 @@ def test_large_remote_call(ray_start_regular_shared):
         assert ray.get(a.some_method.remote(large_obj))
 
 
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25554 --num-cpus 1"],
+    indirect=True,
+)
+def test_ignore_reinit(call_ray_start):
+    import ray
+
+    ctx1 = ray.init("ray://localhost:25554")
+    ctx2 = ray.init("ray://localhost:25554", ignore_reinit_error=True)
+    assert ctx1 == ctx2
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/util/client_connect.py
+++ b/python/ray/util/client_connect.py
@@ -36,7 +36,10 @@ def connect(
     if ray.is_connected():
         ignore_reinit_error = ray_init_kwargs.get("ignore_reinit_error", False)
         if ignore_reinit_error:
-            logger.info("Calling ray.init() again after it has already been called.")
+            logger.info(
+                "Calling ray.init() again after it has already been called. "
+                "Reusing the existing Ray client connection."
+            )
             return ray.get_context().client_worker.connection_info()
         raise RuntimeError(
             "Ray Client is already connected. Maybe you called "

--- a/python/ray/util/client_connect.py
+++ b/python/ray/util/client_connect.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional, Tuple
+import logging
 
 import grpc
 
@@ -10,6 +11,8 @@ from ray.job_config import JobConfig
 from ray.util.annotations import Deprecated
 from ray.util.client import ray
 from ray._private.utils import get_ray_doc_version
+
+logger = logging.getLogger(__name__)
 
 
 @Deprecated(
@@ -31,6 +34,10 @@ def connect(
     ray_init_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     if ray.is_connected():
+        ignore_reinit_error = ray_init_kwargs.get("ignore_reinit_error", False)
+        if ignore_reinit_error:
+            logger.info("Calling ray.init() again after it has already been called.")
+            return ray.get_context().client_worker.connection_info()
         raise RuntimeError(
             "Ray Client is already connected. Maybe you called "
             'ray.init("ray://<address>") twice by accident?'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray client currently errors on reinit even if ignore_reinit_error is set.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #24888

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
