### PR TITLE
[Core] Set c++ terminate handler to print stack trace

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -178,6 +178,7 @@ test:segfault --run_under="bash -c 'unset GREP_OPTIONS && if ! grep -q -o Micros
 # Debug build:
 build:debug -c dbg
 build:debug --copt="-g"
+build:debug --copt -fno-omit-frame-pointer
 build:debug --strip="never"
 
 # Undefined Behavior Sanitizer

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1401,7 +1401,7 @@ cc_test(
     name = "logging_test",
     size = "small",
     srcs = ["src/ray/util/logging_test.cc"],
-    args = ["--gtest_filter=PrintLogTest*"],
+    args = ["--gtest_filter=PrintLogTest*", "--gtest_catch_exceptions=0"],
     copts = COPTS,
     tags = ["team:core"],
     deps = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1401,7 +1401,11 @@ cc_test(
     name = "logging_test",
     size = "small",
     srcs = ["src/ray/util/logging_test.cc"],
-    args = ["--gtest_filter=PrintLogTest*", "--gtest_catch_exceptions=0"],
+    args = [
+        "--gtest_filter=PrintLogTest*",
+        # Disable so we can test terminate handler.
+        "--gtest_catch_exceptions=0",
+    ],
     copts = COPTS,
     tags = ["team:core"],
     deps = [

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -95,6 +95,7 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
       // Also, call the previous crash handler, e.g. the one installed by the Python
       // worker.
       RayLog::InstallFailureSignalHandler(nullptr, /*call_previous_handler=*/true);
+      RayLog::InstallTerminateHandler();
     }
   } else {
     RAY_CHECK(options_.log_dir.empty())

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -40,6 +40,7 @@ int main(int argc, char *argv[]) {
                                          ray::RayLogLevel::INFO,
                                          /*log_dir=*/"");
   ray::RayLog::InstallFailureSignalHandler(argv[0]);
+  ray::RayLog::InstallTerminateHandler();
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   const std::string redis_address = FLAGS_redis_address;

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -83,6 +83,7 @@ int main(int argc, char *argv[]) {
                                          ray::RayLogLevel::INFO,
                                          /*log_dir=*/"");
   ray::RayLog::InstallFailureSignalHandler(argv[0]);
+  ray::RayLog::InstallTerminateHandler();
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   const std::string raylet_socket_name = FLAGS_raylet_socket_name;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -55,19 +55,55 @@ long RayLog::log_rotation_file_num_ = 10;
 bool RayLog::is_failure_signal_handler_installed_ = false;
 std::atomic<bool> RayLog::initialized_ = false;
 
-std::string GetCallTrace() {
-  std::vector<void *> local_stack;
-  local_stack.resize(50);
-  absl::GetStackTrace(local_stack.data(), 50, 0);
-  static constexpr size_t buf_size = 16 * 1024;
-  char buf[buf_size];
-  std::string output;
-  for (auto &stack : local_stack) {
-    if (absl::Symbolize(stack, buf, buf_size)) {
-      output.append("    ").append(buf).append("\n");
+std::string GetStackTrace() {
+  std::string result;
+  static constexpr int MAX_NUM_FRAMES = 64;
+  char buf[16 * 1024];
+  void *frames[MAX_NUM_FRAMES];
+
+#ifndef _WIN32
+  const int num_frames = backtrace(frames, MAX_NUM_FRAMES);
+  char **frame_symbols = backtrace_symbols(frames, num_frames);
+  for (int i = 0; i < num_frames; ++i) {
+    result.append(frame_symbols[i]);
+
+    if (absl::Symbolize(frames[i], buf, sizeof(buf))) {
+      result.append(" ").append(buf);
+    }
+
+    result.append("\n");
+  }
+  free(frame_symbols);
+#else
+  const int num_frames = absl::GetStackTrace(frames, MAX_NUM_FRAMES, 0);
+  for (int i = 0; i < num_frames; ++i) {
+    if (absl::Symbolize(frames[i], buf, sizeof(buf))) {
+      result.append(buf);
+    } else {
+      result.append("unknown");
+    }
+    result.append("\n");
+  }
+#endif
+
+  return result;
+}
+
+void TerminateHandler() {
+  // Print the exception info, if any.
+  if (auto e_ptr = std::current_exception()) {
+    try {
+      std::rethrow_exception(e_ptr);
+    } catch (std::exception &e) {
+      RAY_LOG(ERROR) << "Unhandled exception " << e.what();
+    } catch (...) {
+      RAY_LOG(ERROR) << "Unhandled unknown exception.";
     }
   }
-  return output;
+
+  RAY_LOG(ERROR) << GetStackTrace();
+
+  std::abort();
 }
 
 inline const char *ConstBasename(const char *filepath) {
@@ -119,10 +155,10 @@ class SpdLogMessage final {
     }
 
     if (loglevel_ == static_cast<int>(spdlog::level::critical)) {
-      stream() << "\n*** StackTrace Information ***\n" << ray::GetCallTrace();
+      stream() << "\n*** StackTrace Information ***\n" << ray::GetStackTrace();
     }
     if (expose_osstream_) {
-      *expose_osstream_ << "\n*** StackTrace Information ***\n" << ray::GetCallTrace();
+      *expose_osstream_ << "\n*** StackTrace Information ***\n" << ray::GetStackTrace();
     }
     // NOTE(lingxuan.zlx): See more fmt by visiting https://github.com/fmtlib/fmt.
     logger->log(
@@ -354,6 +390,8 @@ void RayLog::InstallFailureSignalHandler(const char *argv0, bool call_previous_h
   absl::InstallFailureSignalHandler(options);
   is_failure_signal_handler_installed_ = true;
 }
+
+void RayLog::InstallTerminateHandler() { std::set_terminate(TerminateHandler); }
 
 bool RayLog::IsLevelEnabled(RayLogLevel log_level) {
   return log_level >= severity_threshold_;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -94,7 +94,8 @@ void TerminateHandler() {
     try {
       std::rethrow_exception(e_ptr);
     } catch (std::exception &e) {
-      RAY_LOG(ERROR) << "Unhandled exception " << e.what();
+      RAY_LOG(ERROR) << "Unhandled exception: " << typeid(e).name()
+                     << ". what(): " << e.what();
     } catch (...) {
       RAY_LOG(ERROR) << "Unhandled unknown exception.";
     }

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -86,7 +86,7 @@ enum { ERROR = 0 };
 
 namespace ray {
 /// This function returns the current call stack information.
-std::string GetCallTrace();
+std::string GetStackTrace();
 
 enum class RayLogLevel {
   TRACE = -2,
@@ -271,6 +271,10 @@ class RayLog : public RayLogBase {
   /// worker.
   static void InstallFailureSignalHandler(const char *argv0,
                                           bool call_previous_handler = false);
+
+  /// Install the terminate handler to output call stack when std::terminate() is called
+  /// (e.g. unhandled exception).
+  static void InstallTerminateHandler();
 
   /// To check failure signal handler enabled or not.
   static bool IsFailureSignalHandlerEnabled();

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -85,8 +85,10 @@ enum { ERROR = 0 };
 #endif
 
 namespace ray {
-/// This function returns the current call stack information.
-std::string GetStackTrace();
+class StackTrace {
+  /// This dumps the current stack trace information.
+  friend std::ostream &operator<<(std::ostream &os, const StackTrace &stack_trace);
+};
 
 enum class RayLogLevel {
   TRACE = -2,

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -281,12 +281,14 @@ TEST(PrintLogTest, TestGetStackTrace) {
 }
 
 int TerminateHandlerLevel0() {
+  RAY_LOG(INFO) << "TerminateHandlerLevel0";
   auto terminate_handler = std::get_terminate();
   (*terminate_handler)();
   return 0;
 }
 
 int TerminateHandlerLevel1() {
+  RAY_LOG(INFO) << "TerminateHandlerLevel1";
   TerminateHandlerLevel0();
   return 1;
 }

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -256,7 +256,9 @@ TEST(PrintLogTest, TestCheckOp) {
 }
 
 std::string TestFunctionLevel0() {
-  std::string stack_trace = GetStackTrace();
+  std::ostringstream oss;
+  oss << ray::StackTrace();
+  std::string stack_trace = oss.str();
   RAY_LOG(INFO) << "TestFunctionLevel0\n" << stack_trace;
   return stack_trace;
 }
@@ -271,7 +273,7 @@ std::string TestFunctionLevel2() {
   return TestFunctionLevel1();
 }
 
-TEST(PrintLogTest, TestGetStackTrace) {
+TEST(PrintLogTest, TestStackTrace) {
   auto ret0 = TestFunctionLevel0();
   EXPECT_TRUE(ret0.find("TestFunctionLevel0") != std::string::npos) << ret0;
   auto ret1 = TestFunctionLevel1();

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -256,9 +256,9 @@ TEST(PrintLogTest, TestCheckOp) {
 }
 
 std::string TestFunctionLevel0() {
-  std::string call_trace = GetCallTrace();
-  RAY_LOG(INFO) << "TestFunctionLevel0\n" << call_trace;
-  return call_trace;
+  std::string stack_trace = GetStackTrace();
+  RAY_LOG(INFO) << "TestFunctionLevel0\n" << stack_trace;
+  return stack_trace;
 }
 
 std::string TestFunctionLevel1() {
@@ -271,37 +271,36 @@ std::string TestFunctionLevel2() {
   return TestFunctionLevel1();
 }
 
-#ifndef _WIN32
-TEST(PrintLogTest, CallstackTraceTest) {
+TEST(PrintLogTest, TestGetStackTrace) {
   auto ret0 = TestFunctionLevel0();
-  EXPECT_TRUE(ret0.find("TestFunctionLevel0") != std::string::npos);
+  EXPECT_TRUE(ret0.find("TestFunctionLevel0") != std::string::npos) << ret0;
   auto ret1 = TestFunctionLevel1();
-  EXPECT_TRUE(ret1.find("TestFunctionLevel1") != std::string::npos);
+  EXPECT_TRUE(ret1.find("TestFunctionLevel1") != std::string::npos) << ret1;
   auto ret2 = TestFunctionLevel2();
-  EXPECT_TRUE(ret2.find("TestFunctionLevel2") != std::string::npos);
-}
-#endif
-
-/// Catch abort signal handler for testing RAY_CHECK.
-/// We'd better to run the following test case manually since process
-/// will terminated if abort signal raising.
-/*
-bool get_abort_signal = false;
-void signal_handler(int signum) {
-  RAY_LOG(WARNING) << "Interrupt signal (" << signum << ") received.";
-  get_abort_signal = signum == SIGABRT;
-  exit(0);
+  EXPECT_TRUE(ret2.find("TestFunctionLevel2") != std::string::npos) << ret2;
 }
 
-TEST(PrintLogTest, RayCheckAbortTest) {
-  get_abort_signal = false;
-  // signal(SIGABRT, signal_handler);
-  ray::RayLog::InstallFailureSignalHandler();
-  RAY_CHECK(0) << "Check for aborting";
-  sleep(1);
-  EXPECT_TRUE(get_abort_signal);
+int TerminateHandlerLevel0() {
+  auto terminate_handler = std::get_terminate();
+  (*terminate_handler)();
+  return 0;
 }
-*/
+
+int TerminateHandlerLevel1() {
+  TerminateHandlerLevel0();
+  return 1;
+}
+
+TEST(PrintLogTest, TestTerminateHandler) {
+  ray::RayLog::InstallTerminateHandler();
+  ASSERT_DEATH(TerminateHandlerLevel1(),
+               ".*TerminateHandlerLevel0.*TerminateHandlerLevel1.*");
+}
+
+TEST(PrintLogTest, TestFailureSignalHandler) {
+  ray::RayLog::InstallFailureSignalHandler(nullptr);
+  ASSERT_DEATH(abort(), ".*SIGABRT received.*");
+}
 
 }  // namespace ray
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
By default, an uncaught exception will abort the program with the following output:
```
terminate called after throwing an instance of 'std::length_error'
    what():  basic_string::_S_create
```

This is not that helpful since it doesn't tell us where the exception is thrown.

This PR overrides the default terminate handler to print the stack trace as well. We can then get the filename and line number with debug build using `addr2line`.

```
[2022-07-11 20:23:25,876 E 2578148 2578148] (raylet) logging.cc:97: Unhandled exception St12length_error. what(): basic_string::_M_create
[2022-07-11 20:23:25,911 E 2578148 2578148] (raylet) logging.cc:103: Stack trace: 
 /home/ubuntu/Workspace/ray1/python/ray/core/src/ray/raylet/raylet(+0x4ef157) [0x5619ead89157] ray::operator<<()
/home/ubuntu/Workspace/ray1/python/ray/core/src/ray/raylet/raylet(+0x4f4051) [0x5619ead8e051] ray::TerminateHandler()
/lib/x86_64-linux-gnu/libstdc++.so.6(+0xaa38c) [0x7fc1120b138c]
/lib/x86_64-linux-gnu/libstdc++.so.6(+0xaa3f7) [0x7fc1120b13f7]
/lib/x86_64-linux-gnu/libstdc++.so.6(+0xaa6a9) [0x7fc1120b16a9]
/lib/x86_64-linux-gnu/libstdc++.so.6(_ZSt20__throw_length_errorPKc+0x41) [0x7fc1120a8326] std::__throw_length_error()
/lib/x86_64-linux-gnu/libstdc++.so.6(+0x142edc) [0x7fc112149edc]
/lib/x86_64-linux-gnu/libstdc++.so.6(_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc+0x5c) [0x7fc112149f7c] std::__cxx11::basic_string<>::_M_construct()
/home/ubuntu/Workspace/ray1/python/ray/core/src/ray/raylet/raylet(+0x28c286) [0x5619eab26286] ray::raylet::NodeManager::NodeManager()
/home/ubuntu/Workspace/ray1/python/ray/core/src/ray/raylet/raylet(+0x2225cb) [0x5619eaabc5cb] ray::raylet::Raylet::Raylet()
```
Then we can do something like `addr2line -e path/to/raylet 0x28c286` to get the filename and line number.

This PR uses backtrace to dump the stack trace instead of absl since absl stack trace only has virtual address but no offset so it cannot be used to find the filename and line number.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
