### PR TITLE
[AIR/Docs] Small improvements to Train user guide

### DIFF
--- a/doc/source/ray-air/checkpoints.rst
+++ b/doc/source/ray-air/checkpoints.rst
@@ -1,3 +1,5 @@
+.. _air-checkpoints:
+
 Checkpoints
 ===========
 

--- a/doc/source/ray-air/key-concepts.rst
+++ b/doc/source/ray-air/key-concepts.rst
@@ -39,7 +39,7 @@ See the documentation on :ref:`Trainers <air-trainer-ref>`.
 
 
 
-Trainer objects will produce a :ref:`Results <air-results-ref>` object after calling ``.fit()``.  These objects will contain training metrics as long as checkpoints to retrieve the best model.
+Trainer objects will produce a :ref:`Result <air-results-ref>` object after calling ``.fit()``.  These objects will contain training metrics as long as checkpoints to retrieve the best model.
 
 .. literalinclude:: doc_code/air_key_concepts.py
     :language: python

--- a/doc/source/ray-air/key-concepts.rst
+++ b/doc/source/ray-air/key-concepts.rst
@@ -46,6 +46,7 @@ Trainer objects will produce a :ref:`Result <air-results-ref>` object after call
     :start-after: __air_trainer_output_start__
     :end-before: __air_trainer_output_end__
 
+.. _air-session-key-concepts:
 
 Session
 -------

--- a/doc/source/ray-air/package-ref.rst
+++ b/doc/source/ray-air/package-ref.rst
@@ -45,6 +45,8 @@ Abstract Classes
     :members:
     :show-inheritance:
 
+.. _air-results-ref:
+
 Training Result
 ###############
 
@@ -112,8 +114,6 @@ Serving
 .. autoclass:: ray.serve.air_integrations.PredictorDeployment
 
 .. autoclass:: ray.serve.air_integrations.PredictorWrapper
-
-.. _air-results-ref:
 
 Trainer and Predictor Integrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/ray-air/preprocessors.rst
+++ b/doc/source/ray-air/preprocessors.rst
@@ -92,7 +92,7 @@ the ``Preprocessor`` and the fitting and transformation logic will occur once pe
 Checkpoint
 ~~~~~~~~~~
 
-``Trainer.fit()`` returns a ``Results`` object which contains a ``Checkpoint``.
+``Trainer.fit()`` returns a ``Result`` object which contains a ``Checkpoint``.
 If a ``Preprocessor`` was passed into the ``Trainer``, then it will be saved in the ``Checkpoint`` along with any fitted state.
 
 As a sanity check, let's confirm the ``Preprocessor`` is available in the ``Checkpoint``. In practice you should not need to do this.

--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -338,7 +338,7 @@ metrics and other relevant data.
 
 For example, you can:
 
-* print the metrics for the last iteration:
+* Print the metrics for the last training iteration:
 
 .. code-block:: python
 

--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -395,6 +395,8 @@ Each ``Trainer`` will have a local directory created for logs and checkpoints.
 You can obtain the path to the directory by accessing the ``log_dir`` attribute
 of the :class:`Result` object returned by ``Trainer.fit``.
 
+.. _train-datasets:
+
 Distributed Data Ingest with Ray Datasets
 -----------------------------------------
 
@@ -503,7 +505,7 @@ is shared with Ray Tune.
 
 .. _train-checkpointing:
 
-Ray Train also provides a way to save state during the training process. This is
+Ray Train also provides a way to save :ref:`Checkpoints <air-checkpoints>` during the training process. This is
 useful for:
 
 1. :ref:`Integration with Ray Tune <train-tune>` to use certain Ray Tune
@@ -515,9 +517,9 @@ useful for:
 Reporting intermediate results and handling checkpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Ray AIR provides a ``session.report(metrics, checkpoint=None)`` API for reporting intermediate
+Ray AIR provides a :ref:`Session <air-session-key-concepts>` API for reporting intermediate
 results and checkpoints from the training function (run on distributed workers) up to the
-``Trainer`` (where your python script is executed).
+``Trainer`` (where your python script is executed) by calling ``session.report(metrics)``.
 
 The primary use-case for reporting is for metrics (accuracy, loss, etc.) at
 the end of each training epoch.
