### PR TITLE
[Serve] Separate internal API and Public API

### DIFF
--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -1,0 +1,59 @@
+from ray.serve.context import get_global_client
+from ray.serve.deployment import Deployment
+from typing import Dict
+
+
+def get_deployment(name: str):
+    """Dynamically fetch a handle to a Deployment object.
+
+    Args:
+        name(str): name of the deployment. This must have already been
+        deployed.
+
+    Returns:
+        Deployment
+    """
+    try:
+        (
+            deployment_info,
+            route_prefix,
+        ) = get_global_client().get_deployment_info(name)
+    except KeyError:
+        raise KeyError(
+            f"Deployment {name} was not found. Did you call Deployment.deploy()?"
+        )
+    return Deployment(
+        deployment_info.replica_config.deployment_def,
+        name,
+        deployment_info.deployment_config,
+        version=deployment_info.version,
+        init_args=deployment_info.replica_config.init_args,
+        init_kwargs=deployment_info.replica_config.init_kwargs,
+        route_prefix=route_prefix,
+        ray_actor_options=deployment_info.replica_config.ray_actor_options,
+        _internal=True,
+    )
+
+
+def list_deployments() -> Dict[str, Deployment]:
+    """Returns a dictionary of all active deployments.
+
+    Dictionary maps deployment name to Deployment objects.
+    """
+    infos = get_global_client().list_deployments()
+
+    deployments = {}
+    for name, (deployment_info, route_prefix) in infos.items():
+        deployments[name] = Deployment(
+            deployment_info.replica_config.deployment_def,
+            name,
+            deployment_info.deployment_config,
+            version=deployment_info.version,
+            init_args=deployment_info.replica_config.init_args,
+            init_kwargs=deployment_info.replica_config.init_kwargs,
+            route_prefix=route_prefix,
+            ray_actor_options=deployment_info.replica_config.ray_actor_options,
+            _internal=True,
+        )
+
+    return deployments

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -52,6 +52,8 @@ from ray.serve.utils import (
     install_serve_encoders_to_fastapi,
 )
 
+from ray.serve._private import api as _private_api
+
 logger = logging.getLogger(__file__)
 
 
@@ -483,26 +485,7 @@ def get_deployment(name: str) -> Deployment:
     Returns:
         Deployment
     """
-    try:
-        (
-            deployment_info,
-            route_prefix,
-        ) = get_global_client().get_deployment_info(name)
-    except KeyError:
-        raise KeyError(
-            f"Deployment {name} was not found. Did you call Deployment.deploy()?"
-        )
-    return Deployment(
-        deployment_info.replica_config.deployment_def,
-        name,
-        deployment_info.deployment_config,
-        version=deployment_info.version,
-        init_args=deployment_info.replica_config.init_args,
-        init_kwargs=deployment_info.replica_config.init_kwargs,
-        route_prefix=route_prefix,
-        ray_actor_options=deployment_info.replica_config.ray_actor_options,
-        _internal=True,
-    )
+    return _private_api.get_deployment(name)
 
 
 @deprecated(instructions="Please see https://docs.ray.io/en/latest/serve/index.html")
@@ -512,23 +495,8 @@ def list_deployments() -> Dict[str, Deployment]:
 
     Dictionary maps deployment name to Deployment objects.
     """
-    infos = get_global_client().list_deployments()
 
-    deployments = {}
-    for name, (deployment_info, route_prefix) in infos.items():
-        deployments[name] = Deployment(
-            deployment_info.replica_config.deployment_def,
-            name,
-            deployment_info.deployment_config,
-            version=deployment_info.version,
-            init_args=deployment_info.replica_config.init_args,
-            init_kwargs=deployment_info.replica_config.init_kwargs,
-            route_prefix=route_prefix,
-            ray_actor_options=deployment_info.replica_config.ray_actor_options,
-            _internal=True,
-        )
-
-    return deployments
+    return _private_api.list_deployments()
 
 
 @PublicAPI(stability="alpha")
@@ -611,7 +579,7 @@ def run(
     )
 
     if ingress is not None:
-        return ingress.get_handle()
+        return ingress._get_handle()
 
 
 def build(target: Union[ClassNode, FunctionNode]) -> Application:

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -213,6 +213,18 @@ class Deployment:
             init_kwargs: kwargs to pass to the class __init__
                 method. Not valid if this deployment wraps a function.
         """
+        self._deploy(*init_args, _blocking=_blocking, **init_kwargs)
+
+    # TODO(Sihan) Promote the _deploy to deploy after we fully deprecate the API
+    def _deploy(self, *init_args, _blocking=True, **init_kwargs):
+        """Deploy or update this deployment.
+
+        Args:
+            init_args: args to pass to the class __init__
+                method. Not valid if this deployment wraps a function.
+            init_kwargs: kwargs to pass to the class __init__
+                method. Not valid if this deployment wraps a function.
+        """
         if len(init_args) == 0 and self._init_args is not None:
             init_args = self._init_args
         if len(init_kwargs) == 0 and self._init_kwargs is not None:
@@ -238,6 +250,12 @@ class Deployment:
     def delete(self):
         """Delete this deployment."""
 
+        return self._delete()
+
+    # TODO(Sihan) Promote the _delete to delete after we fully deprecate the API
+    def _delete(self):
+        """Delete this deployment."""
+
         return get_global_client().delete_deployments([self._name])
 
     @deprecated(
@@ -245,6 +263,24 @@ class Deployment:
     )
     @PublicAPI
     def get_handle(
+        self, sync: Optional[bool] = True
+    ) -> Union[RayServeHandle, RayServeSyncHandle]:
+        """Get a ServeHandle to this deployment to invoke it from Python.
+
+        Args:
+            sync: If true, then Serve will return a ServeHandle that
+                works everywhere. Otherwise, Serve will return an
+                asyncio-optimized ServeHandle that's only usable in an asyncio
+                loop.
+
+        Returns:
+            ServeHandle
+        """
+
+        return self._get_handle(sync)
+
+    # TODO(Sihan) Promote the _get_handle to get_handle after we fully deprecate the API
+    def _get_handle(
         self, sync: Optional[bool] = True
     ) -> Union[RayServeHandle, RayServeSyncHandle]:
         """Get a ServeHandle to this deployment to invoke it from Python.

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -307,7 +307,9 @@ class RayServeLazySyncHandle:
 
     def remote(self, *args, **kwargs):
         if not self.handle:
-            handle = serve.get_deployment(self.deployment_name).get_handle()
+            handle = serve._private.api.get_deployment(
+                self.deployment_name
+            )._get_handle()
             self.handle = handle.options(method_name=self.handle_options.method_name)
         # TODO (jiaodong): Polish async handles later for serve pipeline
         return self.handle.remote(*args, **kwargs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

- Introduce the Private API from ongoing deprecating Public API 
- Internally code change should call private api to avoid Public api deprecation warnings.
- After deprecate the Public API, we can promote the private api of Deployment class.
- User will be aware of `_private` attribute when using the  get_deployment() api etc.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
