### PR TITLE
[serve] Update version if import_path or runtime_env in config is changed

### DIFF
--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -414,6 +414,7 @@ class ServeController:
         config_checkpoint = self.kv_store.get(CONFIG_CHECKPOINT_KEY)
         if config_checkpoint is not None:
             _, last_config_dict, last_version_dict = pickle.loads(config_checkpoint)
+            # If import_path or runtime_env is changed, it is considered a code change
             if last_config_dict.get("import_path") == config_dict.get(
                 "import_path"
             ) and last_config_dict.get("runtime_env") == config_dict.get("runtime_env"):

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -414,9 +414,14 @@ class ServeController:
         config_checkpoint = self.kv_store.get(CONFIG_CHECKPOINT_KEY)
         if config_checkpoint is not None:
             _, last_config_dict, last_version_dict = pickle.loads(config_checkpoint)
-            updated_version_dict = _generate_new_version_config(
-                config_dict, last_config_dict, last_version_dict
-            )
+            if last_config_dict.get("import_path") == config_dict.get(
+                "import_path"
+            ) and last_config_dict.get("runtime_env") == config_dict.get("runtime_env"):
+                updated_version_dict = _generate_new_version_config(
+                    config_dict, last_config_dict, last_version_dict
+                )
+            else:
+                updated_version_dict = _generate_new_version_config(config_dict, {}, {})
         else:
             updated_version_dict = _generate_new_version_config(config_dict, {}, {})
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -574,16 +574,18 @@ class ServeController:
 
 
 def _generate_deployment_config_versions(
-    new_config: Dict, last_deployed_config: Dict = {}, last_deployed_versions: Dict = {}
+    new_config: Dict,
+    last_deployed_config: Dict = None,
+    last_deployed_versions: Dict = None,
 ) -> Dict[str, str]:
     """
     This function determines whether each deployment's version should be changed based
     on the newly deployed config.
-                                                                                        
+
     When ``import_path`` or ``runtime_env`` is changed, the versions for all deployments
     should be changed, so old replicas are torn down. When the options for a deployment
     in ``deployments`` change, its version should generally change. The only deployment
-    options that can be changed without tearing down replicas (i.e. changing the 
+    options that can be changed without tearing down replicas (i.e. changing the
     version) are:
     * num_replicas
     * user_config
@@ -608,6 +610,11 @@ def _generate_deployment_config_versions(
         versions for deployments listed in the new config
     """
     # If import_path or runtime_env is changed, it is considered a code change
+    if last_deployed_config is None:
+        last_deployed_config = {}
+    if last_deployed_versions is None:
+        last_deployed_versions = {}
+
     if last_deployed_config.get("import_path") != new_config.get(
         "import_path"
     ) or last_deployed_config.get("runtime_env") != new_config.get("runtime_env"):

--- a/python/ray/serve/tests/test_config_files/pid.py
+++ b/python/ray/serve/tests/test_config_files/pid.py
@@ -1,4 +1,5 @@
 from ray import serve
+from ray.serve.deployment_graph import RayServeDAGHandle
 import os
 
 
@@ -14,4 +15,14 @@ class f:
         return os.getpid()
 
 
+@serve.deployment
+class BasicDriver:
+    def __init__(self, dag: RayServeDAGHandle):
+        self.dag = dag
+
+    async def __call__(self):
+        return await self.dag.remote()
+
+
 node = f.bind()
+bnode = BasicDriver.bind(node)

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -7,7 +7,7 @@ import ray
 from ray import serve
 from ray.serve._private.common import DeploymentInfo
 from ray.serve.generated.serve_pb2 import DeploymentRoute
-from ray.serve.controller import _generate_new_version_config
+from ray.serve.controller import _generate_deployment_config_versions
 
 
 def test_redeploy_start_time(serve_instance):
@@ -52,10 +52,10 @@ def test_redeploy_start_time(serve_instance):
         ("ray_actor_options", False),
     ],
 )
