### PR TITLE
[Data][Split] stable version of split with hints

### DIFF
--- a/python/ray/data/_internal/equalize.py
+++ b/python/ray/data/_internal/equalize.py
@@ -46,7 +46,15 @@ def _equalize(
 
     # phase 2: based on the num rows needed for each shaved split, split the leftovers
     # in the shape that exactly matches the rows needed.
-    leftover_splits = _split_leftovers(leftovers, per_split_needed_rows)
+    leftover_refs = []
+    leftover_meta = []
+    for (ref, meta) in leftovers:
+        leftover_refs.append(ref)
+        leftover_meta.append(meta)
+    leftover_splits = _split_leftovers(
+        BlockList(leftover_refs, leftover_meta, owned_by_consumer=owned_by_consumer),
+        per_split_needed_rows,
+    )
 
     # phase 3: merge the shaved_splits and leftoever splits and return.
     for i, leftover_split in enumerate(leftover_splits):
@@ -133,7 +141,7 @@ def _shave_all_splits(
 
 
 def _split_leftovers(
-    leftovers: BlockPartition, per_split_needed_rows: List[int]
+    leftovers: BlockList, per_split_needed_rows: List[int]
 ) -> List[BlockPartition]:
     """Split leftover blocks by the num of rows needed."""
     num_splits = len(per_split_needed_rows)

--- a/python/ray/data/_internal/equalize.py
+++ b/python/ray/data/_internal/equalize.py
@@ -53,7 +53,9 @@ def _equalize(
         for (block_ref, m) in split:
             block_refs.append(block_ref)
             meta.append(m)
-        equalized_block_lists.append(BlockList(block_refs, meta, owned_by_consumer))
+        equalized_block_lists.append(
+            BlockList(block_refs, meta, owned_by_consumer=owned_by_consumer)
+        )
     return equalized_block_lists
 
 

--- a/python/ray/data/_internal/equalize.py
+++ b/python/ray/data/_internal/equalize.py
@@ -1,0 +1,138 @@
+from typing import Tuple, List
+from ray.data._internal.block_list import BlockList
+
+from ray.data._internal.split import _split_at_indices, _calculate_blocks_rows
+from ray.data.block import (
+    Block,
+    BlockMetadata,
+)
+from ray.types import ObjectRef
+
+BlockRefWithMeta = Tuple[ObjectRef[Block], BlockMetadata]
+
+
+def _equalize(
+    per_split_block_lists: List[BlockList],
+    owned_by_consumer: bool,
+) -> List[BlockList]:
+    """Equalize split block lists into equal number of rows.
+
+    Args:
+        per_split_block_lists: block lists to equalize.
+    Returns:
+        the equalized block lists.
+    """
+    per_split_blocks_with_metadata = [
+        block_list.get_blocks_with_metadata() for block_list in per_split_block_lists
+    ]
+    per_split_num_rows: List[List[int]] = [
+        _calculate_blocks_rows(split) for split in per_split_blocks_with_metadata
+    ]
+    total_rows = sum([sum(blocks_rows) for blocks_rows in per_split_num_rows])
+    target_split_size = total_rows // len(per_split_blocks_with_metadata)
+
+    # phase 1: shave the current splits by dropping blocks (into leftovers)
+    # and calculate num rows needed to the meet target.
+    shaved_splits, per_split_needed_rows, leftovers = _shave_all_splits(
+        per_split_blocks_with_metadata, per_split_num_rows, target_split_size
+    )
+
+    # phase 2: based on the num rows needed for each shaved split, split the leftovers
+    # in the shape that exactly matches the rows needed.
+    leftover_splits = _split_leftovers(leftovers, per_split_needed_rows)
+
+    # phase 3: merge the shaved_splits and leftoever splits and return.
+    for i, leftover_split in enumerate(leftover_splits):
+        shaved_splits[i].extend(leftover_split)
+
+    # Compose the result back to blocklists
+    equalized_block_lists: List[BlockList] = []
+    for split in shaved_splits:
+        block_refs: List[ObjectRef[Block]] = []
+        meta: List[BlockMetadata] = []
+        for (block_ref, m) in split:
+            block_refs.append(block_ref)
+            meta.append(m)
+        equalized_block_lists.append(BlockList(block_refs, meta, owned_by_consumer))
+    return equalized_block_lists
+
+
+def _shave_one_split(
+    split: List[BlockRefWithMeta], num_rows_per_block: List[int], target_size: int
+) -> Tuple[List[BlockRefWithMeta], int, List[BlockRefWithMeta]]:
+    """Shave a block list to the target size.
+
+    Args:
+        split: the block list to shave.
+        num_rows_per_block: num rows for each block in the list.
+        targe_size: the upper bound target size of the shaved list.
+    Returns:
+        A tuple of:
+            - shaved block list.
+            - num of rows needed for the block list to meet the target size.
+            - leftover blocks.
+
+    """
+    # iterates through the blocks from the input list and
+    shaved = []
+    leftovers = []
+    shaved_rows = 0
+    for block_with_meta, block_rows in zip(split, num_rows_per_block):
+        if block_rows + shaved_rows <= target_size:
+            shaved.append(block_with_meta)
+            shaved_rows += block_rows
+        else:
+            leftovers.append(block_with_meta)
+    num_rows_needed = target_size - shaved_rows
+    return shaved, num_rows_needed, leftovers
+
+
+def _shave_all_splits(
+    input_splits: List[List[BlockRefWithMeta]],
+    per_split_num_rows: List[List[int]],
+    target_size: int,
+) -> Tuple[List[List[BlockRefWithMeta]], List[int], List[BlockRefWithMeta]]:
+    """Shave all block list to the target size.
+
+    Args:
+        input_splits: all block list to shave.
+        input_splits: num rows (per block) for each block list.
+        targe_size:  the upper bound target size of the shaved lists.
+    Returns:
+        A tuple of:
+            - all shaved block list.
+            - num of rows needed for the block list to meet the target size.
+            - leftover blocks.
+
+    """
+    shaved_splits = []
+    per_split_needed_rows = []
+    leftovers = []
+
+    for split, num_rows_per_block in zip(input_splits, per_split_num_rows):
+        shaved, num_rows_needed, _leftovers = _shave_one_split(
+            split, num_rows_per_block, target_size
+        )
+        shaved_splits.append(shaved)
+        per_split_needed_rows.append(num_rows_needed)
+        leftovers.extend(_leftovers)
+
+    return shaved_splits, per_split_needed_rows, leftovers
+
+
+def _split_leftovers(
+    leftovers: List[BlockRefWithMeta], per_split_needed_rows: List[int]
+) -> List[List[BlockRefWithMeta]]:
+    """Split leftover blocks by the num of rows needed."""
+    num_splits = len(per_split_needed_rows)
+    split_indices = []
+    prev = 0
+    for i, num_rows_needed in enumerate(per_split_needed_rows):
+        split_indices.append(prev + num_rows_needed)
+        prev = split_indices[i]
+    split_result: Tuple[
+        List[List[ObjectRef[Block]]], List[List[BlockMetadata]]
+    ] = _split_at_indices(leftovers, split_indices)
+    return [list(zip(block_refs, meta)) for block_refs, meta in zip(*split_result)][
+        :num_splits
+    ]

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -32,6 +32,7 @@ from ray.data._internal.compute import (
     TaskPoolStrategy,
 )
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data._internal.equalize import _equalize
 from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data._internal.util import _estimate_available_parallelism
@@ -909,186 +910,27 @@ class Dataset(Generic[T]):
                 )
 
         blocks = self._plan.execute()
-        stats = self._plan.stats()
-
-        def _partition_splits(
-            splits: List[Dataset[T]], part_size: int, counts_cache: Dict[str, int]
-        ):
-            """Partition splits into two sets: splits that are smaller than the
-            target size and splits that are larger than the target size.
-            """
-            splits = sorted(splits, key=lambda s: counts_cache[s._get_uuid()])
-            idx = next(
-                i
-                for i, split in enumerate(splits)
-                if counts_cache[split._get_uuid()] >= part_size
-            )
-            return splits[:idx], splits[idx:]
-
-        def _equalize_larger_splits(
-            splits: List[Dataset[T]],
-            target_size: int,
-            counts_cache: Dict[str, int],
-            num_splits_required: int,
-        ):
-            """Split each split into one or more subsplits that are each the
-            target size, with at most one leftover split that's smaller
-            than the target size.
-
-            This assume that the given splits are sorted in ascending order.
-            """
-            if target_size == 0:
-                return splits, []
-            new_splits = []
-            leftovers = []
-            for split in splits:
-                size = counts_cache[split._get_uuid()]
-                if size == target_size:
-                    new_splits.append(split)
-                    continue
-                split_indices = list(range(target_size, size, target_size))
-                split_splits = split.split_at_indices(split_indices)
-                last_split_size = split_splits[-1].count()
-                if last_split_size < target_size:
-                    # Last split is smaller than the target size, save it for
-                    # our unioning of small splits.
-                    leftover = split_splits.pop()
-                    leftovers.append(leftover)
-                    counts_cache[leftover._get_uuid()] = leftover.count()
-                if len(new_splits) + len(split_splits) >= num_splits_required:
-                    # Short-circuit if the new splits will make us reach the
-                    # desired number of splits.
-                    new_splits.extend(
-                        split_splits[: num_splits_required - len(new_splits)]
-                    )
-                    break
-                new_splits.extend(split_splits)
-            return new_splits, leftovers
-
-        def _equalize_smaller_splits(
-            splits: List[Dataset[T]],
-            target_size: int,
-            counts_cache: Dict[str, int],
-            num_splits_required: int,
-        ):
-            """Union small splits up to the target split size.
-
-            This assume that the given splits are sorted in ascending order.
-            """
-            new_splits = []
-            union_buffer = []
-            union_buffer_size = 0
-            low = 0
-            high = len(splits) - 1
-            while low <= high:
-                # Union small splits up to the target split size.
-                low_split = splits[low]
-                low_count = counts_cache[low_split._get_uuid()]
-                high_split = splits[high]
-                high_count = counts_cache[high_split._get_uuid()]
-                if union_buffer_size + high_count <= target_size:
-                    # Try to add the larger split to the union buffer first.
-                    union_buffer.append(high_split)
-                    union_buffer_size += high_count
-                    high -= 1
-                elif union_buffer_size + low_count <= target_size:
-                    union_buffer.append(low_split)
-                    union_buffer_size += low_count
-                    low += 1
-                else:
-                    # Neither the larger nor smaller split fit in the union
-                    # buffer, so we split the smaller split into a subsplit
-                    # that will fit into the union buffer and a leftover
-                    # subsplit that we add back into the candidate split list.
-                    diff = target_size - union_buffer_size
-                    diff_split, new_low_split = low_split.split_at_indices([diff])
-                    union_buffer.append(diff_split)
-                    union_buffer_size += diff
-                    # We overwrite the old low split and don't advance the low
-                    # pointer since (1) the old low split can be discarded,
-                    # (2) the leftover subsplit is guaranteed to be smaller
-                    # than the old low split, and (3) the low split should be
-                    # the smallest split in the candidate split list, which is
-                    # this subsplit.
-                    splits[low] = new_low_split
-                    counts_cache[new_low_split._get_uuid()] = low_count - diff
-                if union_buffer_size == target_size:
-                    # Once the union buffer is full, we union together the
-                    # splits.
-                    assert len(union_buffer) > 1, union_buffer
-                    first_ds = union_buffer[0]
-                    new_split = first_ds.union(*union_buffer[1:])
-                    new_splits.append(new_split)
-                    # Clear the union buffer.
-                    union_buffer = []
-                    union_buffer_size = 0
-                    if len(new_splits) == num_splits_required:
-                        # Short-circuit if we've reached the desired number of
-                        # splits.
-                        break
-            return new_splits
-
-        def equalize(splits: List[Dataset[T]], num_splits: int) -> List[Dataset[T]]:
-            if not equal:
-                return splits
-            counts = {s._get_uuid(): s.count() for s in splits}
-            total_rows = sum(counts.values())
-            # Number of rows for each split.
-            target_size = total_rows // num_splits
-
-            # Partition splits.
-            smaller_splits, larger_splits = _partition_splits(
-                splits, target_size, counts
-            )
-            if len(smaller_splits) == 0 and num_splits < len(splits):
-                # All splits are already equal.
-                return splits
-
-            # Split larger splits.
-            new_splits, leftovers = _equalize_larger_splits(
-                larger_splits, target_size, counts, num_splits
-            )
-            # Short-circuit if we've already reached the desired number of
-            # splits.
-            if len(new_splits) == num_splits:
-                return new_splits
-            # Add leftovers to small splits and re-sort.
-            smaller_splits += leftovers
-            smaller_splits = sorted(smaller_splits, key=lambda s: counts[s._get_uuid()])
-
-            # Union smaller splits.
-            new_splits_small = _equalize_smaller_splits(
-                smaller_splits, target_size, counts, num_splits - len(new_splits)
-            )
-            new_splits.extend(new_splits_small)
-            return new_splits
-
-        block_refs, metadata = zip(*blocks.get_blocks_with_metadata())
-        metadata_mapping = {b: m for b, m in zip(block_refs, metadata)}
         owned_by_consumer = blocks._owned_by_consumer
+        stats = self._plan.stats()
+        block_refs, metadata = zip(*blocks.get_blocks_with_metadata())
 
         if locality_hints is None:
-            ds = equalize(
-                [
-                    Dataset(
-                        ExecutionPlan(
-                            BlockList(
-                                list(blocks),
-                                [metadata_mapping[b] for b in blocks],
-                                owned_by_consumer=owned_by_consumer,
-                            ),
-                            stats,
-                            run_by_consumer=owned_by_consumer,
-                        ),
-                        self._epoch,
-                        self._lazy,
-                    )
-                    for blocks in np.array_split(block_refs, n)
-                ],
-                n,
-            )
-            assert len(ds) == n, (ds, n)
-            return ds
+            blocks = np.array_split(block_refs, n)
+            meta = np.array_split(metadata, n)
+            return [
+                Dataset(
+                    ExecutionPlan(
+                        BlockList(b.tolist(), m.tolist(), owned_by_consumer=owned_by_consumer),
+                        stats,
+                        run_by_consumer=owned_by_consumer,
+                    ),
+                    self._epoch,
+                    self._lazy,
+                )
+                for b, m in zip(blocks, meta)
+            ]
+
+        metadata_mapping = {b: m for b, m in zip(block_refs, metadata)}
 
         # If the locality_hints is set, we use a two-round greedy algorithm
         # to co-locate the blocks with the actors based on block
@@ -1182,25 +1024,31 @@ class Dataset(Generic[T]):
 
         assert len(remaining_block_refs) == 0, len(remaining_block_refs)
 
-        return equalize(
-            [
-                Dataset(
-                    ExecutionPlan(
-                        BlockList(
-                            allocation_per_actor[actor],
-                            [metadata_mapping[b] for b in allocation_per_actor[actor]],
-                            owned_by_consumer=owned_by_consumer,
-                        ),
-                        stats,
-                        run_by_consumer=owned_by_consumer,
-                    ),
-                    self._epoch,
-                    self._lazy,
-                )
-                for actor in locality_hints
-            ],
-            n,
-        )
+        per_split_block_lists = [
+            BlockList(
+                allocation_per_actor[actor],
+                [metadata_mapping[b] for b in allocation_per_actor[actor]],
+                owned_by_consumer=owned_by_consumer,
+            )
+            for actor in locality_hints
+        ]
+
+        if equal:
+            # equalize the splits
+            per_split_block_lists = _equalize(per_split_block_lists, owned_by_consumer)
+
+        return [
+            Dataset(
+                ExecutionPlan(
+                    block_split,
+                    stats,
+                    run_by_consumer=owned_by_consumer,
+                ),
+                self._epoch,
+                self._lazy,
+            )
+            for block_split in per_split_block_lists
+        ]
 
     def split_at_indices(self, indices: List[int]) -> List["Dataset[T]"]:
         """Split the dataset at the given indices (like np.split).

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -920,7 +920,9 @@ class Dataset(Generic[T]):
             return [
                 Dataset(
                     ExecutionPlan(
-                        BlockList(b.tolist(), m.tolist(), owned_by_consumer=owned_by_consumer),
+                        BlockList(
+                            b.tolist(), m.tolist(), owned_by_consumer=owned_by_consumer
+                        ),
                         stats,
                         run_by_consumer=owned_by_consumer,
                     ),

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -95,9 +95,9 @@ def _test_equal_split_balanced(block_sizes, num_splits):
         blocks.append(ray.put(block))
         metadata.append(BlockAccessor.for_block(block).get_metadata(None, None))
         total_rows += block_size
-    block_list = BlockList(blocks, metadata)
+    block_list = BlockList(blocks, metadata, owned_by_consumer=True)
     ds = Dataset(
-        ExecutionPlan(block_list, DatasetStats.TODO()),
+        ExecutionPlan(block_list, DatasetStats.TODO(), run_by_consumer=True),
         0,
         False,
     )

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -663,6 +663,8 @@ def test_equalize(ray_start_regular_shared):
 
 
 def test_equalize_randomized(ray_start_regular_shared):
+    # verify the entries in the splits are in the range of 0 .. num_rows,
+    # unique, and the total number matches num_rows if exact_num == True.
     def assert_unique_and_inrange(splits, num_rows, exact_num=False):
         unique_set = set([])
         for split in splits:
@@ -674,11 +676,13 @@ def test_equalize_randomized(ray_start_regular_shared):
         if exact_num:
             assert len(unique_set) == num_rows
 
+    # verify that splits are equalized.
     def assert_equal_split(splits, num_rows, num_split):
         split_size = num_rows // num_split
         for split in splits:
             assert len((list(itertools.chain.from_iterable(split)))) == split_size
 
+    # create randomized splits contains entries from 0 ... num_rows.
     def random_split(num_rows, num_split):
         split_point = [int(random.random() * num_rows) for _ in range(num_split - 1)]
         split_index_helper = [0] + sorted(split_point) + [num_rows]


### PR DESCRIPTION
Signed-off-by: scv119 <scv119@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Introduce a stable version of `split with hints` with a stable equalizing algorithm:
1. use the greedy algorithm to generate the initial unbalanced splits.
2. for each splits, first shave them so the number for rows are below the target_size
3. based on how many rows needed for each split, do a one time `split_at_index` to the left over blocks.
4. merge the shaved splits with the leftover splits.

The guarantee of this algorithm is we at most need to split O(split) number of blocks.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
