### PR TITLE
[Serve][Part2] Migrate the tests to use deployment graph api

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -170,6 +170,7 @@ test_python() {
       python/ray/tests/...
       -python/ray/serve:conda_env # pip field in runtime_env not supported
       -python/ray/serve:test_cross_language # Ray java not built on Windows yet.
+      -python/ray/serve:test_gcs_failure # Fork not supported in windows
       -python/ray/tests:test_actor_advanced  # crashes in shutdown
       -python/ray/tests:test_autoscaler # We don't support Autoscaler on Windows
       -python/ray/tests:test_autoscaler_aws

--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -182,6 +182,14 @@ py_test(
     deps = [":serve_lib"],
 )
 
+py_test(
+    name = "test_gcs_failure",
+    size = "medium",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive", "team:serve"],
+    deps = [":serve_lib"],
+)
+
 
 py_test(
     name = "test_handle",

--- a/python/ray/serve/tests/fault_tolerance_tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/fault_tolerance_tests/test_controller_recovery.py
@@ -27,7 +27,7 @@ def test_recover_start_from_replica_actor_names(serve_instance):
         def __call__(self, *args):
             return "hii"
 
-    TransientConstructorFailureDeployment.deploy()
+    serve.run(TransientConstructorFailureDeployment.bind())
     for _ in range(10):
         response = request_with_retries(
             "/recover_start_from_replica_actor_names/", timeout=30
@@ -163,7 +163,7 @@ def test_recover_rolling_update_from_replica_actor_names(serve_instance):
 
         return responses, blocking
 
-    V1.deploy()
+    serve.run(V1.bind())
     responses1, _ = make_nonblocking_calls({"1": 2}, num_returns=2)
     pids1 = responses1["1"]
 
@@ -178,7 +178,7 @@ def test_recover_rolling_update_from_replica_actor_names(serve_instance):
     # Redeploy new version. Since there is one replica blocking, only one new
     # replica should be started up.
     V2 = V1.options(func_or_class=V2, version="2")
-    V2.deploy(_blocking=False)
+    serve.run(V2.bind(), _blocking=False)
     with pytest.raises(TimeoutError):
         client._wait_for_deployment_healthy(V2.name, timeout_s=0.1)
     responses3, blocking3 = make_nonblocking_calls({"1": 1}, expect_blocking=True)

--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -26,7 +26,7 @@ def test_controller_failure(serve_instance):
     def function(_):
         return "hello1"
 
-    function.deploy()
+    serve.run(function.bind())
 
     assert request_with_retries("/controller_failure/", timeout=1).text == "hello1"
 
@@ -45,7 +45,7 @@ def test_controller_failure(serve_instance):
 
     ray.kill(serve.context._global_client._controller, no_restart=False)
 
-    function.options(func_or_class=function2).deploy()
+    serve.run(function.options(func_or_class=function2).bind())
 
     def check_controller_failure():
         response = request_with_retries("/controller_failure/", timeout=30)
@@ -58,7 +58,7 @@ def test_controller_failure(serve_instance):
         return "hello3"
 
     ray.kill(serve.context._global_client._controller, no_restart=False)
-    function3.deploy()
+    serve.run(function3.bind())
     ray.kill(serve.context._global_client._controller, no_restart=False)
 
     for _ in range(10):
@@ -81,7 +81,7 @@ def test_http_proxy_failure(serve_instance):
     def function(_):
         return "hello1"
 
-    function.deploy()
+    serve.run(function.bind())
 
     assert request_with_retries("/proxy_failure/", timeout=1.0).text == "hello1"
 
@@ -94,7 +94,7 @@ def test_http_proxy_failure(serve_instance):
     def function2(_):
         return "hello2"
 
-    function.options(func_or_class=function2).deploy()
+    serve.run(function.options(func_or_class=function2).bind())
 
     def check_new():
         for _ in range(10):
@@ -121,7 +121,7 @@ def test_worker_restart(serve_instance):
         def __call__(self, *args):
             return os.getpid()
 
-    Worker1.deploy()
+    serve.run(Worker1.bind())
 
     # Get the PID of the worker.
     old_pid = request_with_retries("/worker_failure/", timeout=1).text
@@ -168,7 +168,7 @@ def test_worker_replica_failure(serve_instance):
             return self.index
 
     counter = Counter.remote()
-    Worker.options(num_replicas=2).deploy(counter)
+    serve.run(Worker.options(num_replicas=2).bind(counter))
 
     # Wait until both replicas have been started.
     responses = set()

--- a/python/ray/serve/tests/test_gcs_failure.py
+++ b/python/ray/serve/tests/test_gcs_failure.py
@@ -56,7 +56,7 @@ def test_controller_gcs_failure(serve_ha, use_handle):  # noqa: F811
         print("RET=", ret)
         return ret
 
-    d.deploy()
+    serve.run(d.bind())
     pid = call()
 
     # Kill the GCS
@@ -74,7 +74,7 @@ def test_controller_gcs_failure(serve_ha, use_handle):  # noqa: F811
     with pytest.raises(Exception):
         wait_for_condition(lambda: call() != pid, timeout=4)
 
-    d.deploy()
+    serve.run(d.bind())
 
     # Make sure redeploy happens
     assert pid != call()
@@ -86,7 +86,7 @@ def test_controller_gcs_failure(serve_ha, use_handle):  # noqa: F811
 
     # Redeploy should fail
     with pytest.raises(KVStoreError):
-        d.options().deploy()
+        serve.run(d.options().bind())
 
     # TODO: Check status not change once ray serve cover rollback
 

--- a/python/ray/serve/tests/test_gcs_failure.py
+++ b/python/ray/serve/tests/test_gcs_failure.py
@@ -25,6 +25,10 @@ def serve_ha(external_redis, monkeypatch):  # noqa: F811
     ray.shutdown()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Failing on Windows, 'ForkedFunc' object has no attribute 'pid'",
+)
 def test_ray_internal_kv_timeout(serve_ha):  # noqa: F811
     # Firstly make sure it's working
     kv1 = RayInternalKVStore()
@@ -42,6 +46,10 @@ def test_ray_internal_kv_timeout(serve_ha):  # noqa: F811
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Failing on Windows, 'ForkedFunc' object has no attribute 'pid'",
+)
 @pytest.mark.parametrize("use_handle", [False, True])
 def test_controller_gcs_failure(serve_ha, use_handle):  # noqa: F811
     @serve.deployment

--- a/python/ray/serve/tests/test_get_deployment.py
+++ b/python/ray/serve/tests/test_get_deployment.py
@@ -16,8 +16,8 @@ def test_basic_get(serve_instance):
     with pytest.raises(KeyError):
         serve.get_deployment(name=name)
 
-    d.deploy()
-    val1, pid1 = ray.get(d.get_handle().remote())
+    handle = serve.run(d.bind())
+    val1, pid1 = ray.get(handle.remote())
     assert val1 == "1"
 
     del d

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -36,14 +36,13 @@ def test_sync_handle_serializable(serve_instance):
     def f():
         return "hello"
 
-    f.deploy()
+    handle = serve.run(f.bind())
 
     @ray.remote
     def task(handle):
         return ray.get(handle.remote())
 
     # Test pickling via ray.remote()
-    handle = f.get_handle(sync=True)
     result_ref = task.remote(handle)
     assert ray.get(result_ref) == "hello"
 
@@ -67,10 +66,9 @@ def test_handle_serializable_in_deployment_init(serve_instance):
         def __call__(self, *args):
             return {"count": self.count}
 
-    RayServer1.deploy()
-    for sync in [True, False]:
-        rs1_handle = RayServer1.get_handle(sync=sync)
-        RayServer2.deploy(rs1_handle)
+    rs1 = RayServer1.bind()
+    rs2 = RayServer2.bind(rs1)
+    serve.run(rs2)
 
 
 def test_sync_handle_in_thread(serve_instance):
@@ -78,7 +76,7 @@ def test_sync_handle_in_thread(serve_instance):
     def f():
         return "hello"
 
-    f.deploy()
+    handle = serve.run(f.bind())
 
     def thread_get_handle(deploy):
         handle = deploy.get_handle(sync=True)
@@ -98,14 +96,15 @@ def test_handle_in_endpoint(serve_instance):
 
     @serve.deployment
     class Endpoint2:
-        def __init__(self):
-            self.handle = Endpoint1.get_handle()
+        def __init__(self, handle):
+            self.handle = handle
 
         def __call__(self, _):
             return ray.get(self.handle.remote())
 
-    Endpoint1.deploy()
-    Endpoint2.deploy()
+    end_p1 = Endpoint1.bind()
+    end_p2 = Endpoint2.bind(end_p1)
+    serve.run(end_p2)
 
     assert requests.get("http://127.0.0.1:8000/Endpoint2").text == "hello"
 
@@ -145,16 +144,13 @@ def test_handle_option_chaining(serve_instance):
         def __call__(self):
             return "__call__"
 
-    MultiMethod.deploy()
+    handle1 = serve.run(MultiMethod.bind())
+    assert ray.get(handle1.remote()) == "__call__"
 
-    # get_handle should give you a clean handle
-    handle1 = MultiMethod.get_handle().options(method_name="method_a")
-    handle2 = MultiMethod.get_handle()
-    # options().options() override should work
+    handle2 = handle1.options(method_name="method_a")
+    assert ray.get(handle2.remote()) == "method_a"
+
     handle3 = handle1.options(method_name="method_b")
-
-    assert ray.get(handle1.remote()) == "method_a"
-    assert ray.get(handle2.remote()) == "__call__"
     assert ray.get(handle3.remote()) == "method_b"
 
 

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -26,8 +26,7 @@ def test_handle_access_log(serve_instance):
         def throw(self, *args):
             raise RuntimeError("blah blah blah")
 
-    Handler.deploy()
-    h = Handler.get_handle()
+    h = serve.run(Handler.bind())
 
     f = io.StringIO()
     with redirect_stderr(f):
@@ -74,7 +73,7 @@ def test_http_access_log(serve_instance):
 
         return "hi"
 
-    fn.deploy()
+    serve.run(fn.bind())
 
     f = io.StringIO()
     with redirect_stderr(f):
@@ -110,8 +109,7 @@ def test_user_logs(serve_instance):
         logger.info("user log message")
         return serve.get_replica_context().replica_tag
 
-    fn.deploy()
-    handle = fn.get_handle()
+    handle = serve.run(fn.bind())
 
     f = io.StringIO()
     with redirect_stderr(f):
@@ -135,8 +133,7 @@ def test_disable_access_log(serve_instance):
         def __call__(self, *args):
             return serve.get_replica_context().replica_tag
 
-    A.deploy()
-    handle = A.get_handle()
+    handle = serve.run(A.bind())
 
     f = io.StringIO()
     with redirect_stderr(f):
@@ -161,7 +158,7 @@ def test_deprecated_deployment_logger(serve_instance):
             self.count += 1
             logger.info(f"count: {self.count}")
 
-    Counter.deploy()
+    serve.run(Counter.bind())
     f = io.StringIO()
     with redirect_stderr(f):
         requests.get("http://127.0.0.1:8000/counter/")

--- a/python/ray/serve/tests/test_logs.py
+++ b/python/ray/serve/tests/test_logs.py
@@ -16,7 +16,7 @@ def test_slow_allocation_warning(serve_instance, capsys):
             pass
 
     num_replicas = 2
-    D.options(num_replicas=num_replicas).deploy(_blocking=False)
+    serve.run(D.options(num_replicas=num_replicas).bind(), _blocking=False)
 
     expected_warning = (
         f"Deployment '{D.name}' has "
@@ -49,7 +49,7 @@ def test_slow_initialization_warning(serve_instance, capsys):
             time.sleep(99999)
 
     num_replicas = 4
-    D.options(num_replicas=num_replicas).deploy(_blocking=False)
+    serve.run(D.options(num_replicas=num_replicas).bind(), _blocking=False)
 
     expected_warning = (
         f"Deployment '{D.name}' has "
@@ -78,7 +78,7 @@ def test_deployment_init_error_logging(serve_instance, capsys):
             0 / 0
 
     with pytest.raises(RuntimeError):
-        D.deploy()
+        serve.run(D.bind())
 
     captured = capsys.readouterr()
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -15,11 +15,10 @@ def test_serve_metrics_for_successful_connection(serve_instance):
     async def f(request):
         return "hello"
 
-    f.deploy()
+    handle = serve.run(f.bind())
 
     # send 10 concurrent requests
     url = "http://127.0.0.1:8000/metrics"
-    handle = f.get_handle()
     ray.get([block_until_http_ready.remote(url) for _ in range(10)])
     ray.get([handle.remote(url) for _ in range(10)])
 
@@ -103,7 +102,7 @@ def test_http_metrics(serve_instance):
             # Trigger RayActorError
             os._exit(0)
 
-    A.deploy()
+    serve.run(A.bind())
     requests.get("http://127.0.0.1:8000/A/")
     requests.get("http://127.0.0.1:8000/A/")
     try:

--- a/python/ray/serve/tests/test_persistence.py
+++ b/python/ray/serve/tests/test_persistence.py
@@ -14,7 +14,7 @@ from ray import serve
 def driver():
     return "OK!"
 
-driver.deploy()
+serve.run(driver.bind())
 """.format(
         ray._private.worker._global_node.address
     )

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -12,6 +12,7 @@ from ray.exceptions import GetTimeoutError
 from ray import serve
 from ray._private.test_utils import SignalActor
 from ray.serve.context import get_global_client
+from ray.serve.drivers import DAGDriver
 
 
 @pytest.fixture
@@ -54,23 +55,25 @@ def test_np_in_composed_model(serve_instance):
     # in cloudpickle _from_numpy_buffer
 
     @serve.deployment
-    def sum_model(data):
-        return np.sum(data)
+    class Sum:
+        def __call__(self, data):
+            return np.sum(data)
 
     @serve.deployment(name="model")
     class ComposedModel:
-        def __init__(self):
-            self.model = sum_model.get_handle(sync=False)
+        def __init__(self, handle):
+            self.model = handle
 
-        async def __call__(self, _request):
+        async def __call__(self):
             data = np.ones((10, 10))
-            ref = await self.model.remote(data)
-            return await ref
+            return await self.model.remote(data)
 
-    sum_model.deploy()
-    ComposedModel.deploy()
+    sum_d = Sum.bind()
+    cm_d = ComposedModel.bind(sum_d)
+    dag = DAGDriver.bind(cm_d)
+    serve.run(dag)
 
-    result = requests.get("http://127.0.0.1:8000/model")
+    result = requests.get("http://127.0.0.1:8000/")
     assert result.status_code == 200
     assert result.json() == 100.0
 
@@ -83,8 +86,7 @@ def test_replica_memory_growth(serve_instance):
         gc.collect()
         return len(gc.garbage)
 
-    gc_unreachable_objects.deploy()
-    handle = gc_unreachable_objects.get_handle()
+    handle = serve.run(gc_unreachable_objects.bind())
 
     # We are checking that there's constant number of object in gc.
     known_num_objects = ray.get(handle.remote())
@@ -109,8 +111,7 @@ def test_ref_in_handle_input(serve_instance):
     async def blocked_by_ref(data):
         assert not isinstance(data, ray.ObjectRef)
 
-    blocked_by_ref.deploy()
-    handle = blocked_by_ref.get_handle()
+    handle = serve.run(blocked_by_ref.bind())
 
     # Pass in a ref that's not ready yet
     ref = unblock_worker_signal.wait.remote()
@@ -138,7 +139,7 @@ def test_nested_actors(serve_instance):
         def __init__(self) -> None:
             self.a = CustomActor.remote()
 
-    A.deploy()
+    serve.run(A.bind())
 
     # The nested actor should start successfully.
     ray.get(signal.wait.remote(), timeout=10)
@@ -152,8 +153,7 @@ def test_handle_cache_out_of_scope(serve_instance):
     def f():
         return "hi"
 
-    f.deploy()
-    handle = serve.get_deployment("f").get_handle()
+    handle = serve.run(f.bind())
 
     handle_cache = get_global_client().handle_cache
     assert len(handle_cache) == initial_num_cached + 1
@@ -184,36 +184,39 @@ def test_out_of_order_chaining(serve_instance):
     collector = Collector.remote()
 
     @serve.deployment
-    async def composed_model(_id: int):
-        first_func_h = first_func.get_handle()
-        second_func_h = second_func.get_handle()
-        first_res_h = first_func_h.remote(_id=_id)
-        ref = second_func_h.remote(_id=first_res_h)
-        await ref
+    class Combine:
+        def __init__(self, m1, m2):
+            self.m1 = m1
+            self.m2 = m2
+
+        async def run(self, _id):
+            r1_ref = self.m1.compute.remote(_id)
+            r2_ref = self.m2.compute.remote(r1_ref)
+            await r2_ref
 
     @serve.deployment
-    async def first_func(_id):
-        if _id == 0:
-            await asyncio.sleep(1000)
-        print(f"First output: {_id}")
-        ray.get(collector.append.remote(f"first-{_id}"))
-        return _id
+    class FirstModel:
+        async def compute(self, _id):
+            if _id == 0:
+                await asyncio.sleep(1000)
+            print(f"First output: {_id}")
+            ray.get(collector.append.remote(f"first-{_id}"))
+            return _id
 
     @serve.deployment
-    async def second_func(_id):
-        print(f"Second output: {_id}")
-        ray.get(collector.append.remote(f"second-{_id}"))
-        return _id
+    class SecondModel:
+        async def compute(self, _id):
+            print(f"Second output: {_id}")
+            ray.get(collector.append.remote(f"second-{_id}"))
+            return _id
 
-    serve.start(detached=True)
+    m1 = FirstModel.bind()
+    m2 = SecondModel.bind()
+    combine = Combine.bind(m1, m2)
+    handle = serve.run(combine)
 
-    composed_model.deploy()
-    first_func.deploy()
-    second_func.deploy()
-
-    main_p = composed_model.get_handle()
-    main_p.remote(_id=0)
-    ray.get(main_p.remote(_id=1))
+    handle.run.remote(_id=0)
+    ray.get(handle.run.remote(_id=1))
 
     assert ray.get(collector.get.remote()) == ["first-1", "second-1"]
 
@@ -252,8 +255,7 @@ def test_healthcheck_timeout(serve_instance):
         def __call__(self):
             ray.get(signal.wait.remote())
 
-    A.deploy()
-    handle = A.get_handle()
+    handle = serve.run(A.bind())
     ref = handle.remote()
     # without the proper fix, the ref will fail with actor died error.
     with pytest.raises(GetTimeoutError):

--- a/python/ray/serve/tests/test_runtime_env_2.py
+++ b/python/ray/serve/tests/test_runtime_env_2.py
@@ -16,15 +16,13 @@ from ray import serve
 job_config = ray.job_config.JobConfig(runtime_env={"working_dir": "."})
 ray.init(address="auto", namespace="serve", job_config=job_config)
 
-serve.start(detached=True)
 
 @serve.deployment(version="1")
 class Test:
     def __call__(self, *args):
         return open("hello").read()
 
-Test.deploy()
-handle = Test.get_handle()
+handle = serve.run(Test.bind())
 assert ray.get(handle.remote()) == "world"
 """
 
@@ -40,15 +38,13 @@ from ray import serve
 job_config = ray.job_config.JobConfig(runtime_env={"working_dir": "."})
 ray.init(address="auto", namespace="serve", job_config=job_config)
 
-serve.start(detached=True)
 
 @serve.deployment(version="2")
 class Test:
     def __call__(self, *args):
         return open("hello").read()
 
-Test.deploy()
-handle = Test.get_handle()
+handle = serve.run(Test.bind())
 assert ray.get(handle.remote()) == "world2"
 Test.delete()
 """
@@ -68,20 +64,18 @@ import requests
 
 ray.init(address="auto")
 
-serve.start()
-
 
 @serve.deployment
 def requests_version(request):
     return requests.__version__
 
 
-requests_version.options(
+serve.run(requests_version.options(
     ray_actor_options={
         "runtime_env": {
             "pip": ["requests==2.25.1"]
         }
-    }).deploy()
+    }).bind())
 
 assert requests.get("http://127.0.0.1:8000/requests_version").text == "2.25.1"
 """

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -628,8 +628,9 @@ def test_deployment_to_schema_to_deployment():
         "https://github.com/shrekris-anyscale/test_module/archive/HEAD.zip",
     ]
 
-    handle = serve.run(deployment.bind())
-    assert ray.get(handle.remote()) == "Hello world!"
+    serve.start()
+    deployment.deploy()
+    assert ray.get(deployment.get_handle().remote()) == "Hello world!"
     assert requests.get("http://localhost:8000/hello").text == "Hello world!"
     serve.shutdown()
 

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -628,9 +628,8 @@ def test_deployment_to_schema_to_deployment():
         "https://github.com/shrekris-anyscale/test_module/archive/HEAD.zip",
     ]
 
-    serve.start()
-    deployment.deploy()
-    assert ray.get(deployment.get_handle().remote()) == "Hello world!"
+    handle = serve.run(deployment.bind())
+    assert ray.get(handle.remote()) == "Hello world!"
     assert requests.get("http://localhost:8000/hello").text == "Hello world!"
     serve.shutdown()
 

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -189,9 +189,11 @@ def test_get_serve_status(shutdown_ray):
 
 
 def test_controller_deserialization_deployment_def(start_and_shutdown_ray_cli_function):
+    """Ensure controller doesn't deserialize deployment_def or init_args/kwargs."""
+
     @ray.remote
     def run_graph():
-
+        """Deploys a Serve application to the controller's Ray cluster."""
         from ray import serve
         from ray._private.utils import import_attr
         from ray.serve.api import build
@@ -237,6 +239,7 @@ def test_controller_deserialization_deployment_def(start_and_shutdown_ray_cli_fu
 
 
 def test_controller_deserialization_args_and_kwargs():
+    """Ensures init_args and init_kwargs stay serialized in controller."""
 
     ray.init()
     client = serve.start()
@@ -245,6 +248,8 @@ def test_controller_deserialization_args_and_kwargs():
         pass
 
     def generate_pid_based_deserializer(pid, raw_deserializer):
+        """Cannot be deserialized by the process with specified pid."""
+
         def deserializer(*args):
 
             import os
@@ -594,6 +599,7 @@ def test_controller_recover_and_delete():
 
 
 def test_shutdown_remote(start_and_shutdown_ray_cli_function):
+    """Check that serve.shutdown() works on a remote Ray cluster."""
 
     deploy_serve_script = (
         "import ray\n"

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -79,8 +79,7 @@ def test_memory_omitted_option(ray_shutdown):
         return "world"
 
     ray.init(num_gpus=3, namespace="serve")
-    serve.start()
-    hello.deploy()
+    serve.run(hello.bind())
 
     assert ray.get(hello.get_handle().remote()) == "world"
 
@@ -91,13 +90,12 @@ def test_serve_namespace(shutdown_ray, detached, ray_namespace):
     """Test that Serve starts in SERVE_NAMESPACE regardless of driver namespace."""
 
     with ray.init(namespace=ray_namespace):
-        serve.start(detached=detached)
 
         @serve.deployment
         def f(*args):
             return "got f"
 
-        f.deploy()
+        serve.run(f.bind())
 
         actors = ray.util.list_named_actors(all_namespaces=True)
 
@@ -113,23 +111,22 @@ def test_update_num_replicas(shutdown_ray, detached):
     """Test updating num_replicas."""
 
     with ray.init():
-        serve.start(detached=detached)
 
         @serve.deployment(num_replicas=2)
         def f(*args):
             return "got f"
 
-        f.deploy()
+        serve.run(f.bind())
 
         actors = ray.util.list_named_actors(all_namespaces=True)
 
-        f.options(num_replicas=4).deploy()
+        serve.run(f.options(num_replicas=4).bind())
         updated_actors = ray.util.list_named_actors(all_namespaces=True)
 
         # Check that only 2 new replicas were created
         assert len(updated_actors) == len(actors) + 2
 
-        f.options(num_replicas=1).deploy()
+        serve.run(f.options(num_replicas=1).bind())
         updated_actors = ray.util.list_named_actors(all_namespaces=True)
 
         # Check that all but 1 replica has spun down
@@ -174,14 +171,14 @@ def test_refresh_controller_after_death(shutdown_ray, detached):
 def test_get_serve_status(shutdown_ray):
 
     ray.init()
-    client = serve.start()
 
     @serve.deployment
     def f(*args):
         return "Hello world"
 
-    f.deploy()
+    serve.run(f.bind())
 
+    client = get_global_client()
     status_info_1 = client.get_serve_status()
     assert status_info_1.app_status.status == "RUNNING"
     assert status_info_1.deployment_statuses[0].name == "f"
@@ -192,11 +189,9 @@ def test_get_serve_status(shutdown_ray):
 
 
 def test_controller_deserialization_deployment_def(start_and_shutdown_ray_cli_function):
-    """Ensure controller doesn't deserialize deployment_def or init_args/kwargs."""
-
     @ray.remote
     def run_graph():
-        """Deploys a Serve application to the controller's Ray cluster."""
+
         from ray import serve
         from ray._private.utils import import_attr
         from ray.serve.api import build
@@ -242,7 +237,6 @@ def test_controller_deserialization_deployment_def(start_and_shutdown_ray_cli_fu
 
 
 def test_controller_deserialization_args_and_kwargs():
-    """Ensures init_args and init_kwargs stay serialized in controller."""
 
     ray.init()
     client = serve.start()
@@ -252,7 +246,6 @@ def test_controller_deserialization_args_and_kwargs():
 
     def generate_pid_based_deserializer(pid, raw_deserializer):
         def deserializer(*args):
-            """Cannot be deserialized by the process with specified pid."""
 
             import os
 
@@ -276,7 +269,7 @@ def test_controller_deserialization_args_and_kwargs():
         def __call__(self, request):
             return self.arg_str + self.kwarg_str
 
-    Echo.deploy(PidBasedString("hello "), kwarg_str=PidBasedString("world!"))
+    serve.run(Echo.bind(PidBasedString("hello "), kwarg_str=PidBasedString("world!")))
 
     assert requests.get("http://localhost:8000/Echo").text == "hello world!"
 
@@ -601,7 +594,6 @@ def test_controller_recover_and_delete():
 
 
 def test_shutdown_remote(start_and_shutdown_ray_cli_function):
-    """Check that serve.shutdown() works on a remote Ray cluster."""
 
     deploy_serve_script = (
         "import ray\n"
@@ -614,7 +606,7 @@ def test_shutdown_remote(start_and_shutdown_ray_cli_function):
         "def f(*args):\n"
         '   return "got f"\n'
         "\n"
-        "f.deploy()\n"
+        "serve.run(f.bind())\n"
     )
 
     shutdown_serve_script = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Second pr for the test migration in the current session.

- ignore test_deployment_graph file since it is for testing internal deployment graph function, which need to use deploy() or list_deployment() etc to verify the correcness.
- ignore the test_fastapi and multi routes test with multi deployment which is not supported yet in the deployment graph.
- 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
