### PR TITLE
Rip out deterministic torch that could be slowing things down

### DIFF
--- a/rllib/utils/debug/deterministic.py
+++ b/rllib/utils/debug/deterministic.py
@@ -1,5 +1,4 @@
 import numpy as np
-import os
 import random
 from typing import Optional
 
@@ -32,20 +31,6 @@ def update_global_seed_if_necessary(
     if framework == "torch":
         torch, _ = try_import_torch()
         torch.manual_seed(seed)
-        # See https://github.com/pytorch/pytorch/issues/47672.
-        cuda_version = torch.version.cuda
-        if cuda_version is not None and float(torch.version.cuda) >= 10.2:
-            os.environ["CUBLAS_WORKSPACE_CONFIG"] = "4096:8"
-        else:
-            from distutils.version import LooseVersion
-
-            if LooseVersion(torch.__version__) >= LooseVersion("1.8.0"):
-                # Not all Operations support this.
-                torch.use_deterministic_algorithms(True)
-            else:
-                torch.set_deterministic(True)
-        # This is only for Convolution no problem.
-        torch.backends.cudnn.deterministic = True
     elif framework == "tf2" or framework == "tfe":
         tf1, tf, _ = try_import_tf()
         # Tf2.x.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In RLlib, torch has known to be slower than tensorflow. [One reason for this](https://pytorch.org/docs/stable/notes/randomness.html#reproducibility) could be the fact that we force determinism when using torch, yet not when using tensorflow. Since rllib is still not deterministic (try running cartpole-ppo twice and see if you get the same results), we might as well treat torch like tf and remove this code.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
