### PR TITLE
pin pytest to 7.1.0 to keep py36 support

### DIFF
--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -76,7 +76,7 @@ if [[ "$platform" == "linux" ]]; then
     "$PYTHON_EXE" -u -c "import ray; print(ray.__commit__)" | grep "$TRAVIS_COMMIT" || (echo "ray.__commit__ not set properly!" && exit 1)
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.0.1' requests proxy.py
+    "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.1.0' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do
@@ -117,7 +117,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.0.1' requests proxy.py
+    "$PIP_CMD" install -q aiohttp aiosignal frozenlist grpcio 'pytest==7.1.0' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
     for SCRIPT in "${TEST_SCRIPTS[@]}"; do

--- a/ci/env/install-minimal.sh
+++ b/ci/env/install-minimal.sh
@@ -33,7 +33,7 @@ eval "${WORKSPACE_DIR}/ci/ci.sh build"
 
 # Install test requirements
 python -m pip install -U \
-  pytest==7.0.1 \
+  pytest==7.1.0 \
   numpy
 
 # Train requirements.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -78,7 +78,7 @@ pexpect
 Pillow; platform_system != "Windows"
 pygments
 pyspark==3.1.2
-pytest==7.0.1
+pytest==7.1.0
 pytest-asyncio==0.16.0
 pytest-rerunfailures
 pytest-sugar


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray depends on pytest. pytest does not support py36 as it is EOL (https://devguide.python.org/versions/)

Ray however does provide python 3.6 wheels, thus to keep python 3.6 support we need to pin pytest at the latest version compat with py36, 7.1.0.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #23675 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
