### PR TITLE
[Core] ensure uniqueness in spilled file name

### DIFF
--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -181,14 +181,6 @@ class ExternalStorage(metaclass=abc.ABCMeta):
                 f"size of {obtained_data_size}."
             )
 
-    def _get_ique_spill_uri(self, object_refs: List[ObjectRef]):
-        """Generate a unqiue spill uri.
-
-        Args:
-            object_refs: objects to be spilled in this file.
-        """
-        return f"{uuid.uuid4().hex}-multi-{len(object_refs)}"
-
     @abc.abstractmethod
     def spill_objects(self, object_refs, owner_addresses) -> List[str]:
         """Spill objects to the external storage. Objects are specified

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -181,6 +181,14 @@ class ExternalStorage(metaclass=abc.ABCMeta):
                 f"size of {obtained_data_size}."
             )
 
+    def _get_ique_spill_uri(self, object_refs: List[ObjectRef]):
+        """Generate a unqiue spill uri.
+
+        Args:
+            object_refs: objects to be spilled in this file.
+        """
+        return f"{uuid.uuid4().hex}-multi-{len(object_refs)}"
+
     @abc.abstractmethod
     def spill_objects(self, object_refs, owner_addresses) -> List[str]:
         """Spill objects to the external storage. Objects are specified

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -296,7 +296,7 @@ class FileSystemStorage(ExternalStorage):
         )
         directory_path = self._directory_paths[self._current_directory_index]
 
-        filename = f"{uuid.uuid4().hex}-multi-{len(object_refs)}"
+        filename = _get_unique_spill_filename(object_refs)
         url = f"{os.path.join(directory_path, filename)}"
         with open(url, "wb", buffering=self._buffer_size) as f:
             return self._write_multiple_objects(f, object_refs, owner_addresses, url)
@@ -383,7 +383,7 @@ class ExternalStorageRayStorageImpl(ExternalStorage):
     def spill_objects(self, object_refs, owner_addresses) -> List[str]:
         if len(object_refs) == 0:
             return []
-        filename = f"{uuid.uuid4().hex}-multi-{len(object_refs)}"
+        filename = _get_unique_spill_filename(object_refs)
         url = f"{os.path.join(self._prefix, filename)}"
         with self._fs.open_output_stream(url, buffer_size=self._buffer_size) as f:
             return self._write_multiple_objects(f, object_refs, owner_addresses, url)
@@ -519,9 +519,7 @@ class ExternalStorageSmartOpenImpl(ExternalStorage):
         self._current_uri_index = (self._current_uri_index + 1) % len(self._uris)
         uri = self._uris[self._current_uri_index]
 
-        # Always use the first object ref as a key when fusioning objects.
-        first_ref = object_refs[0]
-        key = f"{self.prefix}-{first_ref.hex()}-multi-{len(object_refs)}"
+        key = f"{self.prefix}-{_get_unique_spill_filename(object_refs)}"
         url = f"{uri}/{key}"
 
         with open(
@@ -678,3 +676,12 @@ def delete_spilled_objects(urls: List[str]):
         urls: URLs that store spilled object files.
     """
     _external_storage.delete_spilled_objects(urls)
+
+
+def _get_unique_spill_filename(object_refs: List[ObjectRef]):
+    """Generate a unqiue spill file name.
+
+    Args:
+        object_refs: objects to be spilled in this file.
+    """
+    return f"{uuid.uuid4().hex}-multi-{len(object_refs)}"

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -5,6 +5,7 @@ import random
 import shutil
 import time
 import urllib
+import uuid
 from collections import namedtuple
 from typing import IO, List, Optional, Tuple
 
@@ -295,9 +296,7 @@ class FileSystemStorage(ExternalStorage):
         )
         directory_path = self._directory_paths[self._current_directory_index]
 
-        # Always use the first object ref as a key when fusing objects.
-        first_ref = object_refs[0]
-        filename = f"{first_ref.hex()}-multi-{len(object_refs)}"
+        filename = f"{uuid.uuid4().hex}-multi-{len(object_refs)}"
         url = f"{os.path.join(directory_path, filename)}"
         with open(url, "wb", buffering=self._buffer_size) as f:
             return self._write_multiple_objects(f, object_refs, owner_addresses, url)
@@ -384,9 +383,7 @@ class ExternalStorageRayStorageImpl(ExternalStorage):
     def spill_objects(self, object_refs, owner_addresses) -> List[str]:
         if len(object_refs) == 0:
             return []
-        # Always use the first object ref as a key when fusing objects.
-        first_ref = object_refs[0]
-        filename = f"{first_ref.hex()}-multi-{len(object_refs)}"
+        filename = f"{uuid.uuid4().hex}-multi-{len(object_refs)}"
         url = f"{os.path.join(self._prefix, filename)}"
         with self._fs.open_output_stream(url, buffer_size=self._buffer_size) as f:
             return self._write_multiple_objects(f, object_refs, owner_addresses, url)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are cases that same object is being spilled twice due to failures. This made two spill worker overwrites the same file and causing corruption. The fix is as simple as ensure the uniqueness of the file.

close #26395

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
