### PR TITLE
[AIR] Discard returns of train loops in Trainers

### DIFF
--- a/python/ray/train/_internal/utils.py
+++ b/python/ray/train/_internal/utils.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 import inspect
 import os
 import logging
@@ -127,6 +128,16 @@ def construct_train_func(
     """
     signature = inspect.signature(train_func)
     num_params = len(signature.parameters)
+
+    # Discard any returns from the function so that
+    # BackendExecutor doesn't try to deserialize them.
+    # Those returns are inaccesible with AIR anyway.
+    @functools.wraps(train_func)
+    def discard_return_wrapper(*args, **kwargs):
+        train_func(*args, **kwargs)
+
+    wrapped_train_func = discard_return_wrapper
+
     if num_params > 1:
         err_msg = (
             f"{fn_arg_name} should take in 0 or 1 arguments, but it accepts "
@@ -135,9 +146,9 @@ def construct_train_func(
         raise ValueError(err_msg)
     elif num_params == 1:
         config = {} if config is None else config
-        return lambda: train_func(config)
+        return lambda: wrapped_train_func(config)
     else:  # num_params == 0
-        return train_func
+        return wrapped_train_func
 
 
 class Singleton(abc.ABCMeta):

--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -317,6 +317,7 @@ class DataParallelTrainer(BaseTrainer):
             self._train_loop_per_worker,
             self._train_loop_config,
             fn_arg_name="train_loop_per_worker",
+            discard_returns=True,
         )
 
         additional_resources_per_worker = (

--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -106,6 +106,9 @@ class DataParallelTrainer(BaseTrainer):
             # Returns the rank of the worker on the current node.
             session.get_local_rank()
 
+    Any returns from the ``train_loop_per_worker`` will be discarded and not
+    used or persisted anywhere.
+
     **How do I use ``DataParallelTrainer`` or any of its subclasses?**
 
     Example:

--- a/python/ray/train/horovod/horovod_trainer.py
+++ b/python/ray/train/horovod/horovod_trainer.py
@@ -68,6 +68,9 @@ class HorovodTrainer(DataParallelTrainer):
             # Returns the rank of the worker on the current node.
             session.get_local_rank()
 
+    Any returns from the ``train_loop_per_worker`` will be discarded and not
+    used or persisted anywhere.
+
     You could use ``TensorflowPredictor`` or ``TorchPredictor`` in conjunction with
     HorovodTrainer. You must save the model under the "model" kwarg in the
     ``Checkpoint`` passed to ``session.report()``, so that it can be used by

--- a/python/ray/train/tensorflow/tensorflow_trainer.py
+++ b/python/ray/train/tensorflow/tensorflow_trainer.py
@@ -80,6 +80,9 @@ class TensorflowTrainer(DataParallelTrainer):
             # as the data will be already sharded.
             train.tensorflow.prepare_dataset_shard(...)
 
+    Any returns from the ``train_loop_per_worker`` will be discarded and not
+    used or persisted anywhere.
+
     To save a model to use for the ``TensorflowPredictor``, you must save it under the
     "model" kwarg in ``Checkpoint`` passed to ``session.report()``.
 

--- a/python/ray/train/torch/torch_trainer.py
+++ b/python/ray/train/torch/torch_trainer.py
@@ -87,6 +87,9 @@ class TorchTrainer(DataParallelTrainer):
             # Returns the current torch device.
             train.torch.get_device()
 
+    Any returns from the ``train_loop_per_worker`` will be discarded and not
+    used or persisted anywhere.
+
     To save a model to use for the ``TorchPredictor``, you must save it under the
     "model" kwarg in ``Checkpoint`` passed to ``session.report()``.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Discards returns of user defined train loop functions to prevent deser issues with eg. torch models. Those returns are not used anywhere in AIR, so there is no loss of functionality.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
