### PR TITLE
[Data][split] use split_at_indices for equal split without locality hints

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -877,7 +877,7 @@ class Dataset(Generic[T]):
         if n <= 0:
             raise ValueError(f"The number of splits {n} is not positive.")
 
-        # fallback to spilit_at_indices for equal split without locality hints.
+        # fallback to split_at_indices for equal split without locality hints.
         # simple SSML benchmarks shows spilit_at_indices yields more stable performance.
         # https://github.com/ray-project/ray/pull/26641 for more context.
         if equal and locality_hints is None:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -878,7 +878,7 @@ class Dataset(Generic[T]):
             raise ValueError(f"The number of splits {n} is not positive.")
 
         # fallback to split_at_indices for equal split without locality hints.
-        # simple SSML benchmarks shows spilit_at_indices yields more stable performance.
+        # simple benchmarks shows spilit_at_indices yields more stable performance.
         # https://github.com/ray-project/ray/pull/26641 for more context.
         if equal and locality_hints is None:
             count = self.count()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -877,6 +877,16 @@ class Dataset(Generic[T]):
         if n <= 0:
             raise ValueError(f"The number of splits {n} is not positive.")
 
+        if equal:
+            count = self.count()
+            split_index = count // n
+            # we are creating n split_indices which will generate
+            # n + 1 splits; the last split will at most contains (n - 1)
+            # rows, which could be safely dropped.
+            split_indices = [split_index * i for i in range(1, n + 1)]
+            shards = self.split_at_indices(split_indices)
+            return shards[:n]
+
         if locality_hints and len(locality_hints) != n:
             raise ValueError(
                 f"The length of locality_hints {len(locality_hints)} "

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -239,8 +239,8 @@ class DatasetPipeline(Generic[T]):
             equal: Whether to guarantee each split has an equal
                 number of records. This may drop records if they cannot be
                 divided equally among the splits.
-            locality_hints: A list of Ray actor handles of size ``n``. The
-                system will try to co-locate the blocks of the ith pipeline
+            locality_hints: [Experimental] A list of Ray actor handles of size ``n``.
+                The system will try to co-locate the blocks of the ith pipeline
                 shard with the ith actor to maximize data locality.
 
         Returns:


### PR DESCRIPTION
Signed-off-by: scv119 <scv119@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR replaces dataset.split(.., equal=True)  implementation by dataset.split_at_indices() . My experiments (the [script](https://gist.github.com/scv119/8b769c405bfa1ee6a29fefb8e14bfdc9) 
) showed that dataset.split_at_indices() have more predictable performance than the dataset.split(…)

Concretely: on 10 m5.4xlarge nodes with 5000 iops disk

-  calling ds.split(81)  on 200GB dataset with 400 blocks: the split takes 20-40 seconds, split_at_indices takes ~12 seconds.

-  calling ds.split(163) on 200GB dataset with 400 blocks, the split takes 40-100 seconds, split_at_indices takes ~24 seconds.

I don’t have much insight of dataset.split implementation, but with dataset.split_at_indices() we are just doing SPREAD to num_split_at_indices tasks, which yield much stable performance.

Note: clean up the usage of experimental locality_hints in https://github.com/ray-project/ray/pull/26647

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
