### PR TITLE
[air] Add tests for BatchPredictor and all data batch types

### DIFF
--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -235,7 +235,7 @@ py_test(
 
 py_test(
     name = "test_rl_predictor",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_rl_predictor.py"],
     tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]

--- a/python/ray/train/rl/rl_predictor.py
+++ b/python/ray/train/rl/rl_predictor.py
@@ -66,5 +66,10 @@ class RLPredictor(Predictor):
         actions, _outs, _info = self.policy.compute_actions_from_input_dict(
             input_dict={"obs": obs}
         )
+        actions_arr = np.array(actions)
+        if len(actions_arr.shape) > 1:
+            columns = [f"action{i}" for i in range(actions_arr.shape[1])]
+        else:
+            columns = ["action"]
 
-        return pd.DataFrame(np.array(actions))
+        return pd.DataFrame(actions_arr, columns=columns)

--- a/python/ray/train/tests/conftest.py
+++ b/python/ray/train/tests/conftest.py
@@ -1,13 +1,2 @@
-import pytest
-import ray
-
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
 from ray.tests.conftest import pytest_runtest_makereport  # noqa
-
-
-@pytest.fixture
-def ray_start_4_cpus():
-    address_info = ray.init(num_cpus=4)
-    yield address_info
-    # The code after the yield will run as teardown code.
-    ray.shutdown()

--- a/python/ray/train/tests/conftest.py
+++ b/python/ray/train/tests/conftest.py
@@ -1,2 +1,13 @@
+import pytest
+import ray
+
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
 from ray.tests.conftest import pytest_runtest_makereport  # noqa
+
+
+@pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()

--- a/python/ray/train/tests/test_huggingface_predictor.py
+++ b/python/ray/train/tests/test_huggingface_predictor.py
@@ -26,6 +26,14 @@ tokenizer_checkpoint = "sgugger/gpt2-like-tokenizer"
 
 
 @pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+@pytest.fixture
 def ray_start_runtime_env():
     # Requires at least torch 1.11 to pass
     # TODO update torch version in requirements instead

--- a/python/ray/train/tests/test_huggingface_predictor.py
+++ b/python/ray/train/tests/test_huggingface_predictor.py
@@ -100,6 +100,7 @@ def create_checkpoint():
         model = AutoModelForCausalLM.from_config(model_config)
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_checkpoint)
         checkpoint = HuggingFaceCheckpoint.from_model(model, tokenizer, path=tmpdir)
+        # Serialize to dict so we can remove the temporary directory
         return HuggingFaceCheckpoint.from_dict(checkpoint.to_dict())
 
 

--- a/python/ray/train/tests/test_huggingface_predictor.py
+++ b/python/ray/train/tests/test_huggingface_predictor.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 from ray.air.util.data_batch_conversion import convert_pandas_to_batch_type
+from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers.pipelines import pipeline
@@ -91,6 +92,37 @@ def test_predict_no_preprocessor_no_training(ray_start_runtime_env):
             assert len(predictions) == 3
 
     ray.get(test.remote())
+
+
+def create_checkpoint():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_config = AutoConfig.from_pretrained(model_checkpoint)
+        model = AutoModelForCausalLM.from_config(model_config)
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_checkpoint)
+        checkpoint = HuggingFaceCheckpoint.from_model(model, tokenizer, path=tmpdir)
+        return HuggingFaceCheckpoint.from_dict(checkpoint.to_dict())
+
+
+@pytest.mark.parametrize("batch_type", [pd.DataFrame, pa.Table])
+def test_predict_batch(ray_start_4_cpus, batch_type):
+    checkpoint = create_checkpoint()
+    predictor = BatchPredictor.from_checkpoint(
+        checkpoint, HuggingFacePredictor, task="text-generation"
+    )
+
+    # Todo: Ray data does not support numpy string arrays well
+    if batch_type == np.ndarray:
+        dataset = ray.data.from_numpy(prompts.to_numpy().astype("U"))
+    elif batch_type == pd.DataFrame:
+        dataset = ray.data.from_pandas(prompts)
+    elif batch_type == pa.Table:
+        dataset = ray.data.from_arrow(pa.Table.from_pandas(prompts))
+    else:
+        raise RuntimeError("Invalid batch_type")
+
+    predictions = predictor.predict(dataset)
+
+    assert predictions.count() == 3
 
 
 if __name__ == "__main__":

