### PR TITLE
[Cherry-pick] [AIR - Serve] Check for tensor extension via dtype rather than a NumPy conversion

### DIFF
--- a/python/ray/serve/air_integrations.py
+++ b/python/ray/serve/air_integrations.py
@@ -54,10 +54,10 @@ def _unpack_tensorarray_from_pandas(output_df: "pd.DataFrame") -> "pd.DataFrame"
     TensorArray to list to ensure output is json serializable as http
     response.
     """
-    from ray.data.extensions import TensorArray, TensorArrayElement
+    from ray.data.extensions import TensorDtype
 
-    for col in output_df:
-        if isinstance(output_df[col].values, (TensorArray, TensorArrayElement)):
+    for col in output_df.columns:
+        if isinstance(output_df.dtypes[col], TensorDtype):
             output_df[col] = output_df[col].to_numpy()
 
     return output_df


### PR DESCRIPTION
Cherry-pick of https://github.com/ray-project/ray/pull/26891 onto the 2.0.0 release branch.