### PR TITLE
[RLlib]: Raise deprecation warning in MARWIL OPE methods

### DIFF
--- a/rllib/algorithms/bc/bc.py
+++ b/rllib/algorithms/bc/bc.py
@@ -55,6 +55,7 @@ class BCConfig(MARWILConfig):
         # No off-policy estimation.
         self.off_policy_estimation_methods = {}
 
+
 class BC(MARWIL):
     """Behavioral Cloning (derived from MARWIL).
 

--- a/rllib/algorithms/bc/bc.py
+++ b/rllib/algorithms/bc/bc.py
@@ -49,7 +49,7 @@ class BCConfig(MARWILConfig):
         # not important for behavioral cloning.
         self.postprocess_inputs = False
         # No reward estimation.
-        self.evaluation_config["off_policy_estimation_methods"] = {}
+        self.off_policy_estimation_methods = {}
         # __sphinx_doc_end__
         # fmt: on
 

--- a/rllib/algorithms/bc/bc.py
+++ b/rllib/algorithms/bc/bc.py
@@ -48,11 +48,12 @@ class BCConfig(MARWILConfig):
         # Advantages (calculated during postprocessing)
         # not important for behavioral cloning.
         self.postprocess_inputs = False
-        # No reward estimation.
-        self.off_policy_estimation_methods = {}
         # __sphinx_doc_end__
         # fmt: on
-
+        # TODO: Remove this when the off_polciy_estimation_methods
+        # default config is removed from MARWIL
+        # No off-policy estimation.
+        self.off_policy_estimation_methods = {}
 
 class BC(MARWIL):
     """Behavioral Cloning (derived from MARWIL).

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -115,6 +115,7 @@ class MARWILConfig(AlgorithmConfig):
         # fmt: on
 
         # TODO: Delete this and change off_policy_estimation_methods to {}
+        # Also remove the same section from BC
         self.off_policy_estimation_methods = {
             "is": {"type": ImportanceSampling},
             "wis": {"type": WeightedImportanceSampling},

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -113,12 +113,20 @@ class MARWILConfig(AlgorithmConfig):
         self.num_workers = 0
         # __sphinx_doc_end__
         # fmt: on
-        # TODO: Delete this to change default off_policy_eestimation_methods to {}
-        # Also delete the deprecation warning in .evaluate()
+
+        # TODO: Delete this and change off_policy_estimation_methods to {}
         self.off_policy_estimation_methods = {
             "is": {"type": ImportanceSampling},
             "wis": {"type": WeightedImportanceSampling},
         }
+        deprecation_warning(
+            old="MARWIL currently uses off_policy_estimation_methods: "
+            f"{self.off_policy_estimation_methods} by default. This will"
+            "change to off_policy_estimation_methods: {} in a future release."
+            "If you want to use an off-policy estimator, specify it in"
+            ".evaluation(off_policy_estimation_methods=...)",
+            error=False,
+        )
 
     @override(AlgorithmConfig)
     def training(
@@ -210,19 +218,6 @@ class MARWILConfig(AlgorithmConfig):
         if grad_clip is not None:
             self.grad_clip = grad_clip
         return self
-
-    @override(AlgorithmConfig)
-    def evaluation(self, *, off_policy_estimation_methods: Dict = None, **kwargs):
-        if not off_policy_estimation_methods and self.off_policy_estimation_methods:
-            deprecation_warning(
-                old="MARWIL currently uses off_policy_estimation_methods: "
-                f"{self.off_policy_estimation_methods} by default. This will"
-                "change to off_policy_estimation_methods: {} in a future release."
-                "If you want to use an off-policy estimator, specify it in"
-                ".evaluation(off_policy_estimation_methods=...)",
-                error=False,
-            )
-        return super().evaluation(**kwargs)
 
 
 class MARWIL(Algorithm):

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, Dict
+from typing import Optional, Type
 
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -107,17 +107,18 @@ class MARWILConfig(AlgorithmConfig):
         # discounted returns. It is ok, though, to have multiple episodes in
         # the same line.
         self.input_ = "sampler"
-        # Use importance sampling estimators for reward.
-        self.off_policy_estimation_methods = {
-            "is": {"type": ImportanceSampling},
-            "wis": {"type": WeightedImportanceSampling},
-        }
         self.postprocess_inputs = True
         self.lr = 1e-4
         self.train_batch_size = 2000
         self.num_workers = 0
         # __sphinx_doc_end__
         # fmt: on
+        # TODO: Delete this to change default off_policy_eestimation_methods to {}
+        # Also delete the deprecation warning in .evaluate()
+        self.off_policy_estimation_methods = {
+            "is": {"type": ImportanceSampling},
+            "wis": {"type": WeightedImportanceSampling},
+        }
 
     @override(AlgorithmConfig)
     def training(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

MARWIL currently uses `off_policy_estimation_methods = {"is": {"type": ImportanceSampling}, "wis": {"type": WeightedImportanceSampling}}` by default instead of {} like all of the other algorithms. This should be deprecated and removed in a future release. We can't just remove it because of users that may be using MARWIL with the current default.

<!-- Please give a short summary of the change and the problem this solves. -->

Closes #26667 

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
