### PR TITLE
[tune] Fix `SyncerCallback` having a size limit

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -1,4 +1,5 @@
 import abc
+from functools import partial
 import threading
 from typing import (
     Callable,
@@ -419,7 +420,8 @@ class SyncerCallback(Callback):
 
     def _get_trial_sync_process(self, trial: "Trial"):
         return self._sync_processes.setdefault(
-            trial.trial_id, _BackgroundProcess(sync_dir_between_nodes)
+            trial.trial_id,
+            _BackgroundProcess(partial(sync_dir_between_nodes, max_size_bytes=None)),
         )
 
     def _remove_trial_sync_process(self, trial: "Trial"):

--- a/python/ray/tune/tests/test_syncer_callback.py
+++ b/python/ray/tune/tests/test_syncer_callback.py
@@ -208,6 +208,17 @@ def test_syncer_callback_sync(ray_start_2_cpus, temp_data_dirs):
     assert_file(True, tmp_target, "subdir_exclude/something/somewhere.txt")
 
 
+def test_syncer_callback_no_size_limit(temp_data_dirs):
+    """Check if max_size_bytes is set to None for sync function"""
+    tmp_source, _ = temp_data_dirs
+
+    syncer_callback = SyncerCallback()
+    trial1 = MockTrial(trial_id="a", logdir=tmp_source)
+
+    sync_fn = syncer_callback._get_trial_sync_process(trial1)._fn
+    assert sync_fn.keywords["max_size_bytes"] is None
+
+
 def test_syncer_callback_sync_period(ray_start_2_cpus, temp_data_dirs):
     """Check that on_trial_result triggers syncing, obeying sync period"""
     tmp_source, tmp_target = temp_data_dirs


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/25655 refactored syncing but it introduced a regression - previously, dirs of any size could have been synced, but now only dirs below the default limit of 1 GB can be. This PR fixes this regression allowing dirs of any size to be synced.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
