### PR TITLE
Disable stack trace logging tests for windows

### DIFF
--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -255,6 +255,7 @@ TEST(PrintLogTest, TestCheckOp) {
   ASSERT_DEATH(RAY_CHECK_EQ(i, j), "1 vs 0");
 }
 
+#ifndef _WIN32
 std::string TestFunctionLevel0() {
   std::ostringstream oss;
   oss << ray::StackTrace();
@@ -300,6 +301,7 @@ TEST(PrintLogTest, TestTerminateHandler) {
   ASSERT_DEATH(TerminateHandlerLevel1(),
                ".*TerminateHandlerLevel0.*TerminateHandlerLevel1.*");
 }
+#endif
 
 TEST(PrintLogTest, TestFailureSignalHandler) {
   ray::RayLog::InstallFailureSignalHandler(nullptr);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Getting stack trace doesn't work for Windows yet.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
