### PR TITLE
【Don't merge, just test】fix hide symbol cause mac m1 compile error

### DIFF
--- a/cpp/symbols/ray_api_exported_symbols_mac.lds
+++ b/cpp/symbols/ray_api_exported_symbols_mac.lds
@@ -3,7 +3,7 @@
 # Note: This file is used for macOS only, and should be kept in sync with `ray_api_version_script.lds`.
 # Ray ABI is not finalized, the exact set of exported (C/C++) APIs is subject to change.
 # common
-*[0-9]ray[0-9]*;
+*ray*;
 TaskExecutionHandler;
 GetFunctionManager;
 GetRemoteFunctions;


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
