### PR TITLE
[FLAKY TEST] fix flaky test case: test_ray_shutdown.py

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1,6 +1,7 @@
 import atexit
 import faulthandler
 import functools
+import grpc
 import hashlib
 import inspect
 import io
@@ -756,7 +757,6 @@ class Worker:
 
     def print_logs(self):
         """Prints log messages from workers on all nodes in the same job."""
-        import grpc
 
         subscriber = self.gcs_log_subscriber
         subscriber.subscribe()
@@ -1902,6 +1902,11 @@ def connect(
         if mode == SCRIPT_MODE:
             raise e
         elif mode == WORKER_MODE:
+            if isinstance(e, grpc.RpcError) and e.code() in (
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.StatusCode.UNKNOWN,
+            ):
+                raise e
             traceback_str = traceback.format_exc()
             ray._private.utils.publish_error_to_driver(
                 ray_constants.VERSION_MISMATCH_PUSH_ERROR,

--- a/python/ray/tests/test_ray_shutdown.py
+++ b/python/ray/tests/test_ray_shutdown.py
@@ -11,15 +11,27 @@ from ray._private.test_utils import wait_for_condition, run_string_as_driver_non
 
 
 def get_all_ray_worker_processes():
-    processes = [
-        p.info["cmdline"] for p in psutil.process_iter(attrs=["pid", "name", "cmdline"])
-    ]
+    processes = psutil.process_iter(attrs=["pid", "name", "cmdline"])
 
     result = []
     for p in processes:
-        if p is not None and len(p) > 0 and "ray::" in p[0]:
+        cmd_line = p.info["cmdline"]
+        if cmd_line is not None and len(cmd_line) > 0 and "ray::" in cmd_line[0]:
             result.append(p)
     return result
+
+
+@pytest.fixture
+def kill_all_ray_worker_process():
+    # Avoiding the previous test doesn't kill the relevant process,
+    # thus making the current test fail.
+    ray_process = get_all_ray_worker_processes()
+    for p in ray_process:
+        try:
+            p.kill()
+        except Exception:
+            pass
+    yield
 
 
 @pytest.fixture
@@ -29,8 +41,11 @@ def short_gcs_publish_timeout(monkeypatch):
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Hang on Windows.")
-def test_ray_shutdown(short_gcs_publish_timeout, shutdown_only):
+def test_ray_shutdown(
+    kill_all_ray_worker_process, short_gcs_publish_timeout, shutdown_only
+):
     """Make sure all ray workers are shutdown when driver is done."""
+
     ray.init()
 
     @ray.remote
@@ -45,12 +60,15 @@ def test_ray_shutdown(short_gcs_publish_timeout, shutdown_only):
 
     ray.shutdown()
 
-    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0)
+    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0, timeout=20)
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Hang on Windows.")
-def test_driver_dead(short_gcs_publish_timeout, shutdown_only):
+def test_driver_dead(
+    kill_all_ray_worker_process, short_gcs_publish_timeout, shutdown_only
+):
     """Make sure all ray workers are shutdown when driver is killed."""
+
     driver = """
 import ray
 ray.init(_system_config={"gcs_rpc_server_reconnect_timeout_s": 1})
@@ -74,12 +92,15 @@ tasks = [f.remote() for _ in range(num_cpus)]
     p.wait()
     time.sleep(0.1)
 
-    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0)
+    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0, timeout=20)
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Hang on Windows.")
-def test_node_killed(short_gcs_publish_timeout, ray_start_cluster):
+def test_node_killed(
+    kill_all_ray_worker_process, short_gcs_publish_timeout, ray_start_cluster
+):
     """Make sure all ray workers when nodes are dead."""
+
     cluster = ray_start_cluster
     # head node.
     cluster.add_node(
@@ -106,12 +127,15 @@ def test_node_killed(short_gcs_publish_timeout, ray_start_cluster):
     for worker in workers:
         cluster.remove_node(worker)
 
-    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0)
+    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0, timeout=20)
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Hang on Windows.")
-def test_head_node_down(short_gcs_publish_timeout, ray_start_cluster):
+def test_head_node_down(
+    kill_all_ray_worker_process, short_gcs_publish_timeout, ray_start_cluster
+):
     """Make sure all ray workers when head node is dead."""
+
     cluster = ray_start_cluster
     # head node.
     head = cluster.add_node(
@@ -149,7 +173,7 @@ time.sleep(100)
 
     cluster.remove_node(head)
 
-    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0)
+    wait_for_condition(lambda: len(get_all_ray_worker_processes()) == 0, timeout=20)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

After the raylet dies, the CoreWorker will have two ways to exit:
1. Finished the construction of CPP class CoreWorker, it will exit by monitor thread.
2. Before the construction of CPP class CoreWorker, it will raise Exception when trying to connect GCS

the worst-case in **case 2**: it will get time out when [`check_version_info`](https://github.com/ray-project/ray/blob/729566d8ffb1b5e4ac6f8b8ef76cc1a445a33c64/python/ray/_private/worker.py#L1900), then [try to publish error to GCS](https://github.com/ray-project/ray/blob/729566d8ffb1b5e4ac6f8b8ef76cc1a445a33c64/python/ray/_private/worker.py#L1906), it will get timeout too, but publish timeout is 60s, our default timeout of function `wait_for_condition` is 10s, so the test case will fail.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
