### PR TITLE
[Serve] Enable lightweight config update (#27000)

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -352,6 +352,12 @@ def deployment(
             "autoscaling_config is provided."
         )
 
+    if version is not None:
+        logger.warning(
+            "DeprecationWarning: `version` in `@serve.deployment` has been deprecated. "
+            "Explicitly specifying version will raise an error in the future!"
+        )
+
     config = DeploymentConfig.from_default(
         ignore_none=True,
         num_replicas=num_replicas,

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -41,6 +41,7 @@ from ray.serve.schema import ServeApplicationSchema
 from ray.serve._private.storage.kv_store import RayInternalKVStore
 from ray.serve._private.utils import (
     override_runtime_envs_except_env_vars,
+    get_random_letters,
 )
 from ray.types import ObjectRef
 
@@ -290,7 +291,7 @@ class ServeController:
     def _recover_config_from_checkpoint(self):
         checkpoint = self.kv_store.get(CONFIG_CHECKPOINT_KEY)
         if checkpoint is not None:
-            self.deployment_timestamp, config = pickle.loads(checkpoint)
+            self.deployment_timestamp, config, _ = pickle.loads(checkpoint)
             self.deploy_app(ServeApplicationSchema.parse_obj(config), update_time=False)
 
     def _all_running_replicas(self) -> Dict[str, List[RunningReplicaInfo]]:
@@ -408,10 +409,25 @@ class ServeController:
             self.deployment_timestamp = time.time()
 
         config_dict = config.dict(exclude_unset=True)
+
+        # Compare new config options with old ones and set versions of new deployments
+        config_checkpoint = self.kv_store.get(CONFIG_CHECKPOINT_KEY)
+        if config_checkpoint is not None:
+            _, last_config_dict, last_version_dict = pickle.loads(config_checkpoint)
+            updated_version_dict = _generate_new_version_config(
+                config_dict, last_config_dict, last_version_dict
+            )
+        else:
+            updated_version_dict = _generate_new_version_config(config_dict, {}, {})
+
         self.kv_store.put(
             CONFIG_CHECKPOINT_KEY,
-            pickle.dumps((self.deployment_timestamp, config_dict)),
+            pickle.dumps(
+                (self.deployment_timestamp, config_dict, updated_version_dict)
+            ),
         )
+
+        deployment_override_options = config_dict.get("deployments", [])
 
         if self.config_deployment_request_ref is not None:
             ray.cancel(self.config_deployment_request_ref)
@@ -420,13 +436,14 @@ class ServeController:
                 "previous request."
             )
 
-        deployment_override_options = config.dict(
-            by_alias=True, exclude_unset=True
-        ).get("deployments", [])
-
         self.config_deployment_request_ref = run_graph.options(
             runtime_env=config.runtime_env
-        ).remote(config.import_path, config.runtime_env, deployment_override_options)
+        ).remote(
+            config.import_path,
+            config.runtime_env,
+            deployment_override_options,
+            updated_version_dict,
+        )
 
     def delete_deployment(self, name: str):
         self.endpoint_state.delete_endpoint(name)
@@ -551,15 +568,100 @@ class ServeController:
         if checkpoint is None:
             return ServeApplicationSchema.get_empty_schema_dict()
         else:
-            _, config = pickle.loads(checkpoint)
+            _, config, _ = pickle.loads(checkpoint)
             return config
+
+
+def _generate_new_version_config(
+    new_config: Dict, last_deployed_config: Dict, last_deployed_versions: Dict
+) -> Dict[str, str]:
+    """
+    This function determines whether each deployment's version
+    should be changed based on the updated options.
+
+    When a deployment's options change, its version should generally change,
+    so old replicas are torn down. The only options which can be changed
+    without tearing down replicas (i.e. changing the version) are:
+    * num_replicas
+    * user_config
+    * autoscaling_config
+
+    An option is considered changed when:
+    * it was not specified in last_deployed_config and is specified in new_config
+    * it was specified in last_deployed_config and is not specified in new_config
+    * it is specified in both last_deployed_config and new_config but the specified
+      value has changed
+
+    Args:
+        new_config: Newly deployed config dict that follows ServeApplicationSchema
+        last_deployed_config: Last deployed config dict that follows
+            ServeApplicationSchema, which is an empty dictionary if there is no previous
+            deployment
+        last_deployed_versions: Dictionary of {deployment_name: str -> version: str}
+            tracking the versions of deployments listed in the last deployed config
+
+    Returns:
+        Dictionary of {deployment_name: str -> version: str} containing updated
+        versions for deployments listed in the new config
+    """
+
+    new_deployments = {d["name"]: d for d in new_config.get("deployments", [])}
+    old_deployments = {
+        d["name"]: d for d in last_deployed_config.get("deployments", [])
+    }
+
+    def exclude_lightweight_update_options(dict):
+        # Exclude config options from dict that qualify for a lightweight config
+        # update. Changes in any other config options are considered a code change,
+        # and require a version change to trigger an update that tears
+        # down existing replicas and replaces them with updated ones.
+        lightweight_update_options = [
+            "num_replicas",
+            "user_config",
+            "autoscaling_config",
+        ]
+        return {
+            option: dict[option]
+            for option in dict
+            if option not in lightweight_update_options
+        }
+
+    updated_versions = {}
+    for name in new_deployments:
+        new_deployment = exclude_lightweight_update_options(new_deployments[name])
+        old_deployment = exclude_lightweight_update_options(
+            old_deployments.get(name, {})
+        )
+
+        # If config options haven't changed, version stays the same
+        # otherwise, generate a new random version
+        if old_deployment == new_deployment:
+            updated_versions[name] = last_deployed_versions[name]
+        else:
+            updated_versions[name] = get_random_letters()
+
+    return updated_versions
 
 
 @ray.remote(num_cpus=0, max_calls=1)
 def run_graph(
-    import_path: str, graph_env: dict, deployment_override_options: List[Dict]
+    import_path: str,
+    graph_env: Dict,
+    deployment_override_options: List[Dict],
+    deployment_versions: Dict,
 ):
