### PR TITLE
[air/tune/docs] Change Tuner() occurences in rest of ray/tune

### DIFF
--- a/python/ray/tune/callback.py
+++ b/python/ray/tune/callback.py
@@ -80,7 +80,7 @@ class Callback(metaclass=_CallbackMeta):
 
     .. code-block:: python
 
-        from ray import tune
+        from ray import air, tune
         from ray.tune import Callback
 
 
@@ -94,10 +94,13 @@ class Callback(metaclass=_CallbackMeta):
             for i in range(10):
                 tune.report(metric=i)
 
-
-        tune.run(
+        tuner = tune.Tuner(
             train,
-            callbacks=[MyCallback()])
+            run_config=air.RunConfig(
+                callbacks=[MyCallback()]
+            )
+        )
+        tuner.fit()
 
     """
 
@@ -116,7 +119,7 @@ class Callback(metaclass=_CallbackMeta):
 
         Arguments:
             stop: Stopping criteria.
-                If ``time_budget_s`` was passed to ``tune.run``, a
+                If ``time_budget_s`` was passed to ``air.RunConfig``, a
                 ``TimeoutStopper`` will be passed here, either by itself
                 or as a part of a ``CombinedStopper``.
             num_samples: Number of times to sample from the

--- a/python/ray/tune/execution/placement_groups.py
+++ b/python/ray/tune/execution/placement_groups.py
@@ -67,11 +67,15 @@ class PlacementGroupFactory:
 
         from ray import tune
 
-        tune.run(
-            train,
-            tune.PlacementGroupFactory([
-                {"CPU": 1, "GPU": 0.5, "custom_resource": 2}
-            ]))
+        tuner = tune.Tuner(
+            tune.with_resources(
+                train,
+                resources=tune.PlacementGroupFactory([
+                    {"CPU": 1, "GPU": 0.5, "custom_resource": 2}
+                ])
+            )
+        )
+        tuner.fit()
 
     If the trial itself schedules further remote workers, the resource
     requirements should be specified in additional bundles. You can also
@@ -82,13 +86,17 @@ class PlacementGroupFactory:
 
         from ray import tune
 
-        tune.run(
-            train,
-            resources_per_trial=tune.PlacementGroupFactory([
-                {"CPU": 1, "GPU": 0.5, "custom_resource": 2},
-                {"CPU": 2},
-                {"CPU": 2},
-            ], strategy="PACK"))
+        tuner = tune.Tuner(
+            tune.with_resources(
+                train,
+                resources=tune.PlacementGroupFactory([
+                    {"CPU": 1, "GPU": 0.5, "custom_resource": 2},
+                    {"CPU": 2},
+                    {"CPU": 2},
+                ], strategy="PACK")
+            )
+        )
+        tuner.fit()
 
     The example above will reserve 1 CPU, 0.5 GPUs and 2 custom_resources
     for the trainable itself, and reserve another 2 bundles of 2 CPUs each.
@@ -103,13 +111,17 @@ class PlacementGroupFactory:
 
         from ray import tune
 
-        tune.run(
-            train,
-            resources_per_trial=tune.PlacementGroupFactory([
-                {},
-                {"CPU": 2},
-                {"CPU": 2},
-            ], strategy="PACK"))
+        tuner = tune.Tuner(
+            tune.with_resources(
+                train,
+                resources=tune.PlacementGroupFactory([
+                    {},
+                    {"CPU": 2},
+                    {"CPU": 2},
+                ], strategy="PACK")
+            )
+        )
+        tuner.fit()
 
     Args:
         bundles(List[Dict]): A list of bundles which

--- a/python/ray/tune/execution/ray_trial_executor.py
+++ b/python/ray/tune/execution/ray_trial_executor.py
@@ -422,7 +422,7 @@ class RayTrialExecutor:
                 if log_once("trial_executor_buffer_checkpoint"):
                     logger.warning(
                         "Disabling buffered training as you passed "
-                        "`checkpoint_at_end` to `tune.run()`."
+                        "`checkpoint_at_end` to `air.CheckpointConfig()`."
                     )
                 buffer_length = 1
 

--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -602,7 +602,7 @@ class TrialRunner:
                     f'a new experiment, use `resume="AUTO"` or '
                     f"`resume=None`. If you expected an experiment to "
                     f"already exist, check if you supplied the correct "
-                    f"`local_dir` to `tune.run()`."
+                    f"`local_dir` to `air.RunConfig()`."
                 )
             elif resume_type == "PROMPT":
                 if click.confirm(
@@ -621,7 +621,7 @@ class TrialRunner:
                     "Called resume from remote without remote directory or "
                     "without valid syncer. "
                     "Fix this by passing a `SyncConfig` object with "
-                    "`upload_dir` set to `tune.run(sync_config=...)`."
+                    "`upload_dir` set to `Tuner(sync_config=...)`."
                 )
 
             # Try syncing down the upload directory.
@@ -649,7 +649,7 @@ class TrialRunner:
                     "`resume=None`. If you expected an experiment to "
                     "already exist, check if you supplied the correct "
                     "`upload_dir` to the `tune.SyncConfig` passed to "
-                    "`tune.run()`."
+                    "`Tuner()`."
                 ) from e
 
             if not self.checkpoint_exists(self._local_checkpoint_dir):
@@ -1155,7 +1155,7 @@ class TrialRunner:
 
             if base_metric and base_metric not in result:
                 report_metric = base_metric
-                location = "tune.run()"
+                location = "tune.TuneConfig()"
             elif scheduler_metric and scheduler_metric not in result:
                 report_metric = scheduler_metric
                 location = type(self._scheduler_alg).__name__

--- a/python/ray/tune/execution/trial_runner.py
+++ b/python/ray/tune/execution/trial_runner.py
@@ -649,7 +649,7 @@ class TrialRunner:
                     "`resume=None`. If you expected an experiment to "
                     "already exist, check if you supplied the correct "
                     "`upload_dir` to the `tune.SyncConfig` passed to "
-                    "`Tuner()`."
+                    "`tune.Tuner()`."
                 ) from e
 
             if not self.checkpoint_exists(self._local_checkpoint_dir):

--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 def _validate_log_to_file(log_to_file):
-    """Validate ``tune.run``'s ``log_to_file`` parameter. Return
+    """Validate ``air.RunConfig``'s ``log_to_file`` parameter. Return
     validated relative stdout and stderr filenames."""
     if not log_to_file:
         stdout_file = stderr_file = None
