### PR TITLE
[K8s][Ray Operator] Ignore resource requests when detected container resources.

### DIFF
--- a/python/ray/autoscaler/_private/_kubernetes/config.py
+++ b/python/ray/autoscaler/_private/_kubernetes/config.py
@@ -140,7 +140,7 @@ def get_autodetected_resources(container_data):
 def get_resource(container_resources, resource_name):
     request = _get_resource(container_resources, resource_name, field_name="requests")
     limit = _get_resource(container_resources, resource_name, field_name="limits")
-    resource = min(request, limit)
+    resource = max(request, limit)
     # float("inf") value means the resource wasn't detected in either
     # requests or limits
     return 0 if resource == float("inf") else int(resource)

--- a/python/ray/autoscaler/_private/_kubernetes/config.py
+++ b/python/ray/autoscaler/_private/_kubernetes/config.py
@@ -138,12 +138,9 @@ def get_autodetected_resources(container_data):
 
 
 def get_resource(container_resources, resource_name):
-    request = _get_resource(container_resources, resource_name, field_name="requests")
     limit = _get_resource(container_resources, resource_name, field_name="limits")
-    resource = max(request, limit)
-    # float("inf") value means the resource wasn't detected in either
-    # requests or limits
-    return 0 if resource == float("inf") else int(resource)
+    # float("inf") means there's no limit set
+    return 0 if limit == float("inf") else int(limit)
 
 
 def _get_resource(container_resources, resource_name, field_name):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://ray-distributed.slack.com/archives/CN2RGCHRR/p1656526649406509

When detecting resource capacities to advertise to Ray, the Ray operator takes into account requests. This doesn't make sense -- taking a min of resources and limits definitely doesn't make sense. Only limits should be considered. 

This PR modifies the code to only consider resource limits.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
