### PR TITLE
[Core][C++ worker]Add GetNamespace api

### DIFF
--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -162,6 +162,11 @@ PlacementGroup GetPlacementGroup(const std::string &name);
 /// Returns true if the current actor was restarted, otherwise false.
 bool WasCurrentActorRestarted();
 
+/// Get the namespace of this job.
+inline std::string GetNamespace() {
+  return ray::internal::GetRayRuntime()->GetNamespace();
+}
+
 // --------- inline implementation ------------
 
 template <typename T>

--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -134,7 +134,7 @@ boost::optional<ActorHandle<T>> GetActor(const std::string &actor_name,
 /// It is used to disconnect an actor and exit the worker.
 /// \Throws RayException if the current process is a driver or the current worker is not
 /// an actor.
-inline void ExitActor() { ray::internal::GetRayRuntime()->ExitActor(); }
+void ExitActor();
 
 template <typename T>
 std::vector<std::shared_ptr<T>> Get(const std::vector<std::string> &ids);
@@ -163,9 +163,7 @@ PlacementGroup GetPlacementGroup(const std::string &name);
 bool WasCurrentActorRestarted();
 
 /// Get the namespace of this job.
-inline std::string GetNamespace() {
-  return ray::internal::GetRayRuntime()->GetNamespace();
-}
+std::string GetNamespace();
 
 // --------- inline implementation ------------
 
@@ -304,6 +302,8 @@ boost::optional<ActorHandle<T>> GetActor(const std::string &actor_name,
   return ActorHandle<T>(actor_id);
 }
 
+inline void ExitActor() { ray::internal::GetRayRuntime()->ExitActor(); }
+
 inline PlacementGroup CreatePlacementGroup(
     const ray::PlacementGroupCreationOptions &create_options) {
   return ray::internal::GetRayRuntime()->CreatePlacementGroup(create_options);
@@ -327,6 +327,10 @@ inline PlacementGroup GetPlacementGroup(const std::string &name) {
 
 inline bool WasCurrentActorRestarted() {
   return ray::internal::GetRayRuntime()->WasCurrentActorRestarted();
+}
+
+inline std::string GetNamespace() {
+  return ray::internal::GetRayRuntime()->GetNamespace();
 }
 
 }  // namespace ray

--- a/cpp/include/ray/api/ray_runtime.h
+++ b/cpp/include/ray/api/ray_runtime.h
@@ -92,6 +92,7 @@ class RayRuntime {
   virtual PlacementGroup GetPlacementGroupById(const std::string &id) = 0;
   virtual PlacementGroup GetPlacementGroup(const std::string &name) = 0;
   virtual bool IsLocalMode() { return false; }
+  virtual std::string GetNamespace() = 0;
 };
 }  // namespace internal
 }  // namespace ray

--- a/cpp/src/ray/runtime/abstract_ray_runtime.cc
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.cc
@@ -361,5 +361,10 @@ PlacementGroup AbstractRayRuntime::GetPlacementGroup(const std::string &name) {
   return group;
 }
 
+std::string AbstractRayRuntime::GetNamespace() {
+  auto &core_worker = CoreWorkerProcess::GetCoreWorker();
+  return core_worker.GetJobConfig().ray_namespace();
+}
+
 }  // namespace internal
 }  // namespace ray

