### PR TITLE
[autoscaler] Remove deprecated fields from schema 

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -7,7 +7,7 @@ set -x
 
 GPU=""
 BASE_IMAGE="ubuntu:focal"
-WHEEL_URL="https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl"
+WHEEL_URL="https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0rc0-cp37-cp37m-manylinux2014_x86_64.whl"
 PYTHON_VERSION="3.7.7"
 
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -189,6 +189,10 @@ test_python() {
       -python/ray/tests:test_k8s_operator_unit_tests
       -python/ray/tests:test_tracing  # tracing not enabled on windows
       -python/ray/tests:kuberay/test_autoscaling_e2e # irrelevant on windows
+      -python/ray/tests/xgboost/... # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/lightgbm/... # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/horovod/... # Requires ML dependencies, should not be run on Windows
+      -python/ray/tests/ray_lightning/... # Requires ML dependencies, should not be run on Windows
     )
   fi
   if [ 0 -lt "${#args[@]}" ]; then  # Any targets to test?

--- a/doc/source/ray-air/examples/tfx_tabular_train_to_serve.ipynb
+++ b/doc/source/ray-air/examples/tfx_tabular_train_to_serve.ipynb
@@ -115,7 +115,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -127,7 +127,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.10', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-20_18-45-26_127581_21006/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-20_18-45-26_127581_21006/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-20_18-45-26_127581_21006', 'metrics_export_port': 63884, 'gcs_address': '127.0.0.1:63685', 'address': '127.0.0.1:63685', 'dashboard_agent_listen_port': 52365, 'node_id': 'c21f810137e56bd967ab3f246c66aadc5262e00bdbe19c34c23456e7'})"
+       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.10', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-20_18-45-26_127581_21006/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-20_18-45-26_127581_21006/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-20_18-45-26_127581_21006', 'metrics_export_port': 63884, 'gcs_address': '127.0.0.1:63685', 'address': '127.0.0.1:63685', 'dashboard_agent_listen_port': 52365, 'node_id': 'c21f810137e56bd967ab3f246c66aadc5262e00bdbe19c34c23456e7'})"
       ]
      },
      "execution_count": 2,

--- a/doc/source/ray-air/examples/torch_incremental_learning.ipynb
+++ b/doc/source/ray-air/examples/torch_incremental_learning.ipynb
@@ -143,7 +143,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -155,7 +155,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.10', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-20_21-47-47_297236_39344/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-20_21-47-47_297236_39344/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-20_21-47-47_297236_39344', 'metrics_export_port': 62008, 'gcs_address': '127.0.0.1:57307', 'address': '127.0.0.1:57307', 'dashboard_agent_listen_port': 52365, 'node_id': 'db68eafa3bbe9042df574f3c9974b40ce8d97728db90282feefb4690'})"
+       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.10', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-20_21-47-47_297236_39344/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-20_21-47-47_297236_39344/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-20_21-47-47_297236_39344', 'metrics_export_port': 62008, 'gcs_address': '127.0.0.1:57307', 'address': '127.0.0.1:57307', 'dashboard_agent_listen_port': 52365, 'node_id': 'db68eafa3bbe9042df574f3c9974b40ce8d97728db90282feefb4690'})"
       ]
      },
      "execution_count": 2,

--- a/doc/source/tune/examples/ax_example.ipynb
+++ b/doc/source/tune/examples/ax_example.ipynb
@@ -249,7 +249,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -261,7 +261,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-04-13_664725_44631/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-04-13_664725_44631/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-04-13_664725_44631', 'metrics_export_port': 59224, 'gcs_address': '127.0.0.1:64758', 'address': '127.0.0.1:64758', 'dashboard_agent_listen_port': 52365, 'node_id': 'a52a99236a0b34036e994d7625d5743a08836b40ea2b3deb2cd33752'})"
+       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-04-13_664725_44631/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-04-13_664725_44631/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-04-13_664725_44631', 'metrics_export_port': 59224, 'gcs_address': '127.0.0.1:64758', 'address': '127.0.0.1:64758', 'dashboard_agent_listen_port': 52365, 'node_id': 'a52a99236a0b34036e994d7625d5743a08836b40ea2b3deb2cd33752'})"
       ]
      },
      "execution_count": 6,

--- a/doc/source/tune/examples/bayesopt_example.ipynb
+++ b/doc/source/tune/examples/bayesopt_example.ipynb
@@ -162,7 +162,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -174,7 +174,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-30-02_149801_46800/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-30-02_149801_46800/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-30-02_149801_46800', 'metrics_export_port': 61358, 'gcs_address': '127.0.0.1:61452', 'address': '127.0.0.1:61452', 'dashboard_agent_listen_port': 52365, 'node_id': 'af68dd2eb5791913931005bd8d62a94b3507a476cef5cdb6cb08521a'})"
+       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-30-02_149801_46800/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-30-02_149801_46800/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-30-02_149801_46800', 'metrics_export_port': 61358, 'gcs_address': '127.0.0.1:61452', 'address': '127.0.0.1:61452', 'dashboard_agent_listen_port': 52365, 'node_id': 'af68dd2eb5791913931005bd8d62a94b3507a476cef5cdb6cb08521a'})"
       ]
      },
      "execution_count": 5,

--- a/doc/source/tune/examples/bohb_example.ipynb
+++ b/doc/source/tune/examples/bohb_example.ipynb
@@ -203,7 +203,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -215,7 +215,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-07-22_184925_45026/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-07-22_184925_45026/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-07-22_184925_45026', 'metrics_export_port': 57745, 'gcs_address': '127.0.0.1:58825', 'address': '127.0.0.1:58825', 'dashboard_agent_listen_port': 52365, 'node_id': 'c1cef9dffdd1fc9628495d1329d74226b0fa64cb8709e45af80fc254'})"
+       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-07-22_184925_45026/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-07-22_184925_45026/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-07-22_184925_45026', 'metrics_export_port': 57745, 'gcs_address': '127.0.0.1:58825', 'address': '127.0.0.1:58825', 'dashboard_agent_listen_port': 52365, 'node_id': 'c1cef9dffdd1fc9628495d1329d74226b0fa64cb8709e45af80fc254'})"
       ]
      },
      "execution_count": 5,

--- a/doc/source/tune/examples/flaml_example.ipynb
+++ b/doc/source/tune/examples/flaml_example.ipynb
@@ -168,7 +168,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -180,7 +180,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-18-05_176636_45728/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-18-05_176636_45728/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-18-05_176636_45728', 'metrics_export_port': 63113, 'gcs_address': '127.0.0.1:63688', 'address': '127.0.0.1:63688', 'dashboard_agent_listen_port': 52365, 'node_id': '35eafee40228cabb8ae4ddafa3e39f41262af0440bf69a0d776f8fe8'})"
+       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-18-05_176636_45728/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-18-05_176636_45728/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-18-05_176636_45728', 'metrics_export_port': 63113, 'gcs_address': '127.0.0.1:63688', 'address': '127.0.0.1:63688', 'dashboard_agent_listen_port': 52365, 'node_id': '35eafee40228cabb8ae4ddafa3e39f41262af0440bf69a0d776f8fe8'})"
       ]
      },
      "execution_count": 4,

