### PR TITLE
[air/train] Add FunctionTrainer for generic function trainables

### DIFF
--- a/doc/source/ray-air/package-ref.rst
+++ b/doc/source/ray-air/package-ref.rst
@@ -118,6 +118,13 @@ Serving
 Trainer and Predictor Integrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+FunctionTrainer
+###############
+
+.. autoclass:: ray.train.function_trainer.FunctionTrainer
+    :members:
+    :show-inheritance:
+
 XGBoost
 #######
 

--- a/doc/source/ray-air/package-ref.rst
+++ b/doc/source/ray-air/package-ref.rst
@@ -118,13 +118,6 @@ Serving
 Trainer and Predictor Integrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-FunctionTrainer
-###############
-
-.. autoclass:: ray.train.function_trainer.FunctionTrainer
-    :members:
-    :show-inheritance:
-
 XGBoost
 #######
 
@@ -173,6 +166,12 @@ Scikit-Learn
 .. automodule:: ray.train.sklearn
     :members:
     :show-inheritance:
+
+FunctionTrainer
+###############
+
+.. autoclass:: ray.train.function_trainer.FunctionTrainer
+    :members:
 
 .. _air-builtin-callbacks:
 

--- a/python/ray/air/session.py
+++ b/python/ray/air/session.py
@@ -260,7 +260,7 @@ def get_dataset_shard(
     if not isinstance(session, _TrainSessionImpl):
         raise RuntimeError(
             "`get_dataset_shard` can only be called for TrainSession! "
-            "Make sure you only use that in `train_loop_per_worker` function"
+            "Make sure you only use that in `train_loop_per_worker` function "
             "that is passed into `DataParallelTrainer`."
         )
     return session.get_dataset_shard(dataset_name)

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -154,6 +154,14 @@ py_test(
 )
 
 py_test(
+    name = "test_function_trainer",
+    size = "medium",
+    srcs = ["tests/test_function_trainer.py"],
+    tags = ["team:ml", "exclusive"],
+    deps = [":train_lib"]
+)
+
+py_test(
     name = "test_gpu",
     size = "large",
     srcs = ["tests/test_gpu.py"],

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -337,12 +337,8 @@ class BaseTrainer(abc.ABC):
             raise TrainingFailedError from e
         return result
 
-    def as_trainable(self) -> Type[Trainable]:
-        """Convert self to a ``tune.Trainable`` class."""
-
-        base_config = self._param_dict
+    def _get_base_trainable(self) -> Type[Trainable]:
         trainer_cls = self.__class__
-        scaling_config = self.scaling_config
 
         def train_func(config, checkpoint_dir=None):
             # config already contains merged values.
@@ -363,7 +359,16 @@ class BaseTrainer(abc.ABC):
         # stdout messages and the results directory.
         train_func.__name__ = trainer_cls.__name__
 
-        trainable_cls = wrap_function(train_func, warn=False)
+        return wrap_function(train_func, warn=False)
+
+    def as_trainable(self) -> Type[Trainable]:
+        """Convert self to a ``tune.Trainable`` class."""
+
+        base_config = self._param_dict
+        trainer_cls = self.__class__
+        scaling_config = self.scaling_config
+
+        trainable_cls = self._get_base_trainable()
 
         class TrainTrainable(trainable_cls):
             """Add default resources to the Trainable."""

--- a/python/ray/train/function_trainer.py
+++ b/python/ray/train/function_trainer.py
@@ -1,0 +1,121 @@
+import inspect
+from typing import Any, Optional, Callable, Type
+
+from ray.air.checkpoint import Checkpoint
+from ray.air.config import RunConfig, ScalingConfig
+from ray.train.trainer import BaseTrainer
+from ray.tune.trainable import Trainable, wrap_function
+from ray.tune.utils import detect_checkpoint_function, detect_config_single
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class FunctionTrainer(BaseTrainer):
+    """Trainer for generic (non-distributed) training functions.
+
+    This trainer can be used to wrap a generic function trainable. In contrast
+    to e.g. the DataParallelTrainer, this trainer will only start up one worker
+    (the trainer). Starting up potential distributed workers is then up
+    to the custom training function.
+
+    The trainer accepts a ``train_fn``, which can be any Ray Tune-compatible
+    function trainable.
+
+    If a scaling config is given, resources will be requested for all workers.
+    Starting potential distributed workers within the current placement group
+    is up to the user.
+
+    If a checkpoint to resume from is given, it will be passed as the
+    ``checkpoint_dir`` argument of the training function, if supported.
+    Alternatively, ``ray.air.session.get_checkpoint()`` can be used.
+
+    This trainer does not handle datasets and preprocessors. If this is needed,
+    consider implementing a DataParallelTrainer with only one worker instead.
+
+    Args:
+        train_fn: Callable training function taking a ``config`` argument.
+        scaling_config: Configuration for how to scale data parallel training.
+        run_config: Configuration for the execution of the training run.
+        resume_from_checkpoint: A checkpoint to resume training from.
+
+    Example:
+
+        .. code-block:: python
+
+            from ray.air.config import ScalingConfig
+            from ray.train.function_trainer import FunctionTrainer
+
+            def train_fn(config):
+                # ...
+                return {"metric": 5}
+
+            trainer = FunctionTrainer(
+                train_fn,
+                scaling_config=ScalingConfig(
+                    trainer_resources={"CPU": 4}
+                )
+            )
+            trainer.fit()
+
+    """
+
+    _scaling_config_allowed_keys = BaseTrainer._scaling_config_allowed_keys + [
+        "num_workers",
+        "resources_per_worker",
+        "use_gpu",
+        "placement_strategy",
+    ]
+    _handles_checkpoint_freq = False
+    _handles_checkpoint_at_end = False
+
+    def __init__(
+        self,
+        train_fn: Callable[[dict, Any], Any],
+        *,
+        scaling_config: Optional[ScalingConfig] = None,
+        run_config: Optional[RunConfig] = None,
+        resume_from_checkpoint: Optional[Checkpoint] = None,
+    ):
+        self.train_fn = train_fn
+        super().__init__(
+            scaling_config=scaling_config,
+            run_config=run_config,
+            datasets=None,
+            preprocessor=None,
+            resume_from_checkpoint=resume_from_checkpoint,
+        )
+
+    def _validate_attributes(self):
+        super()._validate_attributes()
+
+        use_checkpoint = detect_checkpoint_function(self.train_fn)
+        use_config_single = detect_config_single(self.train_fn)
+
+        if not any([use_checkpoint, use_config_single]):
+            func_args = inspect.getfullargspec(self.train_fn).args
+
+            raise ValueError(
+                f"Unknown argument found in the Trainable function. "
+                f"The function args must include a 'config' positional "
+                f"parameter. Any other args must be 'checkpoint_dir'. "
+                f"Found: {func_args}"
+            )
+
+    def _get_base_trainable(self) -> Type[Trainable]:
+        use_checkpoint = detect_checkpoint_function(self.train_fn)
+
+        if use_checkpoint and self.resume_from_checkpoint:
+
+            def wrap_fn(config, checkpoint_dir=None):
+                if not checkpoint_dir:
+                    checkpoint_dir = self.resume_from_checkpoint.to_directory()
+                return self.train_fn(config, checkpoint_dir=checkpoint_dir)
+
+            train_fn = wrap_fn
+        else:
+            train_fn = self.train_fn
+
+        return wrap_function(train_fn, warn=False)
+
+    def training_loop(self) -> None:
+        raise NotImplementedError

--- a/python/ray/train/tests/test_function_trainer.py
+++ b/python/ray/train/tests/test_function_trainer.py
@@ -1,0 +1,195 @@
+import logging
+import os
+import time
+
+import pytest
+
+import ray
+from ray import tune
+from ray.air import ScalingConfig, Checkpoint, RunConfig
+from ray.train.function_trainer import FunctionTrainer
+from ray.tune import Callback, TuneError
+from ray.tune.tuner import Tuner
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+@pytest.fixture
+def ray_start_8_cpus_2_gpus():
+    address_info = ray.init(num_cpus=48, num_gpus=2)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+def test_fn_trainer_invalid():
+    def train_fn(config, invalid_param):
+        pass
+
+    with pytest.raises(ValueError):
+        FunctionTrainer(train_fn)
+
+
+def test_fn_trainer_fit(ray_start_4_cpus):
+    def train_fn(config):
+        tune.report(my_metric=1)
+
+    trainer = FunctionTrainer(train_fn)
+    result = trainer.fit()
+    assert result.metrics["my_metric"] == 1
+
+
+def test_fn_trainer_fit_return(ray_start_4_cpus):
+    def train_fn(config):
+        return 4
+
+    trainer = FunctionTrainer(train_fn)
+    result = trainer.fit()
+    assert result.metrics["_metric"] == 4
+
+
+def test_fn_trainer_scaling_config(ray_start_8_cpus_2_gpus):
+    def train_fn(config):
+        pg = ray.util.get_current_placement_group()
+        return {
+            "trainer_gpus": len(ray.get_gpu_ids()),
+            "trainer_cpus": pg.bundle_specs[0]["CPU"],
+            "worker_1_cpu": pg.bundle_specs[1]["CPU"],
+            "worker_1_gpu": pg.bundle_specs[1]["GPU"],
+            "worker_2_cpu": pg.bundle_specs[2]["CPU"],
+            "worker_2_gpu": pg.bundle_specs[2]["GPU"],
+        }
+
+    trainer = FunctionTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(
+            trainer_resources={"CPU": 2},
+            num_workers=2,
+            resources_per_worker={"CPU": 3},
+            use_gpu=True,
+        ),
+    )
+    result = trainer.fit()
+    assert result.metrics["trainer_gpus"] == 0
+    assert result.metrics["worker_1_cpu"] == 3
+    assert result.metrics["worker_1_gpu"] == 1
+    assert result.metrics["worker_2_cpu"] == 3
+    assert result.metrics["worker_2_gpu"] == 1
+
+
+def test_fn_trainer_continue_checkpoint(ray_start_4_cpus):
+    def train_fn(config, checkpoint_dir):
+        state = Checkpoint.from_directory(checkpoint_dir).to_dict()
+
+        return state["foo"]
+
+    checkpoint = Checkpoint.from_dict({"foo": 7})
+
+    trainer = FunctionTrainer(train_fn, resume_from_checkpoint=checkpoint)
+    result = trainer.fit()
+    assert result.metrics["_metric"] == 7
+
+
+def test_fn_trainer_tune(ray_start_4_cpus):
+    def train_fn(config):
+        return config["foo"]
+
+    trainer = FunctionTrainer(train_fn)
+    tuner = Tuner(trainer, param_space={"foo": tune.grid_search([1, 2, 3, 4])})
+    results = tuner.fit()
+
+    assert [result.metrics["_metric"] for result in results] == [1, 2, 3, 4]
+
+
+def test_fn_trainer_tune_checkpoint(ray_start_4_cpus):
+    def train_fn(config, checkpoint_dir):
+        state = Checkpoint.from_directory(checkpoint_dir).to_dict()
+
+        return config["foo"] + state["bar"]
+
+    checkpoint = Checkpoint.from_dict({"bar": 10})
+
+    trainer = FunctionTrainer(train_fn, resume_from_checkpoint=checkpoint)
+    tuner = Tuner(trainer, param_space={"foo": tune.grid_search([1, 2, 3, 4])})
+    results = tuner.fit()
+
+    assert [result.metrics["_metric"] for result in results] == [11, 12, 13, 14]
+
+
+@pytest.mark.parametrize("pass_trainer", [True, False])
+def test_fn_trainer_tune_resume(ray_start_4_cpus, tmpdir, pass_trainer):
+    os.environ["TUNE_GLOBAL_CHECKPOINT_S"] = "0"
+
+    def train_fn(config, checkpoint_dir=None):
+        if checkpoint_dir:
+            state = Checkpoint.from_directory(checkpoint_dir).to_dict()
+            print("THIS IS A CHECKPOINT DIR", checkpoint_dir)
+        else:
+            state = {"it": 0}
+
+        for i in range(0, 5):
+            state["it"] += 1
+
+            with tune.checkpoint_dir(step=i) as cp_dir:
+                Checkpoint.from_dict(state).to_directory(cp_dir)
+
+            tune.report(metric=state["it"])
+            if (i + 1) == state["it"]:  # Only on first run (before restore)
+                if state["it"] >= 3:  # Sleep so other trials can catch up
+                    time.sleep(10)
+
+    class FailureInjectionCallback(Callback):
+        """Inject failure at the configured iteration number."""
+
+        def __init__(self):
+            self._die_soon = -1
+
+        def on_step_end(self, iteration, trials, **kwargs):
+            if iteration >= self._die_soon >= 0:
+                raise RuntimeError("Failing after receiving results.")
+
+            if len(trials) < 4:
+                return
+
+            if all(trial.last_result.get("metric") == 3 for trial in trials):
+                self._die_soon = iteration + 1  # Leave time to process last result
+
+    if pass_trainer:
+        trainer = FunctionTrainer(train_fn)
+    else:
+        trainer = train_fn
+
+    tuner = Tuner(
+        trainer,
+        param_space={"foo": tune.grid_search([1, 2, 3, 4])},
+        run_config=RunConfig(
+            name="fn_trainer_tune_resume",
+            callbacks=[FailureInjectionCallback()],
+            local_dir=str(tmpdir),
+        ),
+    )
+
+    with pytest.raises(TuneError):
+        tuner.fit()
+
+    tuner = Tuner.restore(str(tmpdir / "fn_trainer_tune_resume"))
+    # A hack before we figure out RunConfig semantics across resumes.
+    tuner._local_tuner._run_config.callbacks = None
+    results = tuner.fit()
+
+    # Failure after step 3, continuing for another 5 steps
+    assert all(result.metrics["metric"] > 5 for result in results)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -166,6 +166,7 @@ class TunerInternal:
     def _get_tune_run_arguments(self) -> Dict[str, Any]:
         """Get tune.run arguments common for both new and resumed runs."""
         return dict(
+            local_dir=self._run_config.local_dir,
             mode=self._tune_config.mode,
             metric=self._tune_config.metric,
             callbacks=self._run_config.callbacks,


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a function trainer that can be used to request resources for generic training functions (e.g. tune trainables).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
