### PR TITLE
[tune] Docs for custom command based syncer (awscli / gsutil)

### DIFF
--- a/doc/source/tune/doc_code/faq.py
+++ b/doc/source/tune/doc_code/faq.py
@@ -231,7 +231,69 @@ if not MOCK:
             upload_dir="s3://my-log-dir", syncer=CustomSyncer()
         ),
     )
-# __log_2_end__
+    # __log_2_end__
+
+    # __custom_command_syncer_start__
+    import subprocess
+    from ray.tune.syncer import Syncer
+
+    class CustomCommandSyncer(Syncer):
+        def __init__(
+            self,
+            sync_up_template: str,
+            sync_down_template: str,
+            delete_template: str,
+            sync_period: float = 300.0,
+        ):
+            self.sync_up_template = sync_up_template
+            self.sync_down_template = sync_down_template
+            self.delete_template = delete_template
+
+            super().__init__(sync_period=sync_period)
+
+        def sync_up(
+            self, local_dir: str, remote_dir: str, exclude: list = None
+        ) -> bool:
+            cmd_str = self.sync_up_template.format(
+                source=local_dir,
+                target=remote_dir,
+            )
+            subprocess.check_call(cmd_str, shell=True)
+            return True
+
+        def sync_down(
+            self, remote_dir: str, local_dir: str, exclude: list = None
+        ) -> bool:
+            cmd_str = self.sync_down_template.format(
+                source=remote_dir,
+                local_dir=local_dir,
+            )
+            subprocess.check_call(cmd_str, shell=True)
+            return True
+
+        def delete(self, remote_dir: str) -> bool:
+            cmd_str = self.delete_template.format(
+                target=remote_dir,
+            )
+            subprocess.check_call(cmd_str, shell=True)
+            return True
+
+        def retry(self):
+            raise NotImplementedError
+
+        def wait(self):
+            pass
+
+    sync_config = tune.SyncConfig(
+        syncer=CustomCommandSyncer(
+            sync_up_template="aws s3 sync {source} {target}",
+            sync_down_template="aws s3 sync {source} {target}",
+            delete_template="aws s3 rm {target} --recursive",
+        ),
+        upload_dir="s3://bucket/path",
+    )
+    # __custom_command_syncer_end__
+
 
 if not MOCK:
     # __s3_start__

--- a/doc/source/tune/faq.rst
+++ b/doc/source/tune/faq.rst
@@ -603,6 +603,50 @@ Failing to do so would cause error messages like ``Error message (1): fatal erro
 For AWS set up, this involves adding an IamInstanceProfile configuration for worker nodes.
 Please :ref:`see here for more tips <aws-cluster-s3>`.
 
