### PR TITLE
[air/benchmarks] Drop OMP_NUM_THREADS in vanilla torch/tf training

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
@@ -197,6 +197,10 @@ def train_tf_vanilla(
         for rank in range(num_workers)
     ]
 
+    run_fn_on_actors(
+        actors=actors, fn=lambda: os.environ.setdefault("OMP_NUM_THREADS", "1")
+    )
+
     start_time = time.monotonic()
     run_commands_on_actors(actors=actors, cmds=cmds)
     time_taken = time.monotonic() - start_time

--- a/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
@@ -171,7 +171,7 @@ def train_tf_vanilla(
         },
     )
 
-    run_fn_on_actors(lambda: os.environ.pop("OMP_NUM_THREADS", None))
+    run_fn_on_actors(actors=actors, fn=lambda: os.environ.pop("OMP_NUM_THREADS", None))
 
     ips_ports = get_ip_port_actors(actors=actors)
     ip_port_list = [f"{ip}:{port}" for ip, port in ips_ports]

--- a/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/tensorflow_benchmark.py
@@ -154,6 +154,7 @@ def train_tf_vanilla(
         upload_file_to_all_nodes,
         create_actors_with_resources,
         run_commands_on_actors,
+        run_fn_on_actors,
         get_ip_port_actors,
     )
 
@@ -169,6 +170,8 @@ def train_tf_vanilla(
             "GPU": int(use_gpu),
         },
     )
+
+    run_fn_on_actors(lambda: os.environ.pop("OMP_NUM_THREADS", None))
 
     ips_ports = get_ip_port_actors(actors=actors)
     ip_port_list = [f"{ip}:{port}" for ip, port in ips_ports]

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -280,6 +280,7 @@ def train_torch_vanilla(
         upload_file_to_all_nodes,
         create_actors_with_resources,
         run_commands_on_actors,
+        run_fn_on_actors,
         get_ip_port_actors,
         get_gpu_ids_actors,
         map_ips_to_gpus,
@@ -298,6 +299,8 @@ def train_torch_vanilla(
             "GPU": int(use_gpu),
         },
     )
+
+    run_fn_on_actors(lambda: os.environ.pop("OMP_NUM_THREADS", None))
 
     # Get IPs and ports for all actors
     ip_ports = get_ip_port_actors(actors=actors)

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -300,7 +300,7 @@ def train_torch_vanilla(
         },
     )
 
-    run_fn_on_actors(lambda: os.environ.pop("OMP_NUM_THREADS", None))
+    run_fn_on_actors(actors=actors, fn=lambda: os.environ.pop("OMP_NUM_THREADS", None))
 
     # Get IPs and ports for all actors
     ip_ports = get_ip_port_actors(actors=actors)

--- a/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/torch_benchmark.py
@@ -350,6 +350,10 @@ def train_torch_vanilla(
         for rank in range(num_workers)
     ]
 
+    run_fn_on_actors(
+        actors=actors, fn=lambda: os.environ.setdefault("OMP_NUM_THREADS", "1")
+    )
+
     start_time = time.monotonic()
     run_commands_on_actors(actors=actors, cmds=cmds)
     time_taken = time.monotonic() - start_time


### PR DESCRIPTION
Signed-off-by: Kai Fricke <kai@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray automatically sets OMP_NUM_THREADS=1, potentially limiting multithreading in native pytorch/tensorflow. If this leads to performance differences, we should address this either in Ray Train or in Ray core.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