--- a/doc/source/tune/examples/hebo_example.ipynb
+++ b/doc/source/tune/examples/hebo_example.ipynb
@@ -228,7 +228,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -240,7 +240,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-34-28_908798_47358/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-34-28_908798_47358/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-34-28_908798_47358', 'metrics_export_port': 65083, 'gcs_address': '127.0.0.1:61944', 'address': '127.0.0.1:61944', 'dashboard_agent_listen_port': 52365, 'node_id': '6fb8a71e3e7e8ba1b689be3f4802c238368cfef20015b5abd0aa742f'})"
+       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-34-28_908798_47358/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-34-28_908798_47358/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-34-28_908798_47358', 'metrics_export_port': 65083, 'gcs_address': '127.0.0.1:61944', 'address': '127.0.0.1:61944', 'dashboard_agent_listen_port': 52365, 'node_id': '6fb8a71e3e7e8ba1b689be3f4802c238368cfef20015b5abd0aa742f'})"
       ]
      },
      "execution_count": 5,

--- a/doc/source/tune/examples/hyperopt_example.ipynb
+++ b/doc/source/tune/examples/hyperopt_example.ipynb
@@ -205,7 +205,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -217,7 +217,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-30-59_720199_47076/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-30-59_720199_47076/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-30-59_720199_47076', 'metrics_export_port': 61594, 'gcs_address': '127.0.0.1:63379', 'address': '127.0.0.1:63379', 'dashboard_agent_listen_port': 52365, 'node_id': '433e2d825b2bbfe76eb6845ceeda5c337fc35c367b60f2b28526b153'})"
+       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-30-59_720199_47076/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-30-59_720199_47076/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-30-59_720199_47076', 'metrics_export_port': 61594, 'gcs_address': '127.0.0.1:63379', 'address': '127.0.0.1:63379', 'dashboard_agent_listen_port': 52365, 'node_id': '433e2d825b2bbfe76eb6845ceeda5c337fc35c367b60f2b28526b153'})"
       ]
      },
      "execution_count": 5,

--- a/doc/source/tune/examples/nevergrad_example.ipynb
+++ b/doc/source/tune/examples/nevergrad_example.ipynb
@@ -190,7 +190,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -202,7 +202,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-23-54_250484_46348/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-23-54_250484_46348/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-23-54_250484_46348', 'metrics_export_port': 60625, 'gcs_address': '127.0.0.1:63562', 'address': '127.0.0.1:63562', 'dashboard_agent_listen_port': 52365, 'node_id': '833f68610f3299cf23cacacc02fe1c7dce7e9ea49bb948b17af93bf0'})"
+       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-23-54_250484_46348/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-23-54_250484_46348/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-23-54_250484_46348', 'metrics_export_port': 60625, 'gcs_address': '127.0.0.1:63562', 'address': '127.0.0.1:63562', 'dashboard_agent_listen_port': 52365, 'node_id': '833f68610f3299cf23cacacc02fe1c7dce7e9ea49bb948b17af93bf0'})"
       ]
      },
      "execution_count": 5,

--- a/doc/source/tune/examples/optuna_example.ipynb
+++ b/doc/source/tune/examples/optuna_example.ipynb
@@ -142,7 +142,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -154,7 +154,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-21-42_643152_46061/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-21-42_643152_46061/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-21-42_643152_46061', 'metrics_export_port': 60351, 'gcs_address': '127.0.0.1:65028', 'address': '127.0.0.1:65028', 'dashboard_agent_listen_port': 52365, 'node_id': 'b7abfa8f9f137b294759a2e68a71edb9920c011a97e390fd1e0b71bf'})"
+       "RayContext(dashboard_url='127.0.0.1:8265', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-21-42_643152_46061/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-21-42_643152_46061/sockets/raylet', 'webui_url': '127.0.0.1:8265', 'session_dir': '/tmp/ray/session_2022-07-22_15-21-42_643152_46061', 'metrics_export_port': 60351, 'gcs_address': '127.0.0.1:65028', 'address': '127.0.0.1:65028', 'dashboard_agent_listen_port': 52365, 'node_id': 'b7abfa8f9f137b294759a2e68a71edb9920c011a97e390fd1e0b71bf'})"
       ]
      },
      "execution_count": 3,

--- a/doc/source/tune/examples/skopt_example.ipynb
+++ b/doc/source/tune/examples/skopt_example.ipynb
@@ -130,7 +130,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -142,7 +142,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8268', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-46-17_712380_48353/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-46-17_712380_48353/sockets/raylet', 'webui_url': '127.0.0.1:8268', 'session_dir': '/tmp/ray/session_2022-07-22_15-46-17_712380_48353', 'metrics_export_port': 64916, 'gcs_address': '127.0.0.1:64371', 'address': '127.0.0.1:64371', 'dashboard_agent_listen_port': 52365, 'node_id': 'bf206482b99028fd8c8cfaea9d94a1bd982869a6c7d6f7531ac6bcb8'})"
+       "RayContext(dashboard_url='127.0.0.1:8268', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-46-17_712380_48353/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-46-17_712380_48353/sockets/raylet', 'webui_url': '127.0.0.1:8268', 'session_dir': '/tmp/ray/session_2022-07-22_15-46-17_712380_48353', 'metrics_export_port': 64916, 'gcs_address': '127.0.0.1:64371', 'address': '127.0.0.1:64371', 'dashboard_agent_listen_port': 52365, 'node_id': 'bf206482b99028fd8c8cfaea9d94a1bd982869a6c7d6f7531ac6bcb8'})"
       ]
      },
      "execution_count": 3,

--- a/doc/source/tune/examples/zoopt_example.ipynb
+++ b/doc/source/tune/examples/zoopt_example.ipynb
@@ -170,7 +170,7 @@
        "            </tr>\n",
        "            <tr>\n",
        "                <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "                <td style=\"text-align: left\"><b> 3.0.0.dev0</b></td>\n",
+       "                <td style=\"text-align: left\"><b> 2.0.0rc0</b></td>\n",
        "            </tr>\n",
        "            <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
@@ -182,7 +182,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-35-29_724425_47582/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-35-29_724425_47582/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-35-29_724425_47582', 'metrics_export_port': 63508, 'gcs_address': '127.0.0.1:65155', 'address': '127.0.0.1:65155', 'dashboard_agent_listen_port': 52365, 'node_id': 'cecb81f61b8504b3ccfcd881ed1c79c3b7d184be1ba13216cb7e3957'})"
+       "RayContext(dashboard_url='127.0.0.1:8266', python_version='3.7.7', ray_version='2.0.0rc0', ray_commit='{{RAY_COMMIT_SHA}}', address_info={'node_ip_address': '127.0.0.1', 'raylet_ip_address': '127.0.0.1', 'redis_address': None, 'object_store_address': '/tmp/ray/session_2022-07-22_15-35-29_724425_47582/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2022-07-22_15-35-29_724425_47582/sockets/raylet', 'webui_url': '127.0.0.1:8266', 'session_dir': '/tmp/ray/session_2022-07-22_15-35-29_724425_47582', 'metrics_export_port': 63508, 'gcs_address': '127.0.0.1:65155', 'address': '127.0.0.1:65155', 'dashboard_agent_listen_port': 52365, 'node_id': 'cecb81f61b8504b3ccfcd881ed1c79c3b7d184be1ba13216cb7e3957'})"
       ]
      },
      "execution_count": 5,

--- a/java/api/pom_template.xml
+++ b/java/api/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0rc0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/performance_test/pom_template.xml
+++ b/java/performance_test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0rc0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.ray</groupId>
   <artifactId>ray-superpom</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0rc0</version>
   <packaging>pom</packaging>
   <name>Ray Project Parent POM</name>
   <description>An open source framework that provides a simple, universal API for building distributed applications.
