### PR TITLE
[tune/air/release/2.0.0] Exclude files in sync_dir_between_nodes, exclude temporary directories

### DIFF
--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 # Syncing period for syncing checkpoints between nodes or to cloud.
 DEFAULT_SYNC_PERIOD = 300
 
+_EXCLUDE_FROM_SYNC = [
+    "./checkpoint_-00001",
+    "./checkpoint_tmp*",
+    "./save_to_object*",
+    "./rank_*",
+]
+
 
 def _validate_upload_dir(sync_config: "SyncConfig") -> bool:
     if not sync_config.upload_dir:
@@ -504,6 +511,7 @@ class SyncerCallback(Callback):
             source_path=self._remote_trial_logdir(trial),
             target_ip=ray.util.get_node_ip_address(),
             target_path=self._local_trial_logdir(trial),
+            exclude=_EXCLUDE_FROM_SYNC,
         )
         self._sync_times[trial.trial_id] = time.time()
         if wait:

--- a/python/ray/tune/tests/test_syncer_callback.py
+++ b/python/ray/tune/tests/test_syncer_callback.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 import ray.util
 from ray.air._internal.checkpoint_manager import CheckpointStorage, _TrackedCheckpoint
 from ray.tune import TuneError
+from ray.tune.logger import NoopLogger
 from ray.tune.result import NODE_IP
 from ray.tune.syncer import (
     DEFAULT_SYNC_PERIOD,
@@ -17,6 +18,8 @@ from ray.tune.syncer import (
     SyncerCallback,
     _BackgroundProcess,
 )
+from ray.tune.trainable import wrap_function
+from ray.tune.trainable.function_trainable import NULL_MARKER
 from ray.tune.utils.callback import create_default_callbacks
 from ray.tune.utils.file_transfer import sync_dir_between_nodes
 
@@ -395,6 +398,58 @@ def test_syncer_callback_log_error(caplog, ray_start_2_cpus, temp_data_dirs):
 
     syncer_callback.wait_for_all()
     assert_file(True, tmp_target, "level0.txt")
+
+
+def test_sync_directory_exclude(ray_start_2_cpus, temp_data_dirs):
+    tmp_source, tmp_target = temp_data_dirs
+
+    def logger_creator(config):
+        return NoopLogger(config, tmp_source)
+
+    def train_fn(config):
+        pass
+
+    trainable_cls = wrap_function(train_fn)
+    trainable = ray.remote(trainable_cls).remote(
+        config={}, logger_creator=logger_creator
+    )
+
+    ray.get(trainable.save_to_object.remote())
+
+    # Temporary directory exists
+    assert_file(True, tmp_source, "checkpoint_-00001/" + NULL_MARKER)
+    assert_file(True, tmp_source, "checkpoint_-00001")
+
+    # Create some bogus test directories for testing
+    os.mkdir(os.path.join(tmp_source, "checkpoint_tmp123"))
+    os.link(
+        os.path.join(tmp_source, "level0.txt"),
+        os.path.join(tmp_source, "checkpoint_tmp123", "some_content.txt"),
+    )
+    os.mkdir(os.path.join(tmp_source, "save_to_object1234"))
+    os.link(
+        os.path.join(tmp_source, "level0.txt"),
+        os.path.join(tmp_source, "save_to_object1234", "some_content.txt"),
+    )
+
+    # Sanity check
+    assert_file(True, tmp_source, "checkpoint_tmp123")
+    assert_file(True, tmp_source, "save_to_object1234")
+
+    trial1 = MockTrial(trial_id="a", logdir=tmp_source)
+    syncer_callback = TestSyncerCallback(
+        sync_period=0,
+        local_logdir_override=tmp_target,
+    )
+    syncer_callback.on_trial_complete(iteration=1, trials=[], trial=trial1)
+
+    # Regular files are synced
+    assert_file(True, tmp_target, "level0.txt")
+    # Temporary checkpoints are not synced
+    assert_file(False, tmp_target, "checkpoint_-00001/" + NULL_MARKER)
+    assert_file(False, tmp_target, "checkpoint_-00001")
+    assert_file(False, tmp_target, "checkpoint_tmp123")
+    assert_file(False, tmp_target, "save_to_object1234")
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/utils/file_transfer.py
+++ b/python/ray/tune/utils/file_transfer.py
@@ -1,9 +1,10 @@
+import fnmatch
 import io
 import os
 import shutil
 import tarfile
 
-from typing import Optional, Tuple, Dict, Generator, Union
+from typing import Optional, Tuple, Dict, Generator, Union, List
 
 import ray
 from ray.air._internal.filelock import TempFileLock
@@ -19,6 +20,7 @@ def sync_dir_between_nodes(
     target_ip: str,
     target_path: str,
     force_all: bool = False,
+    exclude: Optional[List] = None,
     chunk_size_bytes: int = _DEFAULT_CHUNK_SIZE_BYTES,
     max_size_bytes: Optional[int] = _DEFAULT_MAX_SIZE_BYTES,
     return_futures: bool = False,
@@ -44,6 +46,8 @@ def sync_dir_between_nodes(
         target_path: Path to directory on target node.
         force_all: If True, all files will be transferred (not just differing files).
             Ignored if ``source_ip==target_ip``.
+        exclude: Pattern of files to exclude, e.g.
+            ``["*/checkpoint_*]`` to exclude trial checkpoints.
         chunk_size_bytes: Chunk size for data transfer. Ignored if
             ``source_ip==target_ip``.
         max_size_bytes: If packed data exceeds this value, raise an error before
@@ -65,6 +69,7 @@ def sync_dir_between_nodes(
             target_ip=target_ip,
             target_path=target_path,
             force_all=force_all,
+            exclude=exclude,
             chunk_size_bytes=chunk_size_bytes,
             max_size_bytes=max_size_bytes,
             return_futures=return_futures,
@@ -74,6 +79,7 @@ def sync_dir_between_nodes(
             ip=source_ip,
             source_path=source_path,
             target_path=target_path,
+            exclude=exclude,
             return_futures=return_futures,
         )
         if return_futures:
@@ -85,6 +91,7 @@ def _sync_dir_on_same_node(
     ip: str,
     source_path: str,
     target_path: str,
+    exclude: Optional[List] = None,
     return_futures: bool = False,
 ) -> Optional[ray.ObjectRef]:
     """Synchronize directory to another directory on the same node.
@@ -96,6 +103,8 @@ def _sync_dir_on_same_node(
         ip: IP of the node.
         source_path: Path to source directory.
         target_path: Path to target directory.
+        exclude: Pattern of files to exclude, e.g.
+            ``["*/checkpoint_*]`` to exclude trial checkpoints.
         return_futures: If True, returns a future of the copy task.
 
     Returns:
@@ -105,7 +114,9 @@ def _sync_dir_on_same_node(
     copy_on_node = _remote_copy_dir.options(
         num_cpus=0, resources={f"node:{ip}": 0.01}, placement_group=None
     )
-    copy_future = copy_on_node.remote(source_dir=source_path, target_dir=target_path)
+    copy_future = copy_on_node.remote(
+        source_dir=source_path, target_dir=target_path, exclude=exclude
+    )
 
     if return_futures:
         return copy_future
@@ -119,6 +130,7 @@ def _sync_dir_between_different_nodes(
     target_ip: str,
     target_path: str,
     force_all: bool = False,
+    exclude: Optional[List] = None,
     chunk_size_bytes: int = _DEFAULT_CHUNK_SIZE_BYTES,
     max_size_bytes: Optional[int] = _DEFAULT_MAX_SIZE_BYTES,
     return_futures: bool = False,
@@ -135,6 +147,8 @@ def _sync_dir_between_different_nodes(
         target_ip: IP of target node.
         target_path: Path to directory on target node.
         force_all: If True, all files will be transferred (not just differing files).
+        exclude: Pattern of files to exclude, e.g.
+            ``["*/checkpoint_*]`` to exclude trial checkpoints.
         chunk_size_bytes: Chunk size for data transfer.
         max_size_bytes: If packed data exceeds this value, raise an error before
             transfer. If ``None``, no limit is enforced.
@@ -165,6 +179,7 @@ def _sync_dir_between_different_nodes(
         files_stats=files_stats,
         chunk_size_bytes=chunk_size_bytes,
         max_size_bytes=max_size_bytes,
+        exclude=exclude,
     )
     unpack_future = unpack_on_target_node.remote(pack_actor, target_path)
 
@@ -226,7 +241,9 @@ _remote_get_recursive_files_and_stats = ray.remote(_get_recursive_files_and_stat
 
 
 def _pack_dir(
-    source_dir: str, files_stats: Optional[Dict[str, Tuple[float, int]]] = None
+    source_dir: str,
+    exclude: Optional[List] = None,
+    files_stats: Optional[Dict[str, Tuple[float, int]]] = None,
 ) -> io.BytesIO:
     """Pack whole directory contents into an uncompressed tarfile.
 
@@ -240,6 +257,8 @@ def _pack_dir(
 
     Args:
         source_dir: Path to local directory to pack into tarfile.
+        exclude: Pattern of files to exclude, e.g.
+            ``["*/checkpoint_*]`` to exclude trial checkpoints.
         files_stats: Dict of relative filenames mapping to a tuple of
             (mtime, filesize). Only files that differ from these stats
             will be packed.
@@ -247,12 +266,24 @@ def _pack_dir(
     Returns:
         Tarfile as a stream object.
     """
+
+    def _should_exclude(candidate: str) -> bool:
+        if not exclude:
+            return False
+
+        for excl in exclude:
+            if fnmatch.fnmatch(candidate, excl):
+                return True
+        return False
+
     stream = io.BytesIO()
     with tarfile.open(fileobj=stream, mode="w", format=tarfile.PAX_FORMAT) as tar:
-        if not files_stats:
+
+        if not files_stats and not exclude:
             # If no `files_stats` is passed, pack whole directory
             tar.add(source_dir, arcname="", recursive=True)
         else:
+            files_stats = files_stats or {}
             # Otherwise, only pack differing files
             tar.add(source_dir, arcname="", recursive=False)
             for root, dirs, files in os.walk(source_dir, topdown=False):
@@ -266,8 +297,16 @@ def _pack_dir(
                     key = os.path.join(rel_root, file)
                     stat = os.lstat(os.path.join(source_dir, key))
                     file_stat = stat.st_mtime, stat.st_size
-                    if key not in files_stats or file_stat != files_stats[key]:
-                        tar.add(os.path.join(source_dir, key), arcname=key)
+
+                    if _should_exclude(key):
+                        # If the file matches an exclude pattern, skip
+                        continue
+
+                    if key in files_stats and files_stats[key] == file_stat:
+                        # If the file did not change, skip
+                        continue
+
+                    tar.add(os.path.join(source_dir, key), arcname=key)
 
     return stream
 
@@ -288,6 +327,8 @@ class _PackActor:
 
     Args:
         source_dir: Path to local directory to pack into tarfile.
+        exclude: Pattern of files to exclude, e.g.
+            ``["*/checkpoint_*]`` to exclude trial checkpoints.
         files_stats: Dict of relative filenames mapping to a tuple of
             (mtime, filesize). Only files that differ from these stats
             will be packed.
@@ -299,11 +340,14 @@ class _PackActor:
     def __init__(
         self,
         source_dir: str,
+        exclude: Optional[List] = None,
         files_stats: Optional[Dict[str, Tuple[float, int]]] = None,
         chunk_size_bytes: int = _DEFAULT_CHUNK_SIZE_BYTES,
         max_size_bytes: Optional[int] = _DEFAULT_MAX_SIZE_BYTES,
     ):
-        self.stream = _pack_dir(source_dir=source_dir, files_stats=files_stats)
+        self.stream = _pack_dir(
+            source_dir=source_dir, exclude=exclude, files_stats=files_stats
+        )
 
         # Get buffer size
         self.stream.seek(0, 2)
@@ -387,7 +431,13 @@ def _unpack_from_actor(pack_actor: ray.ActorID, target_dir: str) -> None:
     _unpack_dir(stream, target_dir=target_dir)
 
 
-def _copy_dir(source_dir: str, target_dir: str, *, _retry: bool = True) -> None:
+def _copy_dir(
+    source_dir: str,
+    target_dir: str,
+    *,
+    exclude: Optional[List] = None,
+    _retry: bool = True,
+) -> None:
     """Copy dir with shutil on the actor."""
     target_dir = os.path.normpath(target_dir)
     try:
@@ -396,7 +446,22 @@ def _copy_dir(source_dir: str, target_dir: str, *, _retry: bool = True) -> None:
         # will be thrown.
         with TempFileLock(f"{target_dir}.lock", timeout=0):
             _delete_path_unsafe(target_dir)
-            shutil.copytree(source_dir, target_dir)
+
+            _ignore = None
+            if exclude:
+
+                def _ignore(path, names):
+                    ignored_names = set()
+                    rel_path = os.path.relpath(path, source_dir)
+                    for name in names:
+                        candidate = os.path.join(rel_path, name)
+                        for excl in exclude:
+                            if fnmatch.fnmatch(candidate, excl):
+                                ignored_names.add(name)
+                                break
+                    return ignored_names
+
+            shutil.copytree(source_dir, target_dir, ignore=_ignore)
     except TimeoutError:
         # wait, but do not do anything
         with TempFileLock(f"{target_dir}.lock"):

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -58,7 +58,7 @@ def run_and_time_it(f):
                     self._exception = self._pconn.recv()
                 return self._exception
 
-        p = MyProcess(target=f, *args, **kwargs)
+        p = MyProcess(target=f, args=args, kwargs=kwargs)
         start = time.monotonic()
         p.start()
         p.join()

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -58,7 +58,7 @@ def run_and_time_it(f):
                     self._exception = self._pconn.recv()
                 return self._exception
 
-        p = MyProcess(target=f, args=args, kwargs=kwargs)
+        p = MyProcess(target=f, *args, **kwargs)
         start = time.monotonic()
         p.start()
         p.join()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Following up from #27174, this PR excludes temporary checkpoint files from being synced from worker nodes to driver.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
