### PR TITLE
[RLLib] Fix APPO Torch release test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2713,7 +2713,7 @@
 
   cluster:
     cluster_env: app_config.yaml
-    cluster_compute: 2gpus_32cpus.yaml
+    cluster_compute: appo_1gpu_32cpus.yaml
 
   run:
     timeout: 18000

--- a/release/rllib_tests/appo_1gpu_32cpus.yaml
+++ b/release/rllib_tests/appo_1gpu_32cpus.yaml
@@ -1,0 +1,21 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: g4dn.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+aws:
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 500


### PR DESCRIPTION
## Why are these changes needed?

APPO Torch has a /10th of the throughput of TF, which fails the release test.
After running the release test on product with an T4 instead of an M60 (g3 vs g4dn), the throughput normalizes.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
