### PR TITLE
[Serve] Support Multiple DAG Entrypoints in DAGDriver

### DIFF
--- a/python/ray/serve/air_integrations.py
+++ b/python/ray/serve/air_integrations.py
@@ -269,7 +269,7 @@ class PredictorWrapper(SimpleSchemaIngress):
 
         super().__init__(http_adapter)
 
-    async def predict(self, inp, route_path=None):
+    async def predict(self, inp):
         """Perform inference directly without HTTP."""
         return await self.predict_impl(inp)
 

--- a/python/ray/serve/air_integrations.py
+++ b/python/ray/serve/air_integrations.py
@@ -269,7 +269,7 @@ class PredictorWrapper(SimpleSchemaIngress):
 
         super().__init__(http_adapter)
 
-    async def predict(self, inp):
+    async def predict(self, inp, route_path=None):
         """Perform inference directly without HTTP."""
         return await self.predict_impl(inp)
 

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -134,7 +134,7 @@ class DAGDriver:
         """Perform inference directly without HTTP."""
         return await self.dags[self.MATCH_ALL_ROUTE_PREFIX].remote(*args, **kwargs)
 
-    async def multi_dag_predict(self, route_path, *args, **kwargs):
+    async def predict_with_route(self, route_path, *args, **kwargs):
         """Perform inference directly without HTTP for multi dags."""
         if route_path not in self.dags:
             raise RayServeException(f"{route_path} does not exist in dags routes")

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -67,9 +67,7 @@ class SimpleSchemaIngress:
 
         @self.app.get("/")
         @self.app.post("/")
-        async def handle_request(
-            request: starlette.requests.Request, inp=Depends(http_adapter)
-        ):
+        async def handle_request(inp=Depends(http_adapter)):
             resp = await self.predict(inp)
             return resp
 
@@ -110,7 +108,7 @@ class DAGDriver:
 
         else:
             assert isinstance(dags, (RayServeDAGHandle, RayServeLazySyncHandle))
-            self.dag = dags
+            self.dag_handle = dags
 
             @self.app.get(f"/")
             @self.app.post(f"/")
@@ -126,7 +124,7 @@ class DAGDriver:
 
     async def predict(self, *args, **kwargs):
         """Perform inference directly without HTTP."""
-        return await self.dag.remote(*args, **kwargs)
+        return await self.dag_handle.remote(*args, **kwargs)
 
     async def multi_dag_predict(self, route_path, *args, **kwargs):
         """Perform inference directly without HTTP for multi dags."""

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -110,8 +110,8 @@ class DAGDriver:
             assert isinstance(dags, (RayServeDAGHandle, RayServeLazySyncHandle))
             self.dag_handle = dags
 
-            @self.app.get(f"/")
-            @self.app.post(f"/")
+            @self.app.get("/")
+            @self.app.post("/")
             async def handle_request(inp=Depends(http_adapter)):
                 return await self.predict(inp)
 

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -116,8 +116,8 @@ class DAGDriver:
             self.dag_handle = dags
 
             # Single dag case, we will receive all prefix route
-            @self.app.get("/{path}")
-            @self.app.post("/{path}")
+            @self.app.get("/{path:path}")
+            @self.app.post("/{path:path}")
             async def handle_request(inp=Depends(http_adapter)):
                 return await self.predict(inp)
 

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -115,8 +115,9 @@ class DAGDriver:
             assert isinstance(dags, (RayServeDAGHandle, RayServeLazySyncHandle))
             self.dag_handle = dags
 
-            @self.app.get("/")
-            @self.app.post("/")
+            # Single dag case, we will receive all prefix route
+            @self.app.get("/{path}")
+            @self.app.post("/{path}")
             async def handle_request(inp=Depends(http_adapter)):
                 return await self.predict(inp)
 

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -65,7 +65,6 @@ class SimpleSchemaIngress:
         http_adapter = _load_http_adapter(http_adapter)
         self.app = FastAPI()
 
