### PR TITLE
[air/tuner] Add more config arguments to Tuner

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -436,8 +436,10 @@ class RunConfig:
             when possible. This can drastically speed up experiments that start
             and stop actors often (e.g., PBT in time-multiplexing mode). This
             requires trials to have the same resource requirements.
-            Defaults to ``True`` for function trainables and ``False`` for
-            class and registered trainables.
+            Defaults to ``True`` for function trainables (including most
+            Ray AIR trainers) and ``False`` for class and registered trainables
+            (e.g. RLLib).
+
     """
 
     name: Optional[str] = None

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -438,7 +438,7 @@ class RunConfig:
             requires trials to have the same resource requirements.
             Defaults to ``True`` for function trainables (including most
             Ray AIR trainers) and ``False`` for class and registered trainables
-            (e.g. RLLib).
+            (e.g. RLlib).
 
     """
 

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -1,5 +1,15 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Union,
+    Tuple,
+)
 
 from ray.air.constants import WILDCARD_KEY
 from ray.tune.progress_reporter import ProgressReporter
@@ -414,6 +424,14 @@ class RunConfig:
         verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
             results, 3 = status and detailed results. Defaults to 2.
+        log_to_file: Log stdout and stderr to files in
+            trial directories. If this is `False` (default), no files
+            are written. If `true`, outputs are written to `trialdir/stdout`
+            and `trialdir/stderr`, respectively. If this is a single string,
+            this is interpreted as a file relative to the trialdir, to which
+            both streams are written. If this is a Sequence (e.g. a Tuple),
+            it has to have length 2 and the elements indicate the files to
+            which stdout and stderr are written, respectively.
         reuse_actors: Whether to reuse actors between different trials
             when possible. This can drastically speed up experiments that start
             and stop actors often (e.g., PBT in time-multiplexing mode). This
@@ -432,4 +450,5 @@ class RunConfig:
     checkpoint_config: Optional[CheckpointConfig] = None
     progress_reporter: Optional[ProgressReporter] = None
     verbose: Union[int, Verbosity] = Verbosity.V3_TRIAL_DETAILS
+    log_to_file: Union[bool, str, Tuple[str, str]] = False
     reuse_actors: Optional[bool] = None

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -451,3 +451,13 @@ class RunConfig:
     verbose: Union[int, Verbosity] = Verbosity.V3_TRIAL_DETAILS
     log_to_file: Union[bool, str, Tuple[str, str]] = False
     reuse_actors: Optional[bool] = None
+
+    def __post_init__(self):
+        if not self.failure_config:
+            self.failure_config = FailureConfig()
+
+        if not self.sync_config:
+            self.sync_config = SyncConfig()
+
+        if not self.checkpoint_config:
+            self.checkpoint_config = CheckpointConfig()

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Union
 
 from ray.air.constants import WILDCARD_KEY
+from ray.tune import ProgressReporter
 from ray.tune.syncer import SyncConfig
 from ray.tune.utils.log import Verbosity
 from ray.util.annotations import PublicAPI
@@ -406,6 +407,10 @@ class RunConfig:
         failure_config: Failure mode configuration.
         sync_config: Configuration object for syncing. See tune.SyncConfig.
         checkpoint_config: Checkpointing configuration.
+        progress_reporter: Progress reporter for reporting
+            intermediate experiment progress. Defaults to CLIReporter if
+            running in command-line, or JupyterNotebookReporter if running in
+            a Jupyter notebook.
         verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
             results, 3 = status and detailed results. Defaults to 2.
@@ -419,4 +424,5 @@ class RunConfig:
     failure_config: Optional[FailureConfig] = None
     sync_config: Optional[SyncConfig] = None
     checkpoint_config: Optional[CheckpointConfig] = None
+    progress_reporter: Optional[ProgressReporter] = None
     verbose: Union[int, Verbosity] = Verbosity.V3_TRIAL_DETAILS

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -414,6 +414,12 @@ class RunConfig:
         verbose: 0, 1, 2, or 3. Verbosity mode.
             0 = silent, 1 = only status updates, 2 = status and brief
             results, 3 = status and detailed results. Defaults to 2.
+        reuse_actors: Whether to reuse actors between different trials
+            when possible. This can drastically speed up experiments that start
+            and stop actors often (e.g., PBT in time-multiplexing mode). This
+            requires trials to have the same resource requirements.
+            Defaults to ``True`` for function trainables and ``False`` for
+            class and registered trainables.
     """
 
     # TODO(xwjiang): Add more.
@@ -426,3 +432,4 @@ class RunConfig:
     checkpoint_config: Optional[CheckpointConfig] = None
     progress_reporter: Optional[ProgressReporter] = None
     verbose: Union[int, Verbosity] = Verbosity.V3_TRIAL_DETAILS
+    reuse_actors: Optional[bool] = None

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -440,7 +440,6 @@ class RunConfig:
             class and registered trainables.
     """
 
-    # TODO(xwjiang): Add more.
     name: Optional[str] = None
     local_dir: Optional[str] = None
     callbacks: Optional[List["Callback"]] = None

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Union
 
 from ray.air.constants import WILDCARD_KEY
