### PR TITLE
[tune] Increase volume size for long running pbt failure

### DIFF
--- a/release/long_running_distributed_tests/compute_tpl.yaml
+++ b/release/long_running_distributed_tests/compute_tpl.yaml
@@ -26,4 +26,4 @@ aws:
   BlockDeviceMappings:
     - DeviceName: /dev/sda1
       Ebs:
-        VolumeSize: 202
+        VolumeSize: 400

--- a/release/long_running_distributed_tests/workloads/pytorch_pbt_failure.py
+++ b/release/long_running_distributed_tests/workloads/pytorch_pbt_failure.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import ray
 from ray import tune
-from ray.air.config import RunConfig, ScalingConfig
+from ray.air.config import RunConfig, ScalingConfig, FailureConfig
 from ray.train.examples.tune_cifar_torch_pbt_example import train_func
 from ray.train.torch import TorchConfig, TorchTrainer
 from ray.tune.schedulers import PopulationBasedTraining
@@ -69,6 +69,7 @@ tuner = Tuner(
     ),
     run_config=RunConfig(
         stop={"training_iteration": 1} if args.smoke_test else None,
+        failure_config=FailureConfig(max_failures=-1),
         callbacks=[FailureInjectorCallback(time_between_checks=90), ProgressCallback()],
     ),
 )


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently running into an issue:

```
Cluster startup Failed. Error: RuntimeError: botocore.exceptions.ClientError: An error occurred (InvalidBlockDeviceMapping) when calling the RunInstances operation: Volume of size 202GB is smaller than  snapshot 'snap-02c4e6a0ad06cf3d6', expect size >= 400GB
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
