### PR TITLE
[Data][Split] Fix split ownership

### DIFF
--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -93,9 +93,10 @@ def _split_single_block(
     block: Block,
     meta: BlockMetadata,
     split_indices: List[int],
-) -> Tuple[int, BlockPartition]:
+):
     """Split the provided block at the given indices."""
-    split_result = []
+    split_meta = []
+    split_blocks = []
     block_accessor = BlockAccessor.for_block(block)
     prev_index = 0
     # append one more entry at the last so we don't
@@ -113,9 +114,12 @@ def _split_single_block(
             input_files=meta.input_files,
             exec_stats=stats.build(),
         )
-        split_result.append((ray.put(split_block), split_meta))
+        split_meta.append(split_meta)
+        split_blocks.append(split_block)
         prev_index = index
-    return (block_id, split_result)
+    results = [(block_id, split_meta)]
+    results.extend(split_blocks)
+    return *results
 
 
 def _drop_empty_block_split(block_split_indices: List[int], num_rows: int) -> List[int]:

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -106,7 +106,7 @@ def _split_single_block(
         in the following form. We return blocks in this way
         so that the owner of blocks could be the caller(driver)
         instead of worker itself.
-        Tuple(block_id, split_blocks_meta)), block0, block1 ...
+        Tuple(block_id, split_blocks_meta), block0, block1 ...
     """
     split_meta = []
     split_blocks = []

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -522,47 +522,63 @@ def _create_blocklist(blocks):
 
 def test_split_single_block(ray_start_regular_shared):
     block = [1, 2, 3]
-    meta = _create_meta(3)
+    metadata = _create_meta(3)
 
-    block_id, splits = ray.get(
-        ray.remote(_split_single_block).remote(234, block, meta, [])
+    results = ray.get(
+        ray.remote(_split_single_block)
+        .options(num_returns=2)
+        .remote(234, block, metadata, [])
     )
+    block_id, meta = results[0]
+    blocks = results[1:]
     assert 234 == block_id
-    assert len(splits) == 1
-    assert ray.get(splits[0][0]) == [1, 2, 3]
-    assert splits[0][1].num_rows == 3
+    assert len(blocks) == 1
+    assert blocks[0] == [1, 2, 3]
+    assert meta[0].num_rows == 3
 
-    block_id, splits = ray.get(
-        ray.remote(_split_single_block).remote(234, block, meta, [1])
+    results = ray.get(
+        ray.remote(_split_single_block)
+        .options(num_returns=3)
+        .remote(234, block, metadata, [1])
     )
+    block_id, meta = results[0]
+    blocks = results[1:]
     assert 234 == block_id
-    assert len(splits) == 2
-    assert ray.get(splits[0][0]) == [1]
-    assert splits[0][1].num_rows == 1
-    assert ray.get(splits[1][0]) == [2, 3]
-    assert splits[1][1].num_rows == 2
+    assert len(blocks) == 2
+    assert blocks[0] == [1]
+    assert meta[0].num_rows == 1
+    assert blocks[1] == [2, 3]
+    assert meta[1].num_rows == 2
 
-    block_id, splits = ray.get(
-        ray.remote(_split_single_block).remote(234, block, meta, [0, 1, 1, 3])
+    results = ray.get(
+        ray.remote(_split_single_block)
+        .options(num_returns=6)
+        .remote(234, block, metadata, [0, 1, 1, 3])
     )
+    block_id, meta = results[0]
+    blocks = results[1:]
     assert 234 == block_id
-    assert len(splits) == 5
-    assert ray.get(splits[0][0]) == []
-    assert ray.get(splits[1][0]) == [1]
-    assert ray.get(splits[2][0]) == []
-    assert ray.get(splits[3][0]) == [2, 3]
-    assert ray.get(splits[4][0]) == []
+    assert len(blocks) == 5
+    assert blocks[0] == []
+    assert blocks[1] == [1]
+    assert blocks[2] == []
+    assert blocks[3] == [2, 3]
+    assert blocks[4] == []
 
     block = []
-    meta = _create_meta(0)
+    metadata = _create_meta(0)
 
-    block_id, splits = ray.get(
-        ray.remote(_split_single_block).remote(234, block, meta, [0])
+    results = ray.get(
+        ray.remote(_split_single_block)
+        .options(num_returns=3)
+        .remote(234, block, metadata, [0])
     )
+    block_id, meta = results[0]
+    blocks = results[1:]
     assert 234 == block_id
-    assert len(splits) == 2
-    assert ray.get(splits[0][0]) == []
-    assert ray.get(splits[1][0]) == []
+    assert len(blocks) == 2
+    assert blocks[0] == []
+    assert blocks[1] == []
 
 
 def test_drop_empty_block_split():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/commit/fb54679a239e4c7368a72a2fe3023cac04380827 introduced a bug by calling `ray.put` in the remote _split_single_block. This changes the ownership from driver to the worker who runs _split_single_block, which breaks dataset's lineage requirement and failed the chaos test.

To fix the issue we need to ensure the split block refs are created by the driver, which we can achieved by creating the block_refs as part of function returns.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
