### PR TITLE
[Tune] Restore old max concurrent logic in BOHB

### DIFF
--- a/python/ray/tune/schedulers/hb_bohb.py
+++ b/python/ray/tune/schedulers/hb_bohb.py
@@ -97,9 +97,19 @@ class HyperBandForBOHB(HyperBandScheduler):
         if not bracket.filled() or any(
             status != Trial.PAUSED for t, status in statuses if t is not trial
         ):
+            # BOHB Specific. This hack existed in old Ray versions
+            # and was removed, but it needs to be brought back
+            # as otherwise the BOHB doesn't behave as intended.
+            # There should be a better API for this.
+            # TODO(team-ml): Refactor alongside HyperBandForBOHB
+            trial_runner._search_alg.searcher.on_pause(trial.trial_id)
             return TrialScheduler.PAUSE
         action = self._process_bracket(trial_runner, bracket)
         return action
+
+    def _unpause_trial(self, trial_runner: "trial_runner.TrialRunner", trial: Trial):
+        # Hack. See comment in on_trial_result
+        trial_runner._search_alg.searcher.on_unpause(trial.trial_id)
 
     def choose_trial_to_run(
         self, trial_runner: "trial_runner.TrialRunner", allow_recurse: bool = True

--- a/python/ray/tune/schedulers/hb_bohb.py
+++ b/python/ray/tune/schedulers/hb_bohb.py
@@ -100,6 +100,13 @@ class HyperBandForBOHB(HyperBandScheduler):
             # BOHB Specific. This hack existed in old Ray versions
             # and was removed, but it needs to be brought back
             # as otherwise the BOHB doesn't behave as intended.
+            # The default concurrency limiter works by discarding
+            # new suggestions if there are more running trials
+            # than the limit. That doesn't take into account paused
+            # trials. With BOHB, this leads to N trials finishing
+            # completely and then another N trials starting,
+            # instead of trials being paused and resumed in brackets
+            # as intended.
             # There should be a better API for this.
             # TODO(team-ml): Refactor alongside HyperBandForBOHB
             trial_runner._search_alg.searcher.on_pause(trial.trial_id)

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -272,10 +272,15 @@ class HyperBandScheduler(FIFOScheduler):
                     )
                 if bracket.continue_trial(t):
                     if t.status == Trial.PAUSED:
+                        self._unpause_trial(trial_runner, t)
                         t.status = Trial.PENDING
                     elif t.status == Trial.RUNNING:
                         action = TrialScheduler.CONTINUE
         return action
