### PR TITLE
[AIR CUJ] Add wait_for_nodes for 4x4 gpu test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -567,6 +567,9 @@
     timeout: 10800
     script: python workloads/pytorch_training_e2e.py --data-size-gb=100 --num-workers=16
 
+    wait_for_nodes:
+      num_nodes: 4
+
     type: sdk_command
     file_manager: job
 


### PR DESCRIPTION
## Why are these changes needed?

This helps to reduce test flakiness on multi node tests so we always kick off the workload after autoscaler provisioned all nodes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
