### PR TITLE
Update fault-tolerance.rst

### DIFF
--- a/doc/source/ray-core/actors/fault-tolerance.rst
+++ b/doc/source/ray-core/actors/fault-tolerance.rst
@@ -99,13 +99,13 @@ You can experiment with this behavior by running the following code.
         print(counter)  # Prints the sequence 1-10 5 times.
 
     # After the actor has been restarted 5 times, all subsequent methods will
-    # raise a `RayActorError`.
-    for _ in range(10):
+    # raise a `RayActorError` if the actor dies again.
+    for _ in range(11):
         try:
             counter = ray.get(actor.increment_and_possibly_fail.remote())
             print(counter)  # Unreachable.
         except ray.exceptions.RayActorError:
-            print('FAILURE')  # Prints 10 times.
+            print('FAILURE')  # Prints 1 time.
 
 For at-least-once actors, the system will still guarantee execution ordering
 according to the initial submission order. For example, any tasks submitted


### PR DESCRIPTION
Fix the example code of max_task_retries. 
Existing code has set max actor restarts as 5, which means after 5 restarts, 
actor is alive. Then in testing the max_task_retries, actor keeps alive until self.counter=10.

Signed-off-by: jialin <valiantljk@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
