### PR TITLE
Revert "[tune] fix stacktrace."

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -225,10 +225,7 @@ def run_string_as_driver(driver_script: str, env: Dict = None, encode: str = "ut
         if proc.returncode:
             print(ray._private.utils.decode(output, encode_type=encode))
             raise subprocess.CalledProcessError(
-                proc.returncode,
-                proc.args,
-                ray._private.utils.decode(output, encode_type=encode),
-                proc.stderr,
+                proc.returncode, proc.args, output, proc.stderr
             )
         out = ray._private.utils.decode(output, encode_type=encode)
     return out

--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -914,10 +914,10 @@ class TrialRunner:
     def _on_executor_error(self, trial, e: Union[RayTaskError, TuneError]):
         error_msg = f"Trial {trial}: Error processing event."
         if self._fail_fast == TrialRunner.RAISE:
-            logger.error(error_msg, exc_info=e)
+            logger.error(error_msg)
             raise e
         else:
-            logger.exception(error_msg, exc_info=e)
+            logger.exception(error_msg)
             self._process_trial_failure(trial, exc=e)
 
     def get_trial(self, tid):

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -1,10 +1,8 @@
 # coding: utf-8
 import signal
-import subprocess
 from collections import Counter
 import multiprocessing
 import os
-import pytest
 import shutil
 import tempfile
 import threading
@@ -14,7 +12,7 @@ import unittest
 
 import ray
 from ray import tune
-from ray._private.test_utils import recursive_fnmatch, run_string_as_driver
+from ray._private.test_utils import recursive_fnmatch
 from ray.exceptions import RayTaskError
 from ray.rllib import _register_all
 from ray.tune import TuneError
@@ -572,26 +570,8 @@ class ResourceExhaustedTest(unittest.TestCase):
             tune.run(training_func)
 
 
-def test_stacktrace():
-    """Test proper stacktrace is printed for RayTaskError."""
-    CMD = """
-from ray import tune
-
-def train(config):
-    raise Exception("Inducing exception for testing purposes.")
-
-tune.run(train, num_samples=1)
-    """
-    asserted = False
-    try:
-        run_string_as_driver(CMD)
-    except subprocess.CalledProcessError as e:
-        assert "Inducing exception for testing purposes." in e.output
-        asserted = True
-    assert asserted
-
-
 if __name__ == "__main__":
+    import pytest
     import sys
 
     sys.exit(pytest.main(["-v", __file__] + sys.argv[1:]))


### PR DESCRIPTION
Reverts ray-project/ray#26135

Looks like this breaks test_failure_4 and test_tls_auth.