### PR TITLE
✨ Add extra types for datasets

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from dataclasses import dataclass
 from typing import (
@@ -29,6 +30,10 @@ try:
 except ImportError:
     resource = None
 
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     import pandas
@@ -39,8 +44,8 @@ if TYPE_CHECKING:
     from ray.data.aggregate import AggregateFn
 
 
-T = TypeVar("T")
-U = TypeVar("U")
+T = TypeVar("T", contravariant=True)
+U = TypeVar("U", covariant=True)
 KeyType = TypeVar("KeyType")
 AggType = TypeVar("AggType")
 
@@ -101,14 +106,19 @@ DataBatch = Union[Block, np.ndarray, Dict[str, np.ndarray]]
 # A class type that implements __call__.
 CallableClass = type
 
+
+class CallableClassProtocol(Protocol[T, U]):
+    def __call__(self, __arg: T) -> U:
+        ...
+
+
 # A UDF on data batches.
 BatchUDF = Union[
     # TODO(Clark): Once Ray only supports Python 3.8+, use protocol to constraint batch
     # UDF type.
     # Callable[[DataBatch, ...], DataBatch]
     Callable[[DataBatch], DataBatch],
-    Callable[..., DataBatch],
-    CallableClass,
+    CallableClassProtocol,
 ]
 
 # A UDF on data rows.
@@ -117,8 +127,7 @@ RowUDF = Union[
     # UDF type.
     # Callable[[T, ...], U]
     Callable[[T], U],
-    Callable[..., U],
-    CallableClass,
+    CallableClassProtocol[T, U],
 ]
 
 # A list of block references pending computation by a single task. For example,

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -107,7 +107,7 @@ DataBatch = Union[Block, np.ndarray, Dict[str, np.ndarray]]
 CallableClass = type
 
 
-class CallableClassProtocol(Protocol[T, U]):
+class _CallableClassProtocol(Protocol[T, U]):
     def __call__(self, __arg: T) -> U:
         ...
 
@@ -118,7 +118,7 @@ BatchUDF = Union[
     # UDF type.
     # Callable[[DataBatch, ...], DataBatch]
     Callable[[DataBatch], DataBatch],
-    CallableClassProtocol,
+    _CallableClassProtocol,
 ]
 
 # A UDF on data rows.
@@ -127,7 +127,7 @@ RowUDF = Union[
     # UDF type.
     # Callable[[T, ...], U]
     Callable[[T], U],
-    CallableClassProtocol[T, U],
+    _CallableClassProtocol[T, U],
 ]
 
 # A list of block references pending computation by a single task. For example,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -204,7 +204,7 @@ class Dataset(Generic[T]):
 
     def map(
         self,
-        fn: RowUDF,
+        fn: RowUDF[T, U],
         *,
         compute: Union[str, ComputeStrategy] = None,
         **ray_remote_args,
@@ -270,7 +270,7 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
-        def transform(block: Block, fn: RowUDF) -> Iterable[Block]:
+        def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             block = BlockAccessor.for_block(block)
@@ -575,7 +575,7 @@ class Dataset(Generic[T]):
 
     def flat_map(
         self,
-        fn: RowUDF,
+        fn: RowUDF[T, U],
         *,
         compute: Union[str, ComputeStrategy] = None,
         **ray_remote_args,
@@ -621,7 +621,7 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
-        def transform(block: Block, fn: RowUDF) -> Iterable[Block]:
+        def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             output_buffer = BlockOutputBuffer(None, context.target_max_block_size)
             block = BlockAccessor.for_block(block)
@@ -641,7 +641,7 @@ class Dataset(Generic[T]):
 
     def filter(
         self,
-        fn: RowUDF,
+        fn: RowUDF[T, U],
         *,
         compute: Union[str, ComputeStrategy] = None,
         **ray_remote_args,
@@ -687,7 +687,7 @@ class Dataset(Generic[T]):
         self._warn_slow()
         context = DatasetContext.get_current()
 
-        def transform(block: Block, fn: RowUDF) -> Iterable[Block]:
+        def transform(block: Block, fn: RowUDF[T, U]) -> Iterable[Block]:
             DatasetContext._set_current(context)
             block = BlockAccessor.for_block(block)
             builder = block.builder()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

✨ Add extra types for datasets

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

By using Protocols for the definition of callable classes, the type parameter in datasets can be preserved for the methods that work on rows.

This allows getting typing information, editor support, in transformed datasets. It also enables editor support, including autocompletion, inside of the parameters inside of lambdas passed to things like `ds.map()` and `ds.filter()`.

For example, after several transformations, `ds.filter()` still gets autocompletion for the `x` parameter in the lambda, the editor knows it's an `int`.

![Screenshot 2022-07-17 at 22 21 54](https://user-images.githubusercontent.com/1326112/179423609-6d77da23-5f5e-47ce-a17f-6eb0d06d82d0.png)

I see there was a `TODO` comment to do this trick with the protocol, so Clark already had this idea. 💡  The good news is that it's not necessary to wait until only Python 3.8 is supported by using `typing_extensions`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
