### PR TITLE
[air] fix xgboost_benchmark script by passing in args

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -58,7 +58,7 @@ def run_and_time_it(f):
                     self._exception = self._pconn.recv()
                 return self._exception
 
-        p = MyProcess(target=f, *args, **kwargs)
+        p = MyProcess(target=f, args=args, kwargs=kwargs)
         start = time.monotonic()
         p.start()
         p.join()


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This test was updated in https://github.com/ray-project/ray/pull/27023, and started failing with:

```bash
  File "xgboost_benchmark.py", line 144, in <module>
    main(args)
  File "xgboost_benchmark.py", line 113, in main
    training_time = run_xgboost_training(data_path, num_workers)
  File "xgboost_benchmark.py", line 61, in wrapper
    p = MyProcess(target=f, *args, **kwargs)
  File "xgboost_benchmark.py", line 43, in __init__
    super(MyProcess, self).__init__(*args, **kwargs)
TypeError: __init__() got multiple values for argument 'target'
```

This is because [BaseProcess](https://github.com/python/cpython/blob/main/Lib/multiprocessing/process.py#L80-L81) is expecting to take  in function `args` and `kwargs` as named arguments.



Verification: https://console.anyscale-staging.com/o/anyscale-internal/projects/prj_mWECugke9RzMh79BZQqeykjN/clusters/ses_AqZgwEVpXMXnbjjTxaQPCXha

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
