### PR TITLE
[Release test] Add a memory monitor to nightly test long running actor death

### DIFF
--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -8,6 +8,7 @@ import time
 
 import ray
 from ray.cluster_utils import Cluster
+from ray._private.test_utils import monitor_memory_usage
 
 
 def update_progress(result):
@@ -48,6 +49,7 @@ for i in range(num_nodes):
         dashboard_host="0.0.0.0",
     )
 ray.init(address=cluster.address)
+monitor_actor = monitor_memory_usage()
 
 # Run the workload.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Add a memory monitor to nightly test long running actor death. It will be used to see memory leak from the test

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
