### PR TITLE
[autoscaler] Add support for multiple cluster per Azure resource group

### DIFF
--- a/python/ray/autoscaler/_private/_azure/azure-config-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-config-template.json
@@ -2,42 +2,54 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "uniqueId": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique string appended to resource names to isolate resources from different ray clusters."
+            }
+        },
         "subnet": {
             "type": "string",
             "metadata": {
-                "description": "The subnet to be used"
+                "description": "Subnet parameters."
             }
         }
     },
     "variables": {
-        "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-        "location": "[resourceGroup().location]"
+        "contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+        "location": "[resourceGroup().location]",
+        "msiName": "[concat('ray-msi-', parameters('uniqueId'))]",
+        "roleAssignmentName": "[concat('ray-ra-', parameters('uniqueId'))]",
+        "nsgName": "[concat('ray-nsg-', parameters('uniqueId'))]",
+        "nsg": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]",
+        "vnetName": "[concat('ray-vnet-', parameters('uniqueId'))]",
+        "subnetName": "[concat('ray-subnet-', parameters('uniqueId'))]"
     },
     "resources": [
        {
             "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
             "apiVersion": "2018-11-30",
             "location": "[variables('location')]",
-            "name": "ray-msi-user-identity"
+            "name": "[variables('msiName')]"
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2020-04-01-preview",
-            "name": "[guid(resourceGroup().id)]",
+            "apiVersion": "2020-08-01-preview",
+            "name": "[guid(variables('roleAssignmentName'))]",
             "properties": {
-                "principalId": "[reference('ray-msi-user-identity').principalId]",
-                "roleDefinitionId": "[variables('Contributor')]",
+                "principalId": "[reference(variables('msiName')).principalId]",
+                "roleDefinitionId": "[variables('contributor')]",
                 "scope": "[resourceGroup().id]",
                 "principalType": "ServicePrincipal"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'ray-msi-user-identity')]"
+                "[variables('msiName')]"
             ]
         },
         {
             "type": "Microsoft.Network/networkSecurityGroups",
             "apiVersion": "2019-02-01",
-            "name": "ray-nsg",
+            "name": "[variables('nsgName')]",
             "location": "[variables('location')]",
             "properties": {
                 "securityRules": [
@@ -60,7 +72,7 @@
         {
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2019-11-01",
-            "name": "ray-vnet",
+            "name": "[variables('vnetName')]",
             "location": "[variables('location')]",
             "properties": {
                 "addressSpace": {
@@ -70,19 +82,33 @@
                 },
                 "subnets": [
                     {
-                        "name": "ray-subnet",
+                        "name": "[variables('subnetName')]",
                         "properties": {
                             "addressPrefix": "[parameters('subnet')]",
                             "networkSecurityGroup": {
-                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups','ray-nsg')]"
+                                "id": "[variables('nsg')]"
                               }
                         }
                     }
                 ]
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'ray-nsg')]"
+                "[variables('nsg')]"
             ]
         }
-    ]
+    ],
+    "outputs": {
+        "subnet": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('subnetName'))]"
+        },
+        "nsg": {
+            "type": "string",
+            "value": "[variables('nsg')]"
+        },
+        "msi": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('msiName'))]"
+        }
+    }
 }

--- a/python/ray/autoscaler/_private/_azure/azure-vm-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-vm-template.json
@@ -82,17 +82,34 @@
             "metadata": {
                 "description": "Specifies the maximum price to pay for Azure Spot VM."
             }
+        },
+        "msi": {
+            "type": "string",
+            "metadata": {
+                "description": "Managed service identity resource id."
+            }
+        },
+        "nsg": {
+            "type": "string",
+            "metadata": {
+                "description": "Network security group resource id."
+            }
+        },
+        "subnet": {
+            "type": "string",
+            "metadata": {
+                "descriptions": "Subnet resource id."
+            }
         }
     },
     "variables": {
         "location": "[resourceGroup().location]",
-        "networkInterfaceNamePrivate": "[concat(parameters('vmName'),'-nic')]",
-        "networkInterfaceNamePublic": "[concat(parameters('vmName'),'-nic-public')]",
+        "networkInterfaceNamePrivate": "[concat(parameters('vmName'), '-nic')]",
+        "networkInterfaceNamePublic": "[concat(parameters('vmName'), '-nic-public')]",
         "networkInterfaceName": "[if(parameters('provisionPublicIp'), variables('networkInterfaceNamePublic'), variables('networkInterfaceNamePrivate'))]",
         "networkIpConfig": "[guid(resourceGroup().id, parameters('vmName'))]",
         "osDiskType": "Standard_LRS",
-        "publicIpAddressName": "[concat(parameters('vmName'), '-ip' )]",
-        "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ray-vnet', 'ray-subnet')]"
+        "publicIpAddressName": "[concat(parameters('vmName'), '-ip')]"
     },
     "resources": [
         {
@@ -113,7 +130,7 @@
                         "name": "[variables('networkIpConfig')]",
                         "properties": {
                             "subnet": {
-                                "id": "[variables('subnetRef')]"
+                                "id": "[parameters('subnet')]"
                             },
                             "privateIPAllocationMethod": "Dynamic",
                             "publicIpAddress": {
@@ -123,7 +140,7 @@
                     }
                 ],
                 "networkSecurityGroup": {
-                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups','ray-nsg')]"
+                    "id": "[parameters('nsg')]"
                 }
             },
             "condition": "[parameters('provisionPublicIp')]"
@@ -143,14 +160,14 @@
                         "name": "[variables('networkIpConfig')]",
                         "properties": {
                             "subnet": {
-                                "id": "[variables('subnetRef')]"
+                                "id": "[parameters('subnet')]"
                             },
                             "privateIPAllocationMethod": "Dynamic"
                         }
                     }
                 ],
                 "networkSecurityGroup": {
-                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups','ray-nsg')]"
+                    "id": "[parameters('nsg')]"
                 }
             },
             "condition": "[not(parameters('provisionPublicIp'))]"
