### PR TITLE
[RLlib] Enable training with offline data for DQN

### DIFF
--- a/rllib/algorithms/dqn/dqn_tf_policy.py
+++ b/rllib/algorithms/dqn/dqn_tf_policy.py
@@ -310,7 +310,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
         q_logits_t_selected,
         q_tp1_best,
         q_dist_tp1_best,
-        train_batch[PRIO_WEIGHTS],
+        train_batch.get(PRIO_WEIGHTS, np.ones(len(train_batch))),
         train_batch[SampleBatch.REWARDS],
         tf.cast(train_batch[SampleBatch.DONES], tf.float32),
         config["gamma"],

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -334,7 +334,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
         q_logits_t_selected,
         q_tp1_best,
         q_probs_tp1_best,
-        train_batch.get(PRIO_WEIGHTS, np.ones(len(train_batch))),
+        train_batch.get(PRIO_WEIGHTS, torch.ones(len(train_batch))),
         train_batch[SampleBatch.REWARDS],
         train_batch[SampleBatch.DONES].float(),
         config["gamma"],

--- a/rllib/algorithms/dqn/dqn_torch_policy.py
+++ b/rllib/algorithms/dqn/dqn_torch_policy.py
@@ -3,6 +3,7 @@
 from typing import Dict, List, Tuple
 
 import gym
+import numpy as np
 import ray
 from ray.rllib.algorithms.dqn.dqn_tf_policy import (
     PRIO_WEIGHTS,
@@ -333,7 +334,7 @@ def build_q_losses(policy: Policy, model, _, train_batch: SampleBatch) -> Tensor
         q_logits_t_selected,
         q_tp1_best,
         q_probs_tp1_best,
-        train_batch[PRIO_WEIGHTS],
+        train_batch.get(PRIO_WEIGHTS, np.ones(len(train_batch))),
         train_batch[SampleBatch.REWARDS],
         train_batch[SampleBatch.DONES].float(),
         config["gamma"],


### PR DESCRIPTION
Since importance weights are computed in postprocessing, offline data will not provide them in many cases and we whould set them to ones.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
