### PR TITLE
[Doc] [Job submission] [Dashboard] Add tip for long runtime_env installation and improve error

### DIFF
--- a/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -187,7 +187,7 @@ const Actor: React.FC<ActorProps> = ({ actor }) => {
         ) : actor.state === ActorState.Infeasible ? (
           <span className={classes.infeasible}>
             {actor.actorClass} cannot be created because the Ray cluster cannot
-            satisfy its resource requirements.
+            satisfy its resource requirements or its runtime_env could not be created.
           </span>
         ) : (
           <span className={classes.pendingResources}>

--- a/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -187,7 +187,8 @@ const Actor: React.FC<ActorProps> = ({ actor }) => {
         ) : actor.state === ActorState.Infeasible ? (
           <span className={classes.infeasible}>
             {actor.actorClass} cannot be created because the Ray cluster cannot
-            satisfy its resource requirements or its runtime_env could not be created.
+            satisfy its resource requirements or its runtime_env could not be
+            created.
           </span>
         ) : (
           <span className={classes.pendingResources}>

--- a/doc/source/cluster/job-submission.rst
+++ b/doc/source/cluster/job-submission.rst
@@ -173,6 +173,12 @@ Here are some examples of CLI commands from the Quick Start example and their ou
     ``ray job submit --working_dir="." -- python script.py`` instead of ``ray job submit --working_dir="." -- "python script.py"``.
     Otherwise you may encounter the error ``/bin/sh: 1: python script.py: not found``.
 
+.. tip::
+
+    If your job is stuck in `PENDING`, the runtime environment installation may be stuck.
+    (For example, the `pip` installation or `working_dir` download may be stalled due to internet issues.)
+    You can check the installation logs at `/tmp/ray/session_latest/logs/runtime_env_setup-*.log` for details.
+
 Using the CLI on a remote cluster
 """""""""""""""""""""""""""""""""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- The dashboard can display the message `<actor> cannot be created because the Ray cluster cannot satisfy its resource requirements` in the case where the runtime env setup is stalled.  This PR updates this message to include the possibility of the runtime env setup failing.
- This PR adds a tip to the Job Submission doc saying that if a job is stalled in PENDING, the runtime env setup may have stalled.  It adds a pointer to the log files which should have more information.

The runtime env cannot stall forever, it fails after 10 minutes.  This is a new feature added after the Ray 1.13 branch cut.  In Ray <= 1.13, the runtime env can still stall forever.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/26332
## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
