### PR TITLE
[doc] update autoscaler config (VM) page

### DIFF
--- a/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
+++ b/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
@@ -2,35 +2,37 @@
 
 .. _deployment-guide-autoscaler-under-construction:
 
-Configuring the Ray Autoscaler
-==============================
+Configuring Autoscaling
+=======================
 
-This page provides an overview of the parameters for the Ray autoscaler. A Ray cluster runs an autoscaler that can modify
-the number of nodes based on the resources required by tasks, actors or placement groups. The autoscaler only considers logical resources (e.g. those specified
-in ray.remote and displayed in ray status). If a user tries to launch
-an actor, task, or placement group but there are insufficient resources, the request will be queued. The autoscaler runs a bin-packing algorithm
-to determine the list of nodes the cluster should use to satisfy the demand, and adds / removes nodes from the cluster to maximize the
-cluster utilization while providing sufficient resources to execute the requests.
+This guide explains how to configure the Ray autoscaler. The Ray autoscaler adjusts
+the number of nodes in the cluster based on the resources required by tasks, actors or
+placement groups.
+
+Note that the autoscaler only considers logical resource requests for scaling (i.e., those specified
+in ``@ray.remote`` and displayed in ``ray status``), not machine utilization.
+If a user tries to launch an actor, task, or placement group but there are insufficient resources, the request will be queued.
+The autoscaler adds nodes to satisfy resource demands in the queue, and removes nodes when they become idle.
 
 Parameters
 ==========
 
-**max_workers[default_value=2, min_value=0]**: Indicates the maximum number of workers the cluster will have at any given time. This value
-excludes the head node -- there should always be exactly one in the cluster.
+The following are the autoscaling parameters that are specified with cluster launch. They can also be modified at runtime by
+updating the cluster config.
+
+**max_workers[default_value=2, min_value=0]**: Specify the max number of cluster worker nodes. Note that this excludes the head node.
 
 .. note::
-  When this value changes and drops below the number of running workers, the autoscaler will remove nodes to satisfy the new constraint even
-  if the node is running a workload. Workers that are the least recently used will be removed first.
+
+  If this value is modified at runtime, the autoscaler will immediately remove nodes until this constraint
+  is satisfied. This may disrupt running workloads.
 
 **upscaling_speed[default_value=1.0, min_value=1.0]**: The number of nodes allowed to be pending as a multiple of the current number of nodes.
 For example, if this is set to 1.0, the cluster can grow in size by at most 100% at any time, so if the cluster currently has 20 nodes, at most 20 pending
-launches are allowed. The mininum number of pending launches is 5 regardless of this setting.
+launches are allowed. The minimum number of pending launches is 5 regardless of this setting.
 
 **idle_timeout_minutes[default_value=5, min_value=0]**: The number of minutes that need to pass before an idle worker node is removed by the
-autoscaler. Worker nodes are idle when there are no active tasks or actors running. This parameter does not affect the head node.
-
-.. note::
-  If the Ray object store is used, and a worker node still holds objects (including spilled objects on disk), it won't be removed.
+autoscaler. Worker nodes are idle when they hold no active tasks, actors, or referenced objects (either in-memory or spilled to disk). This parameter does not affect the head node.
 
 **available_node_types.<node_type_name>.min_workers[default_value=0, min_value=0]**: The minimum number of worker nodes of a given type to launch. If this number
 is set to greater than zero, the autoscaler will maintain the number of nodes regardless of utilization. The sum of the min worker of all the node types
@@ -40,6 +42,6 @@ must be less than or equal to the max_workers for the cluster.
 greater than or equal to available_node_types.<node_type_name>.min_workers. It must be less than or equal to the max_workers for the cluster.
 
 .. note::
-  When this value changes and drops below the number of running workers for the given type, the autoscaler will remove nodes to satisfy the new constraint even
-  if the node is running a workload. Workers that are the least recently used will be removed first.
+  If this value is modified at runtime, the autoscaler will immediately remove nodes until this constraint
+  is satisfied. This may disrupt running workloads.
 

