### PR TITLE
[Python]More efficient node_table() in state.py

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -166,10 +166,11 @@ class GlobalState:
                 "NodeName": item.node_name,
             }
             node_info["alive"] = node_info["Alive"]
-            node_info["Resources"] = {
-                key: value
-                for key, value in item.resources_total.items()
-            } if node_info["Alive"] else {}
+            node_info["Resources"] = (
+                {key: value for key, value in item.resources_total.items()}
+                if node_info["Alive"]
+                else {}
+            )
             results.append(node_info)
         return results
 

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -139,28 +139,6 @@ class GlobalState:
         }
         return actor_info
 
-    def node_resource_table(self, node_id=None):
-        """Fetch and parse the node resource table info for one.
-
-        Args:
-            node_id: An node ID to fetch information about.
-
-        Returns:
-            Information from the node resource table.
-        """
-        self._check_connected()
-
-        node_id = ray.NodeID(hex_to_binary(node_id))
-        node_resource_bytes = self.global_state_accessor.get_node_resource_info(node_id)
-        if node_resource_bytes is None:
-            return {}
-        else:
-            node_resource_info = gcs_utils.ResourceMap.FromString(node_resource_bytes)
-            return {
-                key: value.resource_capacity
-                for key, value in node_resource_info.items.items()
-            }
-
     def node_table(self):
         """Fetch and parse the Gcs node info table.
 
@@ -188,11 +166,10 @@ class GlobalState:
                 "NodeName": item.node_name,
             }
             node_info["alive"] = node_info["Alive"]
-            node_info["Resources"] = (
-                self.node_resource_table(node_info["NodeID"])
-                if node_info["Alive"]
-                else {}
-            )
+            node_info["Resources"] = {
+                key: value
+                for key, value in item.resources_total.items()
+            } if node_info["Alive"] else {}
             results.append(node_info)
         return results
 

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -29,7 +29,6 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
         unique_ptr[c_string] GetAllResourceUsage()
         c_vector[c_string] GetAllActorInfo()
         unique_ptr[c_string] GetActorInfo(const CActorID &actor_id)
-        c_string GetNodeResourceInfo(const CNodeID &node_id)
         unique_ptr[c_string] GetWorkerInfo(const CWorkerID &worker_id)
         c_vector[c_string] GetAllWorkerInfo()
         c_bool AddWorkerInfo(const c_string &serialized_string)

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -91,13 +91,6 @@ cdef class GlobalStateAccessor:
             return c_string(actor_info.get().data(), actor_info.get().size())
         return None
 
-    def get_node_resource_info(self, node_id):
-        cdef c_string result
-        cdef CNodeID cnode_id = CNodeID.FromBinary(node_id.binary())
-        with nogil:
-            result = self.inner.get().GetNodeResourceInfo(cnode_id)
-        return result
-
     def get_worker_table(self):
         cdef c_vector[c_string] result
         with nogil:


### PR DESCRIPTION
Signed-off-by: WangTaoTheTonic <dooku.wt@antfin.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This picks up https://github.com/ray-project/ray/pull/24088
The `get_node_table` already has resources of nodes, so we don't need to invoke `get_node_resource_info` for every node again. This change will reduce lots of rpc calls and make the api more efficient.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
