### PR TITLE
Fix the ray version to doc version mapping

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1050,7 +1050,7 @@ def get_call_location(back: int = 1):
 
 def get_ray_doc_version():
     """Get the docs.ray.io version corresponding to the ray.__version__."""
-    if re.match("^\d+\.\d+\.\d+$", ray.__version__) is None:
+    if re.match(r"^\d+\.\d+\.\d+$", ray.__version__) is None:
         return "master"
     return f"releases-{ray.__version__}"
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import multiprocessing
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -1049,7 +1050,7 @@ def get_call_location(back: int = 1):
 
 def get_ray_doc_version():
     """Get the docs.ray.io version corresponding to the ray.__version__."""
-    if re.match("^\d+\.\d+\.\d+$", ray.__version__) == None:
+    if re.match("^\d+\.\d+\.\d+$", ray.__version__) is None:
         return "master"
     return f"releases-{ray.__version__}"
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1050,8 +1050,13 @@ def get_call_location(back: int = 1):
 
 def get_ray_doc_version():
     """Get the docs.ray.io version corresponding to the ray.__version__."""
+    # The ray.__version__ can be official Ray release (such as 1.12.0), or
+    # dev (3.0.0dev0) or release candidate (2.0.0rc0). For the later we map
+    # to the master doc version at docs.ray.io.
     if re.match(r"^\d+\.\d+\.\d+$", ray.__version__) is None:
         return "master"
+    # For the former (official Ray release), we have corresponding doc version
+    # released as well.
     return f"releases-{ray.__version__}"
 
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1049,7 +1049,7 @@ def get_call_location(back: int = 1):
 
 def get_ray_doc_version():
     """Get the docs.ray.io version corresponding to the ray.__version__."""
-    if "dev" in ray.__version__:
+    if re.match("^\d+\.\d+\.\d+$", ray.__version__) == None:
         return "master"
     return f"releases-{ray.__version__}"
 


### PR DESCRIPTION
Signed-off-by: jianoaix <iamjianxiao@gmail.com>

## Why are these changes needed?

It doesn't work if the ray version is something like "2.0.0rc0"

## Related issue number

#27176
#27173

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
