### PR TITLE
[WIP] [Core] redirect stdout/stderr for all types of workers

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -204,7 +204,6 @@ def get_worker_log_file_name(worker_type, job_id=None):
 
 
 def configure_log_file(out_file, err_file):
-    # ANT-INTERNAL: test before python redirect.
     if os.environ.get("WORKER_LOG_REDIRECTED_TEST"):
         sys.stdout.write("stdout test")
         sys.stderr.write("stderr test")

--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -204,6 +204,13 @@ def get_worker_log_file_name(worker_type, job_id=None):
 
 
 def configure_log_file(out_file, err_file):
+    # ANT-INTERNAL: test before python redirect.
+    if os.environ.get("WORKER_LOG_REDIRECTED_TEST"):
+        sys.stdout.write("stdout test")
+        sys.stderr.write("stderr test")
+        sys.stdout.flush()
+        sys.stderr.flush()
+
     # If either of the file handles are None, there are no log files to
     # configure since we're redirecting all output to stdout and stderr.
     if out_file is None or err_file is None:

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -24,8 +24,7 @@ def enable_test_worker_log_redirected():
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_worker_log_redirected(enable_test_worker_log_redirected,
-                               ray_start_regular):
+def test_worker_log_redirected(enable_test_worker_log_redirected, ray_start_regular):
     session_dir = ray.worker._global_node.get_session_dir_path()
     assert os.path.exists(session_dir), "Session dir not found."
 
