### PR TITLE
[core] Fix the deadlock in submit task when actor failed.

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -152,7 +152,7 @@ prepare_docker() {
     " > $tmp_dir/Dockerfile
 
     pushd $tmp_dir
-    docker build . -t ray_ci:v1
+    docker build . -t flovena/ray_ci:s5
     popd
 
     popd

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -152,7 +152,7 @@ prepare_docker() {
     " > $tmp_dir/Dockerfile
 
     pushd $tmp_dir
-    docker build . -t flovena/ray_ci:s5
+    docker build . -t ray_ci:v1
     popd
 
     popd

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -172,6 +172,66 @@ def test_actor_failure_async(ray_start_regular):
     t.join()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Fail on windowns")
+@pytest.mark.parametrize(
+    "ray_start_regular",
+    [{"_system_config": {"timeout_ms_task_wait_for_death_info": 100000000}}],
+    indirect=True,
+)
+def test_actor_failure_async_2(ray_start_regular, tmp_path):
+    p = tmp_path / "a_pid"
+
+    @ray.remote(max_restarts=1)
+    class A:
+        def __init__(self):
+            pid = os.getpid()
+            # The second time start, it'll block,
+            # so that we'll know the actor is restarting.
+            if p.exists():
+                p.write_text(str(pid))
+                time.sleep(100000)
+            else:
+                p.write_text(str(pid))
+
+        def pid(self):
+            return os.getpid()
+
+    a = A.remote()
+
+    pid = ray.get(a.pid.remote())
+
+    os.kill(int(pid), signal.SIGKILL)
+
+    # kill will be in another thred.
+    def kill():
+        # sleep for 2s for the code to be setup
+        time.sleep(2)
+        new_pid = int(p.read_text())
+        while new_pid == pid:
+            new_pid = int(p.read_text())
+            time.sleep(1)
+        os.kill(new_pid, signal.SIGKILL)
+
+    t = threading.Thread(target=kill)
+    t.start()
+
+    try:
+        o = a.pid.remote()
+
+        def new_task(_):
+            print("new_task")
+            # make sure there is no deadlock
+            a.pid.remote()
+
+        o._on_completed(new_task)
+        # When ray.get(o) failed,
+        # new_task will be executed
+        ray.get(o)
+    except Exception as e:
+        pass
+    t.join()
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -227,7 +227,7 @@ def test_actor_failure_async_2(ray_start_regular, tmp_path):
         # When ray.get(o) failed,
         # new_task will be executed
         ray.get(o)
-    except Exception as e:
+    except Exception:
         pass
     t.join()
 

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.cc
@@ -288,6 +288,8 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(
 
       // We need to execute this outside of the lock to prevent deadlock.
       wait_for_death_info_tasks = std::move(queue->second.wait_for_death_info_tasks);
+      // Reset the queue
+      queue->second = std::deque<std::pair<int64_t, TaskSpecification>>();
     } else if (queue->second.state != rpc::ActorTableData::DEAD) {
       // Only update the actor's state if it is not permanently dead. The actor
       // will eventually get restarted or marked as permanently dead.

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.cc
@@ -275,7 +275,8 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(
       // We need to execute this outside of the lock to prevent deadlock.
       wait_for_death_info_tasks = std::move(queue->second.wait_for_death_info_tasks);
       // Reset the queue
-      queue->second = std::deque<std::pair<int64_t, TaskSpecification>>();
+      queue->second.wait_for_death_info_tasks =
+          std::deque<std::pair<int64_t, TaskSpecification>>();
     } else if (queue->second.state != rpc::ActorTableData::DEAD) {
       // Only update the actor's state if it is not permanently dead. The actor
       // will eventually get restarted or marked as permanently dead.

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.h
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.h
@@ -158,6 +158,15 @@ class CoreWorkerDirectActorTaskSubmitter
   std::string DebugString(const ActorID &actor_id) const;
 
  private:
+  /// A helper function to get task finisher without holding mu_
+  /// We should use this function when access
+  ///    - FailOrRetryPendingTask
+  ///    - MarkTaskReturnObjectsFailed
+  TaskFinisherInterface &GetTaskFinisherWithoutMu() {
+    mu_.AssertNotHeld();
+    return task_finisher_;
+  }
+
   struct ClientQueue {
     ClientQueue(ActorID actor_id,
                 bool execute_out_of_order,


### PR DESCRIPTION
Signed-off-by: Yi Cheng <chengyidna@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When actor died, it'll send notification to core workers. Right now, sometimes, core worker will queue the task waiting for actor death info and pop it up for better usability. But in async cases, this is going to cause issues.

The callback might submit tasks which require holding the lock. But it's already being held. This is going to cause a deadlock.

This PR fixed this by moving the failure part out of the lock.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