@@ -535,7 +537,7 @@ the end of each training epoch.
 Saving checkpoints
 ++++++++++++++++++
 
-Checkpoints can be saved by calling ``session.report(metrics, checkpoint=Checkpoint(...))`` in the
+:ref:`Checkpoints <air-checkpoints>` can be saved by calling ``session.report(metrics, checkpoint=Checkpoint(...))`` in the
 training function. This will cause the checkpoint state from the distributed
 workers to be saved on the ``Trainer`` (where your python script is executed).
 

--- a/doc/source/train/user_guide.rst
+++ b/doc/source/train/user_guide.rst
@@ -19,10 +19,10 @@ For other model types, distributed training support is available through other T
 In this guide, we cover examples for the following use cases:
 
 * How do I :ref:`port my code <train-porting-code>` to using Ray Train?
+* How do I use Ray Train to :ref:`train with a large dataset <train-datasets>`?
 * How do I :ref:`monitor <train-monitoring>` my training?
 * How do I run my training on pre-emptible instances
   (:ref:`fault tolerance <train-fault-tolerance>`)?
-* How do I use Ray Train to :ref:`train with a large dataset <train-datasets>`?
 * How do I :ref:`tune <train-tune>` my Ray Train model?
 
 .. _train-backends:
@@ -328,14 +328,62 @@ perform hyperparameter tuning with Ray Train, please refer to the
 
 .. _train-result-object:
 
-The Result Object
------------------
+Accessing Training Results
+--------------------------
 
 .. TODO(ml-team) Flesh this section out.
 
 The return of a ``Trainer.fit`` is a :class:`Result` object, containing
 information about the training run. You can access it to obtain saved checkpoints,
 metrics and other relevant data.
+
+.. automodule:: ray.air.result
+    :members:
+    :noindex:
+
+For example, you can:
+
+* print the metrics for the last iteration:
+
+.. code-block:: python
+
+    from pprint import pprint
+
+    pprint(results.metrics)
+    # {'_time_this_iter_s': 0.001016855239868164,
+    #  '_timestamp': 1657829125,
+    #  '_training_iteration': 2,
+    #  'config': {},
+    #  'date': '2022-07-14_20-05-25',
+    #  'done': True,
+    #  'episodes_total': None,
+    #  'epoch': 1,
+    #  'experiment_id': '5a3f8b9bf875437881a8ddc7e4dd3340',
+    #  'experiment_tag': '0',
+    #  'hostname': 'ip-172-31-43-110',
+    #  'iterations_since_restore': 2,
+    #  'node_ip': '172.31.43.110',
+    #  'pid': 654068,
+    #  'time_since_restore': 3.4353830814361572,
+    #  'time_this_iter_s': 0.00809168815612793,
+    #  'time_total_s': 3.4353830814361572,
+    #  'timestamp': 1657829125,
+    #  'timesteps_since_restore': 0,
+    #  'timesteps_total': None,
+    #  'training_iteration': 2,
+    #  'trial_id': '4913f_00000',
+    #  'warmup_time': 0.003167867660522461}
+
+* View the dataframe containing the metrics from all iterations:
+
+.. code-block:: python
+
+    print(results.metrics_dataframe)
+    #    epoch  _timestamp  _time_this_iter_s  _training_iteration  time_this_iter_s  ...        node_ip  time_since_restore  timesteps_since_restore  iterations_since_restore warmup_time
+    # 0      0  1657829301           0.002509                    1          2.420308  ...  172.31.43.110            2.420308                        0                         1    0.003495
+    # 1      1  1657829301           0.001195                    2          0.010221  ...  172.31.43.110            2.430529                        0                         2    0.003495
+
+* Obtain the :class:`Checkpoint`, used for resuming training, prediction and serving.
 
 .. _train-log-dir:
 
@@ -347,12 +395,105 @@ Each ``Trainer`` will have a local directory created for logs and checkpoints.
 You can obtain the path to the directory by accessing the ``log_dir`` attribute
 of the :class:`Result` object returned by ``Trainer.fit``.
 
