### PR TITLE
[Datasets] Add `size` parameter to `ImageFolderDatasource`

### DIFF
--- a/doc/source/data/package-ref.rst
+++ b/doc/source/data/package-ref.rst
@@ -156,6 +156,7 @@ Built-in Datasources
     :members:
 
 .. autoclass:: ray.data.datasource.ImageFolderDatasource
+    :members:
 
 .. autoclass:: ray.data.datasource.JSONDatasource
     :members:

--- a/doc/source/ray-air/examples/torch_image_batch_pretrained.py
+++ b/doc/source/ray-air/examples/torch_image_batch_pretrained.py
@@ -30,7 +30,9 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
 
 data_url = "s3://anonymous@air-example-data-2/1G-image-data-synthetic-raw"
 print(f"Running GPU batch prediction with 1GB data from {data_url}")
-dataset = ray.data.read_datasource(ImageFolderDatasource(), root=data_url, size=(256, 256))
+dataset = ray.data.read_datasource(
+    ImageFolderDatasource(), root=data_url, size=(256, 256)
+)
 
 model = resnet18(pretrained=True)
 

--- a/doc/source/ray-air/examples/torch_image_batch_pretrained.py
+++ b/doc/source/ray-air/examples/torch_image_batch_pretrained.py
@@ -30,7 +30,7 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
 
 data_url = "s3://anonymous@air-example-data-2/1G-image-data-synthetic-raw"
 print(f"Running GPU batch prediction with 1GB data from {data_url}")
-dataset = ray.data.read_datasource(ImageFolderDatasource(), paths=[data_url])
+dataset = ray.data.read_datasource(ImageFolderDatasource(), root=data_url, size=(256, 256))
 
 model = resnet18(pretrained=True)
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 from typing import Union, Optional, TYPE_CHECKING
 from types import ModuleType
@@ -159,3 +160,24 @@ def _estimate_available_parallelism() -> int:
     If we are currently in a placement group, take that into account."""
     cur_pg = ray.util.get_current_placement_group()
     return _estimate_avail_cpus(cur_pg)
+
+
+def _check_import(obj, *, module: str, package: str) -> None:
+    """Check if a required dependency is installed.
+
+    If `module` can't be imported, this function raises an `ImportError` instructing
+    the user to install `package` from PyPI.
+
+    Args:
+        obj: The object that has a dependency.
+        module: The name of the module to import.
+        package: The name of the package on PyPI.
+    """
+    try:
+        importlib.import_module(module)
+    except ImportError:
+        raise ImportError(
+            f"`{obj.__class__.__name__}` depends on '{package}', but '{package}' "
+            f"couldn't be imported. You can install '{package}' by running `pip "
+            f"install {package}`."
+        )

--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -82,7 +82,13 @@ class ImageFolderDatasource(BinaryDatasource):
         Args:
             root: Path to the dataset root.
             size: The desired height and width of loaded images.
+
+        Raises:
+            ValueError: if ``size`` contains non-positive numbers.
         """
+        if size[0] < 0 or size[1] < 0:
+            raise ValueError("Expected `size` to contain positive integers, but got {size}.")
+
         self._check_import(module="imageio", package="imagio")
         self._check_import(module="skimage", package="scikit-image")
 

--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -100,12 +100,13 @@ class ImageFolderDatasource(BinaryDatasource):
 
         # We call `_resolve_paths_and_filesystem` so that the dataset root is formatted
         # in the same way as the paths passed to `_get_class_from_path`.
-        paths, _ = _resolve_paths_and_filesystem([root])
+        paths, filesystem = _resolve_paths_and_filesystem([root])
         root = paths[0]
 
         return super().create_reader(
             paths=paths,
             partition_filter=FileExtensionFilter(file_extensions=IMAGE_EXTENSIONS),
+            filesystem=filesystem,
             root=root,
             size=size,
         )

--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -1,8 +1,8 @@
-import importlib
 import pathlib
 from typing import TYPE_CHECKING, Tuple
 
 import numpy as np
+from ray.data._internal.util import _check_import
 from ray.data.datasource.binary_datasource import BinaryDatasource
 from ray.data.datasource.datasource import Reader
 from ray.data.datasource.file_based_datasource import (
@@ -87,10 +87,12 @@ class ImageFolderDatasource(BinaryDatasource):
             ValueError: if ``size`` contains non-positive numbers.
         """
         if size[0] < 0 or size[1] < 0:
-            raise ValueError("Expected `size` to contain positive integers, but got {size}.")
+            raise ValueError(
+                "Expected `size` to contain positive integers, but got {size}."
+            )
 
-        self._check_import(module="imageio", package="imagio")
-        self._check_import(module="skimage", package="scikit-image")
+        _check_import(self, module="imageio", package="imagio")
+        _check_import(self, module="skimage", package="scikit-image")
 
         # We call `_resolve_paths_and_filesystem` so that the dataset root is formatted
         # in the same way as the paths passed to `_get_class_from_path`.
@@ -127,25 +129,6 @@ class ImageFolderDatasource(BinaryDatasource):
                 "label": [label],
             }
         )
-
-    def _check_import(self, *, module: str, package: str) -> None:
-        """Check if a required dependency is installed.
-
-        If `module` can't be imported, this function raises an `ImportError` instructing
-        the user to install `package` from PyPI.
-
-        Args:
-            module: The name of the module to import.
-            package: The name of the package on PyPI.
-        """
-        try:
-            importlib.import_module(module)
-        except ImportError:
-            raise ImportError(
-                f"`{self.__class__.__name__}` depends on '{package}', but '{package}' "
-                f"couldn't be imported. You can install '{package}' by running `pip "
-                f"install {package}`."
-            )
 
 
 def _get_class_from_path(path: str, root: str) -> str:

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2775,7 +2775,7 @@ def test_torch_datasource_value_error(ray_start_regular_shared, local_path):
 
 def test_image_folder_datasource(ray_start_regular_shared):
     root = os.path.join(os.path.dirname(__file__), "image-folder")
-    ds = ray.data.read_datasource(ImageFolderDatasource(), paths=[root])
+    ds = ray.data.read_datasource(ImageFolderDatasource(), root=root, size=(32, 32))
 
     assert ds.count() == 3
 
@@ -2783,14 +2783,6 @@ def test_image_folder_datasource(ray_start_regular_shared):
     assert sorted(df["label"]) == ["cat", "cat", "dog"]
     assert type(df["image"].dtype) is TensorDtype
     assert all(tensor.to_numpy().shape == (32, 32, 3) for tensor in df["image"])
-
-
-def test_image_folder_datasource_raises_value_error(ray_start_regular_shared):
-    # `ImageFolderDatasource` should raise an error if more than one path is passed.
-    with pytest.raises(ValueError):
-        ray.data.read_datasource(
-            ImageFolderDatasource(), paths=["imagenet/train", "imagenet/test"]
-        )
 
 
 def test_image_folder_datasource_e2e(ray_start_regular_shared):
@@ -2802,7 +2794,9 @@ def test_image_folder_datasource_e2e(ray_start_regular_shared):
     from torchvision.models import resnet18
 
     root = os.path.join(os.path.dirname(__file__), "image-folder")
-    dataset = ray.data.read_datasource(ImageFolderDatasource(), paths=[root])
+    dataset = ray.data.read_datasource(
+        ImageFolderDatasource(), root=root, size=(32, 32)
+    )
 
     def preprocess(df):
         # We convert the `TensorArrayElement` to a NumPy array because `ToTensor`

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2775,14 +2775,14 @@ def test_torch_datasource_value_error(ray_start_regular_shared, local_path):
 
 def test_image_folder_datasource(ray_start_regular_shared):
     root = os.path.join(os.path.dirname(__file__), "image-folder")
-    ds = ray.data.read_datasource(ImageFolderDatasource(), root=root, size=(32, 32))
+    ds = ray.data.read_datasource(ImageFolderDatasource(), root=root, size=(64, 64))
 
     assert ds.count() == 3
 
     df = ds.to_pandas()
     assert sorted(df["label"]) == ["cat", "cat", "dog"]
     assert type(df["image"].dtype) is TensorDtype
-    assert all(tensor.to_numpy().shape == (32, 32, 3) for tensor in df["image"])
+    assert all(tensor.to_numpy().shape == (64, 64, 3) for tensor in df["image"])
 
 
 def test_image_folder_datasource_e2e(ray_start_regular_shared):

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2791,6 +2791,7 @@ def test_image_folder_datasource_value_error(ray_start_regular_shared, size):
     with pytest.raises(ValueError):
         ray.data.read_datasource(ImageFolderDatasource(), root=root, size=size)
 
+
 def test_image_folder_datasource_e2e(ray_start_regular_shared):
     from ray.air.util.tensor_extensions.pandas import TensorArray
     from ray.train.torch import TorchCheckpoint, TorchPredictor

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2785,6 +2785,12 @@ def test_image_folder_datasource(ray_start_regular_shared):
     assert all(tensor.to_numpy().shape == (64, 64, 3) for tensor in df["image"])
 
 
+@pytest.mark.parametrize("size", [(-32, 32), (32, -32), (-32, -32)])
+def test_image_folder_datasource_value_error(ray_start_regular_shared, size):
+    root = os.path.join(os.path.dirname(__file__), "image-folder")
+    with pytest.raises(ValueError):
+        ray.data.read_datasource(ImageFolderDatasource(), root=root, size=size)
+
 def test_image_folder_datasource_e2e(ray_start_regular_shared):
     from ray.air.util.tensor_extensions.pandas import TensorArray
     from ray.train.torch import TorchCheckpoint, TorchPredictor

--- a/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
+++ b/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
@@ -38,7 +38,7 @@ def main(data_size_gb: int):
     data_url = f"s3://air-example-data-2/{data_size_gb}G-image-data-synthetic-raw"
     print(f"Running GPU batch prediction with {data_size_gb}GB data from {data_url}")
     start = time.time()
-    dataset = ray.data.read_datasource(ImageFolderDatasource(), paths=[data_url])
+    dataset = ray.data.read_datasource(ImageFolderDatasource(), root=data_url, size=(256, 256))
 
     model = resnet18(pretrained=True)
 

--- a/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
+++ b/release/air_tests/air_benchmarks/workloads/gpu_batch_prediction.py
@@ -38,7 +38,9 @@ def main(data_size_gb: int):
     data_url = f"s3://air-example-data-2/{data_size_gb}G-image-data-synthetic-raw"
     print(f"Running GPU batch prediction with {data_size_gb}GB data from {data_url}")
     start = time.time()
-    dataset = ray.data.read_datasource(ImageFolderDatasource(), root=data_url, size=(256, 256))
+    dataset = ray.data.read_datasource(
+        ImageFolderDatasource(), root=data_url, size=(256, 256)
+    )
 
     model = resnet18(pretrained=True)
 

--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -96,7 +96,7 @@ def main(data_size_gb: int, num_epochs=2, num_workers=1):
     # Enable cross host NCCL for larger scale tests
     runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}
     ray.init(runtime_env=runtime_env)
-    dataset = ray.data.read_datasource(ImageFolderDatasource(), paths=[data_url])
+    dataset = ray.data.read_datasource(ImageFolderDatasource(), root=data_url, size=(256, 256))
 
     preprocessor = BatchMapper(preprocess_image_with_label)
 

--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -96,7 +96,9 @@ def main(data_size_gb: int, num_epochs=2, num_workers=1):
     # Enable cross host NCCL for larger scale tests
     runtime_env = {"env_vars": {"NCCL_SOCKET_IFNAME": "ens3"}}
     ray.init(runtime_env=runtime_env)
-    dataset = ray.data.read_datasource(ImageFolderDatasource(), root=data_url, size=(256, 256))
+    dataset = ray.data.read_datasource(
+        ImageFolderDatasource(), root=data_url, size=(256, 256)
+    )
 
     preprocessor = BatchMapper(preprocess_image_with_label)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you read a folder with differently-sized images, `ImageFolderDatasource` errors. This PR fixes the issue by resizing images to a user-specified size.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
