### PR TITLE
[core] Fix the test_failure_3.py in win

### DIFF
--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -13,7 +13,7 @@ from ray._private.test_utils import (
     wait_for_pid_to_exit,
 )
 
-SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
+SIGKILL = SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 
 def test_worker_exit_after_parent_raylet_dies(ray_start_cluster):
@@ -141,7 +141,6 @@ def test_async_actor_task_retries(ray_start_regular):
     assert ray.get(ref_3) == 3
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail on windowns")
 def test_actor_failure_async(ray_start_regular):
     @ray.remote
     class A:
@@ -155,7 +154,7 @@ def test_actor_failure_async(ray_start_regular):
     rs = []
 
     def submit():
-        for i in range(100000):
+        for i in range(10000):
             r = a.echo.remote()
             r._on_completed(lambda x: 1)
             rs.append(r)
@@ -167,12 +166,11 @@ def test_actor_failure_async(ray_start_regular):
     from time import sleep
 
     sleep(0.1)
-    os.kill(pid, signal.SIGKILL)
+    os.kill(pid, SIGKILL)
 
     t.join()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail on windowns")
 @pytest.mark.parametrize(
     "ray_start_regular",
     [{"_system_config": {"timeout_ms_task_wait_for_death_info": 100000000}}],
@@ -200,7 +198,7 @@ def test_actor_failure_async_2(ray_start_regular, tmp_path):
 
     pid = ray.get(a.pid.remote())
 
-    os.kill(int(pid), signal.SIGKILL)
+    os.kill(int(pid), SIGKILL)
 
     # kill will be in another thred.
     def kill():
@@ -210,7 +208,7 @@ def test_actor_failure_async_2(ray_start_regular, tmp_path):
         while new_pid == pid:
             new_pid = int(p.read_text())
             time.sleep(1)
-        os.kill(new_pid, signal.SIGKILL)
+        os.kill(new_pid, SIGKILL)
 
     t = threading.Thread(target=kill)
     t.start()
@@ -232,7 +230,6 @@ def test_actor_failure_async_2(ray_start_regular, tmp_path):
     t.join()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail on windowns")
 @pytest.mark.parametrize(
     "ray_start_regular",
     [{"_system_config": {"timeout_ms_task_wait_for_death_info": 100000000}}],
@@ -262,7 +259,6 @@ def test_actor_failure_async_3(ray_start_regular):
         ray.get(t)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail on windowns")
 @pytest.mark.parametrize(
     "ray_start_regular",
     [{"_system_config": {"timeout_ms_task_wait_for_death_info": 100000000}}],
@@ -279,7 +275,7 @@ def test_actor_failure_async_4(ray_start_regular, tmp_path):
     @ray.remote
     def f():
         with FileLock(l_file):
-            os.kill(os.getpid(), signal.SIGKILL)
+            os.kill(os.getpid(), SIGKILL)
 
     @ray.remote(max_restarts=1)
     class A:
@@ -307,7 +303,6 @@ def test_actor_failure_async_4(ray_start_regular, tmp_path):
         ray.get(t)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Fail on windowns")
 @pytest.mark.parametrize(
     "ray_start_regular",
     [
@@ -346,7 +341,7 @@ def test_actor_failure_no_wait(ray_start_regular, tmp_path):
     a = A.remote()
     pid = ray.get(a.pid.remote())
     t = a.p.remote()
-    os.kill(int(pid), signal.SIGKILL)
+    os.kill(int(pid), SIGKILL)
     with pytest.raises(ray.exceptions.RayActorError):
         # Make sure it'll return within 1s
         ray.get(t)

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -13,7 +13,7 @@ from ray._private.test_utils import (
     wait_for_pid_to_exit,
 )
 
-SIGKILL = SIGKILL if sys.platform != "win32" else signal.SIGTERM
+SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 
 def test_worker_exit_after_parent_raylet_dies(ray_start_cluster):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Win tests were broken because when the child is killed, the parent is also killed. Change the signal sent and make it work.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #26697 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