+Distributed Data Ingest with Ray Datasets
+-----------------------------------------
+
+Ray Train provides native support for :ref:`Ray Datasets <datasets>` to support the following use cases:
+
+1. **Large Datasets**: With Ray Datasets, you can easily work with datasets that are too big to fit on a single node.
+   Ray Datasets will distribute the dataset across the Ray Cluster and allow you to perform dataset operations (map, filter, etc.)
+   on the distributed dataset.
+2. **Automatic locality-aware sharding**: If provided a Ray Dataset, Ray Train will automatically shard the dataset and assign each shard
+   to a training worker while minimizing cross-node data transfer. Unlike with standard Torch or TensorFlow datasets, each training
+   worker will only load its assigned shard into memory rather than the entire ``Dataset``.
+3. **Pipelined Execution**: Ray Datasets also supports pipelining, meaning that data processing operations
+   can be run concurrently with training. Training is no longer blocked on expensive data processing operations (such as global shuffling)
+   and this minimizes the amount of time your GPUs are idle. See :ref:`dataset-pipeline-api` for more information.
+
+To get started, pass in a Ray Dataset (or multiple) into ``Trainer``. Underneath the hood, Ray Train will automatically shard the given dataset.
+
+Using Ray Datasets is the recommended way for ingesting data into ``Trainer``\s and can be used with any ``Trainer`` in Ray AIR.
+
+.. warning::
+
+    If you are doing distributed training with TensorFlow, you will need to
+    disable TensorFlow's built-in autosharding as the data on each worker is
+    already sharded.
+
+    .. code-block:: python
+        :emphasize-lines: 1, 6
+
+        from ray.train.tensorflow import prepare_dataset_shard
+
+        def train_func():
+            ...
+            tf_dataset = ray.train.get_dataset_shard().to_tf(...)
+            tf_dataset = prepare_dataset_shard(tf_dataset)
+
+
+**Simple Dataset Example**
+
+.. code-block:: python
+
+    import ray
+    from ray import train
+    from ray.air import train_test_split
+    from ray.train.torch import TorchTrainer
+
+    def train_func(config):
+        # Create your model here.
+        model = NeuralNetwork()
+
+        batch_size = config["worker_batch_size"]
+
+        train_data_shard = train.get_dataset_shard("train")
+        train_torch_dataset = train_data_shard.to_torch(
+            label_column="label", batch_size=batch_size
+        )
+
+        validation_data_shard = train.get_dataset_shard("validation")
+        validation_torch_dataset = validation_data_shard.to_torch(
+            label_column="label", batch_size=batch_size
+        )
+
+        for epoch in config["num_epochs"]:
+            for X, y in train_torch_dataset:
+                model.train()
+                output = model(X)
+                # Train on one batch.
+            for X, y in validation_torch_dataset:
+                model.eval()
+                output = model(X)
+                # Validate one batch.
+        return model
+
+    # Random split dataset into 80% training data and 20% validation data.
+    train_dataset, validation_dataset = train_test_split(
+        dataset, test_size=0.2, shuffle=True
+    )
+
+    trainer = TorchTrainer(
+        train_func,
+        train_loop_config={"worker_batch_size": 64, "num_epochs": 2},
+        datasets={"train": train_dataset, "validation": validation_dataset},
+        scaling_config=dict(num_workers=8),
+    )
+    dataset = ray.data.read_csv("...")
+
+    results = trainer.fit()
+
+.. _train-dataset-pipeline:
+
+Pipelined Execution
+~~~~~~~~~~~~~~~~~~~
+For details on how to enable pipelined execution, please refer to :ref:`air-ingest`.
+
 .. TODO link to Training Run Iterator API as a 3rd option for logging.
 
 .. _train-monitoring:
 
-Logging, Monitoring, and Callbacks
-----------------------------------
+Logging, Checkpointing and Callbacks
+------------------------------------
 
 Ray Train has mechanisms to easily collect intermediate results from the training workers during the training run
 and also has a :ref:`Callback interface <train-callbacks>` to perform actions on these intermediate results (such as logging, aggregations, etc.).
