### PR TITLE
[Datasets] Improve streaming read performance.

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -18,6 +18,11 @@ DEFAULT_TARGET_MAX_BLOCK_SIZE = 512 * 1024 * 1024
 # This takes precedence over DEFAULT_MIN_PARALLELISM.
 DEFAULT_TARGET_MIN_BLOCK_SIZE = 1 * 1024 * 1024
 
+# Default buffer size when doing streaming reads from local or remote storage.
+# This default appears to work well with most file sizes on remote storage systems,
+# which is very sensitive to the buffer size.
+DEFAULT_STREAMING_READ_BUFFER_SIZE = 32 * 1024 * 1024
+
 # Whether block splitting is on by default
 DEFAULT_BLOCK_SPLITTING_ENABLED = False
 
@@ -71,6 +76,7 @@ class DatasetContext:
         block_splitting_enabled: bool,
         target_max_block_size: int,
         target_min_block_size: int,
+        streaming_read_buffer_size: int,
         enable_pandas_block: bool,
         optimize_fuse_stages: bool,
         optimize_fuse_read_stages: bool,
@@ -88,6 +94,7 @@ class DatasetContext:
         self.block_splitting_enabled = block_splitting_enabled
         self.target_max_block_size = target_max_block_size
         self.target_min_block_size = target_min_block_size
+        self.streaming_read_buffer_size = streaming_read_buffer_size
         self.enable_pandas_block = enable_pandas_block
         self.optimize_fuse_stages = optimize_fuse_stages
         self.optimize_fuse_read_stages = optimize_fuse_read_stages
@@ -119,6 +126,7 @@ class DatasetContext:
                     block_splitting_enabled=DEFAULT_BLOCK_SPLITTING_ENABLED,
                     target_max_block_size=DEFAULT_TARGET_MAX_BLOCK_SIZE,
                     target_min_block_size=DEFAULT_TARGET_MIN_BLOCK_SIZE,
+                    streaming_read_buffer_size=DEFAULT_STREAMING_READ_BUFFER_SIZE,
                     enable_pandas_block=DEFAULT_ENABLE_PANDAS_BLOCK,
                     optimize_fuse_stages=DEFAULT_OPTIMIZE_FUSE_STAGES,
                     optimize_fuse_read_stages=DEFAULT_OPTIMIZE_FUSE_READ_STAGES,


### PR DESCRIPTION
Arrow's default streaming read for S3 is both [synchronous and unbuffered](https://github.com/apache/arrow/blob/e766828c699c6c74eba3b8c5de99e541017b8b9e/cpp/src/arrow/filesystem/s3fs.h#L258-L260), instead of offering a default buffer size. This results in very slow S3 reads (10x slower in some cases) compared to the equivalent buffered read or random access read. This PR adds a default streaming read buffer size of 32 MiB which appears to work well for all file sizes when reading from S3, while not being so large as to introduce OOM concerns for large files.

## TODOs

- [ ] Add I/O nightly test for the many-small-file case.
- [ ] Add I/O nightly test for the large-file case.

## Related issue number

Closes #26383

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
