### PR TITLE
Change Yellow->Red Cyan->Blue

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1708,14 +1708,14 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
             data.get("pid") == "raylet"
             and ray_constants.LOG_PREFIX_INFO_MESSAGE not in line
         ):
-            return colorama.Fore.YELLOW
+            return colorama.Fore.RED
         elif data.get("pid") == "autoscaler":
             if "Error:" in line or "Warning:" in line:
-                return colorama.Style.BRIGHT + colorama.Fore.YELLOW
+                return colorama.Style.BRIGHT + colorama.Fore.RED
             else:
-                return colorama.Style.BRIGHT + colorama.Fore.CYAN
+                return colorama.Style.BRIGHT + colorama.Fore.BLUE
         else:
-            return colorama.Fore.CYAN
+            return colorama.Fore.BLUE
 
     if data.get("pid") == "autoscaler":
         pid = "scheduler +{}".format(time_string())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current default autoscaler error message color is painfully difficult to read on the default background.
<img width="805" alt="image" src="https://user-images.githubusercontent.com/72253920/181826866-a7b1d064-052b-4dc4-b635-c79e1da188b3.png">

<!-- Please give a short summary of the change and the problem this solves. -->
I changed the colour Yellow and Cyan to Red and Blue respectively.

<img width="787" alt="image" src="https://user-images.githubusercontent.com/72253920/181827070-7476bfe6-1821-48e0-a45b-a24cc901c70c.png">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
