### PR TITLE
[air] update xgboost test (catch test failures properly).

### DIFF
--- a/python/ray/train/tests/test_lightgbm_predictor.py
+++ b/python/ray/train/tests/test_lightgbm_predictor.py
@@ -97,9 +97,8 @@ def test_predict_feature_columns_pandas():
 
 
 def test_predict_no_preprocessor_no_training():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        checkpoint = LightGBMCheckpoint.from_model(booster=model, path=tmpdir)
-        predictor = LightGBMPredictor.from_checkpoint(checkpoint)
+    checkpoint = LightGBMCheckpoint.from_model(booster=model)
+    predictor = LightGBMPredictor.from_checkpoint(checkpoint)
 
     data_batch = np.array([[1, 2], [3, 4], [5, 6]])
     predictions = predictor.predict(data_batch)

--- a/python/ray/train/tests/test_xgboost_predictor.py
+++ b/python/ray/train/tests/test_xgboost_predictor.py
@@ -99,9 +99,8 @@ def test_predict_feature_columns_pandas():
 
 
 def test_predict_no_preprocessor_no_training():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        checkpoint = XGBoostCheckpoint.from_model(booster=model, path=tmpdir)
-        predictor = XGBoostPredictor.from_checkpoint(checkpoint)
+    checkpoint = XGBoostCheckpoint.from_model(booster=model)
+    predictor = XGBoostPredictor.from_checkpoint(checkpoint)
 
     data_batch = np.array([[1, 2], [3, 4], [5, 6]])
     predictions = predictor.predict(data_batch)


### PR DESCRIPTION
- Update xgboost test (catch test failures properly)
- Remove `path` from `from_model` for XGBoostCheckpoint and LightGbmCheckpoint.

Signed-off-by: xwjiang2010 <xwjiang2010@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#26612

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
