### PR TITLE
[docs] Mark pipelined prediction as experimental for now

### DIFF
--- a/doc/source/ray-air/predictors.rst
+++ b/doc/source/ray-air/predictors.rst
@@ -114,8 +114,8 @@ Coming soon!
 
 .. _pipelined-prediction:
 
-Lazy/Pipelined Prediction
--------------------------
+Lazy/Pipelined Prediction (experimental)
+----------------------------------------
 
 If you have a large dataset but not a lot of available memory, you can use the 
 :meth:`predict_pipelined <ray.train.batch_predictor.BatchPredictor.predict_pipelined>` method.

--- a/test_log.py
+++ b/test_log.py
@@ -1,9 +1,0 @@
-import ray
-import random
-
-@ray.remote
-def f():
-    while True:
-        print(random.random())
-
-ray.get(f.remote())

--- a/test_log.py
+++ b/test_log.py
@@ -1,0 +1,9 @@
+import ray
+import random
+
+@ray.remote
+def f():
+    while True:
+        print(random.random())
+
+ray.get(f.remote())


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, pipelined prediction has some issues with data imbalance at large scale. Until we have definitively resolved these problems and updated the benchmark results, keep it as experimental to encourage use of bulk prediction.