### PR TITLE
User-friendly rnn sequencing

### DIFF
--- a/rllib/models/tf/recurrent_net.py
+++ b/rllib/models/tf/recurrent_net.py
@@ -3,7 +3,7 @@ import gym
 from gym.spaces import Box, Discrete, MultiDiscrete
 import logging
 import tree  # pip install dm_tree
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Optional, Type, Tuple
 
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.tf.tf_modelv2 import TFModelV2
@@ -63,15 +63,17 @@ class RecurrentNetwork(TFModelV2):
         input_dict: Dict[str, TensorType],
         state: List[TensorType],
         seq_lens: TensorType,
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         """Adds time dimension to batch before sending inputs to forward_rnn().
 
         You should implement forward_rnn() in your subclass."""
         assert seq_lens is not None
-        padded_inputs = input_dict["obs_flat"]
-        max_seq_len = tf.shape(padded_inputs)[0] // tf.shape(seq_lens)[0]
+        flat_inputs = input_dict["obs_flat"]
+        inputs = add_time_dimension(
+            padded_inputs=flat_inputs, seq_lens=seq_lens, framework="tf"
+        )
         output, new_state = self.forward_rnn(
-            add_time_dimension(padded_inputs, max_seq_len=max_seq_len, framework="tf"),
+            inputs,
             state,
             seq_lens,
         )
