### PR TITLE
[RLlib] Get rid of all these deprecation warnings.

### DIFF
--- a/rllib/agents/mock.py
+++ b/rllib/agents/mock.py
@@ -7,7 +7,7 @@ from ray.rllib.algorithms.mock import (  # noqa
 from ray.rllib.utils.deprecation import deprecation_warning
 
 deprecation_warning(
-    old="ray.rllib.agents.callbacks",
-    new="ray.rllib.algorithms.callbacks",
+    old="ray.rllib.agents.mock",
+    new="ray.rllib.algorithms.mock",
     error=False,
 )

--- a/rllib/algorithms/alpha_star/alpha_star.py
+++ b/rllib/algorithms/alpha_star/alpha_star.py
@@ -14,7 +14,7 @@ from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.alpha_star.distributed_learners import DistributedLearners
 from ray.rllib.algorithms.alpha_star.league_builder import AlphaStarLeagueBuilder
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
-from ray.rllib.utils.replay_buffers.multi_agent_mixin_replay_buffer import MultiAgentMixInReplayBuffer
+from ray.rllib.execution.buffers.mixin_replay_buffer import MixInMultiAgentReplayBuffer
 from ray.rllib.execution.parallel_requests import AsyncRequestsManager
 from ray.rllib.policy.policy import Policy, PolicySpec
 from ray.rllib.policy.sample_batch import MultiAgentBatch
@@ -354,7 +354,7 @@ class AlphaStar(appo.APPO):
         ReplayActor = ray.remote(
             num_cpus=1,
             num_gpus=num_gpus,
-        )(MultiAgentMixInReplayBuffer)
+        )(MixInMultiAgentReplayBuffer)
 
         # Setup remote replay buffer shards and policy learner actors
         # (located on any GPU machine in the cluster):

--- a/rllib/algorithms/alpha_star/alpha_star.py
+++ b/rllib/algorithms/alpha_star/alpha_star.py
@@ -14,7 +14,7 @@ from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.alpha_star.distributed_learners import DistributedLearners
 from ray.rllib.algorithms.alpha_star.league_builder import AlphaStarLeagueBuilder
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
-from ray.rllib.execution.buffers.mixin_replay_buffer import MixInMultiAgentReplayBuffer
+from ray.rllib.utils.replay_buffers.multi_agent_mixin_replay_buffer import MultiAgentMixInReplayBuffer
 from ray.rllib.execution.parallel_requests import AsyncRequestsManager
 from ray.rllib.policy.policy import Policy, PolicySpec
 from ray.rllib.policy.sample_batch import MultiAgentBatch
@@ -354,7 +354,7 @@ class AlphaStar(appo.APPO):
         ReplayActor = ray.remote(
             num_cpus=1,
             num_gpus=num_gpus,
-        )(MixInMultiAgentReplayBuffer)
+        )(MultiAgentMixInReplayBuffer)
 
         # Setup remote replay buffer shards and policy learner actors
         # (located on any GPU machine in the cluster):

--- a/rllib/algorithms/alpha_zero/alpha_zero.py
+++ b/rllib/algorithms/alpha_zero/alpha_zero.py
@@ -27,7 +27,7 @@ from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.modelv2 import restore_original_dimensions
 from ray.rllib.models.torch.torch_action_dist import TorchCategorical
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
+from ray.rllib.policy.sample_batch import concat_samples
 from ray.rllib.utils.annotations import Deprecated, override
 from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 from ray.rllib.utils.framework import try_import_torch

--- a/rllib/algorithms/alpha_zero/alpha_zero.py
+++ b/rllib/algorithms/alpha_zero/alpha_zero.py
@@ -27,7 +27,7 @@ from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.modelv2 import restore_original_dimensions
 from ray.rllib.models.torch.torch_action_dist import TorchCategorical
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
 from ray.rllib.utils.annotations import Deprecated, override
 from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 from ray.rllib.utils.framework import try_import_torch
