### PR TITLE
[CI] [runtime env] Fix test_working_dir_2 timeout on Mac

### DIFF
--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 import sys
-import time
 import tempfile
 
 import pytest

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -260,9 +260,9 @@ def test_default_large_cache(start_cluster, option: str, source: str):
     ray.get(f.remote())
     ray.shutdown()
 
-    # If we immediately check that the files weren't GCed, it may spuriously
-    # pass, so sleep first to give time for any deletions to happen.
-    time.sleep(5)
+    # TODO(architkulkarni): We should start several tasks with other files and
+    # check that all of the files are there, since GC is only triggered
+    # when we attempt to create a URI that exceeds the threshold.
     assert not check_local_files_gced(cluster)
 
     ray.init(address)
@@ -281,7 +281,6 @@ def test_default_large_cache(start_cluster, option: str, source: str):
 
     _ = A.remote()
     ray.shutdown()
-    time.sleep(5)
     assert not check_local_files_gced(cluster)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
One GC test has unnecessary sleeps which are quite expensive due to the parametrization (2 x 2 x 2 = 8 iterations). They are unnecessary because they check that garbage collection of runtime env URIs doesn't occur after a certain time, but garbage collection isn't time-based.  This PR removes the sleeps.

This PR is just to fix CI; a followup PR will make the test more effective by attempting to trigger GC in a more targeted way (by starting multiple tasks with different runtime_env resources.  GC is only triggered upon *creation* of a new resource that causes the cache size to be exceeded.)

It's still not clear what exactly caused the test suite to start taking longer recently, but it might be due to some change elsewhere in Ray, since there were no runtime_env related commits in that time period.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/27562
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
