### PR TITLE
[AIR] Support `List[Dict]` output in `TorchPredictor`

### DIFF
--- a/python/ray/train/_internal/dl_predictor.py
+++ b/python/ray/train/_internal/dl_predictor.py
@@ -80,7 +80,7 @@ class DLPredictor(Predictor):
         # Handle model multi-output. For example if model outputs 2 images.
         if isinstance(output, dict):
             return pd.DataFrame(
-                {k: TensorArray(self._tensor_to_array(v)) for k, v in output}
+                {k: TensorArray(self._tensor_to_array(v)) for k, v in output.items()}
             )
         elif isinstance(output, list) or isinstance(output, tuple):
             tensor_name = "output_"
@@ -92,6 +92,5 @@ class DLPredictor(Predictor):
             return pd.DataFrame(output_dict)
         else:
             return pd.DataFrame(
-                {"predictions": TensorArray(self._tensor_to_array(output))},
-                columns=["predictions"],
+                {"predictions": TensorArray(self._tensor_to_array(output))}
             )

--- a/python/ray/train/torch/torch_predictor.py
+++ b/python/ray/train/torch/torch_predictor.py
@@ -108,6 +108,14 @@ class TorchPredictor(DLPredictor):
     ]:
         with torch.no_grad():
             output = self.model(tensor)
+
+        if isinstance(output, list) and isinstance(output[0], dict):
+            # Handle List of Dicts. For example
+            # https://pytorch.org/vision/main/models/generated/torchvision.models.detection\
+            # .ssd300_vgg16.html#torchvision.models.detection.ssd300_vgg16
+
+            # Convert to dict of tensors.
+            output = {k: torch.stack([d[k] for d in output]) for k in output[0]}
         return output
 
     def predict(


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Certain Pytorch models output a list of dicts during inference. For example ssd300_vgg16 (https://pytorch.org/vision/main/models/generated/torchvision.models.detection.ssd300_vgg16.html#torchvision.models.detection.ssd300_vgg16). 

This PR adds support the above output. To be able to properly store the above output tabular format, we use the dict keys as column names, and stack the tensors for each key.

For example, if the model outputs this for  a single prediction
`[{"x": 1, "y": 1}, {"x": 2, "y": 2}]`

The predictions tabular format that we output will be
```
    x  |  y
---------------
[1, 2] | [1, 2]
```


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
