### PR TITLE
[Serve] User custom class name for replica class

### DIFF
--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -211,8 +211,13 @@ def create_replica_wrapper(name: str):
         async def check_health(self):
             await self.replica.check_health()
 
-    RayServeWrappedReplica.__name__ = name
-    return RayServeWrappedReplica
+    # Dynamically create a new class with custom name here so Ray pick it up
+    # correctly in actor metadata table.
+    return type(
+        f"ServeReplica:{name}",
+        (RayServeWrappedReplica,),
+        dict(RayServeWrappedReplica.__dict__),
+    )
 
 
 class RayServeReplica:

--- a/python/ray/serve/replica.py
+++ b/python/ray/serve/replica.py
@@ -211,8 +211,8 @@ def create_replica_wrapper(name: str):
         async def check_health(self):
             await self.replica.check_health()
 
-    # Dynamically create a new class with custom name here so Ray pick it up
-    # correctly in actor metadata table.
+    # Dynamically create a new class with custom name here so Ray picks it up
+    # correctly in actor metadata table and observability stack.
     return type(
         f"ServeReplica:{name}",
         (RayServeWrappedReplica,),

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -181,7 +181,7 @@ def test_intelligent_scale_down(ray_cluster):
         actors = ray._private.state.actors()
         node_to_actors = defaultdict(list)
         for actor in actors.values():
-            if "RayServeWrappedReplica" not in actor["ActorClassName"]:
+            if "ServeReplica" not in actor["ActorClassName"]:
                 continue
             if actor["State"] != "ALIVE":
                 continue

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -151,7 +151,9 @@ def test_actor_summary(serve_instance):
     serve.run(f.bind())
     actors = state_api.list_actors()
     class_names = {actor["class_name"] for actor in actors}
-    assert class_names == {"ServeController", "HTTPProxyActor", "ServeReplica:f"}
+    assert class_names.issuperset(
+        {"ServeController", "HTTPProxyActor", "ServeReplica:f"}
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -7,6 +7,7 @@ import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
 from ray.serve.utils import block_until_http_ready
+import ray.experimental.state.api as state_api
 
 
 def test_serve_metrics_for_successful_connection(serve_instance):
@@ -140,6 +141,17 @@ def test_http_metrics(serve_instance):
         wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=10)
     except RuntimeError:
         verify_error_count(do_assert=True)
+
+
+def test_actor_summary(serve_instance):
+    @serve.deployment
+    def f():
+        pass
+
+    serve.run(f.bind())
+    actors = state_api.list_actors()
+    class_names = {actor["class_name"] for actor in actors}
+    assert class_names == {"ServeController", "HTTPProxyActor", "ServeReplica:f"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The actor class name for replica wrappers are long and hard to read. This PR uses `type` to create the wrapper class so the class name is more informative. This behavior is also compatible with previous approach using `__name__`. But previous approach only affect the proctitle of worker process; while this approach change both proctitle and how Ray recognize the class name. 

This make Serve looks way better through observability api.
```
## before
(base) ➜  ray list actors
---
-   actor_id: 36eaf5c0b16cacee19eed7b101000000
    class_name: ServeController
    name: SERVE_CONTROLLER_ACTOR
    pid: 43088
    state: ALIVE
-   actor_id: a68ec943681d5305aec6c24201000000
    class_name: create_replica_wrapper.<locals>.RayServeWrappedReplica
    name: SERVE_REPLICA::b#ZVpdBy
    pid: 43104
    state: ALIVE
-   actor_id: e4f7395a757050e6f49ce2df01000000
    class_name: HTTPProxyActor
    name: SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-node:127.0.0.1-0
    pid: 43098
    state: ALIVE

## after
(base) ➜ ray list actors
---
-   actor_id: 341f10755762b5c428eb54ec01000000
    class_name: ServeController
    name: SERVE_CONTROLLER_ACTOR
    pid: 44665
    state: ALIVE
-   actor_id: 44d9d9286c8783862898e0da01000000
    class_name: ServeReplicaClass:b
    name: SERVE_REPLICA::b#souBqw
    pid: 44672
    state: ALIVE
-   actor_id: 56968306b7f8c2f79a56b6e701000000
    class_name: HTTPProxyActor
    name: SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-node:127.0.0.1-0
    pid: 44667
    state: ALIVE

```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
