### PR TITLE
[hotfix] Fix runtime_env import statement

### DIFF
--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -10,7 +10,7 @@ from typing import Optional
 from unittest.mock import patch
 
 import pytest
-from ray.runtime_env.runtime_env import RuntimeEnv, RuntimeEnvConfig
+from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
 import yaml
 
 import ray

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List
 from unittest import mock
 
 import pytest
-from ray.runtime_env.runtime_env import RuntimeEnvConfig
+from ray.runtime_env import RuntimeEnvConfig
 import requests
 
 import ray

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -16,7 +16,7 @@ from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.test_utils import enable_external_redis, wait_for_condition
 from ray.exceptions import RuntimeEnvSetupError
-from ray.runtime_env.runtime_env import RuntimeEnv
+from ray.runtime_env import RuntimeEnv
 
 MY_PLUGIN_CLASS_PATH = "ray.tests.test_runtime_env_plugin.MyPlugin"
 MY_PLUGIN_NAME = "MyPlugin"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A user reported `ModuleNotFoundError: No module named 'ray.runtime_env.runtime_env'; 'ray.runtime_env' is not a package` occurs under certain conditions when calling `ray.init()`.  There only a few lines with `ray.runtime_env.runtime_env` in the codebase, this PR changes them to `ray.runtime_env`.  

Not clear if this will fix the issue yet, since the changes are only in test files.  We're still trying to find a way to reproduce the error so we can add a test.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
