### PR TITLE
[Core][Workflow] Set default storage if there is no storage specified when starting a local cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,9 +207,6 @@ project-id
 .anyscale.yaml
 test_state.json
 
-# workflow storage
-workflow_data/
-
 # vscode java extention generated
 .factorypath
 

--- a/doc/source/workflows/advanced.rst
+++ b/doc/source/workflows/advanced.rst
@@ -41,7 +41,7 @@ submitting a workflow. No code changes are required for Ray Workflow afterwards.
 
     try:
         subprocess.check_call(
-            ["ray", "start", "--head", "--ray-client-server-port=10001", "--storage=file:///tmp/ray/workflow_data"])
+            ["ray", "start", "--head", "--ray-client-server-port=10001", "--storage=file:///tmp/ray/storage"])
         ray.init("ray://127.0.0.1:10001")
         assert workflow.run(hello.bind(3)) == ["hello world"] * 3
     finally:

--- a/doc/source/workflows/management.rst
+++ b/doc/source/workflows/management.rst
@@ -85,9 +85,7 @@ Workflows supports two types of storage backends out of the box:
 *  Local file system: the data is stored locally. This is only for single node testing. It needs to be a NFS to work with multi-node clusters. To use local storage, specify ``ray.init(storage="/path/to/storage_dir")``.
 *  S3: Production users should use S3 as the storage backend. Enable S3 storage with ``ray.init(storage="s3://bucket/path")``.
 
-Additional storage backends can be written by subclassing the ``Storage`` class and passing a storage instance to ``ray.init()`` [TODO: note that the Storage API is not currently stable].
-
-If left unspecified, ``/tmp/ray/workflow_data`` will be used for temporary storage. This default setting *will only work for single-node Ray clusters*.
+If left unspecified, ``/tmp/ray/storage`` will be used for temporary storage. This default setting *will only work for a local Ray cluster*.
 
 Concurrency Control
 -------------------

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1355,7 +1355,9 @@ def init(
         else:
             usage_lib.set_usage_stats_enabled_via_env_var(False)
 
-        # assign a default storage if there is no storage.
+        # Assign a default storage if there is no storage.
+        # It only sets a default storage when calling "ray.init()" locally without
+        # connecting to a cluster.
         if storage is None:
             if _temp_dir is None:
                 storage_parent = ray._private.utils.get_ray_temp_dir()

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1355,6 +1355,14 @@ def init(
         else:
             usage_lib.set_usage_stats_enabled_via_env_var(False)
 
+        # assign a default storage if there is no storage.
+        if storage is None:
+            if _temp_dir is None:
+                storage_parent = ray._private.utils.get_ray_temp_dir()
+            else:
+                storage_parent = _temp_dir
+            storage = "file://" + os.path.join(storage_parent, "storage")
+
         # Use a random port by not specifying Redis port / GCS server port.
         ray_params = ray._private.parameter.RayParams(
             node_ip_address=node_ip_address,

--- a/python/ray/workflow/tests/test_basic_workflows_4.py
+++ b/python/ray/workflow/tests/test_basic_workflows_4.py
@@ -68,6 +68,12 @@ def test_no_init_api(shutdown_only):
     workflow.list_all()
 
 
+def test_ray_init_api(shutdown_only):
+    """Test if Ray connects to a local temporary storage."""
+    ray.init()
+    workflow.list_all()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Signed-off-by: Siyuan Zhuang <suquark@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently if users call `ray.init()` to start a ray cluster locally without specifying `storage`, then all libraries that depends on the storage could not work because this would happen when trying to access the storage:

```python
RuntimeError: No storage URI has been configured for the cluster. Specify a storage URI via `ray.init(storage=<uri>)`
```

## Related issue number

Closes https://github.com/ray-project/ray/issues/27046

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
