### PR TITLE
[Serve] Gate the deprecation warnings behind envvar

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -100,3 +100,9 @@ RAY_SERVE_KV_TIMEOUT_S = float(os.environ.get("RAY_SERVE_KV_TIMEOUT_S", "0")) or
 class ServeHandleType(str, Enum):
     SYNC = "SYNC"
     ASYNC = "ASYNC"
+
+
+# Deprecation message for V1 migrations.
+MIGRATION_MESSAGE = (
+    "See https://docs.ray.io/en/latest/serve/index.html for more information."
+)

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -428,3 +428,17 @@ def in_interactive_shell():
     import __main__ as main
 
     return not hasattr(main, "__file__")
+
+
+def deprecated(*args, **kwargs):
+    """Wrapper for deprecation warnings, guarded by a flag."""
+    if os.environ.get("SERVE_WARN_V1_DEPRECATIONS", "0") == "1":
+        from ray._private.utils import deprecated
+
+        return deprecated(*args, **kwargs)
+    else:
+
+        def noop_decorator(func):
+            return func
+
+        return noop_decorator

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -430,7 +430,7 @@ def in_interactive_shell():
     return not hasattr(main, "__file__")
 
 
-def deprecated(*args, **kwargs):
+def guarded_deprecation_warning(*args, **kwargs):
     """Wrapper for deprecation warnings, guarded by a flag."""
     if os.environ.get("SERVE_WARN_V1_DEPRECATIONS", "0") == "1":
         from ray._private.utils import deprecated

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -42,7 +42,7 @@ from ray.serve._private.utils import (
     ensure_serialization_context,
     in_interactive_shell,
     install_serve_encoders_to_fastapi,
-    deprecated,
+    guarded_deprecation_warning,
 )
 
 from ray.serve._private import api as _private_api
@@ -50,7 +50,7 @@ from ray.serve._private import api as _private_api
 logger = logging.getLogger(__file__)
 
 
