### PR TITLE
[air] add placement group max CPU to data benchmark

### DIFF
--- a/doc/source/ray-air/benchmarks.rst
+++ b/doc/source/ray-air/benchmarks.rst
@@ -36,13 +36,13 @@ For this benchmark, we configured the nodes to have reasonable disk size and thr
       - 390 s (0.51 GiB/s)
       - 205 GiB
       - `python data_benchmark.py --dataset-size-gb=200 --num-workers=1`
-    * - 5 m5.4xlarge nodes (2 actors)
+    * - 5 m5.4xlarge nodes (5 actors)
       - 70 s (2.85 GiB/S)
       - 206 GiB
       - `python data_benchmark.py --dataset-size-gb=200 --num-workers=5`
     * - 20 m5.4xlarge nodes (20 actors)
       - 3.8 s (52.6 GiB/s)
-      - 0 GB
+      - 0 GiB
       - `python data_benchmark.py --dataset-size-gb=200 --num-workers=20`
 
 

--- a/release/air_tests/air_benchmarks/workloads/data_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/data_benchmark.py
@@ -29,7 +29,7 @@ def run_ingest_bulk(dataset, num_workers, num_cpus_per_worker):
             "num_workers": num_workers,
             "trainer_resources": {"CPU": 0},
             "resources_per_worker": {"CPU": num_cpus_per_worker},
-            "_max_cpu_fraction_per_node": 0.8
+            "_max_cpu_fraction_per_node": 0.8,
         },
         datasets={"train": dataset},
         preprocessor=dummy_prep,

--- a/release/air_tests/air_benchmarks/workloads/data_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/data_benchmark.py
@@ -29,6 +29,7 @@ def run_ingest_bulk(dataset, num_workers, num_cpus_per_worker):
             "num_workers": num_workers,
             "trainer_resources": {"CPU": 0},
             "resources_per_worker": {"CPU": num_cpus_per_worker},
+            "_max_cpu_fraction_per_node": 0.8
         },
         datasets={"train": dataset},
         preprocessor=dummy_prep,


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Set experimental `_max_cpu_fraction_per_node` to prevent deadlock.

This should technically be a no-op with the SPREAD strategy.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

Re-ran [air-benchmark-data-bulk-ingest](https://buildkite.com/ray-project/release-tests-pr/builds/9753#01820e32-78f5-4a1e-a56d-f0b4cfc3d56f) successfully.

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
