### PR TITLE
[Core][State Observability] Add tests for getting logs with `node-id`

### DIFF
--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -585,25 +585,27 @@ def test_logs_stream_and_tail(ray_start_with_dashboard):
 
 def test_log_list(ray_start_cluster):
     cluster = ray_start_cluster
-    cluster.add_node(num_cpus=0)
+    num_nodes = 5
+    for _ in range(num_nodes):
+        cluster.add_node(num_cpus=0)
     ray.init(address=cluster.address)
 
     def verify():
-        head_node = list_nodes()[0]
-        # When glob filter is not provided, it should provide all logs
-        logs = list_logs(node_id=head_node["node_id"])
-        assert "raylet" in logs
-        assert "gcs_server" in logs
-        assert "dashboard" in logs
-        assert "agent" in logs
-        assert "internal" in logs
-        assert "driver" in logs
-        assert "autoscaler" in logs
+        for node in list_nodes():
+            # When glob filter is not provided, it should provide all logs
+            logs = list_logs(node_id=node["node_id"])
+            assert "raylet" in logs
+            assert "gcs_server" in logs
+            assert "dashboard" in logs
+            assert "agent" in logs
+            assert "internal" in logs
+            assert "driver" in logs
+            assert "autoscaler" in logs
 
-        # Test glob works.
-        logs = list_logs(node_id=head_node["node_id"], glob_filter="raylet*")
-        assert len(logs) == 1
-        return True
+            # Test glob works.
+            logs = list_logs(node_id=node["node_id"], glob_filter="raylet*")
+            assert len(logs) == 1
+            return True
 
     wait_for_condition(verify)
 


### PR DESCRIPTION
Signed-off-by: rickyyx <rickyx@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Making sure `ray logs` with `node-id` works 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #25764 

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Manual CLI test

