### PR TITLE
[Core] Allow task retry for `ray.cancel`

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2430,7 +2430,13 @@ def kill(actor: "ray.actor.ActorHandle", *, no_restart: bool = True):
 
 @PublicAPI
 @client_mode_hook(auto_init=True)
-def cancel(object_ref: "ray.ObjectRef", *, force: bool = False, recursive: bool = True):
+def cancel(
+    object_ref: "ray.ObjectRef",
+    *,
+    force: bool = False,
+    recursive: bool = True,
+    no_retry: bool = True,
+):
     """Cancels a task according to the following conditions.
 
     If the specified task is pending execution, it will not be executed. If
@@ -2452,6 +2458,7 @@ def cancel(object_ref: "ray.ObjectRef", *, force: bool = False, recursive: bool 
             the worker that is running the task.
         recursive: Whether to try to cancel tasks submitted by the
             task specified.
+        no_retry: Whether to disallow retrying tasks if `max_retries` is specified.
     Raises:
         TypeError: This is also raised for actor tasks.
     """
@@ -2463,7 +2470,7 @@ def cancel(object_ref: "ray.ObjectRef", *, force: bool = False, recursive: bool 
             "ray.cancel() only supported for non-actor object refs. "
             f"Got: {type(object_ref)}."
         )
-    return worker.core_worker.cancel_task(object_ref, force, recursive)
+    return worker.core_worker.cancel_task(object_ref, force, recursive, no_retry)
 
 
 def _mode(worker=global_worker):

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1792,13 +1792,13 @@ cdef class CoreWorker:
                   c_actor_id, True, no_restart))
 
     def cancel_task(self, ObjectRef object_ref, c_bool force_kill,
-                    c_bool recursive):
+                    c_bool recursive, c_bool no_retry):
         cdef:
             CObjectID c_object_id = object_ref.native()
             CRayStatus status = CRayStatus.OK()
 
         status = CCoreWorkerProcess.GetCoreWorker().CancelTask(
-                                            c_object_id, force_kill, recursive)
+                                            c_object_id, force_kill, recursive, no_retry)
 
         if not status.ok():
             raise TypeError(status.message().decode())

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1798,7 +1798,7 @@ cdef class CoreWorker:
             CRayStatus status = CRayStatus.OK()
 
         status = CCoreWorkerProcess.GetCoreWorker().CancelTask(
-                                            c_object_id, force_kill, recursive, no_retry)
+            c_object_id, force_kill, recursive, no_retry)
 
         if not status.ok():
             raise TypeError(status.message().decode())

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -132,7 +132,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const CActorID &actor_id, c_bool force_kill,
             c_bool no_restart)
         CRayStatus CancelTask(const CObjectID &object_id, c_bool force_kill,
-                              c_bool recursive)
+                              c_bool recursive, c_bool no_retry)
 
         unique_ptr[CProfileEvent] CreateProfileEvent(
             const c_string &event_type)

--- a/src/mock/ray/core_worker/task_manager.h
+++ b/src/mock/ray/core_worker/task_manager.h
@@ -46,7 +46,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
               (const std::vector<ObjectID> &inlined_dependency_ids,
                const std::vector<ObjectID> &contained_ids),
               (override));
