### PR TITLE
Fix node rows not being removed correctly when using filters

### DIFF
--- a/dashboard/client/src/pages/node/index.tsx
+++ b/dashboard/client/src/pages/node/index.tsx
@@ -278,7 +278,7 @@ const Nodes = () => {
                   )
                   .map((node, i) => (
                     <NodeRows
-                      key={node.hostname + i}
+                      key={node.raylet.nodeId}
                       node={node}
                       isRefreshing={isRefreshing}
                     />


### PR DESCRIPTION
The key needs to be consistent for alive and dead nodes, node.hostname would be null.
raylet.nodeId continues to be passed back by the api for both dead and alive nodes

Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
