### PR TITLE
[air/data] Concatenator preprocessor

### DIFF
--- a/doc/source/ray-air/examples/pytorch_tabular_starter.py
+++ b/doc/source/ray-air/examples/pytorch_tabular_starter.py
@@ -38,7 +38,7 @@ from ray.data.preprocessors import Concatenator, Chain
 # Chain the preprocessors together.
 preprocessor = Chain(
     preprocessor,
-    Concatenator(output_column="input", exclude=["target"], dtype=np.float32),
+    Concatenator(exclude=["target"], dtype=np.float32),
 )
 # __air_pytorch_preprocess_end__
 
@@ -79,7 +79,11 @@ def train_loop_per_worker(config):
             batch_format="numpy", batch_size=batch_size
         )
         for d in data_iterator:
-            yield torch.Tensor(d["input"]).float(), torch.Tensor(d["target"]).float()
+            # "concat_out" is the output column of the Concatenator.
+            yield (
+                torch.Tensor(d["concat_out"]).float(),
+                torch.Tensor(d["target"]).float(),
+            )
 
     # Create model.
     model = create_model(num_features)

--- a/doc/source/ray-air/examples/pytorch_tabular_starter.py
+++ b/doc/source/ray-air/examples/pytorch_tabular_starter.py
@@ -108,19 +108,13 @@ num_features = len(train_dataset.schema().names) - 1
 trainer = TorchTrainer(
     train_loop_per_worker=train_loop_per_worker,
     train_loop_config={
-        # Training batch size
         "batch_size": 128,
-        # Number of epochs to train each task for.
         "num_epochs": 20,
-        # Number of columns of datset
         "num_features": num_features,
-        # Optimizer args.
         "lr": 0.001,
     },
     scaling_config={
-        # Number of workers to use for data parallelism.
-        "num_workers": 3,
-        # Whether to use GPU acceleration.
+        "num_workers": 3,  # Number of data parallel training workers.
         "use_gpu": False,
         # trainer_resources=0 so that the example works on Colab.
         "trainer_resources": {"CPU": 0},

--- a/doc/source/ray-air/examples/tf_tabular_starter.py
+++ b/doc/source/ray-air/examples/tf_tabular_starter.py
@@ -132,19 +132,13 @@ num_features = len(train_dataset.schema().names) - 1
 trainer = TensorflowTrainer(
     train_loop_per_worker=train_loop_per_worker,
     train_loop_config={
-        # Training batch size
         "batch_size": 128,
-        # Number of epochs to train each task for.
         "num_epochs": 50,
-        # Number of columns of dataset
         "num_features": num_features,
-        # Optimizer args.
         "lr": 0.0001,
     },
     scaling_config={
-        # Number of workers to use for data parallelism.
-        "num_workers": 2,
-        # Whether to use GPU acceleration.
+        "num_workers": 2,  # Number of data parallel training workers
         "use_gpu": False,
         # trainer_resources=0 so that the example works on Colab.
         "trainer_resources": {"CPU": 0},

--- a/doc/source/ray-air/examples/tf_tabular_starter.py
+++ b/doc/source/ray-air/examples/tf_tabular_starter.py
@@ -38,7 +38,7 @@ from ray.data.preprocessors import Concatenator, Chain
 # Chain the preprocessors together.
 preprocessor = Chain(
     preprocessor,
-    Concatenator(output_column="input", exclude=["target"], dtype=np.float32),
+    Concatenator(exclude=["target"], dtype=np.float32),
 )
 # __air_tf_preprocess_end__
 
@@ -77,7 +77,8 @@ def to_tf_dataset(dataset, batch_size):
         )
         for d in data_iterator:
             yield (
-                tf.convert_to_tensor(d["input"], dtype=tf.float32),
+                # "concat_out" is the output column of the Concatenator.
+                tf.convert_to_tensor(d["concat_out"], dtype=tf.float32),
                 tf.convert_to_tensor(d["target"], dtype=tf.float32),
             )
 

--- a/doc/source/ray-air/examples/tf_tabular_starter.py
+++ b/doc/source/ray-air/examples/tf_tabular_starter.py
@@ -53,7 +53,10 @@ def concat_for_tensor(dataframe):
 
 
 # Chain the preprocessors together.
-preprocessor = Chain(preprocessor, BatchMapper(concat_for_tensor))
+preprocessor = Chain(
+    preprocessor,
+    Tensorizer(columns=schema_order, output_column="input", dtype=np.float32),
+)
 # __air_tf_preprocess_end__
 
 

--- a/doc/source/ray-air/preprocessors.rst
+++ b/doc/source/ray-air/preprocessors.rst
@@ -135,6 +135,7 @@ Ray AIR provides a handful of ``Preprocessor``\s that you can use out of the box
 .. tabbed:: Tabular
 
     #. :class:`Categorizer <ray.data.preprocessors.Categorizer>`
+    #. :class:`Concatenator <ray.data.preprocessors.Concatenator>`
     #. :class:`FeatureHasher <ray.data.preprocessors.FeatureHasher>`
     #. :class:`LabelEncoder <ray.data.preprocessors.LabelEncoder>`
     #. :class:`MaxAbsScaler <ray.data.preprocessors.MaxAbsScaler>`
@@ -146,7 +147,6 @@ Ray AIR provides a handful of ``Preprocessor``\s that you can use out of the box
     #. :class:`RobustScaler <ray.data.preprocessors.RobustScaler>`
     #. :class:`SimpleImputer <ray.data.preprocessors.SimpleImputer>`
     #. :class:`StandardScaler <ray.data.preprocessors.StandardScaler>`
-    #. :class:`SimpleImputer <ray.data.preprocessors.SimpleImputer>`
 
 .. tabbed:: Text
 

--- a/python/ray/data/preprocessors/__init__.py
+++ b/python/ray/data/preprocessors/__init__.py
@@ -17,7 +17,7 @@ from ray.data.preprocessors.scaler import (
     MaxAbsScaler,
     RobustScaler,
 )
-from ray.data.preprocessors.tensorizer import Tensorizer
+from ray.data.preprocessors.concatenator import Concatenator
 from ray.data.preprocessors.tokenizer import Tokenizer
 from ray.data.preprocessors.transformer import PowerTransformer
 from ray.data.preprocessors.vectorizer import CountVectorizer, HashingVectorizer
@@ -41,6 +41,6 @@ __all__ = [
     "RobustScaler",
     "SimpleImputer",
     "StandardScaler",
-    "Tensorizer",
+    "Concatenator",
     "Tokenizer",
 ]

--- a/python/ray/data/preprocessors/__init__.py
+++ b/python/ray/data/preprocessors/__init__.py
@@ -17,6 +17,7 @@ from ray.data.preprocessors.scaler import (
     MaxAbsScaler,
     RobustScaler,
 )
+from ray.data.preprocessors.tensorizer import Tensorizer
 from ray.data.preprocessors.tokenizer import Tokenizer
 from ray.data.preprocessors.transformer import PowerTransformer
 from ray.data.preprocessors.vectorizer import CountVectorizer, HashingVectorizer
@@ -40,5 +41,6 @@ __all__ = [
     "RobustScaler",
     "SimpleImputer",
     "StandardScaler",
+    "Tensorizer",
     "Tokenizer",
 ]

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -21,10 +21,10 @@ class Concatenator(Preprocessor):
         >>> import pandas as pd
         >>> from ray.data.preprocessors import Concatenator
         >>> df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1, 2, 3, 4],})
