### PR TITLE
[Core] Fix WaitManager dealing with duplicate objects

### DIFF
--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -649,6 +649,7 @@ def test_duplicate_args(ray_start_regular_shared):
     arg2 = ray.put([2])
     ray.get(f.remote(arg1, arg2, arg1, kwarg1=arg1, kwarg2=arg2, kwarg1_duplicate=arg1))
 
+    # Test by-reference arguments on an actor task.
     @ray.remote
     class Actor:
         def f(

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -649,6 +649,30 @@ def test_duplicate_args(ray_start_regular_shared):
     arg2 = ray.put([2])
     ray.get(f.remote(arg1, arg2, arg1, kwarg1=arg1, kwarg2=arg2, kwarg1_duplicate=arg1))
 
+    @ray.remote
+    class Actor:
+        def f(
+            self,
+            arg1,
+            arg2,
+            arg1_duplicate,
+            kwarg1=None,
+            kwarg2=None,
+            kwarg1_duplicate=None,
+        ):
+            assert arg1 == kwarg1
+            assert arg1 != arg2
+            assert arg1 == arg1_duplicate
+            assert kwarg1 != kwarg2
+            assert kwarg1 == kwarg1_duplicate
+
+    actor = Actor.remote()
+    ray.get(
+        actor.f.remote(
+            arg1, arg2, arg1, kwarg1=arg1, kwarg2=arg2, kwarg1_duplicate=arg1
+        )
+    )
+
 
 @pytest.mark.skipif(client_test_enabled(), reason="internal api")
 def test_get_correct_node_ip():

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1681,6 +1681,9 @@ void NodeManager::ProcessWaitForDirectActorCallArgsRequestMessage(
                       TaskID::Nil(),
                       /*ray_get=*/false,
                       /*mark_worker_blocked*/ false);
+  // De-duplicate the object IDs.
+  absl::flat_hash_set<ObjectID> object_id_set(object_ids.begin(), object_ids.end());
+  object_ids.assign(object_id_set.begin(), object_id_set.end());
   wait_manager_.Wait(
       object_ids,
       -1,

--- a/src/ray/raylet/wait_manager.cc
+++ b/src/ray/raylet/wait_manager.cc
@@ -23,7 +23,7 @@ void WaitManager::Wait(const std::vector<ObjectID> &object_ids,
                        int64_t timeout_ms,
                        uint64_t num_required_objects,
                        const WaitCallback &callback) {
-  std::unordered_set<ObjectID> object_id_set(object_ids.begin(), object_ids.end());
+  absl::flat_hash_set<ObjectID> object_id_set(object_ids.begin(), object_ids.end());
   RAY_CHECK_EQ(object_id_set.size(), object_ids.size())
       << "Waiting duplicate objects is not allowed. Please make sure all object IDs are "
          "unique before calling `WaitManager::Wait`.";

--- a/src/ray/raylet/wait_manager.h
+++ b/src/ray/raylet/wait_manager.h
@@ -74,7 +74,7 @@ class WaitManager {
     /// The number of required objects.
     const uint64_t num_required_objects;
     /// The objects that have been locally available.
-    std::vector<ObjectID> ready;
+    std::unordered_set<ObjectID> ready;
   };
 
   /// Completion handler for Wait.

--- a/src/ray/raylet/wait_manager.h
+++ b/src/ray/raylet/wait_manager.h
@@ -74,7 +74,7 @@ class WaitManager {
     /// The number of required objects.
     const uint64_t num_required_objects;
     /// The objects that have been locally available.
-    std::unordered_set<ObjectID> ready;
+    std::vector<ObjectID> ready;
   };
 
   /// Completion handler for Wait.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When calling an actor method with duplicate ObjectRefs, the actor method will never be executed. The root cause is that `WaitRequest::ready` is of type `std::unordered_set` rather than `std::vector`.

https://github.com/ray-project/ray/blob/b9ade079cb2de72332419167305b9ee49d2b0930/src/ray/raylet/wait_manager.h#L77

So the below if conditions won't be true.

https://github.com/ray-project/ray/blob/b9ade079cb2de72332419167305b9ee49d2b0930/src/ray/raylet/wait_manager.cc#L45-L48

https://github.com/ray-project/ray/blob/b9ade079cb2de72332419167305b9ee49d2b0930/src/ray/raylet/wait_manager.cc#L103-L105

The bug was introduced by https://github.com/ray-project/ray/pull/21369, so it exists in Ray 1.11.0+.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
