### PR TITLE
[RLlib] PPO tuned and re-enabled

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2701,6 +2701,30 @@
 
   alert: default
 
+- name: rllib_learning_tests_ppo
+  group: RLlib tests
+  working_dir: rllib_tests
+
+  legacy:
+    test_name: learning_tests
+    test_suite: rllib_tests
+
+  frequency: nightly
+  team: ml
+  env: staging
+
+  cluster:
+    cluster_env: app_config.yaml
+    cluster_compute: 2gpus_32cpus.yaml
+
+  run:
+    timeout: 18000
+    script: python learning_tests/run.py --yaml-sub-dir=ppo
+    type: sdk_command
+    file_manager: job
+
+  alert: default
+
 - name: rllib_learning_tests_bc
   group: RLlib tests
   working_dir: rllib_tests

--- a/release/rllib_tests/learning_tests/yaml_files/ppo/ppo-breakoutnoframeskip-v4.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/ppo/ppo-breakoutnoframeskip-v4.yaml
@@ -6,7 +6,7 @@ ppo-breakoutnoframeskip-v4:
         episode_reward_mean: 50.0
         timesteps_total: 7000000
     stop:
-        time_total_s: 7200
+        time_total_s: 3600
     config:
         lambda: 0.95
         kl_coeff: 0.5
@@ -18,10 +18,13 @@ ppo-breakoutnoframeskip-v4:
         rollout_fragment_length: 100
         sgd_minibatch_size: 500
         num_sgd_iter: 10
-        num_workers: 10
-        num_envs_per_worker: 5
+        num_workers: 30
+        num_envs_per_worker: 1
         batch_mode: truncate_episodes
         observation_filter: NoFilter
         model:
             vf_share_layers: true
-        num_gpus: 1
+        num_gpus: 2
+        min_time_s_per_iteration: 30
+        lr: 0.0001
+        grad_clip: 100


### PR DESCRIPTION
Signed-off-by: avnish <avnish@anyscale.com>

Tuned ppo on breakout params:
(learning rate mainly)
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/38871737/183130578-de887fd2-c352-47ed-94dd-ca4b6be388eb.png">

It learns and processes samples faster when using 2gpus @~30 cpus of workers


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
