### PR TITLE
[serve] Soft SPREAD replicas by default

### DIFF
--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -202,5 +202,47 @@ def test_intelligent_scale_down(ray_cluster):
     assert get_actor_distributions() == {2}
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
+def test_replica_spread(ray_cluster):
+    cluster = ray_cluster
+
+    cluster.add_node(num_cpus=2)
+
+    # NOTE(edoakes): we need to start serve before adding the worker node to
+    # guarantee that the controller is placed on the head node (we should be
+    # able to tolerate being placed on workers, but there's currently a bug).
+    # We should add an explicit test for that in the future when it's fixed.
+    cluster.connect(namespace=SERVE_NAMESPACE)
+    serve.start(detached=True)
+
+    worker_node = cluster.add_node(num_cpus=2)
+
+    @serve.deployment(num_replicas=2)
+    def get_node_id():
+        return os.getpid(), ray.get_runtime_context().node_id.hex()
+
+    h = serve.run(get_node_id.bind())
+
+    def get_num_nodes():
+        pids = set()
+        node_ids = set()
+        while len(pids) < 2:
+            pid, node = ray.get(h.remote())
+            pids.add(pid)
+            node_ids.add(node)
+
+        return len(node_ids)
+
+    # Check that the two replicas are spread across the two nodes.
+    wait_for_condition(lambda: get_num_nodes() == 2)
+
+    # Kill the worker node. The second replica should get rescheduled on
+    # the head node.
+    cluster.remove_node(worker_node)
+
+    # Check that the two replicas are spread across the two nodes.
+    wait_for_condition(lambda: get_num_nodes() == 1)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -240,7 +240,7 @@ def test_replica_spread(ray_cluster):
     # the head node.
     cluster.remove_node(worker_node)
 
-    # Check that the two replicas are spread across the two nodes.
+    # Check that the replica on the dead node can be rescheduled.
     wait_for_condition(lambda: get_num_nodes() == 1)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently replicas for each deployment are packed based on Ray's default scheduling policy. This is problematic when node failures occur because a given deployment may have all of its replicas crash at once.


This PR changes the default behavior to a soft SPREAD. If the replicas can be spread based on current resources, they will be, else they will still be placed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
