### PR TITLE
[runtime env] plugin refactor [5/n]: support priority

### DIFF
--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -6,8 +6,20 @@ RAY_JOB_CONFIG_JSON_ENV_VAR = "RAY_JOB_CONFIG_JSON_ENV_VAR"
 # e.g. [{"class": "xxx.xxx.xxx_plugin", "priority": 10}].
 RAY_RUNTIME_ENV_PLUGINS_ENV_VAR = "RAY_RUNTIME_ENV_PLUGINS"
 
+# The field name of plugin class in the plugin config.
+RAY_RUNTIME_ENV_CLASS_FIELD_NAME = "class"
+
+# The field name of priority in the plugin config.
+RAY_RUNTIME_ENV_PRIORITY_FIELD_NAME = "priority"
+
 # The default priority of runtime env plugin.
 RAY_RUNTIME_ENV_PLUGIN_DEFAULT_PRIORITY = 10
+
+# The minimum priority of runtime env plugin.
+RAY_RUNTIME_ENV_PLUGIN_MIN_PRIORITY = 0
+
+# The maximum priority of runtime env plugin.
+RAY_RUNTIME_ENV_PLUGIN_MAX_PRIORITY = 100
 
 # The schema files or directories of plugins which should be loaded in workers.
 RAY_RUNTIME_ENV_PLUGIN_SCHEMAS_ENV_VAR = "RAY_RUNTIME_ENV_PLUGIN_SCHEMAS"

--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -1,8 +1,13 @@
 # Env var set by job manager to pass runtime env and metadata to subprocess
 RAY_JOB_CONFIG_JSON_ENV_VAR = "RAY_JOB_CONFIG_JSON_ENV_VAR"
 
-# The plugins which should be loaded when ray cluster starts.
+# The plugin config which should be loaded when ray cluster starts.
+# It is a json formatted config,
+# e.g. [{"class": "xxx.xxx.xxx_plugin", "priority": 10}].
 RAY_RUNTIME_ENV_PLUGINS_ENV_VAR = "RAY_RUNTIME_ENV_PLUGINS"
+
+# The default priority of runtime env plugin.
+RAY_RUNTIME_ENV_PLUGIN_DEFAULT_PRIORITY = 10
 
 # The schema files or directories of plugins which should be loaded in workers.
 RAY_RUNTIME_ENV_PLUGIN_SCHEMAS_ENV_VAR = "RAY_RUNTIME_ENV_PLUGIN_SCHEMAS"

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -130,7 +130,8 @@ class RuntimeEnvPluginManager:
             ):
                 raise RuntimeError(
                     f"Invalid runtime env plugin config {plugin_config}, "
-                    "it should be a object which contains the 'class' field."
+                    "it should be a object which contains the "
+                    f"{RAY_RUNTIME_ENV_CLASS_FIELD_NAME} field."
                 )
             plugin_class = import_attr(plugin_config[RAY_RUNTIME_ENV_CLASS_FIELD_NAME])
             if not issubclass(plugin_class, RuntimeEnvPlugin):
@@ -141,14 +142,14 @@ class RuntimeEnvPluginManager:
                 )
             if not plugin_class.name:
                 raise RuntimeError(
-                    f"No valid name in runtime env plugin {plugin_class}"
+                    f"No valid name in runtime env plugin {plugin_class}."
                 )
             if plugin_class.name in self.plugins:
                 raise RuntimeError(
                     f"The name of runtime env plugin {plugin_class} conflicts "
                     f"with {self.plugins[plugin_class.name]}.",
                 )
-            # The priority should should be an integer between 0 and 100.
+            # The priority should be an integer between 0 and 100.
             # The default priority is 10. A smaller number indicates a
             # higher priority and the plugin will be set up first.
             priority = RAY_RUNTIME_ENV_PLUGIN_DEFAULT_PRIORITY
@@ -176,7 +177,6 @@ class RuntimeEnvPluginManager:
         for name, config in inputs:
             if name not in self.plugins:
                 raise RuntimeError(f"Runtime env plugin {name} not found.")
