### PR TITLE
[data] Make lazy mode non-experimental

### DIFF
--- a/doc/source/data/doc_code/key_concepts.py
+++ b/doc/source/data/doc_code/key_concepts.py
@@ -57,7 +57,7 @@ def map_udf(df):
     return df
 
 ds = ray.data.read_parquet("example://iris.parquet") \
-    .experimental_lazy() \
+    .lazy() \
     .map_batches(map_udf) \
     .filter(lambda row: row["sepal.area"] > 15)
 # __block_move_end__

--- a/doc/source/data/memory-management.rst
+++ b/doc/source/data/memory-management.rst
@@ -63,7 +63,7 @@ That's why Datasets offers a lazy execution mode, which you can transition to af
 you're done prototyping your Datasets pipeline.
 
 Lazy execution mode can be enabled by calling
-:meth:`ds = ds.experimental_lazy() <ray.data.Dataset.experimental_lazy()>`, which
+:meth:`ds = ds.lazy() <ray.data.Dataset.lazy()>`, which
 returns a dataset whose all subsequent operations will be **lazy**. These operations
 won't be executed until the dataset is consumed (e.g. via
 :meth:`ds.take() <ray.data.Dataset.take>`,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3446,8 +3446,8 @@ class Dataset(Generic[T]):
         """
         return self._plan.execute().get_blocks()
 
-    def experimental_lazy(self) -> "Dataset[T]":
-        """EXPERIMENTAL: Enable lazy evaluation.
+    def lazy(self) -> "Dataset[T]":
+        """Enable lazy evaluation.
 
         The returned dataset is a lazy dataset, where all subsequent operations on the
         dataset won't be executed until the dataset is consumed (e.g. ``.take()``,
@@ -3457,6 +3457,9 @@ class Dataset(Generic[T]):
         ds = Dataset(self._plan, self._epoch, lazy=True)
         ds._set_uuid(self._get_uuid())
         return ds
+
+    def experimental_lazy(self) -> "Dataset[T]":
+        raise DeprecationWarning("Use self.lazy().")
 
     def has_serializable_lineage(self) -> bool:
         """Whether this dataset's lineage is able to be serialized for storage and

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -41,7 +41,7 @@ def maybe_pipeline(ds, enabled):
 
 def maybe_lazy(ds, enabled):
     if enabled:
-        return ds.experimental_lazy()
+        return ds.lazy()
     else:
         return ds
 
@@ -2246,7 +2246,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
     fn_constructor_args = (ray.put(1),)
     fn_constructor_kwargs = {"b": ray.put(2)}
     ds2 = (
-        ds.experimental_lazy()
+        ds.lazy()
         .map_batches(
             CallableFn,
             batch_size=1,
@@ -2276,7 +2276,7 @@ def test_map_batches_extra_args(ray_start_regular_shared, tmp_path):
     fn_constructor_args = (ray.put(1),)
     fn_constructor_kwargs = {"b": ray.put(2)}
     ds2 = (
-        ds.experimental_lazy()
+        ds.lazy()
         .map_batches(
             lambda df, a, b=None: b * df + a,
             batch_size=1,
@@ -4562,9 +4562,7 @@ def test_dataset_retry_exceptions(ray_start_regular, local_path):
 
 
 def test_split_is_not_disruptive(ray_start_regular):
-    ds = (
-        ray.data.range(100, parallelism=10).map_batches(lambda x: x).experimental_lazy()
-    )
+    ds = ray.data.range(100, parallelism=10).map_batches(lambda x: x).lazy()
 
     def verify_integrity(splits):
         for dss in splits:

--- a/python/ray/tune/impl/test_utils.py
+++ b/python/ray/tune/impl/test_utils.py
@@ -33,8 +33,8 @@ def gen_dataset_func() -> Dataset:
 
 
 def test_grid_search():
-    ds1 = gen_dataset_func().experimental_lazy().map(lambda x: x)
-    ds2 = gen_dataset_func().experimental_lazy().map(lambda x: x)
+    ds1 = gen_dataset_func().lazy().map(lambda x: x)
+    ds2 = gen_dataset_func().lazy().map(lambda x: x)
     assert not ds1._plan._has_final_stage_snapshot()
     assert not ds2._plan._has_final_stage_snapshot()
     param_space = {"train_dataset": tune.grid_search([ds1, ds2])}
@@ -46,8 +46,8 @@ def test_grid_search():
 
 
 def test_choice():
-    ds1 = gen_dataset_func().experimental_lazy().map(lambda x: x)
-    ds2 = gen_dataset_func().experimental_lazy().map(lambda x: x)
+    ds1 = gen_dataset_func().lazy().map(lambda x: x)
+    ds2 = gen_dataset_func().lazy().map(lambda x: x)
     assert not ds1._plan._has_final_stage_snapshot()
     assert not ds2._plan._has_final_stage_snapshot()
     param_space = {"train_dataset": tune.choice([ds1, ds2])}


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Lazy mode is already used and tested at large scale in DatasetPipelines (and during normal execution, which hits the same planning code path). Mark it as non-experimental so we can reference it in docs in a sensible way.