### PR TITLE
[air] update DummyTrainer to report once per epoch

### DIFF
--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -107,8 +107,8 @@ class DummyTrainer(DataParallelTrainer):
                     dict(
                         bytes_read=bytes_read,
                         batches_read=batches_read,
-                        epochs_read=epochs_read,
                         total_batch_delay=np.sum(batch_delays),
+                        epochs_read=epochs_read,
                     )
                 )
             delta = time.perf_counter() - start

--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -102,15 +102,15 @@ class DummyTrainer(DataParallelTrainer):
                         # NOTE: This isn't recursive and will just return the size of
                         # the object pointers if list of non-primitive types.
                         bytes_read += sys.getsizeof(batch)
-                    session.report(
-                        dict(
-                            bytes_read=bytes_read,
-                            batches_read=batches_read,
-                            epochs_read=epochs_read,
-                            batch_delay=batch_delay,
-                        )
-                    )
                     batch_start = time.perf_counter()
+                session.report(
+                    dict(
+                        bytes_read=bytes_read,
+                        batches_read=batches_read,
+                        epochs_read=epochs_read,
+                        total_batch_delay=np.sum(batch_delays),
+                    )
+                )
             delta = time.perf_counter() - start
 
             print("Time to read all data", delta, "seconds")


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Train expects each worker to call `report` the same number of times. 

`Datasets.split(equal=True)` guarantees each split will have the same number of _rows_ but not necessarily the same number of _blocks_. If `batch_size=None` the number of batches will correspond to the number of blocks.

This PR changes the logic to report once per epoch, instead of per batch. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

Ran [air_benchmark_data_bulk_ingest](https://buildkite.com/ray-project/release-tests-pr/builds/10357#01821e4b-6521-408a-ac99-6508972934ad) successfully.

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
