### PR TITLE
[Core] fix typo in InMemoryStoreClient::AsyncMultiGet callback handler name

### DIFF
--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -92,7 +92,7 @@ Status InMemoryStoreClient::AsyncMultiGet(
   }
   main_io_service_.post(
       [result = std::move(result), callback]() mutable { callback(std::move(result)); },
-      "GcsInMemoryStore.GetAll");
+      "GcsInMemoryStore.MultiGet");
   return Status::OK();
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Look like a typo was made in "in_memory_store_client.cc", AsyncMultiGet was using the name "GcsInMemoryStore.GetAll", this lead wrong handler statistics.
So this PR change the name to "GcsInMemoryStore.MultiGet".
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ x] This PR is not tested :(
