### PR TITLE
[Datasets] Better error message for partition filtering if no file found

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -357,7 +357,7 @@ class _FileBasedDatasourceReader(Reader):
             self._file_sizes = [path_to_size[p] for p in self._paths]
             if len(self._paths) == 0:
                 raise ValueError(
-                    "Not found any input file to read from. Please double check "
+                    "No input files found to read. Please double check that "
                     "'partition_filter' field is set properly."
                 )
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -357,10 +357,8 @@ class _FileBasedDatasourceReader(Reader):
             self._file_sizes = [path_to_size[p] for p in self._paths]
             if len(self._paths) == 0:
                 raise ValueError(
-                    "Not found any input file to read from. Please double "
-                    "check the input files are having expected extension(s): "
-                    f"'{self._delegate._FILE_EXTENSION}', or set 'partition_filter' "
-                    "field to 'None' to disable files filtering."
+                    "Not found any input file to read from. Please double check "
+                    "'partition_filter' field is set properly."
                 )
 
     def estimate_inmemory_data_size(self) -> Optional[int]:

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -355,6 +355,13 @@ class _FileBasedDatasourceReader(Reader):
             path_to_size = dict(zip(self._paths, self._file_sizes))
             self._paths = self._partition_filter(self._paths)
             self._file_sizes = [path_to_size[p] for p in self._paths]
+            if len(self._paths) == 0:
+                raise ValueError(
+                    "Not found any input file to read from. Please double "
+                    "check the input files are having expected extension(s): "
+                    f"'{self._delegate._FILE_EXTENSION}', or set 'partition_filter' "
+                    "field to 'None' to disable files filtering."
+                )
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2998,7 +2998,7 @@ def test_csv_read_with_column_type_specified(shutdown_only, tmp_path):
     assert ds.to_pandas().equals(expected_df)
 
 
-def test_csv_read_filter_no_file(ray_start_regular_shared, tmp_path):
+def test_csv_read_filter_no_file(shutdown_only, tmp_path):
     df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     table = pa.Table.from_pandas(df)
     path = os.path.join(str(tmp_path), "test.parquet")

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -3004,7 +3004,7 @@ def test_csv_read_filter_no_file(ray_start_regular_shared, tmp_path):
     path = os.path.join(str(tmp_path), "test.parquet")
     pq.write_table(table, path)
 
-    error_message = "Please double check the input files are having expected extension"
+    error_message = "Not found any input file to read from"
     with pytest.raises(ValueError) as e:
         ray.data.read_csv(path)
     assert error_message in str(e.value)

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -2998,6 +2998,18 @@ def test_csv_read_with_column_type_specified(shutdown_only, tmp_path):
     assert ds.to_pandas().equals(expected_df)
 
 
+def test_csv_read_filter_no_file(ray_start_regular_shared, tmp_path):
+    df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    table = pa.Table.from_pandas(df)
+    path = os.path.join(str(tmp_path), "test.parquet")
+    pq.write_table(table, path)
+
+    error_message = "Please double check the input files are having expected extension"
+    with pytest.raises(ValueError) as e:
+        ray.data.read_csv(path)
+    assert error_message in str(e.value)
+
+
 class NodeLoggerOutputDatasource(Datasource[Union[ArrowRow, int]]):
     """A writable datasource that logs node IDs of write tasks, for testing."""
 

--- a/python/ray/data/tests/test_dataset_formats.py
+++ b/python/ray/data/tests/test_dataset_formats.py
@@ -3004,10 +3004,9 @@ def test_csv_read_filter_no_file(shutdown_only, tmp_path):
     path = os.path.join(str(tmp_path), "test.parquet")
     pq.write_table(table, path)
 
-    error_message = "Not found any input file to read from"
-    with pytest.raises(ValueError) as e:
+    error_message = "No input files found to read"
+    with pytest.raises(ValueError, match=error_message):
         ray.data.read_csv(path)
-    assert error_message in str(e.value)
 
 
 class NodeLoggerOutputDatasource(Datasource[Union[ArrowRow, int]]):


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
User raised issue in https://github.com/ray-project/ray/issues/26605, where the user found the error message was quite non-actionable when partition filtering input files, and no files with required extension being found.

Before this PR, the error message is:

```
>>> import ray
>>> ds = ray.data.read_csv("/Users/chengsu/try/image-2")
2022-08-01 16:49:59,805	INFO worker.py:1490 -- Started a local Ray instance.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 585, in read_csv
    return read_datasource(
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 268, in read_datasource
    requested_parallelism, min_safe_parallelism, read_tasks = ray.get(
  File "/Users/chengsu/ray/python/ray/_private/client_mode_hook.py", line 105, in wrapper
    return func(*args, **kwargs)
  File "/Users/chengsu/ray/python/ray/_private/worker.py", line 2245, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::_get_read_tasks() (pid=27887, ip=127.0.0.1)
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 1143, in _get_read_tasks
    reader.get_read_tasks(requested_parallelism),
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 442, in get_read_tasks
    np.array_split(paths, parallelism), np.array_split(file_sizes, parallelism)
  File "<__array_function__ internals>", line 180, in array_split
  File "/Users/chengsu/opt/anaconda3/envs/chengsu-dev/lib/python3.9/site-packages/numpy/lib/shape_base.py", line 778, in array_split
    raise ValueError('number sections must be larger than 0.') from None
ValueError: number sections must be larger than 0.
```

After this PR, the error message is:

```
>>> import ray
>>> ds = ray.data.read_csv("/Users/chengsu/try/image-2")
2022-08-01 17:12:35,667	INFO worker.py:1490 -- Started a local Ray instance.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 585, in read_csv
    return read_datasource(
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 268, in read_datasource
    requested_parallelism, min_safe_parallelism, read_tasks = ray.get(
  File "/Users/chengsu/ray/python/ray/_private/client_mode_hook.py", line 105, in wrapper
    return func(*args, **kwargs)
  File "/Users/chengsu/ray/python/ray/_private/worker.py", line 2245, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::_get_read_tasks() (pid=31935, ip=127.0.0.1)
  File "/Users/chengsu/ray/python/ray/data/read_api.py", line 1136, in _get_read_tasks
    reader = ds.create_reader(**kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 212, in create_reader
    return _FileBasedDatasourceReader(self, **kwargs)
  File "/Users/chengsu/ray/python/ray/data/datasource/file_based_datasource.py", line 359, in __init__
    raise ValueError(
ValueError: Not found any input file to read from. Please double check 'partition_filter' field is set properly.
```

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/26605

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