--- a/python/ray/train/tests/test_lightgbm_predictor.py
+++ b/python/ray/train/tests/test_lightgbm_predictor.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 
 import lightgbm as lgbm
@@ -8,15 +7,21 @@ import pyarrow as pa
 import pytest
 import ray
 
-from ray.air._internal.checkpointing import save_preprocessor_to_dir
 from ray.air.checkpoint import Checkpoint
-from ray.air.constants import MODEL_KEY
 from ray.air.util.data_batch_conversion import convert_pandas_to_batch_type
 from ray.data.preprocessor import Preprocessor
 from ray.train.batch_predictor import BatchPredictor
 from ray.train.lightgbm import LightGBMCheckpoint, LightGBMPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from typing import Tuple
+
+
+@pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
 
 
 class DummyPreprocessor(Preprocessor):

--- a/python/ray/train/tests/test_lightgbm_predictor.py
+++ b/python/ray/train/tests/test_lightgbm_predictor.py
@@ -39,15 +39,11 @@ def create_checkpoint_preprocessor() -> Tuple[Checkpoint, Preprocessor]:
     preprocessor.attr = 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # This somewhat convoluted procedure is the same as in the
-        # Trainers. The reason for saving model to disk instead
-        # of directly to the dict as bytes is due to all callbacks
-        # following save to disk logic. GBDT models are small
-        # enough that IO should not be an issue.
-        model.save_model(os.path.join(tmpdir, MODEL_KEY))
-        save_preprocessor_to_dir(preprocessor, tmpdir)
-
-        checkpoint = Checkpoint.from_dict(Checkpoint.from_directory(tmpdir).to_dict())
+        checkpoint = LightGBMCheckpoint.from_model(
+            booster=model, path=tmpdir, preprocessor=preprocessor
+        )
+        # Serialize to dict so we can remove the temporary directory
+        checkpoint = LightGBMCheckpoint.from_dict(checkpoint.to_dict())
 
     return checkpoint, preprocessor
 

--- a/python/ray/train/tests/test_lightgbm_predictor.py
+++ b/python/ray/train/tests/test_lightgbm_predictor.py
@@ -6,14 +6,17 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import ray
 
 from ray.air._internal.checkpointing import save_preprocessor_to_dir
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY
 from ray.air.util.data_batch_conversion import convert_pandas_to_batch_type
 from ray.data.preprocessor import Preprocessor
+from ray.train.batch_predictor import BatchPredictor
 from ray.train.lightgbm import LightGBMCheckpoint, LightGBMPredictor
 from ray.train.predictor import TYPE_TO_ENUM
+from typing import Tuple
 
 
 class DummyPreprocessor(Preprocessor):
@@ -31,10 +34,9 @@ def get_num_trees(booster: lgbm.Booster) -> int:
     return booster.current_iteration()
 
 
-def test_init():
+def create_checkpoint_preprocessor() -> Tuple[Checkpoint, Preprocessor]:
     preprocessor = DummyPreprocessor()
     preprocessor.attr = 1
-    predictor = LightGBMPredictor(model=model, preprocessor=preprocessor)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # This somewhat convoluted procedure is the same as in the
@@ -45,8 +47,17 @@ def test_init():
         model.save_model(os.path.join(tmpdir, MODEL_KEY))
         save_preprocessor_to_dir(preprocessor, tmpdir)
 
-        checkpoint = Checkpoint.from_directory(tmpdir)
-        checkpoint_predictor = LightGBMPredictor.from_checkpoint(checkpoint)
+        checkpoint = Checkpoint.from_dict(Checkpoint.from_directory(tmpdir).to_dict())
+
+    return checkpoint, preprocessor
+
+
+def test_init():
+    checkpoint, preprocessor = create_checkpoint_preprocessor()
+
+    predictor = LightGBMPredictor(model=model, preprocessor=preprocessor)
+
+    checkpoint_predictor = LightGBMPredictor.from_checkpoint(checkpoint)
 
     assert get_num_trees(checkpoint_predictor.model) == get_num_trees(predictor.model)
     assert (
@@ -66,6 +77,28 @@ def test_predict(batch_type):
 
     assert len(predictions) == 3
     assert hasattr(predictor.get_preprocessor(), "_batch_transformed")
+
+
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table])
+def test_predict_batch(ray_start_4_cpus, batch_type):
+    checkpoint, _ = create_checkpoint_preprocessor()
+    predictor = BatchPredictor.from_checkpoint(checkpoint, LightGBMPredictor)
+
+    raw_batch = pd.DataFrame(dummy_data, columns=["A", "B"])
+    data_batch = convert_pandas_to_batch_type(raw_batch, type=TYPE_TO_ENUM[batch_type])
+
+    if batch_type == np.ndarray:
+        dataset = ray.data.from_numpy(dummy_data)
+    elif batch_type == pd.DataFrame:
+        dataset = ray.data.from_pandas(data_batch)
+    elif batch_type == pa.Table:
+        dataset = ray.data.from_arrow(data_batch)
+    else:
+        raise RuntimeError("Invalid batch_type")
+
+    predictions = predictor.predict(dataset)
+
+    assert predictions.count() == 3
 
 
 def test_predict_feature_columns():