@@ -198,7 +198,7 @@ class Experiment:
                 stopper_types = [type(s) for s in stop]
                 raise ValueError(
                     "If you pass a list as the `stop` argument to "
-                    "`tune.run()`, each element must be an instance of "
+                    "`air.RunConfig()`, each element must be an instance of "
                     f"`tune.stopper.Stopper`. Got {stopper_types}."
                 )
             self._stopper = CombinedStopper(*stop)

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -213,12 +213,12 @@ class Trial:
         trainable_name: Name of the trainable object to be executed.
         config: Provided configuration dictionary with evaluated params.
         trial_id: Unique identifier for the trial.
-        local_dir: ``local_dir`` as passed to ``tune.run`` joined
+        local_dir: ``local_dir`` as passed to ``air.RunConfig()`` joined
             with the name of the experiment.
         logdir: Directory where the trial logs are saved.
         relative_logdir: Same as ``logdir``, but relative to the parent of
             the ``local_dir`` (equal to ``local_dir`` argument passed
-            to ``tune.run``).
+            to ``air.RunConfig()``).
         evaluated_params: Evaluated parameters by search algorithm,
         experiment_tag: Identifying trial name to show in the console
         status: One of PENDING, RUNNING, PAUSED, TERMINATED, ERROR/

--- a/python/ray/tune/integration/mlflow.py
+++ b/python/ray/tune/integration/mlflow.py
@@ -72,7 +72,7 @@ def mlflow_mixin(func: Callable):
             xgboost_results = xgb.train(config, ...)
 
     The MlFlow configuration is done by passing a ``mlflow`` key to
-    the ``config`` parameter of ``tune.run()`` (see example below).
+    the ``config`` parameter of ``Tuner()`` (see example below).
 
     The content of the ``mlflow`` config entry is used to
     configure MlFlow. Here are the keys you can pass in to this config entry:
@@ -82,12 +82,12 @@ def mlflow_mixin(func: Callable):
             Tune in a multi-node setting, make sure to use a remote server for
             tracking.
         experiment_id: The id of an already created MLflow experiment.
-            All logs from all trials in ``tune.run`` will be reported to this
+            All logs from all trials in ``Tuner()`` will be reported to this
             experiment. If this is not provided or the experiment with this
             id does not exist, you must provide an``experiment_name``. This
             parameter takes precedence over ``experiment_name``.
         experiment_name: The name of an already existing MLflow
-            experiment. All logs from all trials in ``tune.run`` will be
+            experiment. All logs from all trials in ``Tuner()`` will be
             reported to this experiment. If this is not provided, you must
             provide a valid ``experiment_id``.
         token: A token to use for HTTP authentication when
@@ -115,9 +115,9 @@ def mlflow_mixin(func: Callable):
                 mlflow.log_metric(key="loss", value=loss)
             tune.report(loss=loss, done=True)
 
-        tune.run(
+        tuner = tune.Tuner(
             train_fn,
-            config={
+            param_space={
                 # define search space here
                 "a": tune.choice([1, 2, 3]),
                 "b": tune.choice([4, 5, 6]),
@@ -127,6 +127,9 @@ def mlflow_mixin(func: Callable):
                     "tracking_uri": mlflow.get_tracking_uri()
                 }
             })
+
+        tuner.fit()
+
     """
     if ray.util.client.ray.is_connected():
         logger.warning(

--- a/python/ray/tune/integration/mlflow.py
+++ b/python/ray/tune/integration/mlflow.py
@@ -72,7 +72,7 @@ def mlflow_mixin(func: Callable):
             xgboost_results = xgb.train(config, ...)
 
     The MlFlow configuration is done by passing a ``mlflow`` key to
-    the ``config`` parameter of ``Tuner()`` (see example below).
+    the ``config`` parameter of ``tune.Tuner()`` (see example below).
 
     The content of the ``mlflow`` config entry is used to
     configure MlFlow. Here are the keys you can pass in to this config entry:
@@ -82,12 +82,12 @@ def mlflow_mixin(func: Callable):
             Tune in a multi-node setting, make sure to use a remote server for
             tracking.
         experiment_id: The id of an already created MLflow experiment.
-            All logs from all trials in ``Tuner()`` will be reported to this
+            All logs from all trials in ``tune.Tuner()`` will be reported to this
             experiment. If this is not provided or the experiment with this
             id does not exist, you must provide an``experiment_name``. This
             parameter takes precedence over ``experiment_name``.
         experiment_name: The name of an already existing MLflow
-            experiment. All logs from all trials in ``Tuner()`` will be
+            experiment. All logs from all trials in ``tune.Tuner()`` will be
             reported to this experiment. If this is not provided, you must
             provide a valid ``experiment_id``.
         token: A token to use for HTTP authentication when

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -72,7 +72,7 @@ def wandb_mixin(func: Callable):
 
 
     Wandb configuration is done by passing a ``wandb`` key to
-    the ``param_space`` parameter of ``Tuner()`` (see example below).
+    the ``param_space`` parameter of ``tune.Tuner()`` (see example below).
 
     The content of the ``wandb`` config entry is passed to ``wandb.init()``
     as keyword arguments. The exception are the following settings, which

--- a/python/ray/tune/integration/wandb.py
+++ b/python/ray/tune/integration/wandb.py
@@ -72,7 +72,7 @@ def wandb_mixin(func: Callable):
 
 
     Wandb configuration is done by passing a ``wandb`` key to
-    the ``config`` parameter of ``tune.run()`` (see example below).
+    the ``param_space`` parameter of ``Tuner()`` (see example below).
 
     The content of the ``wandb`` config entry is passed to ``wandb.init()``
     as keyword arguments. The exception are the following settings, which
@@ -104,9 +104,9 @@ def wandb_mixin(func: Callable):
                 wandb.log({"loss": loss})
             tune.report(loss=loss, done=True)
 
-        tune.run(
+        tuner = tune.Tuner(
             train_fn,
-            config={
+            param_space={
                 # define search space here
                 "a": tune.choice([1, 2, 3]),
                 "b": tune.choice([4, 5, 6]),
@@ -116,6 +116,7 @@ def wandb_mixin(func: Callable):
                     "api_key_file": "/path/to/file"
                 }
             })
+        tuner.fit()
 
     """
     if hasattr(func, "__mixins__"):

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -225,10 +225,10 @@ class TuneReporterBase(ProgressReporter):
     def set_search_properties(self, metric: Optional[str], mode: Optional[str]):
         if (self._metric and metric) or (self._mode and mode):
             raise ValueError(
-                "You passed a `metric` or `mode` argument to `tune.run()`, but "
+                "You passed a `metric` or `mode` argument to `tune.TuneConfig()`, but "
                 "the reporter you are using was already instantiated with their "
                 "own `metric` and `mode` parameters. Either remove the arguments "
-                "from your reporter or from your call to `tune.run()`"
+                "from your reporter or from your call to `tune.TuneConfig()`"
             )
 
         if metric:
@@ -528,7 +528,7 @@ class JupyterNotebookReporter(TuneReporterBase, RemoteReporterMixin):
                 "If this leads to unformatted output (e.g. like "
                 "<IPython.core.display.HTML object>), consider passing "
                 "a `CLIReporter` as the `progress_reporter` argument "
-                "to `tune.run()` instead."
+                "to `air.RunConfig()` instead."
             )
 
         self._overwrite = overwrite

