### PR TITLE
[Datasets] Add Pandas-native groupby and sorting.

### DIFF
--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -12,16 +12,24 @@ from typing import (
 )
 
 import collections
+import heapq
 import numpy as np
 
-from ray.data.block import BlockAccessor, BlockMetadata, KeyFn, U
+from ray.data.block import (
+    Block,
+    BlockAccessor,
+    BlockMetadata,
+    BlockExecStats,
+    KeyFn,
+    KeyType,
+    U,
+)
 from ray.data.row import TableRow
 from ray.data._internal.table_block import (
     TableBlockAccessor,
     TableBlockBuilder,
     VALUE_COL_NAME,
 )
-from ray.data._internal.arrow_block import ArrowBlockAccessor
 from ray.data.aggregate import AggregateFn
 
 if TYPE_CHECKING:
@@ -210,15 +218,19 @@ class PandasBlockAccessor(TableBlockAccessor):
         self, agg_fn: Callable[["pandas.Series", bool], U], on: KeyFn
     ) -> Optional[U]:
         """Helper providing null handling around applying an aggregation to a column."""
+        pd = lazy_import_pandas()
         if on is not None and not isinstance(on, str):
             raise ValueError(
                 "on must be a string or None when aggregating on Pandas blocks, but "
                 f"got: {type(on)}."
             )
 
+        if self.num_rows() == 0:
+            return None
+
         col = self._table[on]
         try:
-            return agg_fn(col)
+            val = agg_fn(col)
         except TypeError as e:
             # Converting an all-null column in an Arrow Table to a Pandas DataFrame
             # column will result in an all-None column of object type, which will raise
@@ -227,16 +239,23 @@ class PandasBlockAccessor(TableBlockAccessor):
             if np.issubdtype(col.dtype, np.object_) and col.isnull().all():
                 return None
             raise e from None
+        if pd.isnull(val):
+            return None
+        return val
 
     def count(self, on: KeyFn) -> Optional[U]:
         return self._apply_agg(lambda col: col.count(), on)
 
     def sum(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
+        pd = lazy_import_pandas()
         if on is not None and not isinstance(on, str):
             raise ValueError(
                 "on must be a string or None when aggregating on Pandas blocks, but "
                 f"got: {type(on)}."
             )
+
+        if self.num_rows() == 0:
+            return None
 
         col = self._table[on]
         if col.isnull().all():
@@ -244,7 +263,10 @@ class PandasBlockAccessor(TableBlockAccessor):
             # sum() since it will otherwise return 0 when summing on an all-null column,
             # which is not what we want.
             return None
-        return col.sum(skipna=ignore_nulls)
+        val = col.sum(skipna=ignore_nulls)
+        if pd.isnull(val):
+            return None
+        return val
 
     def min(self, on: KeyFn, ignore_nulls: bool) -> Optional[U]:
         return self._apply_agg(lambda col: col.min(skipna=ignore_nulls), on)
@@ -270,28 +292,133 @@ class PandasBlockAccessor(TableBlockAccessor):
 
     def sort_and_partition(
         self, boundaries: List[T], key: "SortKeyT", descending: bool
-    ) -> List["pandas.DataFrame"]:
-        # TODO (kfstorm): A workaround to pass tests. Not efficient.
-        delegated_result = BlockAccessor.for_block(self.to_arrow()).sort_and_partition(
-            boundaries, key, descending
-        )
-        return [BlockAccessor.for_block(_).to_pandas() for _ in delegated_result]
+    ) -> List[Block[T]]:
+        if len(key) > 1:
+            raise NotImplementedError(
+                "sorting by multiple columns is not supported yet"
+            )
+
+        if self._table.shape[0] == 0:
+            # If the pyarrow table is empty we may not have schema
+            # so calling sort_indices() will raise an error.
+            return [self._empty_table() for _ in range(len(boundaries) + 1)]
+
+        col, _ = key[0]
+        table = self._table.sort_values(by=col, ascending=not descending)
+        if len(boundaries) == 0:
+            return [table]
+
+        partitions = []
+        # For each boundary value, count the number of items that are less
+        # than it. Since the block is sorted, these counts partition the items
+        # such that boundaries[i] <= x < boundaries[i + 1] for each x in
+        # partition[i]. If `descending` is true, `boundaries` would also be
+        # in descending order and we only need to count the number of items
+        # *greater than* the boundary value instead.
+        if descending:
+            num_rows = len(table[col])
+            bounds = num_rows - table[col].searchsorted(
+                boundaries, sorter=np.arange(num_rows - 1, -1, -1)
+            )
+        else:
+            bounds = table[col].searchsorted(boundaries)
+        last_idx = 0
+        for idx in bounds:
+            # Slices need to be copied to avoid including the base table
+            # during serialization.
+            partitions.append(table[last_idx:idx])
+            last_idx = idx
+        partitions.append(table[last_idx:])
+        return partitions
 
     def combine(self, key: KeyFn, aggs: Tuple[AggregateFn]) -> "pandas.DataFrame":
