### PR TITLE
[RLlib] Warn on PPO infinite KL loss term

### DIFF
--- a/rllib/algorithms/ppo/ppo_tf_policy.py
+++ b/rllib/algorithms/ppo/ppo_tf_policy.py
@@ -23,7 +23,7 @@ from ray.rllib.policy.tf_mixins import (
 )
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
-from ray.rllib.utils.tf_utils import explained_variance
+from ray.rllib.utils.tf_utils import explained_variance, warn_if_infinite_kl_divergence
 from ray.rllib.utils.typing import AlgorithmConfigDict, TensorType, TFPolicyV2Type
 
 tf1, tf, tfv = try_import_tf()
@@ -160,15 +160,7 @@ def get_ppo_tf_policy(base: TFPolicyV2Type) -> TFPolicyV2Type:
             if self.config["kl_coeff"] > 0.0:
                 action_kl = prev_action_dist.kl(curr_action_dist)
                 mean_kl_loss = reduce_mean_valid(action_kl)
-                # Warn on infinite KL
-                if self.loss_initialized():
-                    # TODO smorad: should we do anything besides warn? Could discard KL term
-                    # for this update
-                    tf.cond(
-                        tf.math.is_inf(mean_kl_loss),
-                        false_fn=lambda: mean_kl_loss,
-                        true_fn=lambda: warn_kl_loss(mean_kl_loss),
-                    )
+                warn_if_infinite_kl_divergence(self, mean_kl_loss)
             else:
                 mean_kl_loss = tf.constant(0.0)
 

--- a/rllib/algorithms/ppo/ppo_tf_policy.py
+++ b/rllib/algorithms/ppo/ppo_tf_policy.py
@@ -50,8 +50,7 @@ def warn_kl_loss(mean_kl_loss):
         " training process. Action(s) in a specific state have near-zero probability."
         " This can happen naturally in deterministic environments where the optimal"
         " policy has zero mass for a specific action. To fix this issue, consider"
-        " setting 'kl_coeff' to zero or increasing 'entropy_coeff'. Discarding KL loss"
-        " term for this update."
+        " setting 'kl_coeff' to zero or increasing 'entropy_coeff'."
     )
     return tf.constant(0.0)
 

--- a/rllib/algorithms/ppo/ppo_tf_policy.py
+++ b/rllib/algorithms/ppo/ppo_tf_policy.py
@@ -44,17 +44,6 @@ def validate_config(config: AlgorithmConfigDict) -> None:
         )
 
 
-def warn_kl_loss(mean_kl_loss):
-    logger.warning(
-        "KL divergence is non-finite, this will likely destabilize your model and the"
-        " training process. Action(s) in a specific state have near-zero probability."
-        " This can happen naturally in deterministic environments where the optimal"
-        " policy has zero mass for a specific action. To fix this issue, consider"
-        " setting 'kl_coeff' to zero or increasing 'entropy_coeff'."
-    )
-    return tf.constant(0.0)
-
-
 # We need this builder function because we want to share the same
 # custom logics between TF1 dynamic and TF2 eager policies.
 def get_ppo_tf_policy(base: TFPolicyV2Type) -> TFPolicyV2Type:

--- a/rllib/algorithms/ppo/ppo_tf_policy.py
+++ b/rllib/algorithms/ppo/ppo_tf_policy.py
@@ -164,12 +164,13 @@ def get_ppo_tf_policy(base: TFPolicyV2Type) -> TFPolicyV2Type:
                 mean_kl_loss = reduce_mean_valid(action_kl)
                 # Warn on infinite KL
                 if self.loss_initialized():
+                    # TODO smorad: should we do anything besides warn? Could discard KL term
+                    # for this update
                     tf.cond(
                         tf.math.is_inf(mean_kl_loss),
                         false_fn=lambda: mean_kl_loss,
                         true_fn=lambda: warn_kl_loss(mean_kl_loss),
                     )
-                    mean_kl_loss = tf.constant(0.0)
             else:
                 mean_kl_loss = tf.constant(0.0)
 

--- a/rllib/algorithms/ppo/ppo_tf_policy.py
+++ b/rllib/algorithms/ppo/ppo_tf_policy.py
@@ -83,7 +83,6 @@ def get_ppo_tf_policy(base: TFPolicyV2Type) -> TFPolicyV2Type:
             existing_model=None,
             existing_inputs=None,
         ):
-            self.should_warn_kl = False
             # First thing first, enable eager execution if necessary.
             base.enable_eager_execution_if_necessary()
 

