### PR TITLE
[dashboard][2/2] Add endpoints to dashboard and dashboard_agent for liveness check of raylet and gcs 

### DIFF
--- a/dashboard/consts.py
+++ b/dashboard/consts.py
@@ -36,3 +36,10 @@ DEFAULT_JOB_ID = "ffff"
 BAD_RUNTIME_ENV_CACHE_TTL_SECONDS = env_integer(
     "BAD_RUNTIME_ENV_CACHE_TTL_SECONDS", 60 * 10
 )
+# Hook that is invoked on the dashboard `/api/component_activities` endpoint.
+# Environment variable stored here should be a callable that does not
+# take any arguments and should return a dictionary mapping
+# activity component type (str) to
+# ray.dashboard.modules.snapshot.snapshot_head.RayActivityResponse.
+# Example: "your.module.ray_cluster_activity_hook".
+RAY_CLUSTER_ACTIVITY_HOOK = "RAY_CLUSTER_ACTIVITY_HOOK"

--- a/dashboard/consts.py
+++ b/dashboard/consts.py
@@ -36,10 +36,3 @@ DEFAULT_JOB_ID = "ffff"
 BAD_RUNTIME_ENV_CACHE_TTL_SECONDS = env_integer(
     "BAD_RUNTIME_ENV_CACHE_TTL_SECONDS", 60 * 10
 )
-# Hook that is invoked on the dashboard `/api/component_activities` endpoint.
-# Environment variable stored here should be a callable that does not
-# take any arguments and should return a dictionary mapping
-# activity component type (str) to
-# ray.dashboard.modules.snapshot.snapshot_head.RayActivityResponse.
-# Example: "your.module.ray_cluster_activity_hook".
-RAY_CLUSTER_ACTIVITY_HOOK = "RAY_CLUSTER_ACTIVITY_HOOK"

--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -12,7 +12,7 @@ import ray.dashboard.utils as dashboard_utils
 import ray.experimental.internal_kv as internal_kv
 from ray._private import ray_constants
 from ray._private.gcs_pubsub import GcsAioErrorSubscriber, GcsAioLogSubscriber
-from ray._private.gcs_utils import GcsClient, check_health
+from ray._private.gcs_utils import GcsClient, GcsAioClient, check_health
 from ray.dashboard.datacenter import DataOrganizer
 from ray.dashboard.utils import async_loop_forever
 
@@ -169,9 +169,8 @@ class DashboardHead:
         # Dashboard will handle connection failure automatically
         self.gcs_client = GcsClient(address=gcs_address, nums_reconnect_retry=0)
         internal_kv._initialize_internal_kv(self.gcs_client)
-        self.aiogrpc_gcs_channel = ray._private.utils.init_grpc_channel(
-            gcs_address, GRPC_CHANNEL_OPTIONS, asynchronous=True
-        )
+        self.gcs_aio_client = GcsAioClient(address=gcs_address)
+        self.aiogrpc_gcs_channel = self.gcs_aio_client.channel.channel()
 
         self.gcs_error_subscriber = GcsAioErrorSubscriber(address=gcs_address)
         self.gcs_log_subscriber = GcsAioLogSubscriber(address=gcs_address)

--- a/dashboard/modules/healthz/healthz_agent.py
+++ b/dashboard/modules/healthz/healthz_agent.py
@@ -1,0 +1,47 @@
+import ray.dashboard.utils as dashboard_utils
+import ray.dashboard.optional_utils as optional_utils
+from ray.dashboard.modules.healthz.utils import HealthChecker
+from aiohttp.web import Request, Response, HTTPServiceUnavailable
+import grpc
+
+routes = optional_utils.ClassMethodRouteTable
+
+
+class HealthzAgent(dashboard_utils.DashboardAgentModule):
+    def __init__(self, dashboard_agent):
+        super().__init__(dashboard_agent)
+        self._health_checker = HealthChecker(
+            dashboard_agent.gcs_aio_client,
+            f"{dashboard_agent.ip}:{dashboard_agent.node_manager_port}",
+        )
+
+    @routes.get("/api/local_raylet_healthz")
+    async def health_check(self, req: Request) -> Response:
+        try:
+            alive = await self._health_checker.check_local_raylet_liveness()
+            if alive is False:
+                return HTTPServiceUnavailable(reason="Local Raylet failed")
+        except grpc.RpcError as e:
+            # We only consider the error other than GCS unreachable as raylet failure
+            # to avoid false positive.
+            # In case of GCS failed, Raylet will crash eventually if GCS is not back
+            # within a given time and the check will fail since agent can't live
+            # without a local raylet.
+            if e.code() not in (
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.StatusCode.UNKNOWN,
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+            ):
+                return HTTPServiceUnavailable(reason=e.message())
+
+        return Response(
+            text="success",
+            content_type="application/text",
+        )
+
+    async def run(self, server):
+        pass
+
+    @staticmethod
+    def is_minimal_module():
+        return True

