### PR TITLE
[RLlib]: Fix torch None conversion

### DIFF
--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -146,6 +146,9 @@ def convert_to_torch_tensor(x: TensorStructType, device: Optional[str] = None):
     """
 
     def mapping(item):
+        if item is None:
+            # returns None with dtype=np.obj
+            return np.asarray(item)
         # Already torch tensor -> make sure it's on right device.
         if torch.is_tensor(item):
             return item if device is None else item.to(device)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

PyTorch does not support `dtype=object` anymore, which is what `np.asarray(None)` returns. This breaks `save_checkpoint` and `load_checkpoint` for algorithms with `pytorch >= 1.12.0`.

Repro script:
```
from ray.rllib.algorithms.dqn import DQNConfig
import os
import shutil

checkpoint_dir = "/tmp/cartpole/torch/"
shutil.rmtree(checkpoint_dir, ignore_errors=True)
os.makedirs(checkpoint_dir, exist_ok=True)
config = (
    DQNConfig()
    .environment(env="CartPole-v0")
    .framework("torch")
    .rollouts(num_rollout_workers=4)
)
algo = config.build()
random = algo.save_checkpoint(checkpoint_dir)
algo.load_checkpoint(random)
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