-    """Deploys a Serve application to the controller's Ray cluster."""
+    """
+    Deploys a Serve application to the controller's Ray cluster.
+
+    Args:
+        import_path: Serve deployment graph's import path
+        graph_env: runtime env to run the deployment graph in
+        deployment_override_options: Dictionary of options that overrides
+            deployment options set in the graph's code itself.
+        deployment_versions: Versions of each deployment, each of which is
+            the same as the last deployment if it is a config update or
+            a new randomly generated version if it is a code update
+    """
     try:
         from ray import serve
         from ray.serve.api import build
@@ -589,8 +691,10 @@ def run_graph(
             ray_actor_options.update({"runtime_env": merged_env})
             options["ray_actor_options"] = ray_actor_options
 
+            options["version"] = deployment_versions[name]
+
             # Update the deployment's options
-            app.deployments[name].set_options(**options)
+            app.deployments[name].set_options(**options, _internal=True)
 
         # Run the graph locally on the cluster
         serve.run(app)

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -316,6 +316,7 @@ class Deployment:
         graceful_shutdown_timeout_s: Optional[float] = None,
         health_check_period_s: Optional[float] = None,
         health_check_timeout_s: Optional[float] = None,
+        _internal: bool = False,
     ) -> "Deployment":
         """Return a copy of this deployment with updated options.
 
@@ -332,6 +333,13 @@ class Deployment:
 
         if num_replicas == 0:
             raise ValueError("num_replicas is expected to larger than 0")
+
+        if not _internal and version is not None:
+            logger.warning(
+                "DeprecationWarning: `version` in `Deployment.options()` has been "
+                "deprecated. Explicitly specifying version will raise an error in the "
+                "future!"
+            )
 
         if num_replicas is not None:
             new_config.num_replicas = num_replicas
@@ -407,6 +415,7 @@ class Deployment:
         graceful_shutdown_timeout_s: Optional[float] = None,
         health_check_period_s: Optional[float] = None,
         health_check_timeout_s: Optional[float] = None,
+        _internal: bool = False,
     ) -> None:
         """Overwrite this deployment's options. Mutates the deployment.
 
@@ -430,6 +439,7 @@ class Deployment:
             graceful_shutdown_timeout_s=graceful_shutdown_timeout_s,
             health_check_period_s=health_check_period_s,
             health_check_timeout_s=health_check_timeout_s,
+            _internal=_internal,
         )
 
         self._func_or_class = validated._func_or_class

--- a/python/ray/serve/tests/test_config_files/pid.py
+++ b/python/ray/serve/tests/test_config_files/pid.py
@@ -1,0 +1,17 @@
+from ray import serve
+import os
+
+
+@serve.deployment
+class f:
+    def __init__(self, name: str = "default_name"):
+        self.name = name
+
+    def reconfigure(self, config: dict):
+        self.name = config.get("name", "default_name")
+
+    async def __call__(self):
+        return os.getpid()
+
+
+node = f.bind()

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -1,11 +1,13 @@
 import pytest
 import time
+import copy
 
 import ray
 
 from ray import serve
 from ray.serve._private.common import DeploymentInfo
 from ray.serve.generated.serve_pb2 import DeploymentRoute
+from ray.serve.controller import _generate_new_version_config
 
 
 def test_redeploy_start_time(serve_instance):
@@ -38,6 +40,58 @@ def test_redeploy_start_time(serve_instance):
     start_time_ms_2 = deployment_info_2.start_time_ms
 
     assert start_time_ms_1 == start_time_ms_2