@@ -63,7 +63,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.version>2.0.0-SNAPSHOT</project.version>
+    <project.version>2.0.0rc0</project.version>
   </properties>
 
   <dependencyManagement>

--- a/java/runtime/pom_template.xml
+++ b/java/runtime/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0rc0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/serve/pom_template.xml
+++ b/java/serve/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0rc0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/test/pom_template.xml
+++ b/java/test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0rc0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -111,7 +111,7 @@ del _configure_system
 
 # Replaced with the current commit when building the wheels.
 __commit__ = "{{RAY_COMMIT_SHA}}"
-__version__ = "3.0.0.dev0"
+__version__ = "2.0.0rc0"
 
 import ray._raylet  # noqa: E402
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1166,13 +1166,13 @@ def get_wheel_filename(
         sys_platform: The platform as returned by sys.platform. Examples:
             "darwin", "linux", "win32"
         ray_version: The Ray version as returned by ray.__version__ or
-            `ray --version`.  Examples: "3.0.0.dev0"
+            `ray --version`.  Examples: "2.0.0rc0"
         py_version (str):
             The major and minor Python versions concatenated.  Examples: "36",
             "37", "38", "39"
     Returns:
         The wheel file name.  Examples:
-            ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+            ray-2.0.0rc0-cp38-cp38-manylinux2014_x86_64.whl
     """
     assert py_version in ["36", "37", "38", "39"], py_version
 

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -923,6 +923,13 @@ def _set_up_config_for_head_node(
     # head node won't be able to connect to workers
     remote_config["auth"].pop("ssh_proxy_command", None)
 
+    # Drop the head_node field if it was introduced. It is technically not a
+    # valid field in the config, but it may have been introduced after
+    # validation (see _bootstrap_config() call to
+    # provider_cls.bootstrap_config(config)). The head node will never try to
+    # launch a head node so it doesn't need these defaults.
+    remote_config.pop("head_node", None)
+
     if "ssh_private_key" in config["auth"]:
         remote_key_path = "~/ray_bootstrap_key.pem"
         remote_config["auth"]["ssh_private_key"] = remote_key_path

--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -182,8 +182,6 @@ def _generate_legacy_autoscaling_config_fields() -> Dict[str, Any]:
         "head_start_ray_commands": [],
         "worker_start_ray_commands": [],
         "auth": {},
-        "head_node": {},
-        "worker_nodes": {},
     }
 
 

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -222,6 +222,23 @@ def prepare_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return with_defaults
 
 
+def translate_trivial_legacy_config(config: Dict[str, Any]):
+    """
+    Drop empty deprecated fields ("head_node" and "worker_node").
+    """
+
+    REMOVABLE_FIELDS = ["head_node", "worker_nodes"]
+
+    for field in REMOVABLE_FIELDS:
+        if field in config and not config[field]:
+            logger.warning(
+                f"Dropping the empty legacy field {field}. {field}"
+                "is not supported for ray>=2.0.0. It is recommended to remove"
+                f"{field} from the cluster config."
+            )
+            del config[field]
+
+
 def fillout_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     defaults = _get_default_config(config["provider"])
     defaults.update(config)
@@ -246,6 +263,8 @@ def fillout_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     # Take care of this here, in case a config does not specify any of head,
     # workers, node types, but does specify min workers:
     merged_config.pop("min_workers", None)
+
+    translate_trivial_legacy_config(merged_config)
 
     return merged_config
 

--- a/python/ray/autoscaler/local/development-example.yaml
+++ b/python/ray/autoscaler/local/development-example.yaml
@@ -9,8 +9,6 @@ provider:
 auth:
     ssh_user: YOUR_USERNAME
     ssh_private_key: ~/.ssh/id_rsa
-head_node: {}
-worker_nodes: {}
 file_mounts:
      "/tmp/ray_sha": "/YOUR/LOCAL/RAY/REPO/.git/refs/heads/YOUR_BRANCH"
 setup_commands: []

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -23,31 +23,10 @@
             "description": "A unique identifier for the head node and workers of this cluster.",
             "type": "string"
         },
-        "min_workers": {
-            "description": "DEPRECATED. Use the per node_type min_workers field instead.",
-            "type": "integer",
-            "minimum": 0
-        },
         "max_workers": {
             "description": "The maximum number of workers nodes to launch in addition to the head node. This takes precedence over min_workers.",
             "type": "integer",
             "minimum": 0
-        },
-        "initial_workers": {
-            "description": "DEPRECATED.",
-            "type": "integer",
-            "minimum": 0
-        },
-        "autoscaling_mode": {
-            "description": "DEPRECATED. Use upscaling_speed instead.",
-            "type": "string",
-            "enum": [ "default", "aggressive" ]
-        },
-        "target_utilization_fraction": {
-            "description": "DEPRECATED. Use upscaling_speed instead.",
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1
         },
         "upscaling_speed": {
             "description": "The autoscaler will scale up the cluster faster with higher upscaling speed. E.g., if the task requires adding more nodes then autoscaler will gradually scale up the cluster in chunks of upscaling_speed*currently_running_nodes. This number should be > 0.",
@@ -69,7 +48,7 @@
                     "type": "string",
                     "description": "e.g. aws, azure, gcp,..."
                 },
-                "region": { 
+                "region": {
                     "type": "string",
                     "description": "e.g. us-east-1"
                 },
@@ -300,18 +279,6 @@
         "head_node_type": {
             "type": "string",
             "description": "If using multiple node types, specifies the head node type."
-        },
-        "worker_default_node_type": {
-            "type": "string",
-            "description": "DEPRECATED."
-        },
-        "head_node": {
-            "type": "object",
-            "description": "Provider-specific config for the head node, e.g. instance type."
-        },
-        "worker_nodes": {
-            "type": "object",
-            "description": "Provider-specific config for worker nodes. e.g. instance type."
         },
         "file_mounts": {
             "type": "object",

--- a/python/ray/tests/horovod/BUILD
+++ b/python/ray/tests/horovod/BUILD
@@ -2,6 +2,7 @@ py_test(
     name = "test_horovod",
     size = "medium",
     srcs = ["test_horovod.py"],
+    deps = ["//:ray_lib"],
     tags = ["team:ml", "exclusive"]
 )
 

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -91,7 +91,6 @@ def _get_basic_autoscaling_config() -> dict:
         "cluster_synced_files": [],
         "file_mounts": {},
         "file_mounts_sync_continuously": False,
-        "head_node": {},
         "head_node_type": "head-group",
         "head_setup_commands": [],
         "head_start_ray_commands": [],
@@ -100,7 +99,6 @@ def _get_basic_autoscaling_config() -> dict:
         "max_workers": 600,
         "setup_commands": [],
         "upscaling_speed": 1000,
-        "worker_nodes": {},
         "worker_setup_commands": [],
         "worker_start_ray_commands": [],
     }

--- a/python/ray/tests/lightgbm/BUILD
+++ b/python/ray/tests/lightgbm/BUILD
@@ -2,6 +2,7 @@ py_test(
  name = "simple_example",
  size = "small",
  srcs = ["simple_example.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"],
 )
 
@@ -9,6 +10,7 @@ py_test(
  name = "simple_tune",
  size="small",
  srcs = ["simple_tune.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"]
 )
 

--- a/python/ray/tests/ray_lightning/BUILD
+++ b/python/ray/tests/ray_lightning/BUILD
@@ -2,6 +2,7 @@ py_test(
  name = "simple_example",
  size = "small",
  srcs = ["simple_example.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"],
 )
 
@@ -9,5 +10,6 @@ py_test(
  name = "simple_tune",
  size="small",
  srcs = ["simple_tune.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"]
 )

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -17,7 +17,6 @@ from unittest.mock import (
 )
 
 import grpc
-import jsonschema
 import pytest
 import yaml
 from jsonschema.exceptions import ValidationError
@@ -465,12 +464,8 @@ class NoUpdaterMockAutoscaler(MockAutoscaler):
 
 SMALL_CLUSTER = {
     "cluster_name": "default",
-    "min_workers": 2,
-    "max_workers": 2,
-    "initial_workers": 0,
-    "autoscaling_mode": "default",
-    "target_utilization_fraction": 0.8,
     "idle_timeout_minutes": 5,
+    "max_workers": 2,
     "provider": {
         "type": "mock",
         "region": "us-east-1",
@@ -484,12 +479,24 @@ SMALL_CLUSTER = {
         "ssh_user": "ubuntu",
         "ssh_private_key": os.devnull,
     },
-    "head_node": {
-        "TestProp": 1,
+    "available_node_types": {
+        NODE_TYPE_LEGACY_HEAD: {
+            "node_config": {
+                "TestProp": 1,
+            },
+            "resources": {},
+            "max_workers": 0,
+        },
+        NODE_TYPE_LEGACY_WORKER: {
+            "node_config": {
+                "TestProp": 2,
+            },
+            "resources": {},
+            "min_workers": 2,
+            "max_workers": 2,
+        },
     },
-    "worker_nodes": {
-        "TestProp": 2,
-    },
+    "head_node_type": NODE_TYPE_LEGACY_HEAD,
     "file_mounts": {},
     "cluster_synced_files": [],
     "initialization_commands": ["init_cmd"],
@@ -544,6 +551,7 @@ TYPES_A = {
     "empty_node": {
         "node_config": {
             "FooProperty": 42,
+            "TestProp": 1,
         },
         "resources": {},
         "max_workers": 0,
@@ -805,7 +813,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, None)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
         runner.assert_has_call("1.2.3.4", pattern="docker run")
         runner.assert_has_call("1.2.3.4", pattern=head_run_option)
         runner.assert_has_call("1.2.3.4", pattern=standard_run_option)
@@ -998,7 +1006,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, None)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
         runner.assert_has_call("1.2.3.4", pattern="podman run")
 
         docker_mount_prefix = get_docker_host_mount_location(
@@ -1048,7 +1056,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, None)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
         runner.assert_has_call("1.2.3.4", pattern="docker run")
 
         docker_mount_prefix = get_docker_host_mount_location(
@@ -1160,7 +1168,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, None)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
         runner.assert_has_call("1.2.3.4", pattern="docker stop")
         runner.assert_has_call("1.2.3.4", pattern="docker run")
 
@@ -1212,7 +1220,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("1.2.3.4", "init_cmd")
         runner.assert_has_call("1.2.3.4", "head_setup_cmd")
         runner.assert_has_call("1.2.3.4", "start_ray_head")
-        self.assertEqual(self.provider.mock_nodes[0].node_type, None)
+        self.assertEqual(self.provider.mock_nodes[0].node_type, NODE_TYPE_LEGACY_HEAD)
         # We only removed amount from the YAML, no changes should happen.
         runner.assert_not_has_call("1.2.3.4", pattern="docker stop")
         runner.assert_not_has_call("1.2.3.4", pattern="docker run")
@@ -1288,7 +1296,7 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_has_call("172.0.0.4", pattern="rsync --rsh")
 
     def testRsyncCommandWithoutDocker(self):
-        cluster_cfg = SMALL_CLUSTER.copy()
+        cluster_cfg = copy.deepcopy(SMALL_CLUSTER)
         cluster_cfg["docker"] = {}
         config_path = self.write_config(cluster_cfg)
         self.provider = MockProvider(unique_ips=True)
@@ -1474,9 +1482,10 @@ class AutoscalingTest(unittest.TestCase):
         self.ScaleUpHelper(disable_node_updaters=True)
 
     def testTerminateOutdatedNodesGracefully(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 5
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 5
         config["max_workers"] = 5
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 5
         config_path = self.write_config(config)
         self.provider = MockProvider()
         self.provider.create_node(
@@ -1671,13 +1680,15 @@ class AutoscalingTest(unittest.TestCase):
         # Update the config to reduce the cluster size
         new_config = copy.deepcopy(SMALL_CLUSTER)
         new_config["max_workers"] = 1
+        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
         self.write_config(new_config)
         fill_in_raylet_ids(self.provider, lm)
         autoscaler.update()
         self.waitForNodes(1, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
 
         # Update the config to increase the cluster size
-        new_config["min_workers"] = 10
+        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
+        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
         new_config["max_workers"] = 10
         self.write_config(new_config)
         autoscaler.update()
@@ -1708,101 +1719,6 @@ class AutoscalingTest(unittest.TestCase):
         assert mock_metrics.stopped_nodes.inc.call_count == 1
         mock_metrics.running_workers.set.assert_called_with(10)
 
-    def testInitialWorkers(self):
-        """initial_workers is deprecated, this tests that it is ignored."""
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 0
-        config["max_workers"] = 20
-        config["initial_workers"] = 10
-        config_path = self.write_config(config)
-        self.provider = MockProvider()
-        runner = MockProcessRunner()
-        autoscaler = MockAutoscaler(
-            config_path,
-            LoadMetrics(),
-            MockNodeInfoStub(),
-            max_launch_batch=5,
-            max_concurrent_launches=5,
-            max_failures=0,
-            process_runner=runner,
-            update_interval_s=0,
-        )
-        self.waitForNodes(0)
-        autoscaler.update()
-        self.waitForNodes(0)
-
-    def testLegacyYamlWithRequestResources(self):
-        """Test when using legacy yamls request_resources() adds workers.
-
-        Makes sure that requested resources are added for legacy yamls when
-        necessary. So if requested resources for instance fit on the headnode
-        we don't add more nodes. But we add more nodes when they don't fit.
-        """
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 0
-        config["max_workers"] = 100
-        config["idle_timeout_minutes"] = 0
-        config["upscaling_speed"] = 1
-        config_path = self.write_config(config)
-
-        self.provider = MockProvider()
-        self.provider.create_node(
-            {},
-            {
-                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
-            },
-            1,
-        )
-        head_ip = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_HEAD},
-        )[0]
-        runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(10)])
-
-        lm = LoadMetrics()
-        lm.local_ip = head_ip
-        lm.update(head_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 1}, {})
-        autoscaler = MockAutoscaler(
-            config_path,
-            lm,
-            MockNodeInfoStub(),
-            max_launch_batch=5,
-            max_concurrent_launches=5,
-            max_failures=0,
-            process_runner=runner,
-            update_interval_s=0,
-        )
-        autoscaler.update()
-        # 1 head node.
-        self.waitForNodes(1)
-        autoscaler.load_metrics.set_resource_requests([{"CPU": 1}])
-        autoscaler.update()
-        # still 1 head node because request_resources fits in the headnode.
-        self.waitForNodes(1)
-        autoscaler.load_metrics.set_resource_requests([{"CPU": 1}] + [{"CPU": 2}] * 9)
-        autoscaler.update()
-        self.waitForNodes(2)  # Adds a single worker to get its resources.
-        autoscaler.update()
-        self.waitForNodes(2)  # Still 1 worker because its resources
-        # aren't known.
-        lm.update("172.0.0.1", mock_raylet_id(), {"CPU": 2}, {"CPU": 2}, {})
-        autoscaler.update()
-        self.waitForNodes(10)  # 9 workers and 1 head node, scaled immediately.
-        lm.update(
-            "172.0.0.1",
-            mock_raylet_id(),
-            {"CPU": 2},
-            {"CPU": 2},
-            {},
-            waiting_bundles=[{"CPU": 2}] * 9,
-            infeasible_bundles=[{"CPU": 1}] * 1,
-        )
-        autoscaler.update()
-        # Make sure that if all the resources fit on the exising nodes not
-        # to add any more.
-        self.waitForNodes(10)
-
     def testAggressiveAutoscaling(self):
         self._aggressiveAutoscalingHelper()
 
@@ -1811,10 +1727,13 @@ class AutoscalingTest(unittest.TestCase):
 
     def _aggressiveAutoscalingHelper(self, foreground_node_launcher: bool = False):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["min_workers"] = 0
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 0
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
         config["max_workers"] = 10
         config["idle_timeout_minutes"] = 0
-        config["upscaling_speed"] = config["max_workers"]
+        config["upscaling_speed"] = config["available_node_types"][
+            NODE_TYPE_LEGACY_WORKER
+        ]["max_workers"]
         if foreground_node_launcher:
             config["provider"][FOREGROUND_NODE_LAUNCH_KEY] = True
         config_path = self.write_config(config)
@@ -1910,13 +1829,12 @@ class AutoscalingTest(unittest.TestCase):
         ] == {"CPU": 1}
 
     def testUnmanagedNodes(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 0
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 0
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 20
         config["max_workers"] = 20
-        config["initial_workers"] = 0
         config["idle_timeout_minutes"] = 0
-        config["autoscaling_mode"] = "aggressive"
-        config["target_utilization_fraction"] = 0.8
+        config["upscaling_speed"] = 9999
         config_path = self.write_config(config)
 
         self.provider = MockProvider()
@@ -1974,13 +1892,13 @@ class AutoscalingTest(unittest.TestCase):
         self.waitForNodes(3)
 
     def testUnmanagedNodes2(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 0
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 0
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 20
         config["max_workers"] = 20
-        config["initial_workers"] = 0
         config["idle_timeout_minutes"] = 0
-        config["autoscaling_mode"] = "aggressive"
-        config["target_utilization_fraction"] = 1.0
+        config["upscaling_speed"] = 9999
         config_path = self.write_config(config)
 
         self.provider = MockProvider()
@@ -2062,16 +1980,17 @@ class AutoscalingTest(unittest.TestCase):
         assert autoscaler.pending_launches.value == 0
 
         # Update the config to reduce the cluster size
-        new_config = SMALL_CLUSTER.copy()
-        new_config["max_workers"] = 1
+        new_config = copy.deepcopy(SMALL_CLUSTER)
+        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
         self.write_config(new_config)
         fill_in_raylet_ids(self.provider, lm)
         autoscaler.update()
         assert len(self.provider.non_terminated_nodes({})) == 1
 
     def testDelayedLaunchWithMinWorkers(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 10
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
         config["max_workers"] = 10
         config_path = self.write_config(config)
         self.provider = MockProvider()
@@ -2133,7 +2052,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         self.waitForNodes(2)
         assert autoscaler.pending_launches.value == 0
-        new_config = SMALL_CLUSTER.copy()
+        new_config = copy.deepcopy(SMALL_CLUSTER)
         new_config["max_workers"] = 1
         self.write_config(new_config)
         autoscaler.update()
@@ -2154,8 +2073,10 @@ class AutoscalingTest(unittest.TestCase):
         self.waitForNodes(2)
 
         # Update the config to change the node type
-        new_config = SMALL_CLUSTER.copy()
-        new_config["worker_nodes"]["InstanceType"] = "updated"
+        new_config = copy.deepcopy(SMALL_CLUSTER)
+        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["node_config"][
+            "InstanceType"
+        ] = "updated"
         self.write_config(new_config)
         self.provider.ready_to_create.clear()
         fill_in_raylet_ids(self.provider, lm)
@@ -2194,6 +2115,7 @@ class AutoscalingTest(unittest.TestCase):
             prom_metrics=mock_metrics,
         )
         autoscaler.update()
+        assert mock_metrics.config_validation_exceptions.inc.call_count == 0
         self.waitForNodes(2, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
 
         # Write a corrupted config
@@ -2214,9 +2136,10 @@ class AutoscalingTest(unittest.TestCase):
         )
 
         # New a good config again
-        new_config = SMALL_CLUSTER.copy()
-        new_config["min_workers"] = 10
+        new_config = copy.deepcopy(SMALL_CLUSTER)
+        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
         new_config["max_workers"] = 10
+        new_config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
         self.write_config(new_config)
         worker_ip = self.provider.non_terminated_node_ips(
             tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
@@ -2358,7 +2281,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE})
         runner.calls = []
-        new_config = SMALL_CLUSTER.copy()
+        new_config = copy.deepcopy(SMALL_CLUSTER)
         new_config["worker_setup_commands"] = ["cmdX", "cmdY"]
         self.write_config(new_config)
         autoscaler.update()
@@ -2456,216 +2379,6 @@ class AutoscalingTest(unittest.TestCase):
         assert not lm
         lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, {})
         assert lm
-
-    def testScaleUpBasedOnLoad(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 1
-        config["max_workers"] = 10
-        config["target_utilization_fraction"] = 0.5
-        config_path = self.write_config(config)
-        self.provider = MockProvider()
-        lm = LoadMetrics()
-        runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(6)])
-        self.provider.create_node(
-            {},
-            {
-                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
-                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
-            },
-            1,
-        )
-        lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, {})
-        autoscaler = MockAutoscaler(
-            config_path,
-            lm,
-            MockNodeInfoStub(),
-            max_failures=0,
-            process_runner=runner,
-            update_interval_s=0,
-        )
-        assert (
-            len(
-                self.provider.non_terminated_nodes(
-                    {TAG_RAY_NODE_KIND: NODE_KIND_WORKER}
-                )
-            )
-            == 0
-        )
-        autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
-        autoscaler.update()
-        assert autoscaler.pending_launches.value == 0
-        assert (
-            len(
-                self.provider.non_terminated_nodes(
-                    {TAG_RAY_NODE_KIND: NODE_KIND_WORKER}
-                )
-            )
-            == 1
-        )
-
-        autoscaler.update()
-        lm.update(
-            "172.0.0.1",
-            mock_raylet_id(),
-            {"CPU": 2},
-            {"CPU": 0},
-            {},
-            waiting_bundles=2 * [{"CPU": 2}],
-        )
-        autoscaler.update()
-        self.waitForNodes(3, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
-        lm.update(
-            "172.0.0.2",
-            mock_raylet_id(),
-            {"CPU": 2},
-            {"CPU": 0},
-            {},
-            waiting_bundles=3 * [{"CPU": 2}],
-        )
-        autoscaler.update()
-        self.waitForNodes(5, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
-
-        # Holds steady when load is removed
-        lm.update("172.0.0.1", mock_raylet_id(), {"CPU": 2}, {"CPU": 2}, {})
-        lm.update("172.0.0.2", mock_raylet_id(), {"CPU": 2}, {"CPU": 2}, {})
-        autoscaler.update()
-        assert autoscaler.pending_launches.value == 0
-        assert (
-            len(
-                self.provider.non_terminated_nodes(
-                    {TAG_RAY_NODE_KIND: NODE_KIND_WORKER}
-                )
-            )
-            == 5
-        )
-
-        # Scales down as nodes become unused
-        lm.last_used_time_by_ip["172.0.0.1"] = 0
-        lm.last_used_time_by_ip["172.0.0.2"] = 0
-        autoscaler.update()
-
-        assert autoscaler.pending_launches.value == 0
-        # This actually remained 4 instead of 3, because the other 2 nodes
-        # are not connected and hence we rely more on connected nodes for
-        # min_workers. When the "pending" nodes show up as connected,
-        # then we can terminate the ones connected before.
-        assert (
-            len(
-                self.provider.non_terminated_nodes(
-                    {TAG_RAY_NODE_KIND: NODE_KIND_WORKER}
-                )
-            )
-            == 4
-        )
-        lm.last_used_time_by_ip["172.0.0.3"] = 0
-        lm.last_used_time_by_ip["172.0.0.4"] = 0
-        fill_in_raylet_ids(self.provider, lm)
-        autoscaler.update()
-        assert autoscaler.pending_launches.value == 0
-        # 2 nodes and not 1 because 1 is needed for min_worker and the other 1
-        # is still not connected.
-        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
-        # when we connect it, we will see 1 node.
-        lm.last_used_time_by_ip["172.0.0.5"] = 0
-        autoscaler.update()
-        self.waitForNodes(1, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
-
-        # Check add/remove events.
-        events = autoscaler.event_summarizer.summary()
-        assert "Adding 5 nodes of type ray-legacy-worker-node-type." in events, events
-        assert (
-            "Removing 4 nodes of type ray-legacy-worker-node-type (idle)." in events
-        ), events
-
-        summary = autoscaler.summary()
-        assert (
-            len(summary.failed_nodes) == 0
-        ), "Autoscaling policy decisions shouldn't result in failed nodes"
-
-    def testTargetUtilizationFraction(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 0
-        config["max_workers"] = 20
-        config["upscaling_speed"] = 10
-        config_path = self.write_config(config)
-        self.provider = MockProvider()
-        lm = LoadMetrics()
-        runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(12)])
-        autoscaler = MockAutoscaler(
-            config_path,
-            lm,
-            MockNodeInfoStub(),
-            max_failures=0,
-            process_runner=runner,
-            update_interval_s=0,
-        )
-        assert len(self.provider.non_terminated_nodes({})) == 0
-        autoscaler.update()
-        assert autoscaler.pending_launches.value == 0
-        assert len(self.provider.non_terminated_nodes({})) == 0
-        self.provider.create_node(
-            {},
-            {
-                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
-                TAG_RAY_USER_NODE_TYPE: NODE_TYPE_LEGACY_HEAD,
-            },
-            1,
-        )
-        head_ip = self.provider.non_terminated_node_ips({})[0]
-        lm.local_ip = head_ip
-        lm.update(
-            head_ip,
-            mock_raylet_id(),
-            {"CPU": 2},
-            {"CPU": 1},
-            {},
-            waiting_bundles=[{"CPU": 1}],
-        )  # head
-        # The headnode should be sufficient for now
-        autoscaler.update()
-        self.waitForNodes(1)
-
-        # Requires 1 more worker as the head node is fully used.
-        lm.update(
-            head_ip,
-            mock_raylet_id(),
-            {"CPU": 2},
-            {"CPU": 0},
-            {},
-            waiting_bundles=[{"CPU": 1}],
-        )
-        autoscaler.update()
-        self.waitForNodes(2)  # 1 worker is added to get its resources.
-        worker_ip = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
-        )[0]
-        lm.update(
-            worker_ip,
-            mock_raylet_id(),
-            {"CPU": 1},
-            {"CPU": 1},
-            {},
-            waiting_bundles=[{"CPU": 1}] * 7,
-            infeasible_bundles=[{"CPU": 1}] * 4,
-        )
-        # Add another 10 workers (frac=1/0.1=10, 1 worker running, 10*1=10)
-        # and bypass constraint of 5 due to target utiization fraction.
-        autoscaler.update()
-        self.waitForNodes(12)
-
-        worker_ips = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
-        )
-        for ip in worker_ips:
-            lm.last_used_time_by_ip[ip] = 0
-        fill_in_raylet_ids(self.provider, lm)
-        autoscaler.update()
-        self.waitForNodes(1)  # only the head node
-        assert len(self.provider.non_terminated_nodes({})) == 1
 
     def testRecoverUnhealthyWorkers(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -2870,7 +2583,7 @@ class AutoscalingTest(unittest.TestCase):
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
 
     def testExternalNodeScaler(self):
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         config["provider"] = {
             "type": "external",
             "module": "ray.autoscaler.node_provider.NodeProvider",
@@ -2885,30 +2598,8 @@ class AutoscalingTest(unittest.TestCase):
         )
         assert isinstance(autoscaler.provider, NodeProvider)
 
-    def testLegacyExternalNodeScalerMissingFields(self):
-        """Should fail to validate legacy external config with missing
-        head_node, worker_nodes, or both."""
-        external_config = copy.deepcopy(SMALL_CLUSTER)
-        external_config["provider"] = {
-            "type": "external",
-            "module": "ray.autoscaler.node_provider.NodeProvider",
-        }
-
-        missing_workers, missing_head, missing_both = [
-            copy.deepcopy(external_config) for _ in range(3)
-        ]
-        del missing_workers["worker_nodes"]
-        del missing_head["head_node"]
-        del missing_both["worker_nodes"]
-        del missing_both["head_node"]
-
-        for faulty_config in missing_workers, missing_head, missing_both:
-            faulty_config = prepare_config(faulty_config)
-            with pytest.raises(jsonschema.ValidationError):
-                validate_config(faulty_config)
-
     def testExternalNodeScalerWrongImport(self):
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         config["provider"] = {
             "type": "external",
             "module": "mymodule.provider_class",
@@ -2920,7 +2611,7 @@ class AutoscalingTest(unittest.TestCase):
             )
 
     def testExternalNodeScalerWrongModuleFormat(self):
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         config["provider"] = {
             "type": "external",
             "module": "does-not-exist",
@@ -2932,8 +2623,9 @@ class AutoscalingTest(unittest.TestCase):
             )
 
     def testSetupCommandsWithNoNodeCaching(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 1
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
         config["max_workers"] = 1
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=False)
@@ -2973,11 +2665,12 @@ class AutoscalingTest(unittest.TestCase):
 
     def testSetupCommandsWithStoppedNodeCachingNoDocker(self):
         file_mount_dir = tempfile.mkdtemp()
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         del config["docker"]
         config["file_mounts"] = {"/root/test-folder": file_mount_dir}
         config["file_mounts_sync_continuously"] = True
-        config["min_workers"] = 1
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
         config["max_workers"] = 1
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
@@ -3042,10 +2735,11 @@ class AutoscalingTest(unittest.TestCase):
         # NOTE(ilr) Setup & Init commands **should** run with stopped nodes
         # when Docker is in use.
         file_mount_dir = tempfile.mkdtemp()
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {"/root/test-folder": file_mount_dir}
         config["file_mounts_sync_continuously"] = True
-        config["min_workers"] = 1
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
         config["max_workers"] = 1
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
@@ -3118,10 +2812,11 @@ class AutoscalingTest(unittest.TestCase):
         runner.assert_not_has_call("172.0.0.1", " ")
 
     def testMultiNodeReuse(self):
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         # Docker re-runs setup commands when nodes are reused.
         del config["docker"]
-        config["min_workers"] = 3
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 3
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 3
         config["max_workers"] = 3
         config_path = self.write_config(config)
         self.provider = MockProvider(cache_stopped=True)
@@ -3147,7 +2842,8 @@ class AutoscalingTest(unittest.TestCase):
         runner.clear_history()
 
         # Scale up to 10 nodes, check we reuse the first 3 and add 7 more.
-        config["min_workers"] = 10
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 10
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 10
         config["max_workers"] = 10
         self.write_config(config)
         autoscaler.update()
@@ -3168,7 +2864,7 @@ class AutoscalingTest(unittest.TestCase):
         file_mount_dir = tempfile.mkdtemp()
 
         self.provider = MockProvider()
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {"/home/test-folder": file_mount_dir}
         config["file_mounts_sync_continuously"] = True
         config["min_workers"] = 2
@@ -3228,7 +2924,7 @@ class AutoscalingTest(unittest.TestCase):
         file_mount_dir = tempfile.mkdtemp()
 
         self.provider = MockProvider()
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         config["file_mounts"] = {"/home/test-folder": file_mount_dir}
         config["min_workers"] = 2
         config["max_workers"] = 2
@@ -3311,7 +3007,7 @@ class AutoscalingTest(unittest.TestCase):
 
     def testAutodetectResources(self):
         self.provider = MockProvider()
-        config = SMALL_CLUSTER.copy()
+        config = copy.deepcopy(SMALL_CLUSTER)
         config_path = self.write_config(config)
         runner = MockProcessRunner()
         proc_meminfo = """
@@ -3344,7 +3040,8 @@ MemAvailable:   33000000 kB
 
     def testDockerImageExistsBeforeInspect(self):
         config = copy.deepcopy(SMALL_CLUSTER)
-        config["min_workers"] = 1
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["min_workers"] = 1
+        config["available_node_types"][NODE_TYPE_LEGACY_WORKER]["max_workers"] = 1
         config["max_workers"] = 1
         config["docker"]["pull_before_run"] = False
         config_path = self.write_config(config)

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -301,7 +301,7 @@ class AutoscalingConfigTest(unittest.TestCase):
         ] = 0
         assert prepared_config == expected_prepared
 
