### PR TITLE
[core] Reconstruct manually freed objects

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -33,6 +33,7 @@ from ray.exceptions import (
     RaySystemError,
     RayTaskError,
     ReferenceCountingAssertionError,
+    ObjectFreedError,
     RuntimeEnvSetupError,
     TaskCancelledError,
     TaskPlacementGroupRemoved,
@@ -283,6 +284,10 @@ class SerializationContext:
                 )
             elif error_type == ErrorType.Value("OBJECT_DELETED"):
                 return ReferenceCountingAssertionError(
+                    object_ref.hex(), object_ref.owner_address(), object_ref.call_site()
+                )
+            elif error_type == ErrorType.Value("OBJECT_FREED"):
+                return ObjectFreedError(
                     object_ref.hex(), object_ref.owner_address(), object_ref.call_site()
                 )
             elif error_type == ErrorType.Value("OWNER_DIED"):

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -444,7 +444,7 @@ class ReferenceCountingAssertionError(ObjectLostError, AssertionError):
 
 
 @DeveloperAPI
-class ObjectFreedError(ObjectLostError, AssertionError):
+class ObjectFreedError(ObjectLostError):
     """Indicates that an object was manually freed by the application.
 
     Attributes:

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -443,6 +443,26 @@ class ReferenceCountingAssertionError(ObjectLostError, AssertionError):
         )
 
 
+@DeveloperAPI
+class ObjectFreedError(ObjectLostError, AssertionError):
+    """Indicates that an object was manually freed by the application.
+
+    Attributes:
+        object_ref_hex: Hex ID of the object.
+    """
+
+    def __str__(self):
+        return (
+            self._base_str()
+            + "\n\n"
+            + (
+                "The object was manually freed using the internal `free` call. "
+                "Please ensure that `free` is only called once the object is no "
+                "longer needed."
+            )
+        )
+
+
 @PublicAPI
 class OwnerDiedError(ObjectLostError):
     """Indicates that the owner of the object has died while there is still a

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -11,7 +11,7 @@ import pytest
 import ray._private.profiling as profiling
 import ray.cluster_utils
 from ray._private.test_utils import RayTestTimeoutException, client_test_enabled
-from ray.exceptions import ReferenceCountingAssertionError
+from ray.exceptions import ObjectFreedError
 
 if client_test_enabled():
     from ray.util.client import ray
@@ -40,7 +40,7 @@ def test_internal_free(shutdown_only):
     obj_ref = sampler.sample.remote()
     ray.get(obj_ref)
     ray._private.internal_api.free(obj_ref)
-    with pytest.raises(ReferenceCountingAssertionError):
+    with pytest.raises(ObjectFreedError):
         ray.get(obj_ref)
 
     # Free deletes big objects from plasma store.
@@ -48,7 +48,7 @@ def test_internal_free(shutdown_only):
     ray.get(big_id)
     ray._private.internal_api.free(big_id)
     time.sleep(1)  # wait for delete RPC to propagate
-    with pytest.raises(ReferenceCountingAssertionError):
+    with pytest.raises(ObjectFreedError):
         ray.get(big_id)
 
 

--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -165,7 +165,7 @@ def test_raylet_crash_when_get(ray_start_regular):
 
     thread = threading.Thread(target=sleep_to_kill_raylet)
     thread.start()
-    with pytest.raises(ray.exceptions.ReferenceCountingAssertionError):
+    with pytest.raises(ray.exceptions.ObjectFreedError):
         ray.get(object_ref)
     thread.join()
 
@@ -194,7 +194,7 @@ def test_eviction(ray_start_cluster):
     # Evict the object.
     ray._private.internal_api.free([obj])
     # ray.get throws an exception.
