### PR TITLE
Revert "Fix file_system_monitor.cc message"

### DIFF
--- a/src/ray/common/file_system_monitor.cc
+++ b/src/ray/common/file_system_monitor.cc
@@ -103,9 +103,8 @@ bool FileSystemMonitor::OverCapacityImpl(
   }
 
   RAY_LOG_EVERY_MS(ERROR, 10 * 1000)
-      << path << " is over " << capacity_threshold_ * 100
+      << path << " is over " << capacity_threshold_
       << "\% full, available space: " << space_info->available
-      << "; capacity: " << space_info->capacity
       << ". Object creation will fail if spilling is required.";
   return true;
 }


### PR DESCRIPTION
Reverts ray-project/ray#26143

Seems to break linux://python/ray/tune:test_progress_reporter, not sure why though.