### PR TITLE
[air] change default strategy to PACK

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -62,7 +62,7 @@ class ScalingConfig:
     num_workers: Optional[Union[int, SampleRange]] = None
     use_gpu: Union[bool, SampleRange] = False
     resources_per_worker: Optional[Union[Dict, SampleRange]] = None
-    placement_strategy: Union[str, SampleRange] = "SPREAD"
+    placement_strategy: Union[str, SampleRange] = "PACK"
     _max_cpu_fraction_per_node: Optional[Union[float, SampleRange]] = None
 
     def __post_init__(self):

--- a/release/air_tests/air_benchmarks/workloads/data_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/data_benchmark.py
@@ -29,7 +29,7 @@ def run_ingest_bulk(dataset, num_workers, num_cpus_per_worker):
             num_workers=num_workers,
             trainer_resources={"CPU": 0},
             resources_per_worker={"CPU": num_cpus_per_worker},
-            _max_cpu_fraction_per_node=0.8,
+            _max_cpu_fraction_per_node=0.1,
         ),
         datasets={"train": dataset},
         preprocessor=dummy_prep,

--- a/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tune_torch_benchmark.py
@@ -44,7 +44,6 @@ def get_trainer(num_workers: int = 4, use_gpu: bool = False):
             resources_per_worker={"CPU": 2},
             trainer_resources={"CPU": 0},
             use_gpu=use_gpu,
-            placement_strategy="STRICT_PACK",
         ),
     )
     return trainer


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Revert https://github.com/ray-project/ray/pull/26633

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Running GPU benchmarks (e.g. https://github.com/ray-project/ray/pull/26564) identifies SPREAD to result in poor performance for multi-GPU nodes, which is reason enough to switch the default behavior back.

For workloads that PACK generally does not work well, the user may consider a few different options:
- Use SPREAD strategy.
- Increase number of CPUs per worker.
- Set `_max_cpu_fraction_per_node` to a small number.

As a follow-up, guidance for this should be upstreamed into documentation.

### Testing

- [x] Successfully run `data_benchmark` release test
    - Test is failing due to a (unrelated) regression in split. Verified that workers are still spread across different nodes.
- [x] Successfully run `tune_torch_benchmark` release tests

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