-from ray.tune import ProgressReporter
+from ray.tune.progress_reporter import ProgressReporter
 from ray.tune.syncer import SyncConfig
 from ray.tune.utils.log import Verbosity
 from ray.util.annotations import PublicAPI

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -179,7 +179,9 @@ class TunerInternal:
                 if self._run_config.failure_config
                 else False
             ),
+            progress_reporter=self._run_config.progress_reporter,
             verbose=self._run_config.verbose,
+            reuse_actors=self._run_config.reuse_actors,
         )
 
     def _fit_internal(self, trainable, param_space) -> ExperimentAnalysis:
@@ -193,8 +195,6 @@ class TunerInternal:
                 search_alg=self._tune_config.search_alg,
                 scheduler=self._tune_config.scheduler,
                 name=self._run_config.name,
-                progress_reporter=self._run_config.progress_reporter,
-                reuse_actors=self._run_config.reuse_actors,
             ),
             **self._tuner_kwargs,
         }
@@ -210,8 +210,6 @@ class TunerInternal:
             **dict(
                 run_or_experiment=trainable,
                 resume=True,
-                progress_reporter=self._run_config.progress_reporter,
-                reuse_actors=self._run_config.reuse_actors,
             ),
             **self._tuner_kwargs,
         }

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -183,6 +183,7 @@ class TunerInternal:
             verbose=self._run_config.verbose,
             reuse_actors=self._run_config.reuse_actors,
             max_concurrent_trials=self._tune_config.max_concurrent_trials,
+            time_budget_s=self._tune_config.time_budget_s,
         )
 
     def _fit_internal(self, trainable, param_space) -> ExperimentAnalysis:

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -194,6 +194,7 @@ class TunerInternal:
                 scheduler=self._tune_config.scheduler,
                 name=self._run_config.name,
                 progress_reporter=self._run_config.progress_reporter,
+                reuse_actors=self._run_config.reuse_actors,
             ),
             **self._tuner_kwargs,
         }
@@ -210,6 +211,7 @@ class TunerInternal:
                 run_or_experiment=trainable,
                 resume=True,
                 progress_reporter=self._run_config.progress_reporter,
+                reuse_actors=self._run_config.reuse_actors,
             ),
             **self._tuner_kwargs,
         }

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -193,6 +193,7 @@ class TunerInternal:
                 search_alg=self._tune_config.search_alg,
                 scheduler=self._tune_config.scheduler,
                 name=self._run_config.name,
+                progress_reporter=self._run_config.progress_reporter,
             ),
             **self._tuner_kwargs,
         }
@@ -208,6 +209,7 @@ class TunerInternal:
             **dict(
                 run_or_experiment=trainable,
                 resume=True,
+                progress_reporter=self._run_config.progress_reporter,
             ),
             **self._tuner_kwargs,
         }

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -195,6 +195,7 @@ class TunerInternal:
                 search_alg=self._tune_config.search_alg,
                 scheduler=self._tune_config.scheduler,
                 name=self._run_config.name,
+                log_to_file=self._run_config.log_to_file,
             ),
             **self._tuner_kwargs,
         }

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -182,6 +182,7 @@ class TunerInternal:
             progress_reporter=self._run_config.progress_reporter,
             verbose=self._run_config.verbose,
             reuse_actors=self._run_config.reuse_actors,
+            max_concurrent_trials=self._tune_config.max_concurrent_trials,
         )
 
     def _fit_internal(self, trainable, param_space) -> ExperimentAnalysis:

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -157,28 +157,14 @@ class TunerInternal:
             callbacks=self._run_config.callbacks,
             sync_config=self._run_config.sync_config,
             stop=self._run_config.stop,
-            max_failures=(
-                self._run_config.failure_config.max_failures
-                if self._run_config.failure_config
-                else 0
-            ),
-            keep_checkpoints_num=(
-                self._run_config.checkpoint_config.num_to_keep
-                if self._run_config.checkpoint_config
-                else None
-            ),
+            max_failures=self._run_config.failure_config.max_failures,
+            keep_checkpoints_num=self._run_config.checkpoint_config.num_to_keep,
             checkpoint_score_attr=(
                 self._run_config.checkpoint_config._tune_legacy_checkpoint_score_attr
-                if self._run_config.checkpoint_config
-                else None
             ),
             _experiment_checkpoint_dir=self._experiment_checkpoint_dir,
             raise_on_failed_trial=False,
-            fail_fast=(
-                self._run_config.failure_config.fail_fast
-                if self._run_config.failure_config
-                else False
-            ),
+            fail_fast=(self._run_config.failure_config.fail_fast),
             progress_reporter=self._run_config.progress_reporter,
             verbose=self._run_config.verbose,
             reuse_actors=self._run_config.reuse_actors,

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -269,6 +269,10 @@ class TunerTest(unittest.TestCase):
             {"run_config": RunConfig(log_to_file="some_file")},
             lambda kw: kw["log_to_file"] == "some_file",
         ),
+        (
+            {"tune_config": TuneConfig(max_concurrent_trials=3)},
+            lambda kw: kw["max_concurrent_trials"] == 3,
+        ),
     ],
 )
 def test_tuner_api_kwargs(params_expected):

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -1,4 +1,7 @@
 import os