--- a/rllib/algorithms/ppo/ppo_torch_policy.py
+++ b/rllib/algorithms/ppo/ppo_torch_policy.py
@@ -129,7 +129,8 @@ class PPOTorchPolicy(
                     " 'kl_coeff' to zero or increasing 'entropy_coeff'. Discarding KL"
                     " loss term for this update."
                 )
-                mean_kl_loss = torch.tensor(0.0, device=logp_ratio.device)
+                # TODO smorad: should we do anything besides warn? Could discard KL term
+                # for this update
         else:
             mean_kl_loss = torch.tensor(0.0, device=logp_ratio.device)
 

--- a/rllib/algorithms/ppo/ppo_torch_policy.py
+++ b/rllib/algorithms/ppo/ppo_torch_policy.py
@@ -126,8 +126,7 @@ class PPOTorchPolicy(
                     " have near-zero probability. This can happen naturally in"
                     " deterministic environments where the optimal policy has zero mass"
                     " for a specific action. To fix this issue, consider setting"
-                    " 'kl_coeff' to zero or increasing 'entropy_coeff'. Discarding KL"
-                    " loss term for this update."
+                    " 'kl_coeff' to zero or increasing 'entropy_coeff'."
                 )
                 # TODO smorad: should we do anything besides warn? Could discard KL term
                 # for this update

--- a/rllib/algorithms/ppo/ppo_torch_policy.py
+++ b/rllib/algorithms/ppo/ppo_torch_policy.py
@@ -24,6 +24,7 @@ from ray.rllib.utils.torch_utils import (
     apply_grad_clipping,
     explained_variance,
     sequence_mask,
+    warn_if_infinite_kl_divergence,
 )
 from ray.rllib.utils.typing import TensorType
 
