### PR TITLE
[Datasets] Doing partition filtering in reader constructor

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -352,9 +352,9 @@ class _FileBasedDatasourceReader(Reader):
         )
         if self._partition_filter is not None:
             # Use partition filter to skip files which are not needed.
-            pathToSize = dict(zip(self._paths, self._file_sizes))
+            path_to_size = dict(zip(self._paths, self._file_sizes))
             self._paths = self._partition_filter(self._paths)
-            self._file_sizes = [pathToSize[p] for p in self._paths]
+            self._file_sizes = [path_to_size[p] for p in self._paths]
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -350,6 +350,11 @@ class _FileBasedDatasourceReader(Reader):
         self._paths, self._file_sizes = meta_provider.expand_paths(
             paths, self._filesystem
         )
+        if self._partition_filter is not None:
+            # Use partition filter to skip files which are not needed.
+            pathToSize = dict(zip(self._paths, self._file_sizes))
+            self._paths = self._partition_filter(self._paths)
+            self._file_sizes = [pathToSize[p] for p in self._paths]
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0
@@ -366,9 +371,6 @@ class _FileBasedDatasourceReader(Reader):
         _block_udf = self._block_udf
 
         paths, file_sizes = self._paths, self._file_sizes
-        if self._partition_filter is not None:
-            paths = self._partition_filter(paths)
-
         read_stream = self._delegate._read_stream
         filesystem = _wrap_s3_serialization_workaround(self._filesystem)
         read_options = reader_args.get("read_options")

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2786,6 +2786,7 @@ def test_image_folder_datasource(ray_start_regular_shared):
     root = os.path.join(os.path.dirname(__file__), "image-folder")
     ds = ray.data.read_datasource(ImageFolderDatasource(), root=root, size=(64, 64))
 
+    assert ds.size_bytes() >= 15000
     assert ds.count() == 3
 
     df = ds.to_pandas()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
currently we are doing things in this ordering:
1. [create the reader for data source](https://github.com/ray-project/ray/blob/master/python/ray/data/read_api.py#L1136)
2. [calculate number of tasks, based on data source estimated size and cluster resource](https://github.com/ray-project/ray/blob/master/python/ray/data/read_api.py#L1137)
3. [doing partition filtering and generate read tasks](https://github.com/ray-project/ray/blob/master/python/ray/data/read_api.py#L1143)

However, we should do partition filtering before step 2, so that the data source estimated size is calculated based on correct set of files. Otherwise estimation is calculated based on all files, while some files could be filtered out later. See https://github.com/ray-project/ray/issues/27152 for more detail.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/27152

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
