### PR TITLE
[AIR][Serve] Add windows check for pd.DataFrame comparison

### DIFF
--- a/python/ray/serve/tests/test_air_integrations.py
+++ b/python/ray/serve/tests/test_air_integrations.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from typing import Optional
 
@@ -90,8 +91,13 @@ class TestBatchingFunctionFunctions:
 
         unpacked_list = BatchingManager.split_dataframe(batched_df, 1)
         assert len(unpacked_list) == 1
-        assert unpacked_list[0]["a"].equals(split_df["a"])
-        assert unpacked_list[0]["b"].equals(split_df["b"])
+        # On windows, conversion dtype is not preserved.
+        check_dtype = not os.name == "nt"
+        pd.testing.assert_frame_equal(
+            unpacked_list[0].reset_index(drop=True),
+            split_df.reset_index(drop=True),
+            check_dtype=check_dtype,
+        )
 
 
 class AdderPredictor(Predictor):


### PR DESCRIPTION
## Why are these changes needed?

In previous implementation #26821 we have windows failure suggesting we behave differently on windows regarding datatype conversion. 

In our https://sourcegraph.com/github.com/ray-project/ray/-/blob/python/ray/data/tests/test_dataset.py?L577 regarding use of TensorArray we seem to rely on pd's`assert_frame_equal` rather than manually comparing frames.

This PR adds a quick conditional on windows only to ignore dtype for now.

```
  | unpacked_list = BatchingManager.split_dataframe(batched_df, 1)
  | assert len(unpacked_list) == 1
  | >       assert unpacked_list[0]["a"].equals(split_df["a"])
  | E       assert False
  | E        +  where False = <bound method NDFrame.equals of 0    1\n1    2\n2    3\n3    4\nName: a, dtype: int32>(0    1\n1    2\n2    3\n3    4\nName: a, dtype: int64)
  | E        +    where <bound method NDFrame.equals of 0    1\n1    2\n2    3\n3    4\nName: a, dtype: int32> = 0    1\n1    2\n2    3\n3    4\nName: a, dtype: int32.equals
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