@@ -119,17 +120,9 @@ class PPOTorchPolicy(
         if self.config["kl_coeff"] > 0.0:
             action_kl = prev_action_dist.kl(curr_action_dist)
             mean_kl_loss = reduce_mean_valid(action_kl)
-            if self.loss_initialized() and mean_kl_loss.isinf():
-                logger.warning(
-                    "KL divergence is non-finite, this will likely destabilize your"
-                    " model and the training process. Action(s) in a specific state"
-                    " have near-zero probability. This can happen naturally in"
-                    " deterministic environments where the optimal policy has zero mass"
-                    " for a specific action. To fix this issue, consider setting"
-                    " 'kl_coeff' to zero or increasing 'entropy_coeff'."
-                )
-                # TODO smorad: should we do anything besides warn? Could discard KL term
-                # for this update
+            # TODO smorad: should we do anything besides warn? Could discard KL term
+            # for this update
+            warn_if_infinite_kl_divergence(self, mean_kl_loss)
         else:
             mean_kl_loss = torch.tensor(0.0, device=logp_ratio.device)
 

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -143,6 +143,7 @@ class TorchPolicy(Policy):
                 divisibility requirement for sample batches given the Policy.
         """
         self.framework = config["framework"] = "torch"
+        self._loss_initialized = False
         super().__init__(observation_space, action_space, config)
 
         # Create multi-GPU model towers, if necessary.

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -75,6 +75,7 @@ class TorchPolicyV2(Policy):
         """
         self.framework = config["framework"] = "torch"
 
+        self._loss_initialized = False
         super().__init__(observation_space, action_space, config)
 
         # Create model.
@@ -195,6 +196,9 @@ class TorchPolicyV2(Policy):
 
         self.batch_divisibility_req = self.get_batch_divisibility_req()
         self.max_seq_len = max_seq_len
+
+    def loss_initialized(self):
+        return self._loss_initialized
 
     @DeveloperAPI
     @OverrideToImplementCustomLogic

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import tree  # pip install dm_tree
 from typing import Any, Callable, List, Optional, Type, TYPE_CHECKING, Union
 
-from ray.rllib.utils.annotations import PublicAPI
+from ray.rllib.utils.annotations import PublicAPI, DeveloperAPI
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.spaces.space_utils import get_base_struct_from_space
 from ray.rllib.utils.typing import (
@@ -545,6 +545,7 @@ def zero_logps_from_actions(actions: TensorStructType) -> TensorType:
     return logp_
 
 
+@DeveloperAPI
 def warn_if_infinite_kl_divergence(
     policy: Type["TFPolicy"], mean_kl_loss: TensorType
 ) -> None:

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -545,14 +545,9 @@ def zero_logps_from_actions(actions: TensorStructType) -> TensorType:
     return logp_
 
 
-def warn_if_infinite_kl_divergence(policy: Type["TFPolicy"], mean_kl_loss: TensorType):
-    if policy.loss_initialized():
-        tf.cond(
-            tf.math.is_inf(mean_kl_loss),
-            false_fn=lambda: tf.constant(0.0),
-            true_fn=lambda: print_warning(),
-        )
-
+def warn_if_infinite_kl_divergence(
+    policy: Type["TFPolicy"], mean_kl_loss: TensorType
+) -> None:
     def print_warning():
         logger.warning(
             "KL divergence is non-finite, this will likely destabilize your model and"
@@ -563,3 +558,10 @@ def warn_if_infinite_kl_divergence(policy: Type["TFPolicy"], mean_kl_loss: Tenso
             " increasing policy entropy."
         )
         return tf.constant(0.0)
+
+    if policy.loss_initialized():
+        tf.cond(
+            tf.math.is_inf(mean_kl_loss),
+            false_fn=lambda: tf.constant(0.0),
+            true_fn=lambda: print_warning(),
+        )

--- a/rllib/utils/tf_utils.py
+++ b/rllib/utils/tf_utils.py
@@ -1,5 +1,6 @@
 import gym
 from gym.spaces import Discrete, MultiDiscrete
+import logging
 import numpy as np
 import tree  # pip install dm_tree
 from typing import Any, Callable, List, Optional, Type, TYPE_CHECKING, Union
@@ -19,6 +20,7 @@ from ray.rllib.utils.typing import (
 if TYPE_CHECKING:
     from ray.rllib.policy.tf_policy import TFPolicy
 
+logger = logging.getLogger(__name__)
 tf1, tf, tfv = try_import_tf()
 
 
@@ -259,7 +261,7 @@ def get_tf_eager_cls_if_necessary(
             pass
         else:
             raise ValueError(
-                "This policy does not support eager " "execution: {}".format(orig_cls)
+                "This policy does not support eager execution: {}".format(orig_cls)
             )
 
         # Now that we know, policy is an eager one, add tracing, if necessary.
@@ -541,3 +543,23 @@ def zero_logps_from_actions(actions: TensorStructType) -> TensorType:
     while len(logp_.shape) > 1:
         logp_ = logp_[:, 0]
     return logp_
+
+
+def warn_if_infinite_kl_divergence(policy: Type["TFPolicy"], mean_kl_loss: TensorType):
+    if policy.loss_initialized():
+        tf.cond(
+            tf.math.is_inf(mean_kl_loss),
+            false_fn=lambda: tf.constant(0.0),
+            true_fn=lambda: print_warning(),
+        )
+
+    def print_warning():
+        logger.warning(
+            "KL divergence is non-finite, this will likely destabilize your model and"
+            " the training process. Action(s) in a specific state have near-zero"
+            " probability. This can happen naturally in deterministic environments"
+            " where the optimal policy has zero mass for a specific action. To fix this"
+            " issue, consider setting the coefficient for the KL loss term to zero or"
+            " increasing policy entropy."
+        )
+        return tf.constant(0.0)

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -531,7 +531,8 @@ def sequence_mask(
 
 
 def warn_if_infinite_kl_divergence(
-    policy: "TorchPolicy", kl_divergence: torch.Tensor
+    policy: "TorchPolicy",
+    kl_divergence: TensorType,
 ) -> None:
     if policy.loss_initialized() and kl_divergence.isinf():
         logger.warning(

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -10,7 +10,7 @@ from gym.spaces import Discrete, MultiDiscrete
 
 import ray
 from ray.rllib.models.repeated_values import RepeatedValues
-from ray.rllib.utils.annotations import Deprecated, PublicAPI
+from ray.rllib.utils.annotations import Deprecated, PublicAPI, DeveloperAPI
 from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.numpy import SMALL_NUMBER
 from ray.rllib.utils.typing import (
@@ -530,6 +530,7 @@ def sequence_mask(
     return mask
 
 
+@DeveloperAPI
 def warn_if_infinite_kl_divergence(
     policy: "TorchPolicy",
     kl_divergence: TensorType,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In some cases, the probability of a specific action may become very close to zero, causing a divide-by-zero error for the action when computing KL divergence for PPO. This can result in the KL loss term going to infinity. We should at least warn the user when this is detected, and possibly even drop the KL term from that specific update.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
