### PR TITLE
[Core] Fix reference counting bug on objects borrowed for a cancelled actor creation.

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -293,6 +293,10 @@ class RayActorError(RayError):
             if cause.node_ip_address != "":
                 error_msg_lines.append(f"\tip: {cause.node_ip_address}")
             error_msg_lines.append(cause.error_message)
+            if cause.never_started:
+                error_msg_lines.append(
+                    "The actor never ran - it was cancelled before it started running."
+                )
             self.error_msg = "\n".join(error_msg_lines)
 
     @property

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -53,6 +53,7 @@ namespace ray {
 #define STATUS_CODE_UNKNOWN "Unknown"
 #define STATUS_CODE_NOT_FOUND "NotFound"
 #define STATUS_CODE_DISCONNECTED "Disconnected"
+#define STATUS_CODE_SCHEDULING_CANCELLED "SchedulingCancelled"
 // object store status
 #define STATUS_CODE_OBJECT_EXISTS "ObjectExists"
 #define STATUS_CODE_OBJECT_NOT_FOUND "ObjectNotFound"
@@ -102,6 +103,7 @@ std::string Status::CodeAsString() const {
       {StatusCode::CreationTaskError, STATUS_CODE_CREATION_TASK_ERROR},
       {StatusCode::NotFound, STATUS_CODE_NOT_FOUND},
       {StatusCode::Disconnected, STATUS_CODE_DISCONNECTED},
+      {StatusCode::SchedulingCancelled, STATUS_CODE_SCHEDULING_CANCELLED},
       {StatusCode::ObjectExists, STATUS_CODE_OBJECT_EXISTS},
       {StatusCode::ObjectNotFound, STATUS_CODE_OBJECT_NOT_FOUND},
       {StatusCode::ObjectAlreadySealed, STATUS_CODE_OBJECT_STORE_ALREADY_SEALED},
@@ -137,6 +139,7 @@ StatusCode Status::StringToCode(const std::string &str) {
       {STATUS_CODE_CREATION_TASK_ERROR, StatusCode::CreationTaskError},
       {STATUS_CODE_NOT_FOUND, StatusCode::NotFound},
       {STATUS_CODE_DISCONNECTED, StatusCode::Disconnected},
+      {STATUS_CODE_SCHEDULING_CANCELLED, StatusCode::SchedulingCancelled},
       {STATUS_CODE_OBJECT_EXISTS, StatusCode::ObjectExists},
       {STATUS_CODE_OBJECT_NOT_FOUND, StatusCode::ObjectNotFound},
       {STATUS_CODE_OBJECT_STORE_ALREADY_SEALED, StatusCode::ObjectAlreadySealed},

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -95,6 +95,7 @@ enum class StatusCode : char {
   CreationTaskError = 16,
   NotFound = 17,
   Disconnected = 18,
+  SchedulingCancelled = 19,
   // object store status
   ObjectExists = 21,
   ObjectNotFound = 22,
@@ -194,6 +195,10 @@ class RAY_EXPORT Status {
     return Status(StatusCode::Disconnected, msg);
   }
 
+  static Status SchedulingCancelled(const std::string &msg) {
+    return Status(StatusCode::SchedulingCancelled, msg);
+  }
+
   static Status ObjectExists(const std::string &msg) {
     return Status(StatusCode::ObjectExists, msg);
   }
@@ -256,6 +261,7 @@ class RAY_EXPORT Status {
   }
   bool IsNotFound() const { return code() == StatusCode::NotFound; }
   bool IsDisconnected() const { return code() == StatusCode::Disconnected; }
+  bool IsSchedulingCancelled() const { return code() == StatusCode::SchedulingCancelled; }
   bool IsObjectExists() const { return code() == StatusCode::ObjectExists; }
   bool IsObjectNotFound() const { return code() == StatusCode::ObjectNotFound; }
   bool IsObjectAlreadySealed() const { return code() == StatusCode::ObjectAlreadySealed; }

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -44,12 +44,19 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
           task_spec,
           [this, actor_id, task_id](Status status, const rpc::CreateActorReply &reply) {
             if (status.ok()) {
-              RAY_LOG(DEBUG) << "Created actor, actor id = " << actor_id;
-              // Copy the actor's reply to the GCS for ref counting purposes.
-              rpc::PushTaskReply push_task_reply;
-              push_task_reply.mutable_borrowed_refs()->CopyFrom(reply.borrowed_refs());
-              task_finisher_->CompletePendingTask(
-                  task_id, push_task_reply, reply.actor_address());
+              if (reply.cancelled()) {
+                RAY_LOG(DEBUG) << "Actor creation cancelled, actor id = " << actor_id;
+                task_finisher_->MarkTaskCanceled(task_id);
+                RAY_UNUSED(task_finisher_->FailOrRetryPendingTask(
+                    task_id, rpc::ErrorType::TASK_CANCELLED, nullptr));
+              } else {
+                RAY_LOG(DEBUG) << "Created actor, actor id = " << actor_id;
+                // Copy the actor's reply to the GCS for ref counting purposes.
+                rpc::PushTaskReply push_task_reply;
+                push_task_reply.mutable_borrowed_refs()->CopyFrom(reply.borrowed_refs());
+                task_finisher_->CompletePendingTask(
+                    task_id, push_task_reply, reply.actor_address());
+              }
             } else {
               RAY_LOG(INFO) << "Failed to create actor " << actor_id
                             << " with status: " << status.ToString();

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -55,7 +55,10 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
               if (status.IsSchedulingCancelled()) {
                 RAY_LOG(DEBUG) << "Actor creation cancelled, actor id = " << actor_id;
                 task_finisher_->MarkTaskCanceled(task_id);
-                ray_error_info.mutable_actor_died_error()->CopyFrom(reply.death_cause());
+                if (reply.has_death_cause()) {
+                  ray_error_info.mutable_actor_died_error()->CopyFrom(
+                      reply.death_cause());
+                }
               } else {
                 RAY_LOG(INFO) << "Failed to create actor " << actor_id
                               << " with status: " << status.ToString();

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -741,7 +741,9 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id,
   const auto creation_callbacks = callback_it != actor_to_create_callbacks_.end()
                                       ? std::move(callback_it->second)
                                       : std::vector<CreateActorCallback>{};
-  actor_to_create_callbacks_.erase(callback_it);
+  if (callback_it != actor_to_create_callbacks_.end()) {
+    actor_to_create_callbacks_.erase(callback_it);
+  }
   auto it = registered_actors_.find(actor_id);
   if (it == registered_actors_.end()) {
     RAY_LOG(INFO) << "Tried to destroy actor that does not exist " << actor_id;

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -39,6 +39,10 @@ void AddActorInfo(const ray::gcs::GcsActor *actor,
   mutable_actor_died_error_ctx->set_ray_namespace(actor->GetRayNamespace());
   mutable_actor_died_error_ctx->set_class_name(actor->GetActorTableData().class_name());
   mutable_actor_died_error_ctx->set_actor_id(actor->GetActorID().Binary());
+  const auto actor_state = actor->GetState();
+  mutable_actor_died_error_ctx->set_never_started(
+      actor_state == ray::rpc::ActorTableData::DEPENDENCIES_UNREADY ||
+      actor_state == ray::rpc::ActorTableData::PENDING_CREATION);
 }
 
 const ray::rpc::ActorDeathCause GenNodeDiedCause(const ray::gcs::GcsActor *actor,

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -164,8 +164,8 @@ class GcsActor {
 };
 
 using RegisterActorCallback = std::function<void(std::shared_ptr<GcsActor>)>;
-using CreateActorCallback =
-    std::function<void(std::shared_ptr<GcsActor>, const rpc::PushTaskReply &reply)>;
+using CreateActorCallback = std::function<void(
+    std::shared_ptr<GcsActor>, const rpc::PushTaskReply &reply, bool creation_cancelled)>;
 
 /// GcsActorManager is responsible for managing the lifecycle of all actors.
 /// This class is not thread-safe.
@@ -273,9 +273,10 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// Create actor asynchronously.
   ///
   /// \param request Contains the meta info to create the actor.
-  /// \param callback Will be invoked after the actor is created successfully or be
-  /// invoked immediately if the actor is already registered to `registered_actors_` and
-  /// its state is `ALIVE`.
+  /// \param callback Will be invoked after the actor is created successfully or if the
+  /// actor creation is cancelled (e.g. due to the actor going out-of-scope or being
+  /// killed before actor creation has been completed), or will be invoked immediately if
+  /// the actor is already registered to `registered_actors_` and its state is `ALIVE`.
   /// \return Status::Invalid if this is a named actor and an actor with the specified
   /// name already exists. The callback will not be called in this case.
   Status CreateActor(const rpc::CreateActorRequest &request,

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -280,7 +280,8 @@ TEST_F(GcsActorManagerTest, TestBasic) {
   Status status = gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](const std::shared_ptr<gcs::GcsActor> &actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       });
   RAY_CHECK_OK(status);
@@ -311,7 +312,8 @@ TEST_F(GcsActorManagerTest, TestSchedulingFailed) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       }));
 
@@ -338,7 +340,8 @@ TEST_F(GcsActorManagerTest, TestWorkerFailure) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       }));
 
@@ -385,7 +388,8 @@ TEST_F(GcsActorManagerTest, TestNodeFailure) {
   Status status = gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       });
   RAY_CHECK_OK(status);
@@ -436,7 +440,8 @@ TEST_F(GcsActorManagerTest, TestActorReconstruction) {
   Status status = gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       });
   RAY_CHECK_OK(status);
@@ -504,7 +509,8 @@ TEST_F(GcsActorManagerTest, TestActorRestartWhenOwnerDead) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       }));
 
