### PR TITLE
[rllib/release] Fix rllib connect test with Tuner() API

### DIFF
--- a/release/ml_user_tests/tune_rllib/run_connect_tests.py
+++ b/release/ml_user_tests/tune_rllib/run_connect_tests.py
@@ -19,7 +19,8 @@ if __name__ == "__main__":
         ray.init(address="auto")
 
     start_time = time.time()
-    exp_analysis = run()
+    results = run()
+    exp_analysis = results._experiment_analysis
     end_time = time.time()
 
     result = {

--- a/rllib/examples/tune/framework.py
+++ b/rllib/examples/tune/framework.py
@@ -38,7 +38,7 @@ def run(smoke_test=False):
 
     # Run the experiment.
     # TODO(jungong) : maybe add checkpointing.
-    tune.Tuner(
+    return tune.Tuner(
         "APPO",
         param_space=config,
         run_config=air.RunConfig(


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently failing because the Tune framework example does not return fitting results.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
