### PR TITLE
[Datasets] Use sampling to estimate in-memory data size for Parquet data source

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -65,8 +65,8 @@ DEFAULT_SCHEDULING_STRATEGY = "DEFAULT"
 # Whether to use Polars for tabular dataset sorts, groupbys, and aggregations.
 DEFAULT_USE_POLARS = False
 
-# Whether to do sampling to estimate in-memory data size for data source.
-DEFAULT_SAMPLING_DATA_SOURCE_ENABLED = True
+# Whether to estimate in-memory decoding data size for data source.
+DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED = True
 
 # Use this to prefix important warning messages for the user.
 WARN_PREFIX = "⚠️ "
@@ -100,7 +100,7 @@ class DatasetContext:
         pipeline_push_based_shuffle_reduce_tasks: bool,
         scheduling_strategy: SchedulingStrategyT,
         use_polars: bool,
-        sampling_data_source: bool,
+        decoding_size_estimation: bool,
         min_parallelism: bool,
     ):
         """Private constructor (use get_current() instead)."""
@@ -121,7 +121,7 @@ class DatasetContext:
         )
         self.scheduling_strategy = scheduling_strategy
         self.use_polars = use_polars
-        self.sampling_data_source = sampling_data_source
+        self.decoding_size_estimation = decoding_size_estimation
         self.min_parallelism = min_parallelism
 
     @staticmethod
@@ -155,7 +155,7 @@ class DatasetContext:
                     pipeline_push_based_shuffle_reduce_tasks=True,
                     scheduling_strategy=DEFAULT_SCHEDULING_STRATEGY,
                     use_polars=DEFAULT_USE_POLARS,
-                    sampling_data_source=DEFAULT_SAMPLING_DATA_SOURCE_ENABLED,
+                    decoding_size_estimation=DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED,
                     min_parallelism=DEFAULT_MIN_PARALLELISM,
                 )
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -65,6 +65,9 @@ DEFAULT_SCHEDULING_STRATEGY = "DEFAULT"
 # Whether to use Polars for tabular dataset sorts, groupbys, and aggregations.
 DEFAULT_USE_POLARS = False
 
+# Whether to do sampling to estimate in-memory data size for data source.
+DEFAULT_SAMPLING_DATA_SOURCE_ENABLED = True
+
 # Use this to prefix important warning messages for the user.
 WARN_PREFIX = "⚠️ "
 
@@ -97,6 +100,7 @@ class DatasetContext:
         pipeline_push_based_shuffle_reduce_tasks: bool,
         scheduling_strategy: SchedulingStrategyT,
         use_polars: bool,
+        sampling_data_source: bool,
         min_parallelism: bool,
     ):
         """Private constructor (use get_current() instead)."""
@@ -117,6 +121,7 @@ class DatasetContext:
         )
         self.scheduling_strategy = scheduling_strategy
         self.use_polars = use_polars
+        self.sampling_data_source = sampling_data_source
         self.min_parallelism = min_parallelism
 
     @staticmethod
@@ -150,6 +155,7 @@ class DatasetContext:
                     pipeline_push_based_shuffle_reduce_tasks=True,
                     scheduling_strategy=DEFAULT_SCHEDULING_STRATEGY,
                     use_polars=DEFAULT_USE_POLARS,
+                    sampling_data_source=DEFAULT_SAMPLING_DATA_SOURCE_ENABLED,
                     min_parallelism=DEFAULT_MIN_PARALLELISM,
                 )
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -40,9 +40,9 @@ PARQUET_READER_ROW_BATCH_SIZE = 100000
 FILE_READING_RETRY = 8
 
 # The default size multiplier for reading Parquet data source in Arrow.
-# Parquet in-memory data format is encoded with various encoding techniques (such as
+# Parquet data format is encoded with various encoding techniques (such as
 # dictionary, RLE, delta), so Arrow in-memory representation uses much more memory
-# compared to Parquet in-memory representation. Parquet file statistics only record
+# compared to Parquet encoded representation. Parquet file statistics only record
 # encoded (i.e. uncompressed) data size information.
 #
 # To estimate real-time in-memory data size, Datasets will try to estimate the correct
@@ -258,7 +258,7 @@ class _ParquetDatasourceReader(Reader):
                 prefetched_metadata=metadata,
             )
             if meta.size_bytes is not None:
-                meta.size_bytes *= self._encoding_ratio
+                meta.size_bytes = int(meta.size_bytes * self._encoding_ratio)
             block_udf, reader_args, columns, schema = (
                 self._block_udf,
                 self._reader_args,
@@ -434,7 +434,7 @@ def _sample_piece(
     row_group = piece.subset(row_group_ids=[row_group_id])
     metadata = row_group.metadata.row_group(0)
     num_rows = min(PARQUET_ENCODING_RATIO_ESTIMATE_NUM_ROWS, metadata.num_rows)
-    assert num_rows >= 0 and metadata.num_rows >= 0, (
+    assert num_rows > 0 and metadata.num_rows > 0, (
         f"Sampled number of rows: {num_rows} and total number of rows: "
         f"{metadata.num_rows} should be positive"
     )

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -37,11 +37,16 @@ PARALLELIZE_META_FETCH_THRESHOLD = 24
 PARQUET_READER_ROW_BATCH_SIZE = 100000
 FILE_READING_RETRY = 8
 
-# The estimated bytes size multiplier for reading Parquet data source in Arrow,
+# The minimum size multiplier for reading Parquet data source in Arrow,
 # as Arrow in-memory representation uses much more memory compared to Parquet
 # uncompressed representation. See https://github.com/ray-project/ray/pull/26516
-# for more context.
-PARQUET_TO_ARROW_SIZE_MULTIPLIER = 5
+# for more context. Datasets will try to estimate the correct multiplier, using this
+# constant as a lower bound for safety.
+PARQUET_COMPRESSION_RATIO_ESTIMATE_LOWER_BOUND = 5
+
+# The number of row samples to take from the dataset to try to get an estimate of the
+# parquet compression ratio.
+PARQUET_COMPRESSION_RATIO_ESTIMATE_NUM_SAMPLES = 4
 
 
 # TODO(ekl) this is a workaround for a pyarrow serialization bug, where serializing a
@@ -202,16 +207,15 @@ class _ParquetDatasourceReader(Reader):
         self._reader_args = reader_args
         self._columns = columns
         self._schema = schema
+        self._decompression_multiplier = self._estimate_decompression_multiplier()
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
-        # TODO(ekl/chengsu) better estimate the in-memory size here,
-        # when columns pruning is used.
         total_size = 0
         for file_metadata in self._metadata:
             for row_group_idx in range(file_metadata.num_row_groups):
                 row_group_metadata = file_metadata.row_group(row_group_idx)
                 total_size += row_group_metadata.total_byte_size
-        return total_size * PARQUET_TO_ARROW_SIZE_MULTIPLIER
+        return total_size * self._decompression_multiplier
 
     def get_read_tasks(self, parallelism: int) -> List[ReadTask]:
         # NOTE: We override the base class FileBasedDatasource.get_read_tasks()
@@ -233,6 +237,7 @@ class _ParquetDatasourceReader(Reader):
                 pieces=pieces,
                 prefetched_metadata=metadata,
             )
+            meta.size_bytes *= self._decompression_multiplier
             block_udf, reader_args, columns, schema = (
                 self._block_udf,
                 self._reader_args,
@@ -253,6 +258,31 @@ class _ParquetDatasourceReader(Reader):
             )
 
         return read_tasks
+
+    def _estimate_decompression_multiplier(self) -> float:
+        """Return an estimate of the decompression multipler.
+
+        To avoid OOMs, it is safer to return an over-estimate than an underestimate.
+        """
+        # Sample a few rows from the row group to estimate the ratio.
+        # TODO(ekl/cheng) take into account column pruning.
+        num_samples = min(
+            PARQUET_COMPRESSION_RATIO_ESTIMATE_NUM_SAMPLES, len(self._pq_ds.pieces))
+        row_group_samples = [
+            p.subset(row_group_ids=[0])
+            for p in self._pq_ds.pieces[:num_samples]
+        ]
+        sample_ratios = []
+        for rg in row_group_samples:
+            metadata = rg.metadata.row_group(0)
+            sample_rg_row_size = metadata.total_byte_size / metadata.num_rows
+            sample_row_size = rg.head(1).nbytes
+            sample_ratios.append(sample_row_size / sample_rg_row_size)
+        mean_ratio = np.mean(sample_ratios)
+        logger.info(
+            f"Estimated parquet decompression ratio {mean_ratio} "
+            f"(mean of samples {sample_ratios}).")
+        return max(PARQUET_COMPRESSION_RATIO_ESTIMATE_LOWER_BOUND, mean_ratio)
 
 
 def _read_pieces(

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -313,7 +313,7 @@ class _ParquetDatasourceReader(Reader):
         else:
             ratio = _sample_piece(file_samples[0], 0)
 
-        logger.info(f"Estimated Parquet encoding ratio from sampling is {ratio}.")
+        logger.debug(f"Estimated Parquet encoding ratio from sampling is {ratio}.")
         return max(ratio, PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND)
 
 
@@ -436,5 +436,5 @@ def _sample_piece(
     # num_rows into memory, o.w. it will read more rows by default in batch manner.
     in_memory_size = row_group.head(num_rows, batch_size=num_rows).nbytes / num_rows
     ratio = in_memory_size / parquet_size
-    logger.info(f"Estimated Parquet encoding ratio is {ratio} for piece {piece}.")
+    logger.debug(f"Estimated Parquet encoding ratio is {ratio} for piece {piece}.")
     return in_memory_size / parquet_size

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -934,6 +934,17 @@ def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs, data_pat
 def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
     tensor_output_path = os.path.join(tmp_path, "tensor")
     ray.data.range_tensor(1000, shape=(1000,)).write_parquet(tensor_output_path)
+    ds = ray.data.read_parquet(tensor_output_path)
+    assert ds.num_blocks() > 1
+    data_size = ds.size_bytes()
+    assert (
+        data_size >= 7_000_000 and data_size <= 10_000_000
+    ), "estimated data size is out of expected bound"
+    data_size = ds.fully_executed().size_bytes()
+    assert (
+        data_size >= 7_000_000 and data_size <= 10_000_000
+    ), "actual data size is out of expected bound"
+
     reader = _ParquetDatasourceReader(tensor_output_path)
     assert (
         reader._encoding_ratio >= 400 and reader._encoding_ratio <= 600
@@ -945,6 +956,17 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
 
     text_output_path = os.path.join(tmp_path, "text")
     ray.data.range(1000).map(lambda _: "a" * 1000).write_parquet(text_output_path)
+    ds = ray.data.read_parquet(text_output_path)
+    assert ds.num_blocks() > 1
+    data_size = ds.size_bytes()
+    assert (
+        data_size >= 1_000_000 and data_size <= 2_000_000
+    ), "estimated data size is out of expected bound"
+    data_size = ds.fully_executed().size_bytes()
+    assert (
+        data_size >= 1_000_000 and data_size <= 2_000_000
+    ), "actual data size is out of expected bound"
+
     reader = _ParquetDatasourceReader(text_output_path)
     assert (
         reader._encoding_ratio >= 150 and reader._encoding_ratio <= 300

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -952,7 +952,11 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
     data_size = reader.estimate_inmemory_data_size()
     assert (
         data_size >= 7_000_000 and data_size <= 10_000_000
-    ), "estimated data size is out of expected bound"
+    ), "estimated data size is either out of expected bound"
+    assert (
+        data_size
+        == _ParquetDatasourceReader(tensor_output_path).estimate_inmemory_data_size()
+    ), "estimated data size is not deterministic in multiple calls."
 
     text_output_path = os.path.join(tmp_path, "text")
     ray.data.range(1000).map(lambda _: "a" * 1000).write_parquet(text_output_path)
@@ -975,6 +979,10 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
     assert (
         data_size >= 1_000_000 and data_size <= 2_000_000
     ), "estimated data size is out of expected bound"
+    assert (
+        data_size
+        == _ParquetDatasourceReader(text_output_path).estimate_inmemory_data_size()
+    ), "estimated data size is not deterministic in multiple calls."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is continuation work from https://github.com/ray-project/ray/pull/26623. The motivation is Parquet in-memory data size estimation can be off, due to the inflation when Arrow reads Parquet encoded data into memory. Parquet only records encoded data size in file footer, which in some cases (when encoding doing very well) the encoded data size is much smaller than our dataset in-memory data size when Arrow reads it.

This PR is to propose to use sampling to do a better job for in-memory data size (i.e. it will influence number of read tasks / parallelism). The core idea is to sample a small number of rows evenly from input Parquet files, read these rows into memory and calculate in-memory size, then estimate for in-memory size of all input rows.

To not impact latency performance of dataset, launch tasks in parallel to do sampling. Also introduce a config in `DatasetContext` to allow people turn this feature off in case there's regression (by default this feature is enabled).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
