### PR TITLE
[CI] Mark chaos_dataset_shuffle_push_based_sort_1tb and chaos_dataset_shuffle_sort_1tb stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4105,8 +4105,6 @@
     test_name: chaos_dataset_shuffle_push_based_sort_1tb
     test_suite: chaos_test
 
-  stable: false
-
   frequency: nightly
   team: core
   cluster:
@@ -4128,8 +4126,6 @@
   legacy:
     test_name: chaos_dataset_shuffle_sort_1tb
     test_suite: chaos_test
-
-  stable: false
 
   frequency: nightly
   team: core


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
They passed for the past 7 runs.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