--- a/python/ray/tune/schedulers/async_hyperband.py
+++ b/python/ray/tune/schedulers/async_hyperband.py
@@ -124,7 +124,7 @@ class AsyncHyperBandScheduler(FIFOScheduler):
                 "{} has been instantiated without a valid `metric` ({}) or "
                 "`mode` ({}) parameter. Either pass these parameters when "
                 "instantiating the scheduler, or pass them as parameters "
-                "to `tune.run()`".format(
+                "to `tune.TuneConfig()`".format(
                     self.__class__.__name__, self._metric, self._mode
                 )
             )

--- a/python/ray/tune/schedulers/hb_bohb.py
+++ b/python/ray/tune/schedulers/hb_bohb.py
@@ -39,7 +39,7 @@ class HyperBandForBOHB(HyperBandScheduler):
                 "{} has been instantiated without a valid `metric` ({}) or "
                 "`mode` ({}) parameter. Either pass these parameters when "
                 "instantiating the scheduler, or pass them as parameters "
-                "to `tune.run()`".format(
+                "to `tune.TuneConfig()`".format(
                     self.__class__.__name__, self._metric, self._mode
                 )
             )

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -158,7 +158,7 @@ class HyperBandScheduler(FIFOScheduler):
                 "{} has been instantiated without a valid `metric` ({}) or "
                 "`mode` ({}) parameter. Either pass these parameters when "
                 "instantiating the scheduler, or pass them as parameters "
-                "to `tune.run()`".format(
+                "to `tune.TuneConfig()`".format(
                     self.__class__.__name__, self._metric, self._mode
                 )
             )

--- a/python/ray/tune/schedulers/median_stopping_rule.py
+++ b/python/ray/tune/schedulers/median_stopping_rule.py
@@ -103,7 +103,7 @@ class MedianStoppingRule(FIFOScheduler):
                 "{} has been instantiated without a valid `metric` ({}) or "
                 "`mode` ({}) parameter. Either pass these parameters when "
                 "instantiating the scheduler, or pass them as parameters "
-                "to `tune.run()`".format(
+                "to `tune.TuneConfig()`".format(
                     self.__class__.__name__, self._metric, self._mode
                 )
             )

--- a/python/ray/tune/schedulers/pb2.py
+++ b/python/ray/tune/schedulers/pb2.py
@@ -276,7 +276,7 @@ class PB2(PopulationBasedTraining):
         ...     hyperparam_bounds={
         ...     "factor": [0.0, 20.0],
         ... })