@@ -41,7 +40,7 @@ def test_worker_log_redirected(enable_test_worker_log_redirected,
                     if line.strip() == expected:
                         ok = True
                         break
-        assert (ok)
+        assert ok
 
     futures = f.remote()
     pid = ray.get(futures)

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -16,6 +16,42 @@ def enable_export_loglevel(func):
     return func
 
 
+@pytest.fixture
+def enable_test_worker_log_redirected():
+    os.environ["WORKER_LOG_REDIRECTED_TEST"] = "true"
+    yield
+    os.environ.pop("WORKER_LOG_REDIRECTED_TEST", None)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+def test_worker_log_redirected(enable_test_worker_log_redirected,
+                               ray_start_regular):
+    session_dir = ray.worker._global_node.get_session_dir_path()
+    assert os.path.exists(session_dir), "Session dir not found."
+
+    @ray.remote
+    def f():
+        return os.getpid()
+
+    def check_log(file, expected):
+        ok = False
+        for filename in glob.glob(file):
+            with open(filename, "r") as f:
+                for line in f:
+                    if line.strip() == expected:
+                        ok = True
+                        break
+        assert (ok)
+
+    futures = f.remote()
+    pid = ray.get(futures)
+    print(pid)
+    worker_out_file = "{}/logs/python-worker-*-{}.out".format(session_dir, pid)
+    check_log(worker_out_file, "stdout test")
+    worker_err_file = "{}/logs/python-worker-*-{}.err".format(session_dir, pid)
+    check_log(worker_err_file, "stderr test")
+
+
 @enable_export_loglevel
 def test_ray_log_redirected(ray_start_regular):
     session_dir = ray._private.worker._global_node.get_session_dir_path()

--- a/src/ray/core_worker/common.cc
+++ b/src/ray/core_worker/common.cc
@@ -17,33 +17,6 @@
 namespace ray {
 namespace core {
 
-std::string WorkerTypeString(WorkerType type) {
-  // TODO(suquark): Use proto3 utils to get the string.
-  if (type == WorkerType::DRIVER) {
-    return "driver";
-  } else if (type == WorkerType::WORKER) {
-    return "worker";
-  } else if (type == WorkerType::SPILL_WORKER) {
-    return "spill_worker";
-  } else if (type == WorkerType::RESTORE_WORKER) {
-    return "restore_worker";
-  }
-  RAY_CHECK(false);
-  return "";
-}
-
-std::string LanguageString(Language language) {
-  if (language == Language::PYTHON) {
-    return "python";
-  } else if (language == Language::JAVA) {
-    return "java";
-  } else if (language == Language::CPP) {
-    return "cpp";
-  }
-  RAY_CHECK(false);
-  return "";
-}
-
 std::string GenerateCachedActorName(const std::string &ns,
                                     const std::string &actor_name) {
   return ns + "-" + actor_name;

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -27,12 +27,6 @@ namespace core {
 
 using WorkerType = rpc::WorkerType;
 
-// Return a string representation of the worker type.
-std::string WorkerTypeString(WorkerType type);
-
-// Return a string representation of the language.
-std::string LanguageString(Language language);
-
 // Return a string representation of the named actor to cache, in format of
 // `namespace-[job_id-]actor_name`
 std::string GenerateCachedActorName(const std::string &ns, const std::string &actor_name);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -199,7 +199,8 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
           /*starting_worker_timeout_callback=*/
           [this] { cluster_task_manager_->ScheduleAndDispatchTasks(); },
           config.ray_debugger_external,
-          /*get_time=*/[]() { return absl::GetCurrentTimeNanos() / 1e6; }),
+          /*get_time=*/[]() { return absl::GetCurrentTimeNanos() / 1e6; },
+          config.log_dir),
       client_call_manager_(io_service),
       worker_rpc_pool_(client_call_manager_),
       core_worker_subscriber_(std::make_unique<pubsub::Subscriber>(

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -438,9 +438,9 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
   }
   std::string std_streams_redirect_file_prefix = log_dir_;
   std_streams_redirect_file_prefix.append("/")
-      .append(ray::LanguageString(language))
+      .append(LanguageString(language))
       .append("-")
-      .append(ray::WorkerTypeString(worker_type))
+      .append(WorkerTypeString(worker_type))
       .append("-")
       .append(job_id.Hex())
       .append("-");

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -553,7 +553,8 @@ void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
 }
 
 Process WorkerPool::StartProcess(const std::vector<std::string> &worker_command_args,
-                                 const ProcessEnvironment &env, const std::string &std_streams_redirect_file_prefix) {
+                                 const ProcessEnvironment &env,
+                                 const std::string &std_streams_redirect_file_prefix) {
   if (RAY_LOG_ENABLED(DEBUG)) {
     std::string debug_info;
     debug_info.append("Starting worker process with command:");
@@ -584,7 +585,12 @@ Process WorkerPool::StartProcess(const std::vector<std::string> &worker_command_
   }
   argv.push_back(NULL);
 
-  Process child(argv.data(), io_service_, ec, /*decouple=*/false, env, std_streams_redirect_file_prefix);
+  Process child(argv.data(),
+                io_service_,
+                ec,
+                /*decouple=*/false,
+                env,
+                std_streams_redirect_file_prefix);
   if (!child.IsValid() || ec) {
     // errorcode 24: Too many files. This is caused by ulimit.
     if (ec.value() == 24) {

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -195,7 +195,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
              const std::string &native_library_path,
              std::function<void()> starting_worker_timeout_callback,
              int ray_debugger_external,
-             const std::function<double()> get_time);
+             const std::function<double()> get_time,
+             const std::string &log_dir);
 
   /// Destructor responsible for freeing a set of workers owned by this class.
   virtual ~WorkerPool();
@@ -444,7 +445,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// the environment variables of the parent process.
   /// \return An object representing the started worker process.
   virtual Process StartProcess(const std::vector<std::string> &worker_command_args,
-                               const ProcessEnvironment &env);
+                               const ProcessEnvironment &env,
+                               const std::string &std_streams_redirect_file_prefix);
 
   /// Push an warning message to user if worker pool is getting to big.
   virtual void WarnAboutSize();
@@ -761,6 +763,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   int64_t process_failed_rate_limited_ = 0;
   int64_t process_failed_pending_registration_ = 0;
   int64_t process_failed_runtime_env_setup_failed_ = 0;
+  
+  std::string log_dir_;
 
   friend class WorkerPoolTest;
 };

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -763,7 +763,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   int64_t process_failed_rate_limited_ = 0;
   int64_t process_failed_pending_registration_ = 0;
   int64_t process_failed_runtime_env_setup_failed_ = 0;
-  
+
   std::string log_dir_;
 
   friend class WorkerPoolTest;

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -141,7 +141,8 @@ class WorkerPoolMock : public WorkerPool {
             "",
             []() {},
             0,
-            [this]() { return current_time_ms_; }),
+            [this]() { return current_time_ms_; },
+            ""),
         last_worker_process_(),
         instrumented_io_service_(io_service),
         error_message_type_(1),
@@ -167,7 +168,8 @@ class WorkerPoolMock : public WorkerPool {
   }
 
   Process StartProcess(const std::vector<std::string> &worker_command_args,
-                       const ProcessEnvironment &env) override {
+                       const ProcessEnvironment &env,
+                       const std::string &std_streams_redirect_file_prefix) override {
     // Use a bogus process ID that won't conflict with those in the system
     pid_t pid = static_cast<pid_t>(PID_MAX_LIMIT + 1 + worker_commands_by_proc_.size());
     last_worker_process_ = Process::FromPid(pid);

--- a/src/ray/rpc/common.cc
+++ b/src/ray/rpc/common.cc
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 #include "ray/rpc/common.h"
-#include "ray/util/logging.h"
 
 #include <fstream>
 #include <sstream>
+
+#include "ray/util/logging.h"
 
 namespace ray::rpc {
 

--- a/src/ray/rpc/common.cc
+++ b/src/ray/rpc/common.cc
@@ -13,11 +13,39 @@
 // limitations under the License.
 
 #include "ray/rpc/common.h"
+#include "ray/util/logging.h"
 
 #include <fstream>
 #include <sstream>
 
 namespace ray::rpc {
+
+std::string WorkerTypeString(WorkerType type) {
+  // TODO(suquark): Use proto3 utils to get the string.
+  if (type == WorkerType::DRIVER) {
+    return "driver";
+  } else if (type == WorkerType::WORKER) {
+    return "worker";
+  } else if (type == WorkerType::SPILL_WORKER) {
+    return "spill_worker";
+  } else if (type == WorkerType::RESTORE_WORKER) {
+    return "restore_worker";
+  }
+  RAY_CHECK(false);
+  return "";
+}
+
+std::string LanguageString(Language language) {
+  if (language == Language::PYTHON) {
+    return "python";
+  } else if (language == Language::JAVA) {
+    return "java";
+  } else if (language == Language::CPP) {
+    return "cpp";
+  }
+  RAY_CHECK(false);
+  return "";
+}
 
 std::string ReadCert(const std::string &cert_filepath) {
   std::ifstream t(cert_filepath);

--- a/src/ray/rpc/common.h
+++ b/src/ray/rpc/common.h
@@ -14,7 +14,15 @@
 
 #include <string>
 
+#include "src/ray/protobuf/common.pb.h"
+
 namespace ray::rpc {
+
+// Return a string representation of the worker type.
+std::string WorkerTypeString(WorkerType type);
+
+// Return a string representation of the language.
+std::string LanguageString(Language language);
 
 // Utility to read cert file from a particular location
 std::string ReadCert(const std::string &cert_filepath);

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -377,7 +377,8 @@ Process::Process(const char *argv[],
                  const ProcessEnvironment &env,
                  const std::string &std_streams_redirect_file_prefix) {
   (void)io_service;
-  ProcessFD procfd = ProcessFD::spawnvpe(argv, ec, decouple, env, std_streams_redirect_file_prefix);
+  ProcessFD procfd =
+      ProcessFD::spawnvpe(argv, ec, decouple, env, std_streams_redirect_file_prefix);
   if (!ec) {
     p_ = std::make_shared<ProcessFD>(std::move(procfd));
   }

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -77,7 +77,8 @@ class Process {
                    void *io_service,
                    std::error_code &ec,
                    bool decouple = false,
-                   const ProcessEnvironment &env = {});
+                   const ProcessEnvironment &env = {},
+                   const std::string &std_streams_redirect_file_prefix = "");
   /// Convenience function to run the given command line and wait for it to finish.
   static std::error_code Call(const std::vector<std::string> &args,
                               const ProcessEnvironment &env = {});


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, only stdout/stderr of Python workers are redirected to log files. Java and C++ workers don't have any mechanism to redirect stdout/stderr to files. This PR tries to add redirection for Java and C++ workers by configuring redirection at the Raylet side (when starting new worker processes). The new mechanism is worker language ignorant.

TODO

- [ ] Windows support.
- [ ] Unify redirection for Python workers.
- [ ] Refine log file naming.
- [ ] Doc updates.

## Related issue number

Closes #22664

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
