### PR TITLE
[Datasets] Add clearer actionable error message for AWS S3 credential error

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -167,7 +167,10 @@ class DefaultFileMetadataProvider(BaseFileMetadataProvider):
         expanded_paths = []
         file_infos = []
         for path in paths:
-            file_info = filesystem.get_file_info(path)
+            try:
+                file_info = filesystem.get_file_info(path)
+            except OSError as e:
+                _handle_read_s3_files_error(e, path)
             if file_info.type == FileType.Directory:
                 paths, file_infos_ = _expand_directory(path, filesystem)
                 expanded_paths.extend(paths)
@@ -324,3 +327,25 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
             return _fetch_metadata_remotely(pieces)
         else:
             return _fetch_metadata(pieces)
+
+
+def _handle_read_s3_files_error(error: OSError, paths: Union[str, List[str]]) -> str:
+    # Specially handle AWS error when reading files, to give a clearer error message
+    # to avoid confusing users. The real issus is most likely to be AWS S3 file
+    # credential not haven been properly configured yet.
+    if "AWS Error [code 15]: No response body" in str(error):
+        if isinstance(paths, str):
+            # Quote to highlight single file path in error message for better
+            # readability. List of file paths will be shown up as ['foo', 'boo'],
+            # so only quote single file path here.
+            paths = f'"{paths}"'
+        raise PermissionError(
+            (
+                f"Failing to read AWS S3 file(s): {paths}. "
+                "Please check file exists and has proper AWS credential. "
+                "See https://docs.ray.io/en/latest/data/creating-datasets.html#reading-from-remote-storage "  # noqa
+                "for more information."
+            )
+        )
+    else:
+        raise error

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -331,8 +331,8 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
 
 def _handle_read_s3_files_error(error: OSError, paths: Union[str, List[str]]) -> str:
     # Specially handle AWS error when reading files, to give a clearer error message
-    # to avoid confusing users. The real issus is most likely to be AWS S3 file
-    # credential not haven been properly configured yet.
+    # to avoid confusing users. The real issue is most likely that the AWS S3 file
+    # credentials have not been properly configured yet.
     if "AWS Error [code 15]: No response body" in str(error):
         if isinstance(paths, str):
             # Quote to highlight single file path in error message for better
@@ -342,7 +342,7 @@ def _handle_read_s3_files_error(error: OSError, paths: Union[str, List[str]]) ->
         raise PermissionError(
             (
                 f"Failing to read AWS S3 file(s): {paths}. "
-                "Please check file exists and has proper AWS credential. "
+                "Please check that file exists and has properly configured access. "
                 "See https://docs.ray.io/en/latest/data/creating-datasets.html#reading-from-remote-storage "  # noqa
                 "for more information."
             )

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2903,6 +2903,23 @@ def test_read_text_remote_args(ray_start_cluster, tmp_path):
     assert sorted(ds.take()) == ["goodbye", "hello", "world"]
 
 
+def test_read_s3_file_error(ray_start_regular_shared, s3_path):
+    dummy_path = s3_path + "_dummy"
+    error_message = "Please check file exists and has proper AWS credential"
+    with pytest.raises(PermissionError) as e:
+        ray.data.read_parquet(dummy_path)
+        assert error_message in str(e)
+    with pytest.raises(PermissionError) as e:
+        ray.data.read_binary_files(dummy_path)
+        assert error_message in str(e)
+    with pytest.raises(PermissionError) as e:
+        ray.data.read_csv(dummy_path)
+        assert error_message in str(e)
+    with pytest.raises(PermissionError) as e:
+        ray.data.read_json(dummy_path)
+        assert error_message in str(e)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2905,7 +2905,7 @@ def test_read_text_remote_args(ray_start_cluster, tmp_path):
 
 def test_read_s3_file_error(ray_start_regular_shared, s3_path):
     dummy_path = s3_path + "_dummy"
-    error_message = "Please check file exists and has proper AWS credential"
+    error_message = "Please check that file exists and has properly configured access."
     with pytest.raises(PermissionError) as e:
         ray.data.read_parquet(dummy_path)
         assert error_message in str(e)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
In https://github.com/ray-project/ray/issues/19799, and https://github.com/ray-project/ray/issues/24184, we found when using Datasets to read S3 file, if file's credential is not set up right, the `read_xxx` API would throw confusing error message with `AWS Error [code 15]: No response body` like below:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 758, in read_binary_files
    return read_datasource(
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 267, in read_datasource
    requested_parallelism, min_safe_parallelism, read_tasks = ray.get(
  File "/Users/chengsu/ray/python/ray/_private/client_mode_hook.py", line 105, in wrapper
    return func(*args, **kwargs)
  File "/Users/chengsu/ray/python/ray/_private/worker.py", line 2196, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(PermissionError): ray::_get_read_tasks() (pid=80200, ip=127.0.0.1)
  File "pyarrow/_fs.pyx", line 439, in pyarrow._fs.FileSystem.get_file_info
  File "pyarrow/error.pxi", line 143, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 114, in pyarrow.lib.check_status
OSError: When getting information for key 'trainaasdasd' in bucket 'balajis-tiny-imagenet': AWS Error [code 15]: No response body.
```

The error message mentions nothing related to file credential, so it's quite confusing. This PR is to catch the error and give a better error message:

```
ray::_get_read_tasks() (pid=80200, ip=127.0.0.1)
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 1127, in _get_read_tasks
    reader = ds.create_reader(**kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 212, in create_reader
    return _FileBasedDatasourceReader(self, **kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 350, in __init__
    self._paths, self._file_sizes = meta_provider.expand_paths(
  File "/Users/chengsu/ray/python/ray/data/datasource/file_meta_provider.py", line 173, in expand_paths
    _handle_read_s3_files_error(e, path)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_meta_provider.py", line 342, in _handle_read_s3_files_error
    raise PermissionError(
PermissionError: Failing to read AWS S3 file(s): "balajis-tiny-imagenet/trainaasdasd". Please check file exists and has proper AWS credential. See https://docs.ray.io/en/latest/data/creating-datasets.html#reading-from-remote-storage for more information.
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/19799 and https://github.com/ray-project/ray/issues/24184

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
