### PR TITLE
Fix test_serialization_error_message for pytest 6.x

### DIFF
--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -40,9 +40,10 @@ def scrub_traceback(ex):
     ex = re.sub("\\x1b\[39m", "", ex)
     # When running bazel test with pytest 6.x, the module name becomes
     # "python.ray.tests.test_traceback" instead of just "test_traceback"
-    ex = re.sub(r"python\.ray\.tests\.test_traceback", "test_traceback", ex)
+    # Also remove the "com_github_ray_project_ray" prefix, which may appear on Windows.
+    ex = re.sub(r"(com_github_ray_project_ray.)?python\.ray\.tests\.test_traceback", "test_traceback", ex)
     # Clean up object address.
-    ex = re.sub("object at .*>", "object at ADDRESS>", ex)
+    ex = re.sub("object at .*?>", "object at ADDRESS>", ex)
     return ex
 
 
@@ -350,40 +351,27 @@ def test_serialization_error_message(shutdown_only):
     with pytest.raises(TypeError) as excinfo:
         task_with_unserializable_arg.remote(lock)
 
-    def scrub_traceback(ex):
-        return re.sub("object at .*> for a", "object at ADDRESS> for a", ex)
-
-    test_prefix = "com_github_ray_project_ray.python.ray.tests."
-
-    assert clean_noqa(expected_output_task) == scrub_traceback(
-        str(excinfo.value)
-    ).replace(test_prefix, "")
+    assert clean_noqa(expected_output_task) == scrub_traceback(str(excinfo.value))
     """
     Test an actor with an unserializable object.
     """
     with pytest.raises(TypeError) as excinfo:
         a = A.remote(lock)
         print(a)
-    assert clean_noqa(expected_output_actor) == scrub_traceback(
-        str(excinfo.value)
-    ).replace(test_prefix, "")
+    assert clean_noqa(expected_output_actor) == scrub_traceback(str(excinfo.value))
     """
     Test the case where an unserializable object is captured by tasks.
     """
     with pytest.raises(TypeError) as excinfo:
         capture_lock.remote()
-    assert clean_noqa(expected_capture_output_task) == str(excinfo.value).replace(
-        test_prefix, ""
-    )
+    assert clean_noqa(expected_capture_output_task) == scrub_traceback(str(excinfo.value))
     """
     Test the case where an unserializable object is captured by actors.
     """
     with pytest.raises(TypeError) as excinfo:
         b = B.remote()
         print(b)
-    assert clean_noqa(expected_capture_output_actor) == str(excinfo.value).replace(
-        test_prefix, ""
-    )
+    assert clean_noqa(expected_capture_output_actor) == scrub_traceback(str(excinfo.value))
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -41,7 +41,11 @@ def scrub_traceback(ex):
     # When running bazel test with pytest 6.x, the module name becomes
     # "python.ray.tests.test_traceback" instead of just "test_traceback"
     # Also remove the "com_github_ray_project_ray" prefix, which may appear on Windows.
-    ex = re.sub(r"(com_github_ray_project_ray.)?python\.ray\.tests\.test_traceback", "test_traceback", ex)
+    ex = re.sub(
+        r"(com_github_ray_project_ray.)?python\.ray\.tests\.test_traceback",
+        "test_traceback",
+        ex,
+    )
     # Clean up object address.
     ex = re.sub("object at .*?>", "object at ADDRESS>", ex)
     return ex
@@ -364,14 +368,18 @@ def test_serialization_error_message(shutdown_only):
     """
     with pytest.raises(TypeError) as excinfo:
         capture_lock.remote()
-    assert clean_noqa(expected_capture_output_task) == scrub_traceback(str(excinfo.value))
+    assert clean_noqa(expected_capture_output_task) == scrub_traceback(
+        str(excinfo.value)
+    )
     """
     Test the case where an unserializable object is captured by actors.
     """
     with pytest.raises(TypeError) as excinfo:
         b = B.remote()
         print(b)
-    assert clean_noqa(expected_capture_output_actor) == scrub_traceback(str(excinfo.value))
+    assert clean_noqa(expected_capture_output_actor) == scrub_traceback(
+        str(excinfo.value)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I already fixed pytest 6.x compatibility in #22375.
However test_serialization_error_message uses a new "scrub_traceback" function, instead of the global one.
This PR fixes the issue again.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
