### PR TITLE
[docs] Adding `--keep-going` flag to `sphinx-build` so all lint failures are listed in CI instead of only first

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,7 +52,7 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W --keep-going -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
This PR adds `--keep-going` flag to the `make html` target for building the Ray docs. This means that when there is a lint failure in CI, the BuildKite log will show all lint failures instead of just the first one. Despite continuing past the first lint error, it will still fail the build.

I found it a small annoyance that the linter failed on BK but didn't show me all the reasons why.

From the [sphinx-build docs](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going):

> --keep-going
>     With -W option, keep going processing when getting warnings to the end of build, and sphinx-build exits with exit status 1.
>     
>    _New in version 1.8._

sphinx-build version 1.8 was [released on September 13th, 2018](https://www.sphinx-doc.org/en/master/changes.html#release-1-8-0-released-sep-13-2018).