-    def testValidateNetworkConfig(self):
+    def testValidateNetworkConfigForBackwardsCompatibility(self):
         web_yaml = (
             "https://raw.githubusercontent.com/ray-project/ray/"
             "master/python/ray/autoscaler/aws/example-full.yaml"

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -39,7 +39,7 @@ from ray.runtime_env import RuntimeEnv
 
 
 def test_get_wheel_filename():
-    ray_version = "2.0.0rc0"
+    ray_version = "3.0.0.dev0"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ["36", "37", "38", "39"]:
             if sys_platform == "win32" and py_version == "36":
@@ -52,7 +52,7 @@ def test_get_wheel_filename():
 
 
 def test_get_master_wheel_url():
-    ray_version = "2.0.0rc0"
+    ray_version = "3.0.0.dev0"
     test_commit = "c3ac6fcf3fcc8cfe6930c9a820add0e187bff579"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ["36", "37", "38", "39"]:

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -39,7 +39,7 @@ from ray.runtime_env import RuntimeEnv
 
 
 def test_get_wheel_filename():
-    ray_version = "3.0.0.dev0"
+    ray_version = "2.0.0rc0"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ["36", "37", "38", "39"]:
             if sys_platform == "win32" and py_version == "36":
@@ -52,7 +52,7 @@ def test_get_wheel_filename():
 
 
 def test_get_master_wheel_url():
-    ray_version = "3.0.0.dev0"
+    ray_version = "2.0.0rc0"
     test_commit = "c3ac6fcf3fcc8cfe6930c9a820add0e187bff579"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ["36", "37", "38", "39"]:

--- a/python/ray/tests/xgboost/BUILD
+++ b/python/ray/tests/xgboost/BUILD
@@ -6,6 +6,7 @@ py_test(
  name = "simple_example",
  size = "small",
  srcs = ["simple_example.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"],
 )
 
@@ -13,6 +14,7 @@ py_test(
  name = "simple_tune",
  size="small",
  srcs = ["simple_tune.py"],
+ deps = ["//:ray_lib"],
  tags = ["team:ml", "exclusive"]
 )
 

--- a/python/ray/tune/examples/tune-default.yaml
+++ b/python/ray/tune/examples/tune-default.yaml
@@ -4,7 +4,11 @@ auth: {ssh_user: ubuntu}
 min_workers: 3
 max_workers: 3
 # Deep Learning AMI (Ubuntu) Version 21.0
-head_node: {InstanceType: c5.xlarge, ImageId: ami-0b294f219d14e6a82}
-worker_nodes: {InstanceType: c5.xlarge, ImageId: ami-0b294f219d14e6a82}
+available_node_types:
+  head_node:
+    node_config: {InstanceType: c5.xlarge, ImageId: ami-0b294f219d14e6a82}
+  worker_nodes:
+    node_config: {InstanceType: c5.xlarge, ImageId: ami-0b294f219d14e6a82}
+head_node_type: head_node
 setup_commands: # Set up each node.
     - pip install ray torch torchvision tabulate tensorboard

--- a/release/ray_release/tests/test_wheels.py
+++ b/release/ray_release/tests/test_wheels.py
@@ -48,20 +48,20 @@ class WheelsFinderTest(unittest.TestCase):
             repo_url="https://github.com/ray-project/ray.git",
             branch="master",
             commit="1234",
-            ray_version="3.0.0.dev0",
+            ray_version="2.0.0rc0",
         )
         self.assertEqual(
             url,
             "https://s3-us-west-2.amazonaws.com/ray-wheels/"
-            "master/1234/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl",
+            "master/1234/ray-2.0.0rc0-cp37-cp37m-manylinux2014_x86_64.whl",
         )
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "2.0.0rc0")
     def testFindRayWheelsBuildkite(self):
         repo = DEFAULT_REPO
         branch = "master"
         commit = "1234" * 10
