### PR TITLE
[air/tune/docs] Cont. convert Tune examples to use Tuner.fit()

### DIFF
--- a/python/ray/tune/examples/cifar10_pytorch.py
+++ b/python/ray/tune/examples/cifar10_pytorch.py
@@ -230,7 +230,7 @@ def main(num_samples=10, max_num_epochs=10, gpus_per_trial=2):
         # If using Ray Client, we want to make sure checkpoint access
         # happens on the server. So we wrap `test_best_model` in a Ray task.
         # We have to make sure it gets executed on the same node that
-        # ``tune.run`` is called on.
+        # ``tuner.fit()`` is called on.
         from ray.util.ml_utils.node import force_on_current_node
         remote_fn = force_on_current_node(ray.remote(test_best_model))
         ray.get(remote_fn.remote(best_result.config, best_result.checkpoint))

--- a/python/ray/tune/examples/custom_func_checkpointing.py
+++ b/python/ray/tune/examples/custom_func_checkpointing.py
@@ -30,10 +30,6 @@ def train_func(config):
         )
 
 
-# You can restore a single trial checkpoint by using
-# ``tune.run(restore=<checkpoint_dir>)`` By doing this, you can change
-# whatever experiments' configuration such as the experiment's name.
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/python/ray/tune/examples/logging_example.py
+++ b/python/ray/tune/examples/logging_example.py
@@ -3,7 +3,7 @@
 import argparse
 import time
 
-from ray import tune
+from ray import air, tune
 from ray.air import session
 from ray.tune.logger import LoggerCallback
 
@@ -52,19 +52,27 @@ if __name__ == "__main__":
 
         ray.init(f"ray://{args.server_address}")
 
