### PR TITLE
[Air][Data] Don't promote locality_hints for split

### DIFF
--- a/doc/source/data/doc_code/accessing_datasets.py
+++ b/doc/source/data/doc_code/accessing_datasets.py
@@ -228,7 +228,7 @@ workers = [Worker.remote(i) for i in range(4)]
 ds = ray.data.range(10000)
 # -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)
 
-shards = ds.split(n=4, locality_hints=workers)
+shards = ds.split(n=4)
 # -> [Dataset(num_blocks=13, num_rows=2500, schema=<class 'int'>),
 #     Dataset(num_blocks=13, num_rows=2500, schema=<class 'int'>), ...]
 

--- a/doc/source/data/doc_code/quick_start.py
+++ b/doc/source/data/doc_code/quick_start.py
@@ -134,7 +134,7 @@ class Worker:
 workers = [Worker.remote(i) for i in range(4)]
 # -> [Actor(Worker, ...), Actor(Worker, ...), ...]
 
-shards = ds.split(n=4, locality_hints=workers)
+shards = ds.split(n=4)
 # -> [
 #       Dataset(num_blocks=3, num_rows=45,
 #               schema={sepal.length: double, sepal.width: double,

--- a/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
+++ b/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
@@ -858,7 +858,7 @@
    "id": "8b10fc64",
    "metadata": {},
    "source": [
-    "Next, we split the dataset into ``len(trainers)`` shards, ensuring that the shards are of equal size, and providing the trainer actor handles to Ray Datasets as locality hints, so Datasets can try to colocate shard data with trainers in order to decrease data movement."
+    "Next, we split the dataset into ``len(trainers)`` shards, ensuring that the shards are of equal size."
    ]
   },
   {
@@ -884,7 +884,7 @@
     }
    ],
    "source": [
-    "shards = ds.split(n=len(trainers), equal=True, locality_hints=trainers)\n",
+    "shards = ds.split(n=len(trainers), equal=True)\n",
     "shards"
    ]
   },

--- a/python/ray/train/_internal/dataset_spec.py
+++ b/python/ray/train/_internal/dataset_spec.py
@@ -28,8 +28,8 @@ class RayDatasetSpec:
         training workers (to use as locality hints). The Callable is expected to
         return a list of RayDatasets or a list of dictionaries of RayDatasets,
         with the length of the list equal to the length of the list of actor handles.
-        If None is provided, the provided Ray Dataset(s) will be simply be split using
-        the actor handles as locality hints.
+        If None is provided, the provided Ray Dataset(s) will be simply equally
+        splitted without locality hints.
 
     """
 
@@ -48,7 +48,6 @@ class RayDatasetSpec:
             return dataset_or_pipeline.split(
                 len(training_worker_handles),
                 equal=True,
-                locality_hints=training_worker_handles,
             )
 
         if isinstance(self.dataset_or_dict, dict):
@@ -209,7 +208,6 @@ class DataParallelIngestSpec:
                 dataset_splits = dataset.split(
                     len(training_worker_handles),
                     equal=True,
-                    locality_hints=training_worker_handles,
                 )
             else:
                 dataset_splits = [dataset] * len(training_worker_handles)

--- a/python/ray/train/_internal/dataset_spec.py
+++ b/python/ray/train/_internal/dataset_spec.py
@@ -28,8 +28,7 @@ class RayDatasetSpec:
         training workers (to use as locality hints). The Callable is expected to
         return a list of RayDatasets or a list of dictionaries of RayDatasets,
         with the length of the list equal to the length of the list of actor handles.
-        If None is provided, the provided Ray Dataset(s) will be simply equally
-        splitted without locality hints.
+        If None is provided, the provided Ray Dataset(s) will be equally split.
 
     """
 


### PR DESCRIPTION
Signed-off-by: scv119 <scv119@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Since locality_hints is an experimental feature, we stop promoting it in doc and don't enable it in AIR. See https://github.com/ray-project/ray/pull/26641 for more context

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