--- a/python/ray/train/tests/test_rl_predictor.py
+++ b/python/ray/train/tests/test_rl_predictor.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import ray
 
 from ray.air.checkpoint import Checkpoint
 from ray.air.util.data_batch_conversion import (
@@ -15,6 +16,7 @@ from ray.air.util.data_batch_conversion import (
 from ray.data.preprocessor import Preprocessor
 from ray.rllib.algorithms import Algorithm
 from ray.rllib.policy import Policy
+from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from ray.train.rl import RLTrainer
 from ray.train.rl.rl_predictor import RLPredictor
@@ -113,6 +115,36 @@ def test_predict_with_preprocessor(batch_type, batch_size):
     predictions = predictor.predict(obs)
     actions = convert_batch_type_to_pandas(predictions)
 
+    assert len(actions) == batch_size
+    # Preprocessor doubles observations to 2.0, then we add [0., 1.),
+    # so actions should be in [2., 3.)
+    assert all(2.0 <= action.item() < 3.0 for action in np.array(actions))
+
+
+@pytest.mark.parametrize("batch_type", [np.ndarray, pd.DataFrame, pa.Table])
+@pytest.mark.parametrize("batch_size", [1, 20])
+def test_predict_batch(ray_start_4_cpus, batch_type, batch_size):
+    preprocessor = _DummyPreprocessor()
+    checkpoint = create_checkpoint(preprocessor=preprocessor)
+    predictor = BatchPredictor.from_checkpoint(checkpoint, RLPredictor)
+
+    # Observations
+    data = pd.DataFrame(
+        [[1.0] * 10] * batch_size, columns=[f"X{i:02d}" for i in range(10)]
+    )
+
+    if batch_type == np.ndarray:
+        dataset = ray.data.from_numpy(data.to_numpy())
+    elif batch_type == pd.DataFrame:
+        dataset = ray.data.from_pandas(data)
+    elif batch_type == pa.Table:
+        dataset = ray.data.from_arrow(pa.Table.from_pandas(data))
+    else:
+        raise RuntimeError("Invalid batch_type")
+
+    # Predictions
+    predictions = predictor.predict(dataset)
+    actions = predictions.to_pandas()
     assert len(actions) == batch_size
     # Preprocessor doubles observations to 2.0, then we add [0., 1.),
     # so actions should be in [2., 3.)

--- a/python/ray/train/tests/test_rl_predictor.py
+++ b/python/ray/train/tests/test_rl_predictor.py
@@ -23,6 +23,14 @@ from ray.train.rl.rl_predictor import RLPredictor
 from ray.tune.trainable.util import TrainableUtil
 
 
+@pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
 class _DummyAlgo(Algorithm):
     train_exec_impl = None
 

--- a/python/ray/train/tests/test_sklearn_predictor.py
+++ b/python/ray/train/tests/test_sklearn_predictor.py
@@ -46,11 +46,11 @@ def create_checkpoint_preprocessor() -> Tuple[Checkpoint, Preprocessor]:
     preprocessor.attr = 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, MODEL_KEY), "wb") as f:
-            cpickle.dump(model, f)
-        save_preprocessor_to_dir(preprocessor, tmpdir)
-
-        checkpoint = Checkpoint.from_dict(Checkpoint.from_directory(tmpdir).to_dict())
+        checkpoint = SklearnCheckpoint.from_estimator(
+            estimator=model, path=tmpdir, preprocessor=preprocessor
+        )
+        # Serialize to dict so we can remove the temporary directory
+        checkpoint = SklearnCheckpoint.from_dict(checkpoint.to_dict())
 
     return checkpoint, preprocessor
 