-        # Accept all requests
         @self.app.get("/")
         @self.app.post("/")
         async def handle_request(
@@ -115,9 +114,7 @@ class DAGDriver:
 
             @self.app.get(f"/")
             @self.app.post(f"/")
-            async def handle_request(
-                request: starlette.requests.Request, inp=Depends(http_adapter)
-            ):
+            async def handle_request(inp=Depends(http_adapter)):
                 return await self.predict(inp)
 
     async def __call__(self, request: starlette.requests.Request):

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -144,5 +144,5 @@ class DAGDriver(SimpleSchemaIngress):
         return await self.dags_routes[route_path].remote(*args, **kwargs)
 
     def reconfigure(self, config):
-        dags_routes = config.get("DAG_ROUTES", {})
+        dags_routes = config.get("DAG_ROUTES", [])
         self._update_dag_routes(dags_routes)

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -74,7 +74,7 @@ class SimpleSchemaIngress:
             return resp
 
     @abstractmethod
-    async def predict(self, inp, route_path):
+    async def predict(self, inp):
         raise NotImplementedError()
 
     async def __call__(self, request: starlette.requests.Request):

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -93,7 +93,7 @@ class DAGDriver:
         http_adapter: Optional[Union[str, Callable]] = None,
     ):
         install_serve_encoders_to_fastapi()
-        http_adapter = load_http_adapter(http_adapter)
+        http_adapter = _load_http_adapter(http_adapter)
         self.app = FastAPI()
 
         if isinstance(dags, dict):

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -204,11 +204,6 @@ def test_deploy_change_route_prefix(serve_instance):
 
 @pytest.mark.parametrize("prefixes", [[None, "/f", None], ["/f", None, "/f"]])
 def test_deploy_nullify_route_prefix(serve_instance, prefixes):
-    # With multi dags support, dag driver will receive all route
-    # prefix when route_prefix is "None", since "None" will be converted
-    # to "/" internally.
-    # Note: the expose http endpoint will still be removed for internal
-    # dag node by setting "None" to route_prefix
     @serve.deployment
     def f(*args):
         return "got me"
@@ -216,8 +211,10 @@ def test_deploy_nullify_route_prefix(serve_instance, prefixes):
     for prefix in prefixes:
         dag = DAGDriver.options(route_prefix=prefix).bind(f.bind())
         handle = serve.run(dag)
-        assert requests.get("http://localhost:8000/f").status_code == 200
-        assert requests.get("http://localhost:8000/f").text == '"got me"'
+        if prefix is None:
+            assert requests.get("http://localhost:8000/f").status_code == 404
+        else:
+            assert requests.get("http://localhost:8000/f").text == '"got me"'
         assert ray.get(handle.predict.remote()) == "got me"
 
 

--- a/python/ray/serve/tests/test_deployment_graph_driver.py
+++ b/python/ray/serve/tests/test_deployment_graph_driver.py
@@ -100,24 +100,85 @@ async def json_resolver(request: starlette.requests.Request):
 
 
 def test_multi_dag(serve_instance):
+    """Test multi dags within dag deployment"""
+
     @serve.deployment
     class D1:
-        def __call__(self, input):
-            return input
+        def forward(self):
+            return "D1"
 
     @serve.deployment
-    def D2():
-        return "D2"
+    class D2:
+        def forward(self):
+            return "D2"
 
+    @serve.deployment
+    class D3:
+        def __call__(self):
+            return "D3"
+
+    @serve.deployment
+    def D4():
+        return "D4"
+
+    d1 = D1.bind()
+    d2 = D2.bind()
+    d3 = D3.bind()
+    d4 = D4.bind()
     dag = DAGDriver.bind(
-        {"/my_D1": D1.bind(), "/my_D2": D2.bind()}, http_adapter=json_resolver
+        {
+            "/my_D1": d1.forward.bind(),
+            "/my_D2": d2.forward.bind(),
+            "/my_D3": d3,
+            "/my_D4": d4,
+        }
     )
     handle = serve.run(dag)
 
