### PR TITLE
A2C with microbatching never supported microbatching. 

### DIFF
--- a/release/rllib_tests/multi_gpu_learning_tests/multi_gpu_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_learning_tests/multi_gpu_learning_tests.yaml
@@ -1,18 +1,4 @@
 
-a2c-cartpole-v0:
-    env: CartPole-v0
-    run: A2C
-    # Minimum reward and total ts (in given time_total_s) to pass this test.
-    pass_criteria:
-        episode_reward_mean: 150.0
-        timesteps_total: 500000
-    stop:
-        time_total_s: 600
-    config:
-        num_gpus: 2
-        num_workers: 23
-        lr: 0.001
-
 appo-cartpole-v0-no-vtrace:
     env: CartPole-v0
     run: APPO

--- a/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
+++ b/release/rllib_tests/multi_gpu_with_lstm_learning_tests/multi_gpu_with_lstm_learning_tests.yaml
@@ -1,24 +1,4 @@
 
-a2c-stateless-cartpole:
-    env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
-    run: A2C
-    # Minimum reward and total ts (in given time_total_s) to pass this test.
-    pass_criteria:
-        episode_reward_mean: 150.0
-        timesteps_total: 500000
-    stop:
-        time_total_s: 600
-    config:
-        num_gpus: 2
-        num_workers: 23
-        # Use a large train batch size to make sure mini batches work
-        # after split to 2 GPU towers.
-        train_batch_size: 200
-        lr: 0.001
-        # Test w/ LSTMs.
-        model:
-            use_lstm: true
-
 appo-stateless-cartpole-no-vtrace:
     env: ray.rllib.examples.env.stateless_cartpole.StatelessCartPole
     run: APPO

--- a/rllib/algorithms/a2c/a2c.py
+++ b/rllib/algorithms/a2c/a2c.py
@@ -127,6 +127,8 @@ class A2C(A3C):
                     "`microbatch_size` (try setting them to the same value)! "
                     "Otherwise, microbatches of desired size won't be achievable."
                 )
+        if config.get("num_gpus", 0) > 1:
+            raise ValueError("A2C with gpu learning enabled only supports 1 gpu.")
 
     @override(Algorithm)
     def setup(self, config: PartialAlgorithmConfigDict):

--- a/rllib/algorithms/a2c/a2c.py
+++ b/rllib/algorithms/a2c/a2c.py
@@ -128,7 +128,11 @@ class A2C(A3C):
                     "Otherwise, microbatches of desired size won't be achievable."
                 )
         if config.get("num_gpus", 0) > 1:
-            raise ValueError("A2C with gpu learning enabled only supports 1 gpu.")
+            raise ValueError(
+                "A2C with gpu learning enabled only supports 1 "
+                "gpu. Currently, the methods by which mini-batch"
+                " gradients are computed doesn't support >1 gpus"
+            )
 
     @override(Algorithm)
     def setup(self, config: PartialAlgorithmConfigDict):

--- a/rllib/algorithms/a2c/a2c.py
+++ b/rllib/algorithms/a2c/a2c.py
@@ -129,9 +129,10 @@ class A2C(A3C):
                 )
         if config.get("num_gpus", 0) > 1:
             raise ValueError(
-                "A2C with gpu learning enabled only supports 1 "
-                "gpu. Currently, the methods by which mini-batch"
-                " gradients are computed doesn't support >1 gpus"
+                "A2C with gpu learning enabled only supports 1 gpu. "
+                "Currently, the methods by which mini-batch gpu. Currently, "
+                "the `compute_gradients` method by which mini-batch "
+                "gradients are computed doesn't currently support >1 gpus."
             )
 
     @override(Algorithm)


### PR DESCRIPTION
Users looking for that functionality should use VPG with multi-gpu, which we support today.

The compute_gradients function used by a2c and a3c doesn't support more than 1 gpu when gpu's are enabled. 
![image](https://user-images.githubusercontent.com/38871737/181624965-8d7f1767-17b0-488c-8361-0078f5300508.png)


this should also fix the broken A2C multi gpu release tests.

Signed-off-by: avnish <avnish@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
