### PR TITLE
[AIR - Datasets] Fix column assignment in Concatenator for Pandas 1.2.

### DIFF
--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -89,6 +89,8 @@ class Concatenator(Preprocessor):
         columns_to_concat = list(included_columns - set(self.exclude))
         concatenated = df[columns_to_concat].to_numpy(dtype=self.dtype)
         df = df.drop(columns=columns_to_concat)
+        # Use a Pandas Series for column assignment to get more consistent
+        # behavior across Pandas versions.
         df.loc[:, self.output_column_name] = pd.Series(list(concatenated))
         return df
 

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -89,7 +89,7 @@ class Concatenator(Preprocessor):
         columns_to_concat = list(included_columns - set(self.exclude))
         concatenated = df[columns_to_concat].to_numpy(dtype=self.dtype)
         df = df.drop(columns=columns_to_concat)
-        df.loc[:, self.output_column_name] = list(concatenated)
+        df.loc[:, self.output_column_name] = pd.Series(list(concatenated))
         return df
 
     def __repr__(self):

--- a/python/setup.py
+++ b/python/setup.py
@@ -204,9 +204,18 @@ ray_files += [
 # also update the matching section of requirements/requirements.txt
 # in this directory
 if setup_spec.type == SetupType.RAY:
+    if sys.version_info >= (3, 7):
+        pandas_dep = "pandas >= 1.3"
+        numpy_dep = "numpy >= 1.20"
+    else:
+        # Pandas dropped python 3.6 support in 1.2.
+        pandas_dep = "pandas >= 1.0.5"
+        # Numpy dropped python 3.6 support in 1.20.
+        numpy_dep = "numpy >= 1.19"
     setup_spec.extras = {
         "data": [
-            "pandas",
+            numpy_dep,
+            pandas_dep,
             "pyarrow >= 6.0.1, < 7.0.0",
             "fsspec",
         ],
@@ -225,7 +234,7 @@ if setup_spec.type == SetupType.RAY:
             "smart_open",
         ],
         "serve": ["uvicorn==0.16.0", "requests", "starlette", "fastapi", "aiorwlock"],
-        "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests"],
+        "tune": [pandas_dep, "tabulate", "tensorboardX>=1.9", "requests"],
         "k8s": ["kubernetes", "urllib3"],
         "observability": [
             "opentelemetry-api==1.1.0",
@@ -233,12 +242,6 @@ if setup_spec.type == SetupType.RAY:
             "opentelemetry-exporter-otlp==1.1.0",
         ],
     }
-
-    if sys.version_info >= (3, 7):
-        # Numpy dropped python 3.6 support in 1.20.
-        setup_spec.extras["data"].append("numpy >= 1.20")
-    else:
-        setup_spec.extras["data"].append("numpy >= 1.19")
 
     # Ray Serve depends on the Ray dashboard components.
     setup_spec.extras["serve"] = list(

--- a/python/setup.py
+++ b/python/setup.py
@@ -234,7 +234,7 @@ if setup_spec.type == SetupType.RAY:
             "smart_open",
         ],
         "serve": ["uvicorn==0.16.0", "requests", "starlette", "fastapi", "aiorwlock"],
-        "tune": [pandas_dep, "tabulate", "tensorboardX>=1.9", "requests"],
+        "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests"],
         "k8s": ["kubernetes", "urllib3"],
         "observability": [
             "opentelemetry-api==1.1.0",


### PR DESCRIPTION
Heterogeneous tensor column assignment with a list-of-tensors fails for Pandas 1.2, but succeeds with a manually constructed Pandas Series.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/27503

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
