### PR TITLE
[docs] Adjust the set of global doc owners to those responsible for copy-editing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,8 @@
 
 # ==== Documentation ====
 
-/doc/ @maxpumperla @pcmoritz @richardliaw @edoakes @simon-mo @ericl
+# Authors responsible for copy-editing of the documentation.
+/doc/ @maxpumperla @pcmoritz @ericl @stephanie-wang @dmatrix @sriram-anyscale
 
 # ==== Ray core ====
 


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes the /doc OWNERS to those responsible for copy-editing for 2.0 (i.e., shepherding and editing doc PRs for quality).