### PR TITLE
[docs][ml][kuberay] Add a --disable-check flag to the XGBoost benchmark.

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -122,17 +122,18 @@ def main(args):
     with open(test_output_json, "wt") as f:
         json.dump(result, f)
 
-    if training_time > _TRAINING_TIME_THRESHOLD:
-        raise RuntimeError(
-            f"Training on XGBoost is taking {training_time} seconds, "
-            f"which is longer than expected ({_TRAINING_TIME_THRESHOLD} seconds)."
-        )
+    if not args.no_timeout:
+        if training_time > _TRAINING_TIME_THRESHOLD:
+            raise RuntimeError(
+                f"Training on XGBoost is taking {training_time} seconds, "
+                f"which is longer than expected ({_TRAINING_TIME_THRESHOLD} seconds)."
+            )
 
-    if prediction_time > _PREDICTION_TIME_THRESHOLD:
-        raise RuntimeError(
-            f"Batch prediction on XGBoost is taking {prediction_time} seconds, "
-            f"which is longer than expected ({_PREDICTION_TIME_THRESHOLD} seconds)."
-        )
+        if prediction_time > _PREDICTION_TIME_THRESHOLD:
+            raise RuntimeError(
+                f"Batch prediction on XGBoost is taking {prediction_time} seconds, "
+                f"which is longer than expected ({_PREDICTION_TIME_THRESHOLD} seconds)."
+            )
 
 
 if __name__ == "__main__":
@@ -140,5 +141,13 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--size", type=str, choices=["10G", "100G"], default="100G")
+    # Add a flag for disabling the timeout error.
+    # Use case: running the benchmark as a documented example, in infra settings
+    # different from the formal benchmark's EC2 setup.
+    parser.add_argument(
+        "--no-timeout",
+        action="store_true",
+        help="disable runtime error on benchmark timeout",
+    )
     args = parser.parse_args()
     main(args)

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -122,7 +122,7 @@ def main(args):
     with open(test_output_json, "wt") as f:
         json.dump(result, f)
 
-    if not args.no_timeout:
+    if not args.disable_check:
         if training_time > _TRAINING_TIME_THRESHOLD:
             raise RuntimeError(
                 f"Training on XGBoost is taking {training_time} seconds, "
@@ -145,7 +145,7 @@ if __name__ == "__main__":
     # Use case: running the benchmark as a documented example, in infra settings
     # different from the formal benchmark's EC2 setup.
     parser.add_argument(
-        "--no-timeout",
+        "--disable-check",
         action="store_true",
         help="disable runtime error on benchmark timeout",
     )


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds a flag `--disable-check` to the XGBoost benchmark script which disables the RuntimeError that comes up if training or prediction took too long. This is meant for non-CI exploratory use-cases.

Specifically, the reason is this:
We will include the XGBoost benchmark as an example workload for the KubeRay documentation.
The actual performance of the workload is highly sensitive to infrastructure environment, so we won't want to raise an alarming RuntimeError if the workload took too long on the user's infrastructure.
(When I tried the 100Gb benchmark on KubeRay, training ran just a couple of minutes longer than the 1000 second cutoff.) 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