--- a/dashboard/modules/healthz/healthz_head.py
+++ b/dashboard/modules/healthz/healthz_head.py
@@ -1,0 +1,34 @@
+import ray.dashboard.utils as dashboard_utils
+import ray.dashboard.optional_utils as optional_utils
+from ray.dashboard.modules.healthz.utils import HealthChecker
+from aiohttp.web import Request, Response, HTTPServiceUnavailable
+
+routes = optional_utils.ClassMethodRouteTable
+
+
+class HealthzHead(dashboard_utils.DashboardHeadModule):
+    def __init__(self, dashboard_head):
+        super().__init__(dashboard_head)
+        self._health_checker = HealthChecker(dashboard_head.gcs_aio_client)
+
+    @routes.get("/api/gcs_healthz")
+    async def health_check(self, req: Request) -> Response:
+        alive = False
+        try:
+            alive = await self._health_checker.check_gcs_liveness()
+            if alive is True:
+                return Response(
+                    text="success",
+                    content_type="application/text",
+                )
+        except Exception as e:
+            return HTTPServiceUnavailable(reason=f"Health check failed: {e}")
+
+        return HTTPServiceUnavailable(reason="Health check failed")
+
+    async def run(self, server):
+        pass
+
+    @staticmethod
+    def is_minimal_module():
+        return True

--- a/dashboard/modules/healthz/tests/test_healthz.py
+++ b/dashboard/modules/healthz/tests/test_healthz.py
@@ -1,0 +1,58 @@
+import sys
+import pytest
+import requests
+
+import ray._private.ray_constants as ray_constants
+from ray.tests.conftest import *  # noqa: F401 F403
+from ray._private.test_utils import find_free_port, wait_for_condition
+
+
+def test_healthz_head(ray_start_cluster):
+    dashboard_port = find_free_port()
+    h = ray_start_cluster.add_node(dashboard_port=dashboard_port)
+    uri = f"http://localhost:{dashboard_port}/api/gcs_healthz"
+    wait_for_condition(lambda: requests.get(uri).status_code == 200)
+    h.all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER][0].process.kill()
+    # It'll either timeout or just return an error
+    try:
+        wait_for_condition(lambda: requests.get(uri, timeout=1) != 200, timeout=4)
+    except RuntimeError as e:
+        assert "Read timed out" in str(e)
+
+
+def test_healthz_agent_1(ray_start_cluster):
+    agent_port = find_free_port()
+    h = ray_start_cluster.add_node(dashboard_agent_listen_port=agent_port)
+    uri = f"http://localhost:{agent_port}/api/local_raylet_healthz"
+
+    wait_for_condition(lambda: requests.get(uri).status_code == 200)
+
+    h.all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER][0].process.kill()
+    # GCS's failure will not lead to healthz failure
+    assert requests.get(uri).status_code == 200
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGSTOP only on posix")
+def test_healthz_agent_2(monkeypatch, ray_start_cluster):
+    monkeypatch.setenv("RAY_num_heartbeats_timeout", "3")
+
+    agent_port = find_free_port()
+    h = ray_start_cluster.add_node(dashboard_agent_listen_port=agent_port)
+    uri = f"http://localhost:{agent_port}/api/local_raylet_healthz"
+
+    wait_for_condition(lambda: requests.get(uri).status_code == 200)
+
+    import signal
+
+    h.all_processes[ray_constants.PROCESS_TYPE_RAYLET][0].process.send_signal(
+        signal.SIGSTOP
+    )
+
+    # GCS still think raylet is alive.
+    assert requests.get(uri).status_code == 200
+    # But after heartbeat timeout, it'll think the raylet is down.
+    wait_for_condition(lambda: requests.get(uri).status_code != 200)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/dashboard/modules/healthz/utils.py
+++ b/dashboard/modules/healthz/utils.py
@@ -1,0 +1,23 @@
+from typing import Optional
+from ray._private.gcs_utils import GcsAioClient
+
+
+class HealthChecker:
+    def __init__(
+        self, gcs_aio_client: GcsAioClient, local_node_address: Optional[str] = None
+    ):
+        self._gcs_aio_client = gcs_aio_client
+        self._local_node_address = local_node_address
+
+    async def check_local_raylet_liveness(self) -> bool:
+        if self._local_node_address is None:
+            return False
+
+        liveness = await self._gcs_aio_client.check_alive(
+            [self._local_node_address.encode()], 1
+        )
+        return liveness[0]
+
+    async def check_gcs_liveness(self) -> bool:
+        await self._gcs_aio_client.check_alive([], 1)
+        return True

