### PR TITLE
[Serve] Remove the warning for async handles in 2.0

### DIFF
--- a/python/ray/serve/deployment_graph.py
+++ b/python/ray/serve/deployment_graph.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import json
 
 from ray.dag.class_node import ClassNode  # noqa: F401
@@ -6,14 +5,6 @@ from ray.dag.function_node import FunctionNode  # noqa: F401
 from ray.dag.input_node import InputNode  # noqa: F401
 from ray.dag import DAGNode  # noqa: F401
 from ray.util.annotations import PublicAPI
-import ray.serve._private.client
-
-
-@contextmanager
-def _mute_sync_handle_warnings():
-    ray.serve._private.client._WARN_SYNC_ASYNC_HANDLE_CONTEXT = False
-    yield
-    ray.serve._private.client._WARN_SYNC_ASYNC_HANDLE_CONTEXT = True
 
 
 @PublicAPI(stability="alpha")
@@ -41,12 +32,10 @@ class RayServeDAGHandle:
         return RayServeDAGHandle._deserialize, (self.dag_node_json,)
 
     def remote(self, *args, **kwargs):
-        # NOTE: There's nothing user can do about these warnings, we should hide it.
-        with _mute_sync_handle_warnings():
-            if self.dag_node is None:
-                from ray.serve._private.json_serde import dagnode_from_json
+        if self.dag_node is None:
+            from ray.serve._private.json_serde import dagnode_from_json
 
-                self.dag_node = json.loads(
-                    self.dag_node_json, object_hook=dagnode_from_json
-                )
-            return self.dag_node.execute(*args, **kwargs)
+            self.dag_node = json.loads(
+                self.dag_node_json, object_hook=dagnode_from_json
+            )
+        return self.dag_node.execute(*args, **kwargs)


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR removes the warning about using sync handles in async context (common) and using async handle in sync context (rare). In Serve 2.0, we are helping user to inject the handles via .bind API. However, the only handles we are injecting right now is SyncHandle due to technical limitation. Therefore we want to remove this non-actionable warnings.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #27266

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
