### PR TITLE
GC the blocks that have been splitted during .split() if they are owned by consumer

### DIFF
--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -173,7 +173,8 @@ def _split_all_blocks(
             all_blocks_split_results[block_id] = block_split_result
 
     # We make a copy for the blocks that have been splitted, so the input blocks
-    # can be cleared if they are owned by consumer.
+    # can be cleared if they are owned by consumer (consumer-owned blocks will
+    # only be consumed by the owner).
     if block_list._owned_by_consumer:
         ray._private.internal_api.free(blocks_splitted, local_only=False)
 

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Tuple, List
 
 import ray
+from ray.data._internal.block_list import BlockList
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data.block import (
     Block,
@@ -135,16 +136,18 @@ def _drop_empty_block_split(block_split_indices: List[int], num_rows: int) -> Li
 
 
 def _split_all_blocks(
-    blocks_with_metadata: BlockPartition,
+    block_list: BlockList,
     per_block_split_indices: List[List[int]],
 ) -> Iterable[Tuple[ObjectRef[Block], BlockMetadata]]:
     """Split all the input blocks based on the split indices"""
     split_single_block = cached_remote_fn(_split_single_block)
 
+    blocks_with_metadata = block_list.get_blocks_with_metadata()
     all_blocks_split_results: List[BlockPartition] = [None] * len(blocks_with_metadata)
 
     split_single_block_futures = []
 
+    blocks_splitted = []
     for block_id, block_split_indices in enumerate(per_block_split_indices):
         (block_ref, meta) = blocks_with_metadata[block_id]
         block_row = meta.num_rows
@@ -163,10 +166,17 @@ def _split_all_blocks(
                     block_split_indices,
                 )
             )
+            blocks_splitted.append(block_ref)
     if split_single_block_futures:
         split_single_block_results = ray.get(split_single_block_futures)
         for block_id, block_split_result in split_single_block_results:
             all_blocks_split_results[block_id] = block_split_result
+
+    # We make a copy for the blocks that have been splitted, so the input blocks
+    # can be cleared if they are owned by consumer.
+    if block_list._owned_by_consumer:
+        ray._private.internal_api.free(blocks_splitted, local_only=False)
+
     return itertools.chain.from_iterable(all_blocks_split_results)
 
 
@@ -203,7 +213,7 @@ def _generate_global_split_results(
 
 
 def _split_at_indices(
-    blocks_with_metadata: Iterable[Tuple[ObjectRef[Block], BlockMetadata]],
+    block_list: BlockList,
     indices: List[int],
 ) -> Tuple[List[List[ObjectRef[Block]]], List[List[BlockMetadata]]]:
     """Split blocks at the provided indices.
@@ -216,6 +226,7 @@ def _split_at_indices(
         corresponding block split will be empty .
     """
 
+    blocks_with_metadata = block_list.get_blocks_with_metadata()
     # We implement the split in 3 phases.
     # phase 1: calculate the per block split indices.
     blocks_with_metadata = list(blocks_with_metadata)
@@ -230,7 +241,7 @@ def _split_at_indices(
     # phase 2: split each block based on the indices from previous step.
     all_blocks_split_results: Iterable[
         Tuple[ObjectRef[Block], BlockMetadata]
-    ] = _split_all_blocks(blocks_with_metadata, per_block_split_indices)
+    ] = _split_all_blocks(block_list, per_block_split_indices)
 
     # phase 3: generate the final split.
 

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -259,7 +259,7 @@ def _get_num_rows(block: Block) -> int:
 
 
 def _split_at_index(
-    blocks_with_metadata: Iterable[Tuple[ObjectRef[Block], BlockMetadata]],
+    block_list: BlockList,
     index: int,
     return_right_half: bool,
 ) -> Tuple[
@@ -277,5 +277,5 @@ def _split_at_index(
     Returns:
         The block split futures and their metadata for left and right of the index.
     """
-    blocks_splits, metadata_splits = _split_at_indices(blocks_with_metadata, [index])
+    blocks_splits, metadata_splits = _split_at_indices(block_list, [index])
     return blocks_splits[0], metadata_splits[0], blocks_splits[1], metadata_splits[1]

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3422,9 +3422,8 @@ class Dataset(Generic[T]):
     ) -> ("Dataset[T]", "Dataset[T]"):
         start_time = time.perf_counter()
         block_list = self._plan.execute()
-        blocks_with_metadata = block_list.get_blocks_with_metadata()
         left_blocks, left_metadata, right_blocks, right_metadata = _split_at_index(
-            blocks_with_metadata,
+            block_list,
             index,
             return_right_half,
         )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1234,8 +1234,7 @@ class Dataset(Generic[T]):
             raise ValueError("indices must be positive")
         start_time = time.perf_counter()
         block_list = self._plan.execute()
-        blocks_with_metadata = block_list.get_blocks_with_metadata()
-        blocks, metadata = _split_at_indices(blocks_with_metadata, indices)
+        blocks, metadata = _split_at_indices(block_list, indices)
         split_duration = time.perf_counter() - start_time
         parent_stats = self._plan.stats()
         splits = []

--- a/python/ray/data/tests/test_object_gc.py
+++ b/python/ray/data/tests/test_object_gc.py
@@ -141,6 +141,33 @@ def test_pipeline_splitting_has_no_spilling(shutdown_only):
     assert "Spilled" not in meminfo, meminfo
 
 
+def test_pipeline_splitting_has_no_spilling_with_equal_splitting(shutdown_only):
+    # The object store is about 1200MiB.
+    ctx = ray.init(num_cpus=1, object_store_memory=1200e6)
+    # The size of dataset is 50000*(80*80*4)*8B, about 10GiB, 50MiB/block.
+    ds = ray.data.range_tensor(50000, shape=(80, 80, 4), parallelism=200)
+
+    # 150Mib/window, which is 3 blocks/window, which means equal splitting
+    # will need to split one block.
+    p = ds.window(bytes_per_window=150 * 1024 * 1024).repeat()
+    p1, p2 = p.split(2, equal=True)
+
+    @ray.remote
+    def consume(p):
+        for batch in p.iter_batches():
+            pass
+
+    tasks = [consume.remote(p1), consume.remote(p2)]
+    try:
+        # Run it for 20 seconds.
+        ray.get(tasks, timeout=20)
+    except Exception:
+        for t in tasks:
+            ray.cancel(t, force=True)
+    meminfo = memory_summary(ctx.address_info["address"], stats_only=True)
+    assert "Spilled" not in meminfo, meminfo
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?
Eagerly GC blocks no longer needed to improve memory efficiency and reduce object spilling.

## Related issue number
#25249

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