-        >>> ds = ray.data.from_pandas(df)
-        >>> prep = Concatenator(output_column_name="c")
-        >>> new_ds = prep.transform(ds)
-        >>> assert set(new_ds.take(1)[0]) == {"c"}
+        >>> ds = ray.data.from_pandas(df)  # doctest: +SKIP
+        >>> prep = Concatenator(output_column_name="c") # doctest: +SKIP
+        >>> new_ds = prep.transform(ds) # doctest: +SKIP
+        >>> assert set(new_ds.take(1)[0]) == {"c"} # doctest: +SKIP
 
     Args:
         output_column_name: output_column_name is a string that represents the

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -26,8 +26,8 @@ class Concatenator(Preprocessor):
         >>> new_ds = prep.transform(ds)
 
     Args:
-        output_column: output_column is a string that represents the
-            name of the outputted, concatenated tensor. Defaults to
+        output_column_name: output_column_name is a string that represents the
+            name of the outputted, concatenated tensor column. Defaults to
             "concat_out".
         include: A list of column names to be included for
             concatenation. If None, then all columns will be included.
@@ -44,12 +44,12 @@ class Concatenator(Preprocessor):
 
     def __init__(
         self,
-        output_column: str = "concat_out",
+        output_column_name: str = "concat_out",
         include: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
         dtype: Optional[np.dtype] = None,
     ):
