### PR TITLE
[AIR] Improve `StandardScaler` docstring and remove `ddof` parameter

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,7 +52,7 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,7 +52,7 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -26,10 +26,6 @@ class StandardScaler(Preprocessor):
         Many models assume that data is distributed like a standard normal distribution.
         To make your data look like a standard normal distribution, use :py:class:`StandardScaler`.
 
-    .. seealso::
-        `The Wikapedia article on feature scaling <https://en.wikipedia.org/wiki/Feature_scaling#Motivation>`_
-            An article that provides more information about the motivation behind standard scaling.
-
     Args:
         columns: The columns to separately scale.
 

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -9,7 +9,7 @@ from ray.data.preprocessor import Preprocessor
 
 
 class StandardScaler(Preprocessor):
-    r"""Scale and translate each column by its mean and standard deviation, respectively.
+    r"""Translate and scale each column by its mean and standard deviation, respectively.
 
     The general formula is given by
 
@@ -22,9 +22,9 @@ class StandardScaler(Preprocessor):
     standard deviation. If :math:`s = 0` (i.e., the column is constant-valued),
     then the transformed column will contain zeros.
 
-    .. note::
-        Many models assume that data is distributed like a standard normal distribution.
-        To make your data look like a standard normal distribution, use :py:class:`StandardScaler`.
+    .. warning::
+        :class:`StandardScaler` works best when your data is normal. If your data isn't
+        approximately normal, the transformed features won't be meaningful.
 
     Args:
         columns: The columns to separately scale.

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -9,23 +9,68 @@ from ray.data.preprocessor import Preprocessor
 
 
 class StandardScaler(Preprocessor):
-    """Scale values within columns based on mean and standard deviation.
+    r"""Scale and translate each column by its mean and standard deviation, respectively.
 
-    For each column, each value will be transformed to ``(value-mean)/std``,
-    where ``mean`` and ``std`` are calculated from the fitted dataset.
+    The general formula is given by
+
+    .. math::
+
+        x' = \frac{x - \bar{x}}{s}
+
+    where :math:`x` is the column, :math:`x'` is the transformed column,
+    :math:`\bar{x}` is the column average, and :math:`s` is the column's sample
+    standard deviation. If :math:`s = 0` (i.e., the column is constant-valued),
+    then the transformed column will contain zeros.
+
+    .. note::
+        Many models assume that data is distributed like a standard normal distribution.
+        To make your data look like a standard normal distribution, use :py:class:`StandardScaler`.
+
+    .. seealso::
+        `The Wikapedia article on feature scaling <https://en.wikipedia.org/wiki/Feature_scaling#Motivation>`_
+            An article that provides more information about the motivation behind standard scaling.
 
     Args:
-        columns: The columns that will individually be scaled.
-        ddof: The delta degrees of freedom used to calculate standard deviation.
+        columns: The columns to separately scale.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import ray
+        >>> from ray.data.preprocessors import StandardScaler
+        >>>
+        >>> df = pd.DataFrame({"X1": [-2, 0, 2], "X2": [-3, -3, 3], "X3": [1, 1, 1]})  # doctest: +SKIP # noqa: E501
+        >>> ds = ray.data.from_pandas(df)  # doctest: +SKIP
+        >>> ds.to_pandas()  # doctest: +SKIP
+           X1  X2  X3
+        0  -2  -3   1
+        1   0  -3   1
+        2   2   3   1
+
+        Columns are scaled separately.
+
+        >>> preprocessor = StandardScaler(columns=["X1", "X2"])  # doctest: +SKIP
+        >>> preprocessor.fit_transform(ds).to_pandas()  # doctest: +SKIP
+                 X1        X2  X3
+        0 -1.224745 -0.707107   1
+        1  0.000000 -0.707107   1
+        2  1.224745  1.414214   1
+
+        Constant-valued columns get filled with zeros.
+
+        >>> preprocessor = StandardScaler(columns=["X3"])  # doctest: +SKIP
+        >>> preprocessor.fit_transform(ds).to_pandas()  # doctest: +SKIP
+           X1  X2   X3
+        0  -2  -3  0.0
+        1   0  -3  0.0
+        2   2   3  0.0
     """
 
-    def __init__(self, columns: List[str], ddof=0):
+    def __init__(self, columns: List[str]):
         self.columns = columns
-        self.ddof = ddof
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         mean_aggregates = [Mean(col) for col in self.columns]
-        std_aggregates = [Std(col, ddof=self.ddof) for col in self.columns]
+        std_aggregates = [Std(col, ddof=0) for col in self.columns]
         self.stats_ = dataset.aggregate(*mean_aggregates, *std_aggregates)
         return self
 
@@ -48,9 +93,7 @@ class StandardScaler(Preprocessor):
 
     def __repr__(self):
         stats = getattr(self, "stats_", None)
-        return (
-            f"StandardScaler(columns={self.columns}, ddof={self.ddof}, stats={stats})"
-        )
+        return f"StandardScaler(columns={self.columns}, stats={stats})"
 
 
 class MinMaxScaler(Preprocessor):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The docstring changes are needed to make `StandardScaler` easier to understand.

I've removed `ddof` because:
* It provides consistency with Sklearn's implementation. Sklearn doesn't expose a `ddof` parameter.
* It reduces the number of choices required from the user. `ddof` is not important. From the Sklearn documentation: "Note that the choice of `ddof` is unlikely to affect model performance"
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
