### PR TITLE
Make PipelineExecutor serializable by deferring the thread pool creation

### DIFF
--- a/python/ray/data/_internal/pipeline_executor.py
+++ b/python/ray/data/_internal/pipeline_executor.py
@@ -82,6 +82,13 @@ class PipelineExecutor:
                 "complete or when the driver exits"
             )
 
+    def __reduce__(self):
+        if self._pool is not None:
+            raise RuntimeError(
+                "PipelineExecutor is not serializable once it has started."
+            )
+        return (self.__class__, (self._pipeline,))
+
     def _create_thread_pool(self):
         if self._pool is None:
             self._pool = concurrent.futures.ThreadPoolExecutor(

--- a/python/ray/data/_internal/pipeline_executor.py
+++ b/python/ray/data/_internal/pipeline_executor.py
@@ -29,12 +29,6 @@ class PipelineExecutor:
             len(self._pipeline._optimized_stages) + 1
         )
         self._iter = iter(self._pipeline._base_iterable)
-        self._pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self._stages)
-        )
-        self._stages[0] = self._pool.submit(
-            lambda n: pipeline_stage(n), next(self._iter)
-        )
 
         if self._pipeline._length and self._pipeline._length != float("inf"):
             length = self._pipeline._length
@@ -49,10 +43,23 @@ class PipelineExecutor:
         else:
             self._bars = None
 
+        # The creation of execution thread pool is deferred until this is
+        # actually being iterated. This will make the Python objects containing
+        # a PipelineExecutor serializable (as long as the PipelineExecutor has not
+        # been iterated at the point of serialization), which otherwise are not
+        # because the thread pool contains locks which are not serializable.
+        # The motivation use case is to support pipe.rewindow().split().
+        self._pool = None
+
     def __del__(self):
         for f in self._stages:
             if f is not None:
                 f.cancel()
+
+        # Thread pool wasn't created during the lifetime of PipelineExecutor.
+        if not self._pool:
+            return
+
         self._pool.shutdown(wait=False)
 
         # Signal to all remaining threads to shut down.
@@ -75,10 +82,22 @@ class PipelineExecutor:
                 "complete or when the driver exits"
             )
 
+    def _create_thread_pool(self):
+        if self._pool is None:
+            self._pool = concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(self._stages)
+            )
+            self._stages[0] = self._pool.submit(
+                lambda n: pipeline_stage(n), next(self._iter)
+            )
+
     def __iter__(self):
         return self
 
     def __next__(self):
+        if self._pool is None:
+            self._create_thread_pool()
+
         output = None
         start = time.perf_counter()
 

--- a/python/ray/data/dataset_pipeline.py
+++ b/python/ray/data/dataset_pipeline.py
@@ -424,8 +424,13 @@ class DatasetPipeline(Generic[T]):
         else:
             length = None
 
+        # The newly created DatasetPipeline will contain a PipelineExecutor (because
+        # this will execute the pipeline so far to iter the datasets). In order to
+        # make this new DatasetPipeline serializable, we need to make sure the
+        # PipelineExecutor has not been iterated. So this uses
+        # _iter_datasets_without_peek() instead of iter_datasets().
         return DatasetPipeline(
-            WindowIterable(self.iter_datasets()),
+            WindowIterable(self._iter_datasets_without_peek()),
             length=length,
         )
 
@@ -1037,6 +1042,16 @@ class DatasetPipeline(Generic[T]):
             unsqueeze_label_tensor=unsqueeze_label_tensor,
             unsqueeze_feature_tensors=unsqueeze_feature_tensors,
         )
+
+    def _iter_datasets_without_peek(self):
+        """This is similar to iter_datasets(), but without peeking PipelineExecutor."""
+        if self._executed[0]:
+            raise RuntimeError("Pipeline cannot be read multiple times.")
+        self._executed[0] = True
+        if self._first_dataset:
+            raise RuntimeError("The pipeline has been peeked.")
+        self._optimize_stages()
+        return PipelineExecutor(self)
 
     @DeveloperAPI
     def iter_datasets(self) -> Iterator[Dataset[T]]:

--- a/python/ray/data/tests/test_dataset_pipeline.py
+++ b/python/ray/data/tests/test_dataset_pipeline.py
@@ -686,11 +686,9 @@ def test_in_place_transformation_split_doesnt_clear_objects(ray_start_regular_sh
         .randomize_block_order_each_window()
         .randomize_block_order_each_window()
     )
-    # TODO(https://github.com/ray-project/ray/issues/26766): re-enable this after the
-    # bug is fixed.
-    # verify_integrity(
-    #     ds.repeat(10).randomize_block_order_each_window().rewindow(blocks_per_window=1)
-    # )
+    verify_integrity(
+        ds.repeat(10).randomize_block_order_each_window().rewindow(blocks_per_window=1)
+    )
     # Mix in-place and non-in place transforms.
     verify_integrity(
         ds.repeat(10)


### PR DESCRIPTION
Signed-off-by: jianoaix <iamjianxiao@gmail.com>

## Why are these changes needed?
Currently, pipe.rewindow().split() doesn't work because the rewindow() will create a DatasetPipeline containing PipelineExecutor which contains a threadpoll/locks. This PR fixes it by deferring the threadpool creation in PipelineExecutor, so that PipelineExecutor will be serializable, as long as it's not been iterated.

## Related issue number
#26766

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