--- a/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
+++ b/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
@@ -5,12 +5,12 @@
 Configuring the Ray Autoscaler
 ==============================
 
-This page provides an overview of the parameters for the Ray autoscaler. A Ray cluster by default runs an autoscaler that modifies
-the number of nodes based on the resources requested by the task, actor, or placement group. If there is insufficient resource to serve
-the request they will be put into pending and will not execute. The autoscaler runs a bin-packing algorithm to determine the list of nodes
-the cluster should use to satisfy the resource requests, and adds / removes nodes from the cluster to maximize the cluster utilization
-while providing sufficient resource to execute the requests. The autoscaler currently only looks at the amount of cpu and gpu requested
-and adds / removes nodes accordingly. It does not take into the account the memory request nor the disk usage.
+This page provides an overview of the parameters for the Ray autoscaler. A Ray cluster runs an autoscaler that can modify
+the number of nodes based on the resources set by task, actor or placement group. The autoscaler only considers logical resources (e.g. those specified
+in ray.remote and displayed in ray status), with the exception of object_store_memory which it does not consider. If a user tries to launch
+an actor, task, or placement group but there are insufficient resources, the request will be queued. The autoscaler runs a bin-packing algorithm
+to determine the list of nodes the cluster should use to satisfy the demand, and adds / removes nodes from the cluster to maximize the
+cluster utilization while providing sufficient resource to execute the requests.
 
 Parameters
 ==========
@@ -22,7 +22,7 @@ excludes the head node where there is always exactly one.
   When this value changes and drops below the number of running workers, the autoscaler will remove nodes to satisfy the new constraint even
   if the node is running some workload. Workers that are the least recently used will be removed first.
 
-**upscaling_speed[default_value=1.0, min_value=0.0]**: The number of nodes allowed to be pending as a multiple of the current number of nodes.
+**upscaling_speed[default_value=1.0, min_value=1.0]**: The number of nodes allowed to be pending as a multiple of the current number of nodes.
 For example, if set to 1.0, the cluster can grow in size by at most 100% at any time, so if the cluster currently has 20 nodes, at most 20 pending
 launches are allowed. The mininum number of pending launches is 5 regardless of this setting.
 
@@ -36,7 +36,7 @@ autoscaler. Worker nodes are idle when there are no active tasks or actors runni
 is set to greater than zero, the autoscaler will maintain the number of nodes regardless of utilization. The sum of the min worker of all the node types
 must be less than or equal to the max_workers for the cluster.
 
-**available_node_types.<node_type_name>.max_workers[default_value=0, min_value=0]**: The maximum number of worker nodes of a given type to launch. This must be
+**available_node_types.<node_type_name>.max_workers[default_value=cluster max_workers, min_value=0]**: The maximum number of worker nodes of a given type to launch. This must be
 greater than or equal to available_node_types.<node_type_name>.min_workers. It must be less than or equal to the max_workers for the cluster.
 
 .. note::

--- a/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
+++ b/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
@@ -9,11 +9,8 @@ This page provides an overview of the parameters for the Ray autoscaler. A Ray c
 the number of nodes based on the resources requested by the task, actor, or placement group. If there is insufficient resource to serve
 the request they will be put into pending and will not execute. The autoscaler runs a bin-packing algorithm to determine the list of nodes
 the cluster should use to satisfy the resource requests, and adds / removes nodes from the cluster to maximize the cluster utilization
-while providing sufficient resource to execute the requests.
-
-.. note::
-  The autoscaler currently only looks at the amount of cpu and gpu requested and adds / removes nodes accordingly. It does not take into
-  the account the memory request nor the disk usage.
+while providing sufficient resource to execute the requests. The autoscaler currently only looks at the amount of cpu and gpu requested
+and adds / removes nodes accordingly. It does not take into the account the memory request nor the disk usage.
 
 Parameters
 ==========

