### PR TITLE
[air/tune] Add top-level imports for Tuner, TuneConfig, move CheckpointConfig

### DIFF
--- a/doc/source/ray-air/package-ref.rst
+++ b/doc/source/ray-air/package-ref.rst
@@ -65,8 +65,6 @@ Trainer Configs
 .. automodule:: ray.air.config
     :members:
 
-.. autoclass:: ray.air.config.CheckpointConfig
-
 Checkpoint
 ~~~~~~~~~~
 

--- a/python/ray/train/_internal/checkpoint.py
+++ b/python/ray/train/_internal/checkpoint.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 
-from ray.air import Checkpoint
+from ray.air import Checkpoint, CheckpointConfig
 from ray.train._internal.session import TrainingResult
 from ray.train._internal.utils import construct_path
 from ray.train.constants import (
@@ -11,7 +11,7 @@ from ray.train.constants import (
     TUNE_CHECKPOINT_ID,
     TUNE_INSTALLED,
 )
-from ray.util.ml_utils.checkpoint_manager import CheckpointStorage, CheckpointConfig
+from ray.util.ml_utils.checkpoint_manager import CheckpointStorage
 from ray.util.ml_utils.checkpoint_manager import (
     _CheckpointManager as CommonCheckpointManager,
 )

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -9,10 +9,6 @@ from ray.air.checkpoint import Checkpoint
 from ray.air.config import RunConfig, ScalingConfig
 from ray.air.result import Result
 from ray.train.constants import TRAIN_DATASET_KEY
-from ray.tune import Trainable
-from ray.tune.error import TuneError
-from ray.tune.execution.placement_groups import PlacementGroupFactory
-from ray.tune.trainable import wrap_function
 from ray.util import PublicAPI
 from ray.util.annotations import DeveloperAPI
 from ray.util.ml_utils.dict import merge_dicts
@@ -20,6 +16,8 @@ from ray.util.ml_utils.dict import merge_dicts
 if TYPE_CHECKING:
     from ray.data import Dataset
     from ray.data.preprocessor import Preprocessor
+
+    from ray.tune import Trainable
 
 # A type representing either a ray.data.Dataset or a function that returns a
 # ray.data.Dataset and accepts no arguments.
@@ -325,6 +323,7 @@ class BaseTrainer(abc.ABC):
             ``self.as_trainable()``.
         """
         from ray.tune.tuner import Tuner
+        from ray.tune.error import TuneError
 
         trainable = self.as_trainable()
 
@@ -339,8 +338,10 @@ class BaseTrainer(abc.ABC):
             raise TrainingFailedError from e
         return result
 
-    def as_trainable(self) -> Type[Trainable]:
+    def as_trainable(self) -> Type["Trainable"]:
         """Convert self to a ``tune.Trainable`` class."""
+        from ray.tune.execution.placement_groups import PlacementGroupFactory
+        from ray.tune.trainable import wrap_function
 
         base_config = self._param_dict
         trainer_cls = self.__class__

--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -40,6 +40,8 @@ from ray.tune.search import create_searcher
 from ray.tune.schedulers import create_scheduler
 from ray.tune.execution.placement_groups import PlacementGroupFactory
 from ray.tune.trainable.util import with_parameters, with_resources
+from ray.tune.tuner import Tuner
+from ray.tune.tune_config import TuneConfig
 
 from ray._private.usage import usage_lib
 
@@ -85,4 +87,6 @@ __all__ = [
     "create_searcher",
     "create_scheduler",
     "PlacementGroupFactory",
+    "Tuner",
+    "TuneConfig",
 ]

--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -40,6 +40,7 @@ from ray.tune.search import create_searcher
 from ray.tune.schedulers import create_scheduler
 from ray.tune.execution.placement_groups import PlacementGroupFactory
 from ray.tune.trainable.util import with_parameters, with_resources
+from ray.tune.result_grid import ResultGrid
 from ray.tune.tuner import Tuner
 from ray.tune.tune_config import TuneConfig
 
@@ -84,6 +85,7 @@ __all__ = [
     "is_session_enabled",
     "checkpoint_dir",
     "SyncConfig",
+    "ResultGrid",
     "create_searcher",
     "create_scheduler",
     "PlacementGroupFactory",

--- a/python/ray/tune/execution/checkpoint_manager.py
+++ b/python/ray/tune/execution/checkpoint_manager.py
@@ -3,10 +3,8 @@ import logging
 from typing import Callable, Optional
 
 from ray.tune.result import TRAINING_ITERATION
+from ray.air.config import CheckpointConfig, MIN, MAX
 from ray.util.ml_utils.checkpoint_manager import (
-    CheckpointConfig,
-    MIN,
-    MAX,
     _CheckpointManager as CommonCheckpointManager,
     _TrackedCheckpoint,
     CheckpointStorage,

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -1,10 +1,9 @@
 import copy
 import os
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union, TYPE_CHECKING
 
 import ray.cloudpickle as pickle
 from ray.air.config import RunConfig, ScalingConfig
-from ray.train.trainer import BaseTrainer
 from ray.tune import Experiment, TuneError, ExperimentAnalysis
 from ray.tune.registry import is_function_trainable
 from ray.tune.result_grid import ResultGrid
@@ -12,6 +11,8 @@ from ray.tune.trainable import Trainable
 from ray.tune.tune import run
 from ray.tune.tune_config import TuneConfig
 
+if TYPE_CHECKING:
+    from ray.train.trainer import BaseTrainer
 
 _TRAINABLE_PKL = "trainable.pkl"
 _TUNER_PKL = "tuner.pkl"
@@ -55,7 +56,7 @@ class TunerInternal:
                 str,
                 Callable,
                 Type[Trainable],
-                BaseTrainer,
+                "BaseTrainer",
             ]
         ] = None,
         param_space: Optional[Dict[str, Any]] = None,
@@ -63,6 +64,8 @@ class TunerInternal:
         run_config: Optional[RunConfig] = None,
         _tuner_kwargs: Optional[Dict] = None,
     ):
+        from ray.train.trainer import BaseTrainer
+
         # Restored from Tuner checkpoint.
         if restore_path:
             trainable_ckpt = os.path.join(restore_path, _TRAINABLE_PKL)
@@ -147,6 +150,8 @@ class TunerInternal:
 
     @staticmethod
     def _convert_trainable(trainable: Any) -> Type[Trainable]:
+        from ray.train.trainer import BaseTrainer
+
         if isinstance(trainable, BaseTrainer):
             trainable = trainable.as_trainable()
         else:

--- a/python/ray/tune/result_grid.py
+++ b/python/ray/tune/result_grid.py
@@ -7,7 +7,7 @@ import pandas as pd
 from ray.air.result import Result
 from ray.cloudpickle import cloudpickle
 from ray.exceptions import RayTaskError
-from ray.tune import ExperimentAnalysis
+from ray.tune.analysis import ExperimentAnalysis
 from ray.tune.error import TuneError
 from ray.tune.experiment import Trial
 from ray.util import PublicAPI

--- a/python/ray/tune/tune_config.py
+++ b/python/ray/tune/tune_config.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 from ray.tune.schedulers import TrialScheduler
-from ray.tune.search import Searcher
+from ray.tune.search import Searcher, SearchAlgorithm
 from ray.util import PublicAPI
 
 
@@ -46,7 +46,7 @@ class TuneConfig:
     # We should carefully introduce arguments here instead of just dumping everything.
     mode: Optional[str] = None
     metric: Optional[str] = None
-    search_alg: Optional[Searcher] = None
+    search_alg: Optional[Union[Searcher, SearchAlgorithm]] = None
     scheduler: Optional[TrialScheduler] = None
     num_samples: int = 1
     max_concurrent_trials: Optional[int] = None

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -1,9 +1,8 @@
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union, TYPE_CHECKING
 
 import ray
 
 from ray.air.config import RunConfig
-from ray.train.trainer import BaseTrainer
 from ray.tune import TuneError
 from ray.tune.result_grid import ResultGrid
 from ray.tune.trainable import Trainable
@@ -11,6 +10,9 @@ from ray.tune.impl.tuner_internal import TunerInternal
 from ray.tune.tune_config import TuneConfig
 from ray.util import PublicAPI
 from ray.util.ml_utils.node import force_on_current_node
+
+if TYPE_CHECKING:
+    from ray.train.trainer import BaseTrainer
 
 ClientActorHandle = Any
 
@@ -111,7 +113,7 @@ class Tuner:
                 str,
                 Callable,
                 Type[Trainable],
-                BaseTrainer,
+                "BaseTrainer",
             ]
         ] = None,
         *,

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 
 ClientActorHandle = Any
 
-try:
-    from ray.util.client.common import ClientActorHandle
-except Exception:
-    pass
+# try:
+#     # Breaks lint right now.
+#     from ray.util.client.common import ClientActorHandle
+# except Exception:
+#     pass
 
 # The magic key that is used when instantiating Tuner during resume.
 _TUNER_INTERNAL = "_tuner_internal"

--- a/python/ray/tune/utils/release_test_util.py
+++ b/python/ray/tune/utils/release_test_util.py
@@ -7,9 +7,10 @@ import numpy as np
 import pickle
 
 from ray import tune
+from ray.tune.callback import Callback
 
 
-class ProgressCallback(tune.callback.Callback):
+class ProgressCallback(Callback):
     def __init__(self):
         self.last_update = 0
         self.update_interval = 60

--- a/python/ray/util/ml_utils/checkpoint_manager.py
+++ b/python/ray/util/ml_utils/checkpoint_manager.py
@@ -12,12 +12,14 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import ray
-from ray.air import Checkpoint, CheckpointConfig
-from ray.air.config import MAX
+from ray.air import Checkpoint
+from ray.tune.result import NODE_IP
 from ray.util import log_once
-from ray.util.annotations import Deprecated, DeveloperAPI
+from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 from ray.util.ml_utils.util import is_nan
 
+MAX = "max"
+MIN = "min"
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +65,6 @@ class _TrackedCheckpoint:
         metrics: Optional[Dict] = None,
         node_ip: Optional[str] = None,
     ):
-        from ray.tune.result import NODE_IP
-
         self.dir_or_data = dir_or_data
         self.id = checkpoint_id
         self.storage_mode = storage_mode
@@ -191,6 +191,85 @@ class _HeapCheckpointWrapper:
 
     def __repr__(self):
         return f"_HeapCheckpoint({repr(self.tracked_checkpoint)})"
+
+
+# Move to ray.air.config when ml_utils is deprecated.
+# Doing it now causes a circular import.
+@dataclass
+@PublicAPI(stability="alpha")
+class CheckpointConfig:
+    """Configurable parameters for defining the checkpointing strategy.
+
+    Default behavior is to persist all checkpoints to disk. If
+    ``num_to_keep`` is set, the default retention policy is to keep the
+    checkpoints with maximum timestamp, i.e. the most recent checkpoints.
+
+    Args:
+        num_to_keep: The number of checkpoints to keep
+            on disk for this run. If a checkpoint is persisted to disk after
+            there are already this many checkpoints, then an existing
+            checkpoint will be deleted. If this is ``None`` then checkpoints
+            will not be deleted. If this is ``0`` then no checkpoints will be
+            persisted to disk.
+        checkpoint_score_attribute: The attribute that will be used to
+            score checkpoints to determine which checkpoints should be kept
+            on disk when there are greater than ``num_to_keep`` checkpoints.
+            This attribute must be a key from the checkpoint
+            dictionary which has a numerical value. Per default, the last
+            checkpoints will be kept.
+        checkpoint_score_order: Either "max" or "min".
+            If "max", then checkpoints with highest values of
+            ``checkpoint_score_attribute`` will be kept.
+            If "min", then checkpoints with lowest values of
+            ``checkpoint_score_attribute`` will be kept.
+        checkpoint_frequency: Number of iterations between checkpoints. If 0
+            this will disable checkpointing.
+            Please note that most trainers will still save one checkpoint at
+            the end of training.
+            This attribute is only supported
+            by trainers that don't take in custom training loops.
+        checkpoint_at_end: If True, will save a checkpoint at the end of training.
+            This attribute is only supported by trainers that don't take in
+            custom training loops. Defaults to True for trainers that support it
+            and False for generic function trainables.
+
+    """
+
+    num_to_keep: Optional[int] = None
+    checkpoint_score_attribute: Optional[str] = None
+    checkpoint_score_order: str = MAX
+    checkpoint_frequency: int = 0
+    checkpoint_at_end: Optional[bool] = None
+
+    def __post_init__(self):
+        if self.num_to_keep is not None and self.num_to_keep < 0:
+            raise ValueError(
+                f"Received invalid num_to_keep: "
+                f"{self.num_to_keep}. "
+                f"Must be None or non-negative integer."
+            )
+        if self.checkpoint_score_order not in (MAX, MIN):
+            raise ValueError(
+                f"checkpoint_score_order must be either " f'"{MAX}" or "{MIN}".'
+            )
+
+        if self.checkpoint_frequency < 0:
+            raise ValueError(
+                f"checkpoint_frequency must be >=0, got {self.checkpoint_frequency}"
+            )
+
+    @property
+    def _tune_legacy_checkpoint_score_attr(self) -> Optional[str]:
+        """Same as ``checkpoint_score_attr`` in ``tune.run``.
+
+        Only used for Legacy API compatibility.
+        """
+        if self.checkpoint_score_attribute is None:
+            return self.checkpoint_score_attribute
+        prefix = ""
+        if self.checkpoint_score_order == MIN:
+            prefix = "min-"
+        return f"{prefix}{self.checkpoint_score_attribute}"
 
 
 # Alias for backwards compatibility


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This exposes Tuner and TuneConfig to the top-level ray.tune scope and moves checkpoint config to ray.air.config. This PR fixes circular imports.

## Related issue number

Closes #24703

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
