### PR TITLE
[RLlib] Fixes MARWIL release tests

### DIFF
--- a/release/rllib_tests/learning_tests/yaml_files/f-z/marwil-halfcheetahbulletenv-v0.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/f-z/marwil-halfcheetahbulletenv-v0.yaml
@@ -25,5 +25,5 @@ marwil-halfcheetahbulletenv-v0:
         evaluation_interval: 3
         evaluation_config:
             input: sampler
-            off_policy_estimation_methods:
+            off_policy_estimation_methods: null
         always_attach_evaluation_results: True

--- a/release/rllib_tests/learning_tests/yaml_files/f-z/marwil-halfcheetahbulletenv-v0.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/f-z/marwil-halfcheetahbulletenv-v0.yaml
@@ -25,4 +25,5 @@ marwil-halfcheetahbulletenv-v0:
         evaluation_interval: 3
         evaluation_config:
             input: sampler
+            off_policy_estimation_methods:
         always_attach_evaluation_results: True


### PR DESCRIPTION
## Why are these changes needed?

MARWIL release tests are broken because OPE is enabled by default, requiring action distributions to be present in our offline data, which they are not for the previously collected SAC file.

## Related issue number

#26579 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
