### PR TITLE
Epsilon greedy exploration ignores custom action distributions

### DIFF
--- a/rllib/utils/exploration/epsilon_greedy.py
+++ b/rllib/utils/exploration/epsilon_greedy.py
@@ -123,19 +123,9 @@ class EpsilonGreedy(Exploration):
         )
 
         # Get the exploit action as the one with the highest logit value.
-        exploit_action = tf.argmax(q_values, axis=1)
-
+        exploit_action = action_distribution.deterministic_sample()
         batch_size = tf.shape(q_values)[0]
-        # Mask out actions with q-value=-inf so that we don't even consider
-        # them for exploration.
-        random_valid_action_logits = tf.where(
-            tf.equal(q_values, tf.float32.min),
-            tf.ones_like(q_values) * tf.float32.min,
-            tf.ones_like(q_values),
-        )
-        random_actions = tf.squeeze(
-            tf.random.categorical(random_valid_action_logits, 1), axis=1
-        )
+        random_actions = action_distribution.sample()
 
         chose_random = (
             tf.random.uniform(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Epsilon greedy hard-codes the default action distribution behavior rather than calling the actual distribution. As a result, if there is a custom action dist, it is completely ignored. In cases where there is complex logic in the custom action dist (e.g. autoregression), evaluation results will be garbage as will any training that uses epsilon greedy.

## Notes
1. previously, exploit_action and random_actions were exact copies of [deterministic_sample()](https://github.com/ray-project/ray/blob/4ce9686d9468b710359e2bf1a1942fbdac044c3e/rllib/models/tf/tf_action_dist.py#L62) and [sample()](https://github.com/ray-project/ray/blob/4ce9686d9468b710359e2bf1a1942fbdac044c3e/rllib/models/tf/tf_action_dist.py#L91), respectively, from Categorical in tf_action_dist.py 
2. creating random_valid_action_logits is an unnecessary step because -inf values will not be sampled (assuming a fix is issued for #24055, which so far has not happened)
3. I have only changed _get_tf_exploration_action_op so _get_torch_exploration_action still needs to be addressed

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