-    with pytest.raises(ray.exceptions.ReferenceCountingAssertionError):
+    with pytest.raises(ray.exceptions.ObjectFreedError):
         ray.get(obj)
 
     @ray.remote

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -448,7 +448,10 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
       [this](const ObjectID &object_id, rpc::ErrorType reason, bool pin_object) {
         RAY_LOG(DEBUG) << "Failed to recover object " << object_id << " due to "
                        << rpc::ErrorType_Name(reason);
-        RAY_CHECK_OK(Put(RayObject(reason),
+        // NOTE(swang): Failure here means the local raylet is probably dead.
+        // We do not assert failure though, because we should throw the object
+        // error to the application.
+        RAY_UNUSED(Put(RayObject(reason),
                          /*contained_object_ids=*/{},
                          object_id,
                          /*pin_object=*/pin_object));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -452,9 +452,9 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
         // We do not assert failure though, because we should throw the object
         // error to the application.
         RAY_UNUSED(Put(RayObject(reason),
-                         /*contained_object_ids=*/{},
-                         object_id,
-                         /*pin_object=*/pin_object));
+                       /*contained_object_ids=*/{},
+                       object_id,
+                       /*pin_object=*/pin_object));
       });
 
   // Tell the raylet the port that we are listening on.
@@ -1293,7 +1293,8 @@ Status CoreWorker::Delete(const std::vector<ObjectID> &object_ids, bool local_on
   // no longer reachable.
   memory_store_->Delete(object_ids);
   for (const auto &object_id : object_ids) {
-    RAY_CHECK(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_DELETED), object_id));
+    RAY_LOG(DEBUG) << "Freeing object " << object_id;
+    RAY_CHECK(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_FREED), object_id));
   }
 
   // We only delete from plasma, which avoids hangs (issue #7105). In-memory

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -512,6 +512,14 @@ bool ReferenceCounter::IsPlasmaObjectFreed(const ObjectID &object_id) const {
   return freed_objects_.find(object_id) != freed_objects_.end();
 }
 