-            print(type(self.plugins[name].class_instance))
             used_plugins.append(
                 (
                     name,

--- a/python/ray/tests/test_placement_group_4.py
+++ b/python/ray/tests/test_placement_group_4.py
@@ -117,7 +117,7 @@ def test_remove_placement_group(ray_start_cluster, connect_to_client):
 @pytest.mark.parametrize(
     "set_runtime_env_plugins",
     [
-        MOCK_WORKER_STARTUP_SLOWLY_PLUGIN_CLASS_PATH,
+        '[{"class":"' + MOCK_WORKER_STARTUP_SLOWLY_PLUGIN_CLASS_PATH + '"}]',
     ],
     indirect=True,
 )

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -599,7 +599,7 @@ class MyPlugin(RuntimeEnvPlugin):
 @pytest.mark.parametrize(
     "set_runtime_env_plugins",
     [
-        MY_PLUGIN_CLASS_PATH,
+        '[{"class":"' + MY_PLUGIN_CLASS_PATH + '"}]',
     ],
     indirect=True,
 )

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -256,6 +256,7 @@ PRIORITY_TEST_ENV_VAR_NAME = "PriorityTestEnv"
 
 class PriorityTestPlugin1(RuntimeEnvPlugin):
     name = PRIORITY_TEST_PLUGIN1_NAME
+    priority = 11
     env_value = " world"
 
     @staticmethod
@@ -277,6 +278,7 @@ class PriorityTestPlugin1(RuntimeEnvPlugin):
 
 class PriorityTestPlugin2(RuntimeEnvPlugin):
     name = PRIORITY_TEST_PLUGIN2_NAME
+    priority = 10
     env_value = "hello"
 
     @staticmethod
@@ -296,6 +298,16 @@ class PriorityTestPlugin2(RuntimeEnvPlugin):
                 f"{ctx.env_vars[PRIORITY_TEST_ENV_VAR_NAME]}."
             )
         ctx.env_vars[PRIORITY_TEST_ENV_VAR_NAME] = PriorityTestPlugin2.env_value
+
+
+priority_test_plugin_config_without_priority = [
+    {
+        "class": PRIORITY_TEST_PLUGIN1_CLASS_PATH,
+    },
+    {
+        "class": PRIORITY_TEST_PLUGIN2_CLASS_PATH,
+    },
+]
 
 
 priority_test_plugin_config = [
@@ -326,6 +338,7 @@ priority_test_plugin_bad_config = [
 @pytest.mark.parametrize(
     "set_runtime_env_plugins",
     [
+        json.dumps(priority_test_plugin_config_without_priority),
         json.dumps(priority_test_plugin_config),
         json.dumps(priority_test_plugin_bad_config),
     ],

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import json
 from time import sleep
 from typing import List
 
@@ -47,7 +48,7 @@ class MyPlugin(RuntimeEnvPlugin):
 @pytest.mark.parametrize(
     "set_runtime_env_plugins",
     [
-        MY_PLUGIN_CLASS_PATH,
+        '[{"class":"' + MY_PLUGIN_CLASS_PATH + '"}]',
     ],
     indirect=True,
 )
@@ -124,7 +125,7 @@ class MyPluginForHang(RuntimeEnvPlugin):
 @pytest.mark.parametrize(
     "set_runtime_env_plugins",
     [
-        MY_PLUGIN_FOR_HANG_CLASS_PATH,
+        '[{"class":"' + MY_PLUGIN_FOR_HANG_CLASS_PATH + '"}]',
     ],
     indirect=True,
 )
@@ -197,9 +198,9 @@ class DiasbleTimeoutPlugin(DummyPlugin):
 @pytest.mark.parametrize(
     "set_runtime_env_plugins",
     [
-        f"{DUMMY_PLUGIN_CLASS_PATH},"
-        f"{HANG_PLUGIN_CLASS_PATH},"
-        f"{DISABLE_TIMEOUT_PLUGIN_CLASS_PATH}",
+        '[{"class":"' + DUMMY_PLUGIN_CLASS_PATH + '"},'
+        '{"class":"' + HANG_PLUGIN_CLASS_PATH + '"},'
+        '{"class":"' + DISABLE_TIMEOUT_PLUGIN_CLASS_PATH + '"}]',
     ],
     indirect=True,
 )
@@ -240,6 +241,127 @@ def test_plugin_timeout(set_runtime_env_plugins, start_cluster):
         return bad_fun_num == 1 and good_fun_num == 2
 
     wait_for_condition(condition, timeout=60)
+
+
+PRIORITY_TEST_PLUGIN1_CLASS_PATH = (
+    "ray.tests.test_runtime_env_plugin.PriorityTestPlugin1"
+)
+PRIORITY_TEST_PLUGIN1_NAME = "PriorityTestPlugin1"
+PRIORITY_TEST_PLUGIN2_CLASS_PATH = (
+    "ray.tests.test_runtime_env_plugin.PriorityTestPlugin2"
+)
+PRIORITY_TEST_PLUGIN2_NAME = "PriorityTestPlugin2"
+PRIORITY_TEST_ENV_VAR_NAME = "PriorityTestEnv"
+
+
+class PriorityTestPlugin1(RuntimeEnvPlugin):
+    name = PRIORITY_TEST_PLUGIN1_NAME
+    env_value = " world"
+
+    @staticmethod
+    def validate(runtime_env_dict: dict) -> str:
+        return None
+
+    def modify_context(
+        self,
+        uris: List[str],
+        plugin_config_dict: dict,
+        ctx: RuntimeEnvContext,
+        logger: logging.Logger,
+    ) -> None:
+        if PRIORITY_TEST_ENV_VAR_NAME in ctx.env_vars:
+            ctx.env_vars[PRIORITY_TEST_ENV_VAR_NAME] += PriorityTestPlugin1.env_value
+        else:
+            ctx.env_vars[PRIORITY_TEST_ENV_VAR_NAME] = PriorityTestPlugin1.env_value
+
+
+class PriorityTestPlugin2(RuntimeEnvPlugin):
+    name = PRIORITY_TEST_PLUGIN2_NAME
+    env_value = "hello"
+
+    @staticmethod
+    def validate(runtime_env_dict: dict) -> str:
+        return None
+
+    def modify_context(
+        self,
+        uris: List[str],
+        plugin_config_dict: dict,
+        ctx: RuntimeEnvContext,
+        logger: logging.Logger,
+    ) -> None:
+        if PRIORITY_TEST_ENV_VAR_NAME in ctx.env_vars:
+            raise RuntimeError(
+                f"Env var {PRIORITY_TEST_ENV_VAR_NAME} has been set to "
+                f"{ctx.env_vars[PRIORITY_TEST_ENV_VAR_NAME]}."
+            )
+        ctx.env_vars[PRIORITY_TEST_ENV_VAR_NAME] = PriorityTestPlugin2.env_value
+
+
+priority_test_plugin_config = [
+    {
+        "class": PRIORITY_TEST_PLUGIN1_CLASS_PATH,
+        "priority": 1,
+    },
+    {
+        "class": PRIORITY_TEST_PLUGIN2_CLASS_PATH,
+        "priority": 0,
+    },
+]
+
+priority_test_plugin_bad_config = [
+    {
+        "class": PRIORITY_TEST_PLUGIN1_CLASS_PATH,
+        "priority": 0,
+        # Only used to distinguish the bad config in test body.
+        "tag": "bad",
+    },
+    {
+        "class": PRIORITY_TEST_PLUGIN2_CLASS_PATH,
+        "priority": 1,
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "set_runtime_env_plugins",
+    [
+        json.dumps(priority_test_plugin_config),
+        json.dumps(priority_test_plugin_bad_config),
+    ],
+    indirect=True,
+)
+def test_plugin_priority(set_runtime_env_plugins, ray_start_regular):
+    config = set_runtime_env_plugins
+    _, tmp_file_path = tempfile.mkstemp()
+
+    @ray.remote
+    def f():
+        import os
+
+        return os.environ.get(PRIORITY_TEST_ENV_VAR_NAME)
+
+    if "bad" in config:
+        with pytest.raises(RuntimeEnvSetupError, match="has been set"):
+            value = ray.get(
+                f.options(
+                    runtime_env={
+                        PRIORITY_TEST_PLUGIN1_NAME: {},
+                        PRIORITY_TEST_PLUGIN2_NAME: {},
+                    }
+                ).remote()
+            )
+    else:
+        value = ray.get(
+            f.options(
+                runtime_env={
+                    PRIORITY_TEST_PLUGIN1_NAME: {},
+                    PRIORITY_TEST_PLUGIN2_NAME: {},
+                }
+            ).remote()
+        )
+        assert value is not None
+        assert value == "hello world"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Currently, the setup order of runtime env plugins is not guaranteed and we can not specify the setup priority of plugins. But in some scenes we need priority. For example, the `env_vars` should be set up first because others rely on it, such as `pip`.

So, in this PR, we support priority configuration for the plugins.
- Add "priority" attribute to `RuntimeEnvPlugin`. The plugin developer can set a static priority in the code.
- Change the format of runtime env plugin to json. You can enable the plugins and overwrite the priority like
```
export RAY_RUNTIME_ENV_PLUGINS='[{"class": "xxx.xxx.xxx_plugin", "priority": 10}]'
```
- The priority should be an integer between 0 and 100. The default priority is 10. A smaller number indicates a higher priority and the plugin will be set up first.