### PR TITLE
[Data][split] always spread the split tasks.

### DIFF
--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -139,7 +139,7 @@ def _split_all_blocks(
         else:
             # otherwise call split remote function.
             split_single_block_futures.append(
-                split_single_block.remote(
+                split_single_block.options(scheduling_strategy="SPREAD").remote(
                     block_id,
                     block_ref,
                     meta,


### PR DESCRIPTION
Signed-off-by: scv119 <scv119@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

My experiments (the [script](https://gist.github.com/scv119/8b769c405bfa1ee6a29fefb8e14bfdc9) 
) showed that dataset.split_at_indices() with SPREAD tasks have more predictable performance 
- Concretely: on 10 m5.4xlarge nodes with 5000 iops disk
- calling ds.split_at_indices(81)  on 200GB dataset with 400 blocks: the `split_at_indices` without this PR takes 7-19 seconds, `split_at_indices`  with `SPREAD`  takes 7-12 seconds.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
