### PR TITLE
[RLlib] fix all the erroneous on_trainer_init warning.

### DIFF
--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -12,6 +12,7 @@ from ray.rllib.evaluation.postprocessing import Postprocessing
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import (
+    OverrideToImplementCustomLogic,
     PublicAPI,
     is_overridden,
 )
@@ -50,13 +51,8 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 "a class extending rllib.algorithms.callbacks.DefaultCallbacks",
             )
         self.legacy_callbacks = legacy_callbacks_dict or {}
-        if is_overridden(self.on_trainer_init):
-            deprecation_warning(
-                old="on_trainer_init(trainer, **kwargs)",
-                new="on_algorithm_init(algorithm, **kwargs)",
-                error=False,
-            )
 
+    @OverrideToImplementCustomLogic
     def on_sub_environment_created(
         self,
         *,
@@ -82,6 +78,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         """
         pass
 
+    @OverrideToImplementCustomLogic
     def on_algorithm_init(
         self,
         *,
@@ -99,6 +96,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         """
         pass
 
+    @OverrideToImplementCustomLogic
     def on_episode_start(
         self,
         *,
@@ -133,6 +131,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 }
             )
 
+    @OverrideToImplementCustomLogic
     def on_episode_step(
         self,
         *,
@@ -164,6 +163,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 {"env": base_env, "episode": episode}
             )
 
+    @OverrideToImplementCustomLogic
     def on_episode_end(
         self,
         *,
@@ -203,6 +203,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 }
             )
 
+    @OverrideToImplementCustomLogic
     def on_postprocess_trajectory(
         self,
         *,
@@ -247,6 +248,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 }
             )
 
+    @OverrideToImplementCustomLogic
     def on_sample_end(
         self, *, worker: "RolloutWorker", samples: SampleBatch, **kwargs
     ) -> None:
@@ -267,6 +269,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 }
             )
 
+    @OverrideToImplementCustomLogic
     def on_learn_on_batch(
         self, *, policy: Policy, train_batch: SampleBatch, result: dict, **kwargs
     ) -> None:
@@ -291,6 +294,7 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
 
         pass
 
+    @OverrideToImplementCustomLogic
     def on_train_result(
         self,
         *,
@@ -318,7 +322,9 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 }
             )
 
-    @Deprecated(error=True)
+    @Deprecated(old="on_trainer_init(trainer, **kwargs)",
+                new="on_algorithm_init(algorithm, **kwargs)",
+                error=True)
     def on_trainer_init(self, *args, **kwargs):
         raise DeprecationWarning
 

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -14,7 +14,6 @@ from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import (
     OverrideToImplementCustomLogic,
     PublicAPI,
-    is_overridden,
 )
 from ray.rllib.utils.deprecation import Deprecated, deprecation_warning
 from ray.rllib.utils.exploration.random_encoder import (
@@ -322,9 +321,11 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
                 }
             )
 
-    @Deprecated(old="on_trainer_init(trainer, **kwargs)",
-                new="on_algorithm_init(algorithm, **kwargs)",
-                error=True)
+    @Deprecated(
+        old="on_trainer_init(trainer, **kwargs)",
+        new="on_algorithm_init(algorithm, **kwargs)",
+        error=True,
+    )
     def on_trainer_init(self, *args, **kwargs):
         raise DeprecationWarning
 

--- a/rllib/examples/self_play_league_based_with_open_spiel.py
+++ b/rllib/examples/self_play_league_based_with_open_spiel.py
@@ -242,7 +242,7 @@ class LeagueBasedSelfPlayCallback(DefaultCallbacks):
 
                     def _set(worker):
                         worker.set_policy_mapping_fn(policy_mapping_fn)
-                        worker.set_policies_to_train(self.trainable_policies)
+                        worker.set_is_policy_to_train(self.trainable_policies)
 
                     algorithm.workers.foreach_worker(_set)
                 else:


### PR DESCRIPTION
## Why are these changes needed?

For one, is_overridden only works if an API is decorated with @OverrideToImplementCustomLogic.
For two, the deprecation warning for on_trainer_init already has error=True.
Without this fix, we see tons of errorneous deprecation warnings in terminal output.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
