### PR TITLE
Updates limit-tasks example

### DIFF
--- a/doc/source/ray-core/doc_code/limit_tasks.py
+++ b/doc/source/ray-core/doc_code/limit_tasks.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+import ray
+
+ray.init()
+
+
+# __defining_actor_start__
+@ray.remote
+class Actor:
+    def heavy_compute(self, large_array):
+        # taking a long time...
+        return
+
+
+# __defining_actor_end__
+
+
+# __creating_actor_start__
+actor = Actor.remote()
+# __creating_actor_end__
+
+# __executing_task_start__
+result_refs = []
+results = []
+max_in_flight_tasks = 1000
+for i in range(1_000_000):
+    large_array = np.zeros(1_000_000)
+
+    # Allow 1000 in flight calls
+    # For example, if i = 5000, this call blocks until that
+    # 4000 of the object_refs in result_refs are ready
+    # and available.
+    if len(result_refs) > max_in_flight_tasks:
+        # update result_refs to only
+        # track the remaining tasks.
+        num_ready = len(result_refs) - max_in_flight_tasks
+        newly_completed, result_refs = ray.wait(result_refs, num_returns=num_ready)
+        for completed_ref in newly_completed:
+            results.append(ray.get(completed_ref))
+
+    result_refs.append(actor.heavy_compute.remote(large_array))
+
+newly_completed, result_refs = ray.wait(result_refs, num_returns=len(result_refs))
+for completed_ref in newly_completed:
+    results.append(ray.get(completed_ref))
+# __executing_task_end__

--- a/doc/source/ray-core/doc_code/limit_tasks.py
+++ b/doc/source/ray-core/doc_code/limit_tasks.py
@@ -23,14 +23,14 @@ actor = Actor.remote()
 # __executing_task_start__
 result_refs = []
 results = []
-max_in_flight_tasks = 1000
-for i in range(1_000_000):
+max_in_flight_tasks = 100
+for i in range(1000):
     large_array = np.zeros(1_000_000)
 
-    # Allow 1000 in flight calls
-    # For example, if i = 5000, this call blocks until that
-    # 4000 of the object_refs in result_refs are ready
-    # and available.
+    # Allow 100 in flight calls
+    # For example, if i = 100, ray.wait blocks until
+    # 1 of the object_refs in result_refs is ready
+    # and available before we submit another.
     if len(result_refs) > max_in_flight_tasks:
         # update result_refs to only
         # track the remaining tasks.

--- a/doc/source/ray-core/tasks/patterns/limit-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/limit-tasks.rst
@@ -28,7 +28,7 @@ Code example
 
     actor = Actor.remote()
     result_refs = []
-    for i in range(1_000_000):
+    for i in range(1000):
         large_array = np.zeros(1_000_000)
         result_refs.append(actor.heavy_compute.remote(large_array))
     results = ray.get(result_refs)

--- a/doc/source/ray-core/tasks/patterns/limit-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/limit-tasks.rst
@@ -35,25 +35,8 @@ Code example
 
 **With backpressure:**
 
-.. code-block:: python
+.. literalinclude:: ../../doc_code/limit_tasks.py
+    :language: python
+    :start-after: __executing_task_start__
+    :end-before: __executing_task_end__
 
-    result_refs = []
-    results = []
-    max_in_flight_tasks = 1000
-    for i in range(1_000_000):
-        large_array = np.zeros(1_000_000)
-
-        # Limit in-flight tasks to 1000.
-        # When the 1001st task is added
-        # we wait for 1 task to complete
-        # before adding another.
-        if len(result_refs) > max_in_flight_tasks:
-            num_ready = len(result_refs) - max_in_flight_tasks:
-            completed_refs, result_refs = ray.wait(result_refs, num_returns=num_ready)
-            for completed_ref in completed_refs:
-                results.append(ray.get(completed_ref))
-
-        result_refs.append(actor.heavy_compute.remote(large_array))
-
-    # fetch the remaining results
-    results.extend(ray.get(result_refs))

--- a/doc/source/ray-core/tasks/patterns/limit-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/limit-tasks.rst
@@ -38,6 +38,7 @@ Code example
 .. code-block:: python
 
     result_refs = []
+    results = []
     max_in_flight_tasks = 1000
     for i in range(1_000_000):
         large_array = np.zeros(1_000_000)
@@ -48,6 +49,11 @@ Code example
         # before adding another.
         if len(result_refs) > max_in_flight_tasks:
             num_ready = len(result_refs) - max_in_flight_tasks:
-            _, result_refs = ray.wait(result_refs, num_returns=num_ready)
+            completed_refs, result_refs = ray.wait(result_refs, num_returns=num_ready)
+            for completed_ref in completed_refs:
+                results.append(ray.get(completed_ref))
 
         result_refs.append(actor.heavy_compute.remote(large_array))
+
+    # fetch the remaining results
+    results.extend(ray.get(result_refs))

--- a/doc/source/ray-core/tasks/patterns/limit-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/limit-tasks.rst
@@ -42,7 +42,10 @@ Code example
     for i in range(1_000_000):
         large_array = np.zeros(1_000_000)
 
-        # Limit in-flight tasks to 1000
+        # Limit in-flight tasks to 1000.
+        # When the 1001st task is added
+        # we wait for 1 task to complete
+        # before adding another.
         if len(result_refs) > max_in_flight_tasks:
             num_ready = len(result_refs) - max_in_flight_tasks:
             _, result_refs = ray.wait(result_refs, num_returns=num_ready)

--- a/doc/source/ray-core/tasks/patterns/limit-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/limit-tasks.rst
@@ -41,12 +41,8 @@ Code example
     for i in range(1_000_000):
         large_array = np.zeros(1_000_000)
 
-        # Allow 1000 in flight calls
-        # For example, if i = 5000, this call blocks until that
-        # 4000 of the object_refs in result_refs are ready
-        # and available.
-          if len(result_refs) > 1000:
-            num_ready = i-1000
-            ray.wait(result_refs, num_returns=num_ready)
+        # Limit in-flight tasks to 1000
+        if len(result_refs) >= 1000:
+            _, result_refs = ray.wait(result_refs, num_returns=len(result_refs))
 
         result_refs.append(actor.heavy_compute.remote(large_array))

--- a/doc/source/ray-core/tasks/patterns/limit-tasks.rst
+++ b/doc/source/ray-core/tasks/patterns/limit-tasks.rst
@@ -38,11 +38,13 @@ Code example
 .. code-block:: python
 
     result_refs = []
+    max_in_flight_tasks = 1000
     for i in range(1_000_000):
         large_array = np.zeros(1_000_000)
 
         # Limit in-flight tasks to 1000
-        if len(result_refs) >= 1000:
-            _, result_refs = ray.wait(result_refs, num_returns=len(result_refs))
+        if len(result_refs) > max_in_flight_tasks:
+            num_ready = len(result_refs) - max_in_flight_tasks:
+            _, result_refs = ray.wait(result_refs, num_returns=num_ready)
 
         result_refs.append(actor.heavy_compute.remote(large_array))


### PR DESCRIPTION
Changes:
  - Updates the list of in-flight tasks (results_ref)
  - Bounds the num_returns to the list size

## Why are these changes needed?

The example fails because it can assign an invalid value to the num_returns parameters in ray.wait function

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
