### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/source/data/faq.rst
+++ b/doc/source/data/faq.rst
@@ -300,7 +300,7 @@ particular model under different shuffling policies:
 * no shuffling,
 * local (per-shard) limited-memory shuffle buffer,
 * local (per-shard) shuffling,
-* windowed (psuedo-global) shuffling, and
+* windowed (pseudo-global) shuffling, and
 * fully global shuffling.
 
 From the perspective of keeping preprocessing time in check, as long as your data

--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -501,7 +501,7 @@ class RayServeReplica:
                 )
 
         # Explicitly call the del method to trigger clean up.
-        # We set the del method to noop after succssifully calling it so the
+        # We set the del method to noop after successfully calling it so the
         # destructor is called only once.
         try:
             if hasattr(self.callable, "__del__"):


### PR DESCRIPTION
There are small typos in:
- doc/source/data/faq.rst
- python/ray/serve/replica.py

Fixes:
- Should read `successfully` rather than `succssifully`.
- Should read `pseudo` rather than `psuedo`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md