### PR TITLE
[Serve] Fix Graph Repeated Invocation

### DIFF
--- a/python/ray/dag/format_utils.py
+++ b/python/ray/dag/format_utils.py
@@ -12,7 +12,7 @@ def get_dag_node_str(
         dag_node._bound_other_args_to_resolve
     )
     return (
-        f"({dag_node.__class__.__name__})(\n"
+        f"({dag_node.__class__.__name__}, {dag_node._stable_uuid})(\n"
         f"{indent}body={body_line}\n"
         f"{indent}args={_get_args_lines(dag_node._bound_args)}\n"
         f"{indent}kwargs={_get_kwargs_lines(dag_node._bound_kwargs)}\n"

--- a/python/ray/serve/_private/deployment_executor_node.py
+++ b/python/ray/serve/_private/deployment_executor_node.py
@@ -71,11 +71,14 @@ class DeploymentExecutorNode(DAGNode):
             "deployment_handle": self._deployment_handle,
             "args": self.get_args(),
             "kwargs": self.get_kwargs(),
+            "uuid": self.get_stable_uuid(),
         }
 
     @classmethod
     def from_json(cls, input_json):
         assert input_json[DAGNODE_TYPE_KEY] == DeploymentExecutorNode.__name__
-        return cls(
+        node = cls(
             input_json["deployment_handle"], input_json["args"], input_json["kwargs"]
         )
+        node._stable_uuid = input_json["uuid"]
+        return node

--- a/python/ray/serve/_private/deployment_function_executor_node.py
+++ b/python/ray/serve/_private/deployment_function_executor_node.py
@@ -66,13 +66,16 @@ class DeploymentFunctionExecutorNode(DAGNode):
             "deployment_function_handle": self._deployment_function_handle,
             "args": self.get_args(),
             "kwargs": self.get_kwargs(),
+            "uuid": self.get_stable_uuid(),
         }
 
     @classmethod
     def from_json(cls, input_json):
         assert input_json[DAGNODE_TYPE_KEY] == DeploymentFunctionExecutorNode.__name__
-        return cls(
+        node = cls(
             input_json["deployment_function_handle"],
             input_json["args"],
             input_json["kwargs"],
         )
+        node._stable_uuid = input_json["uuid"]
+        return node

--- a/python/ray/serve/_private/deployment_method_executor_node.py
+++ b/python/ray/serve/_private/deployment_method_executor_node.py
@@ -71,14 +71,17 @@ class DeploymentMethodExecutorNode(DAGNode):
             "args": self.get_args(),
             "kwargs": self.get_kwargs(),
             "other_args_to_resolve": self.get_other_args_to_resolve(),
+            "uuid": self.get_stable_uuid(),
         }
 
     @classmethod
     def from_json(cls, input_json):
         assert input_json[DAGNODE_TYPE_KEY] == DeploymentMethodExecutorNode.__name__
-        return cls(
+        node = cls(
             input_json["deployment_method_name"],
             input_json["args"],
             input_json["kwargs"],
             other_args_to_resolve=input_json["other_args_to_resolve"],
         )
+        node._stable_uuid = input_json["uuid"]
+        return node


### PR DESCRIPTION
This was a bug introduced by executor_node, in which, we missed the uuid when performing serde, causing duplicated nodes in the execution path.

This PR brings in the UUID for JSON serde and adds a regression test suite.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #27415
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
