### PR TITLE
[AIR] Change `Categorizer` constructor signature

### DIFF
--- a/python/ray/data/tests/test_preprocessors.py
+++ b/python/ray/data/tests/test_preprocessors.py
@@ -828,23 +828,22 @@ def test_categorizer(predefined_dtypes):
     in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b, "C": col_c})
     ds = ray.data.from_pandas(in_df)
 
+    columns = ["B", "C"]
     if predefined_dtypes:
         expected_dtypes = {
             "B": pd.CategoricalDtype(["cold", "hot", "warm"], ordered=True),
             "C": pd.CategoricalDtype([1, 5, 10]),
         }
-        columns = {
-            "B": pd.CategoricalDtype(["cold", "hot", "warm"], ordered=True),
-            "C": None,
-        }
+        dtypes = {"B": pd.CategoricalDtype(["cold", "hot", "warm"], ordered=True)}
     else:
         expected_dtypes = {
             "B": pd.CategoricalDtype(["cold", "hot", "warm"]),
             "C": pd.CategoricalDtype([1, 5, 10]),
         }
         columns = ["B", "C"]
+        dtypes = None
 
-    encoder = Categorizer(columns)
+    encoder = Categorizer(columns, dtypes)
 
     # Transform with unfitted preprocessor.
     with pytest.raises(PreprocessorNotFittedException):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Motivation behind this change:
* The signature is easier to understand.
* The parameter documentation is more precise.
* The signature is consistent with the pattern of having a separate `dtype` parameter.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
