### PR TITLE
[Datasets] Fix Parquet in-memory file size estimation

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -36,7 +36,10 @@ PARALLELIZE_META_FETCH_THRESHOLD = 24
 PARQUET_READER_ROW_BATCH_SIZE = 100000
 FILE_READING_RETRY = 8
 
-# The estimated bytes size multiplier for reading Parquet data source in Arrow.
+# The estimated bytes size multiplier for reading Parquet data source in Arrow,
+# as Arrow in-memory representation uses much more memory compared to Parquet
+# uncompressed representation. See https://github.com/ray-project/ray/pull/26516
+# for more context.
 PARQUET_TO_ARROW_SIZE_MULTIPLIER = 5
 
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -36,6 +36,9 @@ PARALLELIZE_META_FETCH_THRESHOLD = 24
 PARQUET_READER_ROW_BATCH_SIZE = 100000
 FILE_READING_RETRY = 8
 
+# The estimated bytes size multiplier for reading Parquet data source in Arrow.
+PARQUET_TO_ARROW_SIZE_MULTIPLIER = 5
+
 
 # TODO(ekl) this is a workaround for a pyarrow serialization bug, where serializing a
 # raw pyarrow file fragment causes S3 network calls.
@@ -197,7 +200,7 @@ class _ParquetDatasourceReader(Reader):
             for row_group_idx in range(file_metadata.num_row_groups):
                 row_group_metadata = file_metadata.row_group(row_group_idx)
                 total_size += row_group_metadata.total_byte_size
-        return total_size
+        return total_size * PARQUET_TO_ARROW_SIZE_MULTIPLIER
 
     def get_read_tasks(self, parallelism: int) -> List[ReadTask]:
         # NOTE: We override the base class FileBasedDatasource.get_read_tasks()

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -21,30 +21,6 @@ def test_auto_parallelism_basic(shutdown_only):
     assert ds.num_blocks() == 150, ds
 
 
-def test_auto_parallelism_parquet(shutdown_only, tmp_path):
-    ray.init(num_cpus=8)
-    context = DatasetContext.get_current()
-    context.min_parallelism = 1
-    ds = ray.data.range(1000)
-    path = os.path.join(tmp_path, "test_parquet_dir")
-    os.mkdir(path)
-    ds.repartition(30).write_parquet(path)
-
-    # CPU bound.
-    ds = ray.data.read_parquet(path, parallelism=-1)
-    assert ds.num_blocks() == 16, ds
-
-    # Datasource bound.
-    context.target_max_block_size = 128
-    ds = ray.data.read_parquet(path, parallelism=-1)
-    assert ds.num_blocks() == 30, ds
-
-    # Block size bound.
-    context.target_max_block_size = 1024 * 2
-    ds = ray.data.read_parquet(path, parallelism=-1)
-    assert ds.num_blocks() == 27, ds
-
-
 def test_auto_parallelism_placement_group(shutdown_only):
     ray.init(num_cpus=16, num_gpus=8)
 

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -21,6 +21,30 @@ def test_auto_parallelism_basic(shutdown_only):
     assert ds.num_blocks() == 150, ds
 
 
+def test_auto_parallelism_parquet(shutdown_only, tmp_path):
+    ray.init(num_cpus=8)
+    context = DatasetContext.get_current()
+    context.min_parallelism = 1
+    ds = ray.data.range(1000)
+    path = os.path.join(tmp_path, "test_parquet_dir")
+    os.mkdir(path)
+    ds.repartition(30).write_parquet(path)
+
+    # CPU bound.
+    ds = ray.data.read_parquet(path, parallelism=-1)
+    assert ds.num_blocks() == 16, ds
+
+    # Datasource bound.
+    context.target_max_block_size = 128
+    ds = ray.data.read_parquet(path, parallelism=-1)
+    assert ds.num_blocks() == 30, ds
+
+    # Block size bound.
+    context.target_max_block_size = 1024 * 2
+    ds = ray.data.read_parquet(path, parallelism=-1)
+    assert ds.num_blocks() == 27, ds
+
+
 def test_auto_parallelism_placement_group(shutdown_only):
     ray.init(num_cpus=16, num_gpus=8)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Was looking at https://github.com/ray-project/ray/pull/25883, and found out a small bug, when we estimate Parquet in-memory/uncompressed file size. Previously it's using [pyarrow.parquet.FileMetaData.serialized_size](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.FileMetaData.html#pyarrow.parquet.FileMetaData.serialized_size), but it is the [size of file footer](https://github.com/apache/arrow/blob/master/python/pyarrow/_parquet.pyx#L695), not file itself. The size of file footer generally is much smaller than the actual data, so this will underestimate parallelism of read tasks quite significantly.

This PR is to change to use the uncompressed data size for all row groups - [pyarrow.parquet.RowGroupMetaData.total_byte_size](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.RowGroupMetaData.html#pyarrow.parquet.RowGroupMetaData.total_byte_size), this is the upper bound of Parquet in-memory file size, so it should be good for performance as we overestimate parallelism here. Adding a TODO here to further improve the estimation if column pruning is used, then we can use columns statistics to do estimation.

## Related issue number

<!-- For example: "Closes #1234" -->
Same issue as https://github.com/ray-project/ray/pull/25883
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
