### PR TITLE
[Datasets] Improve read_xxx experience of HTTP file

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -523,6 +523,19 @@ def _resolve_paths_and_filesystem(
                     _encode_url(path), filesystem
                 )
                 resolved_path = _decode_url(resolved_path)
+            elif "Unrecognized filesystem type in URI" in str(e):
+                scheme = urllib.parse.urlparse(path, allow_fragments=False).scheme
+                if scheme in ["http", "https"]:
+                    # If scheme of path is HTTP and filesystem is not resolved,
+                    # try to use fsspec HTTPFileSystem. This expects fsspec is
+                    # installed.
+                    from fsspec.implementations.http import HTTPFileSystem
+
+                    resolved_filesystem = PyFileSystem(FSSpecHandler(HTTPFileSystem()))
+                    resolved_path = path
+                    need_unwrap_path_protocol = False
+                else:
+                    raise
             else:
                 raise
         if filesystem is None:

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -501,9 +501,9 @@ def _resolve_paths_and_filesystem(
             # If filesystem is not a pyarrow filesystem and fsspec isn't
             # installed, then filesystem is neither a pyarrow filesystem nor
             # an fsspec filesystem, so we raise a TypeError.
-            raise TypeError(err_msg)
+            raise TypeError(err_msg) from None
         if not isinstance(filesystem, fsspec.spec.AbstractFileSystem):
-            raise TypeError(err_msg)
+            raise TypeError(err_msg) from None
         if isinstance(filesystem, HTTPFileSystem):
             # If filesystem is fsspec HTTPFileSystem, the protocol/scheme of paths
             # should not be unwrapped/removed, because HTTPFileSystem expects full file
@@ -537,7 +537,7 @@ def _resolve_paths_and_filesystem(
                     except ModuleNotFoundError:
                         raise ImportError(
                             "Please install fsspec to read files from HTTP."
-                        )
+                        ) from None
 
                     resolved_filesystem = PyFileSystem(FSSpecHandler(HTTPFileSystem()))
                     resolved_path = path

--- a/python/ray/data/tests/mock_http_server.py
+++ b/python/ray/data/tests/mock_http_server.py
@@ -7,15 +7,15 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import pytest
 
 port = 9898
-data_count = 1000
-data = b"\n".join([b"some test data"] * data_count)
-http_file = "http://localhost:%i/index/httpfile" % port
-index = b'<a href="%s">Link</a>' % http_file.encode()
+count = 1000
+data = b"\n".join([b"some test data"] * count)
+data_file = "http://localhost:%i/index/data_file" % port
+index = b'<a href="%s">Link</a>' % data_file.encode()
 
 
 class HTTPTestHandler(BaseHTTPRequestHandler):
     files = {
-        "/index/httpfile": data,
+        "/index/data_file": data,
         "/index": index,
     }
 
@@ -78,3 +78,13 @@ def serve():
 def http_server():
     with serve() as s:
         yield s
+
+
+@pytest.fixture(scope="module")
+def http_file():
+    return data_file
+
+
+@pytest.fixture(scope="module")
+def http_file_data_count():
+    return count

--- a/python/ray/data/tests/mock_http_server.py
+++ b/python/ray/data/tests/mock_http_server.py
@@ -1,4 +1,4 @@
-# extracted from aioboto3
+# extracted from fsspec
 #    https://github.com/fsspec/filesystem_spec/blob/a8cfd9c52a20c930c67ff296b60dbcda89d64db9/fsspec/tests/conftest.py
 import contextlib
 import threading

--- a/python/ray/data/tests/mock_http_server.py
+++ b/python/ray/data/tests/mock_http_server.py
@@ -1,0 +1,108 @@
+# extracted from aioboto3
+#    https://github.com/fsspec/filesystem_spec/blob/a8cfd9c52a20c930c67ff296b60dbcda89d64db9/fsspec/tests/conftest.py
+import contextlib
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+port = 9898
+data_count = 1000
+data = b"\n".join([b"some test data"] * data_count)
+http_file = "http://localhost:%i/index/httpfile" % port
+index = b'<a href="%s">Link</a>' % http_file.encode()
+
+
+class HTTPTestHandler(BaseHTTPRequestHandler):
+    files = {
+        "/index/httpfile": data,
+        "/index": index,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _respond(self, code=200, headers=None, data=b""):
+        headers = headers or {}
+        headers.update({"User-Agent": "test"})
+        self.send_response(code)
+        for k, v in headers.items():
+            self.send_header(k, str(v))
+        self.end_headers()
+        if data:
+            self.wfile.write(data)
+
+    def do_GET(self):
+        file_path = self.path.rstrip("/")
+        file_data = self.files.get(file_path)
+        if file_data is None:
+            return self._respond(404)
+        if "Range" in self.headers:
+            ran = self.headers["Range"]
+            b, ran = ran.split("=")
+            start, end = ran.split("-")
+            if start:
+                file_data = file_data[int(start) : (int(end) + 1) if end else None]
+            else:
+                # suffix only
+                file_data = file_data[-int(end) :]
+        if "give_length" in self.headers:
+            response_headers = {"Content-Length": len(file_data)}
+            self._respond(200, response_headers, file_data)
+        elif "give_range" in self.headers:
+            self._respond(
+                200,
+                {"Content-Range": "0-%i/%i" % (len(file_data) - 1, len(file_data))},
+                file_data,
+            )
+        else:
+            self._respond(200, data=file_data)
+
+    def do_HEAD(self):
+        if "head_not_auth" in self.headers:
+            return self._respond(
+                403, {"Content-Length": 123}, b"not authorized for HEAD request"
+            )
+        elif "head_ok" not in self.headers:
+            return self._respond(405)
+
+        file_path = self.path.rstrip("/")
+        file_data = self.files.get(file_path)
+        if file_data is None:
+            return self._respond(404)
+
+        if "give_length" in self.headers:
+            response_headers = {"Content-Length": len(file_data)}
+            if "zero_length" in self.headers:
+                response_headers["Content-Length"] = 0
+
+            self._respond(200, response_headers)
+        elif "give_range" in self.headers:
+            self._respond(
+                200, {"Content-Range": "0-%i/%i" % (len(file_data) - 1, len(file_data))}
+            )
+        elif "give_etag" in self.headers:
+            self._respond(200, {"ETag": "xxx"})
+        else:
+            self._respond(200)  # OK response, but no useful info
+
+
+@contextlib.contextmanager
+def serve():
+    server_address = ("", port)
+    httpd = HTTPServer(server_address, HTTPTestHandler)
+    th = threading.Thread(target=httpd.serve_forever)
+    th.daemon = True
+    th.start()
+    try:
+        yield "http://localhost:%i" % port
+    finally:
+        httpd.socket.close()
+        httpd.shutdown()
+        th.join()
+
+
+@pytest.fixture(scope="module")
+def http_server():
+    with serve() as s:
+        yield s

--- a/python/ray/data/tests/mock_http_server.py
+++ b/python/ray/data/tests/mock_http_server.py
@@ -58,34 +58,6 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
         else:
             self._respond(200, data=file_data)
 
-    def do_HEAD(self):
-        if "head_not_auth" in self.headers:
-            return self._respond(
-                403, {"Content-Length": 123}, b"not authorized for HEAD request"
-            )
-        elif "head_ok" not in self.headers:
-            return self._respond(405)
-
-        file_path = self.path.rstrip("/")
-        file_data = self.files.get(file_path)
-        if file_data is None:
-            return self._respond(404)
-
-        if "give_length" in self.headers:
-            response_headers = {"Content-Length": len(file_data)}
-            if "zero_length" in self.headers:
-                response_headers["Content-Length"] = 0
-
-            self._respond(200, response_headers)
-        elif "give_range" in self.headers:
-            self._respond(
-                200, {"Content-Range": "0-%i/%i" % (len(file_data) - 1, len(file_data))}
-            )
-        elif "give_etag" in self.headers:
-            self._respond(200, {"ETag": "xxx"})
-        else:
-            self._respond(200)  # OK response, but no useful info
-
 
 @contextlib.contextmanager
 def serve():

--- a/python/ray/data/tests/mock_http_server.py
+++ b/python/ray/data/tests/mock_http_server.py
@@ -7,8 +7,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import pytest
 
 port = 9898
-count = 1000
-data = b"\n".join([b"some test data"] * count)
+data = b"\n".join([b"some test data"] * 1000)
 data_file = "http://localhost:%i/index/data_file" % port
 index = b'<a href="%s">Link</a>' % data_file.encode()
 
@@ -83,8 +82,3 @@ def http_server():
 @pytest.fixture(scope="module")
 def http_file():
     return data_file
-
-
-@pytest.fixture(scope="module")
-def http_file_data_count():
-    return count

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -42,11 +42,7 @@ from ray.data.datasource.parquet_datasource import (
     _deserialize_pieces_with_retry,
 )
 from ray.data.tests.conftest import *  # noqa
-from ray.data.tests.mock_http_server import (  # noqa
-    http_server,
-    http_file,
-    data_count,
-)
+from ray.data.tests.mock_http_server import *  # noqa
 from ray.tests.conftest import *  # noqa
 from ray.types import ObjectRef
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -324,12 +324,14 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     assert ds_df.equals(df)
 
 
-def test_fsspec_http_file_system(ray_start_regular_shared, http_server):
+def test_fsspec_http_file_system(
+    ray_start_regular_shared, http_server, http_file, http_file_data_count
+):
     ds = ray.data.read_text(http_file, filesystem=HTTPFileSystem())
-    assert ds.count() == data_count
+    assert ds.count() == http_file_data_count
     # Test auto-resolve of HTTP file system when it is not provided.
     ds = ray.data.read_text(http_file)
-    assert ds.count() == data_count
+    assert ds.count() == http_file_data_count
 
 
 def test_read_example_data(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -324,14 +324,12 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     assert ds_df.equals(df)
 
 
-def test_fsspec_http_file_system(
-    ray_start_regular_shared, http_server, http_file, http_file_data_count
-):
+def test_fsspec_http_file_system(ray_start_regular_shared, http_server, http_file):
     ds = ray.data.read_text(http_file, filesystem=HTTPFileSystem())
-    assert ds.count() == http_file_data_count
+    assert ds.count() > 0
     # Test auto-resolve of HTTP file system when it is not provided.
     ds = ray.data.read_text(http_file)
-    assert ds.count() == http_file_data_count
+    assert ds.count() > 0
 
 
 def test_read_example_data(ray_start_regular_shared, tmp_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Per https://github.com/ray-project/ray/issues/26423#issue-1299625843, `fsspec.implementations.http. HTTPFileSystem` only works with full file path (e.g. "https://foo"), but does not work with file path removed protocol(e.g. "foo").  By default, we always [remove protocol from file path](https://github.com/ray-project/ray/blob/master/python/ray/data/datasource/file_based_datasource.py#L586).

This PR is to fix the issue and improve user experience when read HTTP file (i.e. read_xxx APIs, such as read_csv, read_parquet, etc):
* when user specifies fsspec `HTTPFileSystem` to read file, do not remove the HTTP file protocol/scheme (i.e. "http://" or "https://")
* automatically resolve the file system to use fsspec `HTTPFileSystem`, if user does not provide one in read_xxx APIs.

Tested with followed example:

```
(chengsu-dev) chengsu@chengs-mbp ray % python
>>> import ray
>>> from fsspec.implementations.http import HTTPFileSystem
>>> ds = ray.data.read_csv('https://air-example-data.s3.us-east-2.amazonaws.com/breast_cancer.csv', filesystem=HTTPFileSystem())
>>> ds.count()
569
>>>
>>> ds = ray.data.read_csv('https://air-example-data.s3.us-east-2.amazonaws.com/breast_cancer.csv')
>>> ds.count()
569
```

Error message in python cli if user does not install fsspec:

```
ray::_get_read_tasks() (pid=72537, ip=127.0.0.1)
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 1123, in _get_read_tasks
    reader = ds.create_reader(**kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 206, in create_reader
    return _FileBasedDatasourceReader(self, **kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 343, in __init__
    paths, self._filesystem = _resolve_paths_and_filesystem(paths, filesystem)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 539, in _resolve_paths_and_filesystem
    raise ImportError(f"Please install fsspec to read files from HTTP.")
ImportError: Please install fsspec to read files from HTTP
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/26423

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