+    for i in range(1, 5):
+        assert ray.get(handle.predict_with_route.remote(f"/my_D{i}")) == f"D{i}"
+        assert requests.post(f"http://127.0.0.1:8000/my_D{i}", json=1).json() == f"D{i}"
+        assert requests.get(f"http://127.0.0.1:8000/my_D{i}", json=1).json() == f"D{i}"
+
+
+def test_multi_dag_with_inputs(serve_instance):
+    @serve.deployment
+    class D1:
+        def forward(self, input):
+            return input
+
+    @serve.deployment
+    class D2:
+        def forward(self, input1, input2):
+            return input1 + input2
+
+    @serve.deployment
+    def D3(input):
+        return input
+
+    d1 = D1.bind()
+    d2 = D2.bind()
+
+    with InputNode() as dag_input:
+        dag = DAGDriver.bind(
+            {
+                "/my_D1": d1.forward.bind(dag_input),
+                "/my_D2": d2.forward.bind(dag_input[0], dag_input[1]),
+                "/my_D3": D3.bind(dag_input),
+            },
+            http_adapter=json_resolver,
+        )
+        handle = serve.run(dag)
+
     assert ray.get(handle.predict_with_route.remote("/my_D1", 1)) == 1
-    assert ray.get(handle.predict_with_route.remote(route_path="/my_D2")) == "D2"
+    assert ray.get(handle.predict_with_route.remote("/my_D2", 10, 2)) == 12
+    assert ray.get(handle.predict_with_route.remote("/my_D3", 100)) == 100
     assert requests.post("http://127.0.0.1:8000/my_D1", json=1).json() == 1
-    assert requests.post("http://127.0.0.1:8000/my_D2").json() == "D2"
+    assert requests.post("http://127.0.0.1:8000/my_D2", json=[1, 2]).json() == 3
+    assert requests.post("http://127.0.0.1:8000/my_D3", json=100).json() == 100
+    assert requests.get("http://127.0.0.1:8000/my_D1", json=1).json() == 1
+    assert requests.get("http://127.0.0.1:8000/my_D2", json=[1, 2]).json() == 3
+    assert requests.get("http://127.0.0.1:8000/my_D3", json=100).json() == 100
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_deployment_graph_driver.py
+++ b/python/ray/serve/tests/test_deployment_graph_driver.py
@@ -1,7 +1,4 @@
-import contextlib
-import io
 import sys
-import numpy as np
 from pydantic import BaseModel
 
 import pytest
@@ -10,11 +7,9 @@ import starlette.requests
 from starlette.testclient import TestClient
 
 from ray.serve.drivers import DAGDriver, SimpleSchemaIngress, _load_http_adapter
-from ray.serve.http_adapters import json_request
 from ray.serve.dag import InputNode
 from ray import serve
 import ray
-from ray._private.test_utils import wait_for_condition
 
 
 def my_resolver(a: int):

--- a/python/ray/serve/tests/test_deployment_graph_driver.py
+++ b/python/ray/serve/tests/test_deployment_graph_driver.py
@@ -40,7 +40,7 @@ def test_loading_check():
 
 
 class EchoIngress(SimpleSchemaIngress):
-    async def predict(self, inp):
+    async def predict(self, inp, route_path=None):
         return inp
 
 
@@ -60,7 +60,7 @@ def test_unit_schema_injection():
 
     response = client.get("/openapi.json")
     assert response.status_code == 200