-        >>> tuner = tune.Tuner(
+        >>> tuner = tune.Tuner(  # doctest: +SKIP
         ...     pbt_function,
         ...     tune_config=tune.TuneConfig(
         ...         scheduler=pb2,

--- a/python/ray/tune/schedulers/pb2.py
+++ b/python/ray/tune/schedulers/pb2.py
@@ -222,7 +222,7 @@ class PB2(PopulationBasedTraining):
     It considers all trials added as part of the PB2 population. If the number
     of trials exceeds the cluster capacity, they will be time-multiplexed as to
     balance training progress across the population. To run multiple trials,
-    use `tune.run(num_samples=<int>)`.
+    use `tune.TuneConfig(num_samples=<int>)`.
 
     In {LOG_DIR}/{MY_EXPERIMENT_NAME}/, all mutations are logged in
     `pb2_global.txt` and individual policy perturbations are recorded
@@ -276,9 +276,16 @@ class PB2(PopulationBasedTraining):
         ...     hyperparam_bounds={
         ...     "factor": [0.0, 20.0],
         ... })
-        >>> tune.run( # doctest: +SKIP
-        ...     pbt_function, config={"lr": 0.0001}, num_samples=8, scheduler=pb2
+        >>> tuner = tune.Tuner(
+        ...     pbt_function,
+        ...     tune_config=tune.TuneConfig(
+        ...         scheduler=pb2,
+        ...         num_samples=8,
+        ...     ),
+        ...     param_space={"lr": 0.0001}
         ... )
+        >>> tuner.fit()  # doctest: +SKIP
+
     """
 
     def __init__(

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -144,7 +144,7 @@ class PopulationBasedTraining(FIFOScheduler):
     This Tune PBT implementation considers all trials added as part of the
     PBT population. If the number of trials exceeds the cluster capacity,
     they will be time-multiplexed as to balance training progress across the
-    population. To run multiple trials, use `tune.run(num_samples=<int>)`.
+    population. To run multiple trials, use `tune.TuneConfig(num_samples=<int>)`.
 
     In {LOG_DIR}/{MY_EXPERIMENT_NAME}/, all mutations are logged in
     `pbt_global.txt` and individual policy perturbations are recorded
@@ -236,7 +236,15 @@ class PopulationBasedTraining(FIFOScheduler):
                 # factor_4 is treated as a continuous hyperparameter.
                 "factor_4": tune.choice([1, 10, 100, 1000, 10000]),
             })
-        tune.run({...}, num_samples=8, scheduler=pbt)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                scheduler=pbt,
+                num_samples=8,
+            ),
+        )
+        tuner.fit()
+
     """
 
     def __init__(
@@ -359,7 +367,7 @@ class PopulationBasedTraining(FIFOScheduler):
                 "{} has been instantiated without a valid `metric` ({}) or "
                 "`mode` ({}) parameter. Either pass these parameters when "
                 "instantiating the scheduler, or pass them as parameters "
-                "to `tune.run()`".format(
+                "to `tune.TuneConfig()`".format(
                     self.__class__.__name__, self._metric, self._mode
                 )
             )
@@ -758,7 +766,7 @@ class PopulationBasedTrainingReplay(FIFOScheduler):
     .. code-block:: python
 
         # Replaying a result from ray.tune.examples.pbt_convnet_example
-        from ray import tune
+        from ray import air, tune
 
         from ray.tune.examples.pbt_convnet_example import PytorchTrainable
         from ray.tune.schedulers import PopulationBasedTrainingReplay
@@ -766,10 +774,16 @@ class PopulationBasedTrainingReplay(FIFOScheduler):
         replay = PopulationBasedTrainingReplay(
             "~/ray_results/pbt_test/pbt_policy_XXXXX_00001.txt")
 
-        tune.run(
+        tuner = tune.Tuner(
             PytorchTrainable,
-            scheduler=replay,
-            stop={"training_iteration": 100})
+            run_config=air.RunConfig(
+                stop={"training_iteration": 100}
+            ),
+            tune_config=tune.TuneConfig(
+                scheduler=replay,
+            ),
+        )
+        tuner.fit()
 
 
     """
@@ -844,7 +858,7 @@ class PopulationBasedTrainingReplay(FIFOScheduler):
         elif not self._trial.config and not self._policy:
             raise ValueError(
                 "No replay policy found and trial initialized without a "
-                "valid config. Either pass a `config` argument to `tune.run()`"
+                "valid config. Either pass a `config` argument to `tune.Tuner()`"
                 "or consider not using PBT replay for this run."
             )
         self._trial.set_config(self.config)

--- a/python/ray/tune/schedulers/resource_changing_scheduler.py
+++ b/python/ray/tune/schedulers/resource_changing_scheduler.py
@@ -537,7 +537,7 @@ class DistributeResourcesToTopJob(DistributeResources):
             raise ValueError(
                 "The metric parameter cannot be None. The parameter can be set in "
                 "either `DistributeResourcesToTopJob`, the base scheduler or in "
-                "`tune.run` (highest to lowest priority)."
+                "`tune.TuneConfig()` (highest to lowest priority)."
             )
 
         free_cpus = total_available_cpus - used_cpus
@@ -608,7 +608,7 @@ class ResourceChangingScheduler(TrialScheduler):
     If the Trainable (class) API is used, you can obtain the current trial
     resources through the ``Trainable.trial_resources`` property.
 
-    Cannot be used if ``reuse_actors`` is True in ``tune.run``. A ValueError
+    Cannot be used if ``reuse_actors`` is True in ``tune.TuneConfig()``. A ValueError
     will be raised in that case.
 
     Args:
@@ -771,7 +771,7 @@ class ResourceChangingScheduler(TrialScheduler):
             raise ValueError(
                 "ResourceChangingScheduler cannot be used with "
                 "`reuse_actors=True`. FIX THIS by setting "
-                "`reuse_actors=False` in `tune.run`."
+                "`reuse_actors=False` in `tune.TuneConfig()`."
             )
 
         any_resources_changed = False

--- a/python/ray/tune/search/__init__.py
+++ b/python/ray/tune/search/__init__.py
@@ -155,22 +155,22 @@ UNRESOLVED_SEARCH_SPACE = str(
     "You passed a `{par}` parameter to {cls} that contained unresolved search "
     "space definitions. {cls} should however be instantiated with fully "
     "configured search spaces only. To use Ray Tune's automatic search space "
-    "conversion, pass the space definition as part of the `config` argument "
-    "to `tune.run()` instead."
+    "conversion, pass the space definition as part of the `param_space` argument "
+    "to `tune.Tuner()` instead."
 )
 
 UNDEFINED_SEARCH_SPACE = str(
     "Trying to sample a configuration from {cls}, but no search "
     "space has been defined. Either pass the `{space}` argument when "
-    "instantiating the search algorithm, or pass a `config` to "
-    "`tune.run()`."
+    "instantiating the search algorithm, or pass a `param_space` to "
+    "`tune.Tuner()`."
 )
 
 UNDEFINED_METRIC_MODE = str(
     "Trying to sample a configuration from {cls}, but the `metric` "
     "({metric}) or `mode` ({mode}) parameters have not been set. "
     "Either pass these arguments when instantiating the search algorithm, "
-    "or pass them to `tune.run()`."
+    "or pass them to `tune.TuneConfig()`."
 )
 
 

--- a/python/ray/tune/search/ax/ax_search.py
+++ b/python/ray/tune/search/ax/ax_search.py
@@ -100,10 +100,14 @@ class AxSearch(Searcher):
                 tune.report(score=intermediate_result)
 
         ax_search = AxSearch(metric="score")
-        tune.run(
-            config=config,
+        tuner = tune.Tuner(
             easy_objective,
-            search_alg=ax_search)
+            tune_config=tune.TuneConfig(
+                search_alg=ax_search,
+            ),
+            param_space=config,
+        )
+        tuner.fit()
 
     If you would like to pass the search space manually, the code would
     look like this:
@@ -124,7 +128,13 @@ class AxSearch(Searcher):
                 tune.report(score=intermediate_result)
 
         ax_search = AxSearch(space=parameters, metric="score")
-        tune.run(easy_objective, search_alg=ax_search)
+        tuner = tune.Tuner(
+            easy_objective,
+            tune_config=tune.TuneConfig(
+                search_alg=ax_search,
+            ),
+        )
+        tuner.fit()
 
     """
 
@@ -196,12 +206,12 @@ class AxSearch(Searcher):
                     "You have to create an Ax experiment by calling "
                     "`AxClient.create_experiment()`, or you should pass an "
                     "Ax search space as the `space` parameter to `AxSearch`, "
-                    "or pass a `config` dict to `tune.run()`."
+                    "or pass a `param_space` dict to `tune.Tuner()`."
                 )
             if self._mode not in ["min", "max"]:
                 raise ValueError(
                     "Please specify the `mode` argument when initializing "
-                    "the `AxSearch` object or pass it to `tune.run()`."
+                    "the `AxSearch` object or pass it to `tune.TuneConfig()`."
                 )
             self._ax.create_experiment(
                 parameters=self._space,

--- a/python/ray/tune/search/bayesopt/bayesopt_search.py
+++ b/python/ray/tune/search/bayesopt/bayesopt_search.py
@@ -95,7 +95,14 @@ class BayesOptSearch(Searcher):
         }
 
         bayesopt = BayesOptSearch(metric="mean_loss", mode="min")
-        tune.run(my_func, config=config, search_alg=bayesopt)
+        tuner = tune.Tuner(
+            my_func,
+            tune_config=tune.TuneConfig(
+                search_alg=baysopt,
+            ),
+            param_space=config,
+        )
+        tuner.fit()
 
     If you would like to pass the search space manually, the code would
     look like this:
@@ -110,7 +117,13 @@ class BayesOptSearch(Searcher):
             'height': (-100, 100),
         }
         bayesopt = BayesOptSearch(space, metric="mean_loss", mode="min")
-        tune.run(my_func, search_alg=bayesopt)
+        tuner = tune.Tuner(
+            my_func,
+            tune_config=tune.TuneConfig(
+                search_alg=bayesopt,
+            ),
+        )
+        tuner.fit()
 
     """
 

--- a/python/ray/tune/search/concurrency_limiter.py
+++ b/python/ray/tune/search/concurrency_limiter.py
@@ -36,7 +36,13 @@ class ConcurrencyLimiter(Searcher):
         from ray.tune.search import ConcurrencyLimiter
         search_alg = HyperOptSearch(metric="accuracy")
         search_alg = ConcurrencyLimiter(search_alg, max_concurrent=2)
-        tune.run(trainable, search_alg=search_alg)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=search_alg
+            ),
+        )
+        tuner.fit()
     """
 
     def __init__(self, searcher: Searcher, max_concurrent: int, batch: bool = False):

--- a/python/ray/tune/search/dragonfly/dragonfly_search.py
+++ b/python/ray/tune/search/dragonfly/dragonfly_search.py
@@ -68,7 +68,7 @@ class DragonflySearch(Searcher):
         space: Search space. Should only be set if you don't pass
             an optimizer as the `optimizer` argument. Defines the search space
             and requires a `domain` to be set. Can be automatically converted
-            from the `config` dict passed to `tune.run()`.
+            from the `param_space` dict passed to `tune.Tuner()`.
         metric: The training result objective value attribute. If None
             but a mode was passed, the anonymous metric `_metric` will be used
             per default.
@@ -109,7 +109,14 @@ class DragonflySearch(Searcher):
             metric="objective",
             mode="max")
 
-        tune.run(my_func, config=config, search_alg=df_search)
+        tuner = tune.Tuner(
+            my_func,
+            tune_config=tune.TuneConfig(
+                search_alg=df_search
+            ),
+            param_space=config
+        )
+        tuner.fit()
 
     If you would like to pass the search space/optimizer manually,
     the code would look like this:
@@ -142,7 +149,13 @@ class DragonflySearch(Searcher):
             metric="objective",
             mode="max")
 
