### PR TITLE
[Cherry-pick] [AIR - Datasets] Avoid redundant reads when truncating datasets with `.limit()`

### DIFF
--- a/python/ray/data/_internal/block_list.py
+++ b/python/ray/data/_internal/block_list.py
@@ -112,6 +112,30 @@ class BlockList:
             )
         return output
 
+    def truncate_by_rows(self, limit: int) -> "BlockList":
+        """Truncate the block list to the minimum number of blocks that contains at
+        least limit rows.
+
+        If the number of rows is not available, it will be treated as a 0-row block and
+        will be included in the truncated output.
+        """
+        self._check_if_cleared()
+        out_blocks = []
+        out_meta = []
+        out_num_rows = 0
+        for b, m in self.iter_blocks_with_metadata():
+            num_rows = m.num_rows
+            if num_rows is None:
+                num_rows = 0
+            out_blocks.append(b)
+            out_meta.append(m)
+            out_num_rows += num_rows
+            if out_num_rows >= limit:
+                break
+        return BlockList(
+            out_blocks, out_meta, owned_by_consumer=self._owned_by_consumer
+        )
+
     def size_bytes(self) -> int:
         """Returns the total size in bytes of the blocks, or -1 if not known."""
         size = 0

--- a/python/ray/data/_internal/lazy_block_list.py
+++ b/python/ray/data/_internal/lazy_block_list.py
@@ -216,6 +216,41 @@ class LazyBlockList(BlockList):
             )
         return output
 
