### PR TITLE
[Serve][AIR] Fix pandas_read_json compatibility issue

### DIFF
--- a/python/ray/serve/http_adapters.py
+++ b/python/ray/serve/http_adapters.py
@@ -93,4 +93,4 @@ async def pandas_read_json(raw_request: Request):
     import pandas as pd
 
     raw_json = await raw_request.body()
-    return pd.read_json(raw_json, **raw_request.query_params)
+    return pd.read_json(raw_json.decode("utf-8"), **raw_request.query_params)

--- a/python/ray/serve/http_adapters.py
+++ b/python/ray/serve/http_adapters.py
@@ -93,4 +93,6 @@ async def pandas_read_json(raw_request: Request):
     import pandas as pd
 
     raw_json = await raw_request.body()
-    return pd.read_json(raw_json.decode("utf-8"), **raw_request.query_params)
+    if isinstance(raw_json, bytes):
+        raw_json = raw_json.decode("utf-8")
+    return pd.read_json(raw_json, **raw_request.query_params)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The following snippet 
```python
pd.read_json(b'[{"a": 1}]')
```

works in pandas 1.3.5; but fails in 1.4.2 and higher because pandas no longer accept bytes anymore. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
