### PR TITLE
[RLlib] Fix complex torch one-hot and flattened layers not being added to module list

### DIFF
--- a/rllib/models/torch/complex_input_net.py
+++ b/rllib/models/torch/complex_input_net.py
@@ -115,6 +115,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                     name="one_hot_{}".format(i),
                 )
                 concat_size += self.one_hot[i].num_outputs
+                self.add_module("one_hot_{}".format(i), self.one_hot[i])
             # Everything else (1D Box).
             else:
                 size = int(np.product(component.shape))
@@ -133,6 +134,7 @@ class ComplexInputNetwork(TorchModelV2, nn.Module):
                 )
                 self.flatten_dims[i] = size
                 concat_size += self.flatten[i].num_outputs
+                self.add_module("flatten_{}".format(i), self.flatten[i])
 
         # Optional post-concat FC-stack.
         post_fc_stack_config = {


### PR DESCRIPTION
## Why are these changes needed?

one-hot and flattened layers are not added to module list of complex torch model.

## Related issue number

Closes #26557 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
