### PR TITLE
Revert "[Test]Disable java call cpp actor case for now (#26288)"

### DIFF
--- a/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
+++ b/java/test/src/main/java/io/ray/test/CrossLanguageInvocationTest.java
@@ -170,9 +170,7 @@ public class CrossLanguageInvocationTest extends BaseTest {
     Assert.assertEquals(res.get(), "2".getBytes());
   }
 
-  // TODO(WangTaoTheTonic): This hangs on Mac and can't be detected by `flakey-tests.ray.io`.
-  // Disable it for now and fix it later.
-  @Test(enabled = false)
+  @Test
   public void testCallingCppActor() {
     CppActorHandle actor = Ray.actor(CppActorClass.of("CreateCounter", "Counter")).remote();
     ObjectRef<Integer> res = actor.task(CppActorMethod.of("Plus1", Integer.class)).remote();


### PR DESCRIPTION
This reverts commit b3ba1e7ea2cd63131d263fa388b422194dc3ffff.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The hanging is caused by hiding symbols(see https://github.com/ray-project/ray/issues/26435), let's enable this test again.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/26323
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
