### PR TITLE
[Core] [Prototype] Add max CPU cores allocatable per node for placement groups.

### DIFF
--- a/cpp/src/ray/runtime/task/native_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/native_task_submitter.cc
@@ -164,7 +164,8 @@ ray::PlacementGroup NativeTaskSubmitter::CreatePlacementGroup(
       create_options.name,
       (ray::core::PlacementStrategy)create_options.strategy,
       create_options.bundles,
-      false);
+      false,
+      0.0);
   ray::PlacementGroupID placement_group_id;
   auto status = CoreWorkerProcess::GetCoreWorker().CreatePlacementGroup(
       options, &placement_group_id);

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1659,7 +1659,8 @@ cdef class CoreWorker:
                             c_string name,
                             c_vector[unordered_map[c_string, double]] bundles,
                             c_string strategy,
-                            c_bool is_detached):
+                            c_bool is_detached,
+                            double max_cpu_fraction_per_node):
         cdef:
             CPlacementGroupID c_placement_group_id
             CPlacementStrategy c_strategy
@@ -1684,8 +1685,8 @@ cdef class CoreWorker:
                                 name,
                                 c_strategy,
                                 bundles,
-                                is_detached
-                            ),
+                                is_detached,
+                                max_cpu_fraction_per_node),
                             &c_placement_group_id))
 
         return PlacementGroupID(c_placement_group_id.Binary())

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -207,6 +207,21 @@ class ResourceDemandScheduler:
         # Step 3: get resource demands of placement groups and return the
         # groups that should be strictly spread.
         logger.debug(f"Placement group demands: {pending_placement_groups}")
+        # TODO(Clark): Refactor placement group bundle demands such that their placement
+        # group provenance is mantained, since we need to keep an accounting of the
+        # cumulative CPU cores allocated as fulfilled during bin packing in order to
+        # ensure that a placement group's cumulative allocation is under the placement
+        # group's max CPU fraction per node. Without this, and placement group with many
+        # bundles might not be schedulable, but will fail to trigger scale-up since the
+        # max CPU fraction is properly applied to the cumulative bundle requests for a
+        # single node.
+        #
+        # placement_group_demand_vector: List[Tuple[List[ResourceDict], double]]
+        #
+        # bin_pack_residual() can keep it's packing priority; we just need to account
+        # for (1) the running CPU allocation for the bundle's placement group for that
+        # particular node, and (2) the max CPU cores allocatable for a single placement
+        # group for that particular node.
         (
             placement_group_demand_vector,
             strict_spreads,
@@ -244,13 +259,16 @@ class ResourceDemandScheduler:
             node_resources,
             node_type_counts,
         ) = self.reserve_and_allocate_spread(
-            strict_spreads, node_resources, node_type_counts
+            strict_spreads,
+            node_resources,
+            node_type_counts,
         )
 
         # Calculate the nodes to add for bypassing max launch limit for
         # placement groups and spreads.
         unfulfilled_placement_groups_demands, _ = get_bin_pack_residual(
-            node_resources, placement_group_demand_vector
+            node_resources,
+            placement_group_demand_vector,
         )
         # Add 1 to account for the head node.
         max_to_add = self.max_workers + 1 - sum(node_type_counts.values())

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -288,7 +288,8 @@ cdef extern from "ray/core_worker/common.h" nogil:
             const c_string &name,
             CPlacementStrategy strategy,
             const c_vector[unordered_map[c_string, double]] &bundles,
