### PR TITLE
[air/predictors] Allow creating Predictor directly from a UDF

### DIFF
--- a/python/ray/train/batch_predictor.py
+++ b/python/ray/train/batch_predictor.py
@@ -46,13 +46,20 @@ class BatchPredictor:
     def from_pandas_udf(
         cls, pandas_udf: Callable[[pd.DataFrame], pd.DataFrame]
     ) -> "BatchPredictor":
+        """Create a Predictor from a Pandas UDF.
+
+        Args:
+            pandas_udf: A function that takes a pandas.DataFrame and other
+                optional kwargs and returns a pandas.DataFrame.
+        """
+
         class PandasUDFPredictor(Predictor):
             @classmethod
             def from_checkpoint(cls, checkpoint, **kwargs):
-                return PandasUDFPredictor(None)
+                return PandasUDFPredictor()
 
             def _predict_pandas(self, df, **kwargs) -> "pd.DataFrame":
-                return pandas_udf(df)
+                return pandas_udf(df, **kwargs)
 
         return cls(
             checkpoint=Checkpoint.from_dict({"dummy": 1}),

--- a/python/ray/train/predictor.py
+++ b/python/ray/train/predictor.py
@@ -87,17 +87,24 @@ class Predictor(abc.ABC):
         """
         raise NotImplementedError
 
-    @staticmethod
+    @classmethod
     def from_pandas_udf(
-        pandas_udf: Callable[[pd.DataFrame], pd.DataFrame]
+        cls, pandas_udf: Callable[[pd.DataFrame], pd.DataFrame]
     ) -> "Predictor":
+        """Create a Predictor from a Pandas UDF.
+
+        Args:
+            pandas_udf: A function that takes a pandas.DataFrame and other
+                optional kwargs and returns a pandas.DataFrame.
+        """
+
         class PandasUDFPredictor(Predictor):
             @classmethod
-            def from_checkpoint(cls, **kwargs):
-                return PandasUDFPredictor(None)
+            def from_checkpoint(cls, checkpoint: Checkpoint, **kwargs):
+                return PandasUDFPredictor()
 
             def _predict_pandas(self, df, **kwargs) -> "pd.DataFrame":
-                return pandas_udf(df)
+                return pandas_udf(df, **kwargs)
 
         return PandasUDFPredictor.from_checkpoint(Checkpoint.from_dict({"dummy": 1}))
 

--- a/python/ray/train/predictor.py
+++ b/python/ray/train/predictor.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, Type
+from typing import Dict, Type, Callable
 
 import numpy as np
 import pandas as pd
@@ -86,6 +86,20 @@ class Predictor(abc.ABC):
             Predictor: Predictor object.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def from_pandas_udf(
+        pandas_udf: Callable[[pd.DataFrame], pd.DataFrame]
+    ) -> "Predictor":
+        class PandasUDFPredictor(Predictor):
+            @classmethod
+            def from_checkpoint(cls, **kwargs):
+                return PandasUDFPredictor(None)
+
+            def _predict_pandas(self, df, **kwargs) -> "pd.DataFrame":
+                return pandas_udf(df)
+
+        return PandasUDFPredictor.from_checkpoint(Checkpoint.from_dict({"dummy": 1}))
 
     @PublicAPI(stability="alpha")
     def predict(self, data: DataBatchType, **kwargs) -> DataBatchType:

--- a/python/ray/train/tests/test_predictor.py
+++ b/python/ray/train/tests/test_predictor.py
@@ -67,6 +67,25 @@ def test_predict(convert_from_pandas_mock, convert_to_pandas_mock):
     convert_from_pandas_mock.assert_called_once()
 
 
+def test_from_udf():
+    def check_truth(df, all_true=False):
+        if all_true:
+            return pd.DataFrame({"bool": [True] * len(df)})
+        return pd.DataFrame({"bool": df["a"] == df["b"]})
+
+    predictor = Predictor.from_pandas_udf(check_truth)
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 5, 6]})
+
+    output = predictor.predict(df)
+    output = output["bool"].tolist()
+    assert output == [True, False, False]
+
+    output = predictor.predict(df, all_true=True)
+    output = output["bool"].tolist()
+    assert output == [True, True, True]
+
+
 @mock.patch.object(DummyPredictor, "_predict_pandas", return_value=mock.DEFAULT)
 def test_kwargs(predict_pandas_mock):
     checkpoint = Checkpoint.from_dict({"factor": 2.0})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, it's very difficult to create a custom Predictor without buying into the whole Checkpoint / etc. framework. We should allow users to write:

BatchPredictor.from_pandas_udf(Callable[[pd.DataFrame], pd.DataFrame])

for custom use cases.

## Related issue number

Closes https://github.com/ray-project/ray/issues/26601

TODO:
- [x] Unit tests