### PR TITLE
[air] Simplify the local shuffle API

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2373,10 +2373,7 @@ class Dataset(Generic[T]):
                 using a local in-memory shuffle buffer, and this value will serve as the
                 minimum number of rows that must be in the local in-memory shuffle
                 buffer in order to yield a batch. When there are no more rows to add to
-                the buffer, the remaining rows in the buffer will be drained. This
-                buffer size must be greater than or equal to ``batch_size``, and
-                therefore ``batch_size`` must also be specified when using local
-                shuffling.
+                the buffer, the remaining rows in the buffer will be drained.
             local_shuffle_seed: The seed to use for the local random shuffle.
 
         Returns:

--- a/python/ray/data/tests/test_batcher.py
+++ b/python/ray/data/tests/test_batcher.py
@@ -18,22 +18,8 @@ def test_shuffling_batcher():
     ):
         ShufflingBatcher(batch_size=None, shuffle_buffer_min_size=buffer_size)
 
-    with pytest.raises(
-        ValueError,
-        match="Shuffle buffer min size must be at least as large as the batch size",
-    ):
-        ShufflingBatcher(batch_size=batch_size, shuffle_buffer_min_size=batch_size - 1)
-
-    with pytest.raises(
-        ValueError,
-        match="Shuffle buffer capacity must be at least as large as the shuffle "
-        "buffer min size plus the batch size",
-    ):
-        ShufflingBatcher(
-            batch_size=batch_size,
-            shuffle_buffer_min_size=buffer_size,
-            shuffle_buffer_capacity=batch_size + buffer_size - 1,
-        )
+    # Should not raise error.
+    ShufflingBatcher(batch_size=batch_size, shuffle_buffer_min_size=batch_size - 1)
 
     batcher = ShufflingBatcher(
         batch_size=batch_size,

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1697,12 +1697,6 @@ def test_iter_batches_local_shuffle(shutdown_only, pipelined, ds_format):
     with pytest.raises(ValueError):
         list(ray.data.range(100).iter_batches(local_shuffle_buffer_size=10))
 
-    # Shuffle buffer min size must be at least as large as batch size.
-    with pytest.raises(ValueError):
-        list(
-            ray.data.range(100).iter_batches(batch_size=10, local_shuffle_buffer_size=5)
-        )
-
     def range(n, parallelism=200):
         if ds_format == "simple":
             ds = ray.data.range(n, parallelism=parallelism)


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Simplify the local shuffle API by removing a constraint in the args that we can calculate internally.