### PR TITLE
[K8s][Autoscaler] expose imagePullSecret to values.yaml

### DIFF
--- a/deploy/charts/ray/Chart.yaml
+++ b/deploy/charts/ray/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deployments of Ray on Kubernetes.
 type: application
 
 # Chart version.
-version: 0.1.0
+version: 0.2.0
 
 # Ray version.
 appVersion: "latest"

--- a/deploy/charts/ray/templates/raycluster.yaml
+++ b/deploy/charts/ray/templates/raycluster.yaml
@@ -90,6 +90,10 @@ spec:
           {{- if $.Values.serviceAccountName }}
           serviceAccountName: {{ $.Values.serviceAccountName }}
           {{- end }}
+          {{- with $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
     {{- end }}
   # Commands to start Ray on the head node. You don't need to change this.
   # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.

--- a/deploy/charts/ray/values.yaml
+++ b/deploy/charts/ray/values.yaml
@@ -18,6 +18,8 @@ headPodType: rayHeadType
 # serviceAccountName is used for the Ray head and each Ray worker.
 # It can be set to your particular service account instead of using the default.
 # serviceAccountName: ...
+# imagePullSecrets is used to authenticate to private docker registry, when you have a custom image.
+imagePullSecrets: []
 # podTypes is the list of pod configurations available for use as Ray nodes.
 podTypes:
     # The key for each podType is a user-defined string.


### PR DESCRIPTION
**Description:**
Sometimes we need to use custom docker images with custom extensions, The custom docker image is hosted in a private docker registry. Currently, there is no option to specify pod imagePullSecret

**Fix**
By exposing imagePullSecrets to values.yaml 
