### PR TITLE
[Java] Make Java test more stable

### DIFF
--- a/java/test/src/main/java/io/ray/test/MetricTest.java
+++ b/java/test/src/main/java/io/ray/test/MetricTest.java
@@ -130,8 +130,8 @@ public class MetricTest extends BaseTest {
     tags.put(new TagKey("histogram_tag"), "default");
     List<Double> boundaries = new ArrayList<>();
     boundaries.add(10.0);
-    boundaries.add(15.0);
     boundaries.add(12.0);
+    boundaries.add(15.0);
     Histogram histogram = new Histogram("metric_histogram", "histogram", "1pc", boundaries, tags);
     for (int i = 1; i <= 200; ++i) {
       histogram.update(i * 1.0d);

--- a/java/test/src/main/java/io/ray/test/NamespaceTest.java
+++ b/java/test/src/main/java/io/ray/test/NamespaceTest.java
@@ -112,6 +112,7 @@ public class NamespaceTest {
       ProcessBuilder builder = TestUtils.buildDriver(driverClass, null);
       builder.redirectError(ProcessBuilder.Redirect.INHERIT);
       driver = builder.start();
+      TestUtils.waitForCondition(() -> Ray.getActor("a", "test1").isPresent(), 10000);
       // Wait for driver to start.
       driver.waitFor(10, TimeUnit.SECONDS);
       runnable.run();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If compile Ray in debug mode,

* run `MetricsTest:: testAddHistogram` will crash with below error message:

```
BucketBoundaries::Explicit called with non-monotonic boundary list.
java: external/io_opencensus_cpp/opencensus/stats/internal/bucket_boundaries.cc:64: opencensus::stats::BucketBoundaries::Explicit(std::__debug::vector<double>)::<lambda()>: Assertion `false && "0"' failed.
```

*  run `NamespaceTest::testIsolationInTheSameNamespaces` can fail with great possibility with below error message:

```
java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:135)
	at io.ray.test.NamespaceTest.lambda$testIsolationInTheSameNamespaces$2(NamespaceTest.java:39)
	at io.ray.test.NamespaceTest.testIsolation(NamespaceTest.java:116)
	at io.ray.test.NamespaceTest.testIsolationInTheSameNamespaces(NamespaceTest.java:36)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
