### PR TITLE
[cherry pick][autoscaler] Fix Prometheus metric autoscaler hang bug (#27532)

### DIFF
--- a/python/ray/autoscaler/_private/prom_metrics.py
+++ b/python/ray/autoscaler/_private/prom_metrics.py
@@ -1,5 +1,19 @@
 from typing import Optional
 
+
+class NullMetric:
+    """Mock metric class to be used in case of prometheus_client import error."""
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+
 try:
 
     from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
@@ -190,16 +204,6 @@ try:
             )
 
 except ImportError:
-
-    class NullMetric:
-        def set(self, value):
-            pass
-
-        def observe(self, value):
-            pass
-
-        def inc(self):
-            pass
 
     class AutoscalerPrometheusMetrics(object):
         def __getattr__(self, attr):

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -34,7 +34,10 @@ from ray.autoscaler._private.constants import (
 )
 from ray.autoscaler._private.load_metrics import LoadMetrics
 from ray.autoscaler._private.monitor import Monitor
-from ray.autoscaler._private.prom_metrics import AutoscalerPrometheusMetrics
+from ray.autoscaler._private.prom_metrics import (
+    AutoscalerPrometheusMetrics,
+    NullMetric,
+)
 from ray.autoscaler._private.providers import (
     _DEFAULT_CONFIGS,
     _NODE_PROVIDERS,
@@ -3666,6 +3669,15 @@ def test_import():
     import ray.autoscaler  # noqa
     import ray.autoscaler.sdk  # noqa
     from ray.autoscaler.sdk import request_resources  # noqa
+
+
+def test_prom_null_metric_inc_fix():
+    """Verify the bug fix https://github.com/ray-project/ray/pull/27532
+    for NullMetric's signature.
+    Check that NullMetric can be called with or without an argument.
+    """
+    NullMetric().inc()
+    NullMetric().inc(5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a pick of https://github.com/ray-project/ray/pull/27532 into the Ray 2.0.0 release branch.

Failed node launch can lead to an extra unexpected error in the node launcher due to the definition of a mock prometheus metric method.
This failure leads to a permanently hanging autoscaler with "launching nodes" never cleared out and the autoscaler unable to proceed to launch nodes.

This PR fixes the method signature leading to the unexpected failure.