-        version = "3.0.0.dev0"
+        version = "2.0.0rc0"
 
         os.environ["BUILDKITE_COMMIT"] = commit
 
@@ -76,12 +76,12 @@ class WheelsFinderTest(unittest.TestCase):
 
         self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "2.0.0rc0")
     def testFindRayWheelsCommitOnly(self):
         repo = DEFAULT_REPO
         branch = "master"
         commit = "1234" * 10
-        version = "3.0.0.dev0"
+        version = "2.0.0rc0"
 
         search_str = commit
 
@@ -110,34 +110,34 @@ class WheelsFinderTest(unittest.TestCase):
 
             self.assertEqual(url, get_ray_wheels_url(repo, branch, commit, version))
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "2.0.0rc0")
     def testFindRayWheelsBranch(self):
         repo = DEFAULT_REPO
         branch = "master"
         commit = "1234" * 10
-        version = "3.0.0.dev0"
+        version = "2.0.0rc0"
 
         self._testFindRayWheelsCheckout(
             repo, branch, commit, version, search_str="master"
         )
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "2.0.0rc0")
     def testFindRayWheelsRepoBranch(self):
         repo = DEFAULT_REPO
         branch = "master"
         commit = "1234" * 10
-        version = "3.0.0.dev0"
+        version = "2.0.0rc0"
 
         self._testFindRayWheelsCheckout(
             repo, branch, commit, version, search_str="ray-project:master"
         )
 
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "2.0.0rc0")
     def testFindRayWheelsPRRepoBranch(self):
         repo = "user"
         branch = "dev-branch"
         commit = "1234" * 10
