### PR TITLE
In env check, step only expected agents

### DIFF
--- a/rllib/env/multi_agent_env.py
+++ b/rllib/env/multi_agent_env.py
@@ -168,7 +168,7 @@ class MultiAgentEnv(gym.Env):
                 self._check_if_space_maps_agent_id_to_sub_space()
             )
         if self._spaces_in_preferred_format:
-            return self.action_space.contains(x)
+            return all([self.action_space[agent].contains(x[agent]) for agent in x])
 
         if log_once("action_space_contains"):
             logger.warning("action_space_contains() has not been implemented")

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -258,7 +258,7 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
         )
         raise ValueError(error)
 
-    sampled_action = env.action_space_sample()
+    sampled_action = env.action_space_sample(reset_obs.keys())
     _check_if_element_multi_agent_dict(env, sampled_action, "action_space_sample")
     try:
         env.action_space_contains(sampled_action)


### PR DESCRIPTION
## Why are these changes needed?

The `check_multiagent_environments()` precheck right now calls `env.step()` with an action dict containing actions for all agents in the environment. For turn-based environments that don't expects all agents to act at the same time, this could break things. 

## Related issue number

Closes #26413 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
