### PR TITLE
Make it so pydantic is required before we launch dashboard api server

### DIFF
--- a/dashboard/optional_deps.py
+++ b/dashboard/optional_deps.py
@@ -1,3 +1,8 @@
+# These imports determine whether or not a user has the required dependencies
+# to launch the optional dashboard API server.
+# If any of these imports fail, the dashboard API server will not be launched.
+# Please add important dashboard-api dependencies to this list.
+
 # These checks have to come first because aiohttp looks
 # for opencensus, too, and raises a different error otherwise.
 import opencensus  # noqa: F401
@@ -10,3 +15,4 @@ import aiohttp_cors  # noqa: F401
 from aiohttp import hdrs  # noqa: F401
 from aiohttp.typedefs import PathLike  # noqa: F401
 from aiohttp.web import RouteDef  # noqa: F401
+import pydantic  # noqa: F401

--- a/python/setup.py
+++ b/python/setup.py
@@ -211,6 +211,8 @@ if setup_spec.type == SetupType.RAY:
             "fsspec",
         ],
         "default": [
+            # If adding dependencies necessary to launch the dashboard api server,
+            # please add it to dashboard/optional_deps.py as well.
             "aiohttp >= 3.7",
             "aiohttp_cors",
             "colorful",


### PR DESCRIPTION
Cherry-pick #27345

* Make it so pydantic is required before we launch dashboard api server

Signed-off-by: Alan Guo <aguo@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
