### PR TITLE
[Datasets] Automatically cast tensor columns when building Pandas blocks.

### DIFF
--- a/python/ray/air/tests/test_data_batch_conversion.py
+++ b/python/ray/air/tests/test_data_batch_conversion.py
@@ -29,7 +29,7 @@ def test_numpy_pandas():
     actual_output = convert_batch_type_to_pandas(input_data)
     assert expected_output.equals(actual_output)
 
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         convert_pandas_to_batch_type(actual_output, type=DataType.NUMPY), input_data
     )
 
@@ -40,18 +40,18 @@ def test_numpy_multi_dim_pandas():
     actual_output = convert_batch_type_to_pandas(input_data)
     assert expected_output.equals(actual_output)
 
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         convert_pandas_to_batch_type(actual_output, type=DataType.NUMPY), input_data
     )
 
 
 def test_numpy_object_pandas():
     input_data = np.array([[1, 2, 3], [1]], dtype=object)
-    expected_output = pd.DataFrame({TENSOR_COLUMN_NAME: TensorArray(input_data)})
+    expected_output = pd.DataFrame({TENSOR_COLUMN_NAME: input_data})
     actual_output = convert_batch_type_to_pandas(input_data)
     assert expected_output.equals(actual_output)
 
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         convert_pandas_to_batch_type(actual_output, type=DataType.NUMPY), input_data
     )
 
@@ -69,7 +69,7 @@ def test_dict_pandas():
     assert expected_output.equals(actual_output)
 
     output_array = convert_pandas_to_batch_type(actual_output, type=DataType.NUMPY)
-    assert np.array_equal(output_array, input_data["x"])
+    np.testing.assert_array_equal(output_array, input_data["x"])
 
 
 def test_dict_multi_dim_to_pandas():
@@ -80,7 +80,7 @@ def test_dict_multi_dim_to_pandas():
     assert expected_output.equals(actual_output)
 
     output_array = convert_pandas_to_batch_type(actual_output, type=DataType.NUMPY)
-    assert np.array_equal(output_array, input_data["x"])
+    np.testing.assert_array_equal(output_array, input_data["x"])
 
 
 def test_dict_pandas_multi_column():
@@ -91,7 +91,7 @@ def test_dict_pandas_multi_column():
 
     output_dict = convert_pandas_to_batch_type(actual_output, type=DataType.NUMPY)
     for k, v in output_dict.items():
-        assert np.array_equal(v, array_dict[k])
+        np.testing.assert_array_equal(v, array_dict[k])
 
 
 def test_arrow_pandas():

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -45,7 +45,7 @@ class ArrowTensorType(pa.PyExtensionType):
         """
         from ray.air.util.tensor_extensions.pandas import TensorDtype
 
-        return TensorDtype()
+        return TensorDtype(self._shape, self.storage_type.value_type.to_pandas_dtype())
 
     def __reduce__(self):
         return ArrowTensorType, (self._shape, self.storage_type.value_type)
@@ -60,10 +60,13 @@ class ArrowTensorType(pa.PyExtensionType):
         """
         return ArrowTensorArray
 
-    def __str__(self):
-        return "<ArrowTensorType: shape={}, dtype={}>".format(
-            self.shape, self.storage_type.value_type
+    def __str__(self) -> str:
+        return (
+            f"ArrowTensorType(shape={self.shape}, dtype={self.storage_type.value_type})"
         )
+
+    def __repr__(self) -> str:
+        return str(self)
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -204,12 +204,12 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         dtype: object
         >>> # Cast column to our TensorDtype extension type.
         >>> from ray.data.extensions import TensorDtype
-        >>> df["two"] = df["two"].astype(TensorDtype())
+        >>> df["two"] = df["two"].astype(TensorDtype((3, 2, 2, 2), np.int64))
         >>> # Note that the column dtype is now TensorDtype instead of
         >>> # np.object.
         >>> df.dtypes # doctest: +SKIP
         one          int64
-        two    TensorDtype
+        two    TensorDtype(shape=(3, 2, 2, 2), dtype=int64)
         dtype: object
         >>> # Pandas is now aware of this tensor column, and we can do the
         >>> # typical DataFrame operations on this column.
@@ -231,7 +231,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
               [38 40]]
              [[42 44]
               [46 48]]]
-        Name: two, dtype: TensorDtype
+        Name: two, dtype: TensorDtype(shape=(3, 2, 2, 2), dtype=int64)
         >>> # Once you do an aggregation on that column that returns a single
         >>> # row's value, you get back our TensorArrayElement type.
         >>> tensor = col.mean()