@@ -234,7 +251,7 @@
             "identity": {
                 "type": "UserAssigned",
                 "userAssignedIdentities": {
-                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'ray-msi-user-identity')]": {
+                    "[parameters('msi')]": {
                     }
                 }
             }

--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import random
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable
 
@@ -9,11 +10,7 @@ from azure.identity import AzureCliCredential
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.models import DeploymentMode
 
-RETRIES = 30
-MSI_NAME = "ray-msi-user-identity"
-NSG_NAME = "ray-nsg"
-SUBNET_NAME = "ray-subnet"
-VNET_NAME = "ray-vnet"
+UNIQUE_ID_LEN = 4
 
 logger = logging.getLogger(__name__)
 
@@ -79,26 +76,53 @@ def _configure_resource_group(config):
     with open(template_path, "r") as template_fp:
         template = json.load(template_fp)
 
-    # choose a random subnet, skipping most common value of 0
-    random.seed(resource_group)
-    subnet_mask = "10.{}.0.0/16".format(random.randint(1, 254))
+    # set unique id for resources in this cluster
+    unique_id = config["provider"].get("unique_id")
+    if unique_id is None:
+        hasher = sha256()
+        hasher.update(config["provider"]["resource_group"].encode("utf-8"))
+        hasher.update(config["cluster_name"].encode("utf-8"))
+        unique_id = hasher.hexdigest()[:UNIQUE_ID_LEN]
+    else:
+        unique_id = str(unique_id)
+    config["provider"]["unique_id"] = unique_id
+    logger.info("Using unique id: %s", unique_id)
+
+    subnet_mask = config["provider"].get("subnet_mask")
+    if subnet_mask is None:
+        # choose a random subnet, skipping most common value of 0
+        random.seed(unique_id)
+        subnet_mask = "10.{}.0.0/16".format(random.randint(1, 254))
+    logger.info("Using subnet mask: %s", subnet_mask)
 
     parameters = {
         "properties": {
             "mode": DeploymentMode.incremental,
             "template": template,
-            "parameters": {"subnet": {"value": subnet_mask}},
+            "parameters": {
+                "subnet": {"value": subnet_mask},
+                "uniqueId": {"value": unique_id},
+            },
         }
     }
 
     create_or_update = get_azure_sdk_function(
         client=resource_client.deployments, function_name="create_or_update"
     )
-    create_or_update(
-        resource_group_name=resource_group,
-        deployment_name="ray-config",
-        parameters=parameters,
-    ).wait()
+    outputs = (
+        create_or_update(
+            resource_group_name=resource_group,
+            deployment_name="ray-config",
+            parameters=parameters,
+        )
+        .result()
+        .properties.outputs
+    )
+
+    # append output resource ids to be used with vm creation
+    config["provider"]["msi"] = outputs["msi"]["value"]
+    config["provider"]["nsg"] = outputs["nsg"]["value"]
+    config["provider"]["subnet"] = outputs["subnet"]["value"]
 
     return config
 

--- a/python/ray/autoscaler/azure/defaults.yaml
+++ b/python/ray/autoscaler/azure/defaults.yaml
@@ -27,6 +27,11 @@ provider:
     resource_group: ray-cluster
     # set subscription id otherwise the default from az cli will be used
     # subscription_id: 00000000-0000-0000-0000-000000000000
+    # set unique subnet mask or a random mask will be used
+    # subnet_mask: 10.0.0.0/16
+    # set unique id for resources in this cluster
+    # if not set a default id will be generated based on the resource group and cluster name
+    # unique_id: RAY1
 
 # How Ray will authenticate with newly launched nodes.
 auth:

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -42,6 +42,11 @@ provider:
     resource_group: ray-cluster
     # set subscription id otherwise the default from az cli will be used
     # subscription_id: 00000000-0000-0000-0000-000000000000
+    # set unique subnet mask or a random mask will be used
+    # subnet_mask: 10.0.0.0/16
+    # set unique id for resources in this cluster
+    # if not set a default id will be generated based on the resource group and cluster name
+    # unique_id: RAY1
 
 # How Ray will authenticate with newly launched nodes.
 auth:

--- a/python/ray/autoscaler/azure/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/azure/example-gpu-docker.yaml
@@ -34,6 +34,11 @@ provider:
     resource_group: ray-cluster
     # set subscription id otherwise the default from az cli will be used
     # subscription_id: 00000000-0000-0000-0000-000000000000
+    # set unique subnet mask or a random mask will be used
+    # subnet_mask: 10.0.0.0/16
+    # set unique id for resources in this cluster
+    # if not set a default id will be generated based on the resource group and cluster name
+    # unique_id: RAY1
 
 # How Ray will authenticate with newly launched nodes.
 auth:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adding support for deploying multiple clusters into the same azure resource group

Changes:
- Adding unique_id field to provider section of yaml, if not provided one will be created based on hashing the resource group and cluster name. This will be appended to the name of all resources deployed to azure so they can co-exist in the same resource group (provided the cluster name is changed)
- Pulled in changes from #22997 to use cluster name when filtering vms to retrieve nodes only in the current cluster
- Added option to explicitly specify the subnet mask, otherwise use the resource group and cluster name as a seed and randomly choose a subnet to use for the vnet (to avoid collisions with other vnets)
- Updated yaml example files with new provider values and explanations
- Pulling resource_ids from initial azure-config-template deployment to pass into vm deployment to avoid matching hard-coded resource names across templates

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #22996 
Supersedes #22997 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [X] Manual tests