### PR TITLE
[Datasets] Add `.iter_torch_batches()` and `.iter_tf_batches()` APIs.

### DIFF
--- a/doc/source/ray-air/doc_code/predictors.py
+++ b/doc/source/ray-air/doc_code/predictors.py
@@ -16,7 +16,8 @@ from ray.train.tensorflow import (
 def build_model() -> tf.keras.Model:
     model = tf.keras.Sequential(
         [
-            tf.keras.layers.InputLayer(input_shape=(1,)),
+            tf.keras.layers.InputLayer(input_shape=()),
+            tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(1),
         ]
     )

--- a/doc/source/ray-air/doc_code/predictors.py
+++ b/doc/source/ray-air/doc_code/predictors.py
@@ -17,6 +17,7 @@ def build_model() -> tf.keras.Model:
     model = tf.keras.Sequential(
         [
             tf.keras.layers.InputLayer(input_shape=()),
+            # Add feature dimension, expanding (batch_size,) to (batch_size, 1).
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(1),
         ]

--- a/doc/source/ray-air/doc_code/tf_starter.py
+++ b/doc/source/ray-air/doc_code/tf_starter.py
@@ -27,6 +27,7 @@ def build_model() -> tf.keras.Model:
     model = tf.keras.Sequential(
         [
             tf.keras.layers.InputLayer(input_shape=()),
+            # Add feature dimension, expanding (batch_size,) to (batch_size, 1).
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(10),
             tf.keras.layers.Dense(1),

--- a/doc/source/ray-air/doc_code/tf_starter.py
+++ b/doc/source/ray-air/doc_code/tf_starter.py
@@ -26,7 +26,8 @@ from ray.air.config import ScalingConfig
 def build_model() -> tf.keras.Model:
     model = tf.keras.Sequential(
         [
-            tf.keras.layers.InputLayer(input_shape=(1,)),
+            tf.keras.layers.InputLayer(input_shape=()),
+            tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(10),
             tf.keras.layers.Dense(1),
         ]

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union, Dict
 
 import numpy as np
 import pandas as pd
@@ -81,3 +81,63 @@ def convert_pandas_to_tf_tensor(
         return tf.expand_dims(concatenated_tensor, axis=1)
 
     return concatenated_tensor
+
+
+def convert_ndarray_to_tf_tensor(
+    ndarray: np.ndarray,
+    dtype: Optional[tf.dtypes.DType] = None,
+) -> tf.Tensor:
+    """Convert a NumPy ndarray to a TensorFlow Tensor.
+
+    Args:
+        ndarray: The NumPy ndarray that we wish to convert to a TensorFlow Tensor.
+        dtype: The TensorFlow dtype for the created tensor; if None, the dtype will be
+            inferred from the NumPy ndarray data.
+
+    Returns: A TensorFlow Tensor.
+    """
+    tf_tensor = tf.convert_to_tensor(ndarray, dtype=dtype)
+
+    # Off-the-shelf Keras Modules expect the input size to have at least 2
+    # dimensions (batch_size, feature_size). If the tensor for the column
+    # is flattened, then we unqueeze it to add an extra dimension.
+    if len(tf_tensor.shape) == 1:
+        tf_tensor = tf.expand_dims(tf_tensor, axis=1)
+    return tf_tensor
+
+
+def convert_ndarray_batch_to_tf_tensor_batch(
+    ndarrays: Union[np.ndarray, Dict[str, np.ndarray]],
+    dtypes: Optional[Union[tf.dtypes.DType, Dict[str, tf.dtypes.DType]]] = None,
+) -> Union[tf.Tensor, Dict[str, tf.Tensor]]:
+    """Convert a NumPy ndarray batch to a TensorFlow Tensor batch.
+
+    Args:
+        ndarray: A (dict of) NumPy ndarray(s) that we wish to convert to a TensorFlow
+            Tensor.
+        dtype: A (dict of) TensorFlow dtype(s) for the created tensor; if None, the
+            dtype will be inferred from the NumPy ndarray data.
+
+    Returns: A (dict of) TensorFlow Tensor(s).
+    """
+    if isinstance(ndarrays, np.ndarray):
+        # Single-tensor case.
+        if isinstance(dtypes, dict):
+            if len(dtypes) != 1:
+                raise ValueError(
+                    "When constructing a single-tensor batch, only a single dtype "
+                    f"should be given, instead got: {dtypes}"
+                )
+            dtypes = next(iter(dtypes.values()))
+        batch = convert_ndarray_to_tf_tensor(ndarrays, dtype=dtypes)
+    else:
+        # Multi-tensor case.
+        batch = {
+            col_name: convert_ndarray_to_tf_tensor(
+                col_ndarray,
+                dtype=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+            )
+            for col_name, col_ndarray in ndarrays.items()
+        }
+
+    return batch

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -83,29 +83,6 @@ def convert_pandas_to_tf_tensor(
     return concatenated_tensor
 
 
-def convert_ndarray_to_tf_tensor(
-    ndarray: np.ndarray,
-    dtype: Optional[tf.dtypes.DType] = None,
-) -> tf.Tensor:
-    """Convert a NumPy ndarray to a TensorFlow Tensor.
-
-    Args:
-        ndarray: The NumPy ndarray that we wish to convert to a TensorFlow Tensor.
-        dtype: The TensorFlow dtype for the created tensor; if None, the dtype will be
-            inferred from the NumPy ndarray data.
-
-    Returns: A TensorFlow Tensor.
-    """
-    tf_tensor = tf.convert_to_tensor(ndarray, dtype=dtype)
-
-    # Off-the-shelf Keras Modules expect the input size to have at least 2
-    # dimensions (batch_size, feature_size). If the tensor for the column
-    # is flattened, then we unqueeze it to add an extra dimension.
-    if len(tf_tensor.shape) == 1:
-        tf_tensor = tf.expand_dims(tf_tensor, axis=1)
-    return tf_tensor
-
-
 def convert_ndarray_batch_to_tf_tensor_batch(
     ndarrays: Union[np.ndarray, Dict[str, np.ndarray]],
     dtypes: Optional[Union[tf.dtypes.DType, Dict[str, tf.dtypes.DType]]] = None,

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -106,11 +106,11 @@ def convert_ndarray_batch_to_tf_tensor_batch(
                     f"should be given, instead got: {dtypes}"
                 )
             dtypes = next(iter(dtypes.values()))
-        batch = convert_ndarray_to_tf_tensor(ndarrays, dtype=dtypes)
+        batch = tf.convert_to_tensor(ndarrays, dtype=dtypes)
     else:
         # Multi-tensor case.
         batch = {
-            col_name: convert_ndarray_to_tf_tensor(
+            col_name: tf.convert_to_tensor(
                 col_ndarray,
                 dtype=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
             )

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -102,25 +102,6 @@ def convert_pandas_to_torch_tensor(
         return get_tensor_for_columns(columns=columns, dtype=column_dtypes)
 
 
-def convert_ndarray_to_torch_tensor(
-    ndarray: np.ndarray,
-    dtype: Optional[torch.dtype] = None,
-    device: Optional[str] = None,
-) -> torch.Tensor:
-    """Convert a NumPy ndarray to a Torch Tensor.
-
-    Args:
-        ndarray: The NumPy ndarray that we wish to convert to a Torch Tensor.
-        dtype: The Torch dtype for the created tensor; if None, the dtype will be
-            inferred from the NumPy ndarray data.
-        device: The device on which the tensor should be placed; if None, the Torch
-            tensor will be constructed on the CPU.
-
-    Returns: A Torch Tensor.
-    """
-    return torch.as_tensor(ndarray, dtype=dtype, device=device)
-
-
 def convert_ndarray_batch_to_torch_tensor_batch(
     ndarrays: Union[np.ndarray, Dict[str, np.ndarray]],
     dtypes: Optional[Union[torch.dtype, Dict[str, torch.dtype]]] = None,
@@ -146,11 +127,11 @@ def convert_ndarray_batch_to_torch_tensor_batch(
                     f"should be given, instead got: {dtypes}"
                 )
             dtypes = next(iter(dtypes.values()))
-        batch = convert_ndarray_to_torch_tensor(ndarrays, dtype=dtypes, device=device)
+        batch = torch.as_tensor(ndarrays, dtype=dtypes, device=device)
     else:
         # Multi-tensor case.
         batch = {
-            col_name: convert_ndarray_to_torch_tensor(
+            col_name: torch.as_tensor(
                 col_ndarray,
                 dtype=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
                 device=device,

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -118,13 +118,7 @@ def convert_ndarray_to_torch_tensor(
 
     Returns: A Torch Tensor.
     """
-    torch_tensor = torch.as_tensor(ndarray, dtype=dtype, device=device)
-    # Off-the-shelf torch Modules expect the input size to have at least 2
-    # dimensions (batch_size, feature_size). If the tensor for the column
-    # is flattened, then we unqueeze it to add an extra dimension.
-    if len(torch_tensor.size()) == 1:
-        torch_tensor = torch_tensor.unsqueeze(dim=1)
-    return torch_tensor
+    return torch.as_tensor(ndarray, dtype=dtype, device=device)
 
 
 def convert_ndarray_batch_to_torch_tensor_batch(

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Optional, Union
 
+import numpy as np
 import pandas as pd
 import torch
 
@@ -99,6 +100,71 @@ def convert_pandas_to_torch_tensor(
         ]
     else:
         return get_tensor_for_columns(columns=columns, dtype=column_dtypes)
+
+
+def convert_ndarray_to_torch_tensor(
+    ndarray: np.ndarray,
+    dtype: Optional[torch.dtype] = None,
+    device: Optional[str] = None,
+) -> torch.Tensor:
+    """Convert a NumPy ndarray to a Torch Tensor.
+
+    Args:
+        ndarray: The NumPy ndarray that we wish to convert to a Torch Tensor.
+        dtype: The Torch dtype for the created tensor; if None, the dtype will be
+            inferred from the NumPy ndarray data.
+        device: The device on which the tensor should be placed; if None, the Torch
+            tensor will be constructed on the CPU.
+
+    Returns: A Torch Tensor.
+    """
+    torch_tensor = torch.as_tensor(ndarray, dtype=dtype, device=device)
+    # Off-the-shelf torch Modules expect the input size to have at least 2
+    # dimensions (batch_size, feature_size). If the tensor for the column
+    # is flattened, then we unqueeze it to add an extra dimension.
+    if len(torch_tensor.size()) == 1:
+        torch_tensor = torch_tensor.unsqueeze(dim=1)
+    return torch_tensor
+
+
+def convert_ndarray_batch_to_torch_tensor_batch(
+    ndarrays: Union[np.ndarray, Dict[str, np.ndarray]],
+    dtypes: Optional[Union[torch.dtype, Dict[str, torch.dtype]]] = None,
+    device: Optional[str] = None,
+) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
+    """Convert a NumPy ndarray batch to a Torch Tensor batch.
+
+    Args:
+        ndarray: A (dict of) NumPy ndarray(s) that we wish to convert to a Torch Tensor.
+        dtype: A (dict of) Torch dtype(s) for the created tensor; if None, the dtype
+            will be inferred from the NumPy ndarray data.
+        device: The device on which the tensor(s) should be placed; if None, the Torch
+            tensor(s) will be constructed on the CPU.
+
+    Returns: A (dict of) Torch Tensor(s).
+    """
+    if isinstance(ndarrays, np.ndarray):
+        # Single-tensor case.
+        if isinstance(dtypes, dict):
+            if len(dtypes) != 1:
+                raise ValueError(
+                    "When constructing a single-tensor batch, only a single dtype "
+                    f"should be given, instead got: {dtypes}"
+                )
+            dtypes = next(iter(dtypes.values()))
+        batch = convert_ndarray_to_torch_tensor(ndarrays, dtype=dtypes, device=device)
+    else:
+        # Multi-tensor case.
+        batch = {
+            col_name: convert_ndarray_to_torch_tensor(
+                col_ndarray,
+                dtype=dtypes[col_name] if isinstance(dtypes, dict) else dtypes,
+                device=device,
+            )
+            for col_name, col_ndarray in ndarrays.items()
+        }
+
+    return batch
 
 
 def load_torch_model(

--- a/python/ray/air/examples/tf/tensorflow_linear_dataset_example.py
+++ b/python/ray/air/examples/tf/tensorflow_linear_dataset_example.py
@@ -27,6 +27,7 @@ def build_model() -> tf.keras.Model:
     model = tf.keras.Sequential(
         [
             tf.keras.layers.InputLayer(input_shape=()),
+            # Add feature dimension, expanding (batch_size,) to (batch_size, 1).
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(10),
             tf.keras.layers.Dense(1),

--- a/python/ray/air/examples/tf/tensorflow_linear_dataset_example.py
+++ b/python/ray/air/examples/tf/tensorflow_linear_dataset_example.py
@@ -26,7 +26,8 @@ def get_dataset(a=5, b=10, size=1000) -> Dataset:
 def build_model() -> tf.keras.Model:
     model = tf.keras.Sequential(
         [
-            tf.keras.layers.InputLayer(input_shape=(1,)),
+            tf.keras.layers.InputLayer(input_shape=()),
+            tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(10),
             tf.keras.layers.Dense(1),
         ]
@@ -72,10 +73,11 @@ def train_func(config: dict):
 def train_tensorflow_linear(num_workers: int = 2, use_gpu: bool = False) -> Result:
     dataset_pipeline = get_dataset()
     config = {"lr": 1e-3, "batch_size": 32, "epochs": 4}
+    scaling_config = ScalingConfig(num_workers=num_workers, use_gpu=use_gpu)
     trainer = TensorflowTrainer(
         train_loop_per_worker=train_func,
         train_loop_config=config,
-        scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),
+        scaling_config=scaling_config,
         datasets={"train": dataset_pipeline},
     )
     results = trainer.fit()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -119,6 +119,9 @@ TensorflowFeatureTypeSpec = Union[
     "tf.TypeSpec", List["tf.TypeSpec"], Dict[str, "tf.TypeSpec"]
 ]
 
+TorchTensorBatchType = Union["torch.Tensor", Dict[str, "torch.Tensor"]]
+TensorFlowTensorBatchType = Union["tf.Tensor", Dict[str, "tf.Tensor"]]
+
 
 @PublicAPI
 class Dataset(Generic[T]):
@@ -2394,6 +2397,151 @@ class Dataset(Generic[T]):
         )
 
         stats.iter_total_s.add(time.perf_counter() - time_start)
+
+    def iter_torch_batches(
+        self,
+        *,
+        prefetch_blocks: int = 0,
+        batch_size: Optional[int] = None,
+        dtypes: Optional[Union["torch.dtype", Dict[str, "torch.dtype"]]] = None,
+        device: Optional[str] = None,
+        drop_last: bool = False,
+        local_shuffle_buffer_size: Optional[int] = None,
+        local_shuffle_seed: Optional[int] = None,
+    ) -> Iterator[TorchTensorBatchType]:
+        """Return a local batched iterator of Torch Tensors over the dataset.
+
+        This iterator will yield single-tensor batches if the underlying dataset
+        consists of a single column; otherwise, it will yield a dictionary of
+        column-tensors. If looking for more flexibility in the tensor conversion (e.g.
+        casting dtypes) or the batch format, try using `.to_torch`, which has a
+        declarative API for tensor casting and batch formatting, or use `.iter_batches`
+        directly, which is a lower-level API.
+
+        Examples:
+            >>> import ray
+            >>> for batch in ray.data.range( # doctest: +SKIP
+            ...     1000000,
+            ... ).iter_torch_batches():
+            ...     print(batch) # doctest: +SKIP
+
+        Time complexity: O(1)
+
+        Args:
+            prefetch_blocks: The number of blocks to prefetch ahead of the
+                current block during the scan.
+            batch_size: Record batch size, or None to let the system pick.
+            dtypes: The Torch dtype(s) for the created tensor(s); if None, the dtype
+                will be inferred from the tensor data.
+            device: The device on which the tensor should be placed; if None, the Torch
+                tensor will be constructed on the CPU.
+            drop_last: Whether to drop the last batch if it's incomplete.
+            local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
+                using a local in-memory shuffle buffer, and this value will serve as the
+                minimum number of rows that must be in the local in-memory shuffle
+                buffer in order to yield a batch. This is a light-weight alternative to
+                the global `.random_shuffle()` operation; this shuffle will be less
+                random but will be faster and less resource-intensive. This buffer size
+                must be greater than or equal to ``batch_size``, and therefore
+                ``batch_size`` must also be specified when using local shuffling.
+                When there are no more rows to be added to the buffer, the number of
+                rows in the buffer *will* decrease below this value while yielding
+                the remaining batches, and the final batch may have less than
+                ``batch_size`` rows. Increasing this will improve the randomness of
+                the shuffle but will increase CPU memory utilization and the latency
+                to the first batch. The CPU memory utilization ceiling is the max of
+                the prefetch buffer size (controlled by ``prefetch_blocks``) and
+                this shuffle buffer size.
+            local_shuffle_seed: The seed to use for the local random shuffle.
+
+        Returns:
+            An iterator over Torch Tensor batches.
+        """
+        from ray.air._internal.torch_utils import (
+            convert_ndarray_batch_to_torch_tensor_batch,
+        )
+
+        for batch in self.iter_batches(
+            prefetch_blocks=prefetch_blocks,
+            batch_size=batch_size,
+            batch_format="numpy",
+            drop_last=drop_last,
+            local_shuffle_buffer_size=local_shuffle_buffer_size,
+            local_shuffle_seed=local_shuffle_seed,
+        ):
+            yield convert_ndarray_batch_to_torch_tensor_batch(
+                batch,
+                dtypes=dtypes,
+                device=device,
+            )
+
+    def iter_tf_batches(
+        self,
+        *,
+        prefetch_blocks: int = 0,
+        batch_size: Optional[int] = None,
+        dtypes: Optional[Union["tf.dtypes.DType", Dict[str, "tf.dtypes.DType"]]] = None,
+        drop_last: bool = False,
+        local_shuffle_buffer_size: Optional[int] = None,
+        local_shuffle_seed: Optional[int] = None,
+    ) -> Iterator[TensorFlowTensorBatchType]:
+        """Return a local batched iterator of TensorFlow Tensors over the dataset.
+
+        This iterator will yield single-tensor batches of the underlying dataset
+        consists of a single column; otherwise, it will yield a dictionary of
+        column-tensors. If looking for more flexibility in the tensor conversion (e.g.
+        casting dtypes) or the batch format, try using `.to_tf`, which has a
+        declarative API for tensor casting and batch formatting, or use `.iter_batches`
+        directly, which is a lower-level API.
+
+        Examples:
+            >>> import ray
+            >>> for batch in ray.data.range(1000000).iter_tf_batches(): # doctest: +SKIP
+            ...     print(batch) # doctest: +SKIP
+
+        Time complexity: O(1)
+
+        Args:
+            prefetch_blocks: The number of blocks to prefetch ahead of the
+                current block during the scan.
+            batch_size: Record batch size, or None to let the system pick.
+            dtypes: The TensorFlow dtype(s) for the created tensor(s); if None, the
+                dtype will be inferred from the tensor data.
+            drop_last: Whether to drop the last batch if it's incomplete.
+            local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
+                using a local in-memory shuffle buffer, and this value will serve as the
+                minimum number of rows that must be in the local in-memory shuffle
+                buffer in order to yield a batch. This is a light-weight alternative to
+                the global `.random_shuffle()` operation; this shuffle will be less
+                random but will be faster and less resource-intensive. This buffer size
+                must be greater than or equal to ``batch_size``, and therefore
+                ``batch_size`` must also be specified when using local shuffling.
+                When there are no more rows to be added to the buffer, the number of
+                rows in the buffer *will* decrease below this value while yielding
+                the remaining batches, and the final batch may have less than
+                ``batch_size`` rows. Increasing this will improve the randomness of
+                the shuffle but will increase CPU memory utilization and the latency
+                to the first batch. The CPU memory utilization ceiling is the max of
+                the prefetch buffer size (controlled by ``prefetch_blocks``) and
+                this shuffle buffer size.
+            local_shuffle_seed: The seed to use for the local random shuffle.
+
+        Returns:
+            An iterator over TensorFlow Tensor batches.
+        """
+        from ray.air._internal.tensorflow_utils import (
+            convert_ndarray_batch_to_tf_tensor_batch,
+        )
+
+        for batch in self.iter_batches(
+            prefetch_blocks=prefetch_blocks,
+            batch_size=batch_size,
+            batch_format="numpy",
+            drop_last=drop_last,
+            local_shuffle_buffer_size=local_shuffle_buffer_size,
+            local_shuffle_seed=local_shuffle_seed,
+        ):
+            yield convert_ndarray_batch_to_tf_tensor_batch(batch, dtypes=dtypes)
 
     def to_torch(
         self,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2362,19 +2362,11 @@ class Dataset(Generic[T]):
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the
                 minimum number of rows that must be in the local in-memory shuffle
-                buffer in order to yield a batch. This is a light-weight alternative to
-                the global `.random_shuffle()` operation; this shuffle will be less
-                random but will be faster and less resource-intensive. This buffer size
-                must be greater than or equal to ``batch_size``, and therefore
-                ``batch_size`` must also be specified when using local shuffling.
-                When there are no more rows to be added to the buffer, the number of
-                rows in the buffer *will* decrease below this value while yielding
-                the remaining batches, and the final batch may have less than
-                ``batch_size`` rows. Increasing this will improve the randomness of
-                the shuffle but will increase CPU memory utilization and the latency
-                to the first batch. The CPU memory utilization ceiling is the max of
-                the prefetch buffer size (controlled by ``prefetch_blocks``) and
-                this shuffle buffer size.
+                buffer in order to yield a batch. When there are no more rows to add to
+                the buffer, the remaining rows in the buffer will be drained. This
+                buffer size must be greater than or equal to ``batch_size``, and
+                therefore ``batch_size`` must also be specified when using local
+                shuffling.
             local_shuffle_seed: The seed to use for the local random shuffle.
 
         Returns:
@@ -2414,16 +2406,18 @@ class Dataset(Generic[T]):
         This iterator will yield single-tensor batches if the underlying dataset
         consists of a single column; otherwise, it will yield a dictionary of
         column-tensors. If looking for more flexibility in the tensor conversion (e.g.
-        casting dtypes) or the batch format, try using `.to_torch`, which has a
-        declarative API for tensor casting and batch formatting, or use `.iter_batches`
-        directly, which is a lower-level API.
+        casting dtypes) or the batch format, try use `.iter_batches` directly, which is
+        a lower-level API.
 
         Examples:
             >>> import ray
             >>> for batch in ray.data.range( # doctest: +SKIP
-            ...     1000000,
-            ... ).iter_torch_batches():
-            ...     print(batch) # doctest: +SKIP
+            ...     12,
+            ... ).iter_torch_batches(batch_size=4):
+            ...     print(batch.shape) # doctest: +SKIP
+            torch.Size([4, 1])
+            torch.Size([4, 1])
+            torch.Size([4, 1])
 
         Time complexity: O(1)
 
@@ -2439,19 +2433,11 @@ class Dataset(Generic[T]):
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the
                 minimum number of rows that must be in the local in-memory shuffle
-                buffer in order to yield a batch. This is a light-weight alternative to
-                the global `.random_shuffle()` operation; this shuffle will be less
-                random but will be faster and less resource-intensive. This buffer size
-                must be greater than or equal to ``batch_size``, and therefore
-                ``batch_size`` must also be specified when using local shuffling.
-                When there are no more rows to be added to the buffer, the number of
-                rows in the buffer *will* decrease below this value while yielding
-                the remaining batches, and the final batch may have less than
-                ``batch_size`` rows. Increasing this will improve the randomness of
-                the shuffle but will increase CPU memory utilization and the latency
-                to the first batch. The CPU memory utilization ceiling is the max of
-                the prefetch buffer size (controlled by ``prefetch_blocks``) and
-                this shuffle buffer size.
+                buffer in order to yield a batch. When there are no more rows to add to
+                the buffer, the remaining rows in the buffer will be drained. This
+                buffer size must be greater than or equal to ``batch_size``, and
+                therefore ``batch_size`` must also be specified when using local
+                shuffling.
             local_shuffle_seed: The seed to use for the local random shuffle.
 
         Returns:
@@ -2496,8 +2482,13 @@ class Dataset(Generic[T]):
 
         Examples:
             >>> import ray
-            >>> for batch in ray.data.range(1000000).iter_tf_batches(): # doctest: +SKIP
-            ...     print(batch) # doctest: +SKIP
+            >>> for batch in ray.data.range( # doctest: +SKIP
+            ...     12,
+            ... ).iter_torch_batches(batch_size=4):
+            ...     print(batch.shape) # doctest: +SKIP
+            (4, 1)
+            (4, 1)
+            (4, 1)
 
         Time complexity: O(1)
 
@@ -2511,19 +2502,11 @@ class Dataset(Generic[T]):
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the
                 minimum number of rows that must be in the local in-memory shuffle
-                buffer in order to yield a batch. This is a light-weight alternative to
-                the global `.random_shuffle()` operation; this shuffle will be less
-                random but will be faster and less resource-intensive. This buffer size
-                must be greater than or equal to ``batch_size``, and therefore
-                ``batch_size`` must also be specified when using local shuffling.
-                When there are no more rows to be added to the buffer, the number of
-                rows in the buffer *will* decrease below this value while yielding
-                the remaining batches, and the final batch may have less than
-                ``batch_size`` rows. Increasing this will improve the randomness of
-                the shuffle but will increase CPU memory utilization and the latency
-                to the first batch. The CPU memory utilization ceiling is the max of
-                the prefetch buffer size (controlled by ``prefetch_blocks``) and
-                this shuffle buffer size.
+                buffer in order to yield a batch. When there are no more rows to add to
+                the buffer, the remaining rows in the buffer will be drained. This
+                buffer size must be greater than or equal to ``batch_size``, and
+                therefore ``batch_size`` must also be specified when using local
+                shuffling.
             local_shuffle_seed: The seed to use for the local random shuffle.
 
         Returns:
@@ -2630,15 +2613,11 @@ class Dataset(Generic[T]):
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the
                 minimum number of rows that must be in the local in-memory shuffle
-                buffer in order to yield a batch. This is a light-weight alternative to
-                the global `.random_shuffle()` operation; this shuffle will be less
-                random but will be faster and less resource-intensive. This buffer size
-                must be greater than or equal to ``batch_size``, and therefore
-                ``batch_size`` must also be specified when using local shuffling.
-                Increasing this will improve the randomness of the shuffle but will
-                increase CPU memory utilization and the latency to the first batch. The
-                CPU memory utilization ceiling is the max of the prefetch buffer size
-                (controlled by ``prefetch_blocks``) and this shuffle buffer size.
+                buffer in order to yield a batch. When there are no more rows to add to
+                the buffer, the remaining rows in the buffer will be drained. This
+                buffer size must be greater than or equal to ``batch_size``, and
+                therefore ``batch_size`` must also be specified when using local
+                shuffling.
             local_shuffle_seed: The seed to use for the local random shuffle.
             unsqueeze_label_tensor: If set to True, the label tensor
                 will be unsqueezed (reshaped to (N, 1)). Otherwise, it will
@@ -2811,15 +2790,11 @@ class Dataset(Generic[T]):
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the
                 minimum number of rows that must be in the local in-memory shuffle
-                buffer in order to yield a batch. This is a light-weight alternative to
-                the global `.random_shuffle()` operation; this shuffle will be less
-                random but will be faster and less resource-intensive. This buffer size
-                must be greater than or equal to ``batch_size``, and therefore
-                ``batch_size`` must also be specified when using local shuffling.
-                Increasing this will improve the randomness of the shuffle but will
-                increase CPU memory utilization and the latency to the first batch. The
-                CPU memory utilization ceiling is the max of the prefetch buffer size
-                (controlled by ``prefetch_blocks``) and this shuffle buffer size.
+                buffer in order to yield a batch. When there are no more rows to add to
+                the buffer, the remaining rows in the buffer will be drained. This
+                buffer size must be greater than or equal to ``batch_size``, and
+                therefore ``batch_size`` must also be specified when using local
+                shuffling.
             local_shuffle_seed: The seed to use for the local random shuffle.
 
         Returns:

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -944,6 +944,50 @@ class DatasetPipeline(Generic[T]):
         output batches from the pipeline"""
         return Dataset.show(self, limit)
 
+    def iter_tf_batches(
+        self,
+        *,
+        prefetch_blocks: int = 0,
+        batch_size: Optional[int] = None,
+        batch_format: str = "native",
+        drop_last: bool = False,
+        local_shuffle_buffer_size: Optional[int] = None,
+        local_shuffle_seed: Optional[int] = None,
+    ) -> Iterator[Union["tf.Tensor", Dict[str, "tf.Tensor"]]]:
+        """Call
+        :py:meth:`Dataset.iter_tf_batches <ray.data.Dataset.iter_tf_batches>`
+        over the stream of output batches from the pipeline."""
+        return Dataset.iter_tf_batches(
+            self,
+            prefetch_blocks=prefetch_blocks,
+            batch_size=batch_size,
+            drop_last=drop_last,
+            local_shuffle_buffer_size=local_shuffle_buffer_size,
+            local_shuffle_seed=local_shuffle_seed,
+        )
+
+    def iter_torch_batches(
+        self,
+        *,
+        prefetch_blocks: int = 0,
+        batch_size: Optional[int] = None,
+        batch_format: str = "native",
+        drop_last: bool = False,
+        local_shuffle_buffer_size: Optional[int] = None,
+        local_shuffle_seed: Optional[int] = None,
+    ) -> Iterator[Union["torch.Tensor", Dict[str, "torch.Tensor"]]]:
+        """Call
+        :py:meth:`Dataset.iter_torch_batches <ray.data.Dataset.iter_torch_batches>`
+        over the stream of output batches from the pipeline."""
+        return Dataset.iter_torch_batches(
+            self,
+            prefetch_blocks=prefetch_blocks,
+            batch_size=batch_size,
+            drop_last=drop_last,
+            local_shuffle_buffer_size=local_shuffle_buffer_size,
+            local_shuffle_seed=local_shuffle_seed,
+        )
+
     def to_tf(
         self,
         *,

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -170,16 +170,11 @@ class DatasetPipeline(Generic[T]):
             local_shuffle_buffer_size: If non-None, the data will be randomly shuffled
                 using a local in-memory shuffle buffer, and this value will serve as the
                 minimum number of rows that must be in the local in-memory shuffle
-                buffer in order to yield a batch. This is a light-weight alternative to
-                the global :py:meth:`Dataset.random_shuffle()` operation; this shuffle
-                will be less random but will be faster and less resource-intensive.
-                This buffer size must be greater than or equal to ``batch_size``, and
+                buffer in order to yield a batch. When there are no more rows to add to
+                the buffer, the remaining rows in the buffer will be drained. This
+                buffer size must be greater than or equal to ``batch_size``, and
                 therefore ``batch_size`` must also be specified when using local
-                shuffling. Increasing this will improve the randomness of the shuffle
-                but will increase CPU memory utilization and the latency to the first
-                batch. The CPU memory utilization ceiling is the max of the prefetch
-                buffer size (controlled by ``prefetch_blocks``) and this shuffle
-                buffer size.
+                shuffling.
             local_shuffle_seed: The seed to use for the local random shuffle.
 
         Returns:

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2422,7 +2422,7 @@ def test_iter_tf_batches(ray_start_regular_shared, pipelined):
         iterations = []
         for batch in ds.iter_tf_batches(batch_size=3):
             iterations.append(
-                np.concatenate((batch["one"], batch["two"], batch["label"]), axis=1)
+                np.stack((batch["one"], batch["two"], batch["label"]), axis=1)
             )
         combined_iterations = np.concatenate(iterations)
         np.testing.assert_array_equal(np.sort(df.values), np.sort(combined_iterations))
@@ -2627,7 +2627,7 @@ def test_iter_torch_batches(ray_start_regular_shared, pipelined):
         iterations = []
         for batch in ds.iter_torch_batches(batch_size=3):
             iterations.append(
-                torch.cat(
+                torch.stack(
                     (batch["one"], batch["two"], batch["label"]),
                     dim=1,
                 ).numpy()

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -2401,7 +2401,48 @@ def test_to_tf(ray_start_regular_shared, pipelined):
     for batch in tfd.as_numpy_iterator():
         iterations.append(np.concatenate((batch[0], batch[1].reshape(-1, 1)), axis=1))
     combined_iterations = np.concatenate(iterations)
-    assert np.array_equal(df.values, combined_iterations)
+    np.testing.assert_array_equal(df.values, combined_iterations)
+
+
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_iter_tf_batches(ray_start_regular_shared, pipelined):
+    df1 = pd.DataFrame(
+        {"one": [1, 2, 3], "two": [1.0, 2.0, 3.0], "label": [1.0, 2.0, 3.0]}
+    )
+    df2 = pd.DataFrame(
+        {"one": [4, 5, 6], "two": [4.0, 5.0, 6.0], "label": [4.0, 5.0, 6.0]}
+    )
+    df3 = pd.DataFrame({"one": [7, 8], "two": [7.0, 8.0], "label": [7.0, 8.0]})
+    df = pd.concat([df1, df2, df3])
+    ds = ray.data.from_pandas([df1, df2, df3])
+    ds = maybe_pipeline(ds, pipelined)
+
+    num_epochs = 1 if pipelined else 2
+    for _ in range(num_epochs):
+        iterations = []
+        for batch in ds.iter_tf_batches(batch_size=3):
+            iterations.append(
+                np.concatenate((batch["one"], batch["two"], batch["label"]), axis=1)
+            )
+        combined_iterations = np.concatenate(iterations)
+        np.testing.assert_array_equal(np.sort(df.values), np.sort(combined_iterations))
+
+
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_iter_tf_batches_tensor_ds(ray_start_regular_shared, pipelined):
+    arr1 = np.arange(12).reshape((3, 2, 2))
+    arr2 = np.arange(12, 24).reshape((3, 2, 2))
+    arr = np.concatenate((arr1, arr2))
+    ds = ray.data.from_numpy([arr1, arr2])
+    ds = maybe_pipeline(ds, pipelined)
+
+    num_epochs = 1 if pipelined else 2
+    for _ in range(num_epochs):
+        iterations = []
+        for batch in ds.iter_tf_batches(batch_size=2):
+            iterations.append(batch)
+        combined_iterations = np.concatenate(iterations)
+        np.testing.assert_array_equal(arr, combined_iterations)
 
 
 def test_to_tf_feature_columns_list(ray_start_regular_shared):
@@ -2447,10 +2488,10 @@ def test_to_tf_feature_columns_list_with_label(ray_start_regular_shared):
     assert len(batches) == math.ceil(len(df) / batch_size)
     # Each batch should be a two-tuple corresponding to (features, labels).
     assert all(len(batch) == 2 for batch in batches)
-    assert np.array_equal(batches[0][0], np.array([[1, 4], [2, 5]]))
-    assert np.array_equal(batches[0][1], np.array([7, 8]))
-    assert np.array_equal(batches[1][0], np.array([[3, 6]]))
-    assert np.array_equal(batches[1][1], np.array([9]))
+    np.testing.assert_array_equal(batches[0][0], np.array([[1, 4], [2, 5]]))
+    np.testing.assert_array_equal(batches[0][1], np.array([7, 8]))
+    np.testing.assert_array_equal(batches[1][0], np.array([[3, 6]]))
+    np.testing.assert_array_equal(batches[1][1], np.array([9]))
 
 
 def test_to_tf_feature_columns_nested_list(ray_start_regular_shared):
@@ -2474,10 +2515,10 @@ def test_to_tf_feature_columns_nested_list(ray_start_regular_shared):
     batches = list(dataset.as_numpy_iterator())
     assert len(batches) == math.ceil(len(df) / batch_size)
     assert all(len(batch) == len(feature_columns) for batch in batches)
-    assert np.array_equal(batches[0][0], np.array([[1, 4], [2, 5]]))
-    assert np.array_equal(batches[0][1], np.array([[7], [8]]))
-    assert np.array_equal(batches[1][0], np.array([[3, 6]]))
-    assert np.array_equal(batches[1][1], np.array([[9]]))
+    np.testing.assert_array_equal(batches[0][0], np.array([[1, 4], [2, 5]]))
+    np.testing.assert_array_equal(batches[0][1], np.array([[7], [8]]))
+    np.testing.assert_array_equal(batches[1][0], np.array([[3, 6]]))
+    np.testing.assert_array_equal(batches[1][1], np.array([[9]]))
 
 
 def test_to_tf_feature_columns_dict(ray_start_regular_shared):
@@ -2499,10 +2540,10 @@ def test_to_tf_feature_columns_dict(ray_start_regular_shared):
     batches = list(dataset.as_numpy_iterator())
     assert len(batches) == math.ceil(len(df) / batch_size)
     assert all(batch.keys() == feature_columns.keys() for batch in batches)
-    assert np.array_equal(batches[0]["A"], np.array([[1, 4], [2, 5]]))
-    assert np.array_equal(batches[0]["B"], np.array([[7], [8]]))
-    assert np.array_equal(batches[1]["A"], np.array([[3, 6]]))
-    assert np.array_equal(batches[1]["B"], np.array([[9]]))
+    np.testing.assert_array_equal(batches[0]["A"], np.array([[1, 4], [2, 5]]))
+    np.testing.assert_array_equal(batches[0]["B"], np.array([[7], [8]]))
+    np.testing.assert_array_equal(batches[1]["A"], np.array([[3, 6]]))
+    np.testing.assert_array_equal(batches[1]["B"], np.array([[9]]))
 
 
 def test_to_tf_feature_columns_dict_with_label(ray_start_regular_shared):
@@ -2533,12 +2574,12 @@ def test_to_tf_feature_columns_dict_with_label(ray_start_regular_shared):
     assert all(features.keys() == feature_columns.keys() for features, _ in batches)
 
     features0, labels0 = batches[0]
-    assert np.array_equal(features0["A"], np.array([[1, 4], [2, 5]]))
-    assert np.array_equal(labels0, np.array([7, 8]))
+    np.testing.assert_array_equal(features0["A"], np.array([[1, 4], [2, 5]]))
+    np.testing.assert_array_equal(labels0, np.array([7, 8]))
 
     features1, labels1 = batches[1]
-    assert np.array_equal(features1["A"], np.array([[3, 6]]))
-    assert np.array_equal(labels1, np.array([9]))
+    np.testing.assert_array_equal(features1["A"], np.array([[3, 6]]))
+    np.testing.assert_array_equal(labels1, np.array([9]))
 
 
 @pytest.mark.parametrize("pipelined", [False, True])
@@ -2563,7 +2604,53 @@ def test_to_torch(ray_start_regular_shared, pipelined):
         for batch in iter(torchd):
             iterations.append(torch.cat((batch[0], batch[1]), dim=1).numpy())
         combined_iterations = np.concatenate(iterations)
-        assert np.array_equal(np.sort(df.values), np.sort(combined_iterations))
+        np.testing.assert_array_equal(np.sort(df.values), np.sort(combined_iterations))
+
+
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_iter_torch_batches(ray_start_regular_shared, pipelined):
+    import torch
+
+    df1 = pd.DataFrame(
+        {"one": [1, 2, 3], "two": [1.0, 2.0, 3.0], "label": [1.0, 2.0, 3.0]}
+    )
+    df2 = pd.DataFrame(
+        {"one": [4, 5, 6], "two": [4.0, 5.0, 6.0], "label": [4.0, 5.0, 6.0]}
+    )
+    df3 = pd.DataFrame({"one": [7, 8], "two": [7.0, 8.0], "label": [7.0, 8.0]})
+    df = pd.concat([df1, df2, df3])
+    ds = ray.data.from_pandas([df1, df2, df3])
+    ds = maybe_pipeline(ds, pipelined)
+
+    num_epochs = 1 if pipelined else 2
+    for _ in range(num_epochs):
+        iterations = []
+        for batch in ds.iter_torch_batches(batch_size=3):
+            iterations.append(
+                torch.cat(
+                    (batch["one"], batch["two"], batch["label"]),
+                    dim=1,
+                ).numpy()
+            )
+        combined_iterations = np.concatenate(iterations)
+        np.testing.assert_array_equal(np.sort(df.values), np.sort(combined_iterations))
+
+
+@pytest.mark.parametrize("pipelined", [False, True])
+def test_iter_torch_batches_tensor_ds(ray_start_regular_shared, pipelined):
+    arr1 = np.arange(12).reshape((3, 2, 2))
+    arr2 = np.arange(12, 24).reshape((3, 2, 2))
+    arr = np.concatenate((arr1, arr2))
+    ds = ray.data.from_numpy([arr1, arr2])
+    ds = maybe_pipeline(ds, pipelined)
+
+    num_epochs = 1 if pipelined else 2
+    for _ in range(num_epochs):
+        iterations = []
+        for batch in ds.iter_torch_batches(batch_size=2):
+            iterations.append(batch.numpy())
+        combined_iterations = np.concatenate(iterations)
+        np.testing.assert_array_equal(arr, combined_iterations)
 
 
 @pytest.mark.parametrize("input", ["single", "list", "dict"])
@@ -2664,7 +2751,7 @@ def test_to_torch_feature_columns(
     combined_iterations = np.concatenate(iterations)
     if not label_type:
         df.drop("label", axis=1, inplace=True)
-    assert np.array_equal(df.values, combined_iterations)
+    np.testing.assert_array_equal(df.values, combined_iterations)
 
 
 def test_block_builder_for_block(ray_start_regular_shared):

--- a/python/ray/train/tests/test_tensorflow_predictor.py
+++ b/python/ray/train/tests/test_tensorflow_predictor.py
@@ -26,7 +26,9 @@ class DummyPreprocessor(Preprocessor):
 def build_model() -> tf.keras.Model:
     model = tf.keras.Sequential(
         [
-            tf.keras.layers.InputLayer(input_shape=(1,)),
+            tf.keras.layers.InputLayer(input_shape=()),
+            # Add feature dimension, expanding (batch_size,) to (batch_size, 1).
+            tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(1),
         ]
     )

--- a/python/ray/train/tests/test_tensorflow_trainer.py
+++ b/python/ray/train/tests/test_tensorflow_trainer.py
@@ -28,7 +28,9 @@ def build_model():
 
     model = tf.keras.Sequential(
         [
-            tf.keras.layers.InputLayer(input_shape=(1,)),
+            tf.keras.layers.InputLayer(input_shape=()),
+            # Add feature dimension, expanding (batch_size,) to (batch_size, 1).
+            tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(1),
         ]
     )

--- a/python/ray/train/tests/test_torch_predictor.py
+++ b/python/ray/train/tests/test_torch_predictor.py
@@ -180,6 +180,8 @@ def test_multi_modal_real_model(use_gpu):
             self.linear2 = torch.nn.Linear(1, 1)
 
         def forward(self, input_dict: dict):
+            input_dict["A"] = input_dict["A"].unsqueeze(1)
+            input_dict["B"] = input_dict["B"].unsqueeze(1)
             out1 = self.linear1(input_dict["A"])
             out2 = self.linear2(input_dict["B"])
             return out1 + out2

--- a/python/ray/train/tests/test_torch_predictor.py
+++ b/python/ray/train/tests/test_torch_predictor.py
@@ -180,6 +180,7 @@ def test_multi_modal_real_model(use_gpu):
             self.linear2 = torch.nn.Linear(1, 1)
 
         def forward(self, input_dict: dict):
+            # Add feature dimension, expanding (batch_size,) to (batch_size, 1).
             input_dict["A"] = input_dict["A"].unsqueeze(1)
             input_dict["B"] = input_dict["B"].unsqueeze(1)
             out1 = self.linear1(input_dict["A"])


### PR DESCRIPTION
This PR adds `.iter_torch_batches()` and `.iter_tf_batches()` convenience APIs, which takes care of ML framework tensor conversion, the narrow tensor waste for the `.iter_batches()` call (`"numpy"` format), and unifies batch formats around two options: a single tensor for simple/pure-tensor/single-column datasets, and a dictionary of tensors for multi-column datasets.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