-        tune.run(my_func, search_alg=df_search)
+        tuner = tune.Tuner(
+            my_func,
+            tune_config=tune.TuneConfig(
+                search_alg=df_search
+            ),
+        )
+        tuner.fit()
 
     """
 
@@ -225,8 +238,8 @@ class DragonflySearch(Searcher):
         if not self._space:
             raise ValueError(
                 "You have to pass a `space` when initializing dragonfly, or "
-                "pass a search space definition to the `config` parameter "
-                "of `tune.run()`."
+                "pass a search space definition to the `param_space` parameter "
+                "of `tune.Tuner()`."
             )
 
         if not self._domain:

--- a/python/ray/tune/search/hebo/hebo_search.py
+++ b/python/ray/tune/search/hebo/hebo_search.py
@@ -101,7 +101,14 @@ class HEBOSearch(Searcher):
         }
 
         hebo = HEBOSearch(metric="mean_loss", mode="min")
-        tune.run(my_func, config=config, search_alg=hebo)
+        tuner = tune.Tuner(
+            trainable_function,
+            tune_config=tune.TuneConfig(
+                search_alg=hebo
+            ),
+            param_space=config
+        )
+        tuner.fit()
 
     Alternatively, you can pass a HEBO `DesignSpace` object manually to the
     Searcher:
@@ -119,7 +126,13 @@ class HEBOSearch(Searcher):
         space = DesignSpace().parse(space_config)
 
         hebo = HEBOSearch(space, metric="mean_loss", mode="min")
-        tune.run(my_func, search_alg=hebo)
+        tuner = tune.Tuner(
+            trainable_function,
+            tune_config=tune.TuneConfig(
+                search_alg=hebo
+            )
+        )
+        tuner.fit()
 
     """
 
@@ -205,7 +218,7 @@ class HEBOSearch(Searcher):
             raise ValueError(
                 f"Invalid search space: {type(self._space)}. Either pass a "
                 f"valid search space to the `HEBOSearch` class or pass "
-                f"a `config` parameter to `tune.run()`"
+                f"a `param_space` parameter to `tune.Tuner()`"
             )
 
         if self._space.num_paras <= 0:

--- a/python/ray/tune/search/hyperopt/hyperopt_search.py
+++ b/python/ray/tune/search/hyperopt/hyperopt_search.py
@@ -101,7 +101,14 @@ class HyperOptSearch(Searcher):
             metric="mean_loss", mode="min",
             points_to_evaluate=current_best_params)
 
-        tune.run(trainable, config=config, search_alg=hyperopt_search)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=hyperopt_search
+            ),
+            param_space=config
+        )
+        tuner.fit()
 
     If you would like to pass the search space manually, the code would
     look like this:
@@ -124,8 +131,13 @@ class HyperOptSearch(Searcher):
             space, metric="mean_loss", mode="min",
             points_to_evaluate=current_best_params)
 
-        tune.run(trainable, search_alg=hyperopt_search)
-
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=hyperopt_search
+            ),
+        )
+        tuner.fit()
 
     """
 

--- a/python/ray/tune/search/optuna/optuna_search.py
+++ b/python/ray/tune/search/optuna/optuna_search.py
@@ -101,7 +101,7 @@ class OptunaSearch(Searcher):
             .. warning::
                 No actual computation should take place in the define-by-run
                 function. Instead, put the training logic inside the function
-                or class trainable passed to ``tune.run``.
+                or class trainable passed to ``tune.Tuner()``.
 
         metric: The training result objective value attribute. If
             None but a mode was passed, the anonymous metric ``_metric``
@@ -162,7 +162,14 @@ class OptunaSearch(Searcher):
             metric="loss",
             mode="min")
 
-        tune.run(trainable, config=config, search_alg=optuna_search)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=optuna_search,
+            ),
+            param_space=config,
+        )
+        tuner.fit()
 
     If you would like to pass the search space manually, the code would
     look like this:
@@ -182,7 +189,13 @@ class OptunaSearch(Searcher):
             metric="loss",
             mode="min")
 
-        tune.run(trainable, search_alg=optuna_search)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=optuna_search,
+            ),
+        )
+        tuner.fit()
 
         # Equivalent Optuna define-by-run function approach:
 
@@ -197,7 +210,13 @@ class OptunaSearch(Searcher):
             metric="loss",
             mode="min")
 
-        tune.run(trainable, search_alg=optuna_search)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=optuna_search,
+            ),
+        )
+        tuner.fit()
 
     Multi-objective optimization is supported:
 
@@ -212,17 +231,20 @@ class OptunaSearch(Searcher):
         }
 
         # Note you have to specify metric and mode here instead of
-        # in tune.run
+        # in tune.TuneConfig
         optuna_search = OptunaSearch(
             space,
             metric=["loss1", "loss2"],
             mode=["min", "max"])
 
         # Do not specify metric and mode here!
-        tune.run(
+        tuner = tune.Tuner(
             trainable,
-            search_alg=optuna_search
+            tune_config=tune.TuneConfig(
+                search_alg=optuna_search,
+            ),
         )
+        tuner.fit()
 
     You can pass configs that will be evaluated first using
     ``points_to_evaluate``:
@@ -243,7 +265,13 @@ class OptunaSearch(Searcher):
             metric="loss",
             mode="min")
 
-        tune.run(trainable, search_alg=optuna_search)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=optuna_search,
+            ),
+        )
+        tuner.fit()
 
     Avoid re-running evaluated trials by passing the rewards together with
     `points_to_evaluate`:
@@ -265,7 +293,13 @@ class OptunaSearch(Searcher):
             metric="loss",
             mode="min")
 
-        tune.run(trainable, search_alg=optuna_search)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=optuna_search,
+            ),
+        )
+        tuner.fit()
 
     .. versionadded:: 0.8.8
 
@@ -418,7 +452,7 @@ class OptunaSearch(Searcher):
                 f"took {time_taken} seconds to "
                 "run. Ensure that actual computation, training takes "
                 "place inside Tune's train functions or Trainables "
-                "passed to `tune.run`."
+                "passed to `tune.Tuner()`."
             )
         if ret is not None:
             if not isinstance(ret, dict):
@@ -541,7 +575,7 @@ class OptunaSearch(Searcher):
                 "Define-by-run function passed in `space` argument is not "
                 "yet supported when using `evaluated_rewards`. Please provide "
                 "an `OptunaDistribution` dict or pass a Ray Tune "
-                "search space to `tune.run()`."
+                "search space to `tune.Tuner()`."
             )
 
         ot_trial_state = OptunaTrialState.COMPLETE

--- a/python/ray/tune/search/repeater.py
+++ b/python/ray/tune/search/repeater.py
@@ -75,7 +75,7 @@ class _TrialGroup:
 class Repeater(Searcher):
     """A wrapper algorithm for repeating trials of same parameters.
 