--- a/python/ray/train/tests/test_sklearn_predictor.py
+++ b/python/ray/train/tests/test_sklearn_predictor.py
@@ -11,7 +11,6 @@ from sklearn.ensemble import RandomForestClassifier
 
 import ray
 import ray.cloudpickle as cpickle
-from ray.air._internal.checkpointing import save_preprocessor_to_dir
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY
 from ray.data.preprocessor import Preprocessor

--- a/python/ray/train/tests/test_tensorflow_predictor.py
+++ b/python/ray/train/tests/test_tensorflow_predictor.py
@@ -15,6 +15,7 @@ from ray.data.preprocessor import Preprocessor
 from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from ray.train.tensorflow import TensorflowCheckpoint, TensorflowPredictor
+from typing import Tuple
 
 
 class DummyPreprocessor(Preprocessor):
@@ -52,16 +53,23 @@ def build_model_multi_output() -> tf.keras.Model:
 weights = [np.array([[2.0]]), np.array([0.0])]
 
 
-def test_init():
+def create_checkpoint_preprocessor() -> Tuple[Checkpoint, Preprocessor]:
     preprocessor = DummyPreprocessor()
+    checkpoint = Checkpoint.from_dict(
+        {MODEL_KEY: weights, PREPROCESSOR_KEY: preprocessor}
+    )
+
+    return checkpoint, preprocessor
+
+
+def test_init():
+    checkpoint, preprocessor = create_checkpoint_preprocessor()
+
     predictor = TensorflowPredictor(
         model_definition=build_model, preprocessor=preprocessor, model_weights=weights
     )
 
-    checkpoint = {MODEL_KEY: weights, PREPROCESSOR_KEY: preprocessor}
-    checkpoint_predictor = TensorflowPredictor.from_checkpoint(
-        Checkpoint.from_dict(checkpoint), build_model
-    )
+    checkpoint_predictor = TensorflowPredictor.from_checkpoint(checkpoint, build_model)
 
     assert checkpoint_predictor.model_definition == predictor.model_definition
     assert checkpoint_predictor.model_weights == predictor.model_weights
@@ -109,6 +117,31 @@ def test_predict(batch_type):
 
     assert len(predictions) == 3
     assert predictions.to_numpy().flatten().tolist() == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.parametrize("batch_type", [pd.DataFrame, pa.Table])
+def test_predict_batch(ray_start_4_cpus, batch_type):
+    checkpoint = Checkpoint.from_dict({MODEL_KEY: {}})
+    predictor = BatchPredictor.from_checkpoint(
+        checkpoint, TensorflowPredictor, model_definition=build_model_multi_input
+    )
+
+    dummy_data = pd.DataFrame([[0.0, 1.0], [0.0, 2.0], [0.0, 3.0]], columns=["A", "B"])
+
+    # Todo: Ray data does not support numpy dicts
+    if batch_type == np.ndarray:
+        dataset = ray.data.from_numpy(dummy_data.to_numpy())
+    elif batch_type == pd.DataFrame:
+        dataset = ray.data.from_pandas(dummy_data)
+    elif batch_type == pa.Table:
+        dataset = ray.data.from_arrow(pa.Table.from_pandas(dummy_data))
+    else:
+        raise RuntimeError("Invalid batch_type")
+
+    predictions = predictor.predict(dataset)
+
+    assert predictions.count() == 3
+    assert predictions.to_pandas().to_numpy().flatten().tolist() == [1.0, 2.0, 3.0]
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])

--- a/python/ray/train/tests/test_tensorflow_predictor.py
+++ b/python/ray/train/tests/test_tensorflow_predictor.py
@@ -18,6 +18,14 @@ from ray.train.tensorflow import TensorflowCheckpoint, TensorflowPredictor
 from typing import Tuple
 
 
+@pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
 class DummyPreprocessor(Preprocessor):
     def transform_batch(self, df):
         self._batch_transformed = True
@@ -121,7 +129,7 @@ def test_predict(batch_type):
 
 @pytest.mark.parametrize("batch_type", [pd.DataFrame, pa.Table])
 def test_predict_batch(ray_start_4_cpus, batch_type):
-    checkpoint = Checkpoint.from_dict({MODEL_KEY: {}})
+    checkpoint = TensorflowCheckpoint.from_dict({MODEL_KEY: {}})
     predictor = BatchPredictor.from_checkpoint(
         checkpoint, TensorflowPredictor, model_definition=build_model_multi_input
     )

