### PR TITLE
[Datasets] [Docs] Improve `.limit()` and `.take()` docstrings

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1793,8 +1793,8 @@ class Dataset(Generic[T]):
     def take_all(self, limit: int = 100000) -> List[T]:
         """Return all the records in the dataset.
         
-        This will move up to ``limit`` records to the caller's machine; if
-        ``limit`` is very large, this can result in an OutOfMemory crash on
+        This will move the entire dataset to the caller's machine; if the
+        dataset is very large, this can result in an OutOfMemory crash on
         the caller.
 
         Time complexity: O(dataset size)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1744,7 +1744,12 @@ class Dataset(Generic[T]):
         return Dataset(plan, self._epoch, self._lazy)
 
     def limit(self, limit: int) -> "Dataset[T]":
-        """Limit the dataset to the first number of records specified.
+        """Truncate the dataset to the first number of records specified.
+        
+        Contrary to :meth`.take`, this will not move any data to the caller's
+        machine. Instead, it will send out tasks to truncate the distributed
+        data and return a new ``Dataset`` pointing to that truncated
+        distributed data.
 
         Examples:
             >>> import ray
@@ -1764,7 +1769,11 @@ class Dataset(Generic[T]):
         return left
 
     def take(self, limit: int = 20) -> List[T]:
-        """Take up to the given number of records from the dataset.
+        """Return up to the given number of records from the dataset.
+        
+        This will move up to ``limit`` records to the caller's machine; if
+        ``limit`` is very large, this can result in an OutOfMemory crash on
+        the caller.
 
         Time complexity: O(limit specified)
 
@@ -1782,7 +1791,11 @@ class Dataset(Generic[T]):
         return output
 
     def take_all(self, limit: int = 100000) -> List[T]:
-        """Take all the records in the dataset.
+        """Return all the records in the dataset.
+        
+        This will move up to ``limit`` records to the caller's machine; if
+        ``limit`` is very large, this can result in an OutOfMemory crash on
+        the caller.
 
         Time complexity: O(dataset size)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1744,11 +1744,10 @@ class Dataset(Generic[T]):
         return Dataset(plan, self._epoch, self._lazy)
 
     def limit(self, limit: int) -> "Dataset[T]":
-        """Truncate the dataset to the first number of records specified.
+        """Truncate the dataset to the first ``limit`` records.
         
         Contrary to :meth`.take`, this will not move any data to the caller's
-        machine. Instead, it will send out tasks to truncate the distributed
-        data and return a new ``Dataset`` pointing to that truncated
+        machine. Instead, it will return a new ``Dataset`` pointing to the truncated
         distributed data.
 
         Examples:
@@ -1769,7 +1768,7 @@ class Dataset(Generic[T]):
         return left
 
     def take(self, limit: int = 20) -> List[T]:
-        """Return up to the given number of records from the dataset.
+        """Return up to ``limit`` records from the dataset.
         
         This will move up to ``limit`` records to the caller's machine; if
         ``limit`` is very large, this can result in an OutOfMemory crash on
@@ -1791,7 +1790,7 @@ class Dataset(Generic[T]):
         return output
 
     def take_all(self, limit: int = 100000) -> List[T]:
-        """Return all the records in the dataset.
+        """Return all of the records in the dataset.
         
         This will move the entire dataset to the caller's machine; if the
         dataset is very large, this can result in an OutOfMemory crash on

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1745,7 +1745,7 @@ class Dataset(Generic[T]):
 
     def limit(self, limit: int) -> "Dataset[T]":
         """Truncate the dataset to the first ``limit`` records.
-        
+
         Contrary to :meth`.take`, this will not move any data to the caller's
         machine. Instead, it will return a new ``Dataset`` pointing to the truncated
         distributed data.
@@ -1769,7 +1769,7 @@ class Dataset(Generic[T]):
 
     def take(self, limit: int = 20) -> List[T]:
         """Return up to ``limit`` records from the dataset.
-        
+
         This will move up to ``limit`` records to the caller's machine; if
         ``limit`` is very large, this can result in an OutOfMemory crash on
         the caller.
@@ -1791,7 +1791,7 @@ class Dataset(Generic[T]):
 
     def take_all(self, limit: int = 100000) -> List[T]:
         """Return all of the records in the dataset.
-        
+
         This will move the entire dataset to the caller's machine; if the
         dataset is very large, this can result in an OutOfMemory crash on
         the caller.


### PR DESCRIPTION
Improve docstrings for `.limit()` and `.take()`, making the distinction more clear.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
