### PR TITLE
[Datasets] Handle any error code when encountering AWS S3 credential error

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -330,6 +330,7 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
 
 
 def _handle_read_os_error(error: OSError, paths: Union[str, List[str]]) -> str:
+    # NOTE: this is not comprehensive yet, and should be extended as more errors arise.
     if "AWS Error [code 15]: No response body" in str(error):
         # Specially handle AWS error when reading files, to give a clearer error
         # message to avoid confusing users. The real issue is most likely that the AWS

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import (
     List,
     Optional,
@@ -331,7 +332,8 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
 
 def _handle_read_os_error(error: OSError, paths: Union[str, List[str]]) -> str:
     # NOTE: this is not comprehensive yet, and should be extended as more errors arise.
-    if "AWS Error [code 15]: No response body" in str(error):
+    aws_error_pattern = r"^(.*)AWS Error \[code \d+\]: No response body\.$"
+    if re.match(aws_error_pattern, str(error)):
         # Specially handle AWS error when reading files, to give a clearer error
         # message to avoid confusing users. The real issue is most likely that the AWS
         # S3 file credentials have not been properly configured yet.

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -15,7 +15,7 @@ from ray.data.datasource.file_based_datasource import _resolve_paths_and_filesys
 from ray.data.datasource.file_meta_provider import (
     DefaultParquetMetadataProvider,
     ParquetMetadataProvider,
-    _handle_read_s3_files_error,
+    _handle_read_os_error,
 )
 from ray.data.datasource.parquet_base_datasource import ParquetBaseDatasource
 from ray.types import ObjectRef
@@ -167,7 +167,7 @@ class _ParquetDatasourceReader(Reader):
                 paths, **dataset_kwargs, filesystem=filesystem, use_legacy_dataset=False
             )
         except OSError as e:
-            _handle_read_s3_files_error(e, paths)
+            _handle_read_os_error(e, paths)
         if schema is None:
             schema = pq_ds.schema
         if columns:

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -190,7 +190,11 @@ class _ParquetDatasourceReader(Reader):
                 inferred_schema = schema
         else:
             inferred_schema = schema
-        self._metadata = meta_provider.prefetch_file_metadata(pq_ds.pieces) or []
+
+        try:
+            self._metadata = meta_provider.prefetch_file_metadata(pq_ds.pieces) or []
+        except OSError as e:
+            _handle_read_os_error(e, paths)
         self._pq_ds = pq_ds
         self._meta_provider = meta_provider
         self._inferred_schema = inferred_schema

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2963,16 +2963,16 @@ def test_read_text_remote_args(ray_start_cluster, tmp_path):
 def test_read_s3_file_error(ray_start_regular_shared, s3_path):
     dummy_path = s3_path + "_dummy"
     error_message = "Please check that file exists and has properly configured access."
-    with pytest.raises(PermissionError) as e:
+    with pytest.raises(OSError) as e:
         ray.data.read_parquet(dummy_path)
         assert error_message in str(e)
-    with pytest.raises(PermissionError) as e:
+    with pytest.raises(OSError) as e:
         ray.data.read_binary_files(dummy_path)
         assert error_message in str(e)
-    with pytest.raises(PermissionError) as e:
+    with pytest.raises(OSError) as e:
         ray.data.read_csv(dummy_path)
         assert error_message in str(e)
-    with pytest.raises(PermissionError) as e:
+    with pytest.raises(OSError) as e:
         ray.data.read_json(dummy_path)
         assert error_message in str(e)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As a followup of https://github.com/ray-project/ray/pull/26619#issuecomment-1186036076 and https://github.com/ray-project/ray/pull/26619#discussion_r922629145, here we change from `PermissionError` to `OSError`, to be consistent as original error, and also change function name from `_handle_read_s3_files_error` to `_handle_read_os_error`, which is more general that we can handle other file systems such as GCS in the future.

Also change to hanlde any error message with pattern `AWS Error [code xxx]: No response body` as new issue with error code 100 is raised in https://github.com/ray-project/ray/issues/26672 .

Tested the example in https://github.com/ray-project/ray/issues/26672 and verified it shows new error message now:

```
>>> import ray
>>> ds = ray.data.read_parquet([
...     "s3://anonymous@ursa-labs-taxi-data/2009/01/data.parquet",
...     "s3://anonymous@ursa-labs-taxi-data/2009/02/data.parquet",
... ])

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 365, in read_parquet
    return read_datasource(
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 267, in read_datasource
    requested_parallelism, min_safe_parallelism, read_tasks = ray.get(
  File "/Users/chengsu/ray/python/ray/_private/client_mode_hook.py", line 105, in wrapper
    return func(*args, **kwargs)
  File "/Users/chengsu/ray/python/ray/_private/worker.py", line 2196, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(OSError): ray::_get_read_tasks() (pid=37757, ip=127.0.0.1)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_meta_provider.py", line 330, in prefetch_file_metadata
    return _fetch_metadata(pieces)
  File "/Users/chengsu/ray/python/ray/data/datasource/parquet_datasource.py", line 341, in _fetch_metadata
    piece_metadata.append(p.metadata)
  File "pyarrow/_dataset.pyx", line 1315, in pyarrow._dataset.ParquetFileFragment.metadata.__get__
  File "pyarrow/_dataset.pyx", line 1304, in pyarrow._dataset.ParquetFileFragment.ensure_complete_metadata
  File "pyarrow/error.pxi", line 114, in pyarrow.lib.check_status
OSError: When reading information for key '2009/02/data.parquet' in bucket 'anonymous@ursa-labs-taxi-data': AWS Error [code 100]: No response body.

During handling of the above exception, another exception occurred:

ray::_get_read_tasks() (pid=37757, ip=127.0.0.1)
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 1129, in _get_read_tasks
    reader = ds.create_reader(**kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/parquet_datasource.py", line 142, in create_reader
    return _ParquetDatasourceReader(**kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/parquet_datasource.py", line 197, in __init__
    _handle_read_os_error(e, paths)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_meta_provider.py", line 345, in _handle_read_os_error
    raise OSError(
OSError: Failing to read AWS S3 file(s): ['ursa-labs-taxi-data/2009/01/data.parquet', 'anonymous@ursa-labs-taxi-data/2009/02/data.parquet']. Please check that file exists and has properly configured access. See https://docs.ray.io/en/latest/data/creating-datasets.html#reading-from-remote-storage for more information.
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/26672 .

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
