### PR TITLE
[build] Add support for bazelisk : fall back to bazelisk if bazel is not found

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -329,6 +329,7 @@ def bazel_invoke(invoker, cmdline, *args, **kwargs):
             candidates.append(mingw_dir + "/bin/bazel.exe")
     else:
         candidates.append(os.path.join(home, ".bazel", "bin", "bazel"))
+        candidates.append(os.path.join("bazelisk"))
     result = None
     for i, cmd in enumerate(candidates):
         try:


### PR DESCRIPTION
Right now Ray won't build unless bazel is present. Per bazelisk guide (https://github.com/bazelbuild/bazelisk) 
users could either symlink bazelisk as bazel or use bazelisk directly. When someone is using bazelisk directly Ray won't build and will fail with the following error. This PR allows someone to use bazellisk directly, with no configuration needed, and make it smoother for someone who is just trying Ray the first time.


```

Installing collected packages: ray
  Running setup.py develop for ray
    Running command python setup.py develop
    running develop
    running egg_info
    writing ray.egg-info/PKG-INFO
    writing dependency_links to ray.egg-info/dependency_links.txt
    writing entry points to ray.egg-info/entry_points.txt
    writing requirements to ray.egg-info/requires.txt
    writing top-level names to ray.egg-info/top_level.txt
    reading manifest file 'ray.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    writing manifest file 'ray.egg-info/SOURCES.txt'
    running build_ext
    ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
    anyscale 0.5.36 requires ray>=1.4.0, which is not installed.
    awscli 1.25.6 requires botocore==1.27.6, but you have botocore 1.19.52 which is incompatible.
    awscli 1.25.6 requires colorama<0.4.5,>=0.2.5, but you have colorama 0.4.5 which is incompatible.
    awscli 1.25.6 requires s3transfer<0.7.0,>=0.6.0, but you have s3transfer 0.3.7 which is incompatible.
    WARNING: Target directory /home/ray/workspace-project-clng-raydeve/python/ray/thirdparty_files/colorama already exists. Specify --upgrade to force replacement.
    WARNING: Target directory /home/ray/workspace-project-clng-raydeve/python/ray/thirdparty_files/psutil already exists. Specify --upgrade to force replacement.
    WARNING: Target directory /home/ray/workspace-project-clng-raydeve/python/ray/thirdparty_files/colorama-0.4.5.dist-info already exists. Specify --upgrade to force replacement.
    WARNING: Target directory /home/ray/workspace-project-clng-raydeve/python/ray/thirdparty_files/setproctitle.cpython-38-x86_64-linux-gnu.so already exists. Specify --upgrade to force replacement.
    WARNING: Target directory /home/ray/workspace-project-clng-raydeve/python/ray/thirdparty_files/setproctitle-1.2.2.dist-info already exists. Specify --upgrade to force replacement.
    WARNING: Target directory /home/ray/workspace-project-clng-raydeve/python/ray/thirdparty_files/psutil-5.9.1.dist-info already exists. Specify --upgrade to force replacement.
    /home/ray/anaconda3/lib/python3.8/site-packages/setuptools/command/easy_install.py:144: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    /home/ray/anaconda3/lib/python3.8/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    error: [Errno 2] No such file or directory: '/home/ray/.bazel/bin/bazel'
    error: subprocess-exited-with-error
    
    × python setup.py develop did not run successfully.
    │ exit code: 1
    ╰─> See above for output.
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
    full command: /home/ray/anaconda3/bin/python -c '
    exec(compile('"'"''"'"''"'"'
    # This is <pip-setuptools-caller> -- a caller that pip uses to run setup.py
    #
    # - It imports setuptools before invoking setup.py, to enable projects that directly
    #   import from `distutils.core` to work with newer packaging standards.
    # - It provides a clear error message when setuptools is not installed.
    # - It sets `sys.argv[0]` to the underlying `setup.py`, when invoking `setup.py` so
    #   setuptools doesn'"'"'t think the script is `-c`. This avoids the following warning:
    #     manifest_maker: standard file '"'"'-c'"'"' not found".
    # - It generates a shim setup.py, for handling setup.cfg-only projects.
    import os, sys, tokenize
    
    try:
        import setuptools
    except ImportError as error:
        print(
            "ERROR: Can not execute `setup.py` since setuptools is not available in "
            "the build environment.",
            file=sys.stderr,
        )
        sys.exit(1)
    
    __file__ = %r
    sys.argv[0] = __file__
    
    if os.path.exists(__file__):
        filename = __file__
        with tokenize.open(__file__) as f:
            setup_py_code = f.read()
    else:
        filename = "<auto-generated setuptools caller>"
        setup_py_code = "from setuptools import setup; setup()"
    
    exec(compile(setup_py_code, filename, "exec"))
    '"'"''"'"''"'"' % ('"'"'/home/ray/workspace-project-clng-raydeve/python/setup.py'"'"',), "<pip-setuptools-caller>", "exec"))' develop --no-deps
    cwd: /home/ray/workspace-project-clng-raydeve/python/
error: subprocess-exited-with-error

× python setup.py develop did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

```
