### PR TITLE
[docs] Add codeowners for subdirectories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,8 @@
 # ==== Documentation ====
 
 # Authors responsible for copy-editing of the documentation.
-/doc/ @maxpumperla @pcmoritz @ericl @stephanie-wang @dmatrix @sriram-anyscale @richardliaw
+# NOTE: Add @ray-docs to all following docs subdirs.
+/doc/ @ray-docs
 
 # ==== Ray core ====
 
@@ -62,30 +63,30 @@
 
 # Ray data.
 /python/ray/data/ @ericl @scv119 @clarkzinzow @jjyao @jianoaix
-/doc/source/data/ @ericl @scv119 @clarkzinzow @jjyao @jianoaix @maxpumperla
+/doc/source/data/ @ericl @scv119 @clarkzinzow @jjyao @jianoaix @maxpumperla @ray-docs
 
 # Ray workflows.
 /python/ray/workflow/ @ericl @iycheng @stephanie-wang @suquark
-/doc/source/workflows/ @ericl @iycheng @stephanie-wang @suquark @maxpumperla
+/doc/source/workflows/ @ericl @iycheng @stephanie-wang @suquark @maxpumperla @ray-docs
 
 # RLlib.
 /rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke
-/doc/source/rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke
+/doc/source/rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke @ray-docs
 
 # Cluster (docs)
-/doc/source/cluster/ @wuisawesome @DmitriGekhtman @maxpumperla @pcmoritz
+/doc/source/cluster/ @wuisawesome @DmitriGekhtman @maxpumperla @pcmoritz @ray-docs
 
 # Tune (docs)
-/doc/source/tune/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla
+/doc/source/tune/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-docs
 
 # Train (docs)
-/doc/source/train/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla
+/doc/source/train/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-docs
 
 # Serve (docs)
-/doc/source/serve/ @edoakes @simon-mo @jiaodong @shrekris-anyscale @sihanwang41
+/doc/source/serve/ @edoakes @simon-mo @jiaodong @shrekris-anyscale @sihanwang41 @ray-docs
 
 # AIR (docs)
-/doc/source/air/ @richardliaw @gjoliver @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla
+/doc/source/air/ @richardliaw @gjoliver @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-docs
 
 # ML Docker Dependencies
 /python/requirements/ml/requirements_dl.txt @amogkam @sven1977 @richardliaw @matthewdeng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,8 @@
 # ==== Documentation ====
 
 # Authors responsible for copy-editing of the documentation.
-# NOTE: Add @ray-docs to all following docs subdirs.
-/doc/ @ray-docs
+# NOTE: Add @ray-project/ray-docs to all following docs subdirs.
+/doc/ @ray-project/ray-docs
 
 # ==== Ray core ====
 
@@ -63,30 +63,30 @@
 
 # Ray data.
 /python/ray/data/ @ericl @scv119 @clarkzinzow @jjyao @jianoaix
-/doc/source/data/ @ericl @scv119 @clarkzinzow @jjyao @jianoaix @maxpumperla @ray-docs
+/doc/source/data/ @ericl @scv119 @clarkzinzow @jjyao @jianoaix @maxpumperla @ray-project/ray-docs
 
 # Ray workflows.
 /python/ray/workflow/ @ericl @iycheng @stephanie-wang @suquark
-/doc/source/workflows/ @ericl @iycheng @stephanie-wang @suquark @maxpumperla @ray-docs
+/doc/source/workflows/ @ericl @iycheng @stephanie-wang @suquark @maxpumperla @ray-project/ray-docs
 
 # RLlib.
 /rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke
-/doc/source/rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke @ray-docs
+/doc/source/rllib/ @sven1977 @gjoliver @avnishn @arturniederfahrenhorst @smorad @maxpumperla @kouroshhakha @krfricke @ray-project/ray-docs
 
 # Cluster (docs)
-/doc/source/cluster/ @wuisawesome @DmitriGekhtman @maxpumperla @pcmoritz @ray-docs
+/doc/source/cluster/ @wuisawesome @DmitriGekhtman @maxpumperla @pcmoritz @ray-project/ray-docs
 
 # Tune (docs)
-/doc/source/tune/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-docs
+/doc/source/tune/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-project/ray-docs
 
 # Train (docs)
-/doc/source/train/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-docs
+/doc/source/train/ @richardliaw @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-project/ray-docs
 
 # Serve (docs)
-/doc/source/serve/ @edoakes @simon-mo @jiaodong @shrekris-anyscale @sihanwang41 @ray-docs
+/doc/source/serve/ @edoakes @simon-mo @jiaodong @shrekris-anyscale @sihanwang41 @ray-project/ray-docs
 
 # AIR (docs)
-/doc/source/air/ @richardliaw @gjoliver @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-docs
+/doc/source/air/ @richardliaw @gjoliver @krfricke @xwjiang2010 @amogkam @matthewdeng @Yard1 @maxpumperla @ray-project/ray-docs
 
 # ML Docker Dependencies
 /python/requirements/ml/requirements_dl.txt @amogkam @sven1977 @richardliaw @matthewdeng


### PR DESCRIPTION
Signed-off-by: Stephanie Wang <swang@cs.berkeley.edu>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

CODEOWNERS only respects the last matching entry for a file. This PR hopefully adds the top-level docs group to all subdirs.