### PR TITLE
[tune] revert change in `run_string_as_driver`

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -225,10 +225,7 @@ def run_string_as_driver(driver_script: str, env: Dict = None, encode: str = "ut
         if proc.returncode:
             print(ray._private.utils.decode(output, encode_type=encode))
             raise subprocess.CalledProcessError(
-                proc.returncode,
-                proc.args,
-                ray._private.utils.decode(output, encode_type=encode),
-                proc.stderr,
+                proc.returncode, proc.args, output, proc.stderr
             )
         out = ray._private.utils.decode(output, encode_type=encode)
     return out

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -582,13 +582,9 @@ def train(config):
 
 tune.run(train, num_samples=1)
     """
-    asserted = False
-    try:
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
         run_string_as_driver(CMD)
-    except subprocess.CalledProcessError as e:
-        assert "Inducing exception for testing purposes." in e.output
-        asserted = True
-    assert asserted
+    assert "Inducing exception for testing purposes." in exc_info.value.output.decode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This PR does the following:
1. revert the change in `run_string_as_driver`
2. instead, update `test_stacktrace` and do decoding in caller side.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
