### PR TITLE
Add back job_id to submit_job API to maintain backwards-compatibility

### DIFF
--- a/dashboard/modules/job/common.py
+++ b/dashboard/modules/job/common.py
@@ -185,6 +185,8 @@ class JobSubmitRequest:
     # is not specified, one will be generated. If a job with the same
     # submission_id already exists, it will be rejected.
     submission_id: Optional[str] = None
+    # DEPRECATED. Use submission_id instead
+    job_id: Optional[str] = None
     # Dict to setup execution environment.
     runtime_env: Optional[Dict[str, Any]] = None
     # Metadata to pass in to the JobConfig.
@@ -198,6 +200,11 @@ class JobSubmitRequest:
             raise TypeError(
                 "submission_id must be a string if provided, "
                 f"got {type(self.submission_id)}"
+            )
+
+        if self.job_id is not None and not isinstance(self.job_id, str):
+            raise TypeError(
+                "job_id must be a string if provided, " f"got {type(self.job_id)}"
             )
 
         if self.runtime_env is not None:

--- a/dashboard/modules/job/job_head.py
+++ b/dashboard/modules/job/job_head.py
@@ -179,10 +179,12 @@ class JobHead(dashboard_utils.DashboardHeadModule):
         else:
             submit_request = result
 
+        request_submission_id = submit_request.submission_id or submit_request.job_id
+
         try:
             submission_id = self._job_manager.submit_job(
                 entrypoint=submit_request.entrypoint,
-                submission_id=submit_request.submission_id,
+                submission_id=request_submission_id,
                 runtime_env=submit_request.runtime_env,
                 metadata=submit_request.metadata,
             )

--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -500,7 +500,7 @@ def test_submit_still_accepts_job_id_or_submission_id(job_sdk_client):
     """Check that job_id, runtime_env, and metadata are optional."""
     client = job_sdk_client
 
-    r = client._do_request(
+    client._do_request(
         "POST",
         "/api/jobs/",
         json_data={"entrypoint": "ls", "job_id": "raysubmit_12345"},
@@ -508,7 +508,7 @@ def test_submit_still_accepts_job_id_or_submission_id(job_sdk_client):
 
     wait_for_condition(_check_job_succeeded, client=client, job_id="raysubmit_12345")
 
-    r = client._do_request(
+    client._do_request(
         "POST",
         "/api/jobs/",
         json_data={"entrypoint": "ls", "submission_id": "raysubmit_23456"},

--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -496,6 +496,27 @@ def test_submit_optional_args(job_sdk_client):
     )
 
 
+def test_submit_still_accepts_job_id_or_submission_id(job_sdk_client):
+    """Check that job_id, runtime_env, and metadata are optional."""
+    client = job_sdk_client
+
+    r = client._do_request(
+        "POST",
+        "/api/jobs/",
+        json_data={"entrypoint": "ls", "job_id": "raysubmit_12345"},
+    )
+
+    wait_for_condition(_check_job_succeeded, client=client, job_id="raysubmit_12345")
+
+    r = client._do_request(
+        "POST",
+        "/api/jobs/",
+        json_data={"entrypoint": "ls", "submission_id": "raysubmit_23456"},
+    )
+
+    wait_for_condition(_check_job_succeeded, client=client, job_id="raysubmit_23456")
+
+
 def test_missing_resources(job_sdk_client):
     """Check that 404s are raised for resources that don't exist."""
     client = job_sdk_client


### PR DESCRIPTION
Fix for a unintentional backwards-compatibility breakage for #25902
job submit api should still accept job_id as a parameter

Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
