### PR TITLE
[RLlib] Small SlateQ example fix

### DIFF
--- a/rllib/examples/recommender_system_with_recsim_and_slateq.py
+++ b/rllib/examples/recommender_system_with_recsim_and_slateq.py
@@ -181,7 +181,7 @@ def main():
         if args.run == "DQN":
             trainer = dqn.DQN(config=config)
         else:
-            trainer = slateq.SlateQTrainer(config=config)
+            trainer = slateq.SlateQ(config=config)
         for i in range(10):
             result = trainer.train()
             print(pretty_print(result))


### PR DESCRIPTION
## Why are these changes needed?

The example script in this PR uses the SlateQTrainer, which is no longer available.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
