### PR TITLE
[air] update DummyTrainer to handle DatasetPipelines

### DIFF
--- a/doc/source/ray-air/doc_code/air_ingest.py
+++ b/doc/source/ray-air/doc_code/air_ingest.py
@@ -25,7 +25,7 @@ trainer = DummyTrainer(
     scaling_config={"num_workers": 1, "use_gpu": False},
     datasets={"train": dataset},
     preprocessor=preprocessor,
-    runtime_seconds=1,  # Stop after this amount or time or 1 epoch is read.
+    num_epochs=1,  # Stop after this number of epochs is read.
     prefetch_blocks=1,  # Number of blocks to prefetch when reading data.
     batch_size=None,  # Use whole blocks as batches.
 )

--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -140,12 +140,18 @@ if __name__ == "__main__":
         "--num-epochs", "-e", type=int, default=1, help="Number of epochs to read."
     )
     parser.add_argument(
-        "--prefetch-blocks", "-b", type=int, default=1, help="Number of blocks to prefetch when reading data."
+        "--prefetch-blocks",
+        "-b",
+        type=int,
+        default=1,
+        help="Number of blocks to prefetch when reading data.",
     )
 
     parser.add_argument(
-        "--use-stream-api", "-s", action="store_true",
-        help="If enabled, the input Dataset will be streamed (as a DatasetPipeline)."
+        "--use-stream-api",
+        "-s",
+        action="store_true",
+        help="If enabled, the input Dataset will be streamed (as a DatasetPipeline).",
     )
     args = parser.parse_args()
 

--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -144,7 +144,8 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--use-stream-api", "-s", action="store_true", help="Number of blocks to prefetch when reading data."
+        "--use-stream-api", "-s", action="store_true",
+        help="If enabled, the input Dataset will be streamed (as a DatasetPipeline)."
     )
     args = parser.parse_args()
 

--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -2,13 +2,14 @@
 
 import sys
 import time
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 import ray
 from ray import train
 from ray.air.config import DatasetConfig
+from ray.data import DatasetPipeline, Dataset
 from ray.data.preprocessors import BatchMapper, Chain
 from ray.train.data_parallel_trainer import DataParallelTrainer
 from ray.util.annotations import DeveloperAPI
@@ -16,7 +17,7 @@ from ray.util.annotations import DeveloperAPI
 
 @DeveloperAPI
 class DummyTrainer(DataParallelTrainer):
-    """A Trainer that does nothing except read the data for a given period of time.
+    """A Trainer that does nothing except read the data for a given number of epochs.
 
     It prints out as much debugging statistics as possible.
 
@@ -28,7 +29,7 @@ class DummyTrainer(DataParallelTrainer):
         self,
         *args,
         scaling_config: dict = None,
-        runtime_seconds: int = 30,
+        num_epochs: int = 1,
         prefetch_blocks: int = 1,
         batch_size: Optional[int] = None,
         **kwargs
