### PR TITLE
[train] set split locality_hints

### DIFF
--- a/python/ray/train/_internal/dataset_spec.py
+++ b/python/ray/train/_internal/dataset_spec.py
@@ -47,6 +47,7 @@ class RayDatasetSpec:
             return dataset_or_pipeline.split(
                 len(training_worker_handles),
                 equal=True,
+                locality_hints=training_worker_handles,
             )
 
         if isinstance(self.dataset_or_dict, dict):
@@ -207,6 +208,7 @@ class DataParallelIngestSpec:
                 dataset_splits = dataset.split(
                     len(training_worker_handles),
                     equal=True,
+                    locality_hints=training_worker_handles,
                 )
             else:
                 dataset_splits = [dataset] * len(training_worker_handles)


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

1. Locality hints were disabled in https://github.com/ray-project/ray/pull/26647.
2. Locality hint logic was added back in https://github.com/ray-project/ray/pull/26778.
3. This PR enables them for Train again.

Verification: https://buildkite.com/ray-project/release-tests-pr/builds/10968

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
