### PR TITLE
[dashboard] Add last_activity_at field to /api/component_activities

### DIFF
--- a/dashboard/modules/snapshot/component_activities_schema.json
+++ b/dashboard/modules/snapshot/component_activities_schema.json
@@ -15,6 +15,9 @@
         },
         "timestamp": {
           "type": ["number"]
+        },
+        "last_activity_at": {
+          "type": ["number", "null"]
         }
       },
       "required": ["is_active"]

--- a/dashboard/modules/snapshot/tests/test_snapshot.py
+++ b/dashboard/modules/snapshot/tests/test_snapshot.py
@@ -126,6 +126,9 @@ import ray
 ray.init(address="auto", namespace="{namespace}")
     """
     run_string_as_driver_nonblocking(driver_template.format(namespace="my_namespace"))
+    # Wait for above driver to start and finish
+    time.sleep(2)
+
     run_string_as_driver_nonblocking(driver_template.format(namespace="my_namespace"))
     run_string_as_driver_nonblocking(
         driver_template.format(namespace="_ray_internal_job_info_id1")
@@ -135,7 +138,7 @@ ray.init(address="auto", namespace="{namespace}")
         driver_template.format(namespace="_ray_internal_dashboard")
     )
 
-    # Wait 1 sec for drivers to start
+    # Wait 1.5 sec for drivers to start (but not finish)
     time.sleep(1.5)
 
     # Verify drivers are considered active after running script
@@ -158,10 +161,22 @@ ray.init(address="auto", namespace="{namespace}")
 
     assert driver_ray_activity_response.is_active == "ACTIVE"
     # Drivers with namespace starting with "_ray_internal" are not
-    # considered active drivers. Three active drivers are the two
+    # considered active drivers. Two active drivers are the second one
     # run with namespace "my_namespace" and the one started
     # from ray_start_with_dashboard
-    assert driver_ray_activity_response.reason == "Number of active drivers: 3"
+    assert driver_ray_activity_response.reason == "Number of active drivers: 2"
+
+    # Get expected_last_activity at from snapshot endpoint which returns details
+    # about all jobs
+    jobs_snapshot_data = requests.get(f"{webui_url}/api/snapshot").json()["data"][
+        "snapshot"
+    ]["jobs"]
+    # Divide endTime by 1000 to convert from milliseconds to seconds
+    expected_last_activity_at = max(
+        [job.get("endTime", 0) / 1000 for (job_id, job) in jobs_snapshot_data.items()]
+    )
+
+    assert driver_ray_activity_response.last_activity_at == expected_last_activity_at
 
 
 def test_snapshot(ray_start_with_dashboard):


### PR DESCRIPTION
Signed-off-by: Nikita Vemuri <nikitavemuri@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re-opening https://github.com/ray-project/ray/pull/27382 against `releases/2.0.0`

Commit in master: https://github.com/ray-project/ray/pull/27284

Hoping to add this to the 2.0.0 release so all planned changes to `component_activities` endpoint are included

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