-        version = "3.0.0.dev0"
+        version = "2.0.0rc0"
 
         self._testFindRayWheelsCheckout(
             repo, branch, commit, version, search_str="user:dev-branch"
@@ -151,12 +151,12 @@ class WheelsFinderTest(unittest.TestCase):
         )
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "3.0.0.dev0")
+    @patch("ray_release.wheels.get_ray_version", lambda *a, **kw: "2.0.0rc0")
     def testFindAndWaitWheels(self):
         repo = DEFAULT_REPO
         branch = "master"
         commit = "1234" * 10
-        version = "3.0.0.dev0"
+        version = "2.0.0rc0"
 
         class TrueAfter:
             def __init__(self, after: float):

--- a/rllib/tuned_examples/pg/cartpole-crashing-pg.yaml
+++ b/rllib/tuned_examples/pg/cartpole-crashing-pg.yaml
@@ -2,7 +2,7 @@ cartpole-crashing-pg:
     env: ray.rllib.examples.env.cartpole_crashing.CartPoleCrashing
     run: PG
     stop:
-        evaluation/episode_reward_mean: 180.0
+        evaluation/episode_reward_mean: 150.0
         num_env_steps_sampled: 150000
     config:
         # Works for both torch and tf.
@@ -21,6 +21,11 @@ cartpole-crashing-pg:
         horizon: 200
         num_workers: 2
         num_envs_per_worker: 5
