### PR TITLE
[ci] fix determine_tests_to_run.py by finding merge base

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -24,8 +24,12 @@ def list_changed_files(commit_range):
     Returns:
         list: List of changed files within the commit range
     """
+    base, target = commit_range.split("...", maxsplit=1)
 
-    command = ["git", "diff", "--name-only", commit_range, "--"]
+    merge_base = subprocess.check_output(["git", "merge-base", base, target])
+
+    new_commit_range = f"{merge_base}...{target}"
+    command = ["git", "diff", "--name-only", new_commit_range, "--"]
     out = subprocess.check_output(command)
     return [s.strip() for s in out.decode().splitlines() if s is not None]
 

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -24,12 +24,8 @@ def list_changed_files(commit_range):
     Returns:
         list: List of changed files within the commit range
     """
-    base, target = commit_range.split("...", maxsplit=1)
 
-    merge_base = subprocess.check_output(["git", "merge-base", base, target])
-
-    new_commit_range = f"{merge_base}...{target}"
-    command = ["git", "diff", "--name-only", new_commit_range, "--"]
+    command = ["git", "diff", "--name-only", commit_range, "--"]
     out = subprocess.check_output(command)
     return [s.strip() for s in out.decode().splitlines() if s is not None]
 
@@ -58,9 +54,9 @@ def get_commit_range():
         with open(os.environ["GITHUB_EVENT_PATH"], "rb") as f:
             event = json.loads(f.read())
         base = event["pull_request"]["base"]["sha"]
-        commit_range = "{}...{}".format(base, event.get("after", ""))
+        commit_range = "{}..{}".format(base, event.get("after", ""))
     elif os.environ.get("BUILDKITE"):
-        commit_range = "origin/{}...{}".format(
+        commit_range = "origin/{}..{}".format(
             os.environ["BUILDKITE_PULL_REQUEST_BASE_BRANCH"],
             os.environ["BUILDKITE_COMMIT"],
         )


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We previously found all differences between origin/master and the PR branch, which includes forward changes if origin/master is ahead of the branch. By finding file differences with respect to the merge base we will only include actually changed files.

See https://matthew-brett.github.io/pydagogue/git_diff_dots.html

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
