### PR TITLE
Add C++ worker code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 /java/api/ @jovany-wang @kfstorm @raulchen @ericl @iycheng @WangTaoTheTonic
 
 # C++ worker
-/cpp/include/ray @SongGuyang @raulchen
+/cpp/include/ray @SongGuyang @raulchen @kfstorm
 
 # Ray Client
 /src/ray/protobuf/ray_client.proto @ijrsvt @ameerhajali @ckw017


### PR DESCRIPTION
Signed-off-by: 久龙 <guyang.sgy@antfin.com>

## Why are these changes needed?

Add @kfstorm to the C++ worker code owner group.