-    Set tune.run(num_samples=...) to be a multiple of `repeat`. For example,
+    Set tune.TuneConfig(num_samples=...) to be a multiple of `repeat`. For example,
     set num_samples=15 if you intend to obtain 3 search algorithm suggestions
     and repeat each suggestion 5 times. Any leftover trials
     (num_samples mod repeat) will be ignored.
@@ -105,7 +105,14 @@ class Repeater(Searcher):
         re_search_alg = Repeater(search_alg, repeat=10)
 
         # Repeat 2 samples 10 times each.
-        tune.run(trainable, num_samples=20, search_alg=re_search_alg)
+        tuner = tune.Tuner(
+            trainable,
+            tune_config=tune.TuneConfig(
+                search_alg=re_search_alg,
+                num_samples=20,
+            ),
+        )
+        tuner.fit()
 
     """
 

--- a/python/ray/tune/search/searcher.py
+++ b/python/ray/tune/search/searcher.py
@@ -57,7 +57,13 @@ class Searcher:
                 if result and self.metric in result:
                     self.optimizer.update(configuration, result[self.metric])
 
-        tune.run(trainable_function, search_alg=ExampleSearch())
+        tuner = tune.Tuner(
+            trainable_function,
+            tune_config=tune.TuneConfig(
+                search_alg=ExampleSearch()
+            )
+        )
+        tuner.fit()
 
 
     """
@@ -275,18 +281,21 @@ class Searcher:
 
             search_alg = Searcher(...)
 
-            analysis = tune.run(
+            tuner = tune.Tuner(
                 cost,
-                num_samples=5,
-                search_alg=search_alg,
-                name=self.experiment_name,
-                local_dir=self.tmpdir)
+                tune_config=tune.TuneConfig(
+                    search_alg=search_alg,
+                    num_samples=5
+                ),
+                param_space=config
+            )
+            results = tuner.fit()
 
             search_alg.save("./my_favorite_path.pkl")
 
         .. versionchanged:: 0.8.7
-            Save is automatically called by `tune.run`. You can use
-            `restore_from_dir` to restore from an experiment directory
+            Save is automatically called by `Tuner().fit()`. You can use
+            `Tuner().restore()` to restore from an experiment directory
             such as `~/ray_results/trainable`.
 
         """
@@ -310,7 +319,14 @@ class Searcher:
             search_alg2 = Searcher(...)
             search_alg2 = ConcurrencyLimiter(search_alg2, 1)
             search_alg2.restore(checkpoint_path)
-            tune.run(cost, num_samples=5, search_alg=search_alg2)
+            tuner = tune.Tuner(
+                cost,
+                tune_config=tune.TuneConfig(
+                    search_alg=search_alg2,
+                    num_samples=5
+                ),
+            )
+            tuner.fit()
 
         """
         raise NotImplementedError
@@ -340,7 +356,7 @@ class Searcher:
     def save_to_dir(self, checkpoint_dir: str, session_str: str = "default"):
         """Automatically saves the given searcher to the checkpoint_dir.
 
-        This is automatically used by tune.run during a Tune job.
+        This is automatically used by Tuner().fit() during a Tune job.
 
         Args:
             checkpoint_dir: Filepath to experiment dir.
@@ -370,13 +386,19 @@ class Searcher:
 
         .. code-block:: python
 
-            experiment_1 = tune.run(
+            tuner = tune.Tuner(
                 cost,
-                num_samples=5,
-                search_alg=search_alg,
-                verbose=0,
-                name=self.experiment_name,
-                local_dir="~/my_results")
+                run_config=air.RunConfig(
+                    name=self.experiment_name,
+                    local_dir="~/my_results",
+                ),
+                tune_config=tune.TuneConfig(
+                    search_alg=search_alg,
+                    num_samples=5
+                ),
+                param_space=config
+            )
+            tuner.fit()
 
             search_alg2 = Searcher()
             search_alg2.restore_from_dir(
@@ -429,7 +451,14 @@ class ConcurrencyLimiter(Searcher):
         from ray.tune.search import ConcurrencyLimiter
         search_alg = HyperOptSearch(metric="accuracy")
         search_alg = ConcurrencyLimiter(search_alg, max_concurrent=2)
-        tune.run(trainable, search_alg=search_alg)
+        tuner = tune.Tuner(
+            trainable_function,
+            tune_config=tune.TuneConfig(
+                search_alg=search_alg
+            ),
+        )
+        tuner.fit()
+
     """
 
     def __init__(self, searcher: Searcher, max_concurrent: int, batch: bool = False):

--- a/python/ray/tune/search/skopt/skopt_search.py
+++ b/python/ray/tune/search/skopt/skopt_search.py
@@ -101,7 +101,14 @@ class SkOptSearch(Searcher):
             mode="min",
             points_to_evaluate=current_best_params)
 
