### PR TITLE
[tune] Introduce tune.with_resources() to specify function trainable resources

### DIFF
--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -39,7 +39,7 @@ from ray.tune.search.sample import (
 from ray.tune.search import create_searcher
 from ray.tune.schedulers import create_scheduler
 from ray.tune.execution.placement_groups import PlacementGroupFactory
-from ray.tune.trainable.util import with_parameters
+from ray.tune.trainable.util import with_parameters, with_resources
 
 from ray._private.usage import usage_lib
 
@@ -57,6 +57,7 @@ __all__ = [
     "run",
     "run_experiments",
     "with_parameters",
+    "with_resources",
     "Stopper",
     "Experiment",
     "function",

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -380,6 +380,38 @@ def with_resources(
         Dict[str, float], PlacementGroupFactory, Callable[[dict], PlacementGroupFactory]
     ],
 ):
+    """Wrapper for trainables to specify resource requests.
+
+    This wrapper allows specification of resource requirements for a specific
+    trainable. It will override potential existing resource requests (use
+    with caution!).
+
+    The main use case is to request resources for function trainables when used
+    with the Tuner() API.
+
+    Class trainables should usually just implement the ``default_resource_request()``
+    method.
+
+    Args:
+        trainable: Trainable to wrap.
+        resources: Resource dict, placement group factory, or callable that takes
+            in a config dict and returns a placement group factory.
+
+    Example:
+
+    .. code-block:: python
+
+        from ray import tune
+
+        def train(config):
+            return len(ray.get_gpu_ids())  # Returns 2
+
+        tune.run(
+            tune.with_resources(train, resources={"gpu": 2}),
+            # ...
+        )
+
+    """
     from ray.tune.trainable import Trainable
 
     if not callable(trainable) or (
@@ -403,6 +435,7 @@ def with_resources(
         )
 
     if not inspect.isclass(trainable):
+        # Just set an attribute. This will be resolved later in `wrap_function()`.
         trainable._resources = pgf
     else:
 

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -17,7 +17,7 @@ from ray.tune.registry import _ParameterRegistry
 from ray.tune.resources import Resources
 from ray.tune.utils import detect_checkpoint_function
 from ray.util import placement_group
-from ray.util.annotations import DeveloperAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 logger = logging.getLogger(__name__)
 
@@ -231,6 +231,7 @@ class PlacementGroupUtil:
         return options, pg
 
 
+@PublicAPI(stability="beta")
 def with_parameters(trainable, **kwargs):
     """Wrapper for trainables to pass arbitrary large data objects.
 
@@ -374,6 +375,7 @@ def with_parameters(trainable, **kwargs):
         return inner
 
 
+@PublicAPI(stability="beta")
 def with_resources(
     trainable,
     resources: Union[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We don't have a way to specify resource requirements with the Tuner() API. This PR introduces `tune.with_resources()` to attach a resource request to class and function trainables. In class trainables, it will override potential existing default resource requests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