-        # TODO (kfstorm): A workaround to pass tests. Not efficient.
-        return BlockAccessor.for_block(self.to_arrow()).combine(key, aggs).to_pandas()
+        """Combine rows with the same key into an accumulator.
+
+        This assumes the block is already sorted by key in ascending order.
+
+        Args:
+            key: The column name of key or None for global aggregation.
+            aggs: The aggregations to do.
+
+        Returns:
+            A sorted block of [k, v_1, ..., v_n] columns where k is the groupby
+            key and v_i is the partially combined accumulator for the ith given
+            aggregation.
+            If key is None then the k column is omitted.
+        """
+        if key is not None and not isinstance(key, str):
+            raise ValueError(
+                "key must be a string or None when aggregating on Arrow blocks, but "
+                f"got: {type(key)}."
+            )
+
+        def iter_groups() -> Iterator[Tuple[KeyType, Block]]:
+            """Creates an iterator over zero-copy group views."""
+            if key is None:
+                # Global aggregation consists of a single "group", so we short-circuit.
+                yield None, self.to_block()
+                return
+
+            start = end = 0
+            iter = self.iter_rows()
+            next_row = None
+            while True:
+                try:
+                    if next_row is None:
+                        next_row = next(iter)
+                    next_key = next_row[key]
+                    while next_row[key] == next_key:
+                        end += 1
+                        try:
+                            next_row = next(iter)
+                        except StopIteration:
+                            next_row = None
+                            break
+                    yield next_key, self.slice(start, end, copy=False)
+                    start = end
+                except StopIteration:
+                    break
+
+        builder = PandasBlockBuilder()
+        for group_key, group_view in iter_groups():
+            # Aggregate.
+            accumulators = [agg.init(group_key) for agg in aggs]
+            for i in range(len(aggs)):
+                accumulators[i] = aggs[i].accumulate_block(accumulators[i], group_view)
+
+            # Build the row.
+            row = {}
+            if key is not None:
+                row[key] = group_key
+
+            count = collections.defaultdict(int)
+            for agg, accumulator in zip(aggs, accumulators):
+                name = agg.name
+                # Check for conflicts with existing aggregation name.
+                if count[name] > 0:
+                    name = self._munge_conflict(name, count[name])
+                count[name] += 1
+                row[name] = accumulator
+
+            builder.add(row)
+
+        return builder.build()
 
     @staticmethod
     def merge_sorted_blocks(
-        blocks: List["pandas.DataFrame"], key: "SortKeyT", _descending: bool
+        blocks: List[Block[T]], key: "SortKeyT", _descending: bool
     ) -> Tuple["pandas.DataFrame", BlockMetadata]:
-        # TODO (kfstorm): A workaround to pass tests. Not efficient.
-        block, metadata = ArrowBlockAccessor.merge_sorted_blocks(
-            [BlockAccessor.for_block(block).to_arrow() for block in blocks],
-            key,
-            _descending,
+        pd = lazy_import_pandas()
+        stats = BlockExecStats.builder()
+        blocks = [b for b in blocks if b.shape[0] > 0]
+        if len(blocks) == 0:
+            ret = PandasBlockAccessor._empty_table()
+        else:
+            ret = pd.concat(blocks, ignore_index=True)
+            ret = ret.sort_values(by=key[0][0], ascending=not _descending)
+        return ret, PandasBlockAccessor(ret).get_metadata(
+            None, exec_stats=stats.build()
         )
-        return BlockAccessor.for_block(block).to_pandas(), metadata
 
     @staticmethod
     def aggregate_combined_blocks(
@@ -300,11 +427,94 @@ class PandasBlockAccessor(TableBlockAccessor):
         aggs: Tuple[AggregateFn],
         finalize: bool,
     ) -> Tuple["pandas.DataFrame", BlockMetadata]:
-        # TODO (kfstorm): A workaround to pass tests. Not efficient.
-        block, metadata = ArrowBlockAccessor.aggregate_combined_blocks(
-            [BlockAccessor.for_block(block).to_arrow() for block in blocks],
-            key,
-            aggs,
-            finalize,
+        """Aggregate sorted, partially combined blocks with the same key range.
+
+        This assumes blocks are already sorted by key in ascending order,
+        so we can do merge sort to get all the rows with the same key.
+
+        Args:
+            blocks: A list of partially combined and sorted blocks.
+            key: The column name of key or None for global aggregation.
+            aggs: The aggregations to do.
+            finalize: Whether to finalize the aggregation. This is used as an
+                optimization for cases where we repeatedly combine partially
+                aggregated groups.
+
+        Returns:
+            A block of [k, v_1, ..., v_n] columns and its metadata where k is
+            the groupby key and v_i is the corresponding aggregation result for
+            the ith given aggregation.
+            If key is None then the k column is omitted.
+        """
+
+        stats = BlockExecStats.builder()
+        key_fn = (lambda r: r[r._row.columns[0]]) if key is not None else (lambda r: 0)
+
+        iter = heapq.merge(
+            *[PandasBlockAccessor(block).iter_rows() for block in blocks], key=key_fn
         )
-        return BlockAccessor.for_block(block).to_pandas(), metadata
+        next_row = None
+        builder = PandasBlockBuilder()
+        while True:
+            try:
+                if next_row is None:
+                    next_row = next(iter)
+                next_key = key_fn(next_row)
+                next_key_name = next_row._row.columns[0] if key is not None else None
+
+                def gen():
+                    nonlocal iter
+                    nonlocal next_row
+                    while key_fn(next_row) == next_key:
+                        yield next_row
+                        try:
+                            next_row = next(iter)
+                        except StopIteration:
+                            next_row = None
+                            break
+
+                # Merge.
+                first = True
+                accumulators = [None] * len(aggs)
+                resolved_agg_names = [None] * len(aggs)
+                for r in gen():
+                    if first:
+                        count = collections.defaultdict(int)
+                        for i in range(len(aggs)):
+                            name = aggs[i].name
+                            # Check for conflicts with existing aggregation
+                            # name.
+                            if count[name] > 0:
+                                name = PandasBlockAccessor._munge_conflict(
+                                    name, count[name]
+                                )
+                            count[name] += 1
+                            resolved_agg_names[i] = name
+                            accumulators[i] = r[name]
+                        first = False
+                    else:
+                        for i in range(len(aggs)):
+                            accumulators[i] = aggs[i].merge(
+                                accumulators[i], r[resolved_agg_names[i]]
+                            )
+                # Build the row.
+                row = {}
+                if key is not None:
+                    row[next_key_name] = next_key
+
+                for agg, agg_name, accumulator in zip(
+                    aggs, resolved_agg_names, accumulators
+                ):
+                    if finalize:
+                        row[agg_name] = agg.finalize(accumulator)
+                    else:
+                        row[agg_name] = accumulator
+
+                builder.add(row)
+            except StopIteration:
+                break
+
+        ret = builder.build()
+        return ret, PandasBlockAccessor(ret).get_metadata(
+            None, exec_stats=stats.build()
+        )

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -324,8 +324,6 @@ class PandasBlockAccessor(TableBlockAccessor):
             bounds = table[col].searchsorted(boundaries)
         last_idx = 0
         for idx in bounds:
-            # Slices need to be copied to avoid including the base table
-            # during serialization.
             partitions.append(table[last_idx:idx])
             last_idx = idx
         partitions.append(table[last_idx:])
@@ -348,7 +346,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         """
         if key is not None and not isinstance(key, str):
             raise ValueError(
-                "key must be a string or None when aggregating on Arrow blocks, but "
+                "key must be a string or None when aggregating on Pandas blocks, but "
                 f"got: {type(key)}."
             )
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2852,22 +2852,33 @@ def test_groupby_tabular_sum(
     # Test ignore_nulls=False
     nan_agg_ds = nan_grouped_ds.sum("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "sum(B)": None},
-        {"A": 1, "sum(B)": 1617},
-        {"A": 2, "sum(B)": 1650},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "sum(B)": [None, 1617, 1650],
+            }
+        ),
+        check_dtype=False,
+    )
     # Test all nans
     ds = ray.data.from_items([{"A": (x % 3), "B": None} for x in xs]).repartition(
         num_parts
     )
+    if ds_format == "pandas":
+        ds = _to_pandas(ds)
     nan_agg_ds = ds.groupby("A").sum("B")
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "sum(B)": None},
-        {"A": 1, "sum(B)": None},
-        {"A": 2, "sum(B)": None},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "sum(B)": [None, None, None],
+            }
+        ),
+    )
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -2955,11 +2966,16 @@ def test_groupby_tabular_min(ray_start_regular_shared, ds_format, num_parts):
     # Test ignore_nulls=False
     nan_agg_ds = nan_grouped_ds.min("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "min(B)": None},
-        {"A": 1, "min(B)": 1},
-        {"A": 2, "min(B)": 2},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "min(B)": [None, 1, 2],
+            }
+        ),
+        check_dtype=False,
+    )
     # Test all nans
     ds = ray.data.from_items([{"A": (x % 3), "B": None} for x in xs]).repartition(
         num_parts
@@ -2968,11 +2984,16 @@ def test_groupby_tabular_min(ray_start_regular_shared, ds_format, num_parts):
         ds = _to_pandas(ds)
     nan_agg_ds = ds.groupby("A").min("B")
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "min(B)": None},
-        {"A": 1, "min(B)": None},
-        {"A": 2, "min(B)": None},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "min(B)": [None, None, None],
+            }
+        ),
+        check_dtype=False,
+    )
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -3060,11 +3081,16 @@ def test_groupby_tabular_max(ray_start_regular_shared, ds_format, num_parts):
     # Test ignore_nulls=False
     nan_agg_ds = nan_grouped_ds.max("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "max(B)": None},
-        {"A": 1, "max(B)": 97},
-        {"A": 2, "max(B)": 98},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "max(B)": [None, 97, 98],
+            }
+        ),
+        check_dtype=False,
+    )
     # Test all nans
     ds = ray.data.from_items([{"A": (x % 3), "B": None} for x in xs]).repartition(
         num_parts
@@ -3073,11 +3099,16 @@ def test_groupby_tabular_max(ray_start_regular_shared, ds_format, num_parts):
         ds = _to_pandas(ds)
     nan_agg_ds = ds.groupby("A").max("B")
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "max(B)": None},
-        {"A": 1, "max(B)": None},
-        {"A": 2, "max(B)": None},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "max(B)": [None, None, None],
+            }
+        ),
+        check_dtype=False,
+    )
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -3148,7 +3179,7 @@ def test_groupby_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
         {"A": 2, "mean(B)": 50.0},
     ]
 
-    # Test built-in min aggregation with nans
+    # Test built-in mean aggregation with nans
     ds = ray.data.from_items(
         [{"A": (x % 3), "B": x} for x in xs] + [{"A": 0, "B": None}]
     ).repartition(num_parts)
@@ -3165,11 +3196,16 @@ def test_groupby_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
     # Test ignore_nulls=False
     nan_agg_ds = nan_grouped_ds.mean("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "mean(B)": None},
-        {"A": 1, "mean(B)": 49.0},
-        {"A": 2, "mean(B)": 50.0},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "mean(B)": [None, 49.0, 50.0],
+            }
+        ),
+        check_dtype=False,
+    )
     # Test all nans
     ds = ray.data.from_items([{"A": (x % 3), "B": None} for x in xs]).repartition(
         num_parts
@@ -3178,11 +3214,16 @@ def test_groupby_tabular_mean(ray_start_regular_shared, ds_format, num_parts):
         ds = _to_pandas(ds)
     nan_agg_ds = ds.groupby("A").mean("B")
     assert nan_agg_ds.count() == 3
-    assert [row.as_pydict() for row in nan_agg_ds.sort("A").iter_rows()] == [
-        {"A": 0, "mean(B)": None},
-        {"A": 1, "mean(B)": None},
-        {"A": 2, "mean(B)": None},
-    ]
+    pd.testing.assert_frame_equal(
+        nan_agg_ds.sort("A").to_pandas(),
+        pd.DataFrame(
+            {
+                "A": [0, 1, 2],
+                "mean(B)": [None, None, None],
+            }
+        ),
+        check_dtype=False,
+    )
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -4466,7 +4507,11 @@ def test_polars_lazy_import(shutdown_only):
                 pd.DataFrame({"a": a[i * partition_size : (i + 1) * partition_size]})
             )
         # At least one worker should have imported polars.
-        _ = ray.data.from_pandas(dfs).sort(key="a")
+        _ = (
+            ray.data.from_pandas(dfs)
+            .map_batches(lambda t: t, batch_format="pyarrow", batch_size=None)
+            .sort(key="a")
+        )
         assert any(ray.get([f.remote(True) for _ in range(parallelism)]))
 
     finally:


### PR DESCRIPTION
This PR adds a Pandas-native implementation of groupby and sorting for Pandas blocks. Before this PR, we were converting to Arrow, doing groupbys + aggregations and sorting in Arrow land, and then converting back to Pandas; this to-from-Arrow conversion was happening both on the map side and the reduce side, which was very inefficient for Pandas blocks (many extra table copies). By adding Pandas-native groupby + sorting, we should see a decrease in memory utilization and faster performance when using the AIR preprocessors.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #21296 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
