### PR TITLE
[Datasets] Cover more pattern of AWS S3 read error message

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -332,7 +332,7 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
 
 def _handle_read_os_error(error: OSError, paths: Union[str, List[str]]) -> str:
     # NOTE: this is not comprehensive yet, and should be extended as more errors arise.
-    aws_error_pattern = r"^(.*)AWS Error \[code \d+\]: No response body\.$"
+    aws_error_pattern = r"^(.*)AWS Error \[code \d+\]: No response body\.(.*)$"
     if re.match(aws_error_pattern, str(error)):
         # Specially handle AWS error when reading files, to give a clearer error
         # message to avoid confusing users. The real issue is most likely that the AWS

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -10,6 +10,7 @@ import pyarrow as pa
 import pyarrow.json as pajson
 import pyarrow.parquet as pq
 import pytest
+from ray.data.datasource.file_meta_provider import _handle_read_os_error
 import requests
 import snappy
 from fsspec.implementations.local import LocalFileSystem
@@ -3006,16 +3007,23 @@ def test_read_s3_file_error(ray_start_regular_shared, s3_path):
     error_message = "Please check that file exists and has properly configured access."
     with pytest.raises(OSError) as e:
         ray.data.read_parquet(dummy_path)
-        assert error_message in str(e)
+    assert error_message in str(e.value)
     with pytest.raises(OSError) as e:
         ray.data.read_binary_files(dummy_path)
-        assert error_message in str(e)
+    assert error_message in str(e.value)
     with pytest.raises(OSError) as e:
         ray.data.read_csv(dummy_path)
-        assert error_message in str(e)
+    assert error_message in str(e.value)
     with pytest.raises(OSError) as e:
         ray.data.read_json(dummy_path)
-        assert error_message in str(e)
+    assert error_message in str(e.value)
+    with pytest.raises(OSError) as e:
+        error = OSError(
+            f"Error creating dataset. Could not read schema from {dummy_path}: AWS "
+            "Error [code 15]: No response body.. Is this a 'parquet' file?"
+        )
+        _handle_read_os_error(error, dummy_path)
+    assert error_message in str(e.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Seeing one more pattern of AWS S3 read error message related to credential - https://gist.github.com/jiaodong/a805577c35e44e720ff10136f5ec6f6c, shared from @jiaodong. Change the regex pattern to match the error message as well, so it prints out more understandable error message.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
