### PR TITLE
[Hotfix/ML] Don't run ML tests in Windows

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -189,6 +189,10 @@ test_python() {
       -python/ray/tests:test_k8s_operator_unit_tests
       -python/ray/tests:test_tracing  # tracing not enabled on windows
       -python/ray/tests:kuberay/test_autoscaling_e2e # irrelevant on windows
+      -python/ray/tests:xgboost # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests:lightgbm # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests:horovod # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests:ray_lightning # Requires ML dependencies, should not be run on Windows
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -189,7 +189,7 @@ test_python() {
       -python/ray/tests:test_k8s_operator_unit_tests
       -python/ray/tests:test_tracing  # tracing not enabled on windows
       -python/ray/tests:kuberay/test_autoscaling_e2e # irrelevant on windows
-      -python/ray/tests/xgbost/... # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/xgboost/... # Requires ML dependencies, should not be run on Windows
       -python/ray/tests/lightgbm/... # Requires ML dependencies, should not be run on Windows
       -python/ray/tests/horovod/... # Requires ML dependencies, should not be run on Windows
       -python/ray/tests/ray_lightning/... # Requires ML dependencies, should not be run on Windows

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -189,10 +189,10 @@ test_python() {
       -python/ray/tests:test_k8s_operator_unit_tests
       -python/ray/tests:test_tracing  # tracing not enabled on windows
       -python/ray/tests:kuberay/test_autoscaling_e2e # irrelevant on windows
-      -python/ray/tests:xgboost # Requires ML dependencies, should not be run on Windows
-      -python/ray/tests:lightgbm # Requires ML dependencies, should not be run on Windows
-      -python/ray/tests:horovod # Requires ML dependencies, should not be run on Windows
-      -python/ray/tests:ray_lightning # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/xgbost/... # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/lightgbm/... # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/horovod/... # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/ray_lightning/... # Requires ML dependencies, should not be run on Windows
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?

--- a/python/ray/tests/horovod/BUILD
+++ b/python/ray/tests/horovod/BUILD
@@ -2,6 +2,7 @@ py_test(
     name = "test_horovod",
     size = "medium",
     srcs = ["test_horovod.py"],
+    deps = ["//:ray_lib"],
     tags = ["team:ml", "exclusive"]
 )
 

--- a/python/ray/tests/lightgbm/BUILD
+++ b/python/ray/tests/lightgbm/BUILD
@@ -2,6 +2,7 @@ py_test(
  name = "simple_example",
  size = "small",
  srcs = ["simple_example.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"],
 )
 
@@ -9,6 +10,7 @@ py_test(
  name = "simple_tune",
  size="small",
  srcs = ["simple_tune.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"]
 )
 

--- a/python/ray/tests/ray_lightning/BUILD
+++ b/python/ray/tests/ray_lightning/BUILD
@@ -2,6 +2,7 @@ py_test(
  name = "simple_example",
  size = "small",
  srcs = ["simple_example.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"],
 )
 
@@ -9,5 +10,6 @@ py_test(
  name = "simple_tune",
  size="small",
  srcs = ["simple_tune.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"]
 )

--- a/python/ray/tests/xgboost/BUILD
+++ b/python/ray/tests/xgboost/BUILD
@@ -6,6 +6,7 @@ py_test(
  name = "simple_example",
  size = "small",
  srcs = ["simple_example.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"],
 )
 
@@ -13,6 +14,7 @@ py_test(
  name = "simple_tune",
  size="small",
  srcs = ["simple_tune.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"]
 )
 


### PR DESCRIPTION
Signed-off-by: Amog Kamsetty <amogkamsetty@yahoo.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
Tests for upstream ML libraries (xgboost-ray, ray-lightning, etc.) were recently refactored from `ray.util` to `ray.tests`. This caused them to be run in Windows CI, but Windows CI does not have any ML dependencies. This PR disables these tests from being run on Windows, which matches the previous behavior.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
