### PR TITLE
[RFC] Estimate parquet decompression ratio

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -259,10 +259,10 @@ class _ParquetDatasourceReader(Reader):
         # Sample a few rows from the row group to estimate the ratio.
         # TODO(ekl/cheng) take into account column pruning.
         num_samples = min(
-            PARQUET_COMPRESSION_RATIO_ESTIMATE_NUM_SAMPLES, len(self._pq_ds.pieces))
+            PARQUET_COMPRESSION_RATIO_ESTIMATE_NUM_SAMPLES, len(self._pq_ds.pieces)
+        )
         row_group_samples = [
-            p.subset(row_group_ids=[0])
-            for p in self._pq_ds.pieces[:num_samples]
+            p.subset(row_group_ids=[0]) for p in self._pq_ds.pieces[:num_samples]
         ]
         sample_ratios = []
         for rg in row_group_samples:
@@ -271,10 +271,15 @@ class _ParquetDatasourceReader(Reader):
             sample_row_size = rg.head(1).nbytes
             sample_ratios.append(sample_row_size / sample_rg_row_size)
         mean_ratio = np.mean(sample_ratios)
-        logger.info(
-            f"Estimated parquet decompression ratio {mean_ratio} "
-            f"(mean of samples {sample_ratios}).")
-        return max(PARQUET_COMPRESSION_RATIO_ESTIMATE_LOWER_BOUND, mean_ratio)
+
+        if mean_ratio > PARQUET_COMPRESSION_RATIO_ESTIMATE_LOWER_BOUND:
+            logger.info(
+                f"Estimated parquet decompression ratio is {mean_ratio} "
+                f"(mean of samples {sample_ratios})."
+            )
+            return mean_ratio
+
+        return PARQUET_COMPRESSION_RATIO_ESTIMATE_LOWER_BOUND
 
 
 def _read_pieces(


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Datasets relies on size estimation for ensuring block sizes are not too large, and also to enable users to create DatasetPipelines that can fit into memory. However, with parquet we don't know the full decoded size in memory (https://github.com/ray-project/ray/pull/26516). This PR proposes to improve the size estimate by sampling a few rows from row groups, to catch cases where the hard-coded ratio is wildly off (e.g., in the below example, the ratio is 605x).

Before:
```
>>> ray.data.read_parquet("/tmp/tensor").size_bytes()
858550
```

After:
```
>>> ray.data.read_parquet("/tmp/tensor").size_bytes()
INFO parquet_datasource.py:274 -- Estimated parquet decompression ratio 605.905305456875
(mean of samples [605.905305456875, 605.905305456875]).
104040000.0
```