-        self.output_column = output_column
+        self.output_column_name = output_column_name
         self.included_columns = include
         self.excluded_columns = exclude or []
         self.dtype = dtype
@@ -83,12 +83,12 @@ class Concatenator(Preprocessor):
         columns_to_concat = list(included_columns - set(self.excluded_columns))
         concatenated = df[columns_to_concat].to_numpy(dtype=self.dtype)
         df = df.drop(columns=columns_to_concat)
-        df[self.output_column] = TensorArray(concatenated)
+        df[self.output_column_name] = TensorArray(concatenated)
         return df
 
     def __repr__(self):
         return (
-            f"Concatenator(output_column={self.output_column}, "
+            f"Concatenator(output_column_name={self.output_column_name}, "
             f"include={self.included_columns}, "
             f"exclude={self.excluded_columns}, "
             f"dtype={self.dtype})"

--- a/python/ray/data/preprocessors/tensorizer.py
+++ b/python/ray/data/preprocessors/tensorizer.py
@@ -11,6 +11,21 @@ class Tensorizer(Preprocessor):
 
     A tensor column is a a column consisting of ndarrays as elements.
 
+    Example:
+        >>> import pandas as pd
+        >>> from ray.data.preprocessors import Tensorizer
+        >>> df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1, 2, 3, 4],})
+        >>> ds = ray.data.from_pandas(df)
+        >>> prep = Tensorizer(["a", "b"], "c")
+        >>> new_ds = prep.transform(ds)
+        >>> df = new_ds.to_pandas()
+        #         c
+        # 0  [1, 1]
+        # 1  [2, 2]
+        #       ...
+        >>> x = df["c"].iloc[0]
+        >>> assert x.to_numpy().tolist() == [1, 1]
+
     Args:
         columns: A list of column names that should be
             concatenated into a single column. After concatenation,
@@ -40,7 +55,9 @@ class Tensorizer(Preprocessor):
         specified_set = set(self.columns)
         missing_columns = specified_set - ds_columns.intersection(specified_set)
         if missing_columns:
-            raise ValueError(f"Missing specified columns from dataset: {missing_columns}")
+            raise ValueError(
+                f"Missing specified columns from dataset: {missing_columns}"
+            )
 
     def _transform_pandas(self, df: pd.DataFrame):
         self._validate(df)

--- a/python/ray/data/preprocessors/tensorizer.py
+++ b/python/ray/data/preprocessors/tensorizer.py
@@ -52,5 +52,5 @@ class Tensorizer(Preprocessor):
     def __repr__(self):
         return (
             f"Tensorizer(columns={self.columns}, "
-            f"num_features={self.num_features}, dtype={self.dtype})"
+            f"output_column={self.output_column}, dtype={self.dtype})"
         )

--- a/python/ray/data/preprocessors/tensorizer.py
+++ b/python/ray/data/preprocessors/tensorizer.py
@@ -1,0 +1,56 @@
+from typing import List, Optional
+import numpy as np
+import pandas as pd
+
+from ray.data.extensions import TensorArray
+from ray.data.preprocessor import Preprocessor
+
+
+class Tensorizer(Preprocessor):
+    """Create tensor columns via concatenation.
+
+    A tensor column is a a column consisting of ndarrays as elements.
+
+    Args:
+        columns: A list of column names that should be
+            concatenated into a single column. After concatenation,
+            these columns will be dropped.
+        output_column: output_column is a string that represents the
+            name of the outputted, concatenated tensor.
+        dtype: Optional. The dtype to convert the output column array to.
+
+    Raises:
+        ValueError if any element in `columns` does not exist in the dataset.
+    """
+
+    _is_fittable = False
+
+    def __init__(
+        self,
+        columns: List[str],
+        output_column: str,
+        dtype: Optional[np.dtype] = None,
+    ):
+        self.columns = columns
+        self.output_column = output_column
+        self.dtype = dtype
+
+    def _validate(self, df: pd.DataFrame):
+        ds_columns = set(df)
+        specified_set = set(self.columns)
+        missing_columns = specified_set - ds_columns.intersection(specified_set)
+        if missing_columns:
+            raise ValueError(f"Missing specified columns from dataset: {missing_columns}")
+
+    def _transform_pandas(self, df: pd.DataFrame):
+        self._validate(df)
+        concatenated = df[self.columns].to_numpy(dtype=self.dtype)
+        df = df.drop(columns=self.columns)
+        df[self.output_column] = TensorArray(concatenated)
+        return df
+
+    def __repr__(self):
+        return (
+            f"Tensorizer(columns={self.columns}, "
+            f"num_features={self.num_features}, dtype={self.dtype})"
+        )

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -1254,7 +1254,7 @@ def test_concatenator():
         }
     )
     ds = ray.data.from_pandas(df)
