### PR TITLE
[kubernetes] allow to use external image secrets pull

### DIFF
--- a/deploy/charts/ray/templates/raycluster.yaml
+++ b/deploy/charts/ray/templates/raycluster.yaml
@@ -31,6 +31,10 @@ spec:
         metadata:
           generateName: {{ kebabcase $key }}-
         spec:
+          {{- if $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            - name: {{ $.Values.imagePullSecrets }}
+          {{- end }}
           restartPolicy: Never
           # This volume allocates shared memory for Ray to use for its plasma
           # object store. If you do not provide this, Ray will fall back to

--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -6,6 +6,9 @@
 # It's recommended to build custom dependencies for your workload into this image,
 # taking one of the offical `rayproject/ray` images as base.
 image: rayproject/ray:latest
+# name of k8s image pull secrets to pull (custom) Ray image from private regristry
+# the secret need to be created by user before applying this helm chart.
+imagePullSecrets: ""
 # The autoscaler will scale up the cluster faster with higher upscaling speed.
 # If the task requires adding more nodes then autoscaler will gradually
 # scale up the cluster in chunks of upscaling_speed*currently_running_nodes.


### PR DESCRIPTION
## Why are these changes needed?
Allow to specify image secrets pull to use custom Ray docker image hosted in private container registry.

## Related issue number

N/A

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
