### PR TITLE
[RLlib] Bump torch only in release tests

### DIFF
--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -15,6 +15,8 @@ post_build_cmds:
   - pip3 uninstall -y ray || true && pip3 install -U {{ env["RAY_WHEELS"] | default("ray") }}
   # TODO(jungong): remove once nightly image gets upgraded.
   - pip install -U pybullet==3.2.0
+  # TODO(artur): remove once torch is bumped everywhere
+  - pip install -U torch==1.12.0+cu102
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Clone the rl-experiments repo for offline-RL files.
   - git clone https://github.com/ray-project/rl-experiments.git

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -16,7 +16,7 @@ post_build_cmds:
   # TODO(jungong): remove once nightly image gets upgraded.
   - pip install -U pybullet==3.2.0
   # TODO(artur): remove once torch is bumped everywhere
-  - pip install -U torch==1.12.0+cu102
+  - pip install -U torch==1.12.0+cu102 -f https://download.pytorch.org/whl/torch_stable.html
   - {{ env["RAY_WHEELS_SANITY_CHECK"] | default("echo No Ray wheels sanity check") }}
   # Clone the rl-experiments repo for offline-RL files.
   - git clone https://github.com/ray-project/rl-experiments.git


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

After conducting a row of tests, it appears that using torch.nn.utils.clip_grad_norm_ takes up most of GPU time in some of our algorithms. This has been linked to CUDA versions != 10.2 on our CI.

## Related issue number

Might close https://github.com/ray-project/ray/issues/22557 and https://github.com/ray-project/ray/issues/26674.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