-        tune.run(my_trainable, config=config, search_alg=skopt_search)
+        tuner = tune.Tuner(
+            trainable_function,
+            tune_config=tune.TuneConfig(
+                search_alg=skopt_search
+            ),
+            param_space=config
+        )
+        tuner.fit()
 
     If you would like to pass the search space/optimizer manually,
     the code would look like this:
@@ -119,7 +126,13 @@ class SkOptSearch(Searcher):
             mode="min",
             points_to_evaluate=current_best_params)
 
-        tune.run(my_trainable, search_alg=skopt_search)
+        tuner = tune.Tuner(
+            trainable_function,
+            tune_config=tune.TuneConfig(
+                search_alg=skopt_search
+            ),
+        )
+        tuner.fit()
 
     """
 

--- a/python/ray/tune/search/variant_generator.py
+++ b/python/ray/tune/search/variant_generator.py
@@ -285,7 +285,7 @@ def get_preset_variants(
             raise ValueError(
                 f"Pre-set config key `{'/'.join(path)}` does not correspond "
                 f"to a valid key in the search space definition. Please add "
-                f"this path to the `config` variable passed to `tune.run()`."
+                f"this path to the `param_space` variable passed to `tune.Tuner()`."
             ) from exc
 
         if domain:

--- a/python/ray/tune/search/zoopt/zoopt_search.py
+++ b/python/ray/tune/search/zoopt/zoopt_search.py
@@ -61,19 +61,26 @@ class ZOOptSearch(Searcher):
 
         zoopt_search = ZOOptSearch(
             algo="Asracos",  # only support Asracos currently
-            budget=20,  # must match `num_samples` in `tune.run()`.
+            budget=20,  # must match `num_samples` in `tune.TuneConfig()`.
             dim_dict=dim_dict,
             metric="mean_loss",
             mode="min",
             **zoopt_search_config
         )
 
-        tune.run(my_objective,
-            config=config,
-            search_alg=zoopt_search,
-            name="zoopt_search",
-            num_samples=20,
-            stop={"timesteps_total": 10})
+        tuner = tune.Tuner(
+            my_objective,
+            tune_config=tune.TuneConfig(
+                search_alg=zoopt_search,
+                num_samples=20
+            ),
+            run_config=air.RunConfig(
+                name="zoopt_search",
+                stop={"timesteps_total": 10}
+            ),
+            param_space=config
+        )
+        tuner.fit()
 
     If you would like to pass the search space manually, the code would
     look like this:
@@ -100,19 +107,25 @@ class ZOOptSearch(Searcher):
 
         zoopt_search = ZOOptSearch(
             algo="Asracos",  # only support Asracos currently
-            budget=20,  # must match `num_samples` in `tune.run()`.
+            budget=20,  # must match `num_samples` in `tune.TuneConfig()`.
             dim_dict=dim_dict,
             metric="mean_loss",
             mode="min",
             **zoopt_search_config
         )
 
-        tune.run(my_objective,
-            config=config,
-            search_alg=zoopt_search,
-            name="zoopt_search",
-            num_samples=20,
-            stop={"timesteps_total": 10})
+        tuner = tune.Tuner(
+            my_objective,
+            tune_config=tune.TuneConfig(
+                search_alg=zoopt_search,
+                num_samples=20
+            ),
+            run_config=air.RunConfig(
+                name="zoopt_search",
+                stop={"timesteps_total": 10}
+            ),
+        )
+        tuner.fit()
 
     Parameters:
         algo: To specify an algorithm in zoopt you want to use.

--- a/python/ray/tune/stopper/stopper.py
+++ b/python/ray/tune/stopper/stopper.py
@@ -14,7 +14,7 @@ class Stopper(abc.ABC):
     .. code-block:: python
 
         import time
-        from ray import tune
+        from ray import air, tune
         from ray.tune import Stopper
 
         class TimeStopper(Stopper):
@@ -28,7 +28,12 @@ class Stopper(abc.ABC):
             def stop_all(self):
                 return time.time() - self._start > self.deadline
 
-        tune.run(Trainable, num_samples=200, stop=TimeStopper())
+        tuner = Tuner(
+            Trainable,
+            tune_config=tune.TunConfig(num_samples=200),
+            run_config=air.RunConfig(stop=TimeStopper())
+        )
+        tuner.fit()
 
     """
 
@@ -60,7 +65,11 @@ class CombinedStopper(Stopper):
             TrialPlateauStopper(metric="my_metric")
         )
 
-        tune.run(train, stop=stopper)
+        tuner = Tuner(
+            Trainable,
+            run_config=air.RunConfig(stop=stopper)
+        )
+        tuner.fit()
 
     """
 

--- a/python/ray/tune/stopper/timeout.py
+++ b/python/ray/tune/stopper/timeout.py
@@ -12,7 +12,7 @@ class TimeoutStopper(Stopper):
     """Stops all trials after a certain timeout.
 
     This stopper is automatically created when the `time_budget_s`
-    argument is passed to `tune.run()`.
+    argument is passed to `air.RunConfig()`.
 
     Args:
         timeout: Either a number specifying the timeout in seconds, or

--- a/python/ray/tune/tests/example.py
+++ b/python/ray/tune/tests/example.py
@@ -26,8 +26,9 @@ search_space = {
 }
 
 # 3. Start a Tune run and print the best result.
-analysis = tune.run(objective, config=search_space)
-print(analysis.get_best_config(metric="score", mode="min"))
+tuner = tune.Tuner(objective, param_space=search_space)
+results = tuner.fit()
+print(results.get_best_result(metric="score", mode="min").config)
 # __quick_start_end__
 
 # __ml_quick_start_begin__
@@ -45,16 +46,17 @@ def training_function(config):
         tune.report(mean_loss=intermediate_score)
 
 
