### PR TITLE
[RLlib] Make sure we step() after adding init_obs.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1569,6 +1569,13 @@ py_test(
 )
 
 py_test(
+    name = "evaluation/tests/test_env_runner_v2",
+    tags = ["team:rllib", "evaluation"],
+    size = "small",
+    srcs = ["evaluation/tests/test_env_runner_v2.py"]
+)
+
+py_test(
     name = "evaluation/tests/test_episode_v2",
     tags = ["team:rllib", "evaluation"],
     size = "small",

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -777,6 +777,9 @@ class EnvRunnerV2:
                 item = _PolicyEvalData(d.env_id, d.agent_id, d.data.for_action)
                 to_eval[policy_id].append(item)
 
+            # Step after adding initial obs. This will give us 0 env and agent step.
+            new_episode.step()
+
     def end_episode(
         self, env_id: EnvID, episode_or_exception: Union[EpisodeV2, Exception]
     ):

--- a/rllib/evaluation/episode_v2.py
+++ b/rllib/evaluation/episode_v2.py
@@ -49,10 +49,10 @@ class EpisodeV2:
         # Summed reward across all agents in this episode.
         self.total_reward: float = 0.0
         # Active (uncollected) # of env steps taken by this episode.
-        # Start from -1, since after add_init_obs(), we will be at 0 step.
+        # Start from -1. After add_init_obs(), we will be at 0 step.
         self.active_env_steps: int = -1
         # Total # of env steps taken by this episode.
-        # Start from -1, since after add_init_obs(), we will be at 0 step.
+        # Start from -1, After add_init_obs(), we will be at 0 step.
         self.total_env_steps: int = -1
         # Active (uncollected) agent steps.
         self.active_agent_steps: int = 0

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -1,0 +1,82 @@
+from random import sample
+import unittest
+
+import ray
+from ray.rllib.algorithms.ppo import PPO, PPOConfig
+from ray.rllib.examples.env.debug_counter_env import DebugCounterEnv
+from ray.rllib.examples.env.multi_agent import BasicMultiAgent
+from ray.rllib.policy.sample_batch import SampleBatch
+from ray.tune import register_env
+
+
+register_env("basic_multiagent", lambda _: BasicMultiAgent(2))
+
+
+class TestEnvRunnerV2(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        ray.init(num_cpus=1, local_mode=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        ray.shutdown()
+
+    def test_sample_batch_rollout_single_agent_env(self):
+        config = (
+            PPOConfig()
+            .framework("torch")
+            .training(
+                # Specifically ask for a batch of 200 samples.
+                train_batch_size=200,
+            )
+            .rollouts(
+                num_envs_per_worker=1,
+                horizon=4,
+                num_rollout_workers=0,
+                # Enable EnvRunnerV2.
+                enable_connectors=True,
+            )
+        )
+
+        algo = PPO(config, env=DebugCounterEnv)
+
+        rollout_worker = algo.workers.local_worker()
+        sample_batch = rollout_worker.sample()
+
+        self.assertEqual(sample_batch.env_steps(), 200)
+        self.assertEqual(sample_batch.agent_steps(), 200)
+
+    def test_sample_batch_rollout_multi_agent_env(self):
+        config = (
+            PPOConfig()
+            .framework("torch")
+            .training(
+                # Specifically ask for a batch of 200 samples.
+                train_batch_size=200,
+            )
+            .rollouts(
+                num_envs_per_worker=1,
+                horizon=4,
+                num_rollout_workers=0,
+                # Enable EnvRunnerV2.
+                enable_connectors=True,
+            )
+        )
+
+        algo = PPO(config, env="basic_multiagent")
+
+        rollout_worker = algo.workers.local_worker()
+        sample_batch = rollout_worker.sample()
+
+        # 2 agents. So the multi-agent SampleBatch should have
+        # 200 env steps, and 400 agent steps.
+        self.assertEqual(sample_batch.env_steps(), 200)
+        self.assertEqual(sample_batch.agent_steps(), 400)
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -15,7 +15,7 @@ register_env("basic_multiagent", lambda _: BasicMultiAgent(2))
 class TestEnvRunnerV2(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        ray.init(num_cpus=1, local_mode=True)
+        ray.init()
 
     @classmethod
     def tearDownClass(cls):

--- a/rllib/evaluation/tests/test_env_runner_v2.py
+++ b/rllib/evaluation/tests/test_env_runner_v2.py
@@ -1,11 +1,9 @@
-from random import sample
 import unittest
 
 import ray
 from ray.rllib.algorithms.ppo import PPO, PPOConfig
 from ray.rllib.examples.env.debug_counter_env import DebugCounterEnv
 from ray.rllib.examples.env.multi_agent import BasicMultiAgent
-from ray.rllib.policy.sample_batch import SampleBatch
 from ray.tune import register_env
 
 


### PR DESCRIPTION
## Why are these changes needed?

Bug fix. Always step() after add_init_obs() so we start at 0 env step.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