@@ -37,7 +38,7 @@ class DummyTrainer(DataParallelTrainer):
             scaling_config = {"num_workers": 1}
         super().__init__(
             train_loop_per_worker=DummyTrainer.make_train_loop(
-                runtime_seconds, prefetch_blocks, batch_size
+                num_epochs, prefetch_blocks, batch_size
             ),
             *args,
             scaling_config=scaling_config,
@@ -59,9 +60,9 @@ class DummyTrainer(DataParallelTrainer):
 
     @staticmethod
     def make_train_loop(
-        runtime_seconds: int, prefetch_blocks: int, batch_size: Optional[int]
+        num_epochs: int, prefetch_blocks: int, batch_size: Optional[int]
     ):
-        """Make a debug train loop that runs for the given amount of runtime."""
+        """Make a debug train loop that runs for the given amount of epochs."""
 
         def train_loop_per_worker():
             import pandas as pd
@@ -69,33 +70,42 @@ class DummyTrainer(DataParallelTrainer):
             rank = train.world_rank()
             data_shard = train.get_dataset_shard("train")
             start = time.perf_counter()
-            num_epochs, num_batches, num_bytes = 0, 0, 0
+            epochs_read, batches_read, bytes_read = 0, 0, 0
             batch_delays = []
 
+            def generate_epochs(data: Union[Dataset, DatasetPipeline], epochs: int):
+                if isinstance(data, DatasetPipeline):
+                    for epoch in data_shard.iter_epochs(epochs):
+                        yield epoch
+                else:
+                    # Dataset
+                    for _ in range(epochs):
+                        yield data
+
             print("Starting train loop on worker", rank)
-            while time.perf_counter() - start < runtime_seconds:
-                num_epochs += 1
+            for epoch_data in generate_epochs(data_shard, num_epochs):
+                epochs_read += 1
                 batch_start = time.perf_counter()
-                for batch in data_shard.iter_batches(
+                for batch in epoch_data.iter_batches(
                     prefetch_blocks=prefetch_blocks, batch_size=batch_size
                 ):
                     batch_delay = time.perf_counter() - batch_start
                     batch_delays.append(batch_delay)
-                    num_batches += 1
+                    batches_read += 1
                     if isinstance(batch, pd.DataFrame):
-                        num_bytes += int(
+                        bytes_read += int(
                             batch.memory_usage(index=True, deep=True).sum()
                         )
                     elif isinstance(batch, np.ndarray):
-                        num_bytes += batch.nbytes
+                        bytes_read += batch.nbytes
                     else:
                         # NOTE: This isn't recursive and will just return the size of
                         # the object pointers if list of non-primitive types.
-                        num_bytes += sys.getsizeof(batch)
+                        bytes_read += sys.getsizeof(batch)
                     train.report(
-                        bytes_read=num_bytes,
-                        num_batches=num_batches,
-                        num_epochs=num_epochs,
+                        bytes_read=bytes_read,
+                        batches_read=batches_read,
+                        epochs_read=epochs_read,
                         batch_delay=batch_delay,
                     )
                     batch_start = time.perf_counter()
@@ -108,11 +118,11 @@ class DummyTrainer(DataParallelTrainer):
                 np.quantile(batch_delays, 0.95),
                 np.max(batch_delays),
             )
-            print("Num epochs read", num_epochs)
-            print("Num batches read", num_batches)
-            print("Num bytes read", round(num_bytes / (1024 * 1024), 2), "MiB")
+            print("Num epochs read", epochs_read)
+            print("Num batches read", batches_read)
+            print("Num bytes read", round(bytes_read / (1024 * 1024), 2), "MiB")
             print(
-                "Mean throughput", round(num_bytes / (1024 * 1024) / delta, 2), "MiB/s"
+                "Mean throughput", round(bytes_read / (1024 * 1024) / delta, 2), "MiB/s"
             )
 
             if rank == 0:
@@ -122,9 +132,25 @@ class DummyTrainer(DataParallelTrainer):
 
 
 if __name__ == "__main__":
+
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--num-epochs", "-e", type=int, default=1, help="Number of epochs to read."
+    )
+    parser.add_argument(
+        "--prefetch-blocks", "-b", type=int, default=1, help="Number of blocks to prefetch when reading data."
+    )
+
+    parser.add_argument(
+        "--use-stream-api", "-s", action="store_true", help="Number of blocks to prefetch when reading data."
+    )
+    args = parser.parse_args()
+
     # Generate a synthetic dataset of ~10GiB of float64 data. The dataset is sharded
     # into 100 blocks (parallelism=100).
-    dataset = ray.data.range_tensor(50000, shape=(80, 80, 4), parallelism=100)
+    dataset = ray.data.range_tensor(5000, shape=(80, 80, 4), parallelism=100)
 
     # An example preprocessor chain that just scales all values by 4.0 in two stages.
     preprocessor = Chain(
@@ -138,9 +164,9 @@ if __name__ == "__main__":
         scaling_config={"num_workers": 1, "use_gpu": False},
         datasets={"train": dataset},
         preprocessor=preprocessor,
-        runtime_seconds=30,  # Stop after this amount or time or 1 epoch is read.
-        prefetch_blocks=1,  # Number of blocks to prefetch when reading data.
-        dataset_config={"valid": DatasetConfig(transform=False)},
+        num_epochs=args.num_epochs,
+        prefetch_blocks=args.prefetch_blocks,
+        dataset_config={"train": DatasetConfig(use_stream_api=args.use_stream_api)},
         batch_size=None,
     )
     print("Dataset config", trainer.get_dataset_config())

--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
 
     # Generate a synthetic dataset of ~10GiB of float64 data. The dataset is sharded
     # into 100 blocks (parallelism=100).
-    dataset = ray.data.range_tensor(5000, shape=(80, 80, 4), parallelism=100)
+    dataset = ray.data.range_tensor(50000, shape=(80, 80, 4), parallelism=100)
 
     # An example preprocessor chain that just scales all values by 4.0 in two stages.
     preprocessor = Chain(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

1. Update `DummyTrainer` to take `num_epochs` instead of `runtime_seconds`.
    1. Ray Train expects equal number of calls to `train.report()`. Different workers may run at different speeds and terminate after different epoch numbers, which causes an error.
2. Add `generate_epochs` to support `DatasetPipeline` when `use_stream_api` is True.
3. Update `__main__` code to support testing different configurations.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
