### PR TITLE
[Serve] [Docs] Use dashboard agent port 52365 in REST API documentation

### DIFF
--- a/doc/source/serve/package-ref.md
+++ b/doc/source/serve/package-ref.md
@@ -63,7 +63,7 @@ Gets latest config that Serve has received. This config represents the current g
 
 ```
 GET /api/serve/deployments/ HTTP 1.1
-Host: http://localhost:8265/
+Host: http://localhost:52365/
 Accept: application/json
 ```
 
@@ -94,7 +94,7 @@ Declaratively deploys the Serve application. Starts Serve on the Ray cluster if 
 
 ```
 PUT /api/serve/deployments/ HTTP 1.1
-Host: http://localhost:8265/
+Host: http://localhost:52365/
 Accept: application/json
 
 {
@@ -126,7 +126,7 @@ Gets the Serve application's current status, including all the deployment status
 
 ```
 GET /api/serve/deployments/ HTTP 1.1
-Host: http://localhost:8265/
+Host: http://localhost:52365/
 Accept: application/json
 ```
 
@@ -181,7 +181,7 @@ effect if Serve is not running on the Ray cluster.
 
 ```
 DELETE /api/serve/deployments/ HTTP 1.1
-Host: http://localhost:8265/
+Host: http://localhost:52365/
 Accept: application/json
 ```
 


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#26336 moved Serve REST API handling to the dashboard agent. This changed the default Serve REST API port from 8265 to 52365.

This change updates the REST API documentation to use port 52365 in its examples.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
