### PR TITLE
[coe] Remove gil when submit actor and tasks to avoid deadlock for some cases.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1532,6 +1532,7 @@ cdef class CoreWorker:
         cdef:
             unordered_map[c_string, double] c_resources
             CRayFunction ray_function
+            CTaskOptions task_options
             c_vector[unique_ptr[CTaskArg]] args_vector
             c_vector[CObjectReference] return_refs
             CSchedulingStrategy c_scheduling_strategy
@@ -1548,17 +1549,17 @@ cdef class CoreWorker:
                 self, language, args, &args_vector, function_descriptor,
                 &incremented_put_arg_ids)
 
-            # NOTE(edoakes): releasing the GIL while calling this method causes
-            # segfaults. See relevant issue for details:
-            # https://github.com/ray-project/ray/pull/12803
-            return_refs = CCoreWorkerProcess.GetCoreWorker().SubmitTask(
-                ray_function, args_vector, CTaskOptions(
-                    name, num_returns, c_resources,
-                    b"",
-                    serialized_runtime_env_info),
-                max_retries, retry_exceptions,
-                c_scheduling_strategy,
-                debugger_breakpoint)
+            task_options = CTaskOptions(
+                name, num_returns, c_resources,
+                b"",
+                serialized_runtime_env_info)
+            with nogil:
+                return_refs = CCoreWorkerProcess.GetCoreWorker().SubmitTask(
+                    ray_function, args_vector, task_options,
+                    max_retries, retry_exceptions,
+                    c_scheduling_strategy,
+                    debugger_breakpoint,
+                )
 
             # These arguments were serialized and put into the local object
             # store during task submission. The backend increments their local
@@ -1742,15 +1743,13 @@ cdef class CoreWorker:
                 self, language, args, &args_vector, function_descriptor,
                 &incremented_put_arg_ids)
 
-            # NOTE(edoakes): releasing the GIL while calling this method causes
-            # segfaults. See relevant issue for details:
-            # https://github.com/ray-project/ray/pull/12803
-            return_refs = CCoreWorkerProcess.GetCoreWorker().SubmitActorTask(
-                c_actor_id,
-                ray_function,
-                args_vector,
-                CTaskOptions(
-                    name, num_returns, c_resources, concurrency_group_name))
+            with nogil:
+                return_refs = CCoreWorkerProcess.GetCoreWorker().SubmitActorTask(
+                    c_actor_id,
+                    ray_function,
+                    args_vector,
+                    CTaskOptions(
+                        name, num_returns, c_resources, concurrency_group_name))
             # These arguments were serialized and put into the local object
             # store during task submission. The backend increments their local
             # ref count initially to ensure that they remain in scope until we


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When submit task, GIL is not released due to this [PR](https://github.com/ray-project/ray/issues/12644).
This cause a potential deadlock when actor died and got notified by GCS. In this case, the callback function submitted by GetAsync is going to execute some python function  and the GIL is still hold by submit task. And submit task is blocking by a lock which is not released.

In the previous PR, it seems to fix some memory issue, but it's seems not there any more.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
#26414 
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
