### PR TITLE
[Train] Add support for handling multiple batch data types for prepare_data_loader

### DIFF
--- a/python/ray/train/examples/torch_linear_example.py
+++ b/python/ray/train/examples/torch_linear_example.py
@@ -24,6 +24,11 @@ class LinearDataset(torch.utils.data.Dataset):
         return len(self.x)
 
 
+class LinearDatasetDict(LinearDataset):
+    def __getitem__(self, index):
+        return {"x": self.x[index, None], "y": self.y[index, None]}
+
+
 def train_epoch(dataloader, model, loss_fn, optimizer):
     for X, y in dataloader:
         # Compute prediction error

--- a/python/ray/train/examples/torch_linear_example.py
+++ b/python/ray/train/examples/torch_linear_example.py
@@ -24,11 +24,6 @@ class LinearDataset(torch.utils.data.Dataset):
         return len(self.x)
 
 
-class LinearDatasetDict(LinearDataset):
-    def __getitem__(self, index):
-        return {"x": self.x[index, None], "y": self.y[index, None]}
-
-
 def train_epoch(dataloader, model, loss_fn, optimizer):
     for X, y in dataloader:
         # Compute prediction error

--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -21,7 +21,7 @@ from ray.train.examples.tensorflow_mnist_example import (
 from ray.train.examples.torch_fashion_mnist_example import (
     train_func as fashion_mnist_train_func,
 )
-from ray.train.examples.torch_linear_example import LinearDataset, LinearDatasetDict
+from ray.train.examples.torch_linear_example import LinearDataset
 from ray.train.horovod.horovod_trainer import HorovodTrainer
 from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
 from ray.train.torch.torch_trainer import TorchTrainer
@@ -40,6 +40,13 @@ def ray_start_1_cpu_1_gpu():
     address_info = ray.init(num_cpus=1, num_gpus=1)
     yield address_info
     ray.shutdown()
+
+
+class LinearDatasetDict(LinearDataset):
+    """Modifies the LinearDataset to return a Dict instead of a Tuple."""
+
+    def __getitem__(self, index):
+        return {"x": self.x[index, None], "y": self.y[index, None]}
 
 
 # TODO: Refactor as a backend test.

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -552,7 +552,7 @@ class _WrappedDataLoader(DataLoader):
             if isinstance(item, collections.abc.Mapping):
                 item_on_device = {k: self._move_to_device(v) for k, v in item.items()}
             elif isinstance(item, (tuple, list)):
-                item_on_device = tuple(try_move_device(i) for i in item)
+                item_on_device = tuple(self._move_to_device(i) for i in item)
             elif isinstance(item, torch.Tensor):
                 item_on_device = try_move_device(item)
             else:

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -552,7 +552,7 @@ class _WrappedDataLoader(DataLoader):
             if isinstance(item, collections.abc.Mapping):
                 item_on_device = {k: self._move_to_device(v) for k, v in item.items()}
             elif isinstance(item, (tuple, list)):
-                item_on_device = tuple(self._move_to_device(i) for i in item)
+                item_on_device = type(item)(self._move_to_device(i) for i in item)
             elif isinstance(item, torch.Tensor):
                 item_on_device = try_move_device(item)
             else:

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -556,7 +556,7 @@ class _WrappedDataLoader(DataLoader):
             elif isinstance(item, torch.Tensor):
                 item_on_device = try_move_device(item)
             else:
-                logger.debug(
+                logger.info(
                     f"Data type {type(item)} doesn't support being moved to device."
                 )
 

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -4,6 +4,7 @@ import os
 import random
 import types
 import warnings
+import collections
 
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -548,7 +549,18 @@ class _WrappedDataLoader(DataLoader):
             return i
 
         with torch.cuda.stream(self._memcpy_stream):
-            return tuple(try_move_device(i) for i in item)
+            if isinstance(item, collections.abc.Mapping):
+                item_on_device = {k: self._move_to_device(v) for k, v in item.items()}
+            elif isinstance(item, (tuple, list)):
+                item_on_device = tuple(try_move_device(i) for i in item)
+            elif isinstance(item, torch.Tensor):
+                item_on_device = try_move_device(item)
+            else:
+                logger.debug(
+                    f"Data type {type(item)} doesn't support being moved to device."
+                )
+
+            return item_on_device
 
     def _wait_for_batch(self, item):
         if self._memcpy_stream is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When working with Ray Train, using the `ray.train.torch.prepare_data_loader` method with a dataset that returns a dictionary instead of a tuple from its `__getitem__` method causes issues.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #26385

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
