### PR TITLE
[Java]More efficient getAllNodeInfo()

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
+++ b/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
@@ -98,32 +98,13 @@ public class GcsClient {
               data.getRayletSocketName(),
               data.getState() == GcsNodeInfo.GcsNodeState.ALIVE,
               new HashMap<>());
+      if (nodeInfo.isAlive) {
+        nodeInfo.resources.putAll(data.getResourcesTotalMap());
+      }
       nodes.put(nodeId, nodeInfo);
     }
 
-    // Fill resources.
-    for (Map.Entry<UniqueId, NodeInfo> node : nodes.entrySet()) {
-      if (node.getValue().isAlive) {
-        node.getValue().resources.putAll(getResourcesForClient(node.getKey()));
-      }
-    }
-
     return new ArrayList<>(nodes.values());
-  }
-
-  private Map<String, Double> getResourcesForClient(UniqueId clientId) {
-    byte[] resourceMapBytes = globalStateAccessor.getNodeResourceInfo(clientId);
-    Gcs.ResourceMap resourceMap;
-    try {
-      resourceMap = Gcs.ResourceMap.parseFrom(resourceMapBytes);
-    } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeException("Received invalid protobuf data from GCS.");
-    }
-    HashMap<String, Double> resources = new HashMap<>();
-    for (Map.Entry<String, Gcs.ResourceTableData> entry : resourceMap.getItemsMap().entrySet()) {
-      resources.put(entry.getKey(), entry.getValue().getResourceCapacity());
-    }
-    return resources;
   }
 
   /** If the actor exists in GCS. */

--- a/java/runtime/src/main/java/io/ray/runtime/gcs/GlobalStateAccessor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/gcs/GlobalStateAccessor.java
@@ -3,7 +3,6 @@ package io.ray.runtime.gcs;
 import com.google.common.base.Preconditions;
 import io.ray.api.id.ActorId;
 import io.ray.api.id.PlacementGroupId;
-import io.ray.api.id.UniqueId;
 import java.util.List;
 
 /** `GlobalStateAccessor` is used for accessing information from GCS. */
@@ -69,19 +68,6 @@ public class GlobalStateAccessor {
     synchronized (GlobalStateAccessor.class) {
       validateGlobalStateAccessorPointer();
       return this.nativeGetAllNodeInfo(globalStateAccessorNativePointer);
-    }
-  }
-
-  /**
-   * Get node resource info.
-   *
-   * @param nodeId node unique id.
-   * @return A map of node resource info in protobuf schema.
-   */
-  public byte[] getNodeResourceInfo(UniqueId nodeId) {
-    synchronized (GlobalStateAccessor.class) {
-      validateGlobalStateAccessorPointer();
-      return nativeGetNodeResourceInfo(globalStateAccessorNativePointer, nodeId.getBytes());
     }
   }
 
@@ -162,8 +148,6 @@ public class GlobalStateAccessor {
   private native byte[] nativeGetNextJobID(long nativePtr);
 
   private native List<byte[]> nativeGetAllNodeInfo(long nativePtr);
-
-  private native byte[] nativeGetNodeResourceInfo(long nativePtr, byte[] nodeId);
 
   private native List<byte[]> nativeGetAllActorInfo(long nativePtr);
 

--- a/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
@@ -80,15 +80,6 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllNodeInfo(JNIEnv *env,
       });
 }
 
-JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetNodeResourceInfo(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr, jbyteArray node_id_bytes) {
-  auto *gcs_accessor = reinterpret_cast<gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
-  auto node_id = JavaByteArrayToId<NodeID>(env, node_id_bytes);
-  auto node_resource_info = gcs_accessor->GetNodeResourceInfo(node_id);
-  return static_cast<jbyteArray>(NativeStringToJavaByteArray(env, node_resource_info));
-}
-
 JNIEXPORT jobject JNICALL
 Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllActorInfo(
     JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {

--- a/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.h
@@ -78,17 +78,6 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllNodeInfo(JNIEnv *,
 
 /*
  * Class:     io_ray_runtime_gcs_GlobalStateAccessor
- * Method:    nativeGetNodeResourceInfo
- * Signature: (J[B)[B
- */
-JNIEXPORT jbyteArray JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetNodeResourceInfo(JNIEnv *,
-                                                                      jobject,
-                                                                      jlong,
-                                                                      jbyteArray);
-
-/*
- * Class:     io_ray_runtime_gcs_GlobalStateAccessor
  * Method:    nativeGetAllActorInfo
  * Signature: (J)Ljava/util/List;
  */


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Like https://github.com/ray-project/ray/pull/26760, we remove the unnecessary rpc calls for each node to get their resources, instead we use the existing fields.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
