### PR TITLE
[Core] Make "GetTimeoutError" a subclass of "TimeoutError"

### DIFF
--- a/doc/source/ray-core/objects.rst
+++ b/doc/source/ray-core/objects.rst
@@ -69,16 +69,16 @@ If the current node's object store does not contain the object, the object is do
       # You can also set a timeout to return early from a ``get``
       # that's blocking for too long.
       from ray.exceptions import GetTimeoutError
+      # ``GetTimeoutError`` is a subclass of ``TimeoutError``.
 
       @ray.remote
-
       def long_running_function():
           time.sleep(8)
 
       obj_ref = long_running_function.remote()
       try:
           ray.get(obj_ref, timeout=4)
-      except GetTimeoutError:
+      except GetTimeoutError:  # You can capture the standard "TimeoutError" instead
           print("`get` timed out.")
 
 .. tabbed:: Java

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -547,7 +547,7 @@ class ObjectReconstructionFailedLineageEvictedError(ObjectLostError):
 
 
 @PublicAPI
-class GetTimeoutError(RayError):
+class GetTimeoutError(RayError, TimeoutError):
     """Indicates that a call to the worker timed out."""
 
     pass

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -380,6 +380,10 @@ def test_get_with_timeout(ray_start_regular_shared):
     with pytest.raises(GetTimeoutError):
         ray.get(result_id, timeout=0.1)
 
+    assert issubclass(GetTimeoutError, TimeoutError)
+    with pytest.raises(TimeoutError):
+        ray.get(result_id, timeout=0.1)
+
     # Check that a subsequent get() returns early.
     ray.get(signal.send.remote())
     start = time.time()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I am surprised by the fact that `GetTimeoutError` is not a subclass of `TimeoutError`, which is counter-intuitive and may discourage users from trying the timeout feature in `ray.get`, because you have to "guess" the correct error type. For most people, I believe the first error type in their mind would be `TimeoutError`.

This PR fixes this.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
