### PR TITLE
Deflake test_client_library_integration

### DIFF
--- a/python/ray/tests/test_client_library_integration.py
+++ b/python/ray/tests/test_client_library_integration.py
@@ -8,7 +8,7 @@ from ray._private.client_mode_hook import enable_client_mode, client_mode_should
 
 
 @pytest.mark.skip(reason="KV store is not working properly.")
-def test_rllib_integration(ray_start_regular_shared):
+def test_rllib_integration(ray_start_regular):
     with ray_start_client_server():
         import ray.rllib.algorithms.dqn as dqn
 
@@ -34,7 +34,7 @@ def test_rllib_integration(ray_start_regular_shared):
                 trainer.train()
 
 
-def test_rllib_integration_tune(ray_start_regular_shared):
+def test_rllib_integration_tune(ray_start_regular):
     with ray_start_client_server():
         # Confirming the behavior of this context manager.
         # (Client mode hook not yet enabled.)
@@ -49,7 +49,7 @@ def test_rllib_integration_tune(ray_start_regular_shared):
 
 
 @pytest.mark.asyncio
-async def test_serve_handle(ray_start_regular_shared):
+async def test_serve_handle(ray_start_regular):
     with ray_start_client_server() as ray:
         from ray import serve
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Using ray_start_regular_shared test_tune_library_integration seems to make test_serve_handle flake. Separate use ray_start_regular instead.

No flake: 
<img width="610" alt="Screen Shot 2022-07-27 at 1 10 59 PM" src="https://user-images.githubusercontent.com/14043490/181363214-522e9f41-df59-4b84-89b1-d8399b1901c6.png">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