+    def truncate_by_rows(self, limit: int) -> "LazyBlockList":
+        """Truncate the block list to the minimum number of blocks that contains at
+        least limit rows.
+
+        If the number of rows is not available, it will be treated as a 0-row block and
+        will be included in the truncated output.
+        """
+        self._check_if_cleared()
+        out_tasks, out_blocks, out_blocks_meta, out_cached_meta = [], [], [], []
+        out_num_rows = 0
+        for t, b, bm, c in zip(
+            self._tasks,
+            self._block_partition_refs,
+            self._block_partition_meta_refs,
+            self._cached_metadata,
+        ):
+            m = t.get_metadata()
+            num_rows = m.num_rows
+            if num_rows is None:
+                num_rows = 0
+            out_tasks.append(t)
+            out_blocks.append(b)
+            out_blocks_meta.append(bm)
+            out_cached_meta.append(c)
+            out_num_rows += num_rows
+            if out_num_rows >= limit:
+                break
+        return LazyBlockList(
+            out_tasks,
+            out_blocks,
+            out_blocks_meta,
+            out_cached_meta,
+            owned_by_consumer=self._owned_by_consumer,
+        )
+
     # Note: does not force execution prior to division.
     def divide(self, part_idx: int) -> ("LazyBlockList", "LazyBlockList"):
         left = LazyBlockList(

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -288,7 +288,6 @@ def _get_num_rows(block: Block) -> int:
 def _split_at_index(
     block_list: BlockList,
     index: int,
-    return_right_half: bool,
 ) -> Tuple[
     List[ObjectRef[Block]],
     List[BlockMetadata],
@@ -299,8 +298,6 @@ def _split_at_index(
     Args:
         blocks_with_metadata: Block futures to split, including the associated metadata.
         index: The (global) index at which to split the blocks.
-        return_right_half: Whether we want to return or drop the data to the right of
-            the index.
     Returns:
         The block split futures and their metadata for left and right of the index.
     """

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1744,7 +1744,11 @@ class Dataset(Generic[T]):
         return Dataset(plan, self._epoch, self._lazy)
 
     def limit(self, limit: int) -> "Dataset[T]":
-        """Limit the dataset to the first number of records specified.
+        """Truncate the dataset to the first ``limit`` records.
+
+        Contrary to :meth`.take`, this will not move any data to the caller's
+        machine. Instead, it will return a new ``Dataset`` pointing to the truncated
+        distributed data.
 
         Examples:
             >>> import ray
@@ -1795,7 +1799,11 @@ class Dataset(Generic[T]):
         )
 
     def take(self, limit: int = 20) -> List[T]:
-        """Take up to the given number of records from the dataset.
+        """Return up to ``limit`` records from the dataset.
+
+        This will move up to ``limit`` records to the caller's machine; if
+        ``limit`` is very large, this can result in an OutOfMemory crash on
+        the caller.
 
         Time complexity: O(limit specified)
 
@@ -1813,7 +1821,11 @@ class Dataset(Generic[T]):
         return output
 
     def take_all(self, limit: int = 100000) -> List[T]:
-        """Take all the records in the dataset.
+        """Return all of the records in the dataset.
+
+        This will move the entire dataset to the caller's machine; if the
+        dataset is very large, this can result in an OutOfMemory crash on
+        the caller.
 
         Time complexity: O(dataset size)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1759,9 +1759,40 @@ class Dataset(Generic[T]):
         Returns:
             The truncated dataset.
         """
-
-        left, _ = self._split(limit, return_right_half=False)
-        return left
+        start_time = time.perf_counter()
+        # Truncate the block list to the minimum number of blocks that contains at least
+        # `limit` rows.
+        block_list = self._plan.execute().truncate_by_rows(limit)
+        blocks, metadata, _, _ = _split_at_index(block_list, limit)
+        split_duration = time.perf_counter() - start_time
+        meta_for_stats = [
+            BlockMetadata(
+                num_rows=m.num_rows,
+                size_bytes=m.size_bytes,
+                schema=m.schema,
+                input_files=m.input_files,
+                exec_stats=None,
+            )
+            for m in metadata
+        ]
+        dataset_stats = DatasetStats(
+            stages={"limit": meta_for_stats},
+            parent=self._plan.stats(),
+        )
+        dataset_stats.time_total_s = split_duration
+        return Dataset(
+            ExecutionPlan(
+                BlockList(
+                    blocks,
+                    metadata,
+                    owned_by_consumer=block_list._owned_by_consumer,
+                ),
+                dataset_stats,
+                run_by_consumer=block_list._owned_by_consumer,
+            ),
+            self._epoch,
+            self._lazy,
+        )
 
     def take(self, limit: int = 20) -> List[T]:
         """Take up to the given number of records from the dataset.
@@ -3449,78 +3480,6 @@ class Dataset(Generic[T]):
             A deserialized ``Dataset`` instance.
         """
         return pickle.loads(serialized_ds)
-
-    def _split(
-        self, index: int, return_right_half: bool
-    ) -> ("Dataset[T]", "Dataset[T]"):
-        start_time = time.perf_counter()
-        block_list = self._plan.execute()
-        left_blocks, left_metadata, right_blocks, right_metadata = _split_at_index(
-            block_list,
-            index,
-            return_right_half,
-        )
-        split_duration = time.perf_counter() - start_time
-        left_meta_for_stats = [
-            BlockMetadata(
-                num_rows=m.num_rows,
-                size_bytes=m.size_bytes,
-                schema=m.schema,
-                input_files=m.input_files,
-                exec_stats=None,
-            )
-            for m in left_metadata
-        ]
-        left_dataset_stats = DatasetStats(
-            stages={"split": left_meta_for_stats},
-            parent=self._plan.stats(),
-        )
-        left_dataset_stats.time_total_s = split_duration
-        left = Dataset(
-            ExecutionPlan(
-                BlockList(
-                    left_blocks,
-                    left_metadata,
-                    owned_by_consumer=block_list._owned_by_consumer,
-                ),
-                left_dataset_stats,
-                run_by_consumer=block_list._owned_by_consumer,
-            ),
-            self._epoch,
-            self._lazy,
-        )
-        if return_right_half:
-            right_meta_for_stats = [
-                BlockMetadata(
-                    num_rows=m.num_rows,
-                    size_bytes=m.size_bytes,
-                    schema=m.schema,
-                    input_files=m.input_files,
-                    exec_stats=None,
-                )
-                for m in right_metadata
-            ]
-            right_dataset_stats = DatasetStats(
-                stages={"split": right_meta_for_stats},
-                parent=self._plan.stats(),
-            )
-            right_dataset_stats.time_total_s = split_duration
-            right = Dataset(
-                ExecutionPlan(
-                    BlockList(
-                        right_blocks,
-                        right_metadata,
-                        owned_by_consumer=block_list._owned_by_consumer,
-                    ),
-                    right_dataset_stats,
-                    run_by_consumer=block_list._owned_by_consumer,
-                ),
-                self._epoch,
-                self._lazy,
-            )
-        else:
-            right = None
-        return left, right
 
     def _divide(self, block_idx: int) -> ("Dataset[T]", "Dataset[T]"):
         block_list = self._plan.execute()

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -17,9 +17,10 @@ from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data._internal.pandas_block import PandasRow
 from ray.data.aggregate import AggregateFn, Count, Max, Mean, Min, Std, Sum
-from ray.data.block import BlockAccessor
+from ray.data.block import BlockAccessor, BlockMetadata
 from ray.data.context import DatasetContext
 from ray.data.dataset import Dataset, _sliding_window
+from ray.data.datasource.datasource import Datasource, ReadTask
 from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
@@ -1420,10 +1421,92 @@ def test_lazy_loading_exponential_rampup(ray_start_regular_shared):
     assert ds._plan.execute()._num_computed() == 20
 
 
-def test_limit(ray_start_regular_shared):
+@pytest.mark.parametrize("lazy", [False, True])
+def test_limit(ray_start_regular_shared, lazy):
     ds = ray.data.range(100, parallelism=20)
+    if not lazy:
+        ds = ds.fully_executed()
     for i in range(100):
         assert ds.limit(i).take(200) == list(range(i))
+
+
+# NOTE: We test outside the power-of-2 range in order to ensure that we're not reading
+# redundant files due to exponential ramp-up.
+@pytest.mark.parametrize("limit,expected", [(10, 1), (20, 2), (30, 3), (60, 6)])
+def test_limit_no_redundant_read(ray_start_regular_shared, limit, expected):
+    # Test that dataset truncation eliminates redundant reads.
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.count = 0
+
+        def increment(self):
+            self.count += 1
+
+        def get(self):
+            return self.count
+
+        def reset(self):
+            self.count = 0
+
+    class CountingRangeDatasource(Datasource):
+        def __init__(self):
+            self.counter = Counter.remote()
+
+        def prepare_read(self, parallelism, n):
+            def range_(i):
+                ray.get(self.counter.increment.remote())
+                return [list(range(parallelism * i, parallelism * i + n))]
+
+            return [
+                ReadTask(
+                    lambda i=i: range_(i),
+                    BlockMetadata(
+                        num_rows=n,
+                        size_bytes=None,
+                        schema=None,
+                        input_files=None,
+                        exec_stats=None,
+                    ),
+                )
+                for i in range(parallelism)
+            ]
+
+    source = CountingRangeDatasource()
+
+    ds = ray.data.read_datasource(
+        source,
+        parallelism=10,
+        n=10,
+    )
+    ds2 = ds.limit(limit)
+    # Check content.
+    assert ds2.take(limit) == list(range(limit))
+    # Check number of read tasks launched.
+    assert ray.get(source.counter.get.remote()) == expected
+
+
+def test_limit_no_num_row_info(ray_start_regular_shared):
+    # Test that datasources with no number-of-rows metadata available are still able to
+    # be truncated, falling back to kicking off all read tasks.
+    class DumbOnesDatasource(Datasource):
+        def prepare_read(self, parallelism, n):
+            return parallelism * [
+                ReadTask(
+                    lambda: [[1] * n],
+                    BlockMetadata(
+                        num_rows=None,
+                        size_bytes=None,
+                        schema=None,
+                        input_files=None,
+                        exec_stats=None,
+                    ),
+                )
+            ]
+
+    ds = ray.data.read_datasource(DumbOnesDatasource(), parallelism=10, n=10)
+    for i in range(1, 100):
+        assert ds.limit(i).take(100) == [1] * i
 
 
 def test_convert_types(ray_start_regular_shared):


### PR DESCRIPTION
Cherry-pick of https://github.com/ray-project/ray/pull/27343 and https://github.com/ray-project/ray/pull/27367 onto 2.0.0 release branch.