@@ -360,11 +501,22 @@ You can use either the :ref:`built-in callbacks <air-builtin-callbacks>` that Ra
 or implement a :ref:`custom callback <train-custom-callbacks>` for your use case. The callback API
 is shared with Ray Tune.
 
-Reporting intermediate results
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _train-checkpointing:
+
+Ray Train also provides a way to save state during the training process. This is
+useful for:
+
+1. :ref:`Integration with Ray Tune <train-tune>` to use certain Ray Tune
+   schedulers.
+2. Running a long-running training job on a cluster of pre-emptible machines/pods.
+3. Persisting trained model state to later use for serving/inference.
+4. In general, storing any model artifacts.
+
+Reporting intermediate results and handling checkpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Ray AIR provides a ``session.report(metrics, checkpoint=None)`` API for reporting intermediate
-results from the training function (run on distributed workers) up to the
+results and checkpoints from the training function (run on distributed workers) up to the
 ``Trainer`` (where your python script is executed).
 
 The primary use-case for reporting is for metrics (accuracy, loss, etc.) at
@@ -380,128 +532,10 @@ the end of each training epoch.
             results = model.train(...)
             session.report({"results": results})
 
-
-.. _train-callbacks:
-
-Callbacks
-~~~~~~~~~
-
-You may want to plug in your training code with your favorite experiment management framework.
-Ray AIR provides an interface to fetch intermediate results and callbacks to process/log your intermediate results
-(the values passed into ``session.report(...)``).
-
-Ray AIR contains :ref:`built-in callbacks <air-builtin-callbacks>` for popular tracking frameworks, or you can implement your own callback via the :ref:`Callback <tune-callbacks-docs>` interface.
-
-Example: Logging to MLflow and TensorBoard
-++++++++++++++++++++++++++++++++++++++++++
-
-**Step 1: Install the necessary packages**
-
-.. code-block:: bash
-
-    $ pip install mlflow
-    $ pip install tensorboardX
-
-**Step 2: Run the following training script**
-
-.. literalinclude:: /../../python/ray/train/examples/mlflow_simple_example.py
-   :language: python
-
-.. _train-custom-callbacks:
-
-Custom Callbacks
-++++++++++++++++
-
-If the provided callbacks do not cover your desired integrations or use-cases,
-you may always implement a custom callback by subclassing ``Callback``. If
-the callback is general enough, please feel welcome to :ref:`add it <getting-involved>`
-to the ``ray`` `repository <https://github.com/ray-project/ray>`_.
-
-A simple example for creating a callback that will print out results:
-
-.. code-block:: python
-
-    from typing import List, Dict
-
-    from ray.air import session
-    from ray.air.config import RunConfig
-    from ray.train.torch import TorchTrainer
-    from ray.tune.logger import LoggerCallback
-
-    # LoggerCallback is a higher level API of Callback.
-    class LoggingCallback(LoggerCallback):
-        def __init__(self) -> None:
-            self.results = []
-
-        def log_trial_result(self, iteration: int, trial: "Trial", result: Dict):
-            self.results.append(trial.last_result)
-
-    def train_func():
-        for i in range(3):
-            session.report({"epoch": i})
-
-    callback = LoggingCallback()
-    trainer = TorchTrainer(
-        train_func,
-        run_config=RunConfig(callbacks=[callback]),
-        scaling_config=dict(num_workers=2),
-    )
-    trainer.fit()
-
-    print("\n".join([str(x) for x in callback.results]))
-    # {'trial_id': '0f1d0_00000', 'experiment_id': '494a1d050b4a4d11aeabd87ba475fcd3', 'date': '2022-06-27_17-03-28', 'timestamp': 1656349408, 'pid': 23018, 'hostname': 'ip-172-31-43-110', 'node_ip': '172.31.43.110', 'config': {}}
-    # {'epoch': 0, '_timestamp': 1656349412, '_time_this_iter_s': 0.0026497840881347656, '_training_iteration': 1, 'time_this_iter_s': 3.433483362197876, 'done': False, 'timesteps_total': None, 'episodes_total': None, 'training_iteration': 1, 'trial_id': '0f1d0_00000', 'experiment_id': '494a1d050b4a4d11aeabd87ba475fcd3', 'date': '2022-06-27_17-03-32', 'timestamp': 1656349412, 'time_total_s': 3.433483362197876, 'pid': 23018, 'hostname': 'ip-172-31-43-110', 'node_ip': '172.31.43.110', 'config': {}, 'time_since_restore': 3.433483362197876, 'timesteps_since_restore': 0, 'iterations_since_restore': 1, 'warmup_time': 0.003779172897338867, 'experiment_tag': '0'}
-    # {'epoch': 1, '_timestamp': 1656349412, '_time_this_iter_s': 0.0013833045959472656, '_training_iteration': 2, 'time_this_iter_s': 0.016670703887939453, 'done': False, 'timesteps_total': None, 'episodes_total': None, 'training_iteration': 2, 'trial_id': '0f1d0_00000', 'experiment_id': '494a1d050b4a4d11aeabd87ba475fcd3', 'date': '2022-06-27_17-03-32', 'timestamp': 1656349412, 'time_total_s': 3.4501540660858154, 'pid': 23018, 'hostname': 'ip-172-31-43-110', 'node_ip': '172.31.43.110', 'config': {}, 'time_since_restore': 3.4501540660858154, 'timesteps_since_restore': 0, 'iterations_since_restore': 2, 'warmup_time': 0.003779172897338867, 'experiment_tag': '0'}
-
-
-Example: PyTorch Distributed metrics
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In real applications, you may want to calculate optimization metrics besides
-accuracy and loss: recall, precision, Fbeta, etc.
-
-Ray Train natively supports `TorchMetrics <https://torchmetrics.readthedocs.io/en/latest/>`_, which provides a collection of machine learning metrics for distributed, scalable PyTorch models.
-
-Here is an example:
-
-.. code-block:: python
-
-    from typing import List, Dict
-    from ray.air import session
-    from ray.train.torch import TorchTrainer
-
-    import torch
-    import torchmetrics
-
-    def train_func(config):
-        preds = torch.randn(10, 5).softmax(dim=-1)
-        target = torch.randint(5, (10,))
-        accuracy = torchmetrics.functional.accuracy(preds, target).item()
-        session.report({"accuracy": accuracy})
-
-    trainer = TorchTrainer(train_func, scaling_config=dict(num_workers=2))
-    result = trainer.fit()
-    print(result.metrics["accuracy"])
-    # 0.20000000298023224
-
-.. _train-checkpointing:
-
-Checkpointing
--------------
-
-Ray Train provides a way to save state during the training process. This is
-useful for:
-
-1. :ref:`Integration with Ray Tune <train-tune>` to use certain Ray Tune
-   schedulers.
-2. Running a long-running training job on a cluster of pre-emptible machines/pods.
-3. Persisting trained model state to later use for serving/inference.
-4. In general, storing any model artifacts.
-
 Saving checkpoints
