### PR TITLE
[tune/release/2.0.0] Fix tune_cloud_aws_durable_upload_rllib_* release tests

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -58,7 +58,7 @@ def run_and_time_it(f):
                     self._exception = self._pconn.recv()
                 return self._exception
 
-        p = MyProcess(target=f, *args, **kwargs)
+        p = MyProcess(target=f, args=args, kwargs=kwargs)
         start = time.monotonic()
         p.start()
         p.join()

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -58,7 +58,7 @@ def run_and_time_it(f):
                     self._exception = self._pconn.recv()
                 return self._exception
 
-        p = MyProcess(target=f, args=args, kwargs=kwargs)
+        p = MyProcess(target=f, *args, **kwargs)
         start = time.monotonic()
         p.start()
         p.join()

--- a/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
+++ b/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
@@ -644,9 +644,7 @@ def load_trial_checkpoint_data(
             with open(json_path, "rt") as f:
                 checkpoint_data = json.load(f)
         else:
-            meta_path = os.path.join(
-                cp_full_dir, f"checkpoint-{checkpoint_num}.tune_metadata"
-            )
+            meta_path = os.path.join(cp_full_dir, ".tune_metadata")
             with open(meta_path, "rb") as f:
                 checkpoint_meta = pickle.load(f)
                 checkpoint_data = {"internal_iter": checkpoint_meta["iteration"]}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up from #27164, fixes tune_cloud_aws_durable_upload_rllib_* release tests

## Related issue number



## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
