### PR TITLE
[dashboard] Add last_activity_at field to /api/component_activities

### DIFF
--- a/dashboard/modules/snapshot/component_activities_schema.json
+++ b/dashboard/modules/snapshot/component_activities_schema.json
@@ -15,6 +15,9 @@
         },
         "timestamp": {
           "type": ["number"]
+        },
+        "last_activity_at": {
+          "type": ["number", "null"]
         }
       },
       "required": ["is_active"]


### PR DESCRIPTION
Signed-off-by: Nikita Vemuri <nikitavemuri@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Commit in master: https://github.com/ray-project/ray/pull/27284

Hoping to add this to the 2.0.0 release so all planned changes to `component_activities` endpoint are included

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
