### PR TITLE
[serve] Add healthz endpoint for HttpProxy.

### DIFF
--- a/python/ray/serve/http_proxy.py
+++ b/python/ray/serve/http_proxy.py
@@ -290,6 +290,11 @@ class HTTPProxy:
                 scope, receive, send
             )
 
+        if route_path == "/-/healthz":
+            return await starlette.responses.PlainTextResponse("success")(
+                scope, receive, send
+            )
+
         route_prefix, handle = self.prefix_router.match_route(route_path)
         if route_prefix is None:
             self.request_error_counter.inc(

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -41,6 +41,12 @@ def test_path_validation(serve_instance):
     D4.options(name="test2").deploy()
 
 
+def test_routes_healthz(serve_instance):
+    resp = requests.get("http://localhost:8000/-/healthz")
+    assert resp.status_code == 200
+    assert resp.content == b"success"
+
+
 def test_routes_endpoint(serve_instance):
     @serve.deployment
     class D1:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR add an endpoint for http proxy for health check. This feature is critical for serve operator because serve service needs to add the node to the service endpoint in a dynamic way and it'll use this endpoint for health check and add the health one.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
