### PR TITLE
[Jobs] [runtime env] Allow RuntimeEnvConfig object in Job Submission

### DIFF
--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -9,6 +9,7 @@ from typing import Optional
 from unittest.mock import patch
 
 import pytest
+from ray.runtime_env.runtime_env import RuntimeEnv, RuntimeEnvConfig
 import yaml
 
 import ray
@@ -271,6 +272,29 @@ def test_submit_job(job_sdk_client, runtime_env_option, monkeypatch):
 
     logs = client.get_job_logs(job_id)
     assert runtime_env_option["expected_logs"] in logs
+
+
+def test_timeout(job_sdk_client):
+    client = job_sdk_client
+
+    job_id = client.submit_job(
+        entrypoint="echo hello",
+        # Assume pip packages take > 1s to download, or this test will spuriously fail.
+        runtime_env=RuntimeEnv(
+            pip={
+                "packages": ["tensorflow", "requests", "botocore", "torch"],
+                "pip_check": False,
+                "pip_version": "==22.0.2;python_version=='3.8.11'",
+            },
+            config=RuntimeEnvConfig(setup_timeout_seconds=1),
+        ),
+    )
+
+    wait_for_condition(_check_job_failed, client=client, job_id=job_id, timeout=10)
+    data = client.get_job_info(job_id)
+    assert "Failed to setup runtime environment" in data.message
+    assert "Timeout" in data.message
+    assert "consider increasing `setup_timeout_seconds`" in data.message
 
 
 def test_per_task_runtime_env(job_sdk_client: JobSubmissionClient):

--- a/dashboard/modules/runtime_env/runtime_env_agent.py
+++ b/dashboard/modules/runtime_env/runtime_env_agent.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, Dict, List, Set, Tuple
+from ray._private.ray_constants import DEFAULT_RUNTIME_ENV_TIMEOUT_SECONDS
 
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.modules.runtime_env.runtime_env_consts as runtime_env_consts
@@ -375,6 +376,16 @@ class RuntimeEnvAgent(
                     error_message = "".join(
                         traceback.format_exception(type(e), e, e.__traceback__)
                     )
+                    if isinstance(e, asyncio.TimeoutError):
+                        hint = (
+                            f"Failed due to timeout; check runtime_env setup logs"
+                            " and consider increasing `setup_timeout_seconds` beyond "
+                            f"the default of {DEFAULT_RUNTIME_ENV_TIMEOUT_SECONDS}."
+                            "For example: \n"
+                            '    runtime_env={"config": {"setup_timeout_seconds":'
+                            " 1800}, ...}\n"
+                        )
+                        error_message = hint + error_message
                     await asyncio.sleep(
                         runtime_env_consts.RUNTIME_ENV_RETRY_INTERVAL_MS / 1000
                     )

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -119,6 +119,9 @@ class RuntimeEnvConfig(dict):
             eager_install=runtime_env_config.eager_install,
         )
 
+    def to_dict(self) -> Dict:
+        return dict(deepcopy(self))
+
 
 # Due to circular reference, field config can only be assigned a value here
 OPTION_TO_VALIDATION_FN[
@@ -404,7 +407,14 @@ class RuntimeEnv(dict):
         )
 
     def to_dict(self) -> Dict:
-        return dict(deepcopy(self))
+        runtime_env_dict = dict(deepcopy(self))
+
+        # Replace strongly-typed RuntimeEnvConfig with a dict to allow the returned
+        # dict to work properly as a field in a dataclass. Details in issue #26986
+        if runtime_env_dict.get("config"):
+            runtime_env_dict["config"] = runtime_env_dict["config"].to_dict()
+
+        return runtime_env_dict
 
     def has_uris(self) -> bool:
         if (

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+import dataclasses
 import json
 import logging
 import os
@@ -6,10 +8,11 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 from unittest import mock
 
 import pytest
+from ray.runtime_env.runtime_env import RuntimeEnvConfig
 import requests
 
 import ray
@@ -69,6 +72,31 @@ def test_get_release_wheel_url():
             for version, commit in test_commits.items():
                 url = get_release_wheel_url(commit, sys_platform, version, py_version)
                 assert requests.head(url).status_code == 200, url
+
+
+def test_compatible_with_dataclasses():
+    """Test that the output of RuntimeEnv.to_dict() can be used as a dataclass field."""
+    config = RuntimeEnvConfig(setup_timeout_seconds=1)
+    runtime_env = RuntimeEnv(
+        pip={
+            "packages": ["tensorflow", "requests"],
+            "pip_check": False,
+            "pip_version": "==22.0.2;python_version=='3.8.11'",
+        },
+        config=config,
+    )
+
+    @dataclass
+    class RuntimeEnvDataClass:
+        runtime_env: Dict[str, Any]
+
+    dataclasses.asdict(RuntimeEnvDataClass(runtime_env.to_dict()))
+
+    @dataclass
+    class RuntimeEnvConfigDataClass:
+        config: Dict[str, Any]
+
+    dataclasses.asdict(RuntimeEnvConfigDataClass(config.to_dict()))
 
 
 @pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -83,6 +83,7 @@ def test_compatible_with_dataclasses():
             "pip_check": False,
             "pip_version": "==22.0.2;python_version=='3.8.11'",
         },
+        env_vars={"FOO": "BAR"},
         config=config,
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Job Submission uses `dataclasses.asdict` to convert Python and CLI input into JSON to send to the Jobs API server.

Unfortunately, `asdict` breaks when a field subclasses `dict` and has an `__init__` method that doesn't accept a generator as an argument (see #26986 for the traceback):

https://github.com/python/cpython/blob/27055d766ab0ee5ddcfbd1fb51fb47419af1ddba/Lib/dataclasses.py#L1306-L1314

 Since `RuntimeEnvConfig` has this property, Job Submission breaks when using a runtime env with a `RuntimeEnvConfig` field.

This PR 
- modifies `RuntimeEnv.to_dict` to ensure that the nested `RuntimeEnvConfig` field is also converted to a dict.  
- adds a unit test to ensure `RuntimeEnv` is compatible with `dataclasses.asdict`.
- adds a more useful error message on reaching `setup_timeout_seconds`:
```
Status message: runtime_env setup failed: Failed to setup runtime environment.
Could not create the actor because its associated runtime env failed to be created.
Failed due to timeout; check runtime_env setup logs and consider increasing `setup_timeout_seconds` beyond the default of 600. E.g.
    runtime_env={"config": {"setup_timeout_seconds": 1800}, ...}
Traceback (most recent call last):
  File "/Users/archit/ray/python/ray/dashboard/modules/runtime_env/runtime_env_agent.py", line 367, in _create_runtime_env_with_retry
    runtime_env_context = await asyncio.wait_for(
  File "/Users/archit/anaconda3/envs/ray-py38/lib/python3.8/asyncio/tasks.py", line 501, in wait_for
    raise exceptions.TimeoutError()
asyncio.exceptions.TimeoutError
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #26986 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
