### PR TITLE
[P0][Release Blocker Fix] Larger headnode for tune_scalability_network_overhead weekly test

### DIFF
--- a/release/tune_tests/scalability_tests/tpl_100x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_100x2.yaml
@@ -5,7 +5,7 @@ max_workers: 99
 
 head_node_type:
     name: head_node
-    instance_type: m5.large
+    instance_type: m5.4xlarge
 
 worker_node_types:
     - name: worker_node

--- a/release/tune_tests/scalability_tests/tpl_100x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_100x2.yaml
@@ -10,6 +10,6 @@ head_node_type:
 worker_node_types:
     - name: worker_node
       instance_type: m5.large
-      min_workers: 99
+      min_workers: 98
       max_workers: 99
       use_spot: true

--- a/release/tune_tests/scalability_tests/tpl_100x2.yaml
+++ b/release/tune_tests/scalability_tests/tpl_100x2.yaml
@@ -10,6 +10,6 @@ head_node_type:
 worker_node_types:
     - name: worker_node
       instance_type: m5.large
-      min_workers: 98
+      min_workers: 99
       max_workers: 99
       use_spot: true


### PR DESCRIPTION
## Why are these changes needed?

Our `tune_scalability_network_overhead ` failed weekly tests at larger scale. From failed tests we can see a node is under a lot of stress with OOM warning and eventually GCS died. This test increases the headnode size without changing worker node types.

```
== Status ==
Current time: 2022-07-09 23:27:52 (running for 00:02:57.91)
Memory usage on this node: 7.4/7.6 GiB: ***LOW MEMORY*** less than 10% of the memory on this node is available for use. This can cause unexpected crashes. Consider reducing the memory used by your application or reducing the Ray object store size by setting `object_store_memory` when calling `ray.init`.
Using FIFO scheduling algorithm.
Resources requested: 200.0/200 CPUs, 0/0 GPUs, 0.0/558.67 GiB heap, 0.0/214.16 GiB objects
Result logdir: /home/ray/ray_results/function_trainable_2022-07-09_23-24-54
Number of trials: 100/100 (100 RUNNING)


2022-06-18 23:22:40,907 WARNING worker.py:1737 -- WARNING: 124 PYTHON worker processes have been started on node: 9a68c366f805c667e75dfc4e72563fedf6ceedd48a0cc3109d6fd266 with address: 172.31.81.86. This could be a result of using a large number of actors, or due to tasks blocked in ray.get() calls (see https://github.com/ray-project/ray/issues/3644 for some discussion of workarounds).
2022-06-18 23:22:44,668 WARNING worker.py:1737 -- WARNING: 126 PYTHON worker processes have been started on node: 9a68c366f805c667e75dfc4e72563fedf6ceedd48a0cc3109d6fd266 with address: 172.31.81.86. This could be a result of using a large number of actors, or due to tasks blocked in ray.get() calls (see https://github.com/ray-project/ray/issues/3644 for some discussion of workarounds).

[2022-06-18 23:29:40,031 C 1050 1066] gcs_rpc_client.h:509:  Check failed: absl::ToInt64Seconds(absl::Now() - gcs_last_alive_time_) < ::RayConfig::instance().gcs_rpc_server_reconnect_timeout_s() 

Failed to connect to GCS within 60 seconds

*** StackTrace Information ***
    ray::SpdLogMessage::Flush()
    ray::RayLog::~RayLog()
    ray::rpc::GcsRpcClient::CheckChannelStatus()
    boost::asio::detail::wait_handler<>::do_complete()
    boost::asio::detail::scheduler::do_run_one()
    boost::asio::detail::scheduler::run()
    boost::asio::io_context::run()
    std::thread::_State_impl<>::_M_run()
    execute_native_thread_routine
```

## Related issue number

#26722

## If we want to dive deeper ...

The regression seems to happen between 6/11 - 6/18.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
