### PR TITLE
[Tune] Fix storage client creation when sync function tpl is not provided (#26714)

### DIFF
--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -429,7 +429,9 @@ class Trainable:
             "ray_version": ray.__version__,
         }
 
-    def save(self, checkpoint_dir: Optional[str] = None, prevent_upload: bool = False) -> str:
+    def save(
+        self, checkpoint_dir: Optional[str] = None, prevent_upload: bool = False
+    ) -> str:
         """Saves the current model state to a checkpoint.
 
         Subclasses should override ``save_checkpoint()`` instead to save state.
@@ -440,7 +442,7 @@ class Trainable:
 
         Args:
             checkpoint_dir: Optional dir to place the checkpoint.
-            prevent_upload: bool flag to stop tmp folders from uploading
+            prevent_upload: If True, will not upload the saved checkpoint to cloud.
 
         Returns:
             str: path that points to xxx.pkl file.
@@ -488,7 +490,8 @@ class Trainable:
         """Saves the current model state to a Python object.
 
         It also saves to disk but does not return the checkpoint path.
-        It doesn't save to cloud.
+        It does not save the checkpoint to cloud storage.
+
         Returns:
             Object holding checkpoint data.
         """
@@ -543,7 +546,7 @@ class Trainable:
                 pass
             else:
                 checkpoint_exists = True
-        
+
         if checkpoint_exists:
             pass
         elif self.uses_cloud_checkpointing:

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -171,7 +171,7 @@ class Trainable:
         self.sync_function_tpl = sync_function_tpl or self._sync_function_tpl
         self.storage_client = None
 
-        if self.uses_cloud_checkpointing or self.sync_function_tpl:
+        if self.uses_cloud_checkpointing and self.sync_function_tpl:
             # Keep this only for custom sync functions and
             # backwards compatibility.
             # Todo (krfricke): We should find a way to register custom
@@ -544,6 +544,11 @@ class Trainable:
                 # Only keep for backwards compatibility
                 self.storage_client.sync_down(external_uri, local_dir)
                 self.storage_client.wait_or_retry()
+            elif os.path.exists(checkpoint_path):
+                try:
+                    TrainableUtil.find_checkpoint_dir(checkpoint_path)
+                except Exception:
+                    pass
             else:
                 checkpoint = Checkpoint.from_uri(external_uri)
                 retry_fn(

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -171,7 +171,7 @@ class Trainable:
         self.sync_function_tpl = sync_function_tpl or self._sync_function_tpl
         self.storage_client = None
 
-        if self.uses_cloud_checkpointing and self.sync_function_tpl:
+        if self.uses_cloud_checkpointing or self.sync_function_tpl:
             # Keep this only for custom sync functions and
             # backwards compatibility.
             # Todo (krfricke): We should find a way to register custom

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -429,7 +429,7 @@ class Trainable:
             "ray_version": ray.__version__,
         }
 
-    def save(self, checkpoint_dir: Optional[str] = None) -> str:
+    def save(self, checkpoint_dir: Optional[str] = None, prevent_upload: bool = False) -> str:
         """Saves the current model state to a checkpoint.
 
         Subclasses should override ``save_checkpoint()`` instead to save state.
@@ -440,6 +440,7 @@ class Trainable:
 
         Args:
             checkpoint_dir: Optional dir to place the checkpoint.
+            prevent_upload: bool flag to stop tmp folders from uploading
 
         Returns:
             str: path that points to xxx.pkl file.
@@ -459,7 +460,8 @@ class Trainable:
         )
 
         # Maybe sync to cloud
-        self._maybe_save_to_cloud(checkpoint_dir)
+        if not prevent_upload:
+            self._maybe_save_to_cloud(checkpoint_dir)
 
         return checkpoint_path
 
@@ -486,12 +488,12 @@ class Trainable:
         """Saves the current model state to a Python object.
 
         It also saves to disk but does not return the checkpoint path.
-
+        It doesn't save to cloud.
         Returns:
             Object holding checkpoint data.
         """
         tmpdir = tempfile.mkdtemp("save_to_object", dir=self.logdir)
-        checkpoint_path = self.save(tmpdir)
+        checkpoint_path = self.save(tmpdir, prevent_upload=True)
         # Save all files in subtree and delete the tmpdir.
         obj = TrainableUtil.checkpoint_to_object(checkpoint_path)
         shutil.rmtree(tmpdir)

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -535,7 +535,18 @@ class Trainable:
         if isinstance(checkpoint_path, TrialCheckpoint):
             checkpoint_path = checkpoint_path.local_path
 
-        if self.uses_cloud_checkpointing:
+        checkpoint_exists = False
+        if os.path.exists(checkpoint_path):
+            try:
+                TrainableUtil.find_checkpoint_dir(checkpoint_path)
+            except Exception:
+                pass
+            else:
+                checkpoint_exists = True
+        
+        if checkpoint_exists:
+            pass
+        elif self.uses_cloud_checkpointing:
             rel_checkpoint_dir = TrainableUtil.find_rel_checkpoint_dir(
                 self.logdir, checkpoint_path
             )
@@ -546,11 +557,6 @@ class Trainable:
                 # Only keep for backwards compatibility
                 self.storage_client.sync_down(external_uri, local_dir)
                 self.storage_client.wait_or_retry()
-            elif os.path.exists(checkpoint_path):
-                try:
-                    TrainableUtil.find_checkpoint_dir(checkpoint_path)
-                except Exception:
-                    pass
             else:
                 checkpoint = Checkpoint.from_uri(external_uri)
                 retry_fn(


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It solves issue of restore from object failing to work during ray tune with sync config and PBT scheduler.

## Related issue number

Closes https://github.com/ray-project/ray/issues/26714

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
