### PR TITLE
[Core][State Observability] Fix is_alive column with wrong column type that breaks filtering 

### DIFF
--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -147,7 +147,7 @@ class StateAPIManager:
 
         Returns:
             A list of filtered state data in dictionary. Each state data's
-            unncessary columns are filtered by the given state_dataclass schema.
+            unnecessary columns are filtered by the given state_dataclass schema.
         """
         filters = _convert_filters_type(filters, state_dataclass)
         result = []

--- a/python/ray/experimental/state/common.py
+++ b/python/ray/experimental/state/common.py
@@ -310,7 +310,7 @@ class JobState(JobInfo, StateSchema):
 @dataclass(init=True)
 class WorkerState(StateSchema):
     worker_id: str = state_column(filterable=True)
-    is_alive: str = state_column(filterable=True)
+    is_alive: bool = state_column(filterable=True)
     worker_type: str = state_column(filterable=True)
     exit_type: str = state_column(filterable=True)
     node_id: str = state_column(filterable=True)

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -2031,7 +2031,7 @@ def test_filter(shutdown_only):
     wait_for_condition(verify)
 
     """
-    Test filter with different types (integer).
+    Test filter with different types (integer/bool).
     """
     obj_1 = ray.put(123)  # noqa
     ray.get(a.put.remote())
@@ -2043,6 +2043,24 @@ def test_filter(shutdown_only):
             filters=[("pid", "=", pid), ("reference_type", "=", "LOCAL_REFERENCE")]
         )
         return len(result) == 1
+
+    wait_for_condition(verify)
+
+    def verify():
+        workers = list_workers()
+        live_workers = list_workers(filters=[("is_alive", "=", "true")])
+        non_alive_workers = list_workers(filters=[("is_alive", "!=", "true")])
+        assert len(live_workers) + len(non_alive_workers) == len(workers)
+
+        live_workers = list_workers(filters=[("is_alive", "=", "1")])
+        non_alive_workers = list_workers(filters=[("is_alive", "!=", "1")])
+        assert len(live_workers) + len(non_alive_workers) == len(workers)
+
+        live_workers = list_workers(filters=[("is_alive", "=", "True")])
+        non_alive_workers = list_workers(filters=[("is_alive", "!=", "True")])
+        assert len(live_workers) + len(non_alive_workers) == len(workers)
+
+        return True
 
     wait_for_condition(verify)
 

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -2042,7 +2042,7 @@ def test_filter(shutdown_only):
         result = list_objects(
             filters=[("pid", "=", pid), ("reference_type", "=", "LOCAL_REFERENCE")]
         )
-        return len(result) == 1
+        return len(result) == 12
 
     wait_for_condition(verify)
 

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -2042,7 +2042,7 @@ def test_filter(shutdown_only):
         result = list_objects(
             filters=[("pid", "=", pid), ("reference_type", "=", "LOCAL_REFERENCE")]
         )
-        return len(result) == 12
+        return len(result) == 1
 
     wait_for_condition(verify)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`is_alive` column of the `WorkerState` has wrong column type that breaks filtering on `is_alive`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #26613

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] CLI tests
