### PR TITLE
[train] set auto_transfer cuda device

### DIFF
--- a/python/ray/train/tests/test_gpu.py
+++ b/python/ray/train/tests/test_gpu.py
@@ -477,6 +477,28 @@ def test_auto_transfer_data_from_host_to_device(
         assert compute_average_runtime(host_to_device) >= with_auto_transfer
 
 
+def test_auto_transfer_correct_device(ray_start_4_cpus_2_gpus):
+    """Tests that auto_transfer uses the right device for the cuda stream."""
+    import nvidia_smi
+
+    device = torch.device("cuda:1")
+    small_dataloader = [(torch.randn((1024 * 4, 1024 * 4)),) for _ in range(10)]
+    wrapped_dataloader = (  # noqa: F841
+        ray.train.torch.train_loop_utils._WrappedDataLoader(
+            small_dataloader, device, True
+        )
+    )
+
+    nvidia_smi.nvmlInit()
+
+    def get_gpu_used_mem(i):
+        handle = nvidia_smi.nvmlDeviceGetHandleByIndex(i)
+        info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
+        return info.used
+
+    assert get_gpu_used_mem(1) > get_gpu_used_mem(0)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -354,7 +354,7 @@ class _TorchAccelerator(Accelerator):
         data_loader: torch.utils.data.DataLoader,
         add_dist_sampler: bool = True,
         move_to_device: bool = True,
-        auto_transfer: bool = True,
+        auto_transfer: bool = False,
     ) -> torch.utils.data.DataLoader:
         """Prepares DataLoader for distributed execution.
 
@@ -368,7 +368,7 @@ class _TorchAccelerator(Accelerator):
                 the provided DataLoader.
             move_to_device: If set, automatically move the data
                 returned by the data loader to the correct device.
-            auto_transfer: If set and device is GPU, another CUDA stream
+            auto_transfer: (Experimental) If set and device is GPU, another CUDA stream
                 is created to automatically copy data from host (CPU) memory
                 to device (GPU) memory (the default CUDA stream still runs the
                 training procedure). If device is CPU, it will be disabled

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -567,7 +567,7 @@ class _WrappedDataLoader(DataLoader):
         self._auto_transfer = auto_transfer if device.type == "cuda" else False
         # create a new CUDA stream to move data from host to device concurrently
         self._memcpy_stream = (
-            torch.cuda.Stream()
+            torch.cuda.Stream(device)
             if device.type == "cuda" and self._auto_transfer
             else None
         )


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This sets the CUDA Stream on the correct device (and not the default one) when calling ` train.torch.prepare_data_loader(auto_transfer=True)`.

**Repro**
```python
import subprocess

from torch.utils.data import DataLoader
from torchvision import datasets

from ray import train
from ray.air.config import ScalingConfig
from ray.train.torch import TorchTrainer


def train_func(config):
    training_data = datasets.FashionMNIST(
        root="/tmp/data_fashion_mnist",
        train=True,
        download=True,
    )
    train_dataloader = DataLoader(training_data)
    train_dataloader = train.torch.prepare_data_loader(train_dataloader, auto_transfer=True)
    subprocess.run(["nvidia-smi"])


if __name__ == "__main__":
    trainer = TorchTrainer(
        train_loop_per_worker=train_func,
        scaling_config=ScalingConfig(
            num_workers=4,
            use_gpu=True,
        ),
    )
    result = trainer.fit()

```

**Before:**
```
(BaseWorkerMixin pid=4197) +-----------------------------------------------------------------------------+
(BaseWorkerMixin pid=4197) | Processes:                                                                  |
(BaseWorkerMixin pid=4197) |  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
(BaseWorkerMixin pid=4197) |        ID   ID                                                   Usage      |
(BaseWorkerMixin pid=4197) |=============================================================================|
(BaseWorkerMixin pid=4197) |    0   N/A  N/A     47105      C                                    1281MiB |
(BaseWorkerMixin pid=4197) |    0   N/A  N/A     47106      C                                    1281MiB |
(BaseWorkerMixin pid=4197) |    0   N/A  N/A     47107      C                                    1281MiB |
(BaseWorkerMixin pid=4197) |    0   N/A  N/A     47109      C                                    1281MiB |
(BaseWorkerMixin pid=4197) +-----------------------------------------------------------------------------+
```


**After:**
```
(BaseWorkerMixin pid=5604) +-----------------------------------------------------------------------------+
(BaseWorkerMixin pid=5604) | Processes:                                                                  |
(BaseWorkerMixin pid=5604) |  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
(BaseWorkerMixin pid=5604) |        ID   ID                                                   Usage      |
(BaseWorkerMixin pid=5604) |=============================================================================|
(BaseWorkerMixin pid=5604) |    0   N/A  N/A     14123      C                                    1281MiB |
(BaseWorkerMixin pid=5604) |    1   N/A  N/A     14124      C                                    1281MiB |
(BaseWorkerMixin pid=5604) |    2   N/A  N/A     14125      C                                    1281MiB |
(BaseWorkerMixin pid=5604) |    3   N/A  N/A     14126      C                                    1281MiB |
(BaseWorkerMixin pid=5604) +-----------------------------------------------------------------------------+
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/26707

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
