### PR TITLE
[K8s][Autoscaler] expose serviceAccountName to values.yaml

### DIFF
--- a/deploy/charts/ray/templates/raycluster.yaml
+++ b/deploy/charts/ray/templates/raycluster.yaml
@@ -87,6 +87,9 @@ spec:
           tolerations:
           {{- toYaml $val.tolerations | nindent 10 }}
           {{- end }}
+          {{- if $.Values.serviceAccountName }}
+          serviceAccountName: {{ $.Values.serviceAccountName }}
+          {{- end }}
     {{- end }}
   # Commands to start Ray on the head node. You don't need to change this.
   # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.

--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -15,6 +15,9 @@ upscalingSpeed: 1.0
 idleTimeoutMinutes: 5
 # headPodType is the podType used for the Ray head node (as configured below).
 headPodType: rayHeadType
+# serviceAccountName is used for the Ray head and each Ray worker.
+# It can be set to your particular service account instead of using the default.
+# serviceAccountName: ...
 # podTypes is the list of pod configurations available for use as Ray nodes.
 podTypes:
     # The key for each podType is a user-defined string.


### PR DESCRIPTION
[K8s/Autoscaler] Added a field for the service account name
Exposed serviceAccountName on values.yaml (#26657)

Signed-off-by: Andrew Li <orcahmlee@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I'm using Helm Chart to deploy the ray cluster on GKE. For now, the ray head and workers are using `serviceAccountName: default`. I think it would be great if we can set our own service account via [raycluster](https://github.com/ray-project/ray/blob/master/deploy/charts/ray/templates/raycluster.yaml) and [values.yaml](https://github.com/ray-project/ray/blob/master/deploy/charts/ray/values.yaml).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #26657
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
