### PR TITLE
[ci] Deflakey gcs_heartbeat_test in windows.

### DIFF
--- a/src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_heartbeat_manager_test.cc
@@ -66,8 +66,11 @@ TEST_F(GcsHeartbeatManagerTest, TestBasicTimeout) {
   auto start = absl::Now();
   AddNode(node_1);
 
-  while (absl::Now() - start < absl::Seconds(1)) {
+  while (true) {
     absl::MutexLock lock(&mutex_);
+    if (absl::Now() - start >= absl::Seconds(1)) {
+      break;
+    }
     ASSERT_TRUE(dead_nodes.empty());
   }
 
@@ -84,8 +87,11 @@ TEST_F(GcsHeartbeatManagerTest, TestBasicReport) {
   auto start = absl::Now();
   AddNode(node_1);
 
-  while (absl::Now() - start < absl::Seconds(3)) {
+  while (true) {
     absl::MutexLock lock(&mutex_);
+    if (absl::Now() - start >= absl::Seconds(3)) {
+      break;
+    }
     ASSERT_TRUE(dead_nodes.empty());
     io_service.post(
         [&]() {
@@ -116,8 +122,11 @@ TEST_F(GcsHeartbeatManagerTest, TestBasicRestart) {
 
   heartbeat_manager->Initialize(init_data);
 
-  while (absl::Now() - start < absl::Seconds(3)) {
+  while (true) {
     absl::MutexLock lock(&mutex_);
+    if (absl::Now() - start >= absl::Seconds(3)) {
+      break;
+    }
     ASSERT_TRUE(dead_nodes.empty());
   }
 
@@ -158,8 +167,11 @@ TEST_F(GcsHeartbeatManagerTest, TestBasicRestart2) {
     std::this_thread::sleep_for(0.1s);
   }
 
-  while (absl::Now() - start < absl::Seconds(1)) {
+  while (true) {
     absl::MutexLock lock(&mutex_);
+    if (absl::Now() - start >= absl::Seconds(1)) {
+      break;
+    }
     ASSERT_TRUE(dead_nodes.empty());
   }
 


### PR DESCRIPTION
Signed-off-by: Yi Cheng <chengyidna@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We need to check the time after acquiring the lock to make sure the correctness. Otherwise, it might wait for the lock and the heartbeat has been updated.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
