### PR TITLE
[tune] Add external hooks in WandbLoggerCallback

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1369,12 +1369,12 @@ def job_hook(**kwargs):
     sys.exit(0)
 
 
-def find_free_port():
-    sock = socket.socket()
-    sock.bind(("", 0))
-    port = sock.getsockname()[1]
-    sock.close()
-    return port
+def wandb_setup_api_key_hook():
+    """
+    Example external hook to set up W&B API key in
+    WandbIntegrationTest.testWandbLoggerConfig
+    """
+    return "abcd"
 
 
 @dataclasses.dataclass

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1369,6 +1369,14 @@ def job_hook(**kwargs):
     sys.exit(0)
 
 
+def find_free_port():
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
 def wandb_setup_api_key_hook():
     """
     Example external hook to set up W&B API key in

--- a/python/ray/air/callbacks/wandb.py
+++ b/python/ray/air/callbacks/wandb.py
@@ -9,6 +9,7 @@ import numpy as np
 import urllib
 
 from ray import logger
+from ray._private.storage import _load_class
 from ray.tune.logger import LoggerCallback
 from ray.tune.utils import flatten_dict
 from ray.tune.experiment import Trial
@@ -22,6 +23,18 @@ except ImportError:
     wandb = None
 
 WANDB_ENV_VAR = "WANDB_API_KEY"
+WANDB_PROJECT_ENV_VAR = "WANDB_PROJECT_NAME"
+WANDB_GROUP_ENV_VAR = "WANDB_GROUP_NAME"
+# Hook that is invoked before wandb.init in the setup method of WandbLoggerCallback
+# to populate the API key if it isn't already set when initializing the callback.
+# It doesn't take in any arguments and returns the W&B API key.
+# Example: "your.module.wandb_setup_api_key_hook".
+WANDB_SETUP_API_KEY_HOOK = "WANDB_SETUP_API_KEY_HOOK"
+# Hook that is invoked after running wandb.init in WandbLoggerCallback
+# to process information about the W&B run.
+# It takes in a W&B run object and doesn't return anything.
+# Example: "your.module.wandb_process_run_info_hook".
+WANDB_PROCESS_RUN_INFO_HOOK = "WANDB_PROCESS_RUN_INFO_HOOK"
 _VALID_TYPES = (Number, wandb.data_types.Video, wandb.data_types.Image)
 _VALID_ITERABLE_TYPES = (wandb.data_types.Video, wandb.data_types.Image)
 
@@ -87,6 +100,15 @@ def _set_api_key(api_key_file: Optional[str] = None, api_key: Optional[str] = No
             raise ValueError("Both WandB `api_key_file` and `api_key` set.")
         with open(api_key_file, "rt") as fp:
             api_key = fp.readline().strip()
+    # Try to get API key from external hook
+    if not api_key and WANDB_SETUP_API_KEY_HOOK in os.environ:
+        try:
+            api_key = _load_class(os.environ[WANDB_SETUP_API_KEY_HOOK])()
+        except Exception as e:
+            logger.exception(
+                f"Error executing {WANDB_SETUP_API_KEY_HOOK} to setup API key: {e}",
+                exc_info=e,
+            )
     if api_key:
         os.environ[WANDB_ENV_VAR] = api_key
     elif not os.environ.get(WANDB_ENV_VAR):
@@ -148,7 +170,16 @@ class _WandbLoggingProcess(Process):
     def run(self):
         # Since we're running in a separate process already, use threads.
         os.environ["WANDB_START_METHOD"] = "thread"
-        wandb.init(*self.args, **self.kwargs)
+        run = wandb.init(*self.args, **self.kwargs)
+
+        # Run external hook to process information about wandb run
+        if WANDB_PROCESS_RUN_INFO_HOOK in os.environ:
+            try:
+                _load_class(os.environ[WANDB_PROCESS_RUN_INFO_HOOK])(run)
+            except Exception as e:
+                logger.exception(
+                    f"Error calling {WANDB_PROCESS_RUN_INFO_HOOK}: {e}", exc_info=e
+                )
 
         while True:
             item_type, item_content = self.queue.get()
@@ -265,7 +296,7 @@ class WandbLoggerCallback(LoggerCallback):
 
     def __init__(
         self,
-        project: str,
+        project: Optional[str] = None,
         group: Optional[str] = None,
         api_key_file: Optional[str] = None,
         api_key: Optional[str] = None,
@@ -291,6 +322,18 @@ class WandbLoggerCallback(LoggerCallback):
             os.path.expanduser(self.api_key_path) if self.api_key_path else None
         )
         _set_api_key(self.api_key_file, self.api_key)
+
+        # Try to get project and group from environment variables if not
+        # passed through WandbLoggerCallback.
+        if not self.project and os.environ.get(WANDB_PROJECT_ENV_VAR):
+            self.project = os.environ.get(WANDB_PROJECT_ENV_VAR)
+        if not self.project:
+            raise ValueError(
+                "Please pass the project name as argument or through "
+                f"the {WANDB_PROJECT_ENV_VAR} environment variable."
+            )
+        if not self.group and os.environ.get(WANDB_GROUP_ENV_VAR):
+            self.group = os.environ.get(WANDB_GROUP_ENV_VAR)
 
     def log_trial_start(self, trial: "Trial"):
         config = trial.config.copy()

--- a/python/ray/tune/tests/test_integration_wandb.py
+++ b/python/ray/tune/tests/test_integration_wandb.py
@@ -3,6 +3,10 @@ import tempfile
 from collections import namedtuple
 from multiprocessing import Queue
 import unittest
+from unittest.mock import (
+    Mock,
+    patch,
+)
 
 import numpy as np
 
@@ -16,6 +20,9 @@ from ray.air.callbacks.wandb import (
     WandbLoggerCallback,
     _WandbLoggingProcess,
     WANDB_ENV_VAR,
+    WANDB_GROUP_ENV_VAR,
+    WANDB_PROJECT_ENV_VAR,
+    WANDB_SETUP_API_KEY_HOOK,
     _QueueItem,
 )
 from ray.tune.result import TRIAL_INFO
@@ -94,6 +101,37 @@ class WandbIntegrationTest(unittest.TestCase):
         if WANDB_ENV_VAR in os.environ:
             del os.environ[WANDB_ENV_VAR]
 
+    def testWandbLoggingProcessRunInfoHook(self):
+        """
+        Test WANDB_PROCESS_RUN_INFO_HOOK in _WandbLoggingProcess is
+        correctly called by calling _WandbLoggingProcess.run() mocking
+        out calls to wandb.
+        """
+        mock_run = Mock()  # Mock W&B run
+        mock_init = Mock(return_value=mock_run)  # Mock call to wandb.init()
+        mock_finish = Mock()  # Mock call to wandb.finish()
+        mock_external_hook = Mock()  # Mock external hook method
+        mock_load_class = Mock(return_value=mock_external_hook)
+        mock_queue = Mock(get=Mock(return_value=(_QueueItem.END, None)))
+        os.environ["WANDB_PROCESS_RUN_INFO_HOOK"] = "mock_wandb_process_run_info_hook"
+
+        with patch.multiple(
+            "ray.air.callbacks.wandb.wandb", init=mock_init, finish=mock_finish
+        ), patch.multiple(
+            "ray.air.callbacks.wandb", _load_class=mock_load_class
+        ), patch.multiple(
+            "ray.air.callbacks.wandb.os", chdir=Mock()
+        ):
+            logging_process = _WandbLoggingProcess(
+                logdir="mock_logdir", queue=mock_queue, exclude=[], to_config=[]
+            )
+            logging_process.run()
+
+        mock_init.assert_called_once()
+        mock_load_class.assert_called_once_with("mock_wandb_process_run_info_hook")
+        mock_external_hook.assert_called_once_with(mock_run)
+        mock_finish.assert_called_once()
+
     def testWandbLoggerConfig(self):
         trial_config = {"par1": 4, "par2": 9.12345678}
         trial = Trial(
@@ -107,6 +145,17 @@ class WandbIntegrationTest(unittest.TestCase):
 
         if WANDB_ENV_VAR in os.environ:
             del os.environ[WANDB_ENV_VAR]
+
+        # Read project and group name from environment variable
+        os.environ[WANDB_PROJECT_ENV_VAR] = "test_project_from_env_var"
+        os.environ[WANDB_GROUP_ENV_VAR] = "test_group_from_env_var"
+        logger = WandbTestExperimentLogger(api_key="1234")
+        logger.setup()
+        assert logger.project == "test_project_from_env_var"
+        assert logger.group == "test_group_from_env_var"
+
+        del logger
+        del os.environ[WANDB_ENV_VAR]
 
         # No API key
         with self.assertRaises(ValueError):
@@ -134,6 +183,18 @@ class WandbIntegrationTest(unittest.TestCase):
 
         del logger
         del os.environ[WANDB_ENV_VAR]
+
+        # API Key from external hook
+        os.environ[
+            WANDB_SETUP_API_KEY_HOOK
+        ] = "ray._private.test_utils.wandb_setup_api_key_hook"
+        logger = WandbTestExperimentLogger(project="test_project")
+        logger.setup()
+        self.assertEqual(os.environ[WANDB_ENV_VAR], "abcd")
+
+        del logger
+        del os.environ[WANDB_ENV_VAR]
+        del os.environ[WANDB_SETUP_API_KEY_HOOK]
 
         # API Key in env
         os.environ[WANDB_ENV_VAR] = "9012"
@@ -354,10 +415,7 @@ class WandbIntegrationTest(unittest.TestCase):
 
         config = {
             "env": "CartPole-v0",
-            "wandb": {
-                "project": "test_project",
-                "api_key": "1234",
-            },
+            "wandb": {"project": "test_project", "api_key": "1234"},
         }
 
         # Test that trainer object can be initialized


### PR DESCRIPTION
Signed-off-by: Nikita Vemuri <nikitavemuri@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Reopening https://github.com/ray-project/ray/pull/26346
This is an experimental feature, so the following changes are added only to the `WandbLoggerCallback`. We are planning to collect feedback about usage and accordingly update or add these changes to the other W&B integration interfaces.

- Allow reading the W&B project name and group name from environment variable if not already passed to callback
- Add external hooks to fetch W&B API key, and to process any information about W&B run

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
