### PR TITLE
[Core] Reduce surfacing scary `Failed to get the resource load:` messages upon node failures

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -292,7 +292,7 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
               if (status.ok()) {
                 gcs_resource_manager_->UpdateResourceLoads(load.resources());
               } else {
-                RAY_LOG(ERROR) << "Failed to get the resource load: "
+                RAY_LOG_EVERY_N(WARNING, 10) << "Failed to get the resource load: "
                                << status.ToString();
               }
             });

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -292,8 +292,8 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
               if (status.ok()) {
                 gcs_resource_manager_->UpdateResourceLoads(load.resources());
               } else {
-                RAY_LOG_EVERY_N(WARNING, 10) << "Failed to get the resource load: "
-                               << status.ToString();
+                RAY_LOG_EVERY_N(WARNING, 10)
+                    << "Failed to get the resource load: " << status.ToString();
               }
             });
           }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Node failures logs become extremely spammy with `Failed to get the resource load:` logs. This PR removes the logs from driver-side logs and prints it less often

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
