### PR TITLE
[workflow] Standardize workflow blocking and nonblocking APIs

### DIFF
--- a/doc/source/workflows/basics.rst
+++ b/doc/source/workflows/basics.rst
@@ -116,14 +116,13 @@ To retrieve a workflow result, you can assign ``workflow_id`` when running a wor
 
     assert workflow.run(ret, workflow_id="add_example") == 30
 
-Then workflow results can be retrieved with ``workflow.get_output(workflow_id) -> ObjectRef[T]``.
+Then workflow results can be retrieved with ``workflow.get_output(workflow_id)``.
 If a workflow is not given ``workflow_id``, a random string is set as the ``workflow_id``. To confirm ``workflow_id`` in the situation, call ``ray.workflow.list_all()``.
-
-If the workflow has not yet completed, calling ``ray.get()`` on the returned reference will block until the result is computed. For example:
 
 .. code-block:: python
 
-    assert ray.get(workflow.get_output("add_example")) == 30
+    assert workflow.get_output("add_example") == 30
+    # "workflow.get_output_async" is an asynchronous version
 
 We can retrieve the results for individual workflow tasks too with *named tasks*. A task can be named in two ways:
 
@@ -154,8 +153,8 @@ Once a task is given a name, the result of the task will be retrievable via ``wo
     outer_task = double.options(**workflow.options(name="outer")).bind(inner_task)
     result_ref = workflow.run_async(outer_task, workflow_id="double")
 
-    inner = workflow.get_output(workflow_id, name="inner")
-    outer = workflow.get_output(workflow_id, name="outer")
+    inner = workflow.get_output_async(workflow_id, name="inner")
+    outer = workflow.get_output_async(workflow_id, name="outer")
 
     assert ray.get(inner) == 2
     assert ray.get(outer) == 4
@@ -193,9 +192,9 @@ For example,
         x = simple.options(**workflow.options(name="step")).bind(x)
 
     ret = workflow.run_async(x, workflow_id=workflow_id)
-    outputs = [workflow.get_output(workflow_id, name="step")]
+    outputs = [workflow.get_output_async(workflow_id, name="step")]
     for i in range(1, n):
-        outputs.append(workflow.get_output(workflow_id, name=f"step_{i}"))
+        outputs.append(workflow.get_output_async(workflow_id, name=f"step_{i}"))
     assert ray.get(ret) == n - 1
     assert ray.get(outputs) == list(range(n))
 

--- a/doc/source/workflows/metadata.rst
+++ b/doc/source/workflows/metadata.rst
@@ -133,7 +133,7 @@ be updated whenever a workflow is resumed.
 
     # remove flag to make task success
     error_flag.unlink()
-    ref = workflow.resume(workflow_id)
+    ref = workflow.resume_async(workflow_id)
     assert ray.get(ref) == 0
 
     workflow_metadata_resumed = workflow.get_metadata(workflow_id)

--- a/doc/source/workflows/package-ref.rst
+++ b/doc/source/workflows/package-ref.rst
@@ -10,10 +10,12 @@ Workflow Execution API
 
 Management API
 --------------
-.. autofunction:: ray.workflow.resume_all
 .. autofunction:: ray.workflow.resume
+.. autofunction:: ray.workflow.resume_async
+.. autofunction:: ray.workflow.resume_all
 .. autofunction:: ray.workflow.list_all
 .. autofunction:: ray.workflow.get_status
 .. autofunction:: ray.workflow.get_output
+.. autofunction:: ray.workflow.get_output_async
 .. autofunction:: ray.workflow.get_metadata
 .. autofunction:: ray.workflow.cancel