-~~~~~~~~~~~~~~~~~~
+++++++++++++++++++
 
-Checkpoints can be saved by calling ``session.report(checkpoint=Checkpoint(...))`` in the
+Checkpoints can be saved by calling ``session.report(metrics, checkpoint=Checkpoint(...))`` in the
 training function. This will cause the checkpoint state from the distributed
 workers to be saved on the ``Trainer`` (where your python script is executed).
 
@@ -687,8 +721,9 @@ You may also config ``CheckpointConfig`` to keep the "N best" checkpoints persis
     print(results.best_checkpoints[1][0].get_internal_representation())
     # ('local_path', '/home/ubuntu/ray_results/TorchTrainer_2022-06-24_21-34-49/TorchTrainer_7988b_00000_0_2022-06-24_21-34-49/checkpoint_000002')
 
+
 Loading checkpoints
-~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++
 
 Checkpoints can be loaded into the training function in 2 steps:
 
@@ -836,6 +871,108 @@ Checkpoints can be loaded into the training function in 2 steps:
         #    [-1.0043601 ],
         #    [-0.61634773]], dtype=float32), array([0.01889327], dtype=float32)], '_timestamp': 1656108446, '_preprocessor': None, '_current_checkpoint_id': 3}
 
+.. _train-callbacks:
+
+Callbacks
+~~~~~~~~~
+
+You may want to plug in your training code with your favorite experiment management framework.
+Ray AIR provides an interface to fetch intermediate results and callbacks to process/log your intermediate results
+(the values passed into ``session.report(...)``).
+
+Ray AIR contains :ref:`built-in callbacks <air-builtin-callbacks>` for popular tracking frameworks, or you can implement your own callback via the :ref:`Callback <tune-callbacks-docs>` interface.
+
+Example: Logging to MLflow and TensorBoard
+++++++++++++++++++++++++++++++++++++++++++
+
+**Step 1: Install the necessary packages**
+
+.. code-block:: bash
+
+    $ pip install mlflow
+    $ pip install tensorboardX
+
+**Step 2: Run the following training script**
+
+.. literalinclude:: /../../python/ray/train/examples/mlflow_simple_example.py
+   :language: python
+
+.. _train-custom-callbacks:
+
+Custom Callbacks
+++++++++++++++++
+
+If the provided callbacks do not cover your desired integrations or use-cases,
+you may always implement a custom callback by subclassing ``Callback``. If
+the callback is general enough, please feel welcome to :ref:`add it <getting-involved>`
+to the ``ray`` `repository <https://github.com/ray-project/ray>`_.
+
+A simple example for creating a callback that will print out results:
+
+.. code-block:: python
+
+    from typing import List, Dict
+
+    from ray.air import session
+    from ray.air.config import RunConfig
+    from ray.train.torch import TorchTrainer
+    from ray.tune.logger import LoggerCallback
+
+    # LoggerCallback is a higher level API of Callback.
+    class LoggingCallback(LoggerCallback):
+        def __init__(self) -> None:
+            self.results = []
+
+        def log_trial_result(self, iteration: int, trial: "Trial", result: Dict):
+            self.results.append(trial.last_result)
+
+    def train_func():
+        for i in range(3):
+            session.report({"epoch": i})
+
+    callback = LoggingCallback()
+    trainer = TorchTrainer(
+        train_func,
+        run_config=RunConfig(callbacks=[callback]),
+        scaling_config=dict(num_workers=2),
+    )
+    trainer.fit()
+
+    print("\n".join([str(x) for x in callback.results]))
+    # {'trial_id': '0f1d0_00000', 'experiment_id': '494a1d050b4a4d11aeabd87ba475fcd3', 'date': '2022-06-27_17-03-28', 'timestamp': 1656349408, 'pid': 23018, 'hostname': 'ip-172-31-43-110', 'node_ip': '172.31.43.110', 'config': {}}
+    # {'epoch': 0, '_timestamp': 1656349412, '_time_this_iter_s': 0.0026497840881347656, '_training_iteration': 1, 'time_this_iter_s': 3.433483362197876, 'done': False, 'timesteps_total': None, 'episodes_total': None, 'training_iteration': 1, 'trial_id': '0f1d0_00000', 'experiment_id': '494a1d050b4a4d11aeabd87ba475fcd3', 'date': '2022-06-27_17-03-32', 'timestamp': 1656349412, 'time_total_s': 3.433483362197876, 'pid': 23018, 'hostname': 'ip-172-31-43-110', 'node_ip': '172.31.43.110', 'config': {}, 'time_since_restore': 3.433483362197876, 'timesteps_since_restore': 0, 'iterations_since_restore': 1, 'warmup_time': 0.003779172897338867, 'experiment_tag': '0'}
+    # {'epoch': 1, '_timestamp': 1656349412, '_time_this_iter_s': 0.0013833045959472656, '_training_iteration': 2, 'time_this_iter_s': 0.016670703887939453, 'done': False, 'timesteps_total': None, 'episodes_total': None, 'training_iteration': 2, 'trial_id': '0f1d0_00000', 'experiment_id': '494a1d050b4a4d11aeabd87ba475fcd3', 'date': '2022-06-27_17-03-32', 'timestamp': 1656349412, 'time_total_s': 3.4501540660858154, 'pid': 23018, 'hostname': 'ip-172-31-43-110', 'node_ip': '172.31.43.110', 'config': {}, 'time_since_restore': 3.4501540660858154, 'timesteps_since_restore': 0, 'iterations_since_restore': 2, 'warmup_time': 0.003779172897338867, 'experiment_tag': '0'}
+
+
+Example: PyTorch Distributed metrics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In real applications, you may want to calculate optimization metrics besides
+accuracy and loss: recall, precision, Fbeta, etc.
+
+Ray Train natively supports `TorchMetrics <https://torchmetrics.readthedocs.io/en/latest/>`_, which provides a collection of machine learning metrics for distributed, scalable PyTorch models.
+
+Here is an example:
+
+.. code-block:: python
+
+    from typing import List, Dict
+    from ray.air import session
+    from ray.train.torch import TorchTrainer
+
+    import torch
+    import torchmetrics
+
+    def train_func(config):
+        preds = torch.randn(10, 5).softmax(dim=-1)
+        target = torch.randint(5, (10,))
+        accuracy = torchmetrics.functional.accuracy(preds, target).item()
+        session.report({"accuracy": accuracy})
+
+    trainer = TorchTrainer(train_func, scaling_config=dict(num_workers=2))
+    result = trainer.fit()
+    print(result.metrics["accuracy"])
+    # 0.20000000298023224
 
 .. Running on the cloud
 .. --------------------
