### PR TITLE
[Rllib] Fix broken cluster env launcher gym pinning

### DIFF
--- a/release/long_running_tests/app_config_np.yaml
+++ b/release/long_running_tests/app_config_np.yaml
@@ -7,7 +7,7 @@ debian_packages:
 
 python:
   pip_packages:
-    - gym[atari]>=0.21.0,<0.24.0
+    - "gym[atari]>=0.21.0,<0.24.0"
     - pygame
     - pytest
     - tensorflow
@@ -18,7 +18,7 @@ post_build_cmds:
     - 'rm -r wrk || true && git clone https://github.com/wg/wrk.git /tmp/wrk && cd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin'
     - pip3 install numpy==1.19 || true
     - pip3 install pytest || true
-    - pip3 install -U ray[all] gym[atari]>=0.21.0,<0.24.0 autorom[accept-rom-license]
+    - pip3 install -U ray[all] "gym[atari]>=0.21.0,<0.24.0" autorom[accept-rom-license]
     - pip3 install ray[all]
     # TODO (Alex): Ideally we would install all the dependencies from the new
     # version too, but pip won't be able to find the new version of ray-cpp.


### PR DESCRIPTION
Signed-off-by: Avnish <avnishnarayan@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

The long running impala test's cluster env build breaks because the gym package as listed is missing quotes. This pr fixes that.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
