### PR TITLE
[Core][Data] Fix resend protocol

### DIFF
--- a/src/ray/object_manager/push_manager.cc
+++ b/src/ray/object_manager/push_manager.cc
@@ -25,14 +25,15 @@ void PushManager::StartPush(const NodeID &dest_id,
                             int64_t num_chunks,
                             std::function<void(int64_t)> send_chunk_fn) {
   auto push_id = std::make_pair(dest_id, obj_id);
-  if (push_info_.contains(push_id)) {
-    RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", "
-                   << push_id.second;
-    return;
-  }
   RAY_CHECK(num_chunks > 0);
   chunks_remaining_ += num_chunks;
-  push_info_[push_id].reset(new PushState(num_chunks, send_chunk_fn));
+  if (push_info_.contains(push_id)) {
+    RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", "
+                   << push_id.second << ", resending all the chunks.";
+    push_info_[push_id]->ResentAllChunks();
+  } else {
+    push_info_[push_id].reset(new PushState(num_chunks, send_chunk_fn));
+  }
   ScheduleRemainingPushes();
 }
 
@@ -40,7 +41,7 @@ void PushManager::OnChunkComplete(const NodeID &dest_id, const ObjectID &obj_id)
   auto push_id = std::make_pair(dest_id, obj_id);
   chunks_in_flight_ -= 1;
   chunks_remaining_ -= 1;
