### PR TITLE
fix cpp hide symbols cause ut failure and compile error on mac

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -8,7 +8,7 @@ cc_binary(
     copts = COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:darwin": [
-            "-Wl,-exported_symbols_list,$(location :symbols/ray_api_exported_symbols_mac.lds)",
+            #TODO(larry): Hide the symbols when we make it work on mac.
         ],
         "@bazel_tools//src/conditions:windows": [
             #TODO(larry): Hide the symbols when we make it work on Windows.


### PR DESCRIPTION
## Why are these changes needed?

The symbol export of this mac has caused the following two problems, first roll back this code.
1、[RLlib] Build process broken on an M1 #26324
2、[core][c++ worker] RayClusterModeTest.DefaultActorLifetimeTest timed out in macOS #26435

## Related issue number

#26435 

#26324

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
