### PR TITLE
Revert "[log_monitor] Always reopen files (#26730)"

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -264,9 +264,7 @@ WORKER_PROCESS_TYPE_RESTORE_WORKER_DELETE = (
     f"ray::DELETE_{WORKER_PROCESS_TYPE_RESTORE_WORKER_NAME}"
 )
 
-# Effectively reopen every file, every time. To fall back to the old behavior
-# one should set this constant to 200.
-LOG_MONITOR_MAX_OPEN_FILES = int(os.environ.get("RAY_LOG_MONITOR_MAX_OPEN_FILES", "1"))
+LOG_MONITOR_MAX_OPEN_FILES = 200
 
 # Autoscaler events are denoted by the ":event_summary:" magic token.
 LOG_PREFIX_EVENT_SUMMARY = ":event_summary:"


### PR DESCRIPTION
This reverts commit 9e7ddddff780f7e9f17a304b74c31790666409f4.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Seems it breaks `linux://python/ray/tests:test_multi_node_3` and `linux://python/ray/dashboard:test_node`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
