### PR TITLE
Pipelined training test: change num of windows; log the ingestion perf

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3434,7 +3434,7 @@
 
   run:
     timeout: 9600
-    script: python pipelined_training.py --epochs 2 --num-windows 2 --num-files 915
+    script: python pipelined_training.py --epochs 2 --num-windows 5 --num-files 915
       --debug
 
     wait_for_nodes:


### PR DESCRIPTION
## Why are these changes needed?
- Improve test perf
- Log the perf stats

With 2 windows there are a lot of spilling, slowing down the throughput.

Before: with 2 windows
```
...
(consume pid=2018, ip=10.0.3.121) Consumer #3 total time: 2178.413551801, total batches: 4575, P50/P95/Max batch wait time (s): 0.1294746480007234/0.2005310959994859/607.656812227.
(consume pid=1993, ip=10.0.3.121) Consumer #0 total time: 2179.408017697, total batches: 4575, P50/P95/Max batch wait time (s): 0.13072845899932872/0.19195194250023642/621.7302220209995.
success! total time 2203.7494492530823
```

After: with 5 windows
```
...
(consume pid=1286, ip=10.0.3.240) Consumer #12 total time: 1565.352004058, total batches: 4575, P50/P95/Max batch wait time (s): 0.131190413000013/0.18954721110014824/237.86665213000015.
(consume pid=1259, ip=10.0.3.240) Consumer #8 total time: 1566.261799832, total batches: 4575, P50/P95/Max batch wait time (s): 0.13185941199981244/0.19025329009989525/238.59623385500004.
success! total time 1586.723347902298
```

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