@@ -348,7 +348,7 @@ class AlphaZero(Algorithm):
                 self.config["train_batch_size"]
             )
         else:
-            train_batch = SampleBatch.concat_samples(new_sample_batches)
+            train_batch = concat_samples(new_sample_batches)
 
         # Learn on the training batch.
         # Use simple optimizer (only for multi-agent or tf-eager; all other

--- a/rllib/algorithms/dreamer/dreamer.py
+++ b/rllib/algorithms/dreamer/dreamer.py
@@ -7,7 +7,7 @@ from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.algorithms.dreamer.dreamer_torch_policy import DreamerTorchPolicy
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER, _get_shared_metrics
-from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch, concat_samples
+from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, concat_samples
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.algorithms.dreamer.dreamer_model import DreamerModel
 from ray.rllib.execution.rollout_ops import (

--- a/rllib/algorithms/dreamer/dreamer.py
+++ b/rllib/algorithms/dreamer/dreamer.py
@@ -7,7 +7,7 @@ from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.algorithms.dreamer.dreamer_torch_policy import DreamerTorchPolicy
 from ray.rllib.execution.common import STEPS_SAMPLED_COUNTER, _get_shared_metrics
-from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch
+from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch, concat_samples
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.algorithms.dreamer.dreamer_model import DreamerModel
 from ray.rllib.execution.rollout_ops import (
@@ -248,7 +248,7 @@ class EpisodicBuffer(object):
             index = int(random.randint(0, available))
             episodes_buffer.append(episode[index : index + self.length])
 
-        return SampleBatch.concat_samples(episodes_buffer)
+        return concat_samples(episodes_buffer)
 
 
 def total_sampled_timesteps(worker):

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -10,7 +10,7 @@ from ray.rllib import SampleBatch
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.evaluation.rollout_worker import RolloutWorker
-from ray.rllib.utils.replay_buffers.multi_agent_mixin_replay_buffer import MultiAgentMixInReplayBuffer
+from ray.rllib.execution.buffers.mixin_replay_buffer import MixInMultiAgentReplayBuffer
 from ray.rllib.execution.common import (
     STEPS_TRAINED_COUNTER,
     STEPS_TRAINED_THIS_ITER_COUNTER,
@@ -589,7 +589,7 @@ class Impala(Algorithm):
 
             else:
                 # Create our local mixin buffer if the num of aggregation workers is 0.
-                self.local_mixin_buffer = MultiAgentMixInReplayBuffer(
+                self.local_mixin_buffer = MixInMultiAgentReplayBuffer(
                     capacity=(
                         self.config["replay_buffer_num_slots"]
                         if self.config["replay_buffer_num_slots"] > 0
@@ -958,7 +958,7 @@ class AggregatorWorker:
 
     def __init__(self, config: AlgorithmConfigDict):
         self.config = config
-        self._mixin_buffer = MultiAgentMixInReplayBuffer(
+        self._mixin_buffer = MixInMultiAgentReplayBuffer(
             capacity=(
                 self.config["replay_buffer_num_slots"]
                 if self.config["replay_buffer_num_slots"] > 0

--- a/rllib/algorithms/maml/maml.py
+++ b/rllib/algorithms/maml/maml.py
@@ -13,7 +13,7 @@ from ray.rllib.execution.common import (
     _get_shared_metrics,
 )
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
+from ray.rllib.policy.sample_batch import concat_samples
 from ray.rllib.execution.metric_ops import CollectMetrics
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.utils.annotations import override

--- a/rllib/algorithms/maml/maml.py
+++ b/rllib/algorithms/maml/maml.py
@@ -13,7 +13,7 @@ from ray.rllib.execution.common import (
     _get_shared_metrics,
 )
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
 from ray.rllib.execution.metric_ops import CollectMetrics
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.utils.annotations import override
@@ -341,7 +341,7 @@ class MAML(Algorithm):
                 adapt_iter = len(split) - 1
                 metrics = post_process_metrics(adapt_iter, workers, metrics)
                 if len(split) > inner_steps:
-                    out = SampleBatch.concat_samples(buf)
+                    out = concat_samples(buf)
                     out["split"] = np.array(split)
                     buf = []
                     split = []

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Callable, Dict, Optional, Type, Union
 
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
@@ -24,11 +24,13 @@ from ray.rllib.utils.metrics import (
     SYNCH_WORKER_WEIGHTS_TIMER,
     SAMPLE_TIMER,
 )
-from ray.rllib.utils.typing import (
-    ResultDict,
-    AlgorithmConfigDict,
-)
 from ray.rllib.utils.replay_buffers.utils import sample_min_n_steps_from_buffer
+from ray.rllib.utils.typing import (
+    AlgorithmConfigDict,
+    EnvType,
+    ResultDict,
+)
+from ray.tune.logger import Logger
 
 
 class MARWILConfig(AlgorithmConfig):
@@ -120,14 +122,7 @@ class MARWILConfig(AlgorithmConfig):
             "is": {"type": ImportanceSampling},
             "wis": {"type": WeightedImportanceSampling},
         }
-        deprecation_warning(
-            old="MARWIL currently uses off_policy_estimation_methods: "
-            f"{self.off_policy_estimation_methods} by default. This will"
-            "change to off_policy_estimation_methods: {} in a future release."
-            "If you want to use an off-policy estimator, specify it in"
-            ".evaluation(off_policy_estimation_methods=...)",
-            error=False,
-        )
+        self._set_off_policy_estimation_methods = False
 
     @override(AlgorithmConfig)
     def training(
@@ -219,6 +214,38 @@ class MARWILConfig(AlgorithmConfig):
         if grad_clip is not None:
             self.grad_clip = grad_clip
         return self
+
+    def evaluation(
+        self,
+        **kwargs,
+    ) -> "MARWILConfig":
+        """Sets the evaluation related configuration.
+
+        Returns:
+            This updated AlgorithmConfig object.
+        """
+        # Pass kwargs onto super's `evaluation()` method.
+        super().evaluation(**kwargs)
+
+        if "off_policy_estimation_methods" in kwargs:
+            # User specified their OPE methods.
+            self._set_off_policy_estimation_methods = True
+
+    def build(
+        self,
+        env: Optional[Union[str, EnvType]] = None,
+        logger_creator: Optional[Callable[[], Logger]] = None,
+    ) -> "Algorithm":
+        if not self._set_off_policy_estimation_methods:
+            deprecation_warning(
+                old="MARWIL currently uses off_policy_estimation_methods: "
+                f"{self.off_policy_estimation_methods} by default. This will"
+                "change to off_policy_estimation_methods: {} in a future release."
+                "If you want to use an off-policy estimator, specify it in"
+                ".evaluation(off_policy_estimation_methods=...)",
+                error=False,
+            )
+        return super().build(env, logger_creator)
 
 
 class MARWIL(Algorithm):

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional, Type, Union
+from typing import Callable, Optional, Type, Union
 
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -231,6 +231,8 @@ class MARWILConfig(AlgorithmConfig):
             # User specified their OPE methods.
             self._set_off_policy_estimation_methods = True
 
+        return self
+
     def build(
         self,
         env: Optional[Union[str, EnvType]] = None,

--- a/rllib/algorithms/mbmpo/mbmpo.py
+++ b/rllib/algorithms/mbmpo/mbmpo.py
@@ -23,7 +23,7 @@ from ray.rllib.execution.common import (
 )
 from ray.rllib.execution.metric_ops import CollectMetrics
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch
+from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch, concat_samples
 from ray.rllib.utils.annotations import Deprecated, override
 from ray.rllib.utils.deprecation import DEPRECATED_VALUE
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO
@@ -547,7 +547,7 @@ class MBMPO(Algorithm):
                 metrics = post_process_metrics(prefix, workers, metrics)
 
                 if len(split) > num_inner_steps:
-                    out = SampleBatch.concat_samples(buf)
+                    out = concat_samples(buf)
                     out["split"] = np.array(split)
                     buf = []
                     split = []

--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -11,7 +11,7 @@ from ray.rllib.evaluation.collectors.agent_collector import AgentCollector
 from ray.rllib.evaluation.episode import Episode
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.policy_map import PolicyMap
-from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
+from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch, concat_samples
 from ray.rllib.utils.annotations import override, PublicAPI
 from ray.rllib.utils.debug import summarize
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
@@ -89,7 +89,7 @@ class _PolicyCollector:
                 this policy.
         """
         # Create batch from our buffers.
-        batch = SampleBatch.concat_samples(self.batches)
+        batch = concat_samples(self.batches)
         # Clear batches for future samples.
         self.batches = []
         # Reset agent steps to 0.

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -38,7 +38,7 @@ from ray.util.debug import log_once
 if TYPE_CHECKING:
     from gym.envs.classic_control.rendering import SimpleImageViewer
 
-    from ray.rllib.agents.callbacks import DefaultCallbacks
+    from ray.rllib.algorithms.callbacks import DefaultCallbacks
     from ray.rllib.evaluation.rollout_worker import RolloutWorker
 
 
@@ -86,8 +86,8 @@ class _PerfStats:
             ] + self.ema_coef * value
 
     def _get_avg(self):
-        # Mean multiplicator (1000 = ms -> sec).
-        factor = 1000 / self.iters
+        # Mean multiplicator (1000 = sec -> ms).
+        factor = MS_TO_SEC / self.iters
         return {
             # Raw observation preprocessing.
             "mean_raw_obs_processing_ms": self.raw_obs_processing_time * factor,

--- a/rllib/evaluation/episode_v2.py
+++ b/rllib/evaluation/episode_v2.py
@@ -14,7 +14,7 @@ from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.utils.typing import AgentID, EnvID, PolicyID, TensorType
 
 if TYPE_CHECKING:
-    from ray.rllib.agents.callbacks import DefaultCallbacks
+    from ray.rllib.algorithms.callbacks import DefaultCallbacks
     from ray.rllib.evaluation.rollout_worker import RolloutWorker
 
 

--- a/rllib/examples/documentation/replay_buffer_demo.py
+++ b/rllib/examples/documentation/replay_buffer_demo.py
@@ -10,7 +10,7 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import SampleBatchType
 from ray.rllib.utils.replay_buffers.utils import validate_buffer_config
 from ray.rllib.examples.env.random_env import RandomEnv
-from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
 from ray.rllib.algorithms.dqn.dqn import DQNConfig
 
 
@@ -105,7 +105,7 @@ while not done:
     one_step_batch = SampleBatch(
         {"obs": [obs], "t": [t], "reward": [reward], "dones": [done]}
     )
-    batch = SampleBatch.concat_samples([batch, one_step_batch])
+    batch = concat_samples([batch, one_step_batch])
     t += 1
 
 less_sampled_buffer.add(batch)

--- a/rllib/examples/rollout_worker_custom_workflow.py
+++ b/rllib/examples/rollout_worker_custom_workflow.py
@@ -14,7 +14,7 @@ from ray import tune
 from ray.rllib.evaluation import RolloutWorker
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, SampleBatch
+from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID, concat_samples
 from ray.tune.execution.placement_groups import PlacementGroupFactory
 
 parser = argparse.ArgumentParser()
@@ -83,7 +83,7 @@ def training_workflow(config, reporter):
             w.set_weights.remote(weights)
 
         # Gather a batch of samples
-        T1 = SampleBatch.concat_samples(ray.get([w.sample.remote() for w in workers]))
+        T1 = concat_samples(ray.get([w.sample.remote() for w in workers]))
 
         # Update the remote policy replicas and gather another batch of samples
         new_value = policy.w * 2.0
@@ -91,7 +91,7 @@ def training_workflow(config, reporter):
             w.for_policy.remote(lambda p: p.update_some_value(new_value))
 
         # Gather another batch of samples
-        T2 = SampleBatch.concat_samples(ray.get([w.sample.remote() for w in workers]))
+        T2 = concat_samples(ray.get([w.sample.remote() for w in workers]))
 
         # Improve the policy using the T1 batch
         policy.learn_on_batch(T1)

--- a/rllib/examples/two_trainer_workflow.py
+++ b/rllib/examples/two_trainer_workflow.py
@@ -25,7 +25,7 @@ from ray.rllib.utils.replay_buffers.multi_agent_replay_buffer import (
     MultiAgentReplayBuffer,
 )
 from ray.rllib.examples.env.multi_agent import MultiAgentCartPole
-from ray.rllib.policy.sample_batch import MultiAgentBatch, SampleBatch
+from ray.rllib.policy.sample_batch import MultiAgentBatch, concat_samples
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.metrics import (
     NUM_AGENT_STEPS_SAMPLED,
@@ -134,7 +134,7 @@ class MyAlgo(Algorithm):
             ]
 
         # PPO sub-flow.
-        ppo_train_batch = SampleBatch.concat_samples(ppo_batches)
+        ppo_train_batch = concat_samples(ppo_batches)
         self._counters["agent_steps_trained_PPO"] += ppo_train_batch.agent_steps()
         # Standardize advantages.
         ppo_train_batch[Postprocessing.ADVANTAGES] = standardized(

--- a/rllib/execution/buffers/__init__.py
+++ b/rllib/execution/buffers/__init__.py
@@ -1,9 +1,0 @@
-from ray.rllib.utils.deprecation import deprecation_warning
-
-deprecation_warning(
-    old="ray.rllib.execution.buffers",
-    new="ray.rllib.utils.replay_buffers",
-    help="RLlib's ReplayBuffer API has changed. Apart from the replay buffers moving, "
-    "some have altered behaviour. Please refer to the docs for more information.",
-    error=False,
-)

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -17,6 +17,7 @@ from ray.rllib.policy.sample_batch import (
     SampleBatch,
     DEFAULT_POLICY_ID,
     MultiAgentBatch,
+    concat_samples,
 )
 from ray.rllib.utils.annotations import ExperimentalAPI
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO, LEARNER_STATS_KEY
@@ -108,7 +109,7 @@ def synchronous_parallel_sample(
         all_sample_batches.extend(sample_batches)
 
     if concat is True:
-        full_batch = SampleBatch.concat_samples(all_sample_batches)
+        full_batch = concat_samples(all_sample_batches)
         # Discard collected incomplete episodes in episode mode.
         # if max_episodes is not None and episodes >= max_episodes:
         #    last_complete_ep_idx = len(full_batch) - full_batch[
@@ -183,7 +184,7 @@ def ParallelRollouts(
     if mode == "bulk_sync":
         return (
             rollouts.batch_across_shards()
-            .for_each(lambda batches: SampleBatch.concat_samples(batches))
+            .for_each(lambda batches: concat_samples(batches))
             .for_each(report_timesteps)
         )
     elif mode == "async":

--- a/rllib/offline/dataset_reader.py
+++ b/rllib/offline/dataset_reader.py
@@ -267,7 +267,7 @@ class DatasetReader(InputReader):
                     out.append(self._default_policy.postprocess_trajectory(sub_batch))
                 else:
                     out.append(sub_batch)
-            return SampleBatch.concat_samples(out)
+            return concat_samples(out)
         else:
             # TODO(ekl) this is trickier since the alignments between agent
             #  trajectories in the episode are not available any more.

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -406,7 +406,6 @@ class SampleBatch(dict):
         f"which should both have {self.count} timesteps!"
         return slices
 
-    @Deprecated(new="SampleBatch[start:stop]", error=False)
     def slice(
         self, start: int, end: int, state_start=None, state_end=None
     ) -> "SampleBatch":

--- a/rllib/utils/replay_buffers/multi_agent_mixin_replay_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_mixin_replay_buffer.py
@@ -10,6 +10,7 @@ from ray.rllib.policy.sample_batch import (
     DEFAULT_POLICY_ID,
     MultiAgentBatch,
     SampleBatch,
+    concat_samples
 )
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.replay_buffers.multi_agent_prioritized_replay_buffer import (
@@ -298,7 +299,7 @@ class MultiAgentMixInReplayBuffer(MultiAgentPrioritizedReplayBuffer):
 
             # No replay desired
             if self.replay_ratio == 0.0:
-                return SampleBatch.concat_samples(output_batches)
+                return concat_samples(output_batches)
             # Only replay desired
             elif self.replay_ratio == 1.0:
                 return _buffer.sample(num_items, **kwargs)

--- a/rllib/utils/replay_buffers/multi_agent_mixin_replay_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_mixin_replay_buffer.py
@@ -10,7 +10,7 @@ from ray.rllib.policy.sample_batch import (
     DEFAULT_POLICY_ID,
     MultiAgentBatch,
     SampleBatch,
-    concat_samples
+    concat_samples,
 )
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.replay_buffers.multi_agent_prioritized_replay_buffer import (

--- a/rllib/utils/replay_buffers/tests/test_multi_agent_prioritized_replay_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_multi_agent_prioritized_replay_buffer.py
@@ -6,6 +6,7 @@ from ray.rllib.policy.sample_batch import (
     SampleBatch,
     MultiAgentBatch,
     DEFAULT_POLICY_ID,
+    concat_samples,
 )
 
 from ray.rllib.utils.replay_buffers.multi_agent_prioritized_replay_buffer import (
@@ -41,7 +42,7 @@ class TestMultiAgentPrioritizedReplayBuffer(unittest.TestCase):
 
         for i in range(num_batches):
             data = [self._generate_data() for _ in range(batch_size)]
-            batch = SampleBatch.concat_samples(data)
+            batch = concat_samples(data)
             buffer.add(batch, **kwargs)
 
     def _add_multi_agent_batch_to_buffer(

--- a/rllib/utils/replay_buffers/tests/test_multi_agent_replay_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_multi_agent_replay_buffer.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
+from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch, concat_samples
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 
 from ray.rllib.utils.replay_buffers.multi_agent_replay_buffer import (
@@ -43,7 +43,7 @@ class TestMultiAgentReplayBuffer(unittest.TestCase):
         for i in range(num_batches):
             data = [_generate_data() for _ in range(batch_size)]
             self.batch_id += 1
-            batch = SampleBatch.concat_samples(data)
+            batch = concat_samples(data)
             buffer.add(batch, **kwargs)
 
     def _add_multi_agent_batch_to_buffer(

--- a/rllib/utils/replay_buffers/tests/test_prioritized_replay_buffer_replay_buffer_api.py
+++ b/rllib/utils/replay_buffers/tests/test_prioritized_replay_buffer_replay_buffer_api.py
@@ -5,7 +5,7 @@ import unittest
 from ray.rllib.utils.replay_buffers.prioritized_replay_buffer import (
     PrioritizedReplayBuffer,
 )
-from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
+from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch, concat_samples
 from ray.rllib.utils.test_utils import check
 
 
@@ -117,7 +117,7 @@ class TestPrioritizedReplayBuffer(unittest.TestCase):
         )
         for _ in range(40):
             buffer.add(
-                SampleBatch.concat_samples([self._generate_data() for _ in range(5)])
+                concat_samples([self._generate_data() for _ in range(5)])
             )
         assert len(buffer._storage) == 20, len(buffer._storage)
         assert buffer.stats()["added_count"] == 200, buffer.stats()

--- a/rllib/utils/replay_buffers/tests/test_prioritized_replay_buffer_replay_buffer_api.py
+++ b/rllib/utils/replay_buffers/tests/test_prioritized_replay_buffer_replay_buffer_api.py
@@ -116,9 +116,7 @@ class TestPrioritizedReplayBuffer(unittest.TestCase):
             capacity=100, alpha=0.1, storage_unit="fragments"
         )
         for _ in range(40):
-            buffer.add(
-                concat_samples([self._generate_data() for _ in range(5)])
-            )
+            buffer.add(concat_samples([self._generate_data() for _ in range(5)]))
         assert len(buffer._storage) == 20, len(buffer._storage)
         assert buffer.stats()["added_count"] == 200, buffer.stats()
         # Test get_state/set_state.

--- a/rllib/utils/replay_buffers/tests/test_replay_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_replay_buffer.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
+from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch, concat_samples
 
 from ray.rllib.utils.replay_buffers.replay_buffer import ReplayBuffer
 
@@ -27,7 +27,7 @@ class TestReplayBuffer(unittest.TestCase):
         for i in range(num_batches):
             data = [_generate_data() for _ in range(batch_size)]
             self.batch_id += 1
-            batch = SampleBatch.concat_samples(data)
+            batch = concat_samples(data)
             _buffer.add(batch, **kwargs)
 
     def test_stats(self):

--- a/rllib/utils/replay_buffers/tests/test_reservoir_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_reservoir_buffer.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
 from ray.rllib.utils.replay_buffers.reservoir_replay_buffer import ReservoirReplayBuffer
 
 
@@ -28,7 +28,7 @@ class TestReservoirBuffer(unittest.TestCase):
             for i in range(num_batches):
                 data = [_generate_data() for _ in range(batch_size)]
                 self.batch_id += 1
-                batch = SampleBatch.concat_samples(data)
+                batch = concat_samples(data)
                 _buffer.add(batch, **kwargs)
 
         batch_size = 1
@@ -70,7 +70,7 @@ class TestReservoirBuffer(unittest.TestCase):
             for i in range(num_batches):
                 data = [_generate_data() for _ in range(batch_size)]
                 self.batch_id += 1
-                batch = SampleBatch.concat_samples(data)
+                batch = concat_samples(data)
                 _buffer.add(batch, **kwargs)
 
         batch_size = 1

--- a/rllib/utils/replay_buffers/utils.py
+++ b/rllib/utils/replay_buffers/utils.py
@@ -128,7 +128,7 @@ def sample_min_n_steps_from_buffer(
         train_batches.append(batch)
         train_batch_size += batch_len
     # All batch types are the same type, hence we can use any concat_samples()
-    train_batch = SampleBatch.concat_samples(train_batches)
+    train_batch = concat_samples(train_batches)
     return train_batch
 
 

--- a/rllib/utils/replay_buffers/utils.py
+++ b/rllib/utils/replay_buffers/utils.py
@@ -13,7 +13,7 @@ from ray.rllib.utils.replay_buffers import (
     ReplayBuffer,
     MultiAgentReplayBuffer,
 )
-from ray.rllib.policy.sample_batch import MultiAgentBatch
+from ray.rllib.policy.sample_batch import MultiAgentBatch, concat_samples
 from ray.rllib.utils.typing import ResultDict, SampleBatchType, AlgorithmConfigDict
 from ray.util import log_once
 

--- a/rllib/utils/sgd.py
+++ b/rllib/utils/sgd.py
@@ -58,7 +58,7 @@ def minibatches(samples: SampleBatch, sgd_minibatch_size: int, shuffle: bool = T
         if shuffle:
             random.shuffle(data_slices)
         for i, j in data_slices:
-            yield samples.slice(i, j)
+            yield samples[i:j]
     else:
         all_slices = list(zip(data_slices, state_slices))
         if shuffle:


### PR DESCRIPTION
## Why are these changes needed?

Mostly agents -> algorithms, SampleBatch.concat_samples, and switch to use MultiAgentMixInReplayBuffer.
One significant change though is to stop MarwilConfig from printing this long warning message all the time.
This is being printed multiple times at the start of all RLlib runs even if the user is not using Marwil at all.
Changed it to print warning message only if someone is actually using MarwilConfig, and they are not setting ope_method param themselves.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
