### PR TITLE
[RLLib] Fix MultiDiscrete not being one-hotted correctly

### DIFF
--- a/rllib/models/tf/complex_input_net.py
+++ b/rllib/models/tf/complex_input_net.py
@@ -79,7 +79,7 @@ class ComplexInputNetwork(TFModelV2):
                 if isinstance(component, Discrete):
                     size = component.n
                 else:
-                    size = sum(component.nvec)
+                    size = np.sum(component.nvec)
                 config = {
                     "fcnet_hiddens": model_config["fcnet_hiddens"],
                     "fcnet_activation": model_config.get("fcnet_activation"),

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -32,7 +32,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
     `obs` (e.g. Tuple[img0, img1, discrete0]) -> `CNN0 + CNN1 + ONE-HOT`
     `CNN0 + CNN1 + ONE-HOT` -> concat all flat outputs -> `out`
     `out` -> (optional) FC-stack -> `out2`
-    `out2` -> action (logits) and vaulue heads.
+    `out2` -> action (logits) and value heads.
     """
 
     def __init__(self, obs_space, action_space, num_outputs, model_config, name):

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -187,7 +187,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 cnn_out, _ = self.cnns[i](SampleBatch({SampleBatch.OBS: component}))
                 outs.append(cnn_out)
             elif i in self.one_hot:
-                if component.dtype in [torch.int32, torch.int64, torch.uint8]:
+                if component.dtype in [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8]:
                     one_hot_in = {
                         SampleBatch.OBS: one_hot(
                             component, self.flattened_input_space[i]

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -100,7 +100,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 if isinstance(component, Discrete):
                     size = component.n
                 else:
-                    size = sum(component.nvec)
+                    size = np.sum(component.nvec)
                 config = {
                     "fcnet_hiddens": model_config["fcnet_hiddens"],
                     "fcnet_activation": model_config.get("fcnet_activation"),

--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -187,7 +187,13 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 cnn_out, _ = self.cnns[i](SampleBatch({SampleBatch.OBS: component}))
                 outs.append(cnn_out)
             elif i in self.one_hot:
-                if component.dtype in [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8]:
+                if component.dtype in [
+                    torch.int8,
+                    torch.int16,
+                    torch.int32,
+                    torch.int64,
+                    torch.uint8,
+                ]:
                     one_hot_in = {
                         SampleBatch.OBS: one_hot(
                             component, self.flattened_input_space[i]

--- a/rllib/utils/tests/test_utils.py
+++ b/rllib/utils/tests/test_utils.py
@@ -49,9 +49,7 @@ class TestUtils(unittest.TestCase):
     spaces = dict(
         {
             "a": gym.spaces.Discrete(4),
-            "b": (
-                gym.spaces.Box(-1.0, 10.0, (3,)),
-                gym.spaces.Box(-1.0, 1.0, (3, 1))),
+            "b": (gym.spaces.Box(-1.0, 10.0, (3,)), gym.spaces.Box(-1.0, 1.0, (3, 1))),
             "c": dict(
                 {
                     "ca": gym.spaces.MultiDiscrete([4, 6]),

--- a/rllib/utils/tests/test_utils.py
+++ b/rllib/utils/tests/test_utils.py
@@ -1,4 +1,4 @@
-from gym.spaces import Box, Discrete, MultiDiscrete
+import gym
 import numpy as np
 import tree  # pip install dm_tree
 import unittest
@@ -8,8 +8,14 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.numpy import flatten_inputs_to_1d_tensor as flatten_np
 from ray.rllib.utils.numpy import make_action_immutable
 from ray.rllib.utils.test_utils import check
-from ray.rllib.utils.tf_utils import flatten_inputs_to_1d_tensor as flatten_tf
-from ray.rllib.utils.torch_utils import flatten_inputs_to_1d_tensor as flatten_torch
+from ray.rllib.utils.tf_utils import (
+    flatten_inputs_to_1d_tensor as flatten_tf,
+    one_hot as one_hot_tf,
+)
+from ray.rllib.utils.torch_utils import (
+    flatten_inputs_to_1d_tensor as flatten_torch,
+    one_hot as one_hot_torch,
+)
 
 tf1, tf, tfv = try_import_tf()
 torch, _ = try_import_torch()
@@ -42,12 +48,14 @@ class TestUtils(unittest.TestCase):
     # Corresponding space struct.
     spaces = dict(
         {
-            "a": Discrete(4),
-            "b": (Box(-1.0, 10.0, (3,)), Box(-1.0, 1.0, (3, 1))),
+            "a": gym.spaces.Discrete(4),
+            "b": (
+                gym.spaces.Box(-1.0, 10.0, (3,)),
+                gym.spaces.Box(-1.0, 1.0, (3, 1))),
             "c": dict(
                 {
-                    "ca": MultiDiscrete([4, 6]),
-                    "cb": Box(-1.0, 1.0, ()),
+                    "ca": gym.spaces.MultiDiscrete([4, 6]),
+                    "cb": gym.spaces.Box(-1.0, 1.0, ()),
                 }
             ),
         }
@@ -55,6 +63,7 @@ class TestUtils(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        tf1.enable_eager_execution()
         ray.init()
 
     @classmethod
@@ -62,7 +71,6 @@ class TestUtils(unittest.TestCase):
         ray.shutdown()
 
     def test_make_action_immutable(self):
-        import gym
         from types import MappingProxyType
 
         # Test Box space.
@@ -542,6 +550,19 @@ class TestUtils(unittest.TestCase):
                 ]
             ),
         )
+
+    def test_one_hot(self):
+        space = gym.spaces.MultiDiscrete([[3, 3], [3, 3]])
+
+        # TF
+        x = tf.Variable([[0, 2, 1, 0]], dtype=tf.int32)
+        y = one_hot_tf(x, space)
+        self.assertTrue(([1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0] == y.numpy()).all())
+
+        # Torch
+        x = torch.tensor([[0, 2, 1, 0]], dtype=torch.int32)
+        y = one_hot_torch(x, space)
+        self.assertTrue(([1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0] == y.numpy()).all())
 
 
 if __name__ == "__main__":

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -468,14 +468,11 @@ def one_hot(x: TensorType, space: gym.Space) -> TensorType:
     elif isinstance(space, MultiDiscrete):
         if isinstance(space.nvec[0], np.ndarray):
             nvec = np.ravel(space.nvec)
-            x = tf.reshape(x,(x.shape[0],-1))
+            x = tf.reshape(x, (x.shape[0], -1))
         else:
             nvec = space.nvec
         return tf.concat(
-            [
-                tf.one_hot(x[:, i], n, dtype=tf.float32)
-                for i, n in enumerate(nvec)
-            ],
+            [tf.one_hot(x[:, i], n, dtype=tf.float32) for i, n in enumerate(nvec)],
             axis=-1,
         )
     else:

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -466,10 +466,15 @@ def one_hot(x: TensorType, space: gym.Space) -> TensorType:
     if isinstance(space, Discrete):
         return tf.one_hot(x, space.n, dtype=tf.float32)
     elif isinstance(space, MultiDiscrete):
+        if isinstance(space.nvec[0], np.ndarray):
+            nvec = np.ravel(space.nvec)
+            x = tf.reshape(x,(x.shape[0],-1))
+        else:
+            nvec = space.nvec
         return tf.concat(
             [
                 tf.one_hot(x[:, i], n, dtype=tf.float32)
-                for i, n in enumerate(space.nvec)
+                for i, n in enumerate(nvec)
             ],
             axis=-1,
         )

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -461,14 +461,11 @@ def one_hot(x: TensorType, space: gym.Space) -> TensorType:
     elif isinstance(space, MultiDiscrete):
         if isinstance(space.nvec[0], np.ndarray):
             nvec = np.ravel(space.nvec)
-            x = x.reshape(x.shape[0],-1)
+            x = x.reshape(x.shape[0], -1)
         else:
             nvec = space.nvec
         return torch.cat(
-            [
-                nn.functional.one_hot(x[:, i].long(), n)
-                for i, n in enumerate(nvec)
-            ],
+            [nn.functional.one_hot(x[:, i].long(), n) for i, n in enumerate(nvec)],
             dim=-1,
         )
     else:

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -459,10 +459,15 @@ def one_hot(x: TensorType, space: gym.Space) -> TensorType:
     if isinstance(space, Discrete):
         return nn.functional.one_hot(x.long(), space.n)
     elif isinstance(space, MultiDiscrete):
+        if isinstance(space.nvec[0], np.ndarray):
+            nvec = np.ravel(space.nvec)
+            x = x.reshape(x.shape[0],-1)
+        else:
+            nvec = space.nvec
         return torch.cat(
             [
                 nn.functional.one_hot(x[:, i].long(), n)
-                for i, n in enumerate(space.nvec)
+                for i, n in enumerate(nvec)
             ],
             dim=-1,
         )


### PR DESCRIPTION
## Why are these changes needed?

Currently, the python sum used in complex_input_net will return an incorrect size, which will cause an error when trying to create the box. With np.sum the sum is correctly computed and a one-hot box can be created.

Also, the torch utils could not handle multidimensional MultiDiscrete spaces. This has also been fixed.

The old behaviour for the sum:

Space 
```
MultiDiscrete(
[[7 7 7 7 7 7]
[7 7 7 7 7 7]
[7 7 7 7 7 7]
[7 7 7 7 7 7]])
```

Space nvec: 
```
[[7 7 7 7 7 7]
 [7 7 7 7 7 7]
 [7 7 7 7 7 7]
 [7 7 7 7 7 7]]
```

Computed size: ```[28 28 28 28 28 28]```

New behaviour:

Space 
```
MultiDiscrete(
[[7 7 7 7 7 7]
[7 7 7 7 7 7]
[7 7 7 7 7 7]
[7 7 7 7 7 7]])
```

Space nvec: 
```
[[7 7 7 7 7 7]
[7 7 7 7 7 7]
[7 7 7 7 7 7]
[7 7 7 7 7 7]]
```

Computed size: ```168```

## Related issue number

N/A

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
