### PR TITLE
[Core] Remove pipe when creating sub-processes

### DIFF
--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -43,7 +43,7 @@ void ProcessHelper::StartRayNode(const int port,
     cmdargs.insert(cmdargs.end(), head_args.begin(), head_args.end());
   }
   RAY_LOG(INFO) << CreateCommandLine(cmdargs);
-  auto spawn_result = Process::Spawn(cmdargs, true);
+  auto spawn_result = Process::Spawn(cmdargs);
   RAY_CHECK(!spawn_result.second);
   spawn_result.first.Wait();
   return;
@@ -52,7 +52,7 @@ void ProcessHelper::StartRayNode(const int port,
 void ProcessHelper::StopRayNode() {
   std::vector<std::string> cmdargs({"ray", "stop"});
   RAY_LOG(INFO) << CreateCommandLine(cmdargs);
-  auto spawn_result = Process::Spawn(cmdargs, true);
+  auto spawn_result = Process::Spawn(cmdargs);
   RAY_CHECK(!spawn_result.second);
   spawn_result.first.Wait();
   return;

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -58,7 +58,7 @@ int TestSetupUtil::StartUpRedisServer(const int &port) {
   std::vector<std::string> cmdargs({program, "--loglevel", "warning"});
   cmdargs.insert(cmdargs.end(), {"--port", std::to_string(actual_port)});
   RAY_LOG(INFO) << "Start redis command is: " << CreateCommandLine(cmdargs);
-  RAY_CHECK(!Process::Spawn(cmdargs, true).second);
+  RAY_CHECK(!Process::Spawn(cmdargs).second);
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
   return actual_port;
 }
@@ -106,7 +106,7 @@ std::string TestSetupUtil::StartGcsServer(int port) {
            absl::Base64Escape(R"({"object_timeout_milliseconds": 2000})")});
   cmdargs.push_back("--gcs_server_port=6379");
   RAY_LOG(INFO) << "Start gcs server command: " << CreateCommandLine(cmdargs);
-  RAY_CHECK(!Process::Spawn(cmdargs, true, gcs_server_socket_name + ".pid").second);
+  RAY_CHECK(!Process::Spawn(cmdargs, gcs_server_socket_name + ".pid").second);
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
   RAY_LOG(INFO) << "GCS server started.";
   return gcs_server_socket_name;
@@ -146,7 +146,7 @@ std::string TestSetupUtil::StartRaylet(const std::string &node_ip_address,
                                     "--object_store_memory=10000000"});
 
   RAY_LOG(INFO) << "Raylet Start command: " << CreateCommandLine(cmdargs);
-  RAY_CHECK(!Process::Spawn(cmdargs, true, raylet_socket_name + ".pid").second);
+  RAY_CHECK(!Process::Spawn(cmdargs, raylet_socket_name + ".pid").second);
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
   *store_socket_name = plasma_store_socket_name;
   return raylet_socket_name;

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -80,7 +80,7 @@ void AgentManager::StartAgent() {
   ProcessEnvironment env;
   env.insert({"RAY_NODE_ID", options_.node_id.Hex()});
   env.insert({"RAY_RAYLET_PID", std::to_string(getpid())});
-  Process child(argv.data(), nullptr, ec, false, env);
+  Process child(argv.data(), nullptr, ec, env);
   if (!child.IsValid() || ec) {
     // The worker failed to start. This is a fatal error.
     RAY_LOG(FATAL) << "Failed to start agent with return value " << ec << ": "

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -575,7 +575,7 @@ Process WorkerPool::StartProcess(const std::vector<std::string> &worker_command_
   }
   argv.push_back(NULL);
 
-  Process child(argv.data(), io_service_, ec, /*decouple=*/false, env);
+  Process child(argv.data(), io_service_, ec, env);
   if (!child.IsValid() || ec) {
     // errorcode 24: Too many files. This is caused by ulimit.
     if (ec.value() == 24) {

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -70,13 +70,11 @@ class Process {
   /// \param[in] argv The command-line of the process to spawn (terminated with NULL).
   /// \param[in] io_service Boost.Asio I/O service (optional).
   /// \param[in] ec Returns any error that occurred when spawning the process.
-  /// \param[in] decouple True iff the parent will not wait for the child to exit.
   /// \param[in] env Additional environment variables to be set on this process besides
   /// the environment variables of the parent process.
   explicit Process(const char *argv[],
                    void *io_service,
                    std::error_code &ec,
-                   bool decouple = false,
                    const ProcessEnvironment &env = {});
   /// Convenience function to run the given command line and wait for it to finish.
   static std::error_code Call(const std::vector<std::string> &args,
@@ -97,7 +95,6 @@ class Process {
   /// \param pid_file A file to write the PID of the spawned process in.
   static std::pair<Process, std::error_code> Spawn(
       const std::vector<std::string> &args,
-      bool decouple,
       const std::string &pid_file = std::string(),
       const ProcessEnvironment &env = {});
   /// Waits for process to terminate. Not supported for unowned processes.


### PR DESCRIPTION
Currently, we use `pipe` to communicate between the parent and child process about the PID of the child process. This is needed when `decouple==true`, which means that there's a double fork (Raylet as the parent process, a temporary child process, and the worker process as the grandchild process). We also use the file descriptor in `Process::Wait` and `Process::Kill`.

However, I think `decouple==true` is useless and only used in C++ unit tests. in this PR, I deleted the parameter `decouple` and the code path of `decouple==true`.

Note that the file descriptor (`fd_` field in `ProcessFD` class) is actually the child process handle in Windows and cannot be deleted, so I changed many `#ifdef _WIN32` to make the `fd_` field Windows only.

This is the following PR of #25348.

Signed-off-by: Kai Yang <kfstorm@outlook.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