-    prep = Concatenator(output_column="c")
+    prep = Concatenator(output_column_name="c")
     new_ds = prep.transform(ds)
     for i, row in enumerate(new_ds.take()):
         assert np.array_equal(row["c"].to_numpy(), np.array([i + 1, i + 1]))
@@ -1266,7 +1266,7 @@ def test_concatenator():
 
     df = pd.DataFrame({"a": [1, 2, 3, 4]})
     ds = ray.data.from_pandas(df)
-    prep = Concatenator(output_column="c", exclude=["b"])
+    prep = Concatenator(output_column_name="c", exclude=["b"])
 
     with pytest.raises(ValueError, match="'b'"):
         prep.transform(ds)
@@ -1294,7 +1294,7 @@ def test_concatenator():
     # check it works with string types
     df = pd.DataFrame({"a": ["string", "string2", "string3"]})
     ds = ray.data.from_pandas(df)
-    prep = Concatenator(output_column="huh")
+    prep = Concatenator(output_column_name="huh")
     new_ds = prep.transform(ds)
     assert "huh" in df
 

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -28,7 +28,7 @@ from ray.data.preprocessors.encoder import Categorizer, MultiHotEncoder
 from ray.data.preprocessors.hasher import FeatureHasher
 from ray.data.preprocessors.normalizer import Normalizer
 from ray.data.preprocessors.scaler import MaxAbsScaler, RobustScaler
-from ray.data.preprocessors.tensorizer import Tensorizer
+from ray.data.preprocessors.concatenator import Concatenator
 from ray.data.preprocessors.tokenizer import Tokenizer
 from ray.data.preprocessors.transformer import PowerTransformer
 from ray.data.preprocessors.utils import simple_hash, simple_split_tokenizer
@@ -1245,8 +1245,8 @@ def test_power_transformer():
     assert out_df.equals(expected_df)
 
 
-def test_tensorizer():
-    """Tests basic Tensorizer functionality."""
+def test_concatenator():
+    """Tests basic Concatenator functionality."""
     df = pd.DataFrame(
         {
             "a": [1, 2, 3, 4],
@@ -1254,16 +1254,18 @@ def test_tensorizer():
         }
     )
     ds = ray.data.from_pandas(df)
-    prep = Tensorizer(["a", "b"], "c")
+    prep = Concatenator(output_column="c")
     new_ds = prep.transform(ds)
     df = new_ds.to_pandas()
     assert "c" in df
     x = df["c"].iloc[0]
     assert x.to_numpy().tolist() == [1, 1]
 
+    assert "c" in prep.__repr__()
+
     df = pd.DataFrame({"a": [1, 2, 3, 4]})
     ds = ray.data.from_pandas(df)
-    prep = Tensorizer(["a", "b"], "c")
+    prep = Concatenator(output_column="c", exclude=["b"])
 
     with pytest.raises(ValueError, match="'b'"):
         prep.transform(ds)
@@ -1271,7 +1273,7 @@ def test_tensorizer():
     # check it works with string types
     df = pd.DataFrame({"a": ["string", "string2", "string3"]})
     ds = ray.data.from_pandas(df)
