### PR TITLE
[Serve] Disable `test_serve_head.py` on OSX

### DIFF
--- a/dashboard/modules/serve/tests/test_serve_head.py
+++ b/dashboard/modules/serve/tests/test_serve_head.py
@@ -34,6 +34,7 @@ def deploy_and_check_config(config: Dict):
     print("GET request returned correct config.")
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")
 def test_put_get(ray_start_stop):
     config1 = {
         "import_path": (
@@ -99,6 +100,7 @@ def test_put_get(ray_start_stop):
         print("Deployments are live and reachable over HTTP.\n")
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")
 def test_delete(ray_start_stop):
     config = {
         "import_path": "dir.subdir.a.add_and_sub.serve_dag",
@@ -164,6 +166,7 @@ def test_delete(ray_start_stop):
         print("Deployments have been deleted and are not reachable.\n")
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")
 def test_get_status(ray_start_stop):
     print("Checking status info before any deployments.")
 
@@ -213,6 +216,7 @@ def test_get_status(ray_start_stop):
     print("Serve app status is correct.")
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")
 def test_serve_namespace(ray_start_stop):
     """
     Check that the Dashboard's Serve can interact with the Python API


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_serve_head.py` has been very flaky recently on OSX, so this change disables it there:

<img width="1332" alt="Screen Shot 2022-06-28 at 5 31 39 PM" src="https://user-images.githubusercontent.com/92341594/176326424-e8f957ec-4b14-4ce5-9315-9443d88472fc.png">

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
