### PR TITLE
[AIR/Serve] Fixes to `PredictorDeployment.reconfigure`

### DIFF
--- a/doc/source/ray-air/examples/torch_incremental_learning.ipynb
+++ b/doc/source/ray-air/examples/torch_incremental_learning.ipynb
@@ -676,7 +676,9 @@
     "\n",
     "In addition to batch inference, we also want to deploy our model so that we can submit live queries to it for online inference. We use Ray Serve's `PredictorDeployment` utility to deploy our trained model. \n",
     "\n",
-    "Once we deploy the model, we can send HTTP requests to our deployment."
+    "Once we deploy the model, we can send HTTP requests to our deployment.\n",
+    "\n",
+    "We specify a `user_config` in our deployment to update it with the latest checkpoint without needing to teardown and restart the deployment. More information can be found [here](https://docs.ray.io/en/latest/serve/core-apis.html#user-configuration-experimental)"
    ]
   },
   {
@@ -705,7 +707,8 @@
     "      df = pd.DataFrame({\"image\": [arr]})\n",
     "      return df\n",
     "\n",
-    "  deployment = PredictorDeployment.options(name=\"mnist_model\", route_prefix=\"/mnist_predict\", version=f\"v{task_idx}\", num_replicas=2)\n",
+    "  deployment_config = {\"checkpoint\": latest_checkpoint}\n",
+    "  deployment = PredictorDeployment.options(name=\"mnist_model\", user_config=deployment_config, route_prefix=\"/mnist_predict\", version=f\"v{task_idx}\", num_replicas=2)\n",
     "  deployment.deploy(batching_params=False, http_adapter=json_to_pandas, predictor_cls=TorchPredictor, checkpoint=latest_checkpoint, model=SimpleMLP(num_classes=10))\n",
     "  return deployment.url\n",
     "\n",
@@ -1320,10 +1323,7 @@
     "\n",
     "  if ray.available_resources().get(\"CPU\", 0) < num_workers+1:\n",
     "    # If there are no more CPUs left, then shutdown the Serve replicas so we can continue training on the next task.\n",
-    "    serve.shutdown()\n",
-    "\n",
-    "  \n",
-    "serve.shutdown()"
+    "    serve.shutdown()"
    ]
   },
   {

--- a/python/ray/serve/tests/test_air_integrations.py
+++ b/python/ray/serve/tests/test_air_integrations.py
@@ -210,20 +210,17 @@ def test_air_integrations_in_pipeline(serve_instance):
 
 
 def test_air_integrations_reconfigure(serve_instance):
-    path = tempfile.mkdtemp()
-    uri = f"file://{path}/test_uri"
-    Checkpoint.from_dict({"increment": 2}).to_uri(uri)
+    checkpoint = Checkpoint.from_dict({"increment": 2})
 
     predictor_cls = "ray.serve.tests.test_air_integrations.AdderPredictor"
     additional_config = {
-        "checkpoint": {"increment": 5},
-        "predictor_cls": "ray.serve.tests.test_air_integrations.AdderPredictor",
+        "checkpoint": Checkpoint.from_dict({"increment": 5}),
     }
 
     with InputNode() as dag_input:
         m1 = PredictorDeployment.options(user_config=additional_config).bind(
             predictor_cls=predictor_cls,
-            checkpoint=uri,
+            checkpoint=checkpoint,
         )
         dag = m1.predict.bind(dag_input)
     deployments = build(Ingress.bind(dag))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Update `PredictorDeployment.reconfigure` to 
1. Not always use `Checkpoint.from_dict` to support non-dictionary checkpoints
2. Don't require a predictor_cls to be specified and use the original predictor_cls instead

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/24869
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