@@ -264,7 +264,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         >>> read_df = ray.get(read_ds.to_pandas_refs())[0] # doctest: +SKIP
         >>> read_df.dtypes # doctest: +SKIP
         one          int64
-        two    TensorDtype
+        two    TensorDtype(shape=(3, 2, 2, 2), dtype=int64)
         dtype: object
         >>> # The tensor extension type is preserved along the
         >>> # Pandas --> Arrow --> Parquet --> Arrow --> Pandas
@@ -277,6 +277,10 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
     # errors, but is an undocumented ExtensionDtype attribute. See issue:
     # https://github.com/CODAIT/text-extensions-for-pandas/issues/166
     base = None
+
+    def __init__(self, shape: Tuple[int, ...], dtype: np.dtype):
+        self._shape = shape
+        self._dtype = dtype
 
     @property
     def type(self):
@@ -295,7 +299,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         A string identifying the data type.
         Will be used for display in, e.g. ``Series.dtype``
         """
-        return "TensorDtype"
+        return f"{type(self).__name__}(shape={self._shape}, dtype={self._dtype})"
 
     @classmethod
     def construct_from_string(cls, string: str):
@@ -342,16 +346,26 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         ...             f"Cannot construct a '{cls.__name__}' from '{string}'"
         ...         )
         """
+        import ast
+        import re
+
         if not isinstance(string, str):
             raise TypeError(
                 f"'construct_from_string' expects a string, got {type(string)}"
             )
         # Upstream code uses exceptions as part of its normal control flow and
         # will pass this method bogus class names.
-        if string == cls.__name__:
-            return cls()
-        else:
-            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
+        regex = r"^TensorDtype\(shape=(\(\d+,(?:\s\d+,?)*\)), dtype=(\w+)\)$"
+        m = re.search(regex, string)
+        if m is None:
+            raise TypeError(
+                f"Cannot construct a '{cls.__name__}' from '{string}'; expected a "
+                "string like 'TensorDtype(shape=(1, 2, 3), dtype=int64)'."
+            )
+        shape, dtype = m.groups()
+        shape = ast.literal_eval(shape)
+        dtype = np.dtype(dtype)
+        return cls(shape, dtype)
 
     @classmethod
     def construct_array_type(cls):
@@ -387,6 +401,33 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
             values = array.to_numpy()
 
         return TensorArray(values)
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    @property
+    def _is_boolean(self):
+        """
+        Whether this extension array should be considered boolean.
+
+        By default, ExtensionArrays are assumed to be non-numeric.
+        Setting this to True will affect the behavior of several places,
+        e.g.
+
+        * is_bool
+        * boolean indexing
+
+        Returns
+        -------
+        bool
+        """
+        # This is needed to support returning a TensorArray from .isnan().
+        from pandas.core.dtypes.common import is_bool_dtype
+
+        return is_bool_dtype(self._dtype)
 
 
 class TensorOpsMixin(pd.api.extensions.ExtensionScalarOpsMixin):
@@ -552,7 +593,7 @@ class TensorArray(
         >>> # Note that the column dtype is TensorDtype.
         >>> df.dtypes # doctest: +SKIP
         one          int64
-        two    TensorDtype
+        two    TensorDtype(shape=(3, 2, 2, 2), dtype=int64)
         dtype: object
         >>> # Pandas is aware of this tensor column, and we can do the
         >>> # typical DataFrame operations on this column.
@@ -574,7 +615,7 @@ class TensorArray(
               [38 40]]
              [[42 44]
               [46 48]]]
-        Name: two, dtype: TensorDtype
+        Name: two, dtype: TensorDtype(shape=(3, 2, 2, 2), dtype=int64)
         >>> # Once you do an aggregation on that column that returns a single
         >>> # row's value, you get back our TensorArrayElement type.
         >>> tensor = col.mean() # doctest: +SKIP