-  MOCK_METHOD(bool, MarkTaskCanceled, (const TaskID &task_id), (override));
+  MOCK_METHOD(bool, MarkTaskCanceled, (const TaskID &task_id, bool no_retry), (override));
   MOCK_METHOD(void,
               MarkTaskReturnObjectsFailed,
               (const TaskSpecification &spec,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3032,7 +3032,8 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
     success = direct_task_receiver_->CancelQueuedNormalTask(task_id);
   }
   if (request.recursive()) {
-    auto recursive_cancel = CancelChildren(task_id, request.force_kill(), request.no_retry());
+    auto recursive_cancel =
+        CancelChildren(task_id, request.force_kill(), request.no_retry());
     if (!recursive_cancel.ok()) {
       RAY_LOG(ERROR) << "Recursive cancel failed for a task " << task_id
                      << " due to reason: " << recursive_cancel.ToString();

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -543,8 +543,13 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] object_id of the task to kill (must be a Non-Actor task)
   /// \param[in] force_kill Whether to force kill a task by killing the worker.
   /// \param[in] recursive Whether to cancel tasks submitted by the task to cancel.
+  /// \param[in] no_retry Whether to disallow retrying tasks if `max_retries` is
+  /// specified.
   /// \param[out] Status
-  Status CancelTask(const ObjectID &object_id, bool force_kill, bool recursive);
+  Status CancelTask(const ObjectID &object_id,
+                    bool force_kill,
+                    bool recursive,
+                    bool no_retry);
 
   /// Decrease the reference count for this actor. Should be called by the
   /// language frontend when a reference to the ActorHandle destroyed.
@@ -910,7 +915,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// \param[in] task_id of the parent task
   /// \param[in] force_kill Whether to force kill a task by killing the worker.
-  Status CancelChildren(const TaskID &task_id, bool force_kill);
+  /// \param[in] no_retry Whether to disallow retrying tasks if `max_retries` is
+  /// specified.
+  Status CancelChildren(const TaskID &task_id, bool force_kill, bool no_retry);
 
   ///
   /// Private methods related to task execution. Should not be used by driver processes.

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -580,10 +580,10 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
   return total_lineage_footprint_bytes_ - total_lineage_footprint_bytes_prev;
 }
 
-bool TaskManager::MarkTaskCanceled(const TaskID &task_id) {
+bool TaskManager::MarkTaskCanceled(const TaskID &task_id, bool no_retry) {
   absl::MutexLock lock(&mu_);
   auto it = submissible_tasks_.find(task_id);
-  if (it != submissible_tasks_.end()) {
+  if (it != submissible_tasks_.end() && no_retry) {
     it->second.num_retries_left = 0;
   }
   return it != submissible_tasks_.end();

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -55,7 +55,7 @@ class TaskFinisherInterface {
 
   virtual void MarkDependenciesResolved(const TaskID &task_id) = 0;
 
-  virtual bool MarkTaskCanceled(const TaskID &task_id) = 0;
+  virtual bool MarkTaskCanceled(const TaskID &task_id, bool no_retry) = 0;
 
   virtual void MarkTaskReturnObjectsFailed(
       const TaskSpecification &spec,
@@ -211,8 +211,10 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// Set number of retries to zero for a task that is being canceled.
   ///
   /// \param[in] task_id to cancel.
+  /// \param[in] no_retry Whether to disallow retrying tasks if `max_retries` is
+  /// specified.
   /// \return Whether the task was pending and was marked for cancellation.
-  bool MarkTaskCanceled(const TaskID &task_id) override;
+  bool MarkTaskCanceled(const TaskID &task_id, bool no_retry) override;
 
   /// Return the spec for a pending task.
   absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override;

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -133,7 +133,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
       rpc::ErrorType error_type,
       const rpc::RayErrorInfo *ray_error_info = nullptr) override {}
 
-  bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
+  bool MarkTaskCanceled(const TaskID &task_id, bool no_retry) override { return true; }
 
   absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -296,7 +296,7 @@ TEST_F(TaskManagerTest, TestTaskKill) {
   auto return_id = spec.ReturnId(0);
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
 
-  manager_.MarkTaskCanceled(spec.TaskId());
+  manager_.MarkTaskCanceled(spec.TaskId(), /*no_retry=*/true);
   auto error = rpc::ErrorType::TASK_CANCELLED;
   manager_.FailOrRetryPendingTask(spec.TaskId(), error);
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.cc
@@ -126,7 +126,7 @@ Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(TaskSpecification task_spe
         "CoreWorkerDirectActorTaskSubmitter::SubmitTask");
   } else {
     // Do not hold the lock while calling into task_finisher_.
-    task_finisher_.MarkTaskCanceled(task_id);
+    task_finisher_.MarkTaskCanceled(task_id, /*no_retry=*/true);
     rpc::ErrorType error_type;
     rpc::RayErrorInfo error_info;
     {
@@ -276,7 +276,7 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(
       const auto error_info = GetErrorInfoFromActorDeathCause(death_cause);
 
       for (auto &task_id : task_ids) {
-        task_finisher_.MarkTaskCanceled(task_id);
+        task_finisher_.MarkTaskCanceled(task_id, /*no_retry=*/true);
         // No need to increment the number of completed tasks since the actor is
         // dead.
         RAY_UNUSED(!task_finisher_.FailOrRetryPendingTask(

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -600,7 +600,7 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
                                                  bool no_retry) {
   RAY_LOG(INFO) << "Cancelling a task: " << task_spec.TaskId()
                 << " force_kill: " << force_kill << " recursive: " << recursive
-                << "no_retry: " << no_retry;
+                << " no_retry: " << no_retry;
   const SchedulingKey scheduling_key(
       task_spec.GetSchedulingClass(),
       task_spec.GetDependencyIds(),

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -97,12 +97,20 @@ class CoreWorkerDirectTaskSubmitter {
   ///
   /// \param[in] task_spec The task to kill.
   /// \param[in] force_kill Whether to kill the worker executing the task.
-  Status CancelTask(TaskSpecification task_spec, bool force_kill, bool recursive);
+  /// \param[in] recursive Whether to cancel tasks submitted by the task to cancel.
+  /// \param[in] no_retry Whether to disallow retrying tasks if `max_retries` is
+  /// specified.
+  /// \param[out] Status
+  Status CancelTask(TaskSpecification task_spec,
+                    bool force_kill,
+                    bool recursive,
+                    bool no_retry);
 
   Status CancelRemoteTask(const ObjectID &object_id,
                           const rpc::Address &worker_addr,
                           bool force_kill,
-                          bool recursive);
+                          bool recursive,
+                          bool no_retry);
   /// Check that the scheduling_key_entries_ hashmap is empty by calling the private
   /// CheckNoSchedulingKeyEntries function after acquiring the lock.
   bool CheckNoSchedulingKeyEntriesPublic() {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -244,6 +244,8 @@ message CancelTaskRequest {
   bool force_kill = 2;
   // Whether to recursively cancel tasks.
   bool recursive = 3;
+  // Whether to disallow retrying tasks if `max_retries` is specified.
+  bool no_retry = 4;
 }
 
 message CancelTaskReply {
@@ -260,6 +262,8 @@ message RemoteCancelTaskRequest {
   bool force_kill = 2;
   // Whether to recursively cancel tasks.
   bool recursive = 3;
+  // Whether to disallow retrying tasks if `max_retries` is specified.
+  bool no_retry = 4;
 }
 
 message RemoteCancelTaskReply {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sometimes we want to cancel a slow task and we still want to let Ray automatically retry it. The current behavior of `ray.cancel` is that the canceled task is never retried.

This PR adds a new option `no_retry` (similar to `no_restart` of `ray.kill` for killing actors) to `ray.cancel`. The default value is `True` to keep the default behavior unchanged. The only change of logic is that, when `no_retry` is set to `False`, the `num_retries_left` of the task to be canceled won't be set to 0 in `TaskManager`.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #25219

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
