### PR TITLE
Add type validation for ray.autoscaler.sdk.request_resources()

### DIFF
--- a/python/ray/autoscaler/sdk/sdk.py
+++ b/python/ray/autoscaler/sdk/sdk.py
@@ -240,6 +240,24 @@ def request_resources(
         >>> request_resources( # doctest: +SKIP
         ...     bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}])
     """
+    if num_cpus is not None and not isinstance(num_cpus, int):
+        raise TypeError("num_cpus should be of type int.")
+    if bundles is not None:
+        if isinstance(bundles, List):
+            for bundle in bundles:
+                if isinstance(bundle, Dict):
+                    for key in bundle.keys():
+                        if not isinstance(key, str) and not isinstance(
+                            bundle[key], int
+                        ):
+                            raise TypeError(
+                                "each bundle key should be str and value as int."
+                            )
+                else:
+                    raise TypeError("each bundle should be a Dict.")
+        else:
+            raise TypeError("bundles should be of type List")
+
     return commands.request_resources(num_cpus, bundles)
 
 

--- a/python/ray/autoscaler/sdk/sdk.py
+++ b/python/ray/autoscaler/sdk/sdk.py
@@ -247,9 +247,7 @@ def request_resources(
             for bundle in bundles:
                 if isinstance(bundle, Dict):
                     for key in bundle.keys():
-                        if not isinstance(key, str) and not isinstance(
-                            bundle[key], int
-                        ):
+                        if not (isinstance(key, str) and isinstance(bundle[key], int)):
                             raise TypeError(
                                 "each bundle key should be str and value as int."
                             )

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -3561,6 +3561,21 @@ MemAvailable:   33000000 kB
                     monitor.run()
                 mock_publish.assert_called_once()
 
+    def testInitializeSDKArguments(self):
+        # https://github.com/ray-project/ray/issues/23166
+        from ray.autoscaler.sdk import request_resources
+
+        with self.assertRaises(TypeError):
+            request_resources(num_cpus="bar")
+        with self.assertRaises(TypeError):
+            request_resources(bundles="bar")
+        with self.assertRaises(TypeError):
+            request_resources(bundles=["foo"])
+        with self.assertRaises(TypeError):
+            request_resources(bundles=[{"foo": "bar"}])
+        with self.assertRaises(TypeError):
+            request_resources(bundles=[{"foo": 1}, {"bar": "baz"}])
+
 
 def test_import():
     """This test ensures that all the autoscaler imports work as expected to


### PR DESCRIPTION
## Why are these changes needed?

[#23166](https://github.com/ray-project/ray/issues/23166) needed type validation in autoscaler for bundles.

## Related issue number

Closes #23166 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