+
+        # Disable env checking. Env checker doesn't handle Exceptions from
+        # user envs, and will crash rollout worker.
+        disable_env_checking: true
+
         # Switch on resiliency for failed sub environments (within a vectorized stack).
         restart_failed_sub_environments: true
 
@@ -30,4 +35,12 @@ cartpole-crashing-pg:
         evaluation_duration_unit: episodes
         evaluation_parallel_to_training: true
         evaluation_config:
-          explore: false
+            explore: false
+            env_config:
+                config:
+                    # Make eval workers solid.
+                    # This test is to prove that we can learn with crashing env,
+                    # not eval with crashing env.
+                    p_crash: 0.0
+                    p_crash_reset: 0.0
+                    init_time_s: 0.0

--- a/rllib/tuned_examples/pg/cartpole-crashing-with-remote-envs-pg.yaml
+++ b/rllib/tuned_examples/pg/cartpole-crashing-with-remote-envs-pg.yaml
@@ -2,7 +2,7 @@ cartpole-crashing-with-remote-envs-pg:
     env: ray.rllib.examples.env.cartpole_crashing.CartPoleCrashing
     run: PG
     stop:
-        episode_reward_mean: 35.0
+        evaluation/episode_reward_mean: 35.0
         timesteps_total: 25000
     config:
         # Works for both torch and tf.
