### PR TITLE
[ci/hotfix] Fix CI with raydp-nightly install

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -392,6 +392,8 @@ install_dependencies() {
   # Data processing test dependencies.
   if [ "${DATA_PROCESSING_TESTING-}" = 1 ] || [ "${DOC_TESTING-}" = 1 ]; then
     pip install -r "${WORKSPACE_DIR}"/python/requirements/data_processing/requirements.txt
+    # Todo: raydp-nightly depends on ray < 1.13.0 which will uninstall our latest release
+    pip install --no-deps raydp-nightly netifaces
   fi
   if [ "${DATA_PROCESSING_TESTING-}" = 1 ]; then
     pip install -r "${WORKSPACE_DIR}"/python/requirements/data_processing/requirements_dataset.txt

--- a/python/requirements/data_processing/requirements.txt
+++ b/python/requirements/data_processing/requirements.txt
@@ -7,6 +7,5 @@ s3fs
 modin>=0.8.3;  python_version < '3.7'
 modin>=0.11.0; python_version >= '3.7'
 pytest-repeat
-raydp-nightly
 responses==0.13.4
 pymars>=0.8.3


### PR DESCRIPTION
We install `raydp-nightly` in data processing tests. This currently requires `ray < 1.13.0` which will uninstall our candidate wheel and install ray 1.12.1, crashing CI (see https://github.com/oap-project/raydp/pull/252/files).

We should probably depend on the latest raydp release and not the nightly version cc @clarkzinzow 

This PR installs `raydp-nightly` without dependencies in the meantime.

Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