--- a/cpp/src/ray/runtime/abstract_ray_runtime.h
+++ b/cpp/src/ray/runtime/abstract_ray_runtime.h
@@ -107,6 +107,8 @@ class AbstractRayRuntime : public RayRuntime {
   virtual PlacementGroup GetPlacementGroupById(const std::string &id);
   virtual PlacementGroup GetPlacementGroup(const std::string &name);
 
+  std::string GetNamespace();
+
  protected:
   std::unique_ptr<TaskSubmitter> task_submitter_;
   std::unique_ptr<TaskExecutor> task_executor_;

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -21,6 +21,7 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "counter.h"
+#include "cpp/include/ray/api/ray_config.h"
 #include "plus.h"
 
 int cmd_argc = 0;
@@ -512,6 +513,23 @@ TEST(RayClusterModeTest, NamespaceTest) {
   // It is invisible to any other namespaces.
   actor_optional = ray::GetActor<Counter>(actor_name_in_default_ns, isolated_ns_name);
   EXPECT_TRUE(!actor_optional);
+  ray::Shutdown();
+}
+
+TEST(RayClusterModeTest, GetNamespaceApiTest) {
+  std::string ns = "test_get_current_namespace";
+  ray::RayConfig config;
+  config.ray_namespace = ns;
+  ray::Init(config, cmd_argc, cmd_argv);
+  // Get namespace in driver.
+  EXPECT_EQ(ray::GetNamespace(), ns);
+  // Get namespace in task.
+  auto task_ns = ray::Task(GetNamespaceInTask).Remote();
+  EXPECT_EQ(*task_ns.Get(), ns);
+  // Get namespace in actor.
+  auto actor_handle = ray::Actor(RAY_FUNC(Counter::FactoryCreate)).Remote();
+  auto actor_ns = actor_handle.Task(&Counter::GetNamespaceInActor).Remote();
+  EXPECT_EQ(*actor_ns.Get(), ns);
 }
 
 int main(int argc, char **argv) {

--- a/cpp/src/ray/test/cluster/cluster_mode_test.cc
+++ b/cpp/src/ray/test/cluster/cluster_mode_test.cc
@@ -21,7 +21,6 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "counter.h"
-#include "cpp/include/ray/api/ray_config.h"
 #include "plus.h"
 
 int cmd_argc = 0;

--- a/cpp/src/ray/test/cluster/counter.cc
+++ b/cpp/src/ray/test/cluster/counter.cc
@@ -89,6 +89,8 @@ ray::ActorHandle<Counter> Counter::CreateChildActor(std::string actor_name) {
   return child_actor;
 }
 
+std::string Counter::GetNamespaceInActor() { return ray::GetNamespace(); }
+
 RAY_REMOTE(RAY_FUNC(Counter::FactoryCreate),
            Counter::FactoryCreateException,
            RAY_FUNC(Counter::FactoryCreate, int),
@@ -100,6 +102,7 @@ RAY_REMOTE(RAY_FUNC(Counter::FactoryCreate),
            &Counter::ExceptionFunc,
            &Counter::CheckRestartInActorCreationTask,
            &Counter::CheckRestartInActorTask,
+           &Counter::GetNamespaceInActor,
            &Counter::GetVal,
            &Counter::GetIntVal,
            &Counter::Initialized,

--- a/cpp/src/ray/test/cluster/counter.h
+++ b/cpp/src/ray/test/cluster/counter.h
@@ -39,6 +39,8 @@ class Counter {
   bool CheckRestartInActorTask();
   ray::ActorHandle<Counter> CreateChildActor(std::string actor_name);
 
+  std::string GetNamespaceInActor();
+
   std::string GetVal(ray::ObjectRef<std::string> obj) { return *obj.Get(); }
 
   int GetIntVal(ray::ObjectRef<ray::ObjectRef<int>> obj) {

--- a/cpp/src/ray/test/cluster/plus.cc
+++ b/cpp/src/ray/test/cluster/plus.cc
@@ -34,6 +34,8 @@ std::vector<std::string> GetList(std::vector<std::string> list) { return list; }
 
 std::tuple<int, std::string> GetTuple(std::tuple<int, std::string> tp) { return tp; }
 
+std::string GetNamespaceInTask() { return ray::GetNamespace(); }
+
 Student GetStudent(Student student) { return student; }
 
 std::map<int, Student> GetStudents(std::map<int, Student> students) { return students; }
@@ -48,5 +50,6 @@ RAY_REMOTE(Return1,
            GetArray,
            GetList,
            GetTuple,
+           GetNamespaceInTask,
            GetStudent,
            GetStudents);

--- a/cpp/src/ray/test/cluster/plus.h
+++ b/cpp/src/ray/test/cluster/plus.h
@@ -29,6 +29,8 @@ std::array<std::string, 2> GetArray(std::array<std::string, 2> array);
 std::vector<std::string> GetList(std::vector<std::string> list);
 std::tuple<int, std::string> GetTuple(std::tuple<int, std::string> tp);
 
+std::string GetNamespaceInTask();
+
 struct Student {
   std::string name;
   int age;

--- a/doc/source/ray-core/namespaces.rst
+++ b/doc/source/ray-core/namespaces.rst
@@ -192,3 +192,14 @@ You can access to the current namespace using :ref:`runtime_context APIs <runtim
         } finally {
             Ray.shutdown();
         }
+
+.. tabbed:: C++
+
+    .. code-block:: c++
+
+        ray::RayConfig config;
+        config.ray_namespace = "colors";
+        ray::Init(config);
+        // Will print the information about "colors" namespace.
+        std::cout << ray::GetNamespace() << std::endl;
+        ray::Shutdown();

--- a/doc/source/ray-core/namespaces.rst
+++ b/doc/source/ray-core/namespaces.rst
@@ -177,7 +177,7 @@ You can access to the current namespace using :ref:`runtime_context APIs <runtim
 
         import ray
         ray.init(address="auto", namespace="colors")
-        # Will print the information about "colors" namespace.
+        # Will print namespace name "colors".
         print(ray.get_runtime_context().namespace)
 
 .. tabbed:: Java
@@ -187,7 +187,7 @@ You can access to the current namespace using :ref:`runtime_context APIs <runtim
         System.setProperty("ray.job.namespace", "colors");
         try {
             Ray.init();
-            // Will print the information about "colors" namespace.
+            // Will print namespace name "colors".
             System.out.println(Ray.getRuntimeContext().getNamespace());
         } finally {
             Ray.shutdown();
@@ -200,6 +200,6 @@ You can access to the current namespace using :ref:`runtime_context APIs <runtim
         ray::RayConfig config;
         config.ray_namespace = "colors";
         ray::Init(config);
-        // Will print the information about "colors" namespace.
+        // Will print namespace name "colors".
         std::cout << ray::GetNamespace() << std::endl;
         ray::Shutdown();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In c++ worker, we now have supported generating anonymous job namespace and specifying namespace while creating named actor, the `GetNamespace` api is still not supported.
This pr adds the api.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Part of https://github.com/ray-project/ray/issues/20460
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
