### PR TITLE
[Serve] Cherry-pick handle early detection for GCS FT 

### DIFF
--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -148,13 +148,14 @@ class LongPollClient:
         if isinstance(updates, (ray.exceptions.RayTaskError)):
             if isinstance(updates.as_instanceof_cause(), (asyncio.TimeoutError)):
                 logger.debug("LongPollClient polling timed out. Retrying.")
+                self._schedule_to_event_loop(self._reset)
             else:
                 # Some error happened in the controller. It could be a bug or
                 # some undesired state.
                 logger.error("LongPollHost errored\n" + updates.traceback_str)
-            # We must call this in event loop so it works in Ray Client.
-            # See https://github.com/ray-project/ray/issues/20971
-            self._schedule_to_event_loop(self._poll_next)
+                # We must call this in event loop so it works in Ray Client.
+                # See https://github.com/ray-project/ray/issues/20971
+                self._schedule_to_event_loop(self._poll_next)
             return
 
         logger.debug(

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 
 import ray
+import ray.actor
 import ray._private.state
 from ray import serve
 from ray._private.test_utils import wait_for_condition
@@ -648,6 +649,42 @@ def test_shutdown_remote(start_and_shutdown_ray_cli_function):
     finally:
         os.unlink(deploy_file.name)
         os.unlink(shutdown_file.name)
+
+
+def test_handle_early_detect_failure(shutdown_ray):
+    """Check that handle can be notified about replicas failure.
+
+    It should detect replica raises ActorError and take them out of the replicas set.
+    """
+    ray.init()
+    serve.start(detached=True)
+
+    @serve.deployment(num_replicas=2, max_concurrent_queries=1)
+    def f(do_crash: bool = False):
+        if do_crash:
+            os._exit(1)
+        return os.getpid()
+
+    handle = serve.run(f.bind())
+    pids = ray.get([handle.remote() for _ in range(2)])
+    assert len(set(pids)) == 2
+    assert len(handle.router._replica_set.in_flight_queries.keys()) == 2
+
+    client = get_global_client()
+    # Kill the controller so that the replicas membership won't be updated
+    # through controller health check + long polling.
+    ray.kill(client._controller, no_restart=True)
+
+    with pytest.raises(RayActorError):
+        ray.get(handle.remote(do_crash=True))
+
+    pids = ray.get([handle.remote() for _ in range(10)])
+    assert len(set(pids)) == 1
+    assert len(handle.router._replica_set.in_flight_queries.keys()) == 1
+
+    # Restart the controller, and then clean up all the replicas
+    serve.start(detached=True)
+    serve.shutdown()
 
 
 def test_autoscaler_shutdown_node_http_everynode(


### PR DESCRIPTION
…group (#26685)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Cherry-pick 545c51609f0f55b41cf99cec95a9c21bee6846de into the release branch as the last Serve code change needed for GCS Fault Tolerance work.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
