### PR TITLE
[core] Consistently auto init on any public Ray API call

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -760,7 +760,7 @@ def next_job_id():
 
 
 @DeveloperAPI
-@client_mode_hook(auto_init=False)
+@client_mode_hook(auto_init=True)
 def nodes():
     """Get a list of the nodes in the cluster (for debugging only).
 


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are a few random API sites that have auto_init=False for no good reason (e.g., ray.nodes()). Particularly after https://github.com/ray-project/ray/pull/26678, this is inconsistent with Ray initialization and usage. Fix this so all public APIs have auto init set to True.