### PR TITLE
[Workflow] Fix typo in workflow event doc

### DIFF
--- a/doc/source/workflows/events.rst
+++ b/doc/source/workflows/events.rst
@@ -20,8 +20,9 @@ Workflow events are a special type of workflow task. They "finish" when the even
 
 .. code-block:: python
 
-    from ray import workflow
     import time
+    import ray
+    from ray import workflow
 
     # Create an event which finishes after 60 seconds.
     event1_task = workflow.wait_for_event(workflow.event_listener.TimerListener, time.time() + 60)
@@ -34,7 +35,7 @@ Workflow events are a special type of workflow task. They "finish" when the even
         return args
 
     # Gather will run after 60 seconds, when both event1 and event2 are done.
-    workflow.run(gather.bind(event1_task, event_2_task))
+    workflow.run(gather.bind(event1_task, event2_task))
 
 
 Custom event listeners


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix a typo in the workflow doc.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
