### PR TITLE
[RLlib] Fix incorrect calculations in tf_action_dist.py Categorical.

### DIFF
--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -64,7 +64,9 @@ class Categorical(TFActionDistribution):
 
     @override(ActionDistribution)
     def logp(self, x: TensorType) -> TensorType:
-        logp = tf.math.log(tf.nn.softmax(self.inputs))
+        probs = tf.nn.softmax(self.inputs)
+        probs = tf.clip_by_value(probs, tf.keras.backend.epsilon(), 1.0)
+        logp = tf.math.log(probs)
         return tf.gather(logp, x, batch_dims=1)
 
     @override(ActionDistribution)
@@ -76,12 +78,16 @@ class Categorical(TFActionDistribution):
     @override(ActionDistribution)
     def kl(self, other: ActionDistribution) -> TensorType:
         probs = tf.nn.softmax(self.inputs)
+        probs = tf.clip_by_value(probs, tf.keras.backend.epsilon(), 1.0)
         probsOther = tf.nn.softmax(other.inputs)
+        probsOther = tf.clip_by_value(probsOther, tf.keras.backend.epsilon(), 1.0)
         return tf.keras.losses.kl_divergence(probs, probsOther)
 
     @override(TFActionDistribution)
     def _build_sample_op(self) -> TensorType:
-        logp = tf.math.log(tf.nn.softmax(self.inputs))
+        probs = tf.nn.softmax(self.inputs)
+        probs = tf.clip_by_value(probs, tf.keras.backend.epsilon(), 1.0)
+        logp = tf.math.log(probs)
         return tf.squeeze(tf.random.categorical(logp, 1), axis=1)
 
     @staticmethod

--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -64,32 +64,25 @@ class Categorical(TFActionDistribution):
 
     @override(ActionDistribution)
     def logp(self, x: TensorType) -> TensorType:
-        return -tf.nn.sparse_softmax_cross_entropy_with_logits(
-            logits=self.inputs, labels=tf.cast(x, tf.int32)
-        )
+        logp = tf.math.log(tf.nn.softmax(self.inputs))
+        return tf.gather(logp, x, batch_dims=1)
 
     @override(ActionDistribution)
     def entropy(self) -> TensorType:
-        a0 = self.inputs - tf.reduce_max(self.inputs, axis=1, keepdims=True)
-        ea0 = tf.exp(a0)
-        z0 = tf.reduce_sum(ea0, axis=1, keepdims=True)
-        p0 = ea0 / z0
-        return tf.reduce_sum(p0 * (tf.math.log(z0) - a0), axis=1)
+        probs = tf.nn.softmax(self.inputs)
+        probs = tf.clip_by_value(probs, tf.keras.backend.epsilon(), 1.0)
+        return tf.reduce_sum(probs * tf.math.log(probs), axis=1)
 
     @override(ActionDistribution)
     def kl(self, other: ActionDistribution) -> TensorType:
-        a0 = self.inputs - tf.reduce_max(self.inputs, axis=1, keepdims=True)
-        a1 = other.inputs - tf.reduce_max(other.inputs, axis=1, keepdims=True)
-        ea0 = tf.exp(a0)
-        ea1 = tf.exp(a1)
-        z0 = tf.reduce_sum(ea0, axis=1, keepdims=True)
-        z1 = tf.reduce_sum(ea1, axis=1, keepdims=True)
-        p0 = ea0 / z0
-        return tf.reduce_sum(p0 * (a0 - tf.math.log(z0) - a1 + tf.math.log(z1)), axis=1)
+        probs = tf.nn.softmax(self.inputs)
+        probsOther = tf.nn.softmax(other.inputs)
+        return tf.keras.losses.kl_divergence(probs, probsOther)
 
     @override(TFActionDistribution)
     def _build_sample_op(self) -> TensorType:
-        return tf.squeeze(tf.random.categorical(self.inputs, 1), axis=1)
+        logp = tf.math.log(tf.nn.softmax(self.inputs))
+        return tf.squeeze(tf.random.categorical(logp, 1), axis=1)
 
     @staticmethod
     @override(ActionDistribution)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Nearly every method in tf_action_dist.py Categorical produces incorrect results. I have made the following changes:

- **logp: replaced incorrect function usage** The previous implementation calls [tf.nn.sparse_softmax_cross_entropy_with_logits](https://www.tensorflow.org/api_docs/python/tf/nn/sparse_softmax_cross_entropy_with_logits), which does not produce the log probabilities. I replaced this with the actual log probability formula.
- **entropy: replaced questionable formula** I've never seen entropy formulated like this and have observed strange entropy values in my training as a result. Note that the [torch version](https://github.com/ray-project/ray/blob/master/rllib/models/torch/torch_action_dist.py) does not use this odd formula. I replaced this with the usual entropy formula. I added clip_by_value to avoid errors related to log(0) that arise due to masking logits with tf.float32.min.
- **kl: replaced questionable formula** I've also never seen KL divergence formulated like this and have observed odd KL values in my training. Again, the torch version does not use this strange formula. I replaced this with a call to [TF's built-in KL divergence function](https://www.tensorflow.org/api_docs/python/tf/keras/losses/KLDivergence), after calculating probabilities from the logits.
- **_build_sample_op: replaced incorrect function inputs** [tf.random.categorical](https://www.tensorflow.org/api_docs/python/tf/random/categorical) takes in log probabilities as input (scroll down to the bottom of the docs). TF uses "logits" and "log probabilities" interchangeably, but these are _not_ the same quantities in RLlib. Thus, we need to calculate the log probabilities from self.inputs and use those in the function call. This issue is also present in [epsilon_greedy.py](https://github.com/ray-project/ray/blob/master/rllib/utils/exploration/epsilon_greedy.py). Relevant PR: #26604

Similar issues may exist in other classes in this file since I only addressed Categorical.

## Related issue number

Replaces #24278 and closes #24055

Note: In #24278 a lack of benchmarks was mentioned and was part of why the PR went stale. If such benchmarks existed, the current implementation would fail them. Lack of benchmarks is not a good reason to keep methods that are blatantly wrong.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