+
+    def _unpause_trial(self, trial_runner: "trial_runner.TrialRunner", trial: Trial):
+        """No-op by default."""
+        return
 
     def on_trial_remove(self, trial_runner: "trial_runner.TrialRunner", trial: Trial):
         """Notification when trial terminates.

--- a/python/ray/tune/search/bohb/bohb_search.py
+++ b/python/ray/tune/search/bohb/bohb_search.py
@@ -74,6 +74,10 @@ class TuneBOHB(Searcher):
         seed: Optional random seed to initialize the random number
             generator. Setting this should lead to identical initial
             configurations at each run.
+        max_concurrent: Number of maximum concurrent trials.
+            If this Searcher is used in a ``ConcurrencyLimiter``, the
+            ``max_concurrent`` value passed to it will override the
+            value passed here. Set to <= 0 for no limit on concurrency.
 
     Tune automatically converts search spaces to TuneBOHB's format:
 
@@ -128,6 +132,7 @@ class TuneBOHB(Searcher):
         mode: Optional[str] = None,
         points_to_evaluate: Optional[List[Dict]] = None,
         seed: Optional[int] = None,
+        max_concurrent: int = 0,
     ):
         assert (
             BOHB is not None
@@ -152,6 +157,10 @@ class TuneBOHB(Searcher):
         self._space = space
         self._seed = seed
 
+        self.running = set()
+        self.paused = set()
+
+        self._max_concurrent = max_concurrent
         self._points_to_evaluate = points_to_evaluate
 
         super(TuneBOHB, self).__init__(
@@ -161,6 +170,10 @@ class TuneBOHB(Searcher):
 
         if self._space:
             self._setup_bohb()
+
+    def set_max_concurrency(self, max_concurrent: int) -> bool:
+        self._max_concurrent = max_concurrent
+        return True
 
     def _setup_bohb(self):
         from hpbandster.optimizers.config_generators.bohb import BOHB
@@ -176,6 +189,9 @@ class TuneBOHB(Searcher):
 
         if self._seed is not None:
             self._space.seed(self._seed)
+
+        self.running = set()
+        self.paused = set()
 
         bohb_config = self._bohb_config or {}
         self.bohber = BOHB(self._space, **bohb_config)
@@ -211,15 +227,24 @@ class TuneBOHB(Searcher):
                 )
             )
 
+        max_concurrent = (
+            self._max_concurrent if self._max_concurrent > 0 else float("inf")
+        )
+        if len(self.running) >= max_concurrent:
+            return None
+
         if self._points_to_evaluate:
             config = self._points_to_evaluate.pop(0)
         else:
             # This parameter is not used in hpbandster implementation.
             config, _ = self.bohber.get_config(None)
         self.trial_to_params[trial_id] = copy.deepcopy(config)
+        self.running.add(trial_id)
         return unflatten_list_dict(config)
 
     def on_trial_result(self, trial_id: str, result: Dict):
+        if trial_id not in self.paused:
+            self.running.add(trial_id)
         if "hyperband_info" not in result:
             logger.warning(
                 "BOHB Info not detected in result. Are you using "
@@ -233,6 +258,10 @@ class TuneBOHB(Searcher):
         self, trial_id: str, result: Optional[Dict] = None, error: bool = False
     ):
         del self.trial_to_params[trial_id]
+        if trial_id in self.paused:
+            self.paused.remove(trial_id)
+        if trial_id in self.running:
+            self.running.remove(trial_id)
 
     def to_wrapper(self, trial_id: str, result: Dict) -> _BOHBJobWrapper:
         return _BOHBJobWrapper(
@@ -240,6 +269,14 @@ class TuneBOHB(Searcher):
             result["hyperband_info"]["budget"],
             self.trial_to_params[trial_id],
         )
+
+    def on_pause(self, trial_id: str):
+        self.paused.add(trial_id)
+        self.running.remove(trial_id)
+
+    def on_unpause(self, trial_id: str):
+        self.paused.remove(trial_id)
+        self.running.add(trial_id)
 
     @staticmethod
     def convert_search_space(spec: Dict) -> "ConfigSpace.ConfigurationSpace":

--- a/python/ray/tune/search/bohb/bohb_search.py
+++ b/python/ray/tune/search/bohb/bohb_search.py
@@ -270,6 +270,8 @@ class TuneBOHB(Searcher):
             self.trial_to_params[trial_id],
         )
 
+    # BOHB Specific.
+    # TODO(team-ml): Refactor alongside HyperBandForBOHB
     def on_pause(self, trial_id: str):
         self.paused.add(trial_id)
         self.running.remove(trial_id)

--- a/python/ray/tune/search/bohb/bohb_search.py
+++ b/python/ray/tune/search/bohb/bohb_search.py
@@ -258,10 +258,8 @@ class TuneBOHB(Searcher):
         self, trial_id: str, result: Optional[Dict] = None, error: bool = False
     ):
         del self.trial_to_params[trial_id]
-        if trial_id in self.paused:
-            self.paused.remove(trial_id)
-        if trial_id in self.running:
-            self.running.remove(trial_id)
+        self.paused.discard(trial_id)
+        self.running.discard(trial_id)
 
     def to_wrapper(self, trial_id: str, result: Dict) -> _BOHBJobWrapper:
         return _BOHBJobWrapper(

--- a/python/ray/tune/search/concurrency_limiter.py
+++ b/python/ray/tune/search/concurrency_limiter.py
@@ -161,3 +161,11 @@ class ConcurrencyLimiter(Searcher):
 
     def restore(self, checkpoint_path: str):
         self.searcher.restore(checkpoint_path)
+
+    # BOHB Specific.
+    # TODO(team-ml): Refactor alongside HyperBandForBOHB
+    def on_pause(self, trial_id: str):
+        self.searcher.on_pause(trial_id)
+
+    def on_unpause(self, trial_id: str):
+        self.searcher.on_unpause(trial_id)

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -733,6 +733,8 @@ class BOHBSuite(unittest.TestCase):
         decision = sched.on_trial_result(runner, trials[-1], spy_result)
         self.assertEqual(decision, TrialScheduler.STOP)
         sched.choose_trial_to_run(runner)
+        self.assertEqual(runner._search_alg.searcher.on_pause.call_count, 2)
+        self.assertEqual(runner._search_alg.searcher.on_unpause.call_count, 1)
         self.assertTrue("hyperband_info" in spy_result)
         self.assertEqual(spy_result["hyperband_info"]["budget"], 1)
 
@@ -759,6 +761,7 @@ class BOHBSuite(unittest.TestCase):
         decision = sched.on_trial_result(runner, trials[-1], spy_result)
         self.assertEqual(decision, TrialScheduler.CONTINUE)
         sched.choose_trial_to_run(runner)
+        self.assertEqual(runner._search_alg.searcher.on_pause.call_count, 2)
         self.assertTrue("hyperband_info" in spy_result)
         self.assertEqual(spy_result["hyperband_info"]["budget"], 1)
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As discussed on Ray Slack (https://ray-distributed.slack.com/archives/CNECXMW22/p1657051287814569), the changes introduced in https://github.com/ray-project/ray/pull/18770 and https://github.com/ray-project/ray/pull/20822 have caused the concurrency limiting logic in BOHB to work incorrectly. This PR restores the old logic, while making use of the `set_max_concurrency` API (as eg. HEBO), maintaining backwards compatibility.

It should be noted that the old logic this PR reintroduces is essentially a hack and should be refactored in the future. This PR is intended to rapidly fix a bug causing search performance to be suboptimal.

<details>
  <summary>Slack log</summary>

[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
 [Jul 5th at 10:01 PM](https://ray-distributed.slack.com/archives/CNECXMW22/p1657051287814569)
Recently updated Ray Tune to 1.13 from 1.04. BOHB no longer has the parameter max_concurrent so I added a concurrency limiter but this seems to behave differently than I expected. Instead of just limiting the run to just n parallel experiments, it also limits the bucket to the same size. If BOHB was supposed to run 27 experiments in a bucket, and I set concurrency to 3, what I expect is that it'll run 3 parallel experiments back to back 9 times to complete the bucket. Instead it runs 3 in parallel and then moves to the next bucket.
19 replies


[Xiaowei Jiang (Ray Tune)](https://app.slack.com/team/U029UHYGRUL)
  [8 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657063373772069?thread_ts=1657051287.814569&cid=CNECXMW22)
[@Antoni 'Yard1' Baum (Ray Team)](https://ray-distributed.slack.com/team/U01AK865G10)


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657136954442659?thread_ts=1657051287.814569&cid=CNECXMW22)
Should I just use CUDA_VISIBLE_DEVICES before launching the Python file and not use concurrency limiter?


[Antoni 'Yard1' Baum (Ray Team)](https://app.slack.com/team/U01AK865G10)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657142922472049?thread_ts=1657051287.814569&cid=CNECXMW22)
Hey 
[@Philip Bontrager](https://ray-distributed.slack.com/team/U020PEAP0MC)
 would it be possible for you to provide a reproductible script?


[Antoni 'Yard1' Baum (Ray Team)](https://app.slack.com/team/U01AK865G10)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657142966217019?thread_ts=1657051287.814569&cid=CNECXMW22)
Setting that variable will not work as each Ray process will reset it. You can change the trial resource requirements and assign more resources to limit concurrency that way, as a workaround


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657143117233069?thread_ts=1657051287.814569&cid=CNECXMW22)
I provide 1 gpu per trial. Giving more GPUs per trial wouldn't help since I want to be able to run multiple tuning runs on a big machine. I will try to make a small reproducible version. Are you confirming that this is not the intended behavior of ConcurrencyLimiter?


[Antoni 'Yard1' Baum (Ray Team)](https://app.slack.com/team/U01AK865G10)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657143296696399?thread_ts=1657051287.814569&cid=CNECXMW22)
It is possible that it's interacting with BOHB in an unintended way but I would need to investigate more. Can't really confirm anything at this stage (edited) 


[Antoni 'Yard1' Baum (Ray Team)](https://app.slack.com/team/U01AK865G10)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657143498909079?thread_ts=1657051287.814569&cid=CNECXMW22)
Can you replicate that behavior with 1.04? The max_concurrent logic inside BOHB should have been functionally identical to wrapping it in a ConcurrencyLimiter.


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657144189681239?thread_ts=1657051287.814569&cid=CNECXMW22)
In 1.04 it worked differently as that's how I used it for a year. It would just do n concurrent ones but not affect the hyperband schedule


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657144199037299?thread_ts=1657051287.814569&cid=CNECXMW22)
I'll give you a reproducible sample tomorrow


[Antoni 'Yard1' Baum (Ray Team)](https://app.slack.com/team/U01AK865G10)
  [7 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657144537954369?thread_ts=1657051287.814569&cid=CNECXMW22)
thanks!


[Antoni 'Yard1' Baum (Ray Team)](https://app.slack.com/team/U01AK865G10)
  [2 days ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657555837721999?thread_ts=1657051287.814569&cid=CNECXMW22)
Hey 
[@Philip Bontrager](https://ray-distributed.slack.com/team/U020PEAP0MC)
, any updates on this?


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [1 day ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657572273131749?thread_ts=1657051287.814569&cid=CNECXMW22)
Sorry, got behind


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [1 day ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657572298416129?thread_ts=1657051287.814569&cid=CNECXMW22)
Here is script to run on ray[tune] 1.13
```python
import math
import random
from ray import tune
from ray.tune.suggest import bohb, ConcurrencyLimiter
​
R = 30
eta=3
max_concurrent=3 # Try 0 vs 3, compare the final step count for all the experiments run
​
def get_hyperband_schedule(R, eta):
    s_max = round(math.log(R, eta))
    def n0(s): return math.ceil((s_max+1)/(s+1)*eta**s)
    def r0(s): return math.floor(R*eta**-s)
    num_configs = 0
    for s in reversed(range(s_max+1)):
        n = n0(s)
        r = r0(s)
        if r > 0:
            num_configs += n
    return num_configs
​
def experiment(config):
    for i in range(R):
        yield {'loss': random.random(), 'step': i}
​
search = bohb.TuneBOHB(metric='loss',
                       bohb_config={},
                       mode="min")
if max_concurrent > 0:
    search = ConcurrencyLimiter(search, max_concurrent=max_concurrent)
​
schedule = tune.schedulers.HyperBandForBOHB(
    time_attr='step',
    metric="loss",
    mode="min",
    max_t=R,
    reduction_factor=eta)
​
tune.run(experiment,
        search_alg=search,
        scheduler=schedule,
        num_samples=get_hyperband_schedule(R, eta),
        config={'param': tune.uniform(0,1)},
        local_dir="logs",
        resources_per_trial={'cpu': 1})
```

[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [1 day ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657572348433599?thread_ts=1657051287.814569&cid=CNECXMW22)
Run it once with a concurrency limitation and once without (max_concurrent variable is at the top of the script).


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [1 day ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657572394259829?thread_ts=1657051287.814569&cid=CNECXMW22)
Without concurrency limitation you'll see lots of experiments only run with one step as they're all from the first bracket of Hyperband and they should only be run for one step


[Philip Bontrager](https://app.slack.com/team/U020PEAP0MC)
  [1 day ago](https://ray-distributed.slack.com/archives/CNECXMW22/p1657572442263489?thread_ts=1657051287.814569&cid=CNECXMW22)
If you limit the concurrency to say 3, then only 3 of those will run, and once the schedule is complete a bunch of full experiments will be run until the total_experiments limit is reached
</details>

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
