### PR TITLE
[Workflow] Checkpoint off the critical path

### DIFF
--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -5,13 +5,17 @@ import json
 from ray import cloudpickle
 from enum import Enum, unique
 import hashlib
-from typing import Dict, Optional, Any, Tuple
+from typing import Dict, Optional, Any, Tuple, TYPE_CHECKING
 
 from dataclasses import dataclass
 
 import ray
 from ray import ObjectRef
 from ray.util.annotations import PublicAPI
+
+
+if TYPE_CHECKING:
+    from ray.actor import ActorHandle
 
 # Alias types
 Event = Any
@@ -194,11 +198,8 @@ class WorkflowTaskRuntimeOptions:
 class WorkflowExecutionMetadata:
     """Dataclass for the metadata of the workflow execution."""
 
-    # The ID of the node the workflow task executes on.
-    # This can be used for co-locating scheduling, for example, the checkpoint task
-    # could be scheduled to the same node as the task to be checkpointed, this enables
-    # efficient data transfer via shared memory.
-    node_id: str
+    # The object ref of the returned output
+    output_ref: Optional[ObjectRef] = None
     # True if the workflow task returns a workflow DAG.
     is_output_workflow: bool = False
     # True if the upstream checkpointing tasks failed.
@@ -210,3 +211,7 @@ class WorkflowExecutionMetadata:
 class WorkflowMetaData:
     # The current status of the workflow
     status: WorkflowStatus
+
+
+def get_management_actor() -> "ActorHandle":
+    return ray.get_actor(MANAGEMENT_ACTOR_NAME, namespace=MANAGEMENT_ACTOR_NAMESPACE)

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -131,6 +131,19 @@ class CheckpointMode(Enum):
     SKIP = False
 
 
+@unique
+class WorkflowTaskReturnCode(int, Enum):
+    """The return code of a workflow task."""
+
+    # The task succeeds and get checkpointed.
+    CHECKPOINTED = 0
+    # The task succeeds but skips the checkpoint.
+    NOT_CHECKPOINTED = 1
+    # The task exits before starting executing the task function. This could be
+    # because the checkpointing of the upstream tasks fail.
+    EXIT_BEFORE_EXECUTION = 3
+
+
 @ray.remote
 def _hash(obj: Any) -> bytes:
     m = hashlib.sha256()

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -195,6 +195,9 @@ class WorkflowExecutionMetadata:
     """Dataclass for the metadata of the workflow execution."""
 
     # The ID of the node the workflow task executes on.
+    # This can be used for co-locating scheduling, for example, the checkpoint task
+    # could be scheduled to the same node as the task to be checkpointed, this enables
+    # efficient data transfer via shared memory.
     node_id: str
     # True if the workflow task returns a workflow DAG.
     is_output_workflow: bool = False

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -194,8 +194,13 @@ class WorkflowTaskRuntimeOptions:
 class WorkflowExecutionMetadata:
     """Dataclass for the metadata of the workflow execution."""
 
+    # The ID of the node the workflow task executes on.
+    node_id: str
     # True if the workflow task returns a workflow DAG.
     is_output_workflow: bool = False
+    # True if the upstream checkpointing tasks failed.
+    # The workflow task exits before execution in this case.
+    upstream_checkpointing_failed: bool = False
 
 
 @dataclass

--- a/python/ray/workflow/task_executor.py
+++ b/python/ray/workflow/task_executor.py
@@ -107,6 +107,8 @@ def _workflow_task_executor(
         if CheckpointMode(runtime_options.checkpoint) == CheckpointMode.SYNC:
             if isinstance(output, WorkflowExecutionState):
                 store.save_workflow_execution_state(task_id, output)
+            # For normal workflow outputs, we checkpoint them with a checkpoint task
+            # created by workflow management actor.
         return execution_metadata, output
 
 

--- a/python/ray/workflow/workflow_executor.py
+++ b/python/ray/workflow/workflow_executor.py
@@ -37,9 +37,9 @@ class TaskType(enum.IntEnum):
 
 
 @ray.remote(num_cpus=0.1)
-def _checkpoint_task_output(workflow_id: str, task_id: TaskID, output):
+def _checkpoint_task_output(workflow_id: str, task_id: TaskID, output) -> int:
     store = WorkflowStorage(workflow_id)
-    store.save_task_output(task_id, output, exception=None)
+    return store.save_task_output(task_id, output, exception=None)
 
 
 class WorkflowExecutor:

--- a/python/ray/workflow/workflow_state.py
+++ b/python/ray/workflow/workflow_state.py
@@ -100,8 +100,6 @@ class WorkflowExecutionState:
     # the continuation lineage, so all other tasks in the continuation points
     # to the output of the last task instead of the output of themselves.
     output_map: Dict[TaskID, WorkflowRef] = field(default_factory=dict)
-    # The map from a task to its checkpointing task.
-    checkpoint_task_map: Dict[TaskID, ray.ObjectRef] = field(default_factory=dict)
     # The map from a task to its in-storage checkpoints. Normally it is the checkpoint
     # created by the underlying Ray task. For continuations, the semantics is similar
     # to 'output_map'.

--- a/python/ray/workflow/workflow_state.py
+++ b/python/ray/workflow/workflow_state.py
@@ -139,6 +139,8 @@ class WorkflowExecutionState:
     # The set of staged tasks. The dependencies (upstream inputs etc.) of these
     # tasks have been constructed and they are ready to be submitted later.
     # Once a task is submitted, it is moved out of this set.
+    # This field is checked and updated when reconstruct dependencies of failed
+    # tasks to eliminate concurrent issues like reconstructing a task multiple times.
     staged_tasks: Set[TaskID] = field(default_factory=set)
     # -------------------------------- external -------------------------------- #
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a critical performance optimization for Ray Workflow that distinguishes it from some other workflows.

This is not really async checkpointing, but checkpointing off the critical path, like this figure shows

<img width="691" alt="image" src="https://user-images.githubusercontent.com/13750372/182499405-048eff9e-3826-4ae8-a693-31ad11d28673.png">

It does not change the workflow behavior, so the existing unit tests should be enough.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