@@ -934,6 +1071,43 @@ number of retries is configurable through the ``max_failures`` attribute of the
 ..     # View the PyTorch Profiler traces.
 ..     $ open http://localhost:6006/#pytorch_profiler
 
+.. _train-tune:
+
+Hyperparameter tuning (Ray Tune)
+--------------------------------
+
+Hyperparameter tuning with :ref:`Ray Tune <tune-main>` is natively supported
+with Ray Train. Specifically, you can take an existing ``Trainer`` and simply
+pass it into a :class:`Tuner`.
+
+.. code-block:: python
+
+    from ray import tune
+    from ray.air import session
+    from ray.train.torch import TorchTrainer
+    from ray.tune.tuner import Tuner, TuneConfig
+
+    def train_func(config):
+        # In this example, nothing is expected to change over epochs,
+        # and the output metric is equivalent to the input value.
+        for _ in range(config["num_epochs"]):
+            session.report(dict(output=config["input"]))
+
+    trainer = TorchTrainer(train_func, scaling_config=dict(num_workers=2))
+    tuner = Tuner(
+        trainer,
+        param_space={
+            "train_loop_config": {
+                "num_epochs": 2,
+                "input": tune.grid_search([1, 2, 3]),
+            }
+        },
+        tune_config=TuneConfig(num_samples=5, metric="output", mode="max"),
+    )
+    result_grid = tuner.fit()
+    print(result_grid.get_best_result().metrics["output"])
+    # 3
+
 .. _torch-amp:
 
 Automatic Mixed Precision
