### PR TITLE
Fix dashboard link in HTML reprs for `ClientContext`  and `WorkerContext`

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -975,7 +975,7 @@ class RayContext(BaseContext, Mapping):
     def _repr_html_(self):
         if self.dashboard_url:
             dashboard_row = Template("context_dashrow.html.j2").render(
-                dashboard_url=self.dashboard_url
+                dashboard_url="http://" + self.dashboard_url
             )
         else:
             dashboard_row = None

--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -85,7 +85,7 @@ class ClientContext(BaseContext):
     def _repr_html_(self):
         if self.dashboard_url:
             dashboard_row = Template("context_dashrow.html.j2").render(
-                dashboard_url=self.dashboard_url
+                dashboard_url="http://" + self.dashboard_url
             )
         else:
             dashboard_row = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes the dashboard link in https://github.com/ray-project/ray/pull/25730 -- without this I'm getting

<img width="1378" alt="Screen Shot 2022-07-09 at 8 08 06 PM" src="https://user-images.githubusercontent.com/113316/178129698-7ef19ee3-d577-4fd9-a4d5-0cee1ca35f5f.png">

because Jupyter is interpreting the URL as relative to the notebook URL.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