-    prep = Tensorizer(["a"], "huh")
+    prep = Concatenator(output_column="huh")
     new_ds = prep.transform(ds)
     assert "huh" in df
 

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -1296,7 +1296,7 @@ def test_concatenator():
     ds = ray.data.from_pandas(df)
     prep = Concatenator(output_column_name="huh")
     new_ds = prep.transform(ds)
-    assert "huh" in df
+    assert "huh" in set(new_ds.schema().names)
 
 
 def test_tokenizer():

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -1250,20 +1250,23 @@ def test_tensorizer():
     new_ds = prep.transform(ds)
     df = new_ds.to_pandas()
     assert "c" in df
+    x = df["c"].iloc[0]
+    assert x.to_numpy().tolist() == [1, 1]
 
     df = pd.DataFrame({"a": [1, 2, 3, 4]})
     ds = ray.data.from_pandas(df)
     prep = Tensorizer(["a", "b"], "c")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'b'"):
         prep.transform(ds)
 
-    # check it works with
+    # check it works with string types
     df = pd.DataFrame({"a": ["string", "string2", "string3"]})
     ds = ray.data.from_pandas(df)
     prep = Tensorizer(["a"], "huh")
     new_ds = prep.transform(ds)
-    new_ds.show()
+    assert "huh" in df
+
 
 
 def test_tokenizer():

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -1243,6 +1243,28 @@ def test_power_transformer():
 
     assert out_df.equals(expected_df)
 
+def test_tensorizer():
+    df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1, 2, 3, 4],})
+    ds = ray.data.from_pandas(df)
+    prep = Tensorizer(["a", "b"], "c")
+    new_ds = prep.transform(ds)
+    df = new_ds.to_pandas()
+    assert "c" in df
+
+    df = pd.DataFrame({"a": [1, 2, 3, 4]})
+    ds = ray.data.from_pandas(df)
+    prep = Tensorizer(["a", "b"], "c")
+
+    with pytest.raises(ValueError):
+        prep.transform(ds)
+
+    # check it works with
+    df = pd.DataFrame({"a": ["string", "string2", "string3"]})
+    ds = ray.data.from_pandas(df)
+    prep = Tensorizer(["a"], "huh")
+    new_ds = prep.transform(ds)
+    new_ds.show()
+
 
 def test_tokenizer():
     """Tests basic Tokenizer functionality."""

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -1266,7 +1266,7 @@ def test_concatenator():
 
     df = pd.DataFrame({"a": [1, 2, 3, 4]})
     ds = ray.data.from_pandas(df)
-    prep = Concatenator(output_column_name="c", exclude=["b"])
+    prep = Concatenator(output_column_name="c", exclude=["b"], raise_if_missing=True)
 
     with pytest.raises(ValueError, match="'b'"):
         prep.transform(ds)

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -28,6 +28,7 @@ from ray.data.preprocessors.encoder import Categorizer, MultiHotEncoder
 from ray.data.preprocessors.hasher import FeatureHasher
 from ray.data.preprocessors.normalizer import Normalizer
 from ray.data.preprocessors.scaler import MaxAbsScaler, RobustScaler
+from ray.data.preprocessors.tensorizer import Tensorizer
 from ray.data.preprocessors.tokenizer import Tokenizer
 from ray.data.preprocessors.transformer import PowerTransformer
 from ray.data.preprocessors.utils import simple_hash, simple_split_tokenizer
@@ -1243,8 +1244,15 @@ def test_power_transformer():
 
     assert out_df.equals(expected_df)
 
+
 def test_tensorizer():
-    df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1, 2, 3, 4],})
+    """Tests basic Tensorizer functionality."""
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4],
+            "b": [1, 2, 3, 4],
+        }
+    )
     ds = ray.data.from_pandas(df)
     prep = Tensorizer(["a", "b"], "c")
     new_ds = prep.transform(ds)
@@ -1266,7 +1274,6 @@ def test_tensorizer():
     prep = Tensorizer(["a"], "huh")
     new_ds = prep.transform(ds)
     assert "huh" in df
-
 
 
 def test_tokenizer():


### PR DESCRIPTION
## Why are these changes needed?

Adds a tensor concatenation preprocessor to make it easier to work with tabular data
## Related issue number

Closes https://github.com/ray-project/ray/issues/26500

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(