### PR TITLE
[docs] add k8s docs to toc

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -270,6 +270,8 @@ parts:
             - file: cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides
               sections:
                 - file: cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/config.md
+                - file: cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/k8s-cluster-setup.md
+                - file: cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/logging.md
                 - file: cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/gpu.md
                 - file: cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/networking.md
                 - file: cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/kuberay-vs-legacy.md


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Follow-up to https://github.com/ray-project/ray/pull/27239 which broke lint.

```
checking consistency... /ray/doc/source/cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/k8s-cluster-setup.md: WARNING: document isn't included in any toctree
--
  | /ray/doc/source/cluster/cluster_under_construction/ray-clusters-on-kubernetes/user-guides/logging.md: WARNING: document isn't included in any toctree
```

Adding the remaining files. @cadedaniel @DmitriGekhtman feel free to move them if they should be in a different order/section.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
