### PR TITLE
Revert "[CI]Split C++, Java tests in MacOS from the big one (#26434)"

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -61,25 +61,17 @@ steps:
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
 
 
-- label: ":mac: :apple: Ray Core, Dashboard and Serve"
+- label: ":mac: :apple: Ray C++, Java and Libraries"
   <<: *common
-  conditions: ["RAY_CI_SERVE_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DASHBOARD_AFFECTED"]
+  conditions: ["RAY_CI_SERVE_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_CPP_AFFECTED", "RAY_CI_JAVA_AFFECTED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DASHBOARD_AFFECTED"]
   commands:
+    - export RAY_INSTALL_JAVA=1
     - *prelude_commands
     - TORCH_VERSION=1.6 ./ci/env/install-dependencies.sh
     # Use --dynamic_mode=off until MacOS CI runs on Big Sur or newer. Otherwise there are problems with running tests
     # with dynamic linking.
     - bazel test --config=ci --dynamic_mode=off --test_env=CI $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-post_wheel_build --
       //:all python/ray/serve/... python/ray/dashboard/... -rllib/... -core_worker_test
-    - *epilogue_commands
-
-
-- label: ":mac: :apple: Ray C++ and Java"
-  <<: *common
-  conditions: ["RAY_CI_CPP_AFFECTED", "RAY_CI_JAVA_AFFECTED"]
-  commands:
-    - export RAY_INSTALL_JAVA=1
-    - *prelude_commands
     # clang-format is needed by java/test.sh
     - pip install clang-format==12.0.1
     - ./java/test.sh

--- a/python/ray/serve/tests/test_cross_language.py
+++ b/python/ray/serve/tests/test_cross_language.py
@@ -1,5 +1,3 @@
-import pytest
-
 import ray
 from ray.job_config import JobConfig
 from ray import serve
@@ -9,7 +7,6 @@ from ray.serve.generated.serve_pb2 import JAVA, RequestMetadata, RequestWrapper
 from ray.tests.conftest import shutdown_only, maybe_external_redis  # noqa: F401
 
 
-@pytest.mark.skip(reason="TIMEOUT, see https://github.com/ray-project/ray/issues/26513")
 def test_controller_starts_java_replica(shutdown_only):  # noqa: F811
     ray.init(
         num_cpus=8,


### PR DESCRIPTION
This reverts commit 6ddbdaa81a67a746fceb23e6977f756976119638.
## Why are these changes needed?
I suspect this commit is causing osx tests not to run, see https://flaky-tests.ray.io/?owner=serverless
## Related issue number
related to https://github.com/ray-project/ray/pull/26434