### PR TITLE
[core] Suppress the logging error when python exits and actor not del…

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1093,12 +1093,18 @@ class ActorHandle:
                 setattr(self, method_name, method)
 
     def __del__(self):
-        # Mark that this actor handle has gone out of scope. Once all actor
-        # handles are out of scope, the actor will exit.
-        if ray._private.worker:
-            worker = ray._private.worker.global_worker
-            if worker.connected and hasattr(worker, "core_worker"):
-                worker.core_worker.remove_actor_handle_reference(self._ray_actor_id)
+        try:
+            # Mark that this actor handle has gone out of scope. Once all actor
+            # handles are out of scope, the actor will exit.
+            if ray._private.worker:
+                worker = ray._private.worker.global_worker
+                if worker.connected and hasattr(worker, "core_worker"):
+                    worker.core_worker.remove_actor_handle_reference(self._ray_actor_id)
+        except AttributeError:
+            # Suppress the attribtue error which is caused by
+            # python destruction ordering issue.
+            # It only happen when python exits.
+            pass
 
     def _actor_method_call(
         self,

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -122,6 +122,25 @@ def test_internal_kv(ray_start_regular):
         kv._internal_kv_list("@namespace_abc", namespace="n")
 
 
+def test_exit_logging():
+    log = run_string_as_driver(
+        """
+import ray
+
+@ray.remote
+class A:
+    def pid(self):
+        import os
+        return os.getpid()
+
+
+a = A.remote()
+ray.get(a.pid.remote())
+    """
+    )
+    assert "Traceback" not in log
+
+
 def test_run_on_all_workers(call_ray_start, tmp_path):
     # This test is to ensure run_function_on_all_workers are executed
     # on all workers.


### PR DESCRIPTION
…eted. (#27300)

In py39, it seems the destruction order changed and in __del__ some component might have been uninstalled and some error will be thrown.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