@@ -608,7 +649,7 @@ class TensorArray(
         >>> read_df = ray.get(read_ds.to_pandas_refs())[0] # doctest: +SKIP
         >>> read_df.dtypes # doctest: +SKIP
         one          int64
-        two    TensorDtype
+        two    TensorDtype(shape=(3, 2, 2, 2), dtype=int64)
         dtype: object
         >>> # The tensor extension type is preserved along the
         >>> # Pandas --> Arrow --> Parquet --> Arrow --> Pandas
@@ -651,24 +692,40 @@ class TensorArray(
             # Convert series to ndarray and passthrough to ndarray handling
             # logic.
             values = values.to_numpy()
+        elif isinstance(values, Sequence):
+            values = np.array([np.asarray(v) for v in values])
 
         if isinstance(values, np.ndarray):
-            if (
-                values.dtype.type is np.object_
-                and len(values) > 0
-                and isinstance(values[0], (np.ndarray, TensorArrayElement))
-            ):
-                # Convert ndarrays of ndarrays/TensorArrayElements
-                # with an opaque object type to a properly typed ndarray of
-                # ndarrays.
-                self._tensor = np.array([np.asarray(v) for v in values])
+            if values.dtype.type is np.object_:
+                if len(values) == 0 or (
+                    not isinstance(values[0], str)
+                    and isinstance(
+                        values[0], (np.ndarray, TensorArrayElement, Sequence)
+                    )
+                ):
+                    # Convert ndarrays of ndarrays/TensorArrayElements
+                    # with an opaque object type to a properly typed ndarray of
+                    # ndarrays.
+                    self._tensor = np.array([np.asarray(v) for v in values])
+                    if self._tensor.dtype.type is np.object_:
+                        subndarray_types = [v.dtype for v in self._tensor]
+                        raise TypeError(
+                            "Tried to convert an ndarray of ndarray pointers (object "
+                            "dtype) to a well-typed ndarray but this failed; convert "
+                            "the ndarray to a well-typed ndarray before casting it as "
+                            "a TensorArray, and note that ragged tensors are NOT "
+                            "supported by TensorArray. subndarray types: "
+                            f"{subndarray_types}"
+                        )
+                else:
+                    raise TypeError(
+                        "Expected a well-typed ndarray or an object-typed ndarray of "
+                        "ndarray pointers, but got an object-typed ndarray whose "
+                        f"subndarrays are of type {type(values[0])}."
+                    )
             else:
+                # ndarray is well-typed, use it directly as the backing tensor.
                 self._tensor = values
-        elif isinstance(values, Sequence):
-            if len(values) == 0:
-                self._tensor = np.array([])
-            else:
-                self._tensor = np.stack([np.asarray(v) for v in values], axis=0)
         elif isinstance(values, TensorArrayElement):
             self._tensor = np.array([np.asarray(values)])
         elif np.isscalar(values):
@@ -800,7 +857,7 @@ class TensorArray(
         """
         An instance of 'ExtensionDtype'.
         """
-        return TensorDtype()
+        return TensorDtype(self.numpy_shape[1:], self.numpy_dtype)
 
     @property
     def nbytes(self) -> int:
@@ -1184,27 +1241,6 @@ class TensorArray(
         """
         return self._tensor.size
 
-    @property
-    def _is_boolean(self):
-        """
-        Whether this extension array should be considered boolean.
-
-        By default, ExtensionArrays are assumed to be non-numeric.
-        Setting this to True will affect the behavior of several places,
-        e.g.
-
-        * is_bool
-        * boolean indexing
-
-        Returns
-        -------
-        bool
-        """
-        # This is needed to support returning a TensorArray from .isnan().
-        # TODO(Clark): Propagate tensor dtype to extension TensorDtype and
-        # move this property there.
-        return np.issubdtype(self._tensor.dtype, np.bool)
-
     def astype(self, dtype, copy=True):
         """
         Cast to a NumPy array with 'dtype'.
@@ -1288,6 +1324,25 @@ class TensorArray(
         from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
 
         return ArrowTensorArray.from_numpy(self._tensor)
+
+    @property
+    def _is_boolean(self):
+        """
+        Whether this extension array should be considered boolean.
+
+        By default, ExtensionArrays are assumed to be non-numeric.
+        Setting this to True will affect the behavior of several places,
+        e.g.
+
+        * is_bool
+        * boolean indexing
+
+        Returns
+        -------
+        bool
+        """
+        # This is needed to support returning a TensorArray from .isnan().
+        return self.dtype._is_boolean()
 
 
 # Add operators from the mixin to the TensorArrayElement and TensorArray

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -1,3 +1,4 @@
+import logging
 from typing import (
     Callable,
     Dict,
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 _pandas = None
+logger = logging.getLogger(__name__)
 
 
 def lazy_import_pandas():
@@ -95,7 +97,28 @@ class PandasBlockBuilder(TableBlockBuilder[T]):
 
     def _concat_tables(self, tables: List["pandas.DataFrame"]) -> "pandas.DataFrame":
         pandas = lazy_import_pandas()
-        return pandas.concat(tables, ignore_index=True)
+        from ray.data.extensions.tensor_extension import TensorArray
+
+        df = pandas.concat(tables, ignore_index=True)
+        # Try to convert any ndarray columns to TensorArray columns.
+        # TODO(Clark): Once Pandas supports registering extension types for type
+        # inference on construction, implement as much for NumPy ndarrays and remove
+        # this. See https://github.com/pandas-dev/pandas/issues/41848
+        for col_name, col in df.items():
+            if (
+                col.dtype.type is np.object_
+                and not col.empty
+                and isinstance(col[0], np.ndarray)
+            ):
+                try:
+                    df[col_name] = TensorArray(col)
+                except Exception as e:
+                    logger.warning(
+                        f"Tried to transparently convert column {col_name} to a "
+                        "TensorArray but the conversion failed, leaving column as-is: "
+                        f"{e}"
+                    )
+        return df
 
     @staticmethod
     def _empty_table() -> "pandas.DataFrame":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3564,7 +3564,7 @@ class Dataset(Generic[T]):
             for n, t in zip(schema.names, schema.types):
                 if hasattr(t, "__name__"):
                     t = t.__name__
-                schema_str.append("{}: {}".format(n, t))
+                schema_str.append(f"{n}: {t}")
             schema_str = ", ".join(schema_str)
             schema_str = "{" + schema_str + "}"
         count = self._meta_count()

--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -1,7 +1,10 @@
+import logging
 import pathlib
 from typing import TYPE_CHECKING, List, Optional, Union
 
 import numpy as np
+
+import ray
 from ray.data.datasource.binary_datasource import BinaryDatasource
 from ray.data.datasource.datasource import Reader
 from ray.data.datasource.file_based_datasource import (
@@ -15,6 +18,7 @@ if TYPE_CHECKING:
     import pyarrow
     from ray.data.block import T
 
+logger = logging.getLogger(__name__)
 IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "tiff", "bmp", "gif"]
 
 
@@ -126,9 +130,15 @@ class ImageFolderDatasource(BinaryDatasource):
         image = iio.imread(data)
         label = _get_class_from_path(path, self.root)
         try:
+            # Try to convert image ndarray to TensorArrays.
             image = TensorArray([np.array(image)])
-        except TypeError:
-            pass
+        except TypeError as e:
+            # Fall back to existing NumPy array.
+            if ray.util.log_once("datasets_tensor_array_cast_warning"):
+                logger.warning(
+                    "Tried to transparently convert image ndarray to a TensorArray "
+                    f"but the conversion failed, leaving image ndarray as-is: {e}"
+                )
 
         return pd.DataFrame(
             {

--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -125,10 +125,14 @@ class ImageFolderDatasource(BinaryDatasource):
 
         image = iio.imread(data)
         label = _get_class_from_path(path, self.root)
+        try:
+            image = TensorArray([np.array(image)])
+        except TypeError:
+            pass
 
         return pd.DataFrame(
             {
-                "image": TensorArray([np.array(image)]),
+                "image": image,
                 "label": [label],
             }
         )

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -90,7 +90,11 @@ class Concatenator(Preprocessor):
         columns_to_concat = list(included_columns - set(self.excluded_columns))
         concatenated = df[columns_to_concat].to_numpy(dtype=self.dtype)
         df = df.drop(columns=columns_to_concat)
-        df[self.output_column_name] = TensorArray(concatenated)
+        try:
+            concatenated = TensorArray(concatenated)
+        except TypeError:
+            pass
+        df[self.output_column_name] = concatenated
         return df
 
     def __repr__(self):

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -604,7 +604,7 @@ def test_tensors_basic(ray_start_regular_shared):
     ds = ray.data.range_tensor(6, shape=tensor_shape, parallelism=6)
     assert str(ds) == (
         "Dataset(num_blocks=6, num_rows=6, "
-        "schema={__value__: <ArrowTensorType: shape=(3, 5), dtype=int64>})"
+        "schema={__value__: ArrowTensorType(shape=(3, 5), dtype=int64)})"
     )
     assert ds.size_bytes() == 5 * 3 * 6 * 8
 
@@ -795,7 +795,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     ds = ray.data.range(10, parallelism=10).map(lambda _: np.ones((4, 4)))
     assert str(ds) == (
         "Dataset(num_blocks=10, num_rows=10, "
-        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
+        "schema={__value__: ArrowTensorType(shape=(4, 4), dtype=double)})"
     )
 
     # Test map_batches.
@@ -804,7 +804,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     )
     assert str(ds) == (
         "Dataset(num_blocks=4, num_rows=24, "
-        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
+        "schema={__value__: ArrowTensorType(shape=(4, 4), dtype=double)})"
     )
 
     # Test flat_map.
@@ -813,7 +813,7 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
     )
     assert str(ds) == (
         "Dataset(num_blocks=10, num_rows=20, "
-        "schema={__value__: <ArrowTensorType: shape=(4, 4), dtype=double>})"
+        "schema={__value__: ArrowTensorType(shape=(4, 4), dtype=double)})"
     )
 
 
@@ -825,7 +825,7 @@ def test_tensors_in_tables_from_pandas(ray_start_regular_shared):
     arr = np.arange(num_items).reshape(shape)
     df = pd.DataFrame({"one": list(range(outer_dim)), "two": list(arr)})
     # Cast column to tensor extension dtype.
-    df["two"] = df["two"].astype(TensorDtype())
+    df["two"] = df["two"].astype(TensorDtype(shape, np.int64))
     ds = ray.data.from_pandas([df])
     values = [[s["one"], s["two"]] for s in ds.take()]
     expected = list(zip(list(range(outer_dim)), arr))
@@ -904,7 +904,7 @@ def test_tensors_in_tables_parquet_pickle_manual_serde(
     # extension type.
     def deser_mapper(batch: pd.DataFrame):
         batch["two"] = [pickle.loads(a) for a in batch["two"]]
-        batch["two"] = batch["two"].astype(TensorDtype())
+        batch["two"] = batch["two"].astype(TensorDtype(shape, np.int64))
         return batch
 
     casted_ds = ds.map_batches(deser_mapper, batch_format="pandas")

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -1170,7 +1170,7 @@ def test_numpy_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_numpy(data_path, filesystem=fs)
     assert str(ds) == (
         "Dataset(num_blocks=2, num_rows=None, "
-        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
+        "schema={__value__: ArrowTensorType(shape=(1,), dtype=int64)})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1182,7 +1182,7 @@ def test_numpy_read(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path)
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
+        "schema={__value__: ArrowTensorType(shape=(1,), dtype=int64)})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1195,7 +1195,7 @@ def test_numpy_read(ray_start_regular_shared, tmp_path):
     assert ds.count() == 10
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
+        "schema={__value__: ArrowTensorType(shape=(1,), dtype=int64)})"
     )
     assert [v.item() for v in ds.take(2)] == [0, 1]
 
@@ -1208,7 +1208,7 @@ def test_numpy_read_meta_provider(ray_start_regular_shared, tmp_path):
     ds = ray.data.read_numpy(path, meta_provider=FastFileMetadataProvider())
     assert str(ds) == (
         "Dataset(num_blocks=1, num_rows=10, "
-        "schema={__value__: <ArrowTensorType: shape=(1,), dtype=int64>})"
+        "schema={__value__: ArrowTensorType(shape=(1,), dtype=int64)})"
     )
     np.testing.assert_equal(ds.take(2), [np.array([0]), np.array([1])])
 
@@ -1265,7 +1265,7 @@ def test_numpy_read_partitioned_with_filter(
         val_str = "".join(f"array({v}, dtype=int8), " for v in vals)[:-2]
         assert_base_partitioned_ds(
             ds,
-            schema="{__value__: <ArrowTensorType: shape=(2,), dtype=int8>}",
+            schema="{__value__: ArrowTensorType(shape=(2,), dtype=int8)}",
             sorted_values=f"[[{val_str}]]",
             ds_take_transform_fn=lambda taken: [taken],
             sorted_values_transform_fn=lambda sorted_values: str(sorted_values),


### PR DESCRIPTION
This PR tries to automatically cast tensor columns to our `TensorArray` extension type when building Pandas blocks, logging a warning and falling back to the opaque object-typed column if the cast fails. This should allow users to remain mostly tensor extension agnostic.

`TensorArray` now eagerly validates the underlying tensor data, raising an error if e.g. the underlying ndarrays have heterogeneous shapes; previously, `TensorArray` wouldn't validate this on construction and would instead let failures happen downstream. This means that our internal `TensorArray` use needs to follow a try-except pattern, falling back to a plain NumPy object column.

## Drivebys

- Add shape and dtype to `TensorDtype` extension type.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
