### PR TITLE
Revert "Revert "Object GC for block splitting inside the dataset spli…

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3260,9 +3260,7 @@ class Dataset(Generic[T]):
                 self._created_by_pipeline = created_by_pipeline
 
             def __iter__(self):
-                return Iterator(
-                    self._splits, self._epoch, self._created_by_pipeline
-                )
+                return Iterator(self._splits, self._epoch, self._created_by_pipeline)
 
         it = Iterable(blocks, self._epoch, self._created_by_pipeline)
         pipe = DatasetPipeline(it, False, length=len(it._splits))

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -176,7 +176,7 @@ class Dataset(Generic[T]):
         lazy: bool,
         *,
         defer_execution: bool = False,
-        used_from_dataset_pipeline: bool = False,
+        created_by_pipeline: bool = False,
     ):
         """Construct a Dataset (internal API).
 
@@ -190,7 +190,7 @@ class Dataset(Generic[T]):
         self._uuid = uuid4().hex
         self._epoch = epoch
         self._lazy = lazy
-        self._used_from_dataset_pipeline = used_from_dataset_pipeline
+        self._created_by_pipeline = created_by_pipeline
 
         if not lazy and not defer_execution:
             self._plan.execute(allow_clear_input_blocks=False)
@@ -1127,7 +1127,7 @@ class Dataset(Generic[T]):
                         ),
                         self._epoch,
                         self._lazy,
-                        used_from_dataset_pipeline=self._used_from_dataset_pipeline,
+                        created_by_pipeline=self._created_by_pipeline,
                     )
                     for blocks in np.array_split(block_refs, n)
                 ],
@@ -1240,7 +1240,7 @@ class Dataset(Generic[T]):
                     ),
                     self._epoch,
                     self._lazy,
-                    used_from_dataset_pipeline=self._used_from_dataset_pipeline,
+                    created_by_pipeline=self._created_by_pipeline,
                 )
                 for actor in locality_hints
             ],
@@ -1430,7 +1430,7 @@ class Dataset(Generic[T]):
             ExecutionPlan(blocklist, dataset_stats),
             max_epoch,
             self._lazy,
-            used_from_dataset_pipeline=self._used_from_dataset_pipeline,
+            created_by_pipeline=self._created_by_pipeline,
         )
 
     def groupby(self, key: Optional[KeyFn]) -> "GroupedDataset[T]":
@@ -3076,10 +3076,10 @@ class Dataset(Generic[T]):
             raise ValueError("`times` must be >= 1, got {}".format(times))
 
         class Iterator:
-            def __init__(self, blocks, used_from_dataset_pipeline):
+            def __init__(self, blocks, created_by_pipeline):
                 self._blocks = blocks
                 self._i = 0
-                self._used_from_dataset_pipeline = used_from_dataset_pipeline
+                self._created_by_pipeline = created_by_pipeline
 
             def __next__(self) -> "Dataset[T]":
                 if times and self._i >= times:
@@ -3093,7 +3093,7 @@ class Dataset(Generic[T]):
                         ExecutionPlan(blocks, outer_stats, dataset_uuid=uuid),
                         epoch,
                         lazy=False,
-                        used_from_dataset_pipeline=True,
+                        created_by_pipeline=True,
                     )
                     ds._set_uuid(uuid)
                     return ds
@@ -3101,15 +3101,15 @@ class Dataset(Generic[T]):
                 return gen
 
         class Iterable:
-            def __init__(self, blocks, used_from_dataset_pipeline):
+            def __init__(self, blocks, created_by_pipeline):
                 self._blocks = blocks
-                self._used_from_dataset_pipeline = used_from_dataset_pipeline
+                self._created_by_pipeline = created_by_pipeline
 
             def __iter__(self):
-                return Iterator(self._blocks, self._used_from_dataset_pipeline)
+                return Iterator(self._blocks, self._created_by_pipeline)
 
         pipe = DatasetPipeline(
-            Iterable(blocks, self._used_from_dataset_pipeline),
+            Iterable(blocks, self._created_by_pipeline),
             False,
             length=times or float("inf"),
         )
@@ -3119,7 +3119,7 @@ class Dataset(Generic[T]):
                     ds._plan.with_stage(read_stage),
                     ds._epoch,
                     True,
-                    used_from_dataset_pipeline=True,
+                    created_by_pipeline=True,
                 )
             )
         return pipe
@@ -3201,10 +3201,10 @@ class Dataset(Generic[T]):
             read_stage = None
 
         class Iterator:
-            def __init__(self, splits, epoch, used_from_dataset_pipeline):
+            def __init__(self, splits, epoch, created_by_pipeline):
                 self._splits = splits.copy()
                 self._epoch = epoch
-                self._used_from_dataset_pipeline = used_from_dataset_pipeline
+                self._created_by_pipeline = created_by_pipeline
 
             def __next__(self) -> "Dataset[T]":
                 if not self._splits:
@@ -3217,14 +3217,14 @@ class Dataset(Generic[T]):
                         ExecutionPlan(blocks, outer_stats),
                         self._epoch,
                         lazy=True,
-                        used_from_dataset_pipeline=True,
+                        created_by_pipeline=True,
                     )
                     return ds
 
                 return gen
 
         class Iterable:
-            def __init__(self, blocks, epoch, used_from_dataset_pipeline):
+            def __init__(self, blocks, epoch, created_by_pipeline):
                 if bytes_per_window:
                     self._splits = blocks.split_by_bytes(bytes_per_window)
                 else:
@@ -3257,14 +3257,14 @@ class Dataset(Generic[T]):
                         )
                     )
                 self._epoch = epoch
-                self._used_from_dataset_pipeline = used_from_dataset_pipeline
+                self._created_by_pipeline = created_by_pipeline
 
             def __iter__(self):
                 return Iterator(
-                    self._splits, self._epoch, self._used_from_dataset_pipeline
+                    self._splits, self._epoch, self._created_by_pipeline
                 )
 
-        it = Iterable(blocks, self._epoch, self._used_from_dataset_pipeline)
+        it = Iterable(blocks, self._epoch, self._created_by_pipeline)
         pipe = DatasetPipeline(it, False, length=len(it._splits))
         if read_stage:
             pipe = pipe.foreach_window(
@@ -3272,7 +3272,7 @@ class Dataset(Generic[T]):
                     ds._plan.with_stage(read_stage),
                     ds._epoch,
                     True,
-                    used_from_dataset_pipeline=True,
+                    created_by_pipeline=True,
                 )
             )
         return pipe
@@ -3455,7 +3455,7 @@ class Dataset(Generic[T]):
                 left_metadata.append(ray.get(m0))
                 right_blocks.append(b1)
                 right_metadata.append(ray.get(m1))
-                if self._lazy and self._used_from_dataset_pipeline:
+                if self._lazy and self._created_by_pipeline:
                     ray._private.internal_api.free(b, local_only=False)
             count += num_rows
 
@@ -3482,7 +3482,7 @@ class Dataset(Generic[T]):
             ),
             self._epoch,
             self._lazy,
-            used_from_dataset_pipeline=self._used_from_dataset_pipeline,
+            created_by_pipeline=self._created_by_pipeline,
         )
         if return_right_half:
             right_meta_for_stats = [
@@ -3507,7 +3507,7 @@ class Dataset(Generic[T]):
                 ),
                 self._epoch,
                 self._lazy,
-                used_from_dataset_pipeline=self._used_from_dataset_pipeline,
+                created_by_pipeline=self._created_by_pipeline,
             )
         else:
             right = None

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -794,6 +794,7 @@ class DatasetPipeline(Generic[T]):
             ExecutionPlan(BlockList([], []), DatasetStats(stages={}, parent=None)),
             0,
             True,
+            used_from_dataset_pipeline=True,
         )
         # Apply all pipeline operations to the dummy dataset.
         for stage in self._stages:
@@ -806,7 +807,10 @@ class DatasetPipeline(Generic[T]):
         for stage in stages:
             optimized_stages.append(
                 lambda ds, stage=stage: Dataset(
-                    ds._plan.with_stage(stage), ds._epoch, True
+                    ds._plan.with_stage(stage),
+                    ds._epoch,
+                    True,
+                    used_from_dataset_pipeline=True,
                 )
             )
         self._optimized_stages = optimized_stages

--- a/python/ray/data/tests/test_object_gc.py
+++ b/python/ray/data/tests/test_object_gc.py
@@ -141,6 +141,33 @@ def test_pipeline_splitting_has_no_spilling(shutdown_only):
     assert "Spilled" not in meminfo, meminfo
 
 
+def test_pipeline_splitting_has_no_spilling_with_equal_splitting(shutdown_only):
+    # The object store is about 1200MiB.
+    ctx = ray.init(num_cpus=1, object_store_memory=1200e6)
+    # The size of dataset is 50000*(80*80*4)*8B, about 10GiB, 50MiB/block.
+    ds = ray.data.range_tensor(50000, shape=(80, 80, 4), parallelism=200)
+
+    # 150Mib/window, which is 3 blocks/window, which means equal splitting
+    # will need to split one block.
+    p = ds.window(bytes_per_window=150 * 1024 * 1024).repeat()
+    p1, p2 = p.split(2, equal=True)
+
+    @ray.remote
+    def consume(p):
+        for batch in p.iter_batches():
+            pass
+
+    tasks = [consume.remote(p1), consume.remote(p2)]
+    try:
+        # Run it for 20 seconds.
+        ray.get(tasks, timeout=20)
+    except Exception:
+        for t in tasks:
+            ray.cancel(t, force=True)
+    meminfo = memory_summary(ctx.address_info["address"], stats_only=True)
+    assert "Spilled" not in meminfo, meminfo
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?
Fix the original PR https://github.com/ray-project/ray/pull/26196

The issue is we have a in-place transformation (randomize block order) in the pipeline, so we need to make sure it's handled safely.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
