### PR TITLE
[RLLib] Record framework and algorithm used by an RLlib run.

### DIFF
--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -244,6 +244,8 @@ def _put_library_usage(library_usage: str):
 class TagKey(Enum):
     _TEST1 = auto()
     _TEST2 = auto()
+    _RLLIB_FRAMEWORK = auto()
+    _RLLIB_ALGORITHM = auto()
 
 
 def record_extra_usage_tag(key: TagKey, value: str):

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -246,6 +246,7 @@ class TagKey(Enum):
     _TEST2 = auto()
     RLLIB_FRAMEWORK = auto()
     RLLIB_ALGORITHM = auto()
+    RLLIB_NUM_WORKERS = auto()
 
 
 def record_extra_usage_tag(key: TagKey, value: str):

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -244,8 +244,8 @@ def _put_library_usage(library_usage: str):
 class TagKey(Enum):
     _TEST1 = auto()
     _TEST2 = auto()
-    _RLLIB_FRAMEWORK = auto()
-    _RLLIB_ALGORITHM = auto()
+    RLLIB_FRAMEWORK = auto()
+    RLLIB_ALGORITHM = auto()
 
 
 def record_extra_usage_tag(key: TagKey, value: str):

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -29,6 +29,7 @@ import pkg_resources
 from packaging import version
 
 import ray
+from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray.actor import ActorHandle
 from ray.exceptions import GetTimeoutError, RayActorError, RayError
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
@@ -334,6 +335,8 @@ class Algorithm(Trainable):
         update_global_seed_if_necessary(self.config["framework"], self.config["seed"])
 
         self.validate_config(self.config)
+        self._record_usage(self.config)
+
         self.callbacks = self.config["callbacks"]()
         log_level = self.config.get("log_level")
         if log_level in ["WARN", "ERROR"]:
@@ -2561,6 +2564,15 @@ class Algorithm(Trainable):
 
     def __repr__(self):
         return type(self).__name__
+
+    def _record_usage(self, config):
+        """Record the framework and algorithm used.
+
+        Args:
+            config: Algorithm config dict.
+        """
+        record_extra_usage_tag(TagKey._RLLIB_FRAMEWORK, config["framework"])
+        record_extra_usage_tag(TagKey._RLLIB_ALGORITHM, self.__class__.__name__)
 
     @Deprecated(new="Trainer.compute_single_action()", error=False)
     def compute_action(self, *args, **kwargs):

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2573,6 +2573,7 @@ class Algorithm(Trainable):
             config: Algorithm config dict.
         """
         record_extra_usage_tag(TagKey.RLLIB_FRAMEWORK, config["framework"])
+        record_extra_usage_tag(TagKey.RLLIB_NUM_WORKERS, str(config["num_workers"]))
         alg = self.__class__.__name__
         # We do not want to collect user defined algorithm names.
         if alg not in ALL_ALGORITHMS:

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -34,6 +34,7 @@ from ray.actor import ActorHandle
 from ray.exceptions import GetTimeoutError, RayActorError, RayError
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
+from ray.rllib.algorithms.registry import ALGORITHMS as ALL_ALGORITHMS
 from ray.rllib.env.env_context import EnvContext
 from ray.rllib.env.utils import _gym_env_creator
 from ray.rllib.evaluation.episode import Episode
@@ -2571,8 +2572,12 @@ class Algorithm(Trainable):
         Args:
             config: Algorithm config dict.
         """
-        record_extra_usage_tag(TagKey._RLLIB_FRAMEWORK, config["framework"])
-        record_extra_usage_tag(TagKey._RLLIB_ALGORITHM, self.__class__.__name__)
+        record_extra_usage_tag(TagKey.RLLIB_FRAMEWORK, config["framework"])
+        alg = self.__class__.__name__
+        # We do not want to collect user defined algorithm names.
+        if alg not in ALL_ALGORITHMS:
+            alg = "USER_DEFINED"
+        record_extra_usage_tag(TagKey.RLLIB_ALGORITHM, alg)
 
     @Deprecated(new="Trainer.compute_single_action()", error=False)
     def compute_action(self, *args, **kwargs):


### PR DESCRIPTION
## Why are these changes needed?

Automatically record framework and algorithm used by RLlib jobs.
For better planning.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