--- a/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
+++ b/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
@@ -6,24 +6,24 @@ Configuring the Ray Autoscaler
 ==============================
 
 This page provides an overview of the parameters for the Ray autoscaler. A Ray cluster runs an autoscaler that can modify
-the number of nodes based on the resources set by task, actor or placement group. The autoscaler only considers logical resources (e.g. those specified
-in ray.remote and displayed in ray status), with the exception of object_store_memory which it does not consider. If a user tries to launch
+the number of nodes based on the resources required by tasks, actors or placement groups. The autoscaler only considers logical resources (e.g. those specified
+in ray.remote and displayed in ray status). If a user tries to launch
 an actor, task, or placement group but there are insufficient resources, the request will be queued. The autoscaler runs a bin-packing algorithm
 to determine the list of nodes the cluster should use to satisfy the demand, and adds / removes nodes from the cluster to maximize the
-cluster utilization while providing sufficient resource to execute the requests.
+cluster utilization while providing sufficient resources to execute the requests.
 
 Parameters
 ==========
 
-**max_workers[default_value=2, min_value=0]**: Indicates the maximum number of workers the cluster will have at any given time. This number
-excludes the head node where there is always exactly one.
+**max_workers[default_value=2, min_value=0]**: Indicates the maximum number of workers the cluster will have at any given time. This value
+excludes the head node -- there should always be exactly one in the cluster.
 
 .. note::
   When this value changes and drops below the number of running workers, the autoscaler will remove nodes to satisfy the new constraint even
-  if the node is running some workload. Workers that are the least recently used will be removed first.
+  if the node is running a workload. Workers that are the least recently used will be removed first.
 
 **upscaling_speed[default_value=1.0, min_value=1.0]**: The number of nodes allowed to be pending as a multiple of the current number of nodes.
-For example, if set to 1.0, the cluster can grow in size by at most 100% at any time, so if the cluster currently has 20 nodes, at most 20 pending
+For example, if this is set to 1.0, the cluster can grow in size by at most 100% at any time, so if the cluster currently has 20 nodes, at most 20 pending
 launches are allowed. The mininum number of pending launches is 5 regardless of this setting.
 
 **idle_timeout_minutes[default_value=5, min_value=0]**: The number of minutes that need to pass before an idle worker node is removed by the
@@ -41,5 +41,5 @@ greater than or equal to available_node_types.<node_type_name>.min_workers. It m
 
 .. note::
   When this value changes and drops below the number of running workers for the given type, the autoscaler will remove nodes to satisfy the new constraint even
-  if the node is running some workload. Workers that are the least recently used will be removed first.
+  if the node is running a workload. Workers that are the least recently used will be removed first.
 

--- a/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
+++ b/doc/source/cluster/cluster_under_construction/ray-clusters-on-vms/user-guides/configuring-autoscaling.rst
@@ -45,3 +45,7 @@ greater than or equal to available_node_types.<node_type_name>.min_workers. It m
   If this value is modified at runtime, the autoscaler will immediately remove nodes until this constraint
   is satisfied. This may disrupt running workloads.
 
+Autoscaler SDK
+==============
+
+For more information on programmatic access to the autoscaler, see :ref:`Autoscaler SDK<ref-autoscaler-sdk-under-construction>`.


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

## Why are these changes needed?

Update autoscaler configuration docs for VM stack.
Removed the video, after looking at it it fits better in overview / and is possibly outdated

## Related issue number

https://github.com/ray-project/ray/issues/27134

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- Testing Strategy
Build and preview html, see attached

pre:
[Autoscaling with Ray — old.pdf](https://github.com/ray-project/ray/files/9266513/Autoscaling.with.Ray.old.pdf)

post (this PR):
[Configuring the Ray Autoscaler — Ray 3.0.0.dev0 new.pdf](https://github.com/ray-project/ray/files/9266514/Configuring.the.Ray.Autoscaler.Ray.3.0.0.dev0.new.pdf)

