### PR TITLE
[RLLib][Air] MLFlow parsing of RLLib evaluation and custom metrics

### DIFF
--- a/python/ray/air/_internal/mlflow.py
+++ b/python/ray/air/_internal/mlflow.py
@@ -170,15 +170,42 @@ class _MLflowLoggerUtil:
         """
         new_dict = {}
         for key, value in dict_to_log.items():
-            try:
-                value = float(value)
-                new_dict[key] = value
-            except (ValueError, TypeError):
-                logger.debug(
-                    "Cannot log key {} with value {} since the "
-                    "value cannot be converted to float.".format(key, value)
-                )
-                continue
+            if key == "evaluation":
+                for key_eval, value_eval in dict_to_log[key].items():
+                    try:
+                        value_eval = float(value_eval)
+                        new_dict[f"evaluation_{key_eval}"] = value_eval
+                    except (ValueError, TypeError):
+                        logger.debug(
+                            "Cannot log key {} with value {} since the "
+                            "value cannot be converted to float.".format(
+                                key_eval, value_eval
+                            )
+                        )
+                        continue
+            elif key == "custom_metrics":
+                for key_cm, value_cm in dict_to_log[key].items():
+                    try:
+                        value_cm = float(value_cm)
+                        new_dict[f"custom_metrics_{key_cm}"] = value_cm
+                    except (ValueError, TypeError):
+                        logger.debug(
+                            "Cannot log key {} with value {} since the "
+                            "value cannot be converted to float.".format(
+                                key_cm, value_cm
+                            )
+                        )
+                        continue
+            else:
+                try:
+                    value = float(value)
+                    new_dict[key] = value
+                except (ValueError, TypeError):
+                    logger.debug(
+                        "Cannot log key {} with value {} since the "
+                        "value cannot be converted to float.".format(key, value)
+                    )
+                    continue
 
         return new_dict
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, RLLib metrics like the evaluation metrics and custom_metrics are not parsed as they are dicts. This checks for these two specific cases and adds them to MLFlow for tracking.

I chose these two specifically, as including all the other metrics would clutter MLFlow imo. But please tell me if you think that we should have a more general parsing.

## Related issue number

N/A

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
