### PR TITLE
Disable the autoselection of the first instant search result so it's …

### DIFF
--- a/doc/source/_static/js/docsearch.js
+++ b/doc/source/_static/js/docsearch.js
@@ -7,6 +7,9 @@ docsearch({
     algoliaOptions: {
         hitsPerPage: 10,
     },
+    autocompleteOptions: {
+        autoselect: false,
+    },
     handleSelected: function (input, event, suggestion, datasetNumber, context) {
         if (context.selectionMethod === 'click') {
             input.setVal('');


### PR DESCRIPTION
…easier to see the full search results

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Right now there is no intuitive way to see the full list of search results on Ray docs. When you hit `Enter` in the search box, it redirects to the first item in the instant search results. This change redirects `Enter` event to the search result page. Users can still use up and down arrows to navigate in the instant search menu.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
