### PR TITLE
Changed 'tf' to 'tf1' for the 'RunOptions'.

### DIFF
--- a/rllib/utils/tf_run_builder.py
+++ b/rllib/utils/tf_run_builder.py
@@ -73,7 +73,7 @@ def _run_timeline(sess, ops, debug_name, feed_dict=None, timeline_dir=None):
     if timeline_dir:
         from tensorflow.python.client import timeline
 
-        run_options = tf1.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
+        run_options = tf1.RunOptions(trace_level=tf1.RunOptions.FULL_TRACE)
         run_metadata = tf1.RunMetadata()
         start = time.time()
         fetches = sess.run(


### PR DESCRIPTION
## Why are these changes needed?
Running the TF timeline helps developers to trace tensorflow. Trying to do this right now ends up in an error. 

## Related issue number

Closes #26511

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
