### PR TITLE
Mark local mode as deprecated with warning message about possible memory leak

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1303,6 +1303,12 @@ def init(
 
     if local_mode:
         driver_mode = LOCAL_MODE
+        warnings.warn(
+            "DeprecationWarning: local mode is an experimental feature that is no "
+            "longer maintained and will be removed in the future.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     else:
         driver_mode = SCRIPT_MODE
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1306,7 +1306,7 @@ def init(
         warnings.warn(
             "DeprecationWarning: local mode is an experimental feature that is no "
             "longer maintained and will be removed in the future."
-            "To debug, consider using Ray debugger ",
+            "For debugging consider using Ray debugger. ",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1303,6 +1303,13 @@ def init(
 
     if local_mode:
         driver_mode = LOCAL_MODE
+        warnings.warn(
+            "DeprecationWarning: local mode is an experimental feature that is no "
+            "longer maintained and will be removed in the future. "
+            "For debugging consider using Ray debugger instead. ",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     else:
         driver_mode = SCRIPT_MODE
 


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Mark local mode as deprecated with a warning message. 

## Related issue number

https://github.com/ray-project/ray/issues/24216
https://github.com/ray-project/ray/issues/26095

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.