--- a/dashboard/modules/snapshot/component_activities_schema.json
+++ b/dashboard/modules/snapshot/component_activities_schema.json
@@ -7,8 +7,7 @@
       "type": "object",
       "properties":{
         "is_active": {
-          "type": "string",
-          "enum": ["ACTIVE", "INACTIVE", "ERROR"]
+          "type": "boolean"
         },
         "reason": {
           "type": [

--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -2,21 +2,16 @@ import asyncio
 import concurrent.futures
 import dataclasses
 from datetime import datetime
-import enum
-import logging
 import hashlib
 import json
-import os
 from typing import Any, Dict, List, Optional
 
 import aiohttp.web
 
 import ray
-from ray.dashboard.consts import RAY_CLUSTER_ACTIVITY_HOOK
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray._private import ray_constants
-from ray._private.storage import _load_class
 from ray.core.generated import gcs_pb2, gcs_service_pb2, gcs_service_pb2_grpc
 from ray.dashboard.modules.job.common import JOB_ID_METADATA_KEY, JobInfoStorageClient
 from ray.experimental.internal_kv import (
@@ -27,16 +22,7 @@ from ray.experimental.internal_kv import (
 from ray.job_submission import JobInfo
 from ray.runtime_env import RuntimeEnv
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-
 routes = dashboard_optional_utils.ClassMethodRouteTable
-
-
-class RayActivityStatus(str, enum.Enum):
-    ACTIVE = "ACTIVE"
-    INACTIVE = "INACTIVE"
-    ERROR = "ERROR"
 
 
 @dataclasses.dataclass
@@ -46,12 +32,11 @@ class RayActivityResponse:
     active, and metadata about observation.
     """
 
-    # Whether the corresponding Ray component is considered active or inactive,
-    # or if there was an error while collecting this observation.
-    is_active: RayActivityStatus
-    # Reason if Ray component is considered active or errored.
+    # Whether the corresponding Ray component is considered active
+    is_active: bool
+    # Reason if Ray component is considered active
     reason: Optional[str] = None
-    # Timestamp of when this observation about the Ray component was made.
+    # Timestamp of when this observation about the Ray component was made
     timestamp: Optional[float] = None
 
 
@@ -123,64 +108,16 @@ class APIHead(dashboard_utils.DashboardHeadModule):
 
     @routes.get("/api/component_activities")
     async def get_component_activities(self, req) -> aiohttp.web.Response:
+        # Get activity information for driver
         timeout = req.query.get("timeout", None)
         if timeout and timeout.isdigit():
             timeout = int(timeout)
         else:
             timeout = 5
 
-        # Get activity information for driver
         driver_activity_info = await self._get_job_activity_info(timeout=timeout)
+
         resp = {"driver": dataclasses.asdict(driver_activity_info)}
-
-        if RAY_CLUSTER_ACTIVITY_HOOK in os.environ:
-            try:
-                cluster_activity_callable = _load_class(
-                    os.environ[RAY_CLUSTER_ACTIVITY_HOOK]
-                )
-                external_activity_output = cluster_activity_callable()
-                assert isinstance(external_activity_output, dict), (
-                    f"Output of hook {os.environ[RAY_CLUSTER_ACTIVITY_HOOK]} "
-                    "should be Dict[str, RayActivityResponse]. Got "
-                    f"output: {external_activity_output}"
-                )
-                for component_type in external_activity_output:
-                    try:
-                        component_activity_output = external_activity_output[
-                            component_type
-                        ]
-                        # Cast output to type RayActivityResponse
-                        component_activity_output = RayActivityResponse(
-                            **dataclasses.asdict(component_activity_output)
-                        )
-                        # Validate is_active field is of type RayActivityStatus
-                        component_activity_output.is_active = RayActivityStatus[
-                            component_activity_output.is_active
-                        ]
-                        resp[component_type] = dataclasses.asdict(
-                            component_activity_output
-                        )
-                    except Exception as e:
-                        logger.exception(
-                            f"Failed to get activity status of {component_type} "
-                            f"from user hook {os.environ[RAY_CLUSTER_ACTIVITY_HOOK]}."
-                        )
-                        resp[component_type] = {
-                            "is_active": RayActivityStatus.ERROR,
-                            "reason": repr(e),
-                            "timestamp": datetime.now().timestamp(),
-                        }
-            except Exception as e:
-                logger.exception(
-                    "Failed to get activity status from user "
-                    f"hook {os.environ[RAY_CLUSTER_ACTIVITY_HOOK]}."
-                )
-                resp["external_component"] = {
-                    "is_active": RayActivityStatus.ERROR,
-                    "reason": repr(e),
-                    "timestamp": datetime.now().timestamp(),
-                }
-
         return aiohttp.web.Response(
             text=json.dumps(resp),
             content_type="application/json",
@@ -191,40 +128,25 @@ class APIHead(dashboard_utils.DashboardHeadModule):
         # Returns if there is Ray activity from drivers (job).
         # Drivers in namespaces that start with _ray_internal_job_info_ are not
         # considered activity.
-        try:
-            request = gcs_service_pb2.GetAllJobInfoRequest()
-            reply = await self._gcs_job_info_stub.GetAllJobInfo(
-                request, timeout=timeout
-            )
+        request = gcs_service_pb2.GetAllJobInfoRequest()
+        reply = await self._gcs_job_info_stub.GetAllJobInfo(request, timeout=timeout)
 
-            num_active_drivers = 0
-            for job_table_entry in reply.job_info_list:
-                is_dead = bool(job_table_entry.is_dead)
-                in_internal_namespace = job_table_entry.config.ray_namespace.startswith(
-                    JobInfoStorageClient.JOB_DATA_KEY_PREFIX
-                )
-                if not is_dead and not in_internal_namespace:
-                    num_active_drivers += 1
+        num_active_drivers = 0
+        for job_table_entry in reply.job_info_list:
+            is_dead = bool(job_table_entry.is_dead)
+            in_internal_namespace = job_table_entry.config.ray_namespace.startswith(
+                JobInfoStorageClient.JOB_DATA_KEY_PREFIX
+            )
+            if not is_dead and not in_internal_namespace:
+                num_active_drivers += 1
 
-            is_active = (
-                RayActivityStatus.ACTIVE
-                if num_active_drivers > 0
-                else RayActivityStatus.INACTIVE
-            )
-            return RayActivityResponse(
-                is_active=is_active,
-                reason=f"Number of active drivers: {num_active_drivers}"
-                if num_active_drivers
-                else None,
-                timestamp=datetime.now().timestamp(),
-            )
-        except Exception as e:
-            logger.exception("Failed to get activity status of Ray drivers.")
-            return RayActivityResponse(
-                is_active=RayActivityStatus.ERROR,
-                reason=repr(e),
-                timestamp=datetime.now().timestamp(),
-            )
+        return RayActivityResponse(
+            is_active=num_active_drivers > 0,
+            reason=f"Number of active drivers: {num_active_drivers}"
+            if num_active_drivers
+            else None,
+            timestamp=datetime.now().timestamp(),
+        )
 
     def _get_job_info(self, metadata: Dict[str, str]) -> Optional[JobInfo]:
         # If a job submission ID has been added to a job, the status is

--- a/dashboard/modules/snapshot/tests/test_snapshot.py
+++ b/dashboard/modules/snapshot/tests/test_snapshot.py
@@ -18,51 +18,12 @@ from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
 )
 from ray.dashboard import dashboard
-from ray.dashboard.consts import RAY_CLUSTER_ACTIVITY_HOOK
 from ray.dashboard.modules.snapshot.snapshot_head import RayActivityResponse
 from ray.dashboard.tests.conftest import *  # noqa
 
 
-@pytest.fixture
-def set_ray_cluster_activity_hook(request):
-    """
-    Fixture that sets RAY_CLUSTER_ACTIVITY_HOOK environment variable
-    for test_e2e_component_activities_hook.
-    """
-    external_hook = getattr(request, "param")
-    assert (
-        external_hook
-    ), "Please pass value of RAY_CLUSTER_ACTIVITY_HOOK env var to this fixture"
-    old_hook = os.environ.get(RAY_CLUSTER_ACTIVITY_HOOK)
-    os.environ[RAY_CLUSTER_ACTIVITY_HOOK] = external_hook
-
-    yield external_hook
-
-    if old_hook is not None:
-        os.environ[RAY_CLUSTER_ACTIVITY_HOOK] = old_hook
-    else:
-        del os.environ[RAY_CLUSTER_ACTIVITY_HOOK]
-
-
-@pytest.mark.parametrize(
-    "set_ray_cluster_activity_hook",
-    [
-        "ray._private.test_utils.external_ray_cluster_activity_hook1",
-        "ray._private.test_utils.external_ray_cluster_activity_hook2",
-        "ray._private.test_utils.external_ray_cluster_activity_hook3",
-        "ray._private.test_utils.external_ray_cluster_activity_hook4",
-    ],
-    indirect=True,
-)
-async def test_component_activities_hook(set_ray_cluster_activity_hook, call_ray_start):
-    """
-    Tests /api/component_activities returns correctly for various
-    responses of RAY_CLUSTER_ACTIVITY_HOOK defined in ray._private.test_utils.
-
-    Verify no active drivers are correctly reflected in response.
-    """
-    external_hook = set_ray_cluster_activity_hook
-
+def test_inactive_component_activities(call_ray_start):
+    # Verify no activity in response if no active drivers
     response = requests.get("http://127.0.0.1:8265/api/component_activities")
     response.raise_for_status()
 
@@ -75,46 +36,15 @@ async def test_component_activities_hook(set_ray_cluster_activity_hook, call_ray
     pprint.pprint(data)
     jsonschema.validate(instance=data, schema=json.load(open(schema_path)))
 
-    # Validate driver response can be cast to RayActivityResponse object
-    # and that there are no active drivers.
+    # Validate ray_activity_response field can be cast to RayActivityResponse object
     driver_ray_activity_response = RayActivityResponse(**data["driver"])
-    assert driver_ray_activity_response.is_active == "INACTIVE"
+    assert not driver_ray_activity_response.is_active
     assert driver_ray_activity_response.reason is None
-
-    # Validate external component response can be cast to RayActivityResponse object
-    if external_hook[-1] == "4":
-        external_activity_response = RayActivityResponse(**data["external_component"])
-        assert external_activity_response.is_active == "ERROR"
-        assert (
-            external_activity_response.reason
-            == "Exception('Error in external cluster activity hook')"
-        )
-    elif external_hook[-1] == "3":
-        external_activity_response = RayActivityResponse(**data["external_component"])
-        assert external_activity_response.is_active == "ERROR"
-    elif external_hook[-1] == "2":
-        external_activity_response = RayActivityResponse(**data["test_component2"])
-        assert external_activity_response.is_active == "ERROR"
-    elif external_hook[-1] == "1":
-        external_activity_response = RayActivityResponse(**data["test_component1"])
-        assert external_activity_response.is_active == "ACTIVE"
-        assert external_activity_response.reason == "Counter: 1"
-
-        # Call endpoint again to validate different response
-        response = requests.get("http://127.0.0.1:8265/api/component_activities")
-        response.raise_for_status()
-        data = response.json()
-        jsonschema.validate(instance=data, schema=json.load(open(schema_path)))
-
-        external_activity_response = RayActivityResponse(**data["test_component1"])
-        assert external_activity_response.is_active == "ACTIVE"
-        assert external_activity_response.reason == "Counter: 2"
 
 
 def test_active_component_activities(ray_start_with_dashboard):
     # Verify drivers which don't have namespace starting with _ray_internal_job_info_
     # are considered active.
-
     driver_template = """
 import ray
 
@@ -147,7 +77,7 @@ ray.init(address="auto", namespace="{namespace}")
     # Validate ray_activity_response field can be cast to RayActivityResponse object
     driver_ray_activity_response = RayActivityResponse(**data["driver"])
 
-    assert driver_ray_activity_response.is_active == "ACTIVE"
+    assert driver_ray_activity_response.is_active
     # Drivers with namespace starting with "_ray_internal_job_info_" are not
     # considered active drivers. Three active drivers are the two
     # run with namespace "my_namespace" and the one started


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As in this https://github.com/ray-project/ray/pull/26405 we added the health check for gcs and raylets.

This PR expose them in the endpoint in dashboard and dashboard agent.

For dashboard, we added `http://host:port/api/gcs_healthz` and it'll send RPC to GCS directly to see whether the GCS is alive or not.

For agent, we added `http://host:port/api/local_raylet_healthz` and it'll send RPC to GCS to check whether raylet is alive or not.

We think raylet is live if
- GCS is dead
- GCS is alive but GCS think the raylet is dead

If GCS is dead for more than X seconds (60 by default), raylet will just crash itself, so KubeRay can still catch it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