@@ -1006,136 +1180,6 @@ Reproducibility
     .. warning:: ``train.torch.enable_reproducibility`` can't guarantee
         completely reproducible results across executions. To learn more, read
         the `PyTorch notes on randomness <https://pytorch.org/docs/stable/notes/randomness.html>`_.
-
-.. _train-datasets:
-
-Distributed Data Ingest (Ray Datasets)
---------------------------------------
-
-Ray Train provides native support for :ref:`Ray Datasets <datasets>` to support the following use cases:
-
-1. **Large Datasets**: With Ray Datasets, you can easily work with datasets that are too big to fit on a single node.
-   Ray Datasets will distribute the dataset across the Ray Cluster and allow you to perform dataset operations (map, filter, etc.)
-   on the distributed dataset.
-2. **Automatic locality-aware sharding**: If provided a Ray Dataset, Ray Train will automatically shard the dataset and assign each shard
-   to a training worker while minimizing cross-node data transfer. Unlike with standard Torch or TensorFlow datasets, each training
-   worker will only load its assigned shard into memory rather than the entire ``Dataset``.
-3. **Pipelined Execution**: Ray Datasets also supports pipelining, meaning that data processing operations
-   can be run concurrently with training. Training is no longer blocked on expensive data processing operations (such as global shuffling)
-   and this minimizes the amount of time your GPUs are idle. See :ref:`dataset-pipeline-api` for more information.
-
-To get started, pass in a Ray Dataset (or multiple) into ``Trainer``. Underneath the hood, Ray Train will automatically shard the given dataset.
-
-.. warning::
-
-    If you are doing distributed training with TensorFlow, you will need to
-    disable TensorFlow's built-in autosharding as the data on each worker is
-    already sharded.
-
-    .. code-block:: python
-        :emphasize-lines: 1, 6
-
-        from ray.train.tensorflow import prepare_dataset_shard
-
-        def train_func():
-            ...
-            tf_dataset = ray.train.get_dataset_shard().to_tf(...)
-            tf_dataset = prepare_dataset_shard(tf_dataset)
-
-
-**Simple Dataset Example**
-
-.. code-block:: python
-
-    import ray
-    from ray import train
-    from ray.air import train_test_split
-    from ray.train.torch import TorchTrainer
-
-    def train_func(config):
-        # Create your model here.
-        model = NeuralNetwork()
-
-        batch_size = config["worker_batch_size"]
-
-        train_data_shard = train.get_dataset_shard("train")
-        train_torch_dataset = train_data_shard.to_torch(
-            label_column="label", batch_size=batch_size
-        )
-
-        validation_data_shard = train.get_dataset_shard("validation")
-        validation_torch_dataset = validation_data_shard.to_torch(
-            label_column="label", batch_size=batch_size
-        )
-
-        for epoch in config["num_epochs"]:
-            for X, y in train_torch_dataset:
-                model.train()
-                output = model(X)
-                # Train on one batch.
-            for X, y in validation_torch_dataset:
-                model.eval()
-                output = model(X)
-                # Validate one batch.
-        return model
-
-    # Random split dataset into 80% training data and 20% validation data.
-    train_dataset, validation_dataset = train_test_split(
-        dataset, test_size=0.2, shuffle=True
-    )
-
-    trainer = TorchTrainer(
-        train_func,
-        train_loop_config={"worker_batch_size": 64, "num_epochs": 2},
-        datasets={"train": train_dataset, "validation": validation_dataset},
-        scaling_config=dict(num_workers=8),
-    )
-    dataset = ray.data.read_csv("...")
-
-    results = trainer.fit()
-
-.. _train-dataset-pipeline:
-
-Pipelined Execution
-~~~~~~~~~~~~~~~~~~~
-For details on how to enable pipelined execution, please refer to :ref:`air-ingest`.
-
-.. _train-tune:
-
-Hyperparameter tuning (Ray Tune)
---------------------------------
-
-Hyperparameter tuning with :ref:`Ray Tune <tune-main>` is natively supported
-with Ray Train. Specifically, you can take an existing ``Trainer`` and simply
-pass it into a :class:`Tuner`.
-
-.. code-block:: python
-
-    from ray import tune
-    from ray.air import session
-    from ray.train.torch import TorchTrainer
-    from ray.tune.tuner import Tuner, TuneConfig
-
-    def train_func(config):
-        # In this example, nothing is expected to change over epochs,
-        # and the output metric is equivalent to the input value.
-        for _ in range(config["num_epochs"]):
-            session.report(dict(output=config["input"]))
-
-    trainer = TorchTrainer(train_func, scaling_config=dict(num_workers=2))
-    tuner = Tuner(
-        trainer,
-        param_space={
-            "train_loop_config": {
-                "num_epochs": 2,
-                "input": tune.grid_search([1, 2, 3]),
-            }
-        },
-        tune_config=TuneConfig(num_samples=5, metric="output", mode="max"),
-    )
-    result_grid = tuner.fit()
-    print(result_grid.get_best_result().metrics["output"])
-    # 3
 
 ..
     import ray


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Train User Guide:
* Expands the Results section
* Combines reporting and checkpointing sections (both making use of `session`)
* Moving the Ray Datasets section up
* Adding some extra links and references

Also fixes typo of `Results` -> `Result` in a few places.

This is intended to be just an iterative improvement to the Train user guide. Target structure still needs to be decided on.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
