### PR TITLE
[KubeRay][Autoscaler][Core] Add a flag to disable ray status version check

### DIFF
--- a/python/ray/_private/gcs_utils.py
+++ b/python/ray/_private/gcs_utils.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 import time
+import traceback
 from functools import wraps
 from typing import List, Optional
 
@@ -96,13 +97,15 @@ def create_gcs_channel(address: str, aio=False):
     return init_grpc_channel(address, options=_GRPC_OPTIONS, asynchronous=aio)
 
 
-def check_health(address: str, timeout=2) -> bool:
+def check_health(address: str, timeout=2, skip_version_check=False) -> bool:
     """Checks Ray cluster health, before / without actually connecting to the
     cluster via ray.init().
 
     Args:
         address: Ray cluster / GCS address string, e.g. ip:port.
         timeout: request timeout.
+        skip_version_check: If True, will skip comparision of GCS Ray version with local
+            Ray version. If False (default), will raise exception on mismatch.
     Returns:
         Returns True if the cluster is running and has matching Ray version.
         Returns False if no service is running.
@@ -114,9 +117,14 @@ def check_health(address: str, timeout=2) -> bool:
         stub = gcs_service_pb2_grpc.HeartbeatInfoGcsServiceStub(channel)
         resp = stub.CheckAlive(req, timeout=timeout)
     except grpc.RpcError:
+        traceback.print_exc()
         return False
     if resp.status.code != GcsCode.OK:
         raise RuntimeError(f"GCS running at {address} is unhealthy: {resp.status}")
+
+    if skip_version_check:
+        return True
+    # Otherwise, continue to check for Ray version match.
     if resp.ray_version is None:
         resp.ray_version = "<= 1.12"
     if resp.ray_version != ray.__version__:

--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -21,7 +21,9 @@ def run_kuberay_autoscaler(cluster_name: str, cluster_namespace: str):
     ray_address = f"{head_ip}:6379"
     while True:
         try:
-            subprocess.check_call(["ray", "health-check", "--address", ray_address])
+            # Autoscaler Ray version might not exactly match GCS version, so skip the version
+            # check when checking GCS status.
+            subprocess.check_call(["ray", "health-check", "--address", ray_address, "--skip-version-check"])
             # Logging is not ready yet. Print to stdout for now.
             print("The Ray head is ready. Starting the autoscaler.")
             break

--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -21,9 +21,17 @@ def run_kuberay_autoscaler(cluster_name: str, cluster_namespace: str):
     ray_address = f"{head_ip}:6379"
     while True:
         try:
-            # Autoscaler Ray version might not exactly match GCS version, so skip the version
-            # check when checking GCS status.
-            subprocess.check_call(["ray", "health-check", "--address", ray_address, "--skip-version-check"])
+            # Autoscaler Ray version might not exactly match GCS version, so skip the
+            # version check when checking GCS status.
+            subprocess.check_call(
+                [
+                    "ray",
+                    "health-check",
+                    "--address",
+                    ray_address,
+                    "--skip-version-check",
+                ]
+            )
             # Logging is not ready yet. Print to stdout for now.
             print("The Ray head is ready. Starting the autoscaler.")
             break

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2341,7 +2341,9 @@ def healthcheck(address, redis_password, component, skip_version_check):
 
     if not component:
         try:
-            if ray._private.gcs_utils.check_health(address, skip_version_check=skip_version_check):
+            if ray._private.gcs_utils.check_health(
+                address, skip_version_check=skip_version_check
+            ):
                 sys.exit(0)
         except Exception:
             traceback.print_exc()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -6,6 +6,7 @@ import signal
 import subprocess
 import sys
 import time
+import traceback
 import urllib
 import urllib.parse
 from datetime import datetime
@@ -2323,7 +2324,13 @@ def kuberay_autoscaler(cluster_name: str, cluster_namespace: str) -> None:
     help="Health check for a specific component. Currently supports: "
     "[ray_client_server]",
 )
-def healthcheck(address, redis_password, component):
+@click.option(
+    "--skip-version-check",
+    is_flag=True,
+    default=False,
+    help="Skip comparison of GCS version with local Ray version.",
+)
+def healthcheck(address, redis_password, component, skip_version_check):
     """
     This is NOT a public api.
 
@@ -2334,9 +2341,10 @@ def healthcheck(address, redis_password, component):
 
     if not component:
         try:
-            if ray._private.gcs_utils.check_health(address):
+            if ray._private.gcs_utils.check_health(address, skip_version_check):
                 sys.exit(0)
         except Exception:
+            traceback.print_exc()
             pass
         sys.exit(1)
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2341,7 +2341,7 @@ def healthcheck(address, redis_password, component, skip_version_check):
 
     if not component:
         try:
-            if ray._private.gcs_utils.check_health(address, skip_version_check):
+            if ray._private.gcs_utils.check_health(address, skip_version_check=skip_version_check):
                 sys.exit(0)
         except Exception:
             traceback.print_exc()

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -2,7 +2,6 @@ import mock
 import subprocess
 import sys
 
-
 import pytest
 
 import ray

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -1,5 +1,7 @@
+import mock
 import subprocess
 import sys
+
 
 import pytest
 
@@ -110,6 +112,15 @@ def test_check_health(shutdown_only):
     conn = ray.init()
     addr = conn.address_info["address"]
     assert check_health(addr)
+
+
+def test_check_health_version_check():
+    with mock.patch("ray.__version__", "FOO-VERSION"):
+        conn = ray.init()
+        addr = conn.address_info["address"]
+        assert check_health(addr, skip_version_check=True)
+        with pytest.raises(RuntimeError):
+            check_health(addr)
 
 
 def test_back_pressure(shutdown_only_with_initialization_check):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`ray health-check` checks if the local Ray version agrees with the GCS Ray version,
which is a reasonable thing to do,
unless you're deliberately mismatching Ray versions.

During this development phase of the KubeRay autoscaler integration, we are deliberately mismatching Ray and autoscaler versions. As a result, users have encountered trouble starting up the autoscaler.

Thus, we need a way of disabling the version check.
This PR introduces a flag for that.

This PR also has ray health-check print error output in a couple of spots where it previously did not, for ease of debugging.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Manual check
   I'll manually check compatibility of autoscaler with these changes against Ray 1.11.0
  
