### PR TITLE
[Serve] Fix flaky test_controller_recover_and_delete

### DIFF
--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -585,7 +585,7 @@ def test_controller_recover_and_delete(shutdown_ray):
 
     actors = ray.util.list_named_actors(all_namespaces=True)
 
-    # Try to delete the deployments and kill the controlle rright after
+    # Try to delete the deployments and kill the controller right after
     client.delete_deployments(["f"], blocking=False)
     ray.kill(client._controller, no_restart=False)
 

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -36,16 +36,10 @@ def shutdown_ray():
 def start_and_shutdown_ray_cli():
     subprocess.check_output(
         ["ray", "start", "--head"],
-        stdout=subprocess.STDOUT,
-        stderr=subprocess.STDOUT,
-        shell=True,
     )
     yield
     subprocess.check_output(
         ["ray", "stop", "--force"],
-        stdout=subprocess.STDOUT,
-        stderr=subprocess.STDOUT,
-        shell=True,
     )
 
 

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -34,9 +34,19 @@ def shutdown_ray():
 
 @contextmanager
 def start_and_shutdown_ray_cli():
-    subprocess.check_output(["ray", "start", "--head"])
+    subprocess.check_output(
+        ["ray", "start", "--head"],
+        stdout=subprocess.STDOUT,
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
     yield
-    subprocess.check_output(["ray", "stop", "--force"])
+    subprocess.check_output(
+        ["ray", "stop", "--force"],
+        stdout=subprocess.STDOUT,
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
 
 
 @pytest.fixture(scope="function")
@@ -558,7 +568,7 @@ class TestDeployApp:
         assert client.get_serve_status().app_status.deployment_timestamp == 0
 
 
-def test_controller_recover_and_delete():
+def test_controller_recover_and_delete(shutdown_ray):
     """Ensure that in-progress deletion can finish even after controller dies."""
 
     ray.init()
@@ -574,17 +584,16 @@ def test_controller_recover_and_delete():
     f.deploy()
 
     actors = ray.util.list_named_actors(all_namespaces=True)
-    client.delete_deployments(["f"], blocking=False)
 
+    # Try to delete the deployments and kill the controlle rright after
+    client.delete_deployments(["f"], blocking=False)
+    ray.kill(client._controller, no_restart=False)
+
+    # All replicas should be removed already or after the controller revives
     wait_for_condition(
         lambda: len(ray.util.list_named_actors(all_namespaces=True)) < len(actors)
     )
-    ray.kill(client._controller, no_restart=False)
 
-    # There should still be replicas remaining
-    assert len(ray.util.list_named_actors(all_namespaces=True)) > 2
-
-    # All replicas should be removed once the controller revives
     wait_for_condition(
         lambda: len(ray.util.list_named_actors(all_namespaces=True)) == len(actors) - 50
     )


### PR DESCRIPTION
Signed-off-by: simon-mo <simon.mo@hey.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The commit 887f6726d552be38ab79811dd070af1247189ec8 removed the placement group deletion, which made deployment deletion too fast that made our tests flaky.

In particular, we
- removed the check that assumed slow deletion. deflake `test_controller_recover_and_delete`
- added proper cleanup.  deflake `test_shutdown_remote`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #26822

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