+How can I use the awscli or gsutil command line commands for syncing?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Some users reported to run into problems with the default pyarrow-based syncing.
+In this case, a custom syncer that invokes the respective command line tools
+for transferring files between nodes and cloud storage can be implemented.
+
+Here is an example for a syncer that uses string templates that will be run
+as a command:
+
+.. literalinclude:: doc_code/faq.py
+    :dedent:
+    :language: python
+    :start-after: __custom_command_syncer_start__
+    :end-before: __custom_command_syncer_end__
+
+For different cloud services, these are example templates you can use with this syncer:
+
+AWS S3
+''''''
+
+.. code-block::
+
+    sync_up_template="aws s3 sync {source} {target} --exact-timestamps --only-show-errors"
+    sync_down_template="down": "aws s3 sync {source} {target} --exact-timestamps --only-show-errors"
+    delete_template="delete": "aws s3 rm {target} --recursive --only-show-errors"
+
+Google cloud storage
+''''''''''''''''''''
+
+.. code-block::
+
+    sync_up_template="gsutil rsync -r {source} {target}"
+    sync_down_template="down": "gsutil rsync -r {source} {target}"
+    delete_template="delete": "gsutil rm -r {target}"
+
+HDFS
+''''
+
+.. code-block::
+
+    sync_up_template="hdfs dfs -put -f {source} {target}"
+    sync_down_template="down": "hdfs dfs -get -f {source} {target}"
+    delete_template="delete": "hdfs dfs -rm -r {target}"
+
 
 .. _tune-docker:
 

--- a/doc/source/tune/faq.rst
+++ b/doc/source/tune/faq.rst
@@ -626,8 +626,8 @@ AWS S3
 .. code-block::
 
     sync_up_template="aws s3 sync {source} {target} --exact-timestamps --only-show-errors"
-    sync_down_template="down": "aws s3 sync {source} {target} --exact-timestamps --only-show-errors"
-    delete_template="delete": "aws s3 rm {target} --recursive --only-show-errors"
+    sync_down_template="aws s3 sync {source} {target} --exact-timestamps --only-show-errors"
+    delete_template="aws s3 rm {target} --recursive --only-show-errors"
 
 Google cloud storage
 ''''''''''''''''''''

--- a/python/ray/tune/tests/test_syncer.py
+++ b/python/ray/tune/tests/test_syncer.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import subprocess
 import tempfile
 from typing import List, Optional
 
@@ -89,6 +90,54 @@ class CustomSyncer(Syncer):
 
     def delete(self, remote_dir: str) -> bool:
         self._sync_status.pop(remote_dir, None)
+        return True
+
+    def retry(self):
+        raise NotImplementedError
+
+    def wait(self):
+        pass
+
+
+class CustomCommandSyncer(Syncer):
+    def __init__(
+        self,
+        sync_up_template: str,
+        sync_down_template: str,
+        delete_template: str,
+        sync_period: float = 300.0,
+    ):
+        self.sync_up_template = sync_up_template
+        self.sync_down_template = sync_down_template
+        self.delete_template = delete_template
+
+        super().__init__(sync_period=sync_period)
+
+    def sync_up(
+        self, local_dir: str, remote_dir: str, exclude: Optional[List] = None
+    ) -> bool:
+        cmd_str = self.sync_up_template.format(
+            source=local_dir,
+            target=remote_dir,
+        )
+        subprocess.check_call(cmd_str, shell=True)
+        return True
+
+    def sync_down(
+        self, remote_dir: str, local_dir: str, exclude: Optional[List] = None
+    ) -> bool:
+        cmd_str = self.sync_down_template.format(
+            source=remote_dir,
+            local_dir=local_dir,
+        )
+        subprocess.check_call(cmd_str, shell=True)
+        return True
+
+    def delete(self, remote_dir: str) -> bool:
+        cmd_str = self.delete_template.format(
+            target=remote_dir,
+        )
+        subprocess.check_call(cmd_str, shell=True)
         return True
 
     def retry(self):
@@ -368,6 +417,28 @@ def test_trainable_syncer_custom(ray_start_2_cpus, temp_data_dirs):
 
     assert_file(False, tmp_target, os.path.join(checkpoint_dir, "checkpoint.data"))
     assert_file(False, tmp_target, os.path.join(checkpoint_dir, "custom_syncer.txt"))
+
+
+def test_trainable_syncer_custom_command(ray_start_2_cpus, temp_data_dirs):
+    """Check that Trainable.save() triggers syncing using custom syncer"""
+    tmp_source, tmp_target = temp_data_dirs
+
+    trainable = ray.remote(TestTrainable).remote(
+        remote_checkpoint_dir=f"file://{tmp_target}",
+        custom_syncer=CustomCommandSyncer(
+            sync_up_template="cp -rf {source} `echo '{target}' | cut -c 8-`",
+            sync_down_template="cp -rf `echo '{source}' | cut -c 8-` {target}",
+            delete_template="rm -rf `echo '{target}' | cut -c 8-`",
+        ),
+    )
+
+    checkpoint_dir = ray.get(trainable.save.remote())
+
+    assert_file(True, tmp_target, os.path.join(checkpoint_dir, "checkpoint.data"))
+
+    ray.get(trainable.delete_checkpoint.remote(checkpoint_dir))
+
+    assert_file(False, tmp_target, os.path.join(checkpoint_dir, "checkpoint.data"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This adds a test and an example for a custom command-based syncer. This can be used to trigger syncing in the legacy way, i.e. using awscli or gsutil command line interfaces like we did in Ray < 1.13.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
