### PR TITLE
[Serve] Disable macOS tests

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -61,7 +61,7 @@ steps:
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
 
 
-- label: ":mac: :apple: Ray Core, Dashboard and Serve"
+- label: ":mac: :apple: Ray Core Unit Tests and Dashboard"
   <<: *common
   conditions: ["RAY_CI_SERVE_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DASHBOARD_AFFECTED"]
   commands:
@@ -70,7 +70,7 @@ steps:
     # Use --dynamic_mode=off until MacOS CI runs on Big Sur or newer. Otherwise there are problems with running tests
     # with dynamic linking.
     - bazel test --config=ci --dynamic_mode=off --test_env=CI $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-post_wheel_build --
-      //:all python/ray/serve/... python/ray/dashboard/... -rllib/... -core_worker_test
+      //:all python/ray/dashboard/... -python/ray/serve/... -rllib/... -core_worker_test
     - *epilogue_commands
 
 


### PR DESCRIPTION
Signed-off-by: simon-mo <simon.mo@hey.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Serve's macOS didn't do much to help identity breakages and the main deployment target is always based on linux. In the past two year we found close to zero issue related to macOS specific bug. Our mac builds are slow and cost; therefore, disabling them for now..

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Overall this should reduce the CI time of the ":mac: :apple: Ray Core, Dashboard and Serve" by about 30min
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