-    assert response.json()["paths"]["/"]["get"]["parameters"][0] == {
+    assert response.json()["paths"]["/{path_name}"]["get"]["parameters"][0] == {
         "required": True,
         "schema": {"title": "My Custom Param", "type": "integer"},
         "name": "my_custom_param",
@@ -79,7 +79,7 @@ def test_unit_pydantic_class_adapter():
     client = TestClient(server.app)
     response = client.get("/openapi.json")
     assert response.status_code == 200
-    assert response.json()["paths"]["/"]["get"]["requestBody"] == {
+    assert response.json()["paths"]["/{path_name}"]["get"]["requestBody"] == {
         "content": {
             "application/json": {"schema": {"$ref": "#/components/schemas/MyType"}}
         },
@@ -196,6 +196,98 @@ def test_dag_driver_sync_warning(serve_instance):
             "You are retrieving a sync handle inside an asyncio loop."
             not in log_file.getvalue()
         )
+
+
+def test_multi_dag_wrong_inputs(serve_instance):
+    @serve.deployment
+    class D1:
+        def __call__(self):
+            return "D1"
+
+    @serve.deployment
+    class D2:
+        def __call__(self):
+            return "D2"
+
+    with pytest.raises(RuntimeError):
+        dag = DAGDriver.bind(
+            D1.bind(),
+            D2.bind(),
+            dags_routes=[
+                "/D1",
+            ],
+        )
+        serve.run(dag)
+
+    with pytest.raises(RuntimeError):
+        dag = DAGDriver.bind(
+            D1.bind(),
+            D2.bind(),
+            dags_routes=["/D1", "/D2", "/D3"],
+        )
+        serve.run(dag)
+
+    with pytest.raises(RuntimeError):
+        dag = DAGDriver.bind(
+            D1.bind(),
+            D2.bind(),
+            dags_routes=["/D1", "/D1"],
+        )
+        serve.run(dag)
+
+    with pytest.raises(RuntimeError):
+        dag = DAGDriver.bind(
+            D1.bind(),
+            D2.bind(),
+            dags_routes=["/D1", 2],
+        )
+        serve.run(dag)
+
+
+def test_multi_dag(serve_instance):
+    @serve.deployment
+    class D1:
+        def __call__(self):
+            return "D1"
+
+    @serve.deployment
+    def D2():
+        return "D2"
+
+    dag = DAGDriver.bind(
+        D1.bind(),
+        D2.bind(),
+        dags_routes=["/my_D1", "/my_D2"],
+    )
+    handle = serve.run(dag)
+
+    assert ray.get(handle.predict.remote(route_path="/my_D1")) == "D1"
+    assert ray.get(handle.predict.remote(route_path="/my_D2")) == "D2"
+    assert requests.post("http://127.0.0.1:8000/my_D1").json() == "D1"
+    assert requests.post("http://127.0.0.1:8000/my_D2").json() == "D2"
+
+
+def test_multi_dag_with_reconfigure(serve_instance):
+    @serve.deployment
+    class D1:
+        def __call__(self):
+            return "D1"
+
+    @serve.deployment
+    def D2():
+        return "D2"
+
+    dag = DAGDriver.options(user_config={"DAG_ROUTES": ["/my_D11", "/my_D2"]}).bind(
+        D1.bind(),
+        D2.bind(),
+        dags_routes=["/my_D1", "/my_D2"],
+    )
+    handle = serve.run(dag)
+
+    assert ray.get(handle.predict.remote(route_path="/my_D11")) == "D1"
+    assert ray.get(handle.predict.remote(route_path="/my_D2")) == "D2"
+    assert requests.post("http://127.0.0.1:8000/my_D11").json() == "D1"
+    assert requests.post("http://127.0.0.1:8000/my_D2").json() == "D2"
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_deployment_graph_driver.py
+++ b/python/ray/serve/tests/test_deployment_graph_driver.py
@@ -211,8 +211,8 @@ def test_multi_dag(serve_instance):
     dag = DAGDriver.bind({"/my_D1": D1.bind(), "/my_D2": D2.bind()})
     handle = serve.run(dag)
 
-    assert ray.get(handle.multi_dag_predict.remote(route_path="/my_D1")) == "D1"
-    assert ray.get(handle.multi_dag_predict.remote(route_path="/my_D2")) == "D2"
+    assert ray.get(handle.predict_with_route.remote(route_path="/my_D1")) == "D1"
+    assert ray.get(handle.predict_with_route.remote(route_path="/my_D2")) == "D2"
     assert requests.post("http://127.0.0.1:8000/my_D1").json() == "D1"
     assert requests.post("http://127.0.0.1:8000/my_D2").json() == "D2"
 

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 import requests
+from ray.serve.drivers import DAGDriver
 from fastapi import FastAPI, Request
 from starlette.responses import RedirectResponse
 
@@ -9,7 +10,7 @@ import ray
 from ray import serve
 
 
-def test_path_validation(serve_instance):
+def test_path_validation_legacy(serve_instance):
     # Path prefix must start with /.
     with pytest.raises(ValueError):
 
@@ -41,13 +42,36 @@ def test_path_validation(serve_instance):
     D4.options(name="test2").deploy()
 
 
+def test_path_validation(serve_instance):
+    # Path prefix must start with /.
+    with pytest.raises(ValueError):
+
+        @serve.deployment(route_prefix="hello")
+        class D1:
+            pass
+
+    # Path prefix must not end with / unless it's the root.
+    with pytest.raises(ValueError):
+
+        @serve.deployment(route_prefix="/hello/")
+        class D2:
+            pass
+
+    # Wildcards not allowed with new ingress support.
+    with pytest.raises(ValueError):
+
+        @serve.deployment(route_prefix="/{hello}")
+        class D3:
+            pass
+
+
 def test_routes_healthz(serve_instance):
     resp = requests.get("http://localhost:8000/-/healthz")
     assert resp.status_code == 200
     assert resp.content == b"success"
 
 
-def test_routes_endpoint(serve_instance):
+def test_routes_endpoint_legacy(serve_instance):
     @serve.deployment
     class D1:
         pass
@@ -91,6 +115,35 @@ def test_routes_endpoint(serve_instance):
     assert len(routes) == 1, routes
     assert "/hello" in routes, routes
     assert routes["/hello"] == "D3", routes
+
+
+def test_routes_endpoint(serve_instance):
+    @serve.deployment
+    class D1:
+        def __call__(self):
+            return "D1"
+
+    @serve.deployment
+    class D2:
+        def __call__(self):
+            return "D2"
+
+    dag = DAGDriver.bind(
+        D1.bind(),
+        D2.bind(),
+        dags_routes=["/D1", "/hello/world"],
+    )
+    serve.run(dag)
+
+    routes = requests.get("http://localhost:8000/-/routes").json()
+
+    assert len(routes) == 1, routes
+    assert "/" in routes, routes
+
+    assert requests.get("http://localhost:8000/D1").json() == "D1"
+    assert requests.get("http://localhost:8000/D1").status_code == 200
+    assert requests.get("http://localhost:8000/hello/world").json() == "D2"
+    assert requests.get("http://localhost:8000/hello/world").status_code == 200
 
 
 def test_deployment_without_route(serve_instance):
@@ -193,6 +246,33 @@ def test_path_prefixing(serve_instance):
     check_req("/hello/world/again/hi") == '"hi"'
 
 
+def test_multi_dag_with_wrong_route(serve_instance):
+    @serve.deployment
+    class D1:
+        def __call__(self):
+            return "D1"
+
+    @serve.deployment
+    class D2:
+        def __call__(self):
+            return "D2"
+
+    dag = DAGDriver.bind(
+        D1.bind(),
+        D2.bind(),
+        dags_routes=["/D1", "/hello/world"],
+    )
+
+    serve.run(dag)
+
+    assert requests.get("http://localhost:8000/D1").status_code == 200
+    assert requests.get("http://localhost:8000/hello/world").status_code == 200
+    assert requests.get("http://localhost:8000/not_exist").status_code == 500
+    assert requests.get("http://localhost:8000/").status_code == 500
+    resp = requests.get("http://localhost:8000/")
+    assert "Route path (/) does not exist in DAGs routes" in resp.text
+
+
 @pytest.mark.parametrize("base_path", ["", "subpath"])
 def test_redirect(serve_instance, base_path):
     app = FastAPI()
@@ -241,7 +321,7 @@ def test_default_error_handling(serve_instance):
     def f():
         1 / 0
 
-    f.deploy()
+    serve.run(f.bind())
     r = requests.get("http://localhost:8000/f")
     assert r.status_code == 500
     assert "ZeroDivisionError" in r.text, r.text
@@ -255,7 +335,7 @@ def test_default_error_handling(serve_instance):
         ray.get(intentional_kill.remote(ray.get_runtime_context().current_actor))
         time.sleep(100)  # Don't return here to leave time for actor exit.
 
-    h.deploy()
+    serve.run(h.bind())
     r = requests.get("http://localhost:8000/h")
     assert r.status_code == 500
     assert "retries" in r.text, r.text


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Each DAG will have a different endpoint, and DAGDriver will consolidate the routes for all the endpoints from all DAGs .
Note: not support to execute any middle node of one DAG. 

- Create multiple endpoints based on the dag routes information
- DAGDriver will receive customized routes for different DAG.
- Separate predict & multi_dag_predict for inference.
- Not depend on the SimpleSchemaIngress
- Doc will be followed up by seaprate pr


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
