### PR TITLE
[data] When no pipeline stats are available, return a helpful message instead of empty

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -420,6 +420,8 @@ class DatasetPipelineStats:
         """Return a human-readable summary of this pipeline's stats."""
         already_printed = set()
         out = ""
+        if not self.history_buffer:
+            return "No stats available: This pipeline hasn't been run yet."
         for i, stats in self.history_buffer:
             out += "== Pipeline Window {} ==\n".format(i)
             out += stats.summary_string(already_printed)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -201,6 +201,8 @@ def test_dataset_pipeline_stats_basic(ray_start_regular_shared):
     ds = ds.map_batches(lambda x: x)
     pipe = ds.repeat(5)
     pipe = pipe.map(lambda x: x)
+    stats = canonicalize(pipe.stats())
+    assert "No stats available" in stats, stats
     for batch in pipe.iter_batches():
         pass
     stats = canonicalize(pipe.stats())


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, pipeline stats are confusing if you try to get them before pipeline execution.