### PR TITLE
[Datasets] Upgrade Dask dependency to 2022.6.0 for Python 3.8+

### DIFF
--- a/python/requirements/data_processing/requirements.txt
+++ b/python/requirements/data_processing/requirements.txt
@@ -1,5 +1,6 @@
 dask[complete]==2021.03.0; python_version < '3.7'
-dask[complete]==2022.2.0; python_version >= '3.7'
+dask[complete]==2022.2.0; python_version == '3.7'
+dask[complete]==2022.6.0; python_version > '3.7'
 aioboto3==8.3.0
 flask_cors
 moto[s3]==2.3.1


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is a munual redo of https://github.com/ray-project/ray/pull/25697, as Dask `2022.2.0` is the last version to support Python 3.7 - https://docs.dask.org/en/stable/changelog.html#v2022-02-0 .

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