+from unittest.mock import patch
+
+import pytest
 import shutil
 import unittest
 from typing import Optional
@@ -16,7 +19,7 @@ from ray.data.block import BlockMetadata
 from ray.train.torch import TorchTrainer
 from ray.train.trainer import BaseTrainer
 from ray.train.xgboost import XGBoostTrainer
-from ray.tune import Callback, TuneError
+from ray.tune import Callback, TuneError, CLIReporter
 from ray.tune.result import DEFAULT_RESULTS_DIR
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
@@ -251,9 +254,36 @@ class TunerTest(unittest.TestCase):
         assert tuner._local_tuner._run_config.stop == {"metric": 4}
 
 
+@pytest.mark.parametrize(
+    "params_expected",
+    [
+        (
+            {"run_config": RunConfig(progress_reporter=CLIReporter())},
+            lambda kw: isinstance(kw["progress_reporter"], CLIReporter),
+        ),
+        (
+            {"run_config": RunConfig(reuse_actors=True)},
+            lambda kw: kw["reuse_actors"] is True,
+        ),
+    ],
+)
+def test_tuner_api_kwargs(params_expected):
+    tuner_params, assertion = params_expected
+
+    tuner = Tuner(lambda config: 1, **tuner_params)
+
+    caught_kwargs = {}
+
+    def catch_kwargs(**kwargs):
+        caught_kwargs.update(kwargs)
+
+    with patch("ray.tune.impl.tuner_internal.run", catch_kwargs):
+        tuner.fit()
+
+    assert assertion(caught_kwargs)
+
+
 if __name__ == "__main__":
     import sys
-
-    import pytest
 
     sys.exit(pytest.main(["-v", __file__] + sys.argv[1:]))

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -273,6 +273,10 @@ class TunerTest(unittest.TestCase):
             {"tune_config": TuneConfig(max_concurrent_trials=3)},
             lambda kw: kw["max_concurrent_trials"] == 3,
         ),
+        (
+            {"tune_config": TuneConfig(time_budget_s=60)},
+            lambda kw: kw["time_budget_s"] == 60,
+        ),
     ],
 )
 def test_tuner_api_kwargs(params_expected):

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -265,6 +265,10 @@ class TunerTest(unittest.TestCase):
             {"run_config": RunConfig(reuse_actors=True)},
             lambda kw: kw["reuse_actors"] is True,
         ),
+        (
+            {"run_config": RunConfig(log_to_file="some_file")},
+            lambda kw: kw["log_to_file"] == "some_file",
+        ),
     ],
 )
 def test_tuner_api_kwargs(params_expected):

--- a/python/ray/tune/tune_config.py
+++ b/python/ray/tune/tune_config.py
@@ -1,5 +1,6 @@
+import datetime
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from ray.tune.schedulers import TrialScheduler
 from ray.tune.search import Searcher
@@ -35,6 +36,9 @@ class TuneConfig:
             a :class:`ConcurrencyLimiter`, and thus setting this argument
             will raise an exception if the ``search_alg`` is already a
             :class:`ConcurrencyLimiter`. Defaults to None.
+        time_budget_s: Global time budget in
+            seconds after which all trials are stopped. Can also be a
+            ``datetime.timedelta`` object.
     """
 
     # Currently this is not at feature parity with `tune.run`, nor should it be.
@@ -46,3 +50,4 @@ class TuneConfig:
     scheduler: Optional[TrialScheduler] = None
     num_samples: int = 1
     max_concurrent_trials: Optional[int] = None
+    time_budget_s: Optional[Union[int, float, datetime.timedelta]] = None

--- a/python/ray/tune/tune_config.py
+++ b/python/ray/tune/tune_config.py
@@ -29,6 +29,12 @@ class TuneConfig:
             provided as an argument, the grid will be repeated
             `num_samples` of times. If this is -1, (virtually) infinite
             samples are generated until a stopping condition is met.
+        max_concurrent_trials: Maximum number of trials to run
+            concurrently. Must be non-negative. If None or 0, no limit will
+            be applied. This is achieved by wrapping the ``search_alg`` in
+            a :class:`ConcurrencyLimiter`, and thus setting this argument
+            will raise an exception if the ``search_alg`` is already a
+            :class:`ConcurrencyLimiter`. Defaults to None.
     """
 
     # Currently this is not at feature parity with `tune.run`, nor should it be.
@@ -39,3 +45,4 @@ class TuneConfig:
     search_alg: Optional[Searcher] = None
     scheduler: Optional[TrialScheduler] = None
     num_samples: int = 1
+    max_concurrent_trials: Optional[int] = None

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -114,6 +114,7 @@ class Tuner:
                 BaseTrainer,
             ]
         ] = None,
+        *,
         param_space: Optional[Dict[str, Any]] = None,
         tune_config: Optional[TuneConfig] = None,
         run_config: Optional[RunConfig] = None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The Tuner API is missing some arguments that `tune.run()` currently supports. This PR adds a number of them and adds a test to make sure they are correctly passed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
