### PR TITLE
Add query param to limit number of actors in api/snapshot

### DIFF
--- a/dashboard/modules/snapshot/tests/test_snapshot.py
+++ b/dashboard/modules/snapshot/tests/test_snapshot.py
@@ -235,6 +235,13 @@ ray.get(a.ping.remote())
     assert data["data"]["snapshot"]["rayCommit"] == ray.__commit__
     assert data["data"]["snapshot"]["rayVersion"] == ray.__version__
 
+    # test actor limit
+    response = requests.get(f"{webui_url}/api/snapshot?actor_limit=2")
+    response.raise_for_status()
+    data = response.json()
+    pprint.pprint(data)
+    assert len(data["data"]["snapshot"]["actors"]) == 2
+
 
 @pytest.mark.parametrize("ray_start_with_dashboard", [{"num_cpus": 4}], indirect=True)
 def test_serve_snapshot(ray_start_with_dashboard):


### PR DESCRIPTION
Cherry-picks #27489

Default the value to 1000 actors

Signed-off-by: Alan Guo aguo@anyscale.com

Why are these changes needed?
Reduces the latency of the api/snapshot, especially in cases where there is a ton of actors.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
