### PR TITLE
[runtime env] Change plugin warning log from `ERROR` to `WARNING`

### DIFF
--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -180,7 +180,7 @@ class RuntimeEnvPluginManager:
         used_plugins = []
         for name, config in inputs:
             if name not in self.plugins:
-                default_logger.error(
+                default_logger.warning(
                     f"runtime_env field {name} is not recognized by "
                     "Ray and will be ignored.  In the future, unrecognized "
                     "fields in the runtime_env will raise an exception."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The warning message for unrecognized plugins was supposed to be a warning, but was using `logger.error`.  This PR fixes this by using `logger.warning` instead.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
