### PR TITLE
[WIP] [Serve] Log warning when multiple deployments share the same `route_prefix`

### DIFF
--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -579,7 +579,7 @@ def run_graph(
 
         for route_prefix in route_prefixes:
             if len(route_prefixes[route_prefix]) > 1:
-                logger.warning(
+                raise ValueError(
                     "Got more than one deployment with route_prefix "
                     f'"{route_prefix}": {route_prefixes[route_prefix]}. '
                     "One of these deployments will be accessible at "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Serve allows users to specify duplicate `route_prefixes` for their deployments in their deployment graphs. This leads to undefined behavior since one of those deployments will be exposed on that `route_prefix`, but the other deployments won't be. This change logs a warning when the user specifies the same `route_prefix` for more than one deployment in their graph.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #26208.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