-            c_bool is_detached
+            c_bool is_detached,
+            double max_cpu_fraction_per_node
         )
 
     cdef cppclass CObjectLocation "ray::core::ObjectLocation":

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -127,7 +127,8 @@ def placement_group(
     bundles: List[Dict[str, float]],
     strategy: str = "PACK",
     name: str = "",
-    lifetime=None,
+    lifetime: Optional[str] = None,
+    max_cpu_fraction_per_node: Optional[float] = None,
 ) -> PlacementGroup:
     """Asynchronously creates a PlacementGroup.
 
@@ -147,6 +148,12 @@ def placement_group(
             will fate share with its creator and will be deleted once its
             creator is dead, or "detached", which means the placement group
             will live as a global object independent of the creator.
+        max_cpu_fraction_per_node: The maximum fraction of CPU cores this placement
+            group can take up on each node. This must be a float between 0 and 1. If
+            provided, the placement group won't take up more than
+            max_cpu_fraction_per_node * node["num_cpus"] CPU cores on each node. This
+            is useful for ensuring that some percentage of CPU cores are available on
+            each node for workloads that aren't using this placement group.
 
     Raises:
         ValueError if bundle type is not a list.
@@ -161,6 +168,11 @@ def placement_group(
 
     if not isinstance(bundles, list):
         raise ValueError("The type of bundles must be list, got {}".format(bundles))
+
+    if max_cpu_fraction_per_node is None:
+        max_cpu_fraction_per_node = 1.0
+    if max_cpu_fraction_per_node < 0 or max_cpu_fraction_per_node > 1:
+        raise ValueError("max_cpu_fraction_per_node must be a float between 0 and 1.")
 
     # Validate bundles
     for bundle in bundles:
@@ -187,7 +199,11 @@ def placement_group(
         )
 
     placement_group_id = worker.core_worker.create_placement_group(
-        name, bundles, strategy, detached
+        name,
+        bundles,
+        strategy,
+        detached,
+        max_cpu_fraction_per_node,
     )
 
     return PlacementGroup(placement_group_id)

--- a/src/ray/common/placement_group.cc
+++ b/src/ray/common/placement_group.cc
@@ -44,4 +44,8 @@ BundleSpecification PlacementGroupSpecification::GetBundle(int position) const {
 std::string PlacementGroupSpecification::GetName() const {
   return std::string(message_->name());
 }
+
+double PlacementGroupSpecification::GetMaxCpuFractionPerNode() const {
+  return message_->max_cpu_fraction_per_node();
+}
 }  // namespace ray

--- a/src/ray/common/placement_group.h
+++ b/src/ray/common/placement_group.h
@@ -60,6 +60,8 @@ class PlacementGroupSpecification : public MessageWrapper<rpc::PlacementGroupSpe
   BundleSpecification GetBundle(int position) const;
   /// Return the name of this placement group.
   std::string GetName() const;
+  /// Return the max CPU fraction per node for this placement group.
+  double GetMaxCpuFractionPerNode() const;
 
  private:
   /// Construct bundle vector from protobuf.
@@ -82,6 +84,7 @@ class PlacementGroupSpecBuilder {
       const std::vector<std::unordered_map<std::string, double>> &bundles,
       const rpc::PlacementStrategy strategy,
       const bool is_detached,
+      double max_cpu_fraction_per_node,
       const JobID &creator_job_id,
       const ActorID &creator_actor_id,
       bool is_creator_detached_actor) {
@@ -99,6 +102,7 @@ class PlacementGroupSpecBuilder {
     message_->set_creator_actor_id(creator_actor_id.Binary());
     message_->set_creator_actor_dead(creator_actor_id.IsNil());
     message_->set_is_detached(is_detached);
+    message_->set_max_cpu_fraction_per_node(max_cpu_fraction_per_node);
 
     for (size_t i = 0; i < bundles.size(); i++) {
       auto resources = bundles[i];

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -167,11 +167,13 @@ struct PlacementGroupCreationOptions {
       std::string name,
       PlacementStrategy strategy,
       std::vector<std::unordered_map<std::string, double>> bundles,
-      bool is_detached)
+      bool is_detached,
+      double max_cpu_fraction_per_node)
       : name(std::move(name)),
         strategy(strategy),
         bundles(std::move(bundles)),
-        is_detached(is_detached) {}
+        is_detached(is_detached),
+        max_cpu_fraction_per_node(max_cpu_fraction_per_node) {}
 
   /// The name of the placement group.
   const std::string name;
@@ -181,6 +183,8 @@ struct PlacementGroupCreationOptions {
   const std::vector<std::unordered_map<std::string, double>> bundles;
   /// Whether to keep the placement group persistent after its creator dead.
   const bool is_detached = false;
+  /// The maximum fraction of CPU cores this placement group can take up on each node.
+  const double max_cpu_fraction_per_node = false;
 };
 
 class ObjectLocation {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1847,14 +1847,16 @@ Status CoreWorker::CreatePlacementGroup(
   }
   const PlacementGroupID placement_group_id = PlacementGroupID::Of(GetCurrentJobId());
   PlacementGroupSpecBuilder builder;
-  builder.SetPlacementGroupSpec(placement_group_id,
-                                placement_group_creation_options.name,
-                                placement_group_creation_options.bundles,
-                                placement_group_creation_options.strategy,
-                                placement_group_creation_options.is_detached,
-                                worker_context_.GetCurrentJobID(),
-                                worker_context_.GetCurrentActorID(),
-                                worker_context_.CurrentActorDetached());
+  builder.SetPlacementGroupSpec(
+      placement_group_id,
+      placement_group_creation_options.name,
+      placement_group_creation_options.bundles,
+      placement_group_creation_options.strategy,
+      placement_group_creation_options.is_detached,
+      placement_group_creation_options.max_cpu_fraction_per_node,
+      worker_context_.GetCurrentJobID(),
+      worker_context_.GetCurrentActorID(),
+      worker_context_.CurrentActorDetached());
   PlacementGroupSpecification placement_group_spec = builder.Build();
   *return_placement_group_id = placement_group_id;
   RAY_LOG(INFO) << "Submitting Placement Group creation to GCS: " << placement_group_id;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -117,6 +117,10 @@ bool GcsPlacementGroup::IsDetached() const {
   return placement_group_table_data_.is_detached();
 }
 
+double GcsPlacementGroup::GetMaxCpuFractionPerNode() const {
+  return placement_group_table_data_.max_cpu_fraction_per_node();
+}
+
 const rpc::PlacementGroupStats &GcsPlacementGroup::GetStats() const {
   return placement_group_table_data_.stats();
 }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -70,6 +70,8 @@ class GcsPlacementGroup {
     placement_group_table_data_.set_creator_actor_dead(
         placement_group_spec.creator_actor_dead());
     placement_group_table_data_.set_is_detached(placement_group_spec.is_detached());
+    placement_group_table_data_.set_max_cpu_fraction_per_node(
+        placement_group_spec.max_cpu_fraction_per_node());
     placement_group_table_data_.set_ray_namespace(ray_namespace);
     SetupStates();
   }
@@ -126,6 +128,9 @@ class GcsPlacementGroup {
 
   /// Returns whether or not this is a detached placement group.
   bool IsDetached() const;
+
+  /// Returns the maximum CPU fraction per node for this placement group.
+  double GetMaxCpuFractionPerNode() const;
 
   const rpc::PlacementGroupStats &GetStats() const;
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -66,6 +66,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
   auto scheduling_options =
       CreateSchedulingOptions(placement_group->GetPlacementGroupID(), strategy);
+  scheduling_options.cpu_frac_slack = 1.0 - placement_group->GetMaxCpuFractionPerNode();
   auto scheduling_result =
       cluster_resource_scheduler_.Schedule(resource_request_list, scheduling_options);
 
@@ -75,7 +76,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
   if (!result_status.IsSuccess()) {
     RAY_LOG(DEBUG) << "Failed to schedule placement group " << placement_group->GetName()
                    << ", id: " << placement_group->GetPlacementGroupID()
-                   << ", because current reource can't satisfy the required resource.";
+                   << ", because current resources can't satisfy the required resource.";
     bool infeasible = result_status.IsInfeasible();
     // If the placement group creation has failed,
     // but if it is not infeasible, it is retryable to create.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -374,6 +374,8 @@ message PlacementGroupSpec {
   bool creator_actor_dead = 8;
   // Whether the placement group is persistent.
   bool is_detached = 9;
+  // The maximum fraction of CPU cores that this placement group can use on each node.
+  double max_cpu_fraction_per_node = 10;
 }
 
 message ObjectReference {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -544,10 +544,12 @@ message PlacementGroupTableData {
   bool creator_actor_dead = 9;
   // Whether the placement group is persistent.
   bool is_detached = 10;
+  // The maximum fraction of CPU cores that this placement group can use on each node.
+  double max_cpu_fraction_per_node = 11;
   // The pg's namespace. Named `ray_namespace` to avoid confusions when invoked in c++.
-  string ray_namespace = 11;
+  string ray_namespace = 12;
   // The placement group's stats / information such as when it is created or
   // what's the current scheduling state.
-  PlacementGroupStats stats = 12;
+  PlacementGroupStats stats = 13;
 }
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
@@ -58,7 +58,8 @@ class BundleSchedulingPolicy : public IBundleSchedulingPolicy {
   /// \return Score of all nodes.
   std::pair<scheduling::NodeID, const Node *> GetBestNode(
       const ResourceRequest &required_resources,
-      const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes) const;
+      const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
+      const SchedulingOptions &options) const;
 
  protected:
   /// The cluster resource manager.

--- a/src/ray/raylet/scheduling/policy/scheduling_options.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_options.h
@@ -135,6 +135,7 @@ struct SchedulingOptions {
   std::shared_ptr<SchedulingContext> scheduling_context;
   std::string node_affinity_node_id;
   bool node_affinity_soft = false;
+  double cpu_frac_slack = 0.;
 
  private:
   SchedulingOptions(SchedulingType type,


### PR DESCRIPTION
Adds an option to the placement group API for setting a cap on the number of CPU cores that a placement group can take up on a node, as a fraction of the CPU cores on each node.

## API Usage

```python
import ray

ray.init(num_cpus=4)

pg = ray.util.placement_group(
    [{"CPU": 3}], max_cpu_fraction_per_node=0.5
)

# Placement group will never be scheduled since it would violate the max CPU
# fraction reservation.
with pytest.raises(ray.exceptions.GetTimeoutError):
    ray.get(pg.ready(), timeout=5)

ray.shutdown()
ray.init(num_cpus=8)

pg = ray.util.placement_group(
    [{"CPU": 3}], max_cpu_fraction_per_node=0.5
)

# The placement group should be schedulable so this shouldn't raise.
ray.get(pg.ready(), timeout=5)
```

## TODOs

- [ ] Modify autoscaler bin packing algorithm to scale up when a placement group is infeasible due to the max CPU fraction specification.
- [ ] Clean up scheduler integration, ideally consolidating the max CPU frac checks to a single place.
- [ ] Test on Datasets + Tune workload to verify liveness.
- [ ] Get API validation.
- [ ] Add documentation and usage examples to placement group feature guide.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/26243

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
