### PR TITLE
[core] Fix bug in LocalObjectManager reporting for bytes pending spill

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -479,10 +479,10 @@ RAY_CONFIG(int64_t, max_fused_object_count, 2000)
 /// In unlimited allocation mode, this is the time delay prior to fallback allocating.
 RAY_CONFIG(int64_t, oom_grace_period_s, 2)
 
-/// Whether or not the external storage is file system.
+/// Whether or not the external storage is the local file system.
 /// Note that this value should be overridden based on the storage type
 /// specified by object_spilling_config.
-RAY_CONFIG(bool, is_external_storage_type_fs, false)
+RAY_CONFIG(bool, is_external_storage_type_fs, true)
 
 /// Control the capacity threshold for ray local file system (for object store).
 /// Once we are over the capacity, all subsequent object creation will fail.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -480,8 +480,9 @@ RAY_CONFIG(int64_t, max_fused_object_count, 2000)
 RAY_CONFIG(int64_t, oom_grace_period_s, 2)
 
 /// Whether or not the external storage is file system.
-/// This is configured based on object_spilling_config.
-RAY_CONFIG(bool, is_external_storage_type_fs, true)
+/// Note that this value should be overridden based on the storage type
+/// specified by object_spilling_config.
+RAY_CONFIG(bool, is_external_storage_type_fs, false)
 
 /// Control the capacity threshold for ray local file system (for object store).
 /// Once we are over the capacity, all subsequent object creation will fail.

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -420,7 +420,7 @@ void LocalObjectManager::OnObjectSpilled(const std::vector<ObjectID> &object_ids
 }
 
 std::string LocalObjectManager::GetLocalSpilledObjectURL(const ObjectID &object_id) {
-  if (is_external_storage_type_fs_) {
+  if (!is_external_storage_type_fs_) {
     // If the external storage is cloud storage like S3, returns the empty string.
     // In that case, the URL is supposed to be obtained by OBOD.
     return "";
@@ -611,7 +611,8 @@ int64_t LocalObjectManager::GetPrimaryBytes() const {
 }
 
 bool LocalObjectManager::HasLocallySpilledObjects() const {
-  if (is_external_storage_type_fs_) {
+  if (!is_external_storage_type_fs_) {
+    // External storage is not local.
     return false;
   }
   // Report non-zero usage when there are spilled / spill-pending live objects, to

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -420,7 +420,7 @@ void LocalObjectManager::OnObjectSpilled(const std::vector<ObjectID> &object_ids
 }
 
 std::string LocalObjectManager::GetLocalSpilledObjectURL(const ObjectID &object_id) {
-  if (!is_external_storage_type_fs_) {
+  if (is_external_storage_type_fs_) {
     // If the external storage is cloud storage like S3, returns the empty string.
     // In that case, the URL is supposed to be obtained by OBOD.
     return "";
@@ -606,14 +606,18 @@ void LocalObjectManager::RecordMetrics() const {
                                                        "Restored");
 }
 
-int64_t LocalObjectManager::GetPinnedBytes() const {
-  if (pinned_objects_size_ > 0) {
-    return pinned_objects_size_;
+int64_t LocalObjectManager::GetPrimaryBytes() const {
+  return pinned_objects_size_ + num_bytes_pending_spill_;
+}
+
+bool LocalObjectManager::HasLocallySpilledObjects() const {
+  if (is_external_storage_type_fs_) {
+    return false;
   }
   // Report non-zero usage when there are spilled / spill-pending live objects, to
   // prevent this node from being drained. Note that the value reported here is also
   // used for scheduling.
-  return (spilled_objects_url_.empty() && objects_pending_spill_.empty()) ? 0 : 1;
+  return !spilled_objects_url_.empty();
 }
 
 std::string LocalObjectManager::DebugString() const {

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -150,9 +150,13 @@ class LocalObjectManager {
   /// In that case, the URL is supposed to be obtained by the object directory.
   std::string GetLocalSpilledObjectURL(const ObjectID &object_id);
 
-  /// Get the current pinned object store memory usage to help node scale down decisions.
-  /// A node can only be safely drained when this function reports zero.
-  int64_t GetPinnedBytes() const;
+  /// Get the current bytes used by primary object copies. This number includes
+  /// bytes used by objects currently being spilled.
+  int64_t GetPrimaryBytes() const;
+
+  /// Returns true if we have objects spilled to the local
+  /// filesystem.
+  bool HasLocallySpilledObjects() const;
 
   std::string DebugString() const;
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -344,7 +344,15 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
       /*get_used_object_store_memory*/
       [this]() {
         if (RayConfig::instance().scheduler_report_pinned_bytes_only()) {
-          return local_object_manager_.GetPinnedBytes();
+          // Get the current bytes used by local primary object copies.  This
+          // is used to help node scale down decisions. A node can only be
+          // safely drained when this function reports zero.
+          int64_t bytes_used = local_object_manager_.GetPrimaryBytes();
+          // Report nonzero if we have objects spilled to the local filesystem.
+          if (bytes_used == 0) {
+            bytes_used = local_object_manager_.HasLocallySpilledObjects();
+          }
+          return bytes_used;
         } else {
           return object_manager_.GetUsedMemory();
         }

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -322,7 +322,7 @@ class LocalObjectManagerTestWithMinSpillingSize {
             client_pool,
             /*max_io_workers=*/2,
             /*min_spilling_size=*/min_spilling_size,
-            /*is_external_storage_type_fs=*/false,
+            /*is_external_storage_type_fs=*/true,
             /*max_fused_object_count*/ max_fused_object_count_,
             /*on_objects_freed=*/
             [&](const std::vector<ObjectID> &object_ids) {

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -322,7 +322,7 @@ class LocalObjectManagerTestWithMinSpillingSize {
             client_pool,
             /*max_io_workers=*/2,
             /*min_spilling_size=*/min_spilling_size,
-            /*is_external_storage_type_fs=*/true,
+            /*is_external_storage_type_fs=*/false,
             /*max_fused_object_count*/ max_fused_object_count_,
             /*on_objects_freed=*/
             [&](const std::vector<ObjectID> &object_ids) {
@@ -1416,13 +1416,13 @@ TEST_F(LocalObjectManagerTest, TestPinBytes) {
   }
 
   // There is no pinned object yet.
-  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(manager.GetPrimaryBytes(), 0);
 
   // Pin objects.
   manager.PinObjectsAndWaitForFree(object_ids, std::move(objects), owner_address);
 
   // Pinned object memory should be reported.
-  ASSERT_GT(manager.GetPinnedBytes(), 0);
+  ASSERT_GT(manager.GetPrimaryBytes(), 0);
 
   // Spill all objects.
   bool spilled = false;
@@ -1436,14 +1436,20 @@ TEST_F(LocalObjectManagerTest, TestPinBytes) {
   for (size_t i = 0; i < object_ids.size(); i++) {
     urls.push_back(BuildURL("url" + std::to_string(i)));
   }
+
+  // Pinned object memory should be reported as nonzero while there are objects
+  // being spilled.
+  ASSERT_GT(manager.GetPrimaryBytes(), 0);
+
   ASSERT_TRUE(worker_pool.io_worker_client->ReplySpillObjects(urls));
   for (size_t i = 0; i < 2; i++) {
     ASSERT_TRUE(owner_client->ReplyUpdateObjectLocationBatch());
   }
   ASSERT_TRUE(spilled);
 
-  // With all objects spilled, the pinned bytes would be 1.
-  ASSERT_EQ(manager.GetPinnedBytes(), 1);
+  // With all objects spilled, the pinned bytes would be 0.
+  ASSERT_EQ(manager.GetPrimaryBytes(), 0);
+  ASSERT_TRUE(manager.HasLocallySpilledObjects());
 
   // Delete all (spilled) objects.
   for (size_t i = 0; i < free_objects_batch_size; i++) {
@@ -1455,7 +1461,8 @@ TEST_F(LocalObjectManagerTest, TestPinBytes) {
   ASSERT_EQ(deleted_urls_size, object_ids.size());
 
   // With no pinned or spilled object, the pinned bytes should be 0.
-  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(manager.GetPrimaryBytes(), 0);
+  ASSERT_FALSE(manager.HasLocallySpilledObjects());
 
   AssertNoLeaks();
 }
@@ -1483,13 +1490,13 @@ TEST_F(LocalObjectManagerTest, TestConcurrentSpillAndDelete1) {
   }
 
   // There is no pinned object yet.
-  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(manager.GetPrimaryBytes(), 0);
 
   // Pin objects.
   manager.PinObjectsAndWaitForFree(object_ids, std::move(objects), owner_address);
 
   // Pinned object memory should be reported.
-  ASSERT_GT(manager.GetPinnedBytes(), 0);
+  ASSERT_GT(manager.GetPrimaryBytes(), 0);
 
   // Spill all objects.
   bool spilled = false;
@@ -1519,7 +1526,7 @@ TEST_F(LocalObjectManagerTest, TestConcurrentSpillAndDelete1) {
   manager.ProcessSpilledObjectsDeleteQueue(free_objects_batch_size);
   int deleted_urls_size = worker_pool.io_worker_client->ReplyDeleteSpilledObjects();
   ASSERT_EQ(deleted_urls_size, object_ids.size());
-  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(manager.GetPrimaryBytes(), 0);
   ASSERT_EQ(NumBytesPendingSpill(), 0);
 
   AssertNoLeaks();
@@ -1549,13 +1556,13 @@ TEST_F(LocalObjectManagerTest, TestConcurrentSpillAndDelete2) {
   }
 
   // There is no pinned object yet.
-  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(manager.GetPrimaryBytes(), 0);
 
   // Pin objects.
   manager.PinObjectsAndWaitForFree(object_ids, std::move(objects), owner_address);
 
   // Pinned object memory should be reported.
-  ASSERT_GT(manager.GetPinnedBytes(), 0);
+  ASSERT_GT(manager.GetPrimaryBytes(), 0);
 
   // Spill all objects.
   bool spilled = false;
@@ -1581,7 +1588,7 @@ TEST_F(LocalObjectManagerTest, TestConcurrentSpillAndDelete2) {
   manager.ProcessSpilledObjectsDeleteQueue(free_objects_batch_size);
   int deleted_urls_size = worker_pool.io_worker_client->ReplyDeleteSpilledObjects();
   ASSERT_EQ(deleted_urls_size, 0);
-  ASSERT_EQ(manager.GetPinnedBytes(), 0);
+  ASSERT_EQ(manager.GetPrimaryBytes(), 0);
   ASSERT_EQ(NumBytesPendingSpill(), 0);
 
   AssertNoLeaks();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Each node is supposed to report bytes used by its primary in-memory object copies. During spilling, this number is set incorrectly to 1 (see #26639 for more details).

This PR changes the reporting to include objects that are currently being spilled. It also splits out the "return nonzero number if there are local spilled objects" logic into a separate method.

## Related issue number

Closes #26639.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
