### PR TITLE
[Datasets] Improve size estimation of image folder data source

### DIFF
--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import pathlib
 import time
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
@@ -22,6 +23,9 @@ from ray.util.annotations import DeveloperAPI
 if TYPE_CHECKING:
     import pyarrow
     from ray.data.block import T
+
+
+logger = logging.getLogger(__name__)
 
 IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "tiff", "bmp", "gif"]
 
@@ -237,7 +241,8 @@ class _ImageFolderDatasourceReader(_FileBasedDatasourceReader):
         if len(non_empty_path_and_size) == 0:
             logger.warn(
                 "All input image files are empty. "
-                "Use on-disk file size to estimate images in-memory size.")
+                "Use on-disk file size to estimate images in-memory size."
+            )
             return IMAGE_ENCODING_RATIO_ESTIMATE_DEFAULT
 
         # Prefetch first non-empty image file to do estimation.

--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -230,6 +230,9 @@ class _ImageFolderDatasourceReader(_FileBasedDatasourceReader):
         """Return an estimate of the image files encoding ratio."""
         # Prefetch one image file into memory, and use it to estimate data size for
         # all images, because all images are homogeneous with same size after resizing.
+        # Resizing is always enforced when reading every image in ImageFolderDatasource
+        # and we have to prefetch one image file into memory, to get 3rd dimension of
+        # image (RGB or grayscale).
         import pandas as pd
 
         start_time = time.perf_counter()
@@ -253,7 +256,7 @@ class _ImageFolderDatasourceReader(_FileBasedDatasourceReader):
             self._reader_args.get("root"),
             self._reader_args.get("size"),
         )
-        single_image_memory_size = single_image_block.memory_usage().sum()
+        single_image_memory_size = single_image_block.memory_usage(deep=True).sum()
         total_estimated_memory_size = single_image_memory_size * len(
             non_empty_path_and_size
         )

--- a/python/ray/data/datasource/image_folder_datasource.py
+++ b/python/ray/data/datasource/image_folder_datasource.py
@@ -268,7 +268,7 @@ class _ImageFolderDatasourceReader(_FileBasedDatasourceReader):
 
         sampling_duration = time.perf_counter() - start_time
         if sampling_duration > 5:
-            logger.info(
+            logger.warn(
                 "Image input size estimation took "
                 f"{round(sampling_duration, 2)} seconds."
             )

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -11,6 +11,10 @@ import pyarrow.json as pajson
 import pyarrow.parquet as pq
 import pytest
 from ray.data.datasource.file_meta_provider import _handle_read_os_error
+from ray.data.datasource.image_folder_datasource import (
+    IMAGE_EXTENSIONS,
+    _ImageFolderDatasourceReader,
+)
 import requests
 import snappy
 from fsspec.implementations.local import LocalFileSystem
@@ -36,7 +40,10 @@ from ray.data.datasource import (
     SimpleTorchDatasource,
     WriteResult,
 )
-from ray.data.datasource.file_based_datasource import _unwrap_protocol
+from ray.data.datasource.file_based_datasource import (
+    FileExtensionFilter,
+    _unwrap_protocol,
+)
 from ray.data.datasource.parquet_datasource import (
     PARALLELIZE_META_FETCH_THRESHOLD,
     _ParquetDatasourceReader,
@@ -2950,6 +2957,45 @@ def test_image_folder_datasource_e2e(ray_start_regular_shared):
 
     predictor = BatchPredictor.from_checkpoint(checkpoint, TorchPredictor)
     predictor.predict(dataset, feature_columns=["image"])
+
+
+@pytest.mark.parametrize(
+    "image_size,expected_size,expected_ratio",
+    [(64, 30000, 5), (16, 2400, 0.5)],
+)
+def test_image_folder_reader_estimate_data_size(
+    ray_start_regular_shared, image_size, expected_size, expected_ratio
+):
+    root = os.path.join(os.path.dirname(__file__), "image-folder")
+    ds = ray.data.read_datasource(
+        ImageFolderDatasource(), root=root, size=(image_size, image_size)
+    )
+
+    data_size = ds.size_bytes()
+    assert (
+        data_size >= expected_size and data_size <= expected_size * 1.5
+    ), "estimated data size is out of expected bound"
+    data_size = ds.fully_executed().size_bytes()
+    assert (
+        data_size >= expected_size and data_size <= expected_size * 1.5
+    ), "actual data size is out of expected bound"
+
+    reader = _ImageFolderDatasourceReader(
+        delegate=ImageFolderDatasource(),
+        paths=[root],
+        filesystem=LocalFileSystem(),
+        partition_filter=FileExtensionFilter(file_extensions=IMAGE_EXTENSIONS),
+        root=root,
+        size=(image_size, image_size),
+    )
+    assert (
+        reader._encoding_ratio >= expected_ratio
+        and reader._encoding_ratio <= expected_ratio * 1.5
+    ), "encoding ratio is out of expected bound"
+    data_size = reader.estimate_inmemory_data_size()
+    assert (
+        data_size >= expected_size and data_size <= expected_size * 1.5
+    ), "estimated data size is out of expected bound"
 
 
 # NOTE: The last test using the shared ray_start_regular_shared cluster must use the

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2960,15 +2960,18 @@ def test_image_folder_datasource_e2e(ray_start_regular_shared):
 
 
 @pytest.mark.parametrize(
-    "image_size,expected_size,expected_ratio",
-    [(64, 30000, 5), (16, 2400, 0.5)],
+    "image_size,image_mode,expected_size,expected_ratio",
+    [(64, "RGB", 30000, 4), (32, "L", 3500, 0.5), (256, "RGBA", 750000, 85)],
 )
 def test_image_folder_reader_estimate_data_size(
-    ray_start_regular_shared, image_size, expected_size, expected_ratio
+    ray_start_regular_shared, image_size, image_mode, expected_size, expected_ratio
 ):
-    root = os.path.join(os.path.dirname(__file__), "image-folder")
+    root = "example://image-folders/different-sizes"
     ds = ray.data.read_datasource(
-        ImageFolderDatasource(), root=root, size=(image_size, image_size)
+        ImageFolderDatasource(),
+        root=root,
+        size=(image_size, image_size),
+        mode=image_mode,
     )
 
     data_size = ds.size_bytes()
@@ -2987,6 +2990,7 @@ def test_image_folder_reader_estimate_data_size(
         partition_filter=FileExtensionFilter(file_extensions=IMAGE_EXTENSIONS),
         root=root,
         size=(image_size, image_size),
+        mode=image_mode,
     )
     assert (
         reader._encoding_ratio >= expected_ratio


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to improve in-memory data size estimation of image folder data source. Before this PR, we use on-disk file size as estimation of in-memory data size of image folder data source. This can be inaccurate due to image compression and in-memory image resizing.

Given `size` and `mode` is set to be optional in https://github.com/ray-project/ray/pull/27295, so change this PR to tackle the simple case when `size` and `mode` are both provided.
* `size` and `mode` is provided: just calculate the in-memory size based on the dimensions, not need to read any image (this PR)
* `size` or `mode` is not provided: need sampling to determine the in-memory size (will do in another followup PR).

Here is example of estiamted size for our test image folder

```
>>> import ray
>>> from ray.data.datasource.image_folder_datasource import ImageFolderDatasource
>>> root = "example://image-folders/different-sizes"
>>> ds = ray.data.read_datasource(ImageFolderDatasource(), root=root, size=(64, 64), mode="RGB")
>>> ds.size_bytes()
40310
>>> ds.fully_executed().size_bytes()
37428
```

Without this PR:

```
>>> ds.size_bytes()
18978
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