-analysis = tune.run(
+tuner = tune.Tuner(
     training_function,
-    config={
+    param_space={
         "alpha": tune.grid_search([0.001, 0.01, 0.1]),
         "beta": tune.choice([1, 2, 3]),
     },
 )
+results = tuner.fit()
 
-print("Best config: ", analysis.get_best_config(metric="mean_loss", mode="min"))
+print("Best config: ", results.get_best_result(metric="mean_loss", mode="min").config)
 
 # Get a dataframe for analyzing trial results.
-df = analysis.results_df
+df = results.get_dataframe()
 # __ml_quick_start_end__

--- a/python/ray/tune/tests/tutorial.py
+++ b/python/ray/tune/tests/tutorial.py
@@ -11,7 +11,7 @@ from torchvision import datasets, transforms
 from torch.utils.data import DataLoader
 import torch.nn.functional as F
 
-from ray import tune
+from ray import air, tune
 from ray.tune.schedulers import ASHAScheduler
 # __tutorial_imports_end__
 # fmt: on
@@ -125,24 +125,31 @@ search_space = {
 # Download the dataset first
 datasets.MNIST("~/data", train=True, download=True)
 
-analysis = tune.run(train_mnist, config=search_space)
+tuner = tune.Tuner(
+    train_mnist,
+    param_space=search_space,
+)
+results = tuner.fit()
 # __eval_func_end__
 
 # __plot_begin__
-dfs = analysis.trial_dataframes
+dfs = {result.log_dir: result.metrics_dataframe for result in results}
 [d.mean_accuracy.plot() for d in dfs.values()]
 # __plot_end__
 
 # __run_scheduler_begin__
-analysis = tune.run(
+tuner = tune.Tuner(
     train_mnist,
-    num_samples=20,
-    scheduler=ASHAScheduler(metric="mean_accuracy", mode="max"),
-    config=search_space,
+    tune_config=tune.TuneConfig(
+        num_samples=20,
+        scheduler=ASHAScheduler(metric="mean_accuracy", mode="max"),
+    ),
+    param_space=search_space,
 )
+results = tuner.fit()
 
 # Obtain a trial dataframe from all run trials of this `tune.run` call.
-dfs = analysis.trial_dataframes
+dfs = {result.log_dir: result.metrics_dataframe for result in results}
 # __run_scheduler_end__
 
 # fmt: off
@@ -165,7 +172,14 @@ space = {
 
 hyperopt_search = HyperOptSearch(space, metric="mean_accuracy", mode="max")
 
-analysis = tune.run(train_mnist, num_samples=10, search_alg=hyperopt_search)
+tuner = tune.Tuner(
+    train_mnist,
+    tune_config=tune.TuneConfig(
+        num_samples=10,
+        search_alg=hyperopt_search,
+    ),
+)
+results = tuner.fit()
 
 # To enable GPUs, use this instead:
 # analysis = tune.run(
@@ -176,8 +190,7 @@ analysis = tune.run(train_mnist, num_samples=10, search_alg=hyperopt_search)
 # __run_analysis_begin__
 import os
 
-df = analysis.results_df
-logdir = analysis.get_best_logdir("mean_accuracy", mode="max")
+logdir = results.get_best_result("mean_accuracy", mode="max").log_dir
 state_dict = torch.load(os.path.join(logdir, "model.pth"))
 
 model = ConvNet()
@@ -192,5 +205,10 @@ search_space = {
     "momentum": tune.uniform(0.1, 0.9),
 }
 
-analysis = tune.run(TrainMNIST, config=search_space, stop={"training_iteration": 10})
+tuner = tune.Tuner(
+    TrainMNIST,
+    run_config=air.RunConfig(stop={"training_iteration": 10}),
+    param_space=search_space,
+)
+results = tuner.fit()
 # __trainable_run_end__

--- a/python/ray/tune/trainable/session.py
+++ b/python/ray/tune/trainable/session.py
@@ -81,7 +81,7 @@ def get_session():
         if log_once(stack_trace_str):
             logger.warning(
                 "Session not detected. You should not be calling `{}` "
-                "outside `tune.run` or while using the class API. ".format(
+                "outside `tuner.fit()` or while using the class API. ".format(
                     function_name
                 )
             )
@@ -218,7 +218,8 @@ def report(_metric=None, **kwargs):
                 time.sleep(1)
                 tune.report(hello="world", ray="tune")
 
-        analysis = tune.run(run_me)
+        tuner = Tuner(run_me)
+        results = tuner.fit()
 
     Args:
         _metric: Optional default anonymous metric for ``tune.report(value)``

--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -1074,8 +1074,7 @@ class Trainable:
         """Subclasses can optionally override this to customize logging.
 
         The logging here is done on the worker process rather than
-        the driver. You may want to turn off driver logging via the
-        ``loggers`` parameter in ``tune.run`` when overriding this function.
+        the driver.
 
         .. versionadded:: 0.8.7
 

--- a/python/ray/tune/trainable/util.py
+++ b/python/ray/tune/trainable/util.py
@@ -272,10 +272,11 @@ def with_parameters(trainable: Union[Type["Trainable"], Callable], **kwargs):
 
         data = HugeDataset(download=True)
 
-        tune.run(
+        tuner = Tuner(
             tune.with_parameters(train, data=data),
             # ...
         )
+        tuner.fit()
 
     Class API example:
 
@@ -299,7 +300,7 @@ def with_parameters(trainable: Union[Type["Trainable"], Callable], **kwargs):
 
         data = HugeDataset(download=True)
 
-        tune.run(
+        tuner = Tuner(
             tune.with_parameters(MyTrainable, data=data),
             # ...
         )

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -26,7 +26,7 @@ def create_default_callbacks(
     sync_config: SyncConfig,
     metric: Optional[str] = None,
 ):
-    """Create default callbacks for `tune.run()`.
+    """Create default callbacks for `Tuner.fit()`.
 
     This function takes a list of existing callbacks and adds default
     callbacks to it.

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -54,7 +54,7 @@ class UtilMonitor(Thread):
     pinging for information every x seconds in a separate thread.
 
     Requires psutil and GPUtil to be installed. Can be enabled with
-    tune.run(config={"log_sys_usage": True}).
+    Tuner(param_space={"log_sys_usage": True}).
     """
 
     def __init__(self, start=True, delay=0.7):
@@ -289,7 +289,7 @@ def diagnose_serialization(trainable: Callable):
 
     Args:
         trainable: The trainable object passed to
-            tune.run(trainable). Currently only supports
+            tune.Tuner(trainable). Currently only supports
             Function API.
 
     Returns:
@@ -382,7 +382,7 @@ def diagnose_serialization(trainable: Callable):
 def atomic_save(state: Dict, checkpoint_dir: str, file_name: str, tmp_file_name: str):
     """Atomically saves the state object to the checkpoint directory.
 
-    This is automatically used by tune.run during a Tune job.
+    This is automatically used by Tuner().fit during a Tune job.
 
     Args:
         state: Object state to be serialized.
@@ -460,7 +460,15 @@ def wait_for_gpu(
             tune.util.wait_for_gpu()
             train()
 
-        tune.run(tune_func, resources_per_trial={"GPU": 1}, num_samples=10)
+        tuner = tune.Tuner(
+            tune.with_resources(
+                tune_func,
+                resources={"gpu": 1}
+            ),
+            tune_config=tune.TuneConfig(num_samples=10)
+        )
+        tuner.fit()
+
     """
     GPUtil = _import_gputil()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Excluding the rest of the examples (see #26959), this changes all relevant occurences of `tune.run()` in the `python/ray/tune/` directory to `Tuner()`. This excludes tests and the documentation of `tune.run()` itself.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
