### PR TITLE
[release-tests][ci] Fix wait_cluster

### DIFF
--- a/release/ray_release/command_runner/_wait_cluster.py
+++ b/release/ray_release/command_runner/_wait_cluster.py
@@ -45,7 +45,7 @@ while not curr_nodes >= args.num_nodes:
         next_feedback = now + args.feedback_interval_s
 
     time.sleep(5)
-    curr_nodes = len(ray.nodes())
+    curr_nodes = sum(1 for node in ray.nodes() if node["Alive"])
 
 passed = time.time() - start
 print(

--- a/release/ray_release/command_runner/client_runner.py
+++ b/release/ray_release/command_runner/client_runner.py
@@ -64,7 +64,6 @@ class ClientRunner(CommandRunner):
         except Exception as e:
             raise LocalEnvSetupError(f"Error setting up local environment: {e}") from e
 
-
     def wait_for_nodes(self, num_nodes: int, timeout: float = 900):
         import ray
 

--- a/release/ray_release/command_runner/client_runner.py
+++ b/release/ray_release/command_runner/client_runner.py
@@ -64,6 +64,9 @@ class ClientRunner(CommandRunner):
         except Exception as e:
             raise LocalEnvSetupError(f"Error setting up local environment: {e}") from e
 
+    def _num_nodes(self):
+        return sum(1 for node in ray.nodes() if node["Alive"])
+
     def wait_for_nodes(self, num_nodes: int, timeout: float = 900):
         import ray
 
@@ -77,26 +80,26 @@ class ClientRunner(CommandRunner):
             start_time = time.monotonic()
             timeout_at = start_time + timeout
             next_status = start_time + 30
-            nodes_up = len(ray.nodes())
+            nodes_up = self._num_nodes()
             while nodes_up < num_nodes:
                 now = time.monotonic()
                 if now >= timeout_at:
                     raise ClusterNodesWaitTimeout(
-                        f"Only {len(ray.nodes())}/{num_nodes} are up after "
+                        f"Only {nodes_up}/{num_nodes} are up after "
                         f"{timeout} seconds."
                     )
 
                 if now >= next_status:
                     logger.info(
                         f"Waiting for nodes to come up: "
-                        f"{len(ray.nodes())}/{num_nodes} "
+                        f"{nodes_up}/{num_nodes} "
                         f"({now - start_time:.2f} seconds, "
                         f"timeout: {timeout} seconds)."
                     )
                     next_status += 30
 
                 time.sleep(1)
-                nodes_up = len(ray.nodes())
+                nodes_up = self._num_nodes()
 
             ray.shutdown()
         except Exception as e:

--- a/release/ray_release/command_runner/client_runner.py
+++ b/release/ray_release/command_runner/client_runner.py
@@ -64,8 +64,6 @@ class ClientRunner(CommandRunner):
         except Exception as e:
             raise LocalEnvSetupError(f"Error setting up local environment: {e}") from e
 
-    def _num_nodes(self):
-        return sum(1 for node in ray.nodes() if node["Alive"])
 
     def wait_for_nodes(self, num_nodes: int, timeout: float = 900):
         import ray
@@ -80,7 +78,7 @@ class ClientRunner(CommandRunner):
             start_time = time.monotonic()
             timeout_at = start_time + timeout
             next_status = start_time + 30
-            nodes_up = self._num_nodes()
+            nodes_up = sum(1 for node in ray.nodes() if node["Alive"])
             while nodes_up < num_nodes:
                 now = time.monotonic()
                 if now >= timeout_at:
@@ -99,7 +97,7 @@ class ClientRunner(CommandRunner):
                     next_status += 30
 
                 time.sleep(1)
-                nodes_up = self._num_nodes()
+                nodes_up = sum(1 for node in ray.nodes() if node["Alive"])
 
             ray.shutdown()
         except Exception as e:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a bug in wait_cluster where we count the total number of nodes ever in the cluster rather than the alive nodes. This has causes infra/autoscaler failures (e.g. #26138) to be mislabeled as test failures (and probably messes with timing too).


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