+
+
+@pytest.mark.parametrize("last_config_had_option", [True, False])
+@pytest.mark.parametrize(
+    "option_to_update,config_update",
+    [
+        ("num_replicas", True),
+        ("autoscaling_config", True),
+        ("user_config", True),
+        ("ray_actor_options", False),
+    ],
+)
+def test_generate_new_version_config(
+    last_config_had_option: bool, option_to_update: str, config_update: bool
+):
+    """Check that controller._generate_new_version_config() has correct behavior."""
+
+    options = {
+        "num_replicas": {"old": 1, "new": 2},
+        "autoscaling_config": {
+            "old": None,
+            "new": {"max_replicas": 2},
+        },
+        "user_config": {
+            "old": None,
+            "new": {"name": "bob"},
+        },
+        "ray_actor_options": {
+            "old": {"num_cpus": 0.1},
+            "new": {"num_cpus": 0.2},
+        },
+    }
+
+    old_config = {
+        "import_path": "ray.serve.tests.test_config_files.pid.node",
+        "deployments": [{"name": "f"}],
+    }
+
+    if last_config_had_option:
+        old_config["deployments"][0][option_to_update] = options[option_to_update][
+            "old"
+        ]
+
+    new_config = copy.deepcopy(old_config)
+    new_config["deployments"][0][option_to_update] = options[option_to_update]["new"]
+
+    versions = {"f": "v1"}
+    new_versions = _generate_new_version_config(new_config, old_config, versions)
+    assert (
+        new_versions.get("f") is not None
+        and (new_versions.get("f") == versions.get("f")) == config_update
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -17,7 +17,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.cluster_utils import AutoscalingCluster
 from ray.exceptions import RayActorError
 from ray.serve._private.client import ServeControllerClient
-from ray.serve._private.common import ApplicationStatus
+from ray.serve._private.common import ApplicationStatus, DeploymentStatus
 from ray.serve._private.constants import SERVE_NAMESPACE
 from ray.serve.context import get_global_client
 from ray.serve.schema import ServeApplicationSchema
@@ -561,6 +561,69 @@ class TestDeployApp:
 
         # Ensure config checkpoint has been deleted
         assert client.get_serve_status().app_status.deployment_timestamp == 0
+
+    @pytest.mark.parametrize(
+        "option_to_update,config_update",
+        [
+            ("num_replicas", True),
+            ("autoscaling_config", True),
+            ("user_config", True),
+            ("ray_actor_options", False),
+        ],
+    )
+    def test_deploy_config_update(
+        self, client: ServeControllerClient, option_to_update: str, config_update: bool
+    ):
+        """
+        Check that replicas stay alive when lightweight config updates are made and
+        replicas are torn down when code updates are made.
+        """
+
+        def deployment_running():
+            serve_status = client.get_serve_status()
+            return (
+                serve_status.get_deployment_status("f") is not None
+                and serve_status.app_status.status == ApplicationStatus.RUNNING
+                and serve_status.get_deployment_status("f").status
+                == DeploymentStatus.HEALTHY
+            )
+
+        config_template = {
+            "import_path": "ray.serve.tests.test_config_files.pid.node",
+            "deployments": [
+                {
+                    "name": "f",
+                    "autoscaling_config": None,
+                    "user_config": None,
+                    "ray_actor_options": {"num_cpus": 0.1},
+                },
+            ],
+        }
+
+        client.deploy_app(ServeApplicationSchema.parse_obj(config_template))
+        wait_for_condition(deployment_running, timeout=15)
+        pid1 = requests.get("http://localhost:8000/f").text
+
+        updated_options = {
+            "num_replicas": 2,
+            "autoscaling_config": {"max_replicas": 2},
+            "user_config": {"name": "bob"},
+            "ray_actor_options": {"num_cpus": 0.2},
+        }
+        config_template["deployments"][0][option_to_update] = updated_options[
+            option_to_update
+        ]
+
+        client.deploy_app(ServeApplicationSchema.parse_obj(config_template))
+        wait_for_condition(deployment_running, timeout=15)
+
+        # This assumes that Serve implements round-robin routing for its replicas. As
+        # long as that doesn't change, this test shouldn't be flaky; however if that
+        # routing ever changes, this test could become mysteriously flaky
+        pids = []
+        for _ in range(4):
+            pids.append(requests.get("http://localhost:8000/f").text)
+        assert (pid1 in pids) == config_update
 
 
 def test_controller_recover_and_delete(shutdown_ray):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, if user deploys via config using `serve deploy config_file`, a random version for each deployment will be generated each time, meaning existing replicas will be torn down and new replicas will be brought up regardless of the contents of the deployed `config_file`.

We enable lightweight config updates which don't require tearing down existing replicas. For each deployment, if any field other than `num_replicas`, `autoscaling_config`, and `user_config` have changed, bump the version, and redeploy. This will be considered a code change and will trigger tear-down. Otherwise, keep the version the same and redeploy. This will be a config change.

Design Notes:
Only the versions of deployments listed in the config file will be tracked. This means that if a deployment exists in the deployment graph that is imported through `import_path`, but not listed under `deployments` in the config file, then redeployment will tear down existing replicas each time.

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
