### PR TITLE
[Workflow] Fix flaky workflow events CI test by extending timeout

### DIFF
--- a/python/ray/workflow/BUILD
+++ b/python/ray/workflow/BUILD
@@ -7,7 +7,7 @@ load("//bazel:python.bzl", "py_test_module_list")
 
 SRCS = glob(["**/conftest.py"])
 
-LARGE_TESTS = ["tests/test_recovery.py", "tests/test_basic_workflows_2.py", "tests/test_metadata.py"]
+LARGE_TESTS = ["tests/test_recovery.py", "tests/test_basic_workflows_2.py", "tests/test_metadata.py", "tests/test_events.py"]
 
 py_test_module_list(
   files = glob(["tests/test_*.py", "examples/**/*.py"], exclude=LARGE_TESTS),


### PR DESCRIPTION
## Why are these changes needed?

Fix the flaky workflow events CI tests by extending timeout.

(cherry picked from #27124 )

## Related issue number

Closes #27178

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