-@deprecated(instructions=MIGRATION_MESSAGE)
+@guarded_deprecation_warning(instructions=MIGRATION_MESSAGE)
 @Deprecated(message=MIGRATION_MESSAGE)
 def start(
     detached: bool = False,
@@ -383,7 +383,7 @@ def deployment(
     return decorator(_func_or_class) if callable(_func_or_class) else decorator
 
 
-@deprecated(instructions=MIGRATION_MESSAGE)
+@guarded_deprecation_warning(instructions=MIGRATION_MESSAGE)
 @Deprecated(message=MIGRATION_MESSAGE)
 def get_deployment(name: str) -> Deployment:
     """Dynamically fetch a handle to a Deployment object.
@@ -407,7 +407,7 @@ def get_deployment(name: str) -> Deployment:
     return _private_api.get_deployment(name)
 
 
-@deprecated(instructions=MIGRATION_MESSAGE)
+@guarded_deprecation_warning(instructions=MIGRATION_MESSAGE)
 @Deprecated(message=MIGRATION_MESSAGE)
 def list_deployments() -> Dict[str, Deployment]:
     """Returns a dictionary of all active deployments.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -11,8 +11,7 @@ from uvicorn.lifespan.on import LifespanOn
 
 from ray import cloudpickle
 from ray.dag import DAGNode
-from ray.util.annotations import DeveloperAPI, PublicAPI
-from ray._private.utils import deprecated
+from ray.util.annotations import Deprecated, PublicAPI
 
 from ray.serve.application import Application
 from ray.serve._private.client import ServeControllerClient
@@ -20,6 +19,7 @@ from ray.serve.config import AutoscalingConfig, DeploymentConfig, HTTPOptions
 from ray.serve._private.constants import (
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
+    MIGRATION_MESSAGE,
 )
 from ray.serve.context import (
     ReplicaContext,
@@ -42,6 +42,7 @@ from ray.serve._private.utils import (
     ensure_serialization_context,
     in_interactive_shell,
     install_serve_encoders_to_fastapi,
+    deprecated,
 )
 
 from ray.serve._private import api as _private_api
@@ -49,8 +50,8 @@ from ray.serve._private import api as _private_api
 logger = logging.getLogger(__file__)
 
 
-@deprecated(instructions="Please see https://docs.ray.io/en/latest/serve/index.html")
-@PublicAPI(stability="beta")
+@deprecated(instructions=MIGRATION_MESSAGE)
+@Deprecated(message=MIGRATION_MESSAGE)
 def start(
     detached: bool = False,
     http_options: Optional[Union[dict, HTTPOptions]] = None,
@@ -103,7 +104,7 @@ def start(
     return client
 
 
-@PublicAPI
+@PublicAPI(stability="stable")
 def shutdown() -> None:
     """Completely shut down the connected Serve instance.
 
@@ -124,7 +125,7 @@ def shutdown() -> None:
     _set_global_client(None)
 
 
-@PublicAPI
+@PublicAPI(stability="beta")
 def get_replica_context() -> ReplicaContext:
     """If called from a deployment, returns the deployment and replica tag.
 
@@ -270,7 +271,7 @@ def deployment(
     pass
 
 
-@PublicAPI
+@PublicAPI(stability="beta")
 def deployment(
     _func_or_class: Optional[Callable] = None,
     name: Optional[str] = None,
@@ -382,8 +383,8 @@ def deployment(
     return decorator(_func_or_class) if callable(_func_or_class) else decorator
 
 
-@deprecated(instructions="Please see https://docs.ray.io/en/latest/serve/index.html")
-@PublicAPI
+@deprecated(instructions=MIGRATION_MESSAGE)
+@Deprecated(message=MIGRATION_MESSAGE)
 def get_deployment(name: str) -> Deployment:
     """Dynamically fetch a handle to a Deployment object.
 
@@ -406,8 +407,8 @@ def get_deployment(name: str) -> Deployment:
     return _private_api.get_deployment(name)
 
 
-@deprecated(instructions="Please see https://docs.ray.io/en/latest/serve/index.html")
-@PublicAPI
+@deprecated(instructions=MIGRATION_MESSAGE)
+@Deprecated(message=MIGRATION_MESSAGE)
 def list_deployments() -> Dict[str, Deployment]:
     """Returns a dictionary of all active deployments.
 
@@ -503,7 +504,7 @@ def run(
         return ingress._get_handle()
 
 
-@DeveloperAPI
+@PublicAPI(stability="alpha")
 def build(target: Union[ClassNode, FunctionNode]) -> Application:
     """Builds a Serve application into a static application.
 

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -20,7 +20,7 @@ from ray.serve.config import (
 )
 from ray.serve._private.constants import SERVE_LOGGER_NAME, MIGRATION_MESSAGE
 from ray.serve.handle import RayServeHandle, RayServeSyncHandle
-from ray.serve._private.utils import DEFAULT, deprecated
+from ray.serve._private.utils import DEFAULT, guarded_deprecation_warning
 from ray.util.annotations import Deprecated, PublicAPI
 from ray.serve.schema import (
     RayActorOptionsSchema,
@@ -200,7 +200,7 @@ class Deployment:
                 },
             )
 
-    @deprecated(instructions=MIGRATION_MESSAGE)
+    @guarded_deprecation_warning(instructions=MIGRATION_MESSAGE)
     @Deprecated(message=MIGRATION_MESSAGE)
     def deploy(self, *init_args, _blocking=True, **init_kwargs):
         """Deploy or update this deployment.
@@ -242,7 +242,7 @@ class Deployment:
             _blocking=_blocking,
         )
 
-    @deprecated(instructions=MIGRATION_MESSAGE)
+    @guarded_deprecation_warning(instructions=MIGRATION_MESSAGE)
     @Deprecated(message=MIGRATION_MESSAGE)
     def delete(self):
         """Delete this deployment."""
@@ -255,7 +255,7 @@ class Deployment:
 
         return get_global_client().delete_deployments([self._name])
 
-    @deprecated(instructions=MIGRATION_MESSAGE)
+    @guarded_deprecation_warning(instructions=MIGRATION_MESSAGE)
     @Deprecated(message=MIGRATION_MESSAGE)
     def get_handle(
         self, sync: Optional[bool] = True

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -18,15 +18,14 @@ from ray.serve.config import (
     AutoscalingConfig,
     DeploymentConfig,
 )
-from ray.serve._private.constants import SERVE_LOGGER_NAME
+from ray.serve._private.constants import SERVE_LOGGER_NAME, MIGRATION_MESSAGE
 from ray.serve.handle import RayServeHandle, RayServeSyncHandle
-from ray.serve._private.utils import DEFAULT
-from ray.util.annotations import PublicAPI
+from ray.serve._private.utils import DEFAULT, deprecated
+from ray.util.annotations import Deprecated, PublicAPI
 from ray.serve.schema import (
     RayActorOptionsSchema,
     DeploymentSchema,
 )
-from ray._private.utils import deprecated
 
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -201,10 +200,8 @@ class Deployment:
                 },
             )
 
-    @deprecated(
-        instructions="Please see https://docs.ray.io/en/latest/serve/index.html"
-    )
-    @PublicAPI
+    @deprecated(instructions=MIGRATION_MESSAGE)
+    @Deprecated(message=MIGRATION_MESSAGE)
     def deploy(self, *init_args, _blocking=True, **init_kwargs):
         """Deploy or update this deployment.
 
@@ -245,10 +242,8 @@ class Deployment:
             _blocking=_blocking,
         )
 
-    @deprecated(
-        instructions="Please see https://docs.ray.io/en/latest/serve/index.html"
-    )
-    @PublicAPI
+    @deprecated(instructions=MIGRATION_MESSAGE)
+    @Deprecated(message=MIGRATION_MESSAGE)
     def delete(self):
         """Delete this deployment."""
 
@@ -260,10 +255,8 @@ class Deployment:
 
         return get_global_client().delete_deployments([self._name])
 
-    @deprecated(
-        instructions="Please see https://docs.ray.io/en/latest/serve/index.html"
-    )
-    @PublicAPI
+    @deprecated(instructions=MIGRATION_MESSAGE)
+    @Deprecated(message=MIGRATION_MESSAGE)
     def get_handle(
         self, sync: Optional[bool] = True
     ) -> Union[RayServeHandle, RayServeSyncHandle]:


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR makes the deprecation warnings optional when user are using the API. Deprecation will still show up in the docstring regardless; but the warnings will be disabled by default.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually tested
