### PR TITLE
Revert "[log_monitor] Seek when reopening a file due to inode change …

### DIFF
--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -73,13 +73,10 @@ class LogFileInfo:
         would have different inodes, such as log rotation or file syncing
         semantics.
         """
-        open_inode = None
-        if self.file_handle and not self.file_handle.closed:
-            open_inode = os.fstat(self.file_handle.fileno()).st_ino
+        open_inode = os.fstat(self.file_handle.fileno()).st_ino
         new_inode = os.stat(self.filename).st_ino
         if open_inode != new_inode:
             self.file_handle = open(self.filename, "rb")
-            self.file_handle.seek(self.file_position)
 
     def __repr__(self):
         return (

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -15,7 +15,6 @@ from ray._private import ray_constants
 from ray._private.log_monitor import (
     LOG_NAME_UPDATE_INTERVAL_S,
     RAY_LOG_MONITOR_MANY_FILES_THRESHOLD,
-    LogFileInfo,
     LogMonitor,
 )
 from ray._private.test_utils import (
@@ -31,49 +30,6 @@ from ray.cross_language import java_actor_class
 def set_logging_config(monkeypatch, max_bytes, backup_count):
     monkeypatch.setenv("RAY_ROTATION_MAX_BYTES", str(max_bytes))
     monkeypatch.setenv("RAY_ROTATION_BACKUP_COUNT", str(backup_count))
-
-
-def test_reopen_changed_inode(tmp_path):
-    """Make sure that when we reopen a file because the inode has changed, we
-    open to the right location."""
-
-    path1 = tmp_path / "file"
-    path2 = tmp_path / "changed_file"
-
-    with open(path1, "w") as f:
-        for i in range(1000):
-            print(f"{i}", file=f)
-
-    with open(path2, "w") as f:
-        for i in range(2000):
-            print(f"{i}", file=f)
-
-    file_info = LogFileInfo(
-        filename=path1,
-        size_when_last_opened=0,
-        file_position=0,
-        file_handle=None,
-        is_err_file=False,
-        job_id=None,
-        worker_pid=None,
-    )
-
-    file_info.reopen_if_necessary()
-    for _ in range(1000):
-        file_info.file_handle.readline()
-
-    orig_file_pos = file_info.file_handle.tell()
-    file_info.file_position = orig_file_pos
-
-    # NOTE: On windows, an open file can't be deleted.
-    file_info.file_handle.close()
-    os.remove(path1)
-    os.rename(path2, path1)
-
-    file_info.reopen_if_necessary()
-
-    assert file_info.file_position == orig_file_pos
-    assert file_info.file_handle.tell() == orig_file_pos
 
 
 def test_log_rotation_config(ray_start_cluster, monkeypatch):


### PR DESCRIPTION
…(#27508)"
<img width="674" alt="Screen Shot 2022-08-07 at 8 56 42 AM" src="https://user-images.githubusercontent.com/18510752/183299721-2b259aed-6e25-43b3-8e11-d0c00a29dc33.png">

This reverts commit a6b9019d382187ebc165fef1fbdebaa9b7f55547.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