@@ -555,7 +561,8 @@ TEST_F(GcsActorManagerTest, TestDetachedActorRestartWhenCreatorDead) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       }));
 
@@ -674,9 +681,10 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionWorkerFailure) {
   request1.mutable_task_spec()->CopyFrom(
       registered_actor_1->GetCreationTaskSpecification().GetMessage());
 
-  Status status = gcs_actor_manager_->CreateActor(
-      request1,
-      [](std::shared_ptr<gcs::GcsActor> actor, const rpc::PushTaskReply &reply) {});
+  Status status = gcs_actor_manager_->CreateActor(request1,
+                                                  [](std::shared_ptr<gcs::GcsActor> actor,
+                                                     const rpc::PushTaskReply &reply,
+                                                     bool creation_cancelled) {});
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, "test").Binary(),
             request1.task_spec().actor_creation_task_spec().actor_id());
@@ -711,9 +719,10 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionWorkerFailure) {
   request2.mutable_task_spec()->CopyFrom(
       registered_actor_2->GetCreationTaskSpecification().GetMessage());
 
-  status = gcs_actor_manager_->CreateActor(
-      request2,
-      [](std::shared_ptr<gcs::GcsActor> actor, const rpc::PushTaskReply &reply) {});
+  status = gcs_actor_manager_->CreateActor(request2,
+                                           [](std::shared_ptr<gcs::GcsActor> actor,
+                                              const rpc::PushTaskReply &reply,
+                                              bool creation_cancelled) {});
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, "test").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
@@ -730,9 +739,10 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNodeFailure) {
   request1.mutable_task_spec()->CopyFrom(
       registered_actor_1->GetCreationTaskSpecification().GetMessage());
 
-  Status status = gcs_actor_manager_->CreateActor(
-      request1,
-      [](std::shared_ptr<gcs::GcsActor> actor, const rpc::PushTaskReply &reply) {});
+  Status status = gcs_actor_manager_->CreateActor(request1,
+                                                  [](std::shared_ptr<gcs::GcsActor> actor,
+                                                     const rpc::PushTaskReply &reply,
+                                                     bool creation_cancelled) {});
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
             request1.task_spec().actor_creation_task_spec().actor_id());
@@ -766,9 +776,10 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNodeFailure) {
   request2.mutable_task_spec()->CopyFrom(
       registered_actor_2->GetCreationTaskSpecification().GetMessage());
 
-  status = gcs_actor_manager_->CreateActor(
-      request2,
-      [](std::shared_ptr<gcs::GcsActor> actor, const rpc::PushTaskReply &reply) {});
+  status = gcs_actor_manager_->CreateActor(request2,
+                                           [](std::shared_ptr<gcs::GcsActor> actor,
+                                              const rpc::PushTaskReply &reply,
+                                              bool creation_cancelled) {});
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
@@ -786,9 +797,10 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNotHappendWhenReconstructed) {
   request1.mutable_task_spec()->CopyFrom(
       registered_actor_1->GetCreationTaskSpecification().GetMessage());
 
-  Status status = gcs_actor_manager_->CreateActor(
-      request1,
-      [](std::shared_ptr<gcs::GcsActor> actor, const rpc::PushTaskReply &reply) {});
+  Status status = gcs_actor_manager_->CreateActor(request1,
+                                                  [](std::shared_ptr<gcs::GcsActor> actor,
+                                                     const rpc::PushTaskReply &reply,
+                                                     bool creation_cancelled) {});
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
             request1.task_spec().actor_creation_task_spec().actor_id());
@@ -835,7 +847,8 @@ TEST_F(GcsActorManagerTest, TestDestroyActorBeforeActorCreationCompletes) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       }));
 
@@ -871,7 +884,8 @@ TEST_F(GcsActorManagerTest, TestRaceConditionCancelLease) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       }));
 
@@ -915,7 +929,8 @@ TEST_F(GcsActorManagerTest, TestRegisterActor) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(std::move(actor));
       }));
   // Make sure the actor is scheduling.
@@ -1035,7 +1050,8 @@ TEST_F(GcsActorManagerTest, TestOwnerAndChildDiedAtTheSameTimeRaceCondition) {
   RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
       create_actor_request,
       [&finished_actors](std::shared_ptr<gcs::GcsActor> actor,
-                         const rpc::PushTaskReply &reply) {
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
         finished_actors.emplace_back(actor);
       }));
   auto actor = mock_actor_scheduler_->actors.back();

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -255,6 +255,9 @@ message ActorDiedErrorContext {
   string class_name = 8;
   // The id of the actor
   bytes actor_id = 9;
+  // Whether the actor had never started running before it died, i.e. it was cancelled
+  // before scheduling had completed.
+  bool never_started = 10;
 }
 // ---Actor death contexts end----
 

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -325,7 +325,7 @@ message CreateActorReply {
   // Info about any refs that the created actor is borrowing.
   repeated ObjectReferenceCount borrowed_refs = 3;
   // The cause of this actor's death if creation was cancelled.
-  ActorDeathCause death_cause = 4;
+  optional ActorDeathCause death_cause = 4;
 }
 
 message RegisterActorRequest {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -36,8 +36,7 @@ message MarkJobFinishedReply {
   GcsStatus status = 1;
 }
 
-message GetAllJobInfoRequest {
-}
+message GetAllJobInfoRequest {}
 
 message GetAllJobInfoReply {
   GcsStatus status = 1;
@@ -51,8 +50,7 @@ message ReportJobErrorReply {
   GcsStatus status = 1;
 }
 
-message GetNextJobIDRequest {
-}
+message GetNextJobIDRequest {}
 message GetNextJobIDReply {
   GcsStatus status = 1;
   int32 job_id = 2;
@@ -172,8 +170,7 @@ message RegisterNodeReply {
   GcsStatus status = 1;
 }
 
-message GetAllNodeInfoRequest {
-}
+message GetAllNodeInfoRequest {}
 
 message GetAllNodeInfoReply {
   GcsStatus status = 1;
@@ -198,8 +195,7 @@ message CheckAliveReply {
   repeated bool raylet_alive = 3;
 }
 
-message GetInternalConfigRequest {
-}
+message GetInternalConfigRequest {}
 
 message GetInternalConfigReply {
   GcsStatus status = 1;
@@ -219,8 +215,7 @@ message DeleteResourcesReply {
   GcsStatus status = 1;
 }
 
-message GetAllAvailableResourcesRequest {
-}
+message GetAllAvailableResourcesRequest {}
 
 message GetAllAvailableResourcesReply {
   GcsStatus status = 1;
@@ -251,8 +246,7 @@ message AddProfileDataReply {
   GcsStatus status = 1;
 }
 
-message GetAllProfileInfoRequest {
-}
+message GetAllProfileInfoRequest {}
 
 message GetAllProfileInfoReply {
   GcsStatus status = 1;
@@ -330,6 +324,8 @@ message CreateActorReply {
   Address actor_address = 2;
   // Info about any refs that the created actor is borrowing.
   repeated ObjectReferenceCount borrowed_refs = 3;
+  // Whether the actor creation was cancelled.
+  bool cancelled = 4;
 }
 
 message RegisterActorRequest {
@@ -582,8 +578,7 @@ service InternalPubSubGcsService {
       returns (GcsSubscriberCommandBatchReply);
 }
 
-message GetAllResourceUsageRequest {
-}
+message GetAllResourceUsageRequest {}
 
 message GetAllResourceUsageReply {
   GcsStatus status = 1;

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -324,8 +324,8 @@ message CreateActorReply {
   Address actor_address = 2;
   // Info about any refs that the created actor is borrowing.
   repeated ObjectReferenceCount borrowed_refs = 3;
-  // Whether the actor creation was cancelled.
-  bool cancelled = 4;
+  // The cause of this actor's death if creation was cancelled.
+  ActorDeathCause death_cause = 4;
 }
 
 message RegisterActorRequest {


### PR DESCRIPTION
This PR fixes a reference counting bug for borrowed objects sent to an actor creation task that is then cancelled.

Before this PR, when actor creation is cancelled before the creation task has been scheduled, the GCS-based actor manager would would destroy the actor without replying to the task submission RPC from the actor creating worker, resulting in the reference counts on that worker to never get cleaned up. This caused us to leak borrowed objects when such cancellation-before-scheduling happened for actors.

This PR fixes this by ensuring that the task submission RPC receives a reply indicating that the actor creation task has been cancelled, at which point the submitting worker will run through the same reference counting cleanup as is done for normal task cancellation.

## Related issue number

Closes #27297 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
