### PR TITLE
[autoscaler] Fix Prometheus metric autoscaler hang bug

### DIFF
--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -4,13 +4,13 @@ from typing import Optional
 class NullMetric:
     """Mock metric class to be used in case of prometheus_client import error."""
 
-    def set(self, value):
+    def set(self, *args, **kwargs):
         pass
 
-    def observe(self, value):
+    def observe(self, *args, **kwargs):
         pass
 
-    def inc(self, amount=1):
+    def inc(self, *args, **kwargs):
         pass
 
 

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -198,7 +198,7 @@ except ImportError:
         def observe(self, value):
             pass
 
-        def inc(self):
+        def inc(self, amount=1):
             pass
 
     class AutoscalerPrometheusMetrics(object):

--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -1,5 +1,19 @@
 from typing import Optional
 
+
+class NullMetric:
+    """Mock metric class to be used in case of prometheus_client import error."""
+
+    def set(self, value):
+        pass
+
+    def observe(self, value):
+        pass
+
+    def inc(self, amount=1):
+        pass
+
+
 try:
 
     from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
@@ -190,16 +204,6 @@ try:
             )
 
 except ImportError:
-
-    class NullMetric:
-        def set(self, value):
-            pass
-
-        def observe(self, value):
-            pass
-
-        def inc(self, amount=1):
-            pass
 
     class AutoscalerPrometheusMetrics(object):
         def __getattr__(self, attr):

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -33,7 +33,10 @@ from ray.autoscaler._private.constants import (
 )
 from ray.autoscaler._private.load_metrics import LoadMetrics
 from ray.autoscaler._private.monitor import Monitor
-from ray.autoscaler._private.prom_metrics import AutoscalerPrometheusMetrics
+from ray.autoscaler._private.prom_metrics import (
+    AutoscalerPrometheusMetrics,
+    NullMetric,
+)
 from ray.autoscaler._private.providers import (
     _DEFAULT_CONFIGS,
     _NODE_PROVIDERS,
@@ -3363,6 +3366,15 @@ def test_import():
     import ray.autoscaler  # noqa
     import ray.autoscaler.sdk  # noqa
     from ray.autoscaler.sdk import request_resources  # noqa
+
+
+def test_prom_null_metric_inc_fix():
+    """Verify the bug fix https://github.com/ray-project/ray/pull/27532
+    for NullMetric's signature.
+    Check that NullMetric can be called with or without an argument.
+    """
+    NullMetric().inc()
+    NullMetric().inc(5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Failed node launch can lead to an extra unexpected error in the node launcher due to the definition of a mock prometheus metric method.
This failure leads to a permanently hanging autoscaler with "launching nodes" never cleared out and the autoscaler unable to proceed to launch nodes.

This PR fixes the method signature leading to the unexpected failure.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/27515

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
