### PR TITLE
[Doc][namespaces][C++ worker]add document for c++ worker namespace and specifying namespace while creating/getting named actors

### DIFF
--- a/doc/source/ray-core/namespaces.rst
+++ b/doc/source/ray-core/namespaces.rst
@@ -121,7 +121,6 @@ Named actors are only accessible within their namespaces.
 
         // Job 1 creates two actors, "orange" and "purple" in the "colors" namespace.
         ray::RayConfig config;
-        config.address = "ray://localhost:10001";
         config.ray_namespace = "colors";
         ray::Init(config);
         ray::Actor(RAY_FUNC(Counter::FactoryCreate)).SetName("orange").Remote();
@@ -130,7 +129,6 @@ Named actors are only accessible within their namespaces.
 
         // Job 2 is now connecting to a different namespace.
         ray::RayConfig config;
-        config.address = "ray://localhost:10001";
         config.ray_namespace = "fruits";
         ray::Init(config);
         // This fails because "orange" was defined in the "colors" namespace.
@@ -142,7 +140,6 @@ Named actors are only accessible within their namespaces.
 
         // Job 3 connects to the original "colors" namespace.
         ray::RayConfig config;
-        config.address = "ray://localhost:10001";
         config.ray_namespace = "colors";
         ray::Init(config);
         // This fails because "watermelon" was in the fruits namespace.
@@ -201,7 +198,6 @@ the specified namespace, no matter what namespace of the current job is.
         // `ray start --head` has been run to launch a local cluster.
 
         ray::RayConfig config;
-        config.address = "ray://localhost:10001";
         ray::Init(config);
         // Create an actor with specified namespace.
         ray::Actor(RAY_FUNC(Counter::FactoryCreate)).SetName("my_actor", "actor_namespace").Remote();
@@ -272,14 +268,12 @@ will not have access to actors in other namespaces.
 
         // Job 1 connects to an anonymous namespace by default.
         ray::RayConfig config;
-        config.address = "ray://localhost:10001";
         ray::Init(config);
         ray::Actor(RAY_FUNC(Counter::FactoryCreate)).SetName("my_actor").Remote();
         ray::Shutdown();
 
         // Job 2 connects to a _different_ anonymous namespace by default
         ray::RayConfig config;
-        config.address = "ray://localhost:10001";
         ray::Init(config);
         // This succeeds because the second job is in its own namespace.
         ray::Actor(RAY_FUNC(Counter::FactoryCreate)).SetName("my_actor").Remote();

--- a/doc/source/ray-core/namespaces.rst
+++ b/doc/source/ray-core/namespaces.rst
@@ -155,7 +155,7 @@ Specifying namespace for named actors
 -------------------------------------
 
 You can specify a namespace for a named actor while creating it. The created actor belongs to
-the specified namespace, no matter what namespaace of the current job is.
+the specified namespace, no matter what namespace of the current job is.
 
 .. tabbed:: Python
 

--- a/doc/source/ray-core/namespaces.rst
+++ b/doc/source/ray-core/namespaces.rst
@@ -151,6 +151,64 @@ Named actors are only accessible within their namespaces.
         ray::GetActor<Counter>("orange");
         ray::Shutdown();
 
+Specifying namespace for named actors
+--------------------
+
+You can specify a namespace for a named actor while creating it. The created actor belongs to
+the specified namespace, no matter what namespaace of the current job is.
+
+.. tabbed:: Python
+
+    .. code-block:: python
+
+        # `ray start --head` has been run to launch a local cluster
+
+        import ray
+
+        @ray.remote
+        class Actor:
+            pass
+
+        ctx = ray.init("ray://localhost:10001")
+        # Create an actor with specified namespace.
+        Actor.options(name="my_actor", namespace="actor_namespace", lifetime="detached").remote()
+        # It is accessible in its namespace.
+        ray.get_actor("my_actor", namespace="actor_namespace")
+        ctx.disconnect()
+
+.. tabbed:: Java
+
+    .. code-block:: java
+
+        // `ray start --head` has been run to launch a local cluster.
+
+        System.setProperty("ray.address", "localhost:10001");
+        try {
+            Ray.init();
+            // Create an actor with specified namespace.
+            Ray.actor(Actor::new).setName("my_actor", "actor_namespace").remote();
+            // It is accessible in its namespace.
+            Ray.getActor("my_actor", "actor_namespace").isPresent(); // return true
+
+        } finally {
+            Ray.shutdown();
+        }
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        // `ray start --head` has been run to launch a local cluster.
+
+        ray::RayConfig config;
+        config.address = "ray://localhost:10001";
+        ray::Init(config);
+        // Create an actor with specified namespace.
+        ray::Actor(RAY_FUNC(Counter::FactoryCreate)).SetName("my_actor", "actor_namespace").Remote();
+        // It is accessible in its namespace.
+        ray::GetActor<Counter>("orange");
+        ray::Shutdown();
+
 Anonymous namespaces
 --------------------
 

--- a/doc/source/ray-core/namespaces.rst
+++ b/doc/source/ray-core/namespaces.rst
@@ -152,7 +152,7 @@ Named actors are only accessible within their namespaces.
         ray::Shutdown();
 
 Specifying namespace for named actors
---------------------
+-------------------------------------
 
 You can specify a namespace for a named actor while creating it. The created actor belongs to
 the specified namespace, no matter what namespaace of the current job is.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We've supported namespace in c++ worker in https://github.com/ray-project/ray/pull/26327. Here we add doc for usage and also reinforce the documents of Java and Python, like adding explanation of specifying namespace while creating named actors.

- [x] add doc for basic c++ worker namespace usage
- [x] add explanation for specifying namespace while creating named actors, in Python, Java and C++

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
