### PR TITLE
[Datasets] Fix max number of actors for default actor pool strategy

### DIFF
--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4233,7 +4233,7 @@ def test_polars_lazy_import(shutdown_only):
         ctx.use_polars = original_use_polars
 
 
-def test_actorpoolstrategy_apply_interrupt(shutdown_only):
+def test_actor_pool_strategy_apply_interrupt(shutdown_only):
     """Test that _apply kills the actor pool if an interrupt is raised."""
     ray.init(include_dashboard=False, num_cpus=1)
 
@@ -4258,7 +4258,7 @@ def test_actorpoolstrategy_apply_interrupt(shutdown_only):
     wait_for_condition(lambda: (ray.available_resources().get("CPU", 0) == cpus))
 
 
-def test_actorpoolstrategy_default_num_actors(shutdown_only):
+def test_actor_pool_strategy_default_num_actors(shutdown_only):
     def f(x):
         import time
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4258,7 +4258,7 @@ def test_actorpoolstrategy_apply_interrupt(shutdown_only):
     wait_for_condition(lambda: (ray.available_resources().get("CPU", 0) == cpus))
 
 
-def test_actorpoolstrategy_default_max_actors(shutdown_only):
+def test_actorpoolstrategy_default_num_actors(shutdown_only):
     def f(x):
         import time
 
@@ -4273,8 +4273,9 @@ def test_actorpoolstrategy_default_max_actors(shutdown_only):
         num_cpus * (1 / compute_strategy.ready_to_total_workers_ratio)
     )
     assert (
-        compute_strategy.num_workers <= expected_max_num_workers
-    ), "Number of actors exceeds maximal limit"
+        compute_strategy.num_workers >= num_cpus
+        and compute_strategy.num_workers <= expected_max_num_workers
+    ), "Number of actors is out of the expected bound"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4233,7 +4233,7 @@ def test_polars_lazy_import(shutdown_only):
         ctx.use_polars = original_use_polars
 
 
-def test_actorpoolstrategy_apply_interrupt():
+def test_actorpoolstrategy_apply_interrupt(shutdown_only):
     """Test that _apply kills the actor pool if an interrupt is raised."""
     ray.init(include_dashboard=False, num_cpus=1)
 
@@ -4256,6 +4256,25 @@ def test_actorpoolstrategy_apply_interrupt():
 
     # Check that all actors have been killed by counting the available CPUs
     wait_for_condition(lambda: (ray.available_resources().get("CPU", 0) == cpus))
+
+
+def test_actorpoolstrategy_default_max_actors(shutdown_only):
+    def f(x):
+        import time
+
+        time.sleep(1)
+        return x
+
+    num_cpus = 5
+    ray.init(num_cpus=num_cpus)
+    compute_strategy = ray.data.ActorPoolStrategy()
+    ray.data.range(10, parallelism=10).map_batches(f, compute=compute_strategy)
+    expected_max_num_workers = math.ceil(
+        num_cpus * (1 / compute_strategy.ready_to_total_workers_ratio)
+    )
+    assert (
+        compute_strategy.num_workers <= expected_max_num_workers
+    ), "Number of actors exceeds maximal limit"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to fix the maximal number of actors used in datasets tranformation, when using default actor pool strategy (i.e. `ActorPoolStrategy()`). It should not exceed `1.25 * num_cpus` set in the cluster.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/26221

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
