### PR TITLE
[AIR - Serve] [Hotfix] Check for tensor extension via dtype rather than a NumPy conversion

### DIFF
--- a/python/ray/serve/air_integrations.py
+++ b/python/ray/serve/air_integrations.py
@@ -54,10 +54,10 @@ def _unpack_tensorarray_from_pandas(output_df: "pd.DataFrame") -> "pd.DataFrame"
     TensorArray to list to ensure output is json serializable as http
     response.
     """
-    from ray.data.extensions import TensorArray, TensorArrayElement
+    from ray.data.extensions import TensorDtype
 
-    for col in output_df:
-        if isinstance(output_df[col].values, (TensorArray, TensorArrayElement)):
+    for col in output_df.columns:
+        if isinstance(output_df.dtypes[col], TensorDtype):
             output_df[col] = output_df[col].to_numpy()
 
     return output_df


### PR DESCRIPTION
Converting a Pandas DataFrame column to an ndarray (e.g. via `df[col].values`) can often result in a full copy of the column in order to construct the ndarray due to Pandas' 2D block management. This PR ports tensor extension type checking to checking the dtype, which is always an O(1) check.

Signed-off-by: Clark Zinzow <clarkzinzow@gmail.com>

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