@@ -22,5 +22,25 @@ cartpole-crashing-with-remote-envs-pg:
         # Use parallel remote envs.
         remote_worker_envs: true
 
+        # Disable env checking. Env checker doesn't handle Exceptions from
+        # user envs, and will crash rollout worker.
+        disable_env_checking: true
+
         # Switch on resiliency for failed sub environments (within a vectorized stack).
         restart_failed_sub_environments: true
+
+        evaluation_num_workers: 2
+        evaluation_interval: 1
+        evaluation_duration: 20
+        evaluation_duration_unit: episodes
+        evaluation_parallel_to_training: true
+        evaluation_config:
+            explore: false
+            env_config:
+                config:
+                    # Make eval workers solid.
+                    # This test is to prove that we can learn with crashing env,
+                    # not eval with crashing env.
+                    p_crash: 0.0
+                    p_crash_reset: 0.0
+                    init_time_s: 0.0

--- a/rllib/tuned_examples/pg/multi-agent-cartpole-crashing-pg.yaml
+++ b/rllib/tuned_examples/pg/multi-agent-cartpole-crashing-pg.yaml
@@ -2,7 +2,7 @@ multi-agent-cartpole-crashing-pg:
     env: ray.rllib.examples.env.cartpole_crashing.MultiAgentCartPoleCrashing
     run: PG
     stop:
-        evaluation/episode_reward_mean: 320.0
+        evaluation/episode_reward_mean: 300.0
         num_env_steps_sampled: 300000
     config:
         # Works for both torch and tf.
@@ -22,6 +22,11 @@ multi-agent-cartpole-crashing-pg:
         horizon: 200
         num_workers: 2
         num_envs_per_worker: 5
+
+        # Disable env checking. Env checker doesn't handle Exceptions from
+        # user envs, and will crash rollout worker.
+        disable_env_checking: true
+
         # Switch on resiliency for failed sub environments (within a vectorized stack).
         restart_failed_sub_environments: true
 
@@ -31,4 +36,12 @@ multi-agent-cartpole-crashing-pg:
         evaluation_duration_unit: episodes
         evaluation_parallel_to_training: true
         evaluation_config:
-          explore: false
+            explore: false
+            env_config:
+                config:
+                    # Make eval workers solid.
+                    # This test is to prove that we can learn with crashing env,
+                    # not eval with crashing env.
+                    p_crash: 0.0
+                    p_crash_reset: 0.0
+                    init_time_s: 0.0

--- a/rllib/tuned_examples/pg/multi-agent-cartpole-crashing-with-remote-envs-pg.yaml
+++ b/rllib/tuned_examples/pg/multi-agent-cartpole-crashing-with-remote-envs-pg.yaml
@@ -2,7 +2,7 @@ multi-agent-cartpole-crashing-pg:
     env: ray.rllib.examples.env.cartpole_crashing.MultiAgentCartPoleCrashing
     run: PG
     stop:
-        evaluation/episode_reward_mean: 320.0
+        evaluation/episode_reward_mean: 300.0
         num_env_steps_sampled: 300000
     config:
         # Works for both torch and tf.
@@ -25,6 +25,10 @@ multi-agent-cartpole-crashing-pg:
         # Use parallel remote envs.
         remote_worker_envs: true
 
+        # Disable env checking. Env checker doesn't handle Exceptions from
+        # user envs, and will crash rollout worker.
+        disable_env_checking: true
+
         # Switch on resiliency for failed sub environments (within a vectorized stack).
         restart_failed_sub_environments: true
 
@@ -34,4 +38,12 @@ multi-agent-cartpole-crashing-pg:
         evaluation_duration_unit: episodes
         evaluation_parallel_to_training: true
         evaluation_config:
-          explore: false
+            explore: false
+            env_config:
+                config:
+                    # Make eval workers solid.
+                    # This test is to prove that we can learn with crashing env,
+                    # not eval with crashing env.
+                    p_crash: 0.0
+                    p_crash_reset: 0.0
+                    init_time_s: 0.0

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -52,4 +52,4 @@ constexpr int kMessagePackOffset = 9;
 constexpr char kSetupWorkerFilename[] = "setup_worker.py";
 
 /// The version of Ray
-constexpr char kRayVersion[] = "3.0.0.dev0";
+constexpr char kRayVersion[] = "2.0.0rc0";


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is #27040

This change cuts off support for deprecated schema fields. It intentionally breaks backwards compatibility with old configs which set a global min_workers, use head_node or worker_nodes, autoscaling_mode, initial_workers, target_utilization_fraction, and default_worker_node_type fields.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/20837
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
