### PR TITLE
[air] Don't request CPUs by default when use_gpu=True

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -90,7 +90,13 @@ class ScalingConfig:
     @property
     def _resources_per_worker_not_none(self):
         if self.resources_per_worker is None:
-            return {"CPU": 1, "GPU": int(self.use_gpu)}
+            if self.use_gpu:
+                # Note that we don't request any CPUs, which avoids possible
+                # scheduling contention. Generally nodes have many more CPUs than
+                # GPUs, so not requesting a CPU does not lead to oversubscription.
+                return {"GPU": 1}
+            else:
+                return {"CPU": 1}
         resources_per_worker = {
             k: v for k, v in self.resources_per_worker.items() if v != 0
         }


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Requesting both CPUs and GPUs leads to unnecessary resource contention.