### PR TITLE
[AIR] Rename `limit` parameter as `max_categories`

### DIFF
--- a/doc/source/ray-air/examples/tfx_tabular_train_to_serve.ipynb
+++ b/doc/source/ray-air/examples/tfx_tabular_train_to_serve.ipynb
@@ -556,7 +556,7 @@
     "            \"payment_type\",\n",
     "            \"company\",\n",
     "        ],\n",
-    "        limit={\n",
+    "        max_categories={\n",
     "            \"dropoff_census_tract\": 25,\n",
     "            \"pickup_community_area\": 20,\n",
     "            \"dropoff_community_area\": 20,\n",

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -116,8 +116,8 @@ class OneHotEncoder(Preprocessor):
     be set to 1 if the value matches, otherwise 0.
 
     Transforming values not included in the fitted dataset or not among
-    the top popular values (see ``limit``) will result in all of the encoded column
-    values being 0.
+    the top popular values (see ``max_categories``) will result in all of the encoded
+    column values being 0.
 
     All column values must be hashable or lists. Lists will be treated as separate
     categories. If you would like to encode list elements,
@@ -138,7 +138,7 @@ class OneHotEncoder(Preprocessor):
                 "payment_type",
                 "company",
             ],
-            limit={
+            max_categories={
                 "dropoff_census_tract": 25,
                 "pickup_community_area": 20,
                 "dropoff_community_area": 20,
@@ -149,21 +149,26 @@ class OneHotEncoder(Preprocessor):
 
     Args:
         columns: The columns that will individually be encoded.
-        limit: If set, only the top "limit" number of most popular values become
-            categorical variables. The less frequent ones will result in all
-            the encoded column values being 0. This is a dict of column to
-            its corresponding limit. The column in this dictionary has to be
-            in ``columns``.
+        max_categories: If set, only the top "max_categories" number of most popular
+            values become categorical variables. The less frequent ones will result in
+            all the encoded column values being 0. This is a dict of column to its
+            corresponding limit. The column in this dictionary has to be in
+            ``columns``.
     """
 
-    def __init__(self, columns: List[str], *, limit: Optional[Dict[str, int]] = None):
+    def __init__(
+        self, columns: List[str], *, max_categories: Optional[Dict[str, int]] = None
+    ):
         # TODO: add `drop` parameter.
         self.columns = columns
-        self.limit = limit
+        self.max_categories = max_categories
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         self.stats_ = _get_unique_value_indices(
-            dataset, self.columns, limit=self.limit, encode_lists=False
+            dataset,
+            self.columns,
+            max_categories=self.max_categories,
+            encode_lists=False,
         )
         return self
 
@@ -222,8 +227,8 @@ class MultiHotEncoder(Preprocessor):
         assert transformed_batch.equals(expected_batch)
 
     Transforming values not included in the fitted dataset or not among
-    the top popular values (see ``limit``) will result in all of the encoded column
-    values being 0.
+    the top popular values (see ``max_categories``) will result in all of the encoded
+    column values being 0.
 
     The logic is similar to scikit-learn's `MultiLabelBinarizer \
 <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing\
@@ -236,21 +241,23 @@ class MultiHotEncoder(Preprocessor):
 
     Args:
         columns: The columns that will individually be encoded.
-        limit: If set, only the top "limit" number of most popular values become
-            categorical variables. The less frequent ones will result in all
-            the encoded values being 0. This is a dict of column to
-            its corresponding limit. The column in this dictionary has to be
-            in ``columns``.
+        max_categories: If set, only the top "max_categories" number of most popular
+            values become categorical variables. The less frequent ones will result in
+            all the encoded values being 0. This is a dict of column to its
+            corresponding limit. The column in this dictionary has to be in
+            ``columns``.
     """
 
-    def __init__(self, columns: List[str], *, limit: Optional[Dict[str, int]] = None):
+    def __init__(
+        self, columns: List[str], *, max_categories: Optional[Dict[str, int]] = None
+    ):
         # TODO: add `drop` parameter.
         self.columns = columns
-        self.limit = limit
+        self.max_categories = max_categories
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         self.stats_ = _get_unique_value_indices(
-            dataset, self.columns, limit=self.limit, encode_lists=True
+            dataset, self.columns, max_categories=self.max_categories, encode_lists=True
         )
         return self
 
@@ -370,15 +377,17 @@ def _get_unique_value_indices(
     columns: List[str],
     drop_na_values: bool = False,
     key_format: str = "unique_values({0})",
-    limit: Optional[Dict[str, int]] = None,
+    max_categories: Optional[Dict[str, int]] = None,
     encode_lists: bool = True,
 ) -> Dict[str, Dict[str, int]]:
     """If drop_na_values is True, will silently drop NA values."""
-    limit = limit or {}
-    for column in limit:
+    if max_categories is None:
+        max_categories = {}
+    for column in max_categories:
         if column not in columns:
             raise ValueError(
-                f"You set limit for {column}, which is not present in {columns}."
+                f"You set `max_categories` for {column}, which is not present in "
+                f"{columns}."
             )
 
     def get_pd_value_counts_per_column(col: pd.Series):
@@ -425,11 +434,13 @@ def _get_unique_value_indices(
 
     unique_values_with_indices = OrderedDict()
     for column in columns:
-        if column in limit:
+        if column in max_categories:
             # Output sorted by freq.
             unique_values_with_indices[key_format.format(column)] = {
                 k[0]: j
-                for j, k in enumerate(final_counters[column].most_common(limit[column]))
+                for j, k in enumerate(
+                    final_counters[column].most_common(max_categories[column])
+                )
             }
         else:
             # Output sorted by column name.

--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -615,7 +615,7 @@ def test_one_hot_encoder():
     null_encoder.transform_batch(nonnull_df)
 
 
-def test_one_hot_encoder_with_limit():
+def test_one_hot_encoder_with_max_categories():
     """Tests basic OneHotEncoder functionality with limit."""
     col_a = ["red", "green", "blue", "red"]
     col_b = ["warm", "cold", "hot", "cold"]
@@ -623,7 +623,7 @@ def test_one_hot_encoder_with_limit():
     in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b, "C": col_c})
     ds = ray.data.from_pandas(in_df)
 
-    encoder = OneHotEncoder(["B", "C"], limit={"B": 2})
+    encoder = OneHotEncoder(["B", "C"], max_categories={"B": 2})
 
     ds_out = encoder.fit_transform(ds)
     assert len(ds_out.to_pandas().columns) == 1 + 2 + 3
@@ -724,7 +724,7 @@ def test_multi_hot_encoder():
     null_encoder.transform_batch(nonnull_df)
 
 
-def test_multi_hot_encoder_with_limit():
+def test_multi_hot_encoder_with_max_categories():
     """Tests basic MultiHotEncoder functionality with limit."""
     col_a = ["red", "green", "blue", "red"]
     col_b = ["warm", "cold", "hot", "cold"]
@@ -733,7 +733,7 @@ def test_multi_hot_encoder_with_limit():
     in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b, "C": col_c, "D": col_d})
     ds = ray.data.from_pandas(in_df)
 
-    encoder = MultiHotEncoder(["B", "C", "D"], limit={"B": 2})
+    encoder = MultiHotEncoder(["B", "C", "D"], max_categories={"B": 2})
 
     ds_out = encoder.fit_transform(ds)
     assert len(ds_out.to_pandas()["B"].iloc[0]) == 2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I've renamed the `limit` parameter as `max_categories` so that:
1. The interface is consistent with the associated sklearn interface.
2. The interface is more similar to our `CountVectorizer` interface.

See https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