-    analysis = tune.run(
+    tuner = tune.Tuner(
         easy_objective,
-        name="hyperband_test",
-        metric="mean_loss",
-        mode="min",
-        num_samples=5,
-        trial_name_creator=trial_str_creator,
-        callbacks=[TestLoggerCallback()],
-        stop={"training_iteration": 1 if args.smoke_test else 100},
-        config={
+        run_config=air.RunConfig(
+            name="hyperband_test",
+            callbacks=[TestLoggerCallback()],
+            stop={"training_iteration": 1 if args.smoke_test else 100},
+        ),
+        tune_config=tune.TuneConfig(
+            metric="mean_loss",
+            mode="min",
+            num_samples=5,
+        ),
+        param_space={
             "steps": 100,
             "width": tune.randint(10, 100),
             "height": tune.loguniform(10, 100),
         },
+        # Warning: This is an internal property and it's possible that this
+        # API will be changed or dropped without warning. Use with caution!
+        _tuner_kwargs={"trial_name_creator": trial_str_creator},
     )
-    print("Best hyperparameters: ", analysis.best_config)
+    results = tuner.fit()
+
+    print("Best hyperparameters: ", results.get_best_result().config)

--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -14,10 +14,9 @@ from ray.tune.examples.mnist_pytorch import train, test, ConvNet,\
     get_data_loaders
 
 import ray
-from ray import tune
+from ray import air, tune
 from ray.tune.schedulers import PopulationBasedTraining
 from ray.tune.utils import validate_save_restore
-from ray.tune.experiment.trial import ExportFormat
 # __tutorial_imports_end__
 
 
@@ -49,14 +48,6 @@ class PytorchTrainable(tune.Trainable):
 
     def load_checkpoint(self, checkpoint_path):
         self.model.load_state_dict(torch.load(checkpoint_path))
-
-    def _export_model(self, export_formats, export_dir):
-        if export_formats == [ExportFormat.MODEL]:
-            path = os.path.join(export_dir, "exported_convnet.pt")
-            torch.save(self.model.state_dict(), path)
-            return {export_formats[0]: path}
-        else:
-            raise ValueError("unexpected formats: " + str(export_formats))
 
     def reset_config(self, new_config):
         for param_group in self.optimizer.param_groups:
@@ -111,28 +102,36 @@ if __name__ == "__main__":
 
     stopper = CustomStopper()
 
-    analysis = tune.run(
+    tuner = tune.Tuner(
         PytorchTrainable,
-        name="pbt_test",
-        scheduler=scheduler,
-        reuse_actors=True,
-        metric="mean_accuracy",
-        mode="max",
-        verbose=1,
-        stop=stopper,
-        export_formats=[ExportFormat.MODEL],
-        checkpoint_score_attr="mean_accuracy",
-        checkpoint_freq=5,
-        keep_checkpoints_num=4,
-        num_samples=4,
-        config={
+        run_config=air.RunConfig(
+            name="pbt_test",
+            stop=stopper,
+            verbose=1,
+            checkpoint_config=air.CheckpointConfig(
+                checkpoint_score_attribute="mean_accuracy",
+                checkpoint_frequency=5,
+                num_to_keep=4,
+            ),
+        ),
+        tune_config=tune.TuneConfig(
+            scheduler=scheduler,
+            metric="mean_accuracy",
+            mode="max",
+            num_samples=4,
+            reuse_actors=True,
+        ),
+        param_space={
             "lr": tune.uniform(0.001, 1),
             "momentum": tune.uniform(0.001, 1),
-        })
+        },
+    )
+    results = tuner.fit()
     # __tune_end__
 
-    best_trial = analysis.best_trial
-    best_checkpoint = analysis.best_checkpoint
+    best_result = results.get_best_result()
+    best_checkpoint = best_result.checkpoint
+
     restored_trainable = PytorchTrainable()
     restored_trainable.restore(best_checkpoint)
     best_model = restored_trainable.model

--- a/python/ray/tune/examples/pbt_dcgan_mnist/common.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/common.py
@@ -267,7 +267,8 @@ def plot_images(dataloader):
 def demo_gan(checkpoint_paths):
     img_list = []
     fixed_noise = torch.randn(64, nz, 1, 1)
-    for netG_path in checkpoint_paths:
+    for path in checkpoint_paths:
+        netG_path = os.path.join(path, "checkpoint.pt")
         loadedG = Generator()
         loadedG.load_state_dict(torch.load(netG_path)["netGmodel"])
         with torch.no_grad():

--- a/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py
@@ -4,8 +4,7 @@ Example of training DCGAN on MNIST using PBT with Tune's Trainable Class
 API.
 """
 import ray
-from ray import tune
-from ray.tune.experiment.trial import ExportFormat
+from ray import air, tune
 from ray.tune.schedulers import PopulationBasedTraining
 
 import argparse
@@ -59,7 +58,7 @@ class PytorchTrainable(tune.Trainable):
         return {"lossg": lossG, "lossd": lossD, "is_score": is_score}
 
     def save_checkpoint(self, checkpoint_dir):
-        path = os.path.join(checkpoint_dir, "checkpoint")
+        path = os.path.join(checkpoint_dir, "checkpoint.pt")
         torch.save(
             {
                 "netDmodel": self.netD.state_dict(),
@@ -90,20 +89,6 @@ class PytorchTrainable(tune.Trainable):
 
         self.config = new_config
         return True
-
-    def _export_model(self, export_formats, export_dir):
-        if export_formats == [ExportFormat.MODEL]:
-            path = os.path.join(export_dir, "exported_models")
-            torch.save(
-                {
-                    "netDmodel": self.netD.state_dict(),
-                    "netGmodel": self.netG.state_dict(),
-                },
-                path,
-            )
-            return {ExportFormat.MODEL: path}
-        else:
-            raise ValueError("unexpected formats: " + str(export_formats))
 
 
 # __Trainable_end__
@@ -154,21 +139,22 @@ if __name__ == "__main__":
     )
 
     tune_iter = 5 if args.smoke_test else 300
-    analysis = tune.run(
+    tuner = tune.Tuner(
         PytorchTrainable,
-        name="pbt_dcgan_mnist",
-        scheduler=scheduler,
-        reuse_actors=True,
-        verbose=1,
-        metric="is_score",
-        mode="max",
-        checkpoint_at_end=True,
-        stop={
-            "training_iteration": tune_iter,
-        },
-        num_samples=8,
-        export_formats=[ExportFormat.MODEL],
-        config={
+        run_config=air.RunConfig(
+            name="pbt_dcgan_mnist",
+            stop={"training_iteration": tune_iter},
+            verbose=1,
+            checkpoint_config=air.CheckpointConfig(checkpoint_at_end=True),
+        ),
+        tune_config=tune.TuneConfig(
+            metric="is_score",
+            mode="max",
+            num_samples=8,
+            scheduler=scheduler,
+            reuse_actors=True,
+        ),
+        param_space={
             "netG_lr": tune.sample_from(
                 lambda spec: random.choice([0.0001, 0.0002, 0.0005])
             ),
@@ -179,10 +165,12 @@ if __name__ == "__main__":
             "data_dir": args.data_dir,
         },
     )
+    results = tuner.fit()
+
+    # export_formats=[ExportFormat.MODEL]
     # __tune_end__
 
     # demo of the trained Generators
     if not args.smoke_test:
-        logdirs = analysis.results_df["logdir"].tolist()
-        model_paths = [os.path.join(d, "exported_models") for d in logdirs]
-        demo_gan(analysis, model_paths)
+        checkpoint_paths = [result.checkpoint.to_directory() for result in results]
+        demo_gan(checkpoint_paths)

--- a/python/ray/tune/examples/xgboost_example.py
+++ b/python/ray/tune/examples/xgboost_example.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
             # If connecting to a remote server with Ray Client, checkpoint loading
             # should be wrapped in a task so it will execute on the server.
             # We have to make sure it gets executed on the same node that
-            # ``tune.run`` is called on.
+            # ``tuner.fit()`` is called on.
             from ray.util.ml_utils.node import force_on_current_node
 
             remote_fn = force_on_current_node(ray.remote(get_best_model_checkpoint))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes the remaining examples in tune/examples to use the Tuner() API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
