### PR TITLE
Make New Dashboard the default dashboard

### DIFF
--- a/dashboard/client/src/App.tsx
+++ b/dashboard/client/src/App.tsx
@@ -2,7 +2,7 @@ import { CssBaseline } from "@material-ui/core";
 import { ThemeProvider } from "@material-ui/core/styles";
 import React, { Suspense, useEffect, useState } from "react";
 import { Provider } from "react-redux";
-import { HashRouter, Route, Switch } from "react-router-dom";
+import { HashRouter, Redirect, Route, Switch } from "react-router-dom";
 import Dashboard from "./pages/dashboard/Dashboard";
 import Events from "./pages/event/Events";
 import Loading from "./pages/exception/Loading";
@@ -83,7 +83,12 @@ const App = () => {
             <CssBaseline />
             <HashRouter>
               <Switch>
-                <Route component={Dashboard} exact path="/" />
+                <Route
+                  component={() => <Redirect to="/node" />}
+                  exact
+                  path="/"
+                />
+                <Route component={Dashboard} exact path="/legacy" />
                 <Route
                   render={(props) => (
                     <BasicLayout {...props} setTheme={setTheme} theme={theme}>

--- a/dashboard/client/src/common/UsageStatsAlert.tsx
+++ b/dashboard/client/src/common/UsageStatsAlert.tsx
@@ -1,0 +1,37 @@
+import { Alert } from "@material-ui/lab";
+import React, { useEffect, useState } from "react";
+import { getUsageStatsEnabled } from "../api";
+
+export const UsageStatsAlert = () => {
+  const [usageStatsPromptEnabled, setUsageStatsPromptEnabled] = useState(false);
+  const [usageStatsEnabled, setUsageStatsEnabled] = useState(false);
+  useEffect(() => {
+    getUsageStatsEnabled().then((res) => {
+      setUsageStatsPromptEnabled(res.usageStatsPromptEnabled);
+      setUsageStatsEnabled(res.usageStatsEnabled);
+    });
+  }, []);
+
+  return usageStatsPromptEnabled ? (
+    <Alert style={{ marginTop: 30 }} severity="info">
+      {usageStatsEnabled ? (
+        <span>
+          Usage stats collection is enabled. To disable this, add
+          `--disable-usage-stats` to the command that starts the cluster, or run
+          the following command: `ray disable-usage-stats` before starting the
+          cluster. See{" "}
+          <a
+            href="https://docs.ray.io/en/master/cluster/usage-stats.html"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://docs.ray.io/en/master/cluster/usage-stats.html
+          </a>{" "}
+          for more details.
+        </span>
+      ) : (
+        <span>Usage stats collection is disabled.</span>
+      )}
+    </Alert>
+  ) : null;
+};

--- a/dashboard/client/src/pages/dashboard/Dashboard.tsx
+++ b/dashboard/client/src/pages/dashboard/Dashboard.tsx
@@ -7,16 +7,11 @@ import {
   Theme,
   Typography,
 } from "@material-ui/core";
-import { Alert } from "@material-ui/lab";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
-import {
-  getActorGroups,
-  getNodeInfo,
-  getTuneAvailability,
-  getUsageStatsEnabled,
-} from "../../api";
+import { getActorGroups, getNodeInfo, getTuneAvailability } from "../../api";
+import { UsageStatsAlert } from "../../common/UsageStatsAlert";
 import { StoreState } from "../../store";
 import LastUpdated from "./LastUpdated";
 import LogicalView from "./logical-view/LogicalView";
@@ -105,14 +100,6 @@ const Dashboard: React.FC = () => {
   }
 
   const SelectedComponent = tabs[tab].component;
-  const [usageStatsPromptEnabled, setUsageStatsPromptEnabled] = useState(false);
-  const [usageStatsEnabled, setUsageStatsEnabled] = useState(false);
-  useEffect(() => {
-    getUsageStatsEnabled().then((res) => {
-      setUsageStatsPromptEnabled(res.usageStatsPromptEnabled);
-      setUsageStatsEnabled(res.usageStatsEnabled);
-    });
-  }, []);
   return (
     <div className={classes.root}>
       <Typography variant="h5">Ray Dashboard</Typography>
@@ -123,7 +110,7 @@ const Dashboard: React.FC = () => {
         color="primary"
         onClick={() => history.push("/node")}
       >
-        Try Experimental Dashboard
+        Back to new dashboard
       </Button>
       <Tabs
         className={classes.tabs}
@@ -137,28 +124,7 @@ const Dashboard: React.FC = () => {
         ))}
       </Tabs>
       <SelectedComponent />
-      {usageStatsPromptEnabled ? (
-        <Alert style={{ marginTop: 30 }} severity="info">
-          {usageStatsEnabled ? (
-            <span>
-              Usage stats collection is enabled. To disable this, add
-              `--disable-usage-stats` to the command that starts the cluster, or
-              run the following command: `ray disable-usage-stats` before
-              starting the cluster. See{" "}
-              <a
-                href="https://docs.ray.io/en/master/cluster/usage-stats.html"
-                target="_blank"
-                rel="noreferrer"
-              >
-                https://docs.ray.io/en/master/cluster/usage-stats.html
-              </a>{" "}
-              for more details.
-            </span>
-          ) : (
-            <span>Usage stats collection is disabled.</span>
-          )}
-        </Alert>
-      ) : null}
+      <UsageStatsAlert />
       <LastUpdated />
     </div>
   );

--- a/dashboard/client/src/pages/layout/index.tsx
+++ b/dashboard/client/src/pages/layout/index.tsx
@@ -9,6 +9,7 @@ import { NightsStay, VerticalAlignTop, WbSunny } from "@material-ui/icons";
 import classnames from "classnames";
 import React, { PropsWithChildren } from "react";
 import { RouteComponentProps } from "react-router-dom";
+import { UsageStatsAlert } from "../../common/UsageStatsAlert";
 
 import SpeedTools from "../../components/SpeedTools";
 import Logo from "../../logo.svg";
@@ -130,9 +131,9 @@ const BasicLayout = (
           <ListItem
             button
             className={classnames(classes.menuItem)}
-            onClick={() => history.push("/")}
+            onClick={() => history.push("/legacy")}
           >
-            <ListItemText>BACK TO LEGACY DASHBOARD</ListItemText>
+            <ListItemText>TO LEGACY DASHBOARD</ListItemText>
           </ListItem>
           <ListItem>
             <IconButton
@@ -159,7 +160,10 @@ const BasicLayout = (
           <SpeedTools />
         </List>
       </Drawer>
-      <div className={classes.child}>{children}</div>
+      <div className={classes.child}>
+        {children}
+        <UsageStatsAlert />
+      </div>
     </div>
   );
 };

--- a/dashboard/tests/cypress/e2e/test_render.cy.js
+++ b/dashboard/tests/cypress/e2e/test_render.cy.js
@@ -2,7 +2,5 @@ describe('Ray Dashboard Test', () => {
     it('opens a new Ray dashboard', () => {
         cy.visit('localhost:8653')
         cy.contains('Ray')
-        cy.contains('JOBS').click()
-        cy.contains('ACTORS').click()
     })
   })

--- a/dashboard/tests/cypress/e2e/test_render.cy.js
+++ b/dashboard/tests/cypress/e2e/test_render.cy.js
@@ -2,7 +2,7 @@ describe('Ray Dashboard Test', () => {
     it('opens a new Ray dashboard', () => {
         cy.visit('localhost:8653')
         cy.contains('Ray')
-        cy.contains('Jobs').click()
-        cy.contains('Actors').click()
+        cy.contains('JOBS').click()
+        cy.contains('ACTORS').click()
     })
   })

--- a/dashboard/tests/cypress/e2e/test_render.cy.js
+++ b/dashboard/tests/cypress/e2e/test_render.cy.js
@@ -2,7 +2,7 @@ describe('Ray Dashboard Test', () => {
     it('opens a new Ray dashboard', () => {
         cy.visit('localhost:8653')
         cy.contains('Ray')
-        cy.contains('Memory').click()
-        cy.contains('Tune').click()
+        cy.contains('Jobs').click()
+        cy.contains('Actors').click()
     })
   })


### PR DESCRIPTION
Add UsageStats alert to new dashboard
Update wording of "back to legacy dashboard", "try new dashboard" buttons

Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
<img width="1904" alt="Screen Shot 2022-07-25 at 6 16 36 PM" src="https://user-images.githubusercontent.com/711935/180901822-2e050268-e856-496e-a3d6-ae7262d6a1db.png">
<img width="1904" alt="Screen Shot 2022-07-25 at 6 16 41 PM" src="https://user-images.githubusercontent.com/711935/180901844-a0854312-14f9-4608-abba-f2875364bcc1.png">


- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