-def test_generate_new_version_config(
+def test_generate_deployment_config_versions(
     last_config_had_option: bool, option_to_update: str, config_update: bool
 ):
-    """Check that controller._generate_new_version_config() has correct behavior."""
+    """Check that controller._generate_deployment_config_versions() has correct behavior."""
 
     options = {
         "num_replicas": {"old": 1, "new": 2},
@@ -87,7 +87,7 @@ def test_generate_new_version_config(
     new_config["deployments"][0][option_to_update] = options[option_to_update]["new"]
 
     versions = {"f": "v1"}
-    new_versions = _generate_new_version_config(new_config, old_config, versions)
+    new_versions = _generate_deployment_config_versions(new_config, old_config, versions)
     assert (
         new_versions.get("f") is not None
         and (new_versions.get("f") == versions.get("f")) == config_update

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -615,12 +615,7 @@ class TestDeployApp:
                 "import_path"
             ] = "ray.serve.tests.test_config_files.pid.bnode"
         elif field_to_update == "runtime_env":
-            config_template["runtime_env"] = {
-                "working_dir": (
-                    "https://github.com/ray-project/test_dag/archive/"
-                    "76a741f6de31df78411b1f302071cde46f098418.zip"
-                )
-            }
+            config_template["runtime_env"] = {"env_vars": {"test_var": "test_val"}}
         elif field_to_update == "deployments":
             updated_options = {
                 "num_replicas": 2,

--- a/python/ray/serve/tests/test_standalone2.py
+++ b/python/ray/serve/tests/test_standalone2.py
@@ -563,16 +563,22 @@ class TestDeployApp:
         assert client.get_serve_status().app_status.deployment_timestamp == 0
 
     @pytest.mark.parametrize(
-        "option_to_update,config_update",
+        "field_to_update,option_to_update,config_update",
         [
-            ("num_replicas", True),
-            ("autoscaling_config", True),
-            ("user_config", True),
-            ("ray_actor_options", False),
+            ("import_path", "", False),
+            ("runtime_env", "", False),
+            ("deployments", "num_replicas", True),
+            ("deployments", "autoscaling_config", True),
+            ("deployments", "user_config", True),
+            ("deployments", "ray_actor_options", False),
         ],
     )
     def test_deploy_config_update(
-        self, client: ServeControllerClient, option_to_update: str, config_update: bool
+        self,
+        client: ServeControllerClient,
+        field_to_update: str,
+        option_to_update: str,
+        config_update: bool,
     ):
         """
         Check that replicas stay alive when lightweight config updates are made and
@@ -604,15 +610,27 @@ class TestDeployApp:
         wait_for_condition(deployment_running, timeout=15)
         pid1 = requests.get("http://localhost:8000/f").text
 
-        updated_options = {
-            "num_replicas": 2,
-            "autoscaling_config": {"max_replicas": 2},
-            "user_config": {"name": "bob"},
-            "ray_actor_options": {"num_cpus": 0.2},
-        }
-        config_template["deployments"][0][option_to_update] = updated_options[
-            option_to_update
-        ]
+        if field_to_update == "import_path":
+            config_template[
+                "import_path"
+            ] = "ray.serve.tests.test_config_files.pid.bnode"
+        elif field_to_update == "runtime_env":
+            config_template["runtime_env"] = {
+                "working_dir": (
+                    "https://github.com/ray-project/test_dag/archive/"
+                    "76a741f6de31df78411b1f302071cde46f098418.zip"
+                )
+            }
+        elif field_to_update == "deployments":
+            updated_options = {
+                "num_replicas": 2,
+                "autoscaling_config": {"max_replicas": 2},
+                "user_config": {"name": "bob"},
+                "ray_actor_options": {"num_cpus": 0.2},
+            }
+            config_template["deployments"][0][option_to_update] = updated_options[
+                option_to_update
+            ]
 
         client.deploy_app(ServeApplicationSchema.parse_obj(config_template))
         wait_for_condition(deployment_running, timeout=15)


### PR DESCRIPTION
Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previous PR that adds in lightweight config updates: https://github.com/ray-project/ray/pull/27000. It only tracks the config options for `deployments` (bumps version if certain deployment options are changed, but otherwise keeps versions the same). However we should bump the versions of all deployments if `import_path` or `runtime_env` is changed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
