### PR TITLE
Fix exception cause in preprocessors.py

### DIFF
--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -79,12 +79,12 @@ class Preprocessor:
                         else None,
                         self._obs_space,
                     )
-            except AttributeError:
+            except AttributeError as e:
                 raise ValueError(
                     "Observation for a Box/MultiBinary/MultiDiscrete space "
                     "should be an np.array, not a Python list.",
                     observation,
-                )
+                ) from e
         self._i += 1
 
     @property


### PR DESCRIPTION
Fix exception cause in preprocessors.py. More context: https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