-  if (--push_info_[push_id]->chunks_remaining <= 0) {
+  push_info_[push_id]->OnChunkSent() if (push_info_[push_id]->AllChunkSent()) {
     push_info_.erase(push_id);
     RAY_LOG(DEBUG) << "Push for " << push_id.first << ", " << push_id.second
                    << " completed, remaining: " << NumPushesInFlight();
@@ -60,9 +61,7 @@ void PushManager::ScheduleRemainingPushes() {
     while (it != push_info_.end() && chunks_in_flight_ < max_chunks_in_flight_) {
       auto push_id = it->first;
       auto &info = it->second;
-      if (info->next_chunk_id < info->num_chunks) {
-        // Send the next chunk for this push.
-        info->chunk_send_fn(info->next_chunk_id++);
+      if (info->SendOneChunk()) {
         chunks_in_flight_ += 1;
         keep_looping = true;
         RAY_LOG(DEBUG) << "Sending chunk " << info->next_chunk_id << " of "

--- a/src/ray/object_manager/push_manager.cc
+++ b/src/ray/object_manager/push_manager.cc
@@ -30,7 +30,7 @@ void PushManager::StartPush(const NodeID &dest_id,
   if (push_info_.contains(push_id)) {
     RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", " << push_id.second
                    << ", resending all the chunks.";
-    push_info_[push_id]->ResentAllChunks();
+    push_info_[push_id]->ResendAllChunks();
   } else {
     push_info_[push_id].reset(new PushState(num_chunks, send_chunk_fn));
   }
@@ -42,7 +42,7 @@ void PushManager::OnChunkComplete(const NodeID &dest_id, const ObjectID &obj_id)
   chunks_in_flight_ -= 1;
   chunks_remaining_ -= 1;
   push_info_[push_id]->OnChunkComplete();
-  if (push_info_[push_id]->AllChunkComplete()) {
+  if (push_info_[push_id]->AllChunksComplete()) {
     push_info_.erase(push_id);
     RAY_LOG(DEBUG) << "Push for " << push_id.first << ", " << push_id.second
                    << " completed, remaining: " << NumPushesInFlight();

--- a/src/ray/object_manager/push_manager.cc
+++ b/src/ray/object_manager/push_manager.cc
@@ -26,12 +26,12 @@ void PushManager::StartPush(const NodeID &dest_id,
                             std::function<void(int64_t)> send_chunk_fn) {
   auto push_id = std::make_pair(dest_id, obj_id);
   RAY_CHECK(num_chunks > 0);
-  chunks_remaining_ += num_chunks;
   if (push_info_.contains(push_id)) {
     RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", " << push_id.second
                    << ", resending all the chunks.";
-    push_info_[push_id]->ResendAllChunks();
+    chunks_remaining_ += push_info_[push_id]->ResendAllChunks();
   } else {
+    chunks_remaining_ += num_chunks;
     push_info_[push_id].reset(new PushState(num_chunks, send_chunk_fn));
   }
   ScheduleRemainingPushes();

--- a/src/ray/object_manager/push_manager.cc
+++ b/src/ray/object_manager/push_manager.cc
@@ -28,8 +28,8 @@ void PushManager::StartPush(const NodeID &dest_id,
   RAY_CHECK(num_chunks > 0);
   chunks_remaining_ += num_chunks;
   if (push_info_.contains(push_id)) {
-    RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", "
-                   << push_id.second << ", resending all the chunks.";
+    RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", " << push_id.second
+                   << ", resending all the chunks.";
     push_info_[push_id]->ResentAllChunks();
   } else {
     push_info_[push_id].reset(new PushState(num_chunks, send_chunk_fn));
@@ -41,7 +41,8 @@ void PushManager::OnChunkComplete(const NodeID &dest_id, const ObjectID &obj_id)
   auto push_id = std::make_pair(dest_id, obj_id);
   chunks_in_flight_ -= 1;
   chunks_remaining_ -= 1;
-  push_info_[push_id]->OnChunkSent() if (push_info_[push_id]->AllChunkSent()) {
+  push_info_[push_id]->OnChunkComplete();
+  if (push_info_[push_id]->AllChunkComplete()) {
     push_info_.erase(push_id);
     RAY_LOG(DEBUG) << "Push for " << push_id.first << ", " << push_id.second
                    << " completed, remaining: " << NumPushesInFlight();

--- a/src/ray/object_manager/push_manager.cc
+++ b/src/ray/object_manager/push_manager.cc
@@ -29,7 +29,7 @@ void PushManager::StartPush(const NodeID &dest_id,
   if (push_info_.contains(push_id)) {
     RAY_LOG(DEBUG) << "Duplicate push request " << push_id.first << ", " << push_id.second
                    << ", resending all the chunks.";
-    chunks_remaining_ += push_info_[push_id]->ResendAllChunks();
+    chunks_remaining_ += push_info_[push_id]->ResendAllChunks(send_chunk_fn);
   } else {
     chunks_remaining_ += num_chunks;
     push_info_[push_id].reset(new PushState(num_chunks, send_chunk_fn));

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -92,7 +92,7 @@ class PushManager {
           num_chunks_inflight(0),
           num_chunks_to_send(num_chunks) {}
 
-    /// Resend all chunks.
+    /// Resend all chunks and returns how many more chunks will be sent.
     int64_t ResendAllChunks(std::function<void(int64_t)> send_fn) {
       chunk_send_fn = send_fn;
       int64_t additional_chunks_to_send = num_chunks - num_chunks_to_send;

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -60,7 +60,7 @@ class PushManager {
   int64_t NumChunksInFlight() const { return chunks_in_flight_; };
 
   /// Return the number of chunks remaining. For testing only.
-  int64_t NumChunksRemaining() const { return num_chunks_pending_completion_; }
+  int64_t NumChunksRemaining() const { return chunks_remaining_; }
 
   /// Return the number of pushes currently in flight. For testing only.
   int64_t NumPushesInFlight() const { return push_info_.size(); };

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -92,7 +92,11 @@ class PushManager {
           num_chunks_to_send(num_chunks) {}
 
     /// Resend all chunks.
-    void ResendAllChunks() { num_chunks_to_send = num_chunks; }
+    int64_t ResendAllChunks() { 
+      int64_t additional_chunks_to_send = num_chunks - num_chunks_to_send;
+      num_chunks_to_send = num_chunks; 
+      return additional_chunks_to_send;
+    }
 
     /// Send one chunck. Return true if a new chunk is sent, false if no more chunk to
     /// send.

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -77,7 +77,7 @@ class PushManager {
     /// total number of chunks of this object.
     const int64_t num_chunks;
     /// The function to send chunks with.
-    const std::function<void(int64_t)> chunk_send_fn;
+    std::function<void(int64_t)> chunk_send_fn;
     /// The index of the next chunk to send.
     int64_t next_chunk_id;
     /// The number of chunks pending completion.
@@ -93,7 +93,8 @@ class PushManager {
           num_chunks_to_send(num_chunks) {}
 
     /// Resend all chunks.
-    int64_t ResendAllChunks() {
+    int64_t ResendAllChunks(std::function<void(int64_t)> send_fn) {
+      chunk_send_fn = send_fn;
       int64_t additional_chunks_to_send = num_chunks - num_chunks_to_send;
       num_chunks_to_send = num_chunks;
       return additional_chunks_to_send;

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -71,6 +71,7 @@ class PushManager {
   std::string DebugString() const;
 
  private:
+  FRIEND_TEST(TestPushManager, TestPushState);
   /// Tracks the state of an active object push to another node.
   struct PushState {
     /// total number of chunks of this object.

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -88,6 +88,24 @@ class PushManager {
           chunk_send_fn(chunk_send_fn),
           next_chunk_id(0),
           chunks_remaining(num_chunks) {}
+
+    void ResentAllChunks() {
+      next_chunk_id = 0;
+      chunks_remaining += num_chunks;
+    }
+
+    bool SendOneChunk() {
+      if (next_chunk_id < num_chunks) {
+        // Send the next chunk for this push.
+        chunk_send_fn(next_chunk_id++);
+        return true;
+      }
+      return false;
+    }
+
+    void OnChunkSent() { --chunks_remaining; }
+
+    bool AllChunkSent() { return chunks_remaining <= 0; }
   };
 
   /// Called on completion events to trigger additional pushes.

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -131,7 +131,7 @@ class PushManager {
   int64_t chunks_in_flight_ = 0;
 
   /// Remaining count of chunks to push to other nodes.
-  int64_t num_chunks_pending_completion_ = 0;
+  int64_t chunks_remaining_ = 0;
 
   /// Tracks all pushes with chunk transfers in flight.
   absl::flat_hash_map<PushID, std::unique_ptr<PushState>> push_info_;

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -92,9 +92,9 @@ class PushManager {
           num_chunks_to_send(num_chunks) {}
 
     /// Resend all chunks.
-    int64_t ResendAllChunks() { 
+    int64_t ResendAllChunks() {
       int64_t additional_chunks_to_send = num_chunks - num_chunks_to_send;
-      num_chunks_to_send = num_chunks; 
+      num_chunks_to_send = num_chunks;
       return additional_chunks_to_send;
     }
 

--- a/src/ray/object_manager/push_manager.h
+++ b/src/ray/object_manager/push_manager.h
@@ -103,9 +103,9 @@ class PushManager {
       return false;
     }
 
-    void OnChunkSent() { --chunks_remaining; }
+    void OnChunkComplete() { --chunks_remaining; }
 
-    bool AllChunkSent() { return chunks_remaining <= 0; }
+    bool AllChunkComplete() { return chunks_remaining <= 0; }
   };
 
   /// Called on completion events to trigger additional pushes.

--- a/src/ray/object_manager/test/push_manager_test.cc
+++ b/src/ray/object_manager/test/push_manager_test.cc
@@ -40,30 +40,107 @@ TEST(TestPushManager, TestSingleTransfer) {
   }
 }
 
-TEST(TestPushManager, TestRetryDuplicates) {
-  std::vector<int> results;
-  results.resize(10);
-  auto node_id = NodeID::FromRandom();
-  auto obj_id = ObjectID::FromRandom();
-  PushManager pm(5);
+TEST(TestPushManager, TestPushState) {
+  {
+    std::vector<int64_t> sent_chunks;
+    PushManager::PushState state{
+        2, [&](int64_t chunk_id) { sent_chunks.push_back(chunk_id); }};
+    ASSERT_EQ(state.num_chunks, 2);
+    ASSERT_EQ(state.next_chunk_id, 0);
+    ASSERT_EQ(state.num_chunks_inflight, 0);
+    ASSERT_EQ(state.num_chunks_to_send, 2);
+    ASSERT_TRUE(state.SendOneChunk());
+    ASSERT_FALSE(state.AllChunksComplete());
+    ASSERT_EQ(state.num_chunks, 2);
+    ASSERT_EQ(state.next_chunk_id, 1);
+    ASSERT_EQ(state.num_chunks_inflight, 1);
+    ASSERT_EQ(state.num_chunks_to_send, 1);
+    std::vector<int64_t> expected_chunks{0};
+    ASSERT_EQ(sent_chunks, expected_chunks);
 
-  // First send.
-  pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 1; });
-  // Duplicates are all ignored.
-  pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2; });
-  ASSERT_EQ(pm.NumChunksInFlight(), 5);
-  ASSERT_EQ(pm.NumChunksRemaining(), 15);
-  ASSERT_EQ(pm.NumPushesInFlight(), 1);
-  for (int i = 0; i < 10; i++) {
-    pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2; });
-    pm.OnChunkComplete(node_id, obj_id);
+    ASSERT_TRUE(state.SendOneChunk());
+    ASSERT_EQ(state.num_chunks, 2);
+    ASSERT_EQ(state.next_chunk_id, 0);
+    ASSERT_EQ(state.num_chunks_inflight, 2);
+    ASSERT_EQ(state.num_chunks_to_send, 0);
+    std::vector<int64_t> expected_chunks1{0, 1};
+    ASSERT_EQ(sent_chunks, expected_chunks1);
+    ASSERT_FALSE(state.AllChunksComplete());
+
+    ASSERT_FALSE(state.SendOneChunk());
+    state.OnChunkComplete();
+    ASSERT_EQ(state.num_chunks_inflight, 1);
+    ASSERT_FALSE(state.AllChunksComplete());
+    state.OnChunkComplete();
+    ASSERT_EQ(state.num_chunks_inflight, 0);
+    ASSERT_TRUE(state.AllChunksComplete());
   }
-  ASSERT_EQ(pm.NumChunksInFlight(), 5);
-  ASSERT_EQ(pm.NumChunksRemaining(), 0);
-  ASSERT_EQ(pm.NumPushesInFlight(), 0);
-  for (int i = 0; i < 10; i++) {
-    ASSERT_EQ(results[i], 1);
+
+  // Resent all chunks.
+  {
+    std::vector<int64_t> sent_chunks;
+    PushManager::PushState state{
+        3, [&](int64_t chunk_id) { sent_chunks.push_back(chunk_id); }};
+    ASSERT_TRUE(state.SendOneChunk());
+    ASSERT_FALSE(state.AllChunksComplete());
+    ASSERT_EQ(state.num_chunks, 3);
+    ASSERT_EQ(state.next_chunk_id, 1);
+    ASSERT_EQ(state.num_chunks_inflight, 1);
+    ASSERT_EQ(state.num_chunks_to_send, 2);
+    std::vector<int64_t> expected_chunks{0};
+    ASSERT_EQ(sent_chunks, expected_chunks);
+
+    ASSERT_EQ(1, state.ResendAllChunks());
+    ASSERT_EQ(state.num_chunks, 3);
+    ASSERT_EQ(state.next_chunk_id, 1);
+    ASSERT_EQ(state.num_chunks_inflight, 1);
+    ASSERT_EQ(state.num_chunks_to_send, 3);
+
+    for (auto i = 0; i < 3; i++) {
+      ASSERT_TRUE(state.SendOneChunk());
+      ASSERT_EQ(state.num_chunks, 3);
+      ASSERT_EQ(state.next_chunk_id, (2 + i) % 3);
+      ASSERT_EQ(state.num_chunks_inflight, 2 + i);
+      ASSERT_EQ(state.num_chunks_to_send, 3 - i - 1);
+    }
+    std::vector<int64_t> expected_chunks1{0, 1, 2, 0};
+    ASSERT_EQ(sent_chunks, expected_chunks1);
+
+    ASSERT_FALSE(state.SendOneChunk());
+    ASSERT_FALSE(state.AllChunksComplete());
+    state.OnChunkComplete();
+    state.OnChunkComplete();
+    state.OnChunkComplete();
+    ASSERT_FALSE(state.AllChunksComplete());
+    state.OnChunkComplete();
+    ASSERT_TRUE(state.AllChunksComplete());
   }
+}
+
+TEST(TestPushManager, TestRetryDuplicates) {
+  // std::vector<int> results;
+  // results.resize(10);
+  // auto node_id = NodeID::FromRandom();
+  // auto obj_id = ObjectID::FromRandom();
+  // PushManager pm(5);
+
+  // // First send.
+  // pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 1; });
+  // // Duplicates are all ignored.
+  // pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2; });
+  // ASSERT_EQ(pm.NumChunksInFlight(), 5);
+  // ASSERT_EQ(pm.NumChunksRemaining(), 15);
+  // ASSERT_EQ(pm.NumPushesInFlight(), 1);
+  // for (int i = 0; i < 10; i++) {
+  //   pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2;
+  //   }); pm.OnChunkComplete(node_id, obj_id);
+  // }
+  // ASSERT_EQ(pm.NumChunksInFlight(), 5);
+  // ASSERT_EQ(pm.NumChunksRemaining(), 0);
+  // ASSERT_EQ(pm.NumPushesInFlight(), 0);
+  // for (int i = 0; i < 10; i++) {
+  //   ASSERT_EQ(results[i], 1);
+  // }
 
   // // Second allowed send.
   // pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 3; });

--- a/src/ray/object_manager/test/push_manager_test.cc
+++ b/src/ray/object_manager/test/push_manager_test.cc
@@ -40,7 +40,7 @@ TEST(TestPushManager, TestSingleTransfer) {
   }
 }
 
-TEST(TestPushManager, TestSuppressDuplicates) {
+TEST(TestPushManager, TestRetryDuplicates) {
   std::vector<int> results;
   results.resize(10);
   auto node_id = NodeID::FromRandom();
@@ -52,30 +52,30 @@ TEST(TestPushManager, TestSuppressDuplicates) {
   // Duplicates are all ignored.
   pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2; });
   ASSERT_EQ(pm.NumChunksInFlight(), 5);
-  ASSERT_EQ(pm.NumChunksRemaining(), 10);
+  ASSERT_EQ(pm.NumChunksRemaining(), 15);
   ASSERT_EQ(pm.NumPushesInFlight(), 1);
   for (int i = 0; i < 10; i++) {
     pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2; });
     pm.OnChunkComplete(node_id, obj_id);
   }
-  ASSERT_EQ(pm.NumChunksInFlight(), 0);
+  ASSERT_EQ(pm.NumChunksInFlight(), 5);
   ASSERT_EQ(pm.NumChunksRemaining(), 0);
   ASSERT_EQ(pm.NumPushesInFlight(), 0);
   for (int i = 0; i < 10; i++) {
     ASSERT_EQ(results[i], 1);
   }
 
-  // Second allowed send.
-  pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 3; });
-  for (int i = 0; i < 10; i++) {
-    pm.OnChunkComplete(node_id, obj_id);
-  }
-  ASSERT_EQ(pm.NumChunksInFlight(), 0);
-  ASSERT_EQ(pm.NumChunksRemaining(), 0);
-  ASSERT_EQ(pm.NumPushesInFlight(), 0);
-  for (int i = 0; i < 10; i++) {
-    ASSERT_EQ(results[i], 3);
-  }
+  // // Second allowed send.
+  // pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 3; });
+  // for (int i = 0; i < 10; i++) {
+  //   pm.OnChunkComplete(node_id, obj_id);
+  // }
+  // ASSERT_EQ(pm.NumChunksInFlight(), 0);
+  // ASSERT_EQ(pm.NumChunksRemaining(), 0);
+  // ASSERT_EQ(pm.NumPushesInFlight(), 0);
+  // for (int i = 0; i < 10; i++) {
+  //   ASSERT_EQ(results[i], 3);
+  // }
 }
 
 TEST(TestPushManager, TestMultipleTransfers) {

--- a/src/ray/object_manager/test/push_manager_test.cc
+++ b/src/ray/object_manager/test/push_manager_test.cc
@@ -41,6 +41,7 @@ TEST(TestPushManager, TestSingleTransfer) {
 }
 
 TEST(TestPushManager, TestPushState) {
+  // normal sending.
   {
     std::vector<int64_t> sent_chunks;
     PushManager::PushState state{
@@ -76,7 +77,7 @@ TEST(TestPushManager, TestPushState) {
     ASSERT_TRUE(state.AllChunksComplete());
   }
 
-  // Resent all chunks.
+  // resend all chunks.
   {
     std::vector<int64_t> sent_chunks;
     PushManager::PushState state{
@@ -90,6 +91,7 @@ TEST(TestPushManager, TestPushState) {
     std::vector<int64_t> expected_chunks{0};
     ASSERT_EQ(sent_chunks, expected_chunks);
 
+    // resend chunks when 1 chunk is in flight.
     ASSERT_EQ(1, state.ResendAllChunks());
     ASSERT_EQ(state.num_chunks, 3);
     ASSERT_EQ(state.next_chunk_id, 1);
@@ -118,41 +120,44 @@ TEST(TestPushManager, TestPushState) {
 }
 
 TEST(TestPushManager, TestRetryDuplicates) {
-  // std::vector<int> results;
-  // results.resize(10);
-  // auto node_id = NodeID::FromRandom();
-  // auto obj_id = ObjectID::FromRandom();
-  // PushManager pm(5);
+  std::vector<int> results;
+  results.resize(10);
+  auto node_id = NodeID::FromRandom();
+  auto obj_id = ObjectID::FromRandom();
+  PushManager pm(5);
 
-  // // First send.
-  // pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 1; });
-  // // Duplicates are all ignored.
-  // pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2; });
-  // ASSERT_EQ(pm.NumChunksInFlight(), 5);
-  // ASSERT_EQ(pm.NumChunksRemaining(), 15);
-  // ASSERT_EQ(pm.NumPushesInFlight(), 1);
-  // for (int i = 0; i < 10; i++) {
-  //   pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2;
-  //   }); pm.OnChunkComplete(node_id, obj_id);
-  // }
-  // ASSERT_EQ(pm.NumChunksInFlight(), 5);
-  // ASSERT_EQ(pm.NumChunksRemaining(), 0);
-  // ASSERT_EQ(pm.NumPushesInFlight(), 0);
-  // for (int i = 0; i < 10; i++) {
-  //   ASSERT_EQ(results[i], 1);
-  // }
-
-  // // Second allowed send.
-  // pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 3; });
-  // for (int i = 0; i < 10; i++) {
-  //   pm.OnChunkComplete(node_id, obj_id);
-  // }
-  // ASSERT_EQ(pm.NumChunksInFlight(), 0);
-  // ASSERT_EQ(pm.NumChunksRemaining(), 0);
-  // ASSERT_EQ(pm.NumPushesInFlight(), 0);
-  // for (int i = 0; i < 10; i++) {
-  //   ASSERT_EQ(results[i], 3);
-  // }
+  // First push request.
+  pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 1; });
+  ASSERT_EQ(pm.NumChunksInFlight(), 5);
+  ASSERT_EQ(pm.NumChunksRemaining(), 10);
+  ASSERT_EQ(pm.NumPushesInFlight(), 1);
+  // Second push request will resent the full chunks.
+  pm.StartPush(node_id, obj_id, 10, [&](int64_t chunk_id) { results[chunk_id] = 2; });
+  ASSERT_EQ(pm.NumChunksInFlight(), 5);
+  ASSERT_EQ(pm.NumChunksRemaining(), 15);
+  ASSERT_EQ(pm.NumPushesInFlight(), 1);
+  // first 5 chunks will be sent by first push request.
+  for (int i = 0; i < 5; i++) {
+    pm.OnChunkComplete(node_id, obj_id);
+  }
+  for (int i = 0; i < 5; i++) {
+    ASSERT_EQ(results[i], 1);
+  }
+  ASSERT_EQ(pm.NumChunksInFlight(), 5);
+  ASSERT_EQ(pm.NumChunksRemaining(), 10);
+  // we will resend all chunks by second push request.
+  for (int i = 0; i < 10; i++) {
+    pm.OnChunkComplete(node_id, obj_id);
+  }
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ(results[i], 2);
+  }
+  ASSERT_EQ(pm.NumChunksInFlight(), 0);
+  ASSERT_EQ(pm.NumChunksRemaining(), 0);
+  ASSERT_EQ(pm.NumPushesInFlight(), 0);
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ(results[i], 1);
+  }
 }
 
 TEST(TestPushManager, TestMultipleTransfers) {

--- a/src/ray/object_manager/test/push_manager_test.cc
+++ b/src/ray/object_manager/test/push_manager_test.cc
@@ -92,7 +92,9 @@ TEST(TestPushManager, TestPushState) {
     ASSERT_EQ(sent_chunks, expected_chunks);
 
     // resend chunks when 1 chunk is in flight.
-    ASSERT_EQ(1, state.ResendAllChunks());
+    ASSERT_EQ(1, state.ResendAllChunks([&](int64_t chunk_id) {
+      sent_chunks.push_back(chunk_id);
+    }));
     ASSERT_EQ(state.num_chunks, 3);
     ASSERT_EQ(state.next_chunk_id, 1);
     ASSERT_EQ(state.num_chunks_inflight, 1);
@@ -155,9 +157,6 @@ TEST(TestPushManager, TestRetryDuplicates) {
   ASSERT_EQ(pm.NumChunksInFlight(), 0);
   ASSERT_EQ(pm.NumChunksRemaining(), 0);
   ASSERT_EQ(pm.NumPushesInFlight(), 0);
-  for (int i = 0; i < 10; i++) {
-    ASSERT_EQ(results[i], 1);
-  }
 }
 
 TEST(TestPushManager, TestMultipleTransfers) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When Ray is under memory pressure, the pull manager might cancel ongoing pull request and retry it later. There is a race condition that a pull request is initiated and canceled, and the pull request for the same object is retried by pull manager shortly. When this happens, the pusher (where the object is being pulled) ignores the second pull request if it's still sending the object initiated by the first pull request; instead it will continue sending the remaining chunks. This leads to the puller receiving incomplete data chunks (as some chunks has already being received and then canceled), and the puller has to wait for 10 seconds timeout and retry the pull request.

To fix the problem we simply always resent all chunks when a pull request is received.  Since we always send chunks in order, we implement the resend logic by simply reset the remaining number of chunks to send; and treat the chunks as ring buffer.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