--- a/python/ray/workflow/__init__.py
+++ b/python/ray/workflow/__init__.py
@@ -2,17 +2,19 @@ from ray.workflow.api import (
     init,
     run,
     run_async,
-    continuation,
     resume,
     resume_all,
+    resume_async,
     cancel,
     list_all,
     delete,
     get_output,
+    get_output_async,
     get_status,
     get_metadata,
     sleep,
     wait_for_event,
+    continuation,
     options,
 )
 from ray.workflow.exceptions import (
@@ -23,26 +25,31 @@ from ray.workflow.exceptions import (
 from ray.workflow.common import WorkflowStatus
 from ray.workflow.event_listener import EventListener
 
+globals().update(WorkflowStatus.__members__)
+
+
 __all__ = [
+    "init",
     "run",
     "run_async",
     "resume",
+    "resume_async",
+    "resume_all",
+    "cancel",
+    "list_all",
+    "delete",
     "get_output",
+    "get_output_async",
+    "get_status",
+    "get_metadata",
+    "sleep",
+    "wait_for_event",
+    "options",
+    "continuation",
+    # events
+    "EventListener",
+    # exceptions
     "WorkflowError",
     "WorkflowExecutionError",
     "WorkflowCancellationError",
-    "resume_all",
-    "cancel",
-    "get_status",
-    "get_metadata",
-    "list_all",
-    "init",
-    "wait_for_event",
-    "sleep",
-    "EventListener",
-    "delete",
-    "continuation",
-    "options",
 ]
-
-globals().update(WorkflowStatus.__members__)

--- a/python/ray/workflow/api.py
+++ b/python/ray/workflow/api.py
@@ -134,8 +134,33 @@ def run_async(
 
 
 @PublicAPI(stability="beta")
-def resume(workflow_id: str) -> ray.ObjectRef:
+def resume(workflow_id: str) -> Any:
     """Resume a workflow.
+
+    Resume a workflow and retrieve its output. If the workflow was incomplete,
+    it will be re-executed from its checkpointed outputs. If the workflow was
+    complete, returns the result immediately.
+
+    Examples:
+        >>> from ray import workflow
+        >>> start_trip = ... # doctest: +SKIP
+        >>> trip = start_trip.bind() # doctest: +SKIP
+        >>> res1 = workflow.run_async(trip, workflow_id="trip1") # doctest: +SKIP
+        >>> res2 = workflow.resume_async("trip1") # doctest: +SKIP
+        >>> assert ray.get(res1) == ray.get(res2) # doctest: +SKIP
+
+    Args:
+        workflow_id: The id of the workflow to resume.
+
+    Returns:
+        The output of the workflow.
+    """
+    return ray.get(resume_async(workflow_id))
+
+
+@PublicAPI(stability="beta")
+def resume_async(workflow_id: str) -> ray.ObjectRef:
+    """Resume a workflow asynchronously.
 
     Resume a workflow and retrieve its output. If the workflow was incomplete,
     it will be re-executed from its checkpointed outputs. If the workflow was
@@ -160,7 +185,7 @@ def resume(workflow_id: str) -> ray.ObjectRef:
 
 
 @PublicAPI(stability="beta")
-def get_output(workflow_id: str, *, name: Optional[str] = None) -> ray.ObjectRef:
+def get_output(workflow_id: str, *, name: Optional[str] = None) -> Any:
     """Get the output of a running workflow.
 
     Args:
@@ -174,13 +199,28 @@ def get_output(workflow_id: str, *, name: Optional[str] = None) -> ray.ObjectRef
         >>> trip = start_trip.options(name="trip").step() # doctest: +SKIP
         >>> res1 = trip.run_async(workflow_id="trip1") # doctest: +SKIP
         >>> # you could "get_output()" in another machine
-        >>> res2 = workflow.get_output("trip1") # doctest: +SKIP
+        >>> res2 = workflow.get_output_async("trip1") # doctest: +SKIP
         >>> assert ray.get(res1) == ray.get(res2) # doctest: +SKIP
-        >>> step_output = workflow.get_output("trip1", "trip") # doctest: +SKIP
+        >>> step_output = workflow.get_output_async("trip1", "trip") # doctest: +SKIP
         >>> assert ray.get(step_output) == ray.get(res1) # doctest: +SKIP
 
     Returns:
-        An object reference that can be used to retrieve the workflow result.
+        The output of the workflow task.
+    """
+    return ray.get(get_output_async(workflow_id, name=name))
+
+
+@PublicAPI(stability="beta")
+def get_output_async(workflow_id: str, *, name: Optional[str] = None) -> ray.ObjectRef:
+    """Get the output of a running workflow asynchronously.
+
+    Args:
+        workflow_id: The workflow to get the output of.
+        name: If set, fetch the specific step instead of the output of the
+            workflow.
+
+    Returns:
+        An object reference that can be used to retrieve the workflow task result.
     """
     _ensure_workflow_initialized()
     return execution.get_output(workflow_id, name)
@@ -532,16 +572,18 @@ __all__ = (
     "init",
     "run",
     "run_async",
-    "continuation",
     "resume",
+    "resume_async",
     "resume_all",
     "cancel",
     "list_all",
     "delete",
     "get_output",
+    "get_output_async",
     "get_status",
     "get_metadata",
     "sleep",
     "wait_for_event",
     "options",
+    "continuation",
 )

--- a/python/ray/workflow/tests/test_basic_workflows.py
+++ b/python/ray/workflow/tests/test_basic_workflows.py
@@ -160,7 +160,7 @@ def test_run_or_resume_during_running(workflow_start_regular_shared):
     with pytest.raises(RuntimeError):
         workflow.run_async(simple_sequential.bind(), workflow_id="running_workflow")
     with pytest.raises(RuntimeError):
-        workflow.resume(workflow_id="running_workflow")
+        workflow.resume_async(workflow_id="running_workflow")
     assert ray.get(output) == "[source1][append1][append2]"
 
 

--- a/python/ray/workflow/tests/test_basic_workflows_3.py
+++ b/python/ray/workflow/tests/test_basic_workflows_3.py
@@ -105,9 +105,9 @@ def test_task_id_generation(workflow_start_regular_shared, request):
 
     workflow_id = "test_task_id_generation"
     ret = workflow.run_async(x, workflow_id=workflow_id)
-    outputs = [workflow.get_output(workflow_id, name="simple")]
+    outputs = [workflow.get_output_async(workflow_id, name="simple")]
     for i in range(1, n):
-        outputs.append(workflow.get_output(workflow_id, name=f"simple_{i}"))
+        outputs.append(workflow.get_output_async(workflow_id, name=f"simple_{i}"))
     assert ray.get(ret) == n - 1
     assert ray.get(outputs) == list(range(n))
 

--- a/python/ray/workflow/tests/test_checkpoint.py
+++ b/python/ray/workflow/tests/test_checkpoint.py
@@ -60,7 +60,7 @@ def test_checkpoint_dag_skip_all(workflow_start_regular_shared):
         workflow_id="checkpoint_skip",
     )
     assert np.isclose(outputs, 8388607.5)
-    recovered = ray.get(workflow.resume("checkpoint_skip"))
+    recovered = workflow.resume("checkpoint_skip")
     assert np.isclose(recovered, 8388607.5)
 
     wf_storage = workflow_storage.WorkflowStorage("checkpoint_skip")
@@ -76,7 +76,7 @@ def test_checkpoint_dag_skip_partial(workflow_start_regular_shared):
         workflow_id="checkpoint_partial",
     )
     assert np.isclose(outputs, 8388607.5)
-    recovered = ray.get(workflow.resume("checkpoint_partial"))
+    recovered = workflow.resume("checkpoint_partial")
     assert np.isclose(recovered, 8388607.5)
 
     wf_storage = workflow_storage.WorkflowStorage("checkpoint_partial")
@@ -92,7 +92,7 @@ def test_checkpoint_dag_full(workflow_start_regular_shared):
         workflow_id="checkpoint_whole",
     )
     assert np.isclose(outputs, 8388607.5)
-    recovered = ray.get(workflow.resume("checkpoint_whole"))
+    recovered = workflow.resume("checkpoint_whole")
     assert np.isclose(recovered, 8388607.5)
 
     wf_storage = workflow_storage.WorkflowStorage("checkpoint_whole")

--- a/python/ray/workflow/tests/test_checkpoint_2.py
+++ b/python/ray/workflow/tests/test_checkpoint_2.py
@@ -48,7 +48,7 @@ def test_checkpoint_dag_recovery_skip(workflow_start_regular_shared):
     utils.set_global_mark()
 
     start = time.time()
-    recovered = ray.get(workflow.resume("checkpoint_skip_recovery"))
+    recovered = workflow.resume("checkpoint_skip_recovery")
     recover_duration_skipped = time.time() - start
     assert np.isclose(recovered, np.arange(SIZE).mean())
 
@@ -71,7 +71,7 @@ def test_checkpoint_dag_recovery_partial(workflow_start_regular_shared):
     utils.set_global_mark()
 
     start = time.time()
-    recovered = ray.get(workflow.resume("checkpoint_partial_recovery"))
+    recovered = workflow.resume("checkpoint_partial_recovery")
     recover_duration_partial = time.time() - start
     assert np.isclose(recovered, np.arange(SIZE).mean())
     print(
@@ -91,7 +91,7 @@ def test_checkpoint_dag_recovery_whole(workflow_start_regular_shared):
     utils.set_global_mark()
 
     start = time.time()
-    recovered = ray.get(workflow.resume("checkpoint_whole_recovery"))
+    recovered = workflow.resume("checkpoint_whole_recovery")
     recover_duration_whole = time.time() - start
     assert np.isclose(recovered, np.arange(SIZE).mean())
 

--- a/python/ray/workflow/tests/test_events.py
+++ b/python/ray/workflow/tests/test_events.py
@@ -204,10 +204,10 @@ def test_crash_during_event_checkpointing(workflow_start_regular_shared):
 
     ray.init(num_cpus=4, storage=storage_uri)
     workflow.init()
-    workflow.resume("workflow")
+    workflow.resume_async("workflow")
     utils.set_global_mark("resume")
 
-    ray.get(workflow.get_output("workflow"))
+    workflow.get_output("workflow")
     assert utils.check_global_mark("second")
 
 
@@ -255,9 +255,9 @@ def test_crash_after_commit(workflow_start_regular_shared):
 
     ray.init(num_cpus=4, storage=storage_uri)
     workflow.init()
-    workflow.resume("workflow")
+    workflow.resume_async("workflow")
 
-    ray.get(workflow.get_output("workflow"))
+    workflow.get_output("workflow")
     assert utils.check_global_mark("second")
 
 

--- a/python/ray/workflow/tests/test_lifetime.py
+++ b/python/ray/workflow/tests/test_lifetime.py
@@ -38,8 +38,7 @@ def test_workflow_lifetime_1(workflow_start_cluster):
     with patch.dict(os.environ, {"RAY_ADDRESS": address}):
         ray.init()
         run_string_as_driver(driver_script.format(5))
-        output = workflow.get_output("driver_terminated")
-        assert ray.get(output) == 20
+        assert workflow.get_output("driver_terminated") == 20
 
 
 def test_workflow_lifetime_2(workflow_start_cluster):
@@ -51,8 +50,7 @@ def test_workflow_lifetime_2(workflow_start_cluster):
         time.sleep(10)
         proc.kill()
         time.sleep(1)
-        output = workflow.get_output("driver_terminated")
-        assert ray.get(output) == 20
+        assert workflow.get_output("driver_terminated") == 20
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_metadata.py
+++ b/python/ray/workflow/tests/test_metadata.py
@@ -185,8 +185,7 @@ def test_failed_and_resumed_workflow(workflow_start_regular, tmp_path):
     assert workflow_metadata_failed["status"] == "FAILED"
 
     error_flag.unlink()
-    ref = workflow.resume(workflow_id)
-    assert ray.get(ref) == 0
+    assert workflow.resume(workflow_id) == 0
 
     workflow_metadata_resumed = workflow.get_metadata(workflow_id)
     assert workflow_metadata_resumed["status"] == "SUCCESSFUL"

--- a/python/ray/workflow/tests/test_recovery.py
+++ b/python/ray/workflow/tests/test_recovery.py
@@ -145,12 +145,10 @@ def test_recovery_simple_1(workflow_start_regular):
     assert workflow.get_status(workflow_id) == workflow.WorkflowStatus.FAILED
 
     utils.set_global_mark()
-    output = workflow.resume(workflow_id)
-    assert ray.get(output) == "foo(x)"
+    assert workflow.resume(workflow_id) == "foo(x)"
     utils.unset_global_mark()
     # resume from workflow output checkpoint
-    output = workflow.resume(workflow_id)
-    assert ray.get(output) == "foo(x)"
+    assert workflow.resume(workflow_id) == "foo(x)"
 
 
 def test_recovery_simple_2(workflow_start_regular):
@@ -167,13 +165,11 @@ def test_recovery_simple_2(workflow_start_regular):
     assert workflow.get_status(workflow_id) == workflow.WorkflowStatus.FAILED
 
     utils.set_global_mark()
-    output = workflow.resume(workflow_id)
-    assert ray.get(output) == "foo(x)"
+    assert workflow.resume(workflow_id) == "foo(x)"
     utils.unset_global_mark()
     # resume from workflow output checkpoint
 
-    output = workflow.resume(workflow_id)
-    assert ray.get(output) == "foo(x)"
+    assert workflow.resume(workflow_id) == "foo(x)"
 
 
 def test_recovery_simple_3(workflow_start_regular):
@@ -201,12 +197,10 @@ def test_recovery_simple_3(workflow_start_regular):
     assert workflow.get_status(workflow_id) == workflow.WorkflowStatus.FAILED
 
     utils.set_global_mark()
-    output = workflow.resume(workflow_id)
-    assert ray.get(output) == "foo(x[append1])[append2]"
+    assert workflow.resume(workflow_id) == "foo(x[append1])[append2]"
     utils.unset_global_mark()
     # resume from workflow output checkpoint
-    output = workflow.resume(workflow_id)
-    assert ray.get(output) == "foo(x[append1])[append2]"
+    assert workflow.resume(workflow_id) == "foo(x[append1])[append2]"
 
 
 def test_recovery_complex(workflow_start_regular):
@@ -245,19 +239,17 @@ def test_recovery_complex(workflow_start_regular):
     assert workflow.get_status(workflow_id) == workflow.WorkflowStatus.FAILED
 
     utils.set_global_mark()
-    output = workflow.resume(workflow_id)
     r = "join(join(foo(x[append1]), [source1][append2]), join(x, [source1]))"
-    assert ray.get(output) == r
+    assert workflow.resume(workflow_id) == r
     utils.unset_global_mark()
     # resume from workflow output checkpoint
-    output = workflow.resume(workflow_id)
     r = "join(join(foo(x[append1]), [source1][append2]), join(x, [source1]))"
-    assert ray.get(output) == r
+    assert workflow.resume(workflow_id) == r
 
 
 def test_recovery_non_exists_workflow(workflow_start_regular):
     with pytest.raises(WorkflowNotResumableError):
-        ray.get(workflow.resume("this_workflow_id_does_not_exist"))
+        workflow.resume("this_workflow_id_does_not_exist")
 
 
 def test_recovery_cluster_failure(tmp_path, shutdown_only):
@@ -290,7 +282,7 @@ if __name__ == "__main__":
     time.sleep(1)
     ray.init(storage=str(tmp_path))
     workflow.init()
-    assert ray.get(workflow.resume("cluster_failure")) == 20
+    assert workflow.resume("cluster_failure") == 20
     ray.shutdown()
 
 
@@ -360,7 +352,7 @@ def test_resume_different_storage(shutdown_only, tmp_path):
     ray.init(storage=str(tmp_path))
     workflow.init()
     workflow.run(constant.bind(), workflow_id="const")
-    assert ray.get(workflow.resume(workflow_id="const")) == 31416
+    assert workflow.resume(workflow_id="const") == 31416
 
 
 if __name__ == "__main__":

--- a/python/ray/workflow/tests/test_storage.py
+++ b/python/ray/workflow/tests/test_storage.py
@@ -52,15 +52,14 @@ def test_delete(workflow_start_regular):
     workflow.init()
 
     with pytest.raises(ray.exceptions.RaySystemError):
-        result = workflow.get_output("never_finishes")
-        ray.get(result)
+        workflow.get_output("never_finishes")
 
     workflow.delete("never_finishes")
 
     with pytest.raises(ray.exceptions.RaySystemError):
         # TODO(suquark): we should raise "ValueError" without
-        #  ray.get() over the result.
-        ray.get(workflow.get_output("never_finishes"))
+        #  been blocking over the result.
+        workflow.get_output("never_finishes")
 
     # TODO(Alex): Uncomment after
     # https://github.com/ray-project/ray/issues/19481.
@@ -77,15 +76,14 @@ def test_delete(workflow_start_regular):
 
     result = workflow.run(basic_step.bind("hello world"), workflow_id="finishes")
     assert result == "hello world"
-    ouput = workflow.get_output("finishes")
-    assert ray.get(ouput) == "hello world"
+    assert workflow.get_output("finishes") == "hello world"
 
     workflow.delete(workflow_id="finishes")
 
     with pytest.raises(ray.exceptions.RaySystemError):
         # TODO(suquark): we should raise "ValueError" without
-        #  ray.get() over the result.
-        ray.get(workflow.get_output("finishes"))
+        #  blocking over the result.
+        workflow.get_output("finishes")
 
     # TODO(Alex): Uncomment after
     # https://github.com/ray-project/ray/issues/19481.

--- a/python/ray/workflow/tests/test_storage_failure.py
+++ b/python/ray/workflow/tests/test_storage_failure.py
@@ -90,7 +90,7 @@ def test_failure_with_storage(workflow_start_regular):
                     await debug_store.replay(i)
 
             asyncio_run(replay())
-            return ray.get(workflow.resume(workflow_id="complex_workflow"))
+            return workflow.resume(workflow_id="complex_workflow")
 
         with pytest.raises(ValueError):
             # in cases, the replayed records are too few to resume the

--- a/python/ray/workflow/tests/test_workflow_manager.py
+++ b/python/ray/workflow/tests/test_workflow_manager.py
@@ -76,7 +76,7 @@ def test_workflow_manager(workflow_start_regular, tmp_path):
     assert workflow.get_status("0") == "FAILED"
     assert workflow.get_status("1") == "SUCCESSFUL"
     lock.acquire()
-    r = workflow.resume("0")
+    r = workflow.resume_async("0")
     assert workflow.get_status("0") == workflow.RUNNING
     flag_file.unlink()
     lock.release()
@@ -85,7 +85,7 @@ def test_workflow_manager(workflow_start_regular, tmp_path):
 
     # Test cancel
     lock.acquire()
-    workflow.resume("2")
+    workflow.resume_async("2")
     assert workflow.get_status("2") == workflow.RUNNING
     workflow.cancel("2")
     assert workflow.get_status("2") == workflow.CANCELED


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR unified the semantics of some workflow APIs.

Those workflow APIs acts on workflow tasks so they could be blocked for a long time. So we have both the blocking and non-blocking versions for them: `xxx` for blocking and `xxx_async` for non-blocking APIs.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
