### PR TITLE
[Stale bot] Increase the activity per hour limit

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -62,8 +62,7 @@ closeComment: |
   Thanks again for opening the issue! 
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-# It will check 120 issues per day.
-limitPerRun: 5
+limitPerRun: 30
 
 # Limit to only `issues` or `pulls`
 # only: issues


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like the allowed actions per hour for the stale bot is too small (which might backlog closing and marking issues). It increases it to 6X times.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