@@ -79,7 +81,7 @@ class RecurrentNetwork(TFModelV2):
 
     def forward_rnn(
         self, inputs: TensorType, state: List[TensorType], seq_lens: TensorType
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         """Call the model with the given input tensors and state.
 
         Args:
@@ -216,7 +218,7 @@ class LSTMWrapper(RecurrentNetwork):
         input_dict: Dict[str, TensorType],
         state: List[TensorType],
         seq_lens: TensorType,
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         assert seq_lens is not None
         # Push obs through "unwrapped" net's `forward()` first.
         wrapped_out, _ = self._wrapped_forward(input_dict, [], None)
@@ -265,7 +267,7 @@ class LSTMWrapper(RecurrentNetwork):
     @override(RecurrentNetwork)
     def forward_rnn(
         self, inputs: TensorType, state: List[TensorType], seq_lens: TensorType
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         model_out, self._value_out, h, c = self._rnn_model([inputs, seq_lens] + state)
         return model_out, [h, c]
 
@@ -411,7 +413,7 @@ class Keras_LSTMWrapper(tf.keras.Model if tf else object):
 
     def call(
         self, input_dict: SampleBatch
-    ) -> (TensorType, List[TensorType], Dict[str, TensorType]):
+    ) -> Tuple[TensorType, List[TensorType], Dict[str, TensorType]]:
         assert input_dict.get(SampleBatch.SEQ_LENS) is not None
         # Push obs through underlying (wrapped) model first.
         wrapped_out, _, _ = self.wrapped_keras_model(input_dict)
@@ -435,11 +437,8 @@ class Keras_LSTMWrapper(tf.keras.Model if tf else object):
         if prev_a_r:
             wrapped_out = tf.concat([wrapped_out] + prev_a_r, axis=1)
 
-        max_seq_len = (
-            tf.shape(wrapped_out)[0] // tf.shape(input_dict[SampleBatch.SEQ_LENS])[0]
-        )
         wrapped_out_plus_time_dim = add_time_dimension(
-            wrapped_out, max_seq_len=max_seq_len, framework="tf"
+            wrapped_out, seq_lens=input_dict[SampleBatch.SEQ_LENS], framework="tf"
         )
         model_out, value_out, h, c = self._rnn_model(
             [

--- a/rllib/models/torch/recurrent_net.py
+++ b/rllib/models/torch/recurrent_net.py
@@ -2,7 +2,7 @@ import numpy as np
 import gym
 from gym.spaces import Discrete, MultiDiscrete
 import tree  # pip install dm_tree
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Tuple
 
 from ray.rllib.models.modelv2 import ModelV2
 from ray.rllib.models.torch.misc import SlimFC
@@ -70,18 +70,18 @@ class RecurrentNetwork(TorchModelV2):
         input_dict: Dict[str, TensorType],
         state: List[TensorType],
         seq_lens: TensorType,
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         """Adds time dimension to batch before sending inputs to forward_rnn().
 
         You should implement forward_rnn() in your subclass."""
         flat_inputs = input_dict["obs_flat"].float()
-        if isinstance(seq_lens, np.ndarray):
-            seq_lens = torch.Tensor(seq_lens).int()
-        max_seq_len = flat_inputs.shape[0] // seq_lens.shape[0]
+        # Note that max_seq_len != input_dict.max_seq_len != seq_lens.max()
+        # as input_dict may have extra zero-padding beyond seq_lens.max().
+        # Use add_time_dimension to handle this
         self.time_major = self.model_config.get("_time_major", False)
         inputs = add_time_dimension(
             flat_inputs,
-            max_seq_len=max_seq_len,
+            seq_lens=seq_lens,
             framework="torch",
             time_major=self.time_major,
         )
@@ -91,7 +91,7 @@ class RecurrentNetwork(TorchModelV2):
 
     def forward_rnn(
         self, inputs: TensorType, state: List[TensorType], seq_lens: TensorType
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         """Call the model with the given input tensors and state.
 
         Args:
@@ -203,7 +203,7 @@ class LSTMWrapper(RecurrentNetwork, nn.Module):
         input_dict: Dict[str, TensorType],
         state: List[TensorType],
         seq_lens: TensorType,
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         assert seq_lens is not None
         # Push obs through "unwrapped" net's `forward()` first.
         wrapped_out, _ = self._wrapped_forward(input_dict, [], None)
@@ -248,7 +248,7 @@ class LSTMWrapper(RecurrentNetwork, nn.Module):
     @override(RecurrentNetwork)
     def forward_rnn(
         self, inputs: TensorType, state: List[TensorType], seq_lens: TensorType
-    ) -> (TensorType, List[TensorType]):
+    ) -> Tuple[TensorType, List[TensorType]]:
         # Don't show paddings to RNN(?)
         # TODO: (sven) For now, only allow, iff time_major=True to not break
         #  anything retrospectively (time_major not supported previously).

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -171,7 +171,8 @@ def add_time_dimension(
         padded_inputs: a padded batch of sequences. That is,
             for seq_lens=[1, 2, 2], then inputs=[A, *, B, B, C, C], where
             A, B, C are sequence elements and * denotes padding.
-        max_seq_len: The max. sequence length in padded_inputs.
+        seq_lens: A 1D tensor of sequence lengths, denoting the non-padded length
+            in timesteps of each rollout in the batch.
         framework: The framework string ("tf2", "tf", "tfe", "torch").
         time_major: Whether data should be returned in time-major (TxB)
             format or not (BxT).

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -187,7 +187,7 @@ def add_time_dimension(
         assert time_major is False, "time-major not supported yet for tf!"
         padded_batch_size = tf.shape(padded_inputs)[0]
         # Dynamically reshape the padded batch to introduce a time dimension.
-        new_batch_size = seq_lens.shape[0]
+        new_batch_size = tf.shape(seq_lens)[0]
         time_size = padded_batch_size // new_batch_size
         new_shape = tf.concat(
             [

--- a/rllib/policy/rnn_sequencing.py
+++ b/rllib/policy/rnn_sequencing.py
@@ -161,7 +161,7 @@ def pad_batch_to_sequences_of_same_size(
 def add_time_dimension(
     padded_inputs: TensorType,
     *,
-    max_seq_len: int,
+    seq_lens: TensorType,
     framework: str = "tf",
     time_major: bool = False,
 ):
@@ -187,11 +187,12 @@ def add_time_dimension(
         assert time_major is False, "time-major not supported yet for tf!"
         padded_batch_size = tf.shape(padded_inputs)[0]
         # Dynamically reshape the padded batch to introduce a time dimension.
-        new_batch_size = padded_batch_size // max_seq_len
+        new_batch_size = seq_lens.shape[0]
+        time_size = padded_batch_size // new_batch_size
         new_shape = tf.concat(
             [
                 tf.expand_dims(new_batch_size, axis=0),
-                tf.expand_dims(max_seq_len, axis=0),
+                tf.expand_dims(time_size, axis=0),
                 tf.shape(padded_inputs)[1:],
             ],
             axis=0,
@@ -202,8 +203,9 @@ def add_time_dimension(
         padded_batch_size = padded_inputs.shape[0]
 
         # Dynamically reshape the padded batch to introduce a time dimension.
-        new_batch_size = padded_batch_size // max_seq_len
-        batch_major_shape = (new_batch_size, max_seq_len) + padded_inputs.shape[1:]
+        new_batch_size = seq_lens.shape[0]
+        time_size = padded_batch_size // new_batch_size
+        batch_major_shape = (new_batch_size, time_size) + padded_inputs.shape[1:]
         padded_outputs = padded_inputs.view(batch_major_shape)
 
         if time_major:

--- a/rllib/policy/tests/test_rnn_sequencing.py
+++ b/rllib/policy/tests/test_rnn_sequencing.py
@@ -154,6 +154,7 @@ class TestRNNSequencing(unittest.TestCase):
             np.arange(B * T)[:, np.newaxis], repeats=F, axis=-1
         ).astype(np.int32)
         check(inputs_numpy.shape, (B * T, F))
+        seq_lens = np.random.randint(1, T + 1, (B,))
 
         time_shift_diff_batch_major = np.ones(shape=(B, T - 1, F), dtype=np.int32)
         time_shift_diff_time_major = np.ones(shape=(T - 1, B, F), dtype=np.int32)
@@ -162,7 +163,7 @@ class TestRNNSequencing(unittest.TestCase):
             # Test tensorflow batch-major
             padded_inputs = tf.constant(inputs_numpy)
             batch_major_outputs = add_time_dimension(
-                padded_inputs, max_seq_len=T, framework="tf", time_major=False
+                padded_inputs, seq_lens=seq_lens, framework="tf", time_major=False
             )
             check(batch_major_outputs.shape.as_list(), [B, T, F])
             time_shift_diff = batch_major_outputs[:, 1:] - batch_major_outputs[:, :-1]
@@ -172,7 +173,7 @@ class TestRNNSequencing(unittest.TestCase):
             # Test torch batch-major
             padded_inputs = torch.from_numpy(inputs_numpy)
             batch_major_outputs = add_time_dimension(
-                padded_inputs, max_seq_len=T, framework="torch", time_major=False
+                padded_inputs, seq_lens=seq_lens, framework="torch", time_major=False
             )
             check(batch_major_outputs.shape, (B, T, F))
             time_shift_diff = batch_major_outputs[:, 1:] - batch_major_outputs[:, :-1]
@@ -181,7 +182,7 @@ class TestRNNSequencing(unittest.TestCase):
             # Test torch time-major
             padded_inputs = torch.from_numpy(inputs_numpy)
             time_major_outputs = add_time_dimension(
-                padded_inputs, max_seq_len=T, framework="torch", time_major=True
+                padded_inputs, seq_lens=seq_lens, framework="torch", time_major=True
             )
             check(time_major_outputs.shape, (T, B, F))
             time_shift_diff = time_major_outputs[1:] - time_major_outputs[:-1]


### PR DESCRIPTION
Signed-off-by: Steven Morad <smorad@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is a lot of mystery around how recurrent models work. Since we don't have time for a full redesign, we should at least try and hide the nasty bits from the user. Previously, it was not clear which `max_seq_len` should be passed to `add_time_dimension`: `SampleBatch.max_seq_len` or `SampleBatch['seq_lens'].max()` (neither of these, it's actually `SampleBatch['obs'].shape[0] // SampleBatch['seq_lens'].shape[0]`). This is because slicing the `SampleBatch` introduces unnecessary padding beyond the longest sequence in the slice (e.g. `seq_lens = [2,3,4]`, true shape: `obs.shape[3, 10, F]`. Fixing this would require implementing some unpadding functionality in `SampleBatch` or changing how the slice operator works, which seems like a breaking change.

<!-- Please give a short summary of the change and the problem this solves. -->
This makes `add_time_dimension` more easily callable from the model forward pass, and reduces the chance of users introducing bugs. Now, `add_time_dimension` takes the full `seq_lens` tensor and calculates the dimensionality, rather than having the user calculate the dimensionality and pass it to `add_time_dimension` as `max_seq_len`.
## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/21844
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
