### PR TITLE
[kuberay] More aggressive autoscaling defaults

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -21,6 +21,8 @@ AUTOSCALER_OPTIONS_KEY = "autoscalerOptions"
 IDLE_SECONDS_KEY = "idleTimeoutSeconds"
 UPSCALING_KEY = "upscalingMode"
 UPSCALING_VALUE_AGGRESSIVE = "Aggressive"
+UPSCALING_VALUE_DEFAULT = "Default"
+UPSCALING_VALUE_CONSERVATIVE = "Conservative"
 
 MAX_RAYCLUSTER_FETCH_TRIES = 5
 RAYCLUSTER_FETCH_RETRY_S = 5
@@ -108,11 +110,18 @@ def _derive_autoscaling_config_from_ray_cr(ray_cr: Dict[str, Any]) -> Dict[str, 
     if IDLE_SECONDS_KEY in autoscaler_options:
         idle_timeout_minutes = autoscaler_options[IDLE_SECONDS_KEY] / 60.0
     else:
-        idle_timeout_minutes = 5.0
-    if autoscaler_options.get(UPSCALING_KEY) == UPSCALING_VALUE_AGGRESSIVE:
-        upscaling_speed = 1000  # i.e. big
+        idle_timeout_minutes = 1.0
+
+    if autoscaler_options.get(UPSCALING_KEY) == UPSCALING_VALUE_CONSERVATIVE:
+        upscaling_speed = 1  # Rate-limit upscaling if "Conservative" is set by user.
+    # This elif is redudant but included for clarity.
+    elif autoscaler_options.get(UPSCALING_KEY) == UPSCALING_VALUE_DEFAULT:
+        upscaling_speed = 1000  # i.e. big, no rate-limiting by default
+    # This elif is redudant but included for clarity.
+    elif autoscaler_options.get(UPSCALING_KEY) == UPSCALING_VALUE_AGGRESSIVE:
+        upscaling_speed = 1000
     else:
-        upscaling_speed = 1
+        upscaling_speed = 1000
 
     autoscaling_config = {
         "provider": provider_config,

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -93,11 +93,11 @@ def _get_basic_autoscaling_config() -> dict:
         "head_node_type": "head-group",
         "head_setup_commands": [],
         "head_start_ray_commands": [],
-        "idle_timeout_minutes": 5,
+        "idle_timeout_minutes": 1.0,
         "initialization_commands": [],
         "max_workers": 600,
         "setup_commands": [],
-        "upscaling_speed": 1,
+        "upscaling_speed": 1000,
         "worker_nodes": {},
         "worker_setup_commands": [],
         "worker_start_ray_commands": [],
@@ -170,16 +170,16 @@ def _get_gpu_complaint() -> str:
 def _get_ray_cr_with_autoscaler_options() -> dict:
     cr = _get_basic_ray_cr()
     cr["spec"]["autoscalerOptions"] = {
-        "upscalingMode": "Aggressive",
-        "idleTimeoutSeconds": 60,
+        "upscalingMode": "Conservative",
+        "idleTimeoutSeconds": 300,
     }
     return cr
 
 
 def _get_autoscaling_config_with_options() -> dict:
     config = _get_basic_autoscaling_config()
-    config["upscaling_speed"] = 1000
-    config["idle_timeout_minutes"] = 1.0
+    config["upscaling_speed"] = 1
+    config["idle_timeout_minutes"] = 5.0
     return config
 
 


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Together with KubeRay PR https://github.com/ray-project/kuberay/pull/414, addresses KubeRay issue https://github.com/ray-project/kuberay/issues/359: gives the autoscaler more aggressive defaults when using KubeRay
(no upscale rate limit, faster idle timeout).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