+bool ReferenceCounter::TryMarkFreedObjectInUseAgain(const ObjectID &object_id) {
+  absl::MutexLock lock(&mutex_);
+  if (object_id_refs_.count(object_id) == 0) {
+    return false;
+  }
+  return freed_objects_.erase(object_id);
+}
+
 void ReferenceCounter::FreePlasmaObjects(const std::vector<ObjectID> &object_ids) {
   absl::MutexLock lock(&mutex_);
   for (const ObjectID &object_id : object_ids) {

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -236,6 +236,15 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \return Whether the object value has been freed.
   bool IsPlasmaObjectFreed(const ObjectID &object_id) const;
 
+  /// Mark an object that was freed as being in use again. If another copy of
+  /// the object is subsequently pinned, we will not delete it until free is
+  /// called again, or the ObjectRef goes out of scope.
+  ///
+  /// \param[in] object_id The object to un-free.
+  /// \return Whether it was successful. This call will fail if the object ref
+  /// is no longer in scope or if the object was not actually freed.
+  bool TryMarkFreedObjectInUseAgain(const ObjectID &object_id);
+
   /// Release the underlying value from plasma (if any) for these objects.
   ///
   /// \param[in] object_ids The IDs whose values to free.

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -364,152 +364,153 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
       /*grant_or_reject=*/is_spillback,
       [this, scheduling_key, task_id, is_spillback, raylet_address = *raylet_address](
           const Status &status, const rpc::RequestWorkerLeaseReply &reply) {
-        absl::MutexLock lock(&mu_);
+        std::deque<TaskSpecification> tasks_to_fail;
+        rpc::RayErrorInfo error_info;
+        ray::Status error_status;
+        rpc::ErrorType error_type = rpc::ErrorType::WORKER_DIED;
+        {
+          absl::MutexLock lock(&mu_);
 
-        auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
-        auto lease_client = GetOrConnectLeaseClient(&raylet_address);
-        scheduling_key_entry.pending_lease_requests.erase(task_id);
+          auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
+          auto lease_client = GetOrConnectLeaseClient(&raylet_address);
+          scheduling_key_entry.pending_lease_requests.erase(task_id);
 
-        if (status.ok()) {
-          if (reply.canceled()) {
-            RAY_LOG(DEBUG) << "Lease canceled for task: " << task_id
-                           << ", canceled type: "
-                           << rpc::RequestWorkerLeaseReply::SchedulingFailureType_Name(
-                                  reply.failure_type());
-            if (reply.failure_type() ==
-                    rpc::RequestWorkerLeaseReply::
-                        SCHEDULING_CANCELLED_RUNTIME_ENV_SETUP_FAILED ||
-                reply.failure_type() ==
-                    rpc::RequestWorkerLeaseReply::
-                        SCHEDULING_CANCELLED_PLACEMENT_GROUP_REMOVED ||
-                reply.failure_type() ==
-                    rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_UNSCHEDULABLE) {
-              // We need to actively fail all of the pending tasks in the queue when the
-              // placement group was removed or the runtime env failed to be set up. Such
-              // an operation is straightforward for the scenario of placement group
-              // removal as all tasks in the queue are associated with the same placement
-              // group, but in the case of runtime env setup failed, This makes an
-              // implicit assumption that runtime_env failures are not transient -- we may
-              // consider adding some retries in the future.
-              auto &task_queue = scheduling_key_entry.task_queue;
-              while (!task_queue.empty()) {
-                auto &task_spec = task_queue.front();
+          if (status.ok()) {
+            if (reply.canceled()) {
+              RAY_LOG(DEBUG) << "Lease canceled for task: " << task_id
+                             << ", canceled type: "
+                             << rpc::RequestWorkerLeaseReply::SchedulingFailureType_Name(
+                                    reply.failure_type());
+              if (reply.failure_type() ==
+                      rpc::RequestWorkerLeaseReply::
+                          SCHEDULING_CANCELLED_RUNTIME_ENV_SETUP_FAILED ||
+                  reply.failure_type() ==
+                      rpc::RequestWorkerLeaseReply::
+                          SCHEDULING_CANCELLED_PLACEMENT_GROUP_REMOVED ||
+                  reply.failure_type() ==
+                      rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_UNSCHEDULABLE) {
+                // We need to actively fail all of the pending tasks in the queue when the
+                // placement group was removed or the runtime env failed to be set up.
+                // Such an operation is straightforward for the scenario of placement
+                // group removal as all tasks in the queue are associated with the same
+                // placement group, but in the case of runtime env setup failed, This
+                // makes an implicit assumption that runtime_env failures are not
+                // transient -- we may consider adding some retries in the future.
                 if (reply.failure_type() ==
                     rpc::RequestWorkerLeaseReply::
                         SCHEDULING_CANCELLED_RUNTIME_ENV_SETUP_FAILED) {
-                  rpc::RayErrorInfo error_info;
+                  error_type = rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED;
                   error_info.mutable_runtime_env_setup_failed_error()->set_error_message(
                       reply.scheduling_failure_message());
-                  RAY_UNUSED(task_finisher_->FailPendingTask(
-                      task_spec.TaskId(),
-                      rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED,
-                      /*status*/ nullptr,
-                      &error_info));
                 } else if (reply.failure_type() ==
                            rpc::RequestWorkerLeaseReply::
                                SCHEDULING_CANCELLED_UNSCHEDULABLE) {
-                  rpc::RayErrorInfo error_info;
+                  error_type = rpc::ErrorType::TASK_UNSCHEDULABLE_ERROR;
                   *(error_info.mutable_error_message()) =
                       reply.scheduling_failure_message();
-                  RAY_UNUSED(task_finisher_->FailPendingTask(
-                      task_spec.TaskId(),
-                      rpc::ErrorType::TASK_UNSCHEDULABLE_ERROR,
-                      /*status*/ nullptr,
-                      &error_info));
                 } else {
-                  if (task_spec.IsActorCreationTask()) {
-                    RAY_UNUSED(task_finisher_->FailPendingTask(
-                        task_spec.TaskId(),
-                        rpc::ErrorType::ACTOR_PLACEMENT_GROUP_REMOVED));
-                  } else {
-                    RAY_UNUSED(task_finisher_->FailPendingTask(
-                        task_spec.TaskId(),
-                        rpc::ErrorType::TASK_PLACEMENT_GROUP_REMOVED));
-                  }
+                  error_type = rpc::ErrorType::TASK_PLACEMENT_GROUP_REMOVED;
                 }
-                task_queue.pop_front();
+                tasks_to_fail = std::move(scheduling_key_entry.task_queue);
+                scheduling_key_entry.task_queue.clear();
+                if (scheduling_key_entry.CanDelete()) {
+                  scheduling_key_entries_.erase(scheduling_key);
+                }
+              } else {
+                RequestNewWorkerIfNeeded(scheduling_key);
               }
+            } else if (reply.rejected()) {
+              RAY_LOG(DEBUG) << "Lease rejected " << task_id;
+              // It might happen when the first raylet has a stale view
+              // of the spillback raylet resources.
+              // Retry the request at the first raylet since the resource view may be
+              // refreshed.
+              RAY_CHECK(is_spillback);
+              RequestNewWorkerIfNeeded(scheduling_key);
+            } else if (!reply.worker_address().raylet_id().empty()) {
+              // We got a lease for a worker. Add the lease client state and try to
+              // assign work to the worker.
+              rpc::WorkerAddress addr(reply.worker_address());
+              RAY_LOG(DEBUG) << "Lease granted to task " << task_id << " from raylet "
+                             << addr.raylet_id << " with worker " << addr.worker_id;
+
+              auto resources_copy = reply.resource_mapping();
+
+              AddWorkerLeaseClient(
+                  addr, std::move(lease_client), resources_copy, scheduling_key);
+              RAY_CHECK(scheduling_key_entry.active_workers.size() >= 1);
+              OnWorkerIdle(addr,
+                           scheduling_key,
+                           /*error=*/false,
+                           /*worker_exiting=*/false,
+                           resources_copy);
+            } else {
+              // The raylet redirected us to a different raylet to retry at.
+              RAY_CHECK(!is_spillback);
+              RAY_LOG(DEBUG) << "Redirect lease for task " << task_id << " from raylet "
+                             << NodeID::FromBinary(raylet_address.raylet_id())
+                             << " to raylet "
+                             << NodeID::FromBinary(
+                                    reply.retry_at_raylet_address().raylet_id());
+
+              RequestNewWorkerIfNeeded(scheduling_key, &reply.retry_at_raylet_address());
+            }
+          } else if (lease_client != local_lease_client_) {
+            // A lease request to a remote raylet failed. Retry locally if the lease is
+            // still needed.
+            // TODO(swang): Fail after some number of retries?
+            RAY_LOG(INFO)
+                << "Retrying attempt to schedule task at remote node. Try again "
+                   "on a local node. Error: "
+                << status.ToString();
+
+            RequestNewWorkerIfNeeded(scheduling_key);
+
+          } else {
+            if (status.IsGrpcUnavailable()) {
+              RAY_LOG(WARNING)
+                  << "The worker failed to receive a response from the local "
+                  << "raylet because the raylet is unavailable (crashed). "
+                  << "Error: " << status;
+              if (worker_type_ == WorkerType::WORKER) {
+                // Exit the worker so that caller can retry somewhere else.
+                RAY_LOG(WARNING) << "Terminating the worker due to local raylet death";
+                QuickExit();
+              }
+              RAY_CHECK(worker_type_ == WorkerType::DRIVER);
+              error_type = rpc::ErrorType::LOCAL_RAYLET_DIED;
+              error_status = status;
+              tasks_to_fail = std::move(scheduling_key_entry.task_queue);
+              scheduling_key_entry.task_queue.clear();
               if (scheduling_key_entry.CanDelete()) {
                 scheduling_key_entries_.erase(scheduling_key);
               }
             } else {
+              RAY_LOG(WARNING)
+                  << "The worker failed to receive a response from the local raylet, but "
+                     "raylet is still alive. Try again on a local node. Error: "
+                  << status;
+              // TODO(sang): Maybe we should raise FATAL error if it happens too many
+              // times.
               RequestNewWorkerIfNeeded(scheduling_key);
             }
-          } else if (reply.rejected()) {
-            RAY_LOG(DEBUG) << "Lease rejected " << task_id;
-            // It might happen when the first raylet has a stale view
-            // of the spillback raylet resources.
-            // Retry the request at the first raylet since the resource view may be
-            // refreshed.
-            RAY_CHECK(is_spillback);
-            RequestNewWorkerIfNeeded(scheduling_key);
-          } else if (!reply.worker_address().raylet_id().empty()) {
-            // We got a lease for a worker. Add the lease client state and try to
-            // assign work to the worker.
-            rpc::WorkerAddress addr(reply.worker_address());
-            RAY_LOG(DEBUG) << "Lease granted to task " << task_id << " from raylet "
-                           << addr.raylet_id << " with worker " << addr.worker_id;
-
-            auto resources_copy = reply.resource_mapping();
-
-            AddWorkerLeaseClient(
-                addr, std::move(lease_client), resources_copy, scheduling_key);
-            RAY_CHECK(scheduling_key_entry.active_workers.size() >= 1);
-            OnWorkerIdle(addr,
-                         scheduling_key,
-                         /*error=*/false,
-                         /*worker_exiting=*/false,
-                         resources_copy);
-          } else {
-            // The raylet redirected us to a different raylet to retry at.
-            RAY_CHECK(!is_spillback);
-            RAY_LOG(DEBUG) << "Redirect lease for task " << task_id << " from raylet "
-                           << NodeID::FromBinary(raylet_address.raylet_id())
-                           << " to raylet "
-                           << NodeID::FromBinary(
-                                  reply.retry_at_raylet_address().raylet_id());
-
-            RequestNewWorkerIfNeeded(scheduling_key, &reply.retry_at_raylet_address());
           }
-        } else if (lease_client != local_lease_client_) {
-          // A lease request to a remote raylet failed. Retry locally if the lease is
-          // still needed.
-          // TODO(swang): Fail after some number of retries?
-          RAY_LOG(INFO) << "Retrying attempt to schedule task at remote node. Try again "
-                           "on a local node. Error: "
-                        << status.ToString();
+        }
 
-          RequestNewWorkerIfNeeded(scheduling_key);
-
-        } else {
-          if (status.IsGrpcUnavailable()) {
-            RAY_LOG(WARNING) << "The worker failed to receive a response from the local "
-                             << "raylet because the raylet is unavailable (crashed). "
-                             << "Error: " << status;
-            if (worker_type_ == WorkerType::WORKER) {
-              // Exit the worker so that caller can retry somewhere else.
-              RAY_LOG(WARNING) << "Terminating the worker due to local raylet death";
-              QuickExit();
-            }
-            RAY_CHECK(worker_type_ == WorkerType::DRIVER);
-            auto &task_queue = scheduling_key_entry.task_queue;
-            while (!task_queue.empty()) {
-              auto &task_spec = task_queue.front();
-              RAY_UNUSED(task_finisher_->FailPendingTask(
-                  task_spec.TaskId(), rpc::ErrorType::LOCAL_RAYLET_DIED, &status));
-              task_queue.pop_front();
-            }
-            if (scheduling_key_entry.CanDelete()) {
-              scheduling_key_entries_.erase(scheduling_key);
-            }
+        while (!tasks_to_fail.empty()) {
+          auto &task_spec = tasks_to_fail.front();
+          if (task_spec.IsActorCreationTask() &&
+              error_type == rpc::ErrorType::TASK_PLACEMENT_GROUP_REMOVED) {
+            RAY_UNUSED(task_finisher_->FailPendingTask(
+                task_spec.TaskId(),
+                rpc::ErrorType::ACTOR_PLACEMENT_GROUP_REMOVED,
+                &error_status,
+                &error_info));
           } else {
-            RAY_LOG(WARNING)
-                << "The worker failed to receive a response from the local raylet, but "
-                   "raylet is still alive. Try again on a local node. Error: "
-                << status;
-            // TODO(sang): Maybe we should raise FATAL error if it happens too many times.
-            RequestNewWorkerIfNeeded(scheduling_key);
+            RAY_UNUSED(task_finisher_->FailPendingTask(
+                task_spec.TaskId(), error_type, &error_status, &error_info));
           }
+          tasks_to_fail.pop_front();
         }
       },
       task_queue.size(),

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -195,6 +195,10 @@ enum ErrorType {
   ACTOR_UNSCHEDULABLE_ERROR = 19;
   // We use this error for object fetches that failed due to out of disk.
   OUT_OF_DISK_ERROR = 20;
+  // This object is unreachable because the application explicitly freed it,
+  // using the internal free() call. We will only recover this object if it is
+  // needed for reconstruction of another downstream object.
+  OBJECT_FREED = 21;
 }
 
 /// The information per ray error type.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Object freed by the manual and internal `free` call previously would not get reconstructed. This PR introduces the following semantics after a `free` call:
1. If no failures occurs, and the object is needed by a downstream task, an `ObjectFreedError` will be thrown.
2. If a failure occurs, causing a downstream task to be re-executed, the freed object will get reconstructed as usual.

Also fixes some incidental bugs:
1. Don't crash on failure to contact local raylet during object recovery. This will produce a nicer error message because we will instead throw an application-level error when someone tries to get an object.
2. Fix a circular lock dependency between task failure <> task dependency resolution.

## Related issue number

Closes #27265.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
