### PR TITLE
[tune] Clean up ray.tune scope (remove stale objects in __all__)

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -139,7 +139,7 @@ py_test(
 
 py_test(
     name = "test_legacy_import",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_legacy_import.py"],
     deps = [":tune_lib"],
     tags = ["team:ml", "exclusive", "tests_dir_L"],

--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -47,8 +47,6 @@ usage_lib.record_library_usage("tune")
 
 __all__ = [
     "Trainable",
-    "DurableTrainable",
-    "durable",
     "Callback",
     "TuneError",
     "grid_search",
@@ -59,9 +57,7 @@ __all__ = [
     "with_parameters",
     "Stopper",
     "Experiment",
-    "function",
     "sample_from",
-    "track",
     "uniform",
     "quniform",
     "choice",

--- a/python/ray/tune/tests/test_legacy_import.py
+++ b/python/ray/tune/tests/test_legacy_import.py
@@ -66,5 +66,29 @@ def test_import_logger_all(logging_setup):
     import ray.tune.logger  # noqa: F401
 
 
+@pytest.mark.parametrize(
+    "top_level",
+    [
+        "ray.tune",
+        "ray.tune.analysis",
+        "ray.tune.automl",
+        "ray.tune.cli",
+        "ray.tune.execution",
+        "ray.tune.experiment",
+        "ray.tune.impl",
+        "ray.tune.integration",
+        "ray.tune.logger",
+        "ray.tune.schedulers",
+        "ray.tune.search",
+        "ray.tune.stopper",
+        "ray.tune.trainable",
+        "ray.tune.utils",
+    ],
+)
+def test_import_wildcard(top_level):
+    py_cmd = f"from {top_level} import *\n"
+    subprocess.check_call([sys.executable, "-c", py_cmd])
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are a few stale objects in ray.tune's `__all__` list, making `from ray.tune import *` fail.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