--- a/python/ray/train/tests/test_torch_predictor.py
+++ b/python/ray/train/tests/test_torch_predictor.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import ray
 import torch
 
 from ray.air.checkpoint import Checkpoint
@@ -11,6 +12,7 @@ from ray.air.util.data_batch_conversion import (
     convert_batch_type_to_pandas,
 )
 from ray.data.preprocessor import Preprocessor
+from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from ray.train.torch import TorchCheckpoint, TorchPredictor
 
@@ -78,6 +80,32 @@ def test_predict(batch_type):
 
     assert len(predictions) == 3
     assert predictions.to_numpy().flatten().tolist() == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.parametrize("batch_type", [pd.DataFrame, pa.Table])
+def test_predict_batch(ray_start_4_cpus, batch_type):
+    checkpoint = Checkpoint.from_dict({MODEL_KEY: {}})
+    predictor = BatchPredictor.from_checkpoint(
+        checkpoint, TorchPredictor, model=DummyModelMultiInput()
+    )
+
+    dummy_data = pd.DataFrame(
+        [[0.0, 1.0], [0.0, 2.0], [0.0, 3.0]], columns=["X0", "X1"]
+    )
+
+    # Todo: Ray data does not support numpy dicts
+    if batch_type == np.ndarray:
+        dataset = ray.data.from_numpy(dummy_data.to_numpy())
+    elif batch_type == pd.DataFrame:
+        dataset = ray.data.from_pandas(dummy_data)
+    elif batch_type == pa.Table:
+        dataset = ray.data.from_arrow(pa.Table.from_pandas(dummy_data))
+    else:
+        raise RuntimeError("Invalid batch_type")
+
+    predictions = predictor.predict(dataset)
+
+    assert predictions.count() == 3
 
 
 @pytest.mark.parametrize("use_gpu", [False, True])

--- a/python/ray/train/tests/test_xgboost_predictor.py
+++ b/python/ray/train/tests/test_xgboost_predictor.py
@@ -1,5 +1,4 @@
 import json
-import os
 import tempfile
 
 import numpy as np
@@ -9,15 +8,21 @@ import pytest
 import ray.data
 import xgboost as xgb
 
-from ray.air._internal.checkpointing import save_preprocessor_to_dir
 from ray.air.checkpoint import Checkpoint
-from ray.air.constants import MODEL_KEY
 from ray.air.util.data_batch_conversion import convert_pandas_to_batch_type
 from ray.data.preprocessor import Preprocessor
 from ray.train.batch_predictor import BatchPredictor
 from ray.train.predictor import TYPE_TO_ENUM
 from ray.train.xgboost import XGBoostCheckpoint, XGBoostPredictor
 from typing import Tuple
+
+
+@pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
 
 
 class DummyPreprocessor(Preprocessor):

--- a/python/ray/train/tests/test_xgboost_predictor.py
+++ b/python/ray/train/tests/test_xgboost_predictor.py
@@ -41,15 +41,11 @@ def create_checkpoint_preprocessor() -> Tuple[Checkpoint, Preprocessor]:
     preprocessor.attr = 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # This somewhat convoluted procedure is the same as in the
-        # Trainers. The reason for saving model to disk instead
-        # of directly to the dict as bytes is due to all callbacks
-        # following save to disk logic. GBDT models are small
-        # enough that IO should not be an issue.
-        model.save_model(os.path.join(tmpdir, MODEL_KEY))
-        save_preprocessor_to_dir(preprocessor, tmpdir)
-
-        checkpoint = Checkpoint.from_dict(Checkpoint.from_directory(tmpdir).to_dict())
+        checkpoint = XGBoostCheckpoint.from_model(
+            booster=model, path=tmpdir, preprocessor=preprocessor
+        )
+        # Serialize to dict so we can remove the temporary directory
+        checkpoint = XGBoostCheckpoint.from_dict(checkpoint.to_dict())
 
     return checkpoint, preprocessor
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes sure that all predictors work in a BatchPredictor.

Note that passing numpy arrays is not well supported for the deep learning predictors. A Pandas DataFrame for the respective test yields the following array representation:

```
{'A': array([0., 0., 0.]), 'B': array([1., 2., 3.])}
```

But passing a numpy array will lead to:

```
array([[0., 1.], [0., 2.], [0., 3.]])
```

It is not clear how we should address this case - the mutidimensional numpy array could be a valid input to tf/torch models. Let's discuss this cc @amogkam, in the meantime this PR addresses all other cases.

## Related issue number

Closes #25193

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
