### PR TITLE
[air] Render trainer docstring signatures

### DIFF
--- a/doc/source/ray-air/package-ref.rst
+++ b/doc/source/ray-air/package-ref.rst
@@ -35,6 +35,8 @@ Trainer
 .. autoclass:: ray.train.trainer.BaseTrainer
     :members:
 
+    .. automethod:: __init__
+
 Abstract Classes
 ################
 
@@ -42,9 +44,13 @@ Abstract Classes
     :members:
     :show-inheritance:
 
+    .. automethod:: __init__
+
 .. autoclass:: ray.train.gbdt_trainer.GBDTTrainer
     :members:
     :show-inheritance:
+
+    .. automethod:: __init__
 
 .. _air-results-ref:
 
@@ -128,22 +134,46 @@ Trainer and Predictor Integrations
 XGBoost
 #######
 
+.. autoclass:: ray.train.xgboost.XGBoostTrainer
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+
 .. automodule:: ray.train.xgboost
     :members:
+    :exclude-members: XGBoostTrainer
     :show-inheritance:
 
 LightGBM
 ########
 
+.. autoclass:: ray.train.lightgbm.LightGBMTrainer
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+
 .. automodule:: ray.train.lightgbm
     :members:
+    :exclude-members: LightGBMTrainer
     :show-inheritance:
 
 TensorFlow
 ##########
 
+.. autoclass:: ray.train.tensorflow.TensorflowTrainer
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+
 .. automodule:: ray.train.tensorflow
     :members:
+    :exclude-members: TensorflowTrainer
     :show-inheritance:
 
 .. _air-pytorch-ref:
@@ -151,29 +181,61 @@ TensorFlow
 PyTorch
 #######
 
+.. autoclass:: ray.train.torch.TorchTrainer
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+
 .. automodule:: ray.train.torch
     :members:
+    :exclude-members: TorchTrainer
     :show-inheritance:
 
 Horovod
 #######
 
+.. autoclass:: ray.train.horovod.HorovodTrainer
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+
 .. automodule:: ray.train.horovod
     :members:
+    :exclude-members: HorovodTrainer
     :show-inheritance:
 
 HuggingFace
 ###########
 
+.. autoclass:: ray.train.huggingface.HuggingFaceTrainer
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+
 .. automodule:: ray.train.huggingface
     :members:
+    :exclude-members: HuggingFaceTrainer
     :show-inheritance:
 
 Scikit-Learn
 ############
 
+.. autoclass:: ray.train.sklearn.SklearnTrainer
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+
 .. automodule:: ray.train.sklearn
     :members:
+    :exclude-members: SklearnTrainer
     :show-inheritance:
 
 

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -182,7 +182,7 @@ class BaseTrainer(abc.ABC):
         return f"<{self.__class__.__name__}>"
 
     def __new__(cls, *args, **kwargs):
-        """Store the init args as attributes so this can be merged with Tune hparams."""
+        # Store the init args as attributes so this can be merged with Tune hparams.
         trainer = super(BaseTrainer, cls).__new__(cls)
         parameters = inspect.signature(cls.__init__).parameters
         parameters = list(parameters.keys())
@@ -251,7 +251,7 @@ class BaseTrainer(abc.ABC):
     def setup(self) -> None:
         """Called during fit() to perform initial setup on the Trainer.
 
-        Note: this method is run on a remote process.
+        .. note:: This method is run on a remote process.
 
         This method will not be called on the driver, so any expensive setup
         operations should be placed here and not in ``__init__``.
@@ -264,7 +264,7 @@ class BaseTrainer(abc.ABC):
     def preprocess_datasets(self) -> None:
         """Called during fit() to preprocess dataset attributes with preprocessor.
 
-        Note: This method is run on a remote process.
+        .. note:: This method is run on a remote process.
 
         This method is called prior to entering the training_loop.
 
@@ -309,15 +309,16 @@ class BaseTrainer(abc.ABC):
         this training loop.
 
         Example:
-            .. code-block: python
 
-                from ray.train.trainer import BaseTrainer
+        .. code-block: python
 
-                class MyTrainer(BaseTrainer):
-                    def training_loop(self):
-                        for epoch_idx in range(5):
-                            ...
-                            session.report({"epoch": epoch_idx})
+            from ray.train.trainer import BaseTrainer
+
+            class MyTrainer(BaseTrainer):
+                def training_loop(self):
+                    for epoch_idx in range(5):
+                        ...
+                        session.report({"epoch": epoch_idx})
 
         """
         raise NotImplementedError


### PR DESCRIPTION

## Why are these changes needed?

Because we override `__new__`, we can't render signatures correctly, losing valuable type hints. This is a one-off fix to improve this by rendering the __init__ method manually, but it is not a great fix. Ideally we get rid of our usage of `__new__` and render things correctly.

<img width="788" alt="Screen Shot 2022-08-05 at 4 59 36 PM" src="https://user-images.githubusercontent.com/4529381/183224951-284e78a1-900a-413d-90b3-e0dab111943d.png">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(