### PR TITLE
[AIR - Datasets] Ragged tensor extension type.

### DIFF
--- a/doc/source/data/api/data_representations.rst
+++ b/doc/source/data/api/data_representations.rst
@@ -46,3 +46,9 @@ Tensor Column Extension API
 
 .. autoclass:: ray.data.extensions.tensor_extension.ArrowTensorArray
     :members:
+
+.. autoclass:: ray.data.extensions.tensor_extension.ArrowVariableShapedTensorType
+    :members:
+
+.. autoclass:: ray.data.extensions.tensor_extension.ArrowVariableShapedTensorArray
+    :members:

--- a/doc/source/data/dataset-tensor-support.rst
+++ b/doc/source/data/dataset-tensor-support.rst
@@ -3,13 +3,13 @@
 ML Tensor Support
 =================
 
-Tensor (multi-dimensional array) data is ubiquitous in ML workloads. However, popular data formats such as Pandas, Parquet, and Arrow don't natively support tensor data types. To bridge this gap, Datasets provides a unified tensor data type that can be used to represent and store tensor data:
+Tensor (multi-dimensional array) data is ubiquitous in ML workloads. However, popular data formats such as Pandas, Parquet, and Arrow don't natively support tensor data types. To bridge this gap, Datasets provides a unified tensor data type that can be used to represent, transform, and store tensor data:
 
 * For Pandas, Datasets will transparently convert ``List[np.ndarray]`` columns to and from the :class:`TensorDtype <ray.data.extensions.tensor_extension.TensorDtype>` extension type.
-* For Parquet, the Datasets Arrow extension :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>` allows tensors to be loaded from and stored in Parquet format.
-* In addition, single-column Tensor datasets can be created from NumPy (.npy) files.
+* For Parquet, Datasets has an Arrow extension :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>` that allows tensors to be loaded from and stored in the Parquet format.
+* In addition, single-column tensor datasets can be created from NumPy (.npy) files.
 
-Datasets automatically converts between the extension types/arrays above. This means you can just think of ``Tensor`` as a single first-class data type in Datasets.
+Datasets automatically converts between the extension types/arrays above. This means you can think of a ``Tensor`` as a first-class data type in Datasets.
 
 Creating Tensor Datasets
 ------------------------
@@ -240,3 +240,11 @@ below.
 
     ctx = DatasetContext.get_current()
     ctx.enable_tensor_extension_casting = False
+
+
+Limitations
+-----------
+
+The following are current limitations of tensor datasets.
+
+* Arbitrarily `nested/ragged tensors <https://www.tensorflow.org/guide/ragged_tensor>`__ are not supported. Only tensors with all uniform dimensions (i.e. a fully well-defined shape) and tensors representing a collection of variable-shaped tensor elements (e.g. a collection of images with different shapes) are supported; arbitrary raggedness and nested ragged tensors is not supported.

--- a/doc/source/data/dataset-tensor-support.rst
+++ b/doc/source/data/dataset-tensor-support.rst
@@ -6,15 +6,15 @@ ML Tensor Support
 Tensor (multi-dimensional array) data is ubiquitous in ML workloads. However, popular data formats such as Pandas, Parquet, and Arrow don't natively support tensor data types. To bridge this gap, Datasets provides a unified tensor data type that can be used to represent and store tensor data:
 
 * For Pandas, Datasets will transparently convert ``List[np.ndarray]`` columns to and from the :class:`TensorDtype <ray.data.extensions.tensor_extension.TensorDtype>` extension type.
-* For Parquet, the Datasets Arrow extension :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>` allows Tensors to be loaded and stored in Parquet format.
+* For Parquet, the Datasets Arrow extension :class:`ArrowTensorType <ray.data.extensions.tensor_extension.ArrowTensorType>` allows tensors to be loaded from and stored in Parquet format.
 * In addition, single-column Tensor datasets can be created from NumPy (.npy) files.
 
-Datasets automatically converts between the extension types/arrays above. This means you can just think of "Tensors" as a single first-class data type in Datasets.
+Datasets automatically converts between the extension types/arrays above. This means you can just think of ``Tensor`` as a single first-class data type in Datasets.
 
 Creating Tensor Datasets
 ------------------------
 
-This section shows how to create single and multi-column Tensor datasets.
+This section shows how to create single and multi-column tensor datasets.
 
 .. tabbed:: Synthetic Data
 
@@ -48,7 +48,7 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. tabbed:: NumPy
 
-  Create from in-memory numpy data or from previously saved NumPy (.npy) files.
+  Create from in-memory NumPy data or from previously saved NumPy (.npy) files.
 
   **Single-column only**:
 
@@ -59,13 +59,13 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. tabbed:: Parquet
 
-  There are two ways to construct a parquet Tensor dataset: (1) loading a
-  previously-saved Tensor dataset, or (2) casting non-Tensor parquet columns to Tensor
+  There are two ways to construct a Parquet tensor dataset: (1) loading a
+  previously-saved tensor dataset, or (2) casting non-tensor Parquet columns to tensor
   type. When casting data, a tensor schema or deserialization
   :ref:`user-defined function <transform_datasets_writing_udfs>`  must be provided. The
   following are examples for each method.
 
-  **Previously-saved Tensor datasets**:
+  **Previously-saved tensor datasets**:
 
   .. literalinclude:: ./doc_code/tensor.py
     :language: python
@@ -74,7 +74,8 @@ This section shows how to create single and multi-column Tensor datasets.
 
   **Cast from data stored in C-contiguous format**:
 
-  For tensors stored as raw NumPy ndarray bytes in C-contiguous order (e.g., via ``ndarray.tobytes()``), all you need to specify is the tensor column schema. The following is an end-to-end example:
+  For tensors stored as raw NumPy ndarray bytes in C-contiguous order (e.g., via
+  `ndarray.tobytes() <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tobytes.html>`__), all you need to specify is the tensor column schema. The following is an end-to-end example:
 
   .. literalinclude:: ./doc_code/tensor.py
     :language: python
@@ -85,7 +86,7 @@ This section shows how to create single and multi-column Tensor datasets.
 
   For tensors stored in other formats (e.g., pickled), you can specify a deserializer
   :ref:`user-defined function <transform_datasets_writing_udfs>` that returns
-  TensorArray columns:
+  :class:`~ray.data.extensions.tensor_extensions.TensorArray` columns:
 
   .. literalinclude:: ./doc_code/tensor.py
     :language: python
@@ -94,7 +95,7 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. tabbed:: Images (experimental)
 
-  Load image data stored as individual files using :py:class:`~ray.data.datasource.ImageFolderDatasource`:
+  Load image data stored as individual files using :class:`~ray.data.datasource.ImageFolderDatasource`:
 
   **Image and label columns**:
 
@@ -105,8 +106,8 @@ This section shows how to create single and multi-column Tensor datasets.
 
 .. note::
 
-  By convention, single-column Tensor datasets are represented with a single ``__value__`` column.
-  This kind of dataset will be converted automatically to/from NumPy array format in all transformation and consumption APIs.
+  By convention, single-column tensor datasets are represented with a single ``__value__`` column.
+  This kind of dataset will be converted automatically to/from NumPy ndarray format in all transformation and consumption APIs.
 
 Transforming / Consuming Tensor Data
 ------------------------------------
@@ -180,7 +181,9 @@ Like any other Dataset, Datasets with tensor columns can be consumed / transform
 Saving Tensor Datasets
 ----------------------
 
-Because Tensor datasets rely on Datasets-specific extension types, they can only be saved in formats that preserve Arrow metadata (currently only Parquet). In addition, single-column Tensor datasets can be saved in NumPy format.
+Because tensor datasets rely on Datasets-specific extension types, they can only be
+saved in formats that preserve Arrow metadata (currently only Parquet). In addition,
+single-column tensor datasets can be saved in NumPy format.
 
 .. tabbed:: Parquet
 
@@ -196,13 +199,39 @@ Because Tensor datasets rely on Datasets-specific extension types, they can only
     :start-after: __write_2_begin_
     :end-before: __write_2_end__
 
+.. _ragged_tensor_support:
+
+Ragged Tensor Support
+---------------------
+
+`Ragged tensors <https://www.tensorflow.org/guide/ragged_tensor>`__, i.e. tensors with non-uniform dimensions, pop up in NLP
+(`textual sentences/documents of different lengths <https://towardsdatascience.com/using-tensorflow-ragged-tensors-2af07849a7bd>`__,
+`N-grams <https://www.tensorflow.org/guide/ragged_tensor#example_use_case>`__),
+computer vision (images of differing resolution,
+`ssd300_vgg16 detection outputs <https://pytorch.org/vision/main/models/generated/torchvision.models.detection.ssd300_vgg16.html>`__),
+and audio ML (differing durations). Datasets has basic support for ragged tensors,
+namely tensors that are a collection (batch) of variably-shaped subtensors, e.g. a batch
+of images of differing sizes or a batch of sentences of differing lengths.
+
+.. literalinclude:: ./doc_code/tensor.py
+  :language: python
+  :start-after: __create_variable_shaped_tensors_begin__
+  :end-before: __create_variable_shaped_tensors_end__
+
+These variable-shaped tensors can be exchanged with popular training frameworks that support ragged tensors, such as `TensorFlow <https://www.tensorflow.org/guide/ragged_tensor#setup>`__.
+
+.. literalinclude:: ./doc_code/tensor.py
+  :language: python
+  :start-after: __tf_variable_shaped_tensors_begin__
+  :end-before: __tf_variable_shaped_tensors_end__
+
 .. _disable_tensor_extension_casting:
 
 Disabling Tensor Extension Casting
 ----------------------------------
 
 To disable automatic casting of Pandas and Arrow arrays to
-:class:`TensorArray <ray.data.extensions.tensor_extension.TensorArray>`, run the code
+:class:`~ray.data.extensions.tensor_extension.TensorArray`, run the code
 below.
 
 .. code-block::
@@ -211,10 +240,3 @@ below.
 
     ctx = DatasetContext.get_current()
     ctx.enable_tensor_extension_casting = False
-
-Limitations
------------
-
-The following are current limitations of Tensor datasets.
-
-* All tensors in a tensor column must have the same shape; see GitHub issue `#18316 <https://github.com/ray-project/ray/issues/18316>`__. An error will be raised in the ragged tensor case. Automatic casting can be disabled with ``ray.data.context.DatasetContext.get_current().enable_tensor_extension_cast = False`` in the ragged tensor scenario.

--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -496,3 +496,35 @@ read_ds = ray.data.read_numpy("/tmp/some_path")
 print(read_ds.schema())
 # -> __value__: extension<arrow.py_extension_type<ArrowTensorType>>
 # __write_2_end__
+
+# fmt: off
+# __create_variable_shaped_tensors_begin___
+# Create a Dataset of variable-shaped tensors.
+arr = np.array([np.ones((2, 2)), np.ones((3, 3))], dtype=object)
+ds = ray.data.from_numpy([arr, arr])
+# -> Dataset(num_blocks=2, num_rows=4,
+#            schema={__value__: ArrowVariableShapedTensorType(dtype=double)})
+
+ds.take(2)
+# -> [array([[1., 1.],
+#            [1., 1.]]),
+#     array([[1., 1., 1.],
+#            [1., 1., 1.],
+#            [1., 1., 1.]])]
+# __create_variable_shaped_tensors_end__
+
+# fmt: off
+# __tf_variable_shaped_tensors_begin___
+# Convert Ray Dataset to a TensorFlow Dataset.
+tf_ds = ds.to_tf(
+    batch_size=2,
+    output_signature=tf.RaggedTensorSpec(shape=(None, None, None), dtype=tf.float64),
+)
+# Iterate through the tf.RaggedTensors.
+for ragged_tensor in tf_ds:
+    print(ragged_tensor)
+# -> <tf.RaggedTensor [[[1.0, 1.0], [1.0, 1.0]],
+#     [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]]>
+#    <tf.RaggedTensor [[[1.0, 1.0], [1.0, 1.0]],
+#     [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]]>
+# __tf_variable_shaped_tensors_end__

--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -205,18 +205,17 @@ def _cast_ndarray_columns_to_tensor_extension(df: pd.DataFrame) -> pd.DataFrame:
     """
     Cast all NumPy ndarray columns in df to our tensor extension type, TensorArray.
     """
-    from ray.air.util.tensor_extensions.pandas import TensorArray
+    from ray.air.util.tensor_extensions.pandas import (
+        TensorArray,
+        column_needs_tensor_extension,
+    )
 
     # Try to convert any ndarray columns to TensorArray columns.
     # TODO(Clark): Once Pandas supports registering extension types for type
     # inference on construction, implement as much for NumPy ndarrays and remove
     # this. See https://github.com/pandas-dev/pandas/issues/41848
     for col_name, col in df.items():
-        if (
-            col.dtype.type is np.object_
-            and not col.empty
-            and isinstance(col.iloc[0], np.ndarray)
-        ):
+        if column_needs_tensor_extension(col):
             try:
                 df.loc[:, col_name] = TensorArray(col)
             except Exception as e:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -126,14 +126,12 @@ class ArrowTensorArray(pa.ExtensionArray):
         Returns:
             An ArrowTensorArray containing len(arr) tensors of fixed shape.
         """
-        if isinstance(arr, (list, tuple)):
-            if np.isscalar(arr[0]):
-                return pa.array(arr)
-            elif isinstance(arr[0], np.ndarray):
-                # Stack ndarrays and pass through to ndarray handling logic
-                # below.
-                arr = np.stack(arr, axis=0)
+        if isinstance(arr, (list, tuple)) and arr and isinstance(arr[0], np.ndarray):
+            # Stack ndarrays and pass through to ndarray handling logic below.
+            arr = np.stack(arr, axis=0)
         if isinstance(arr, np.ndarray):
+            if len(arr) == 0 or np.isscalar(arr[0]):
+                return pa.array(arr)
             if not arr.flags.c_contiguous:
                 # We only natively support C-contiguous ndarrays.
                 arr = np.ascontiguousarray(arr)

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -46,7 +46,7 @@ class ArrowTensorType(pa.PyExtensionType):
         """
         from ray.air.util.tensor_extensions.pandas import TensorDtype
 
-        return TensorDtype(self.storage_type.value_type.to_pandas_dtype(), self._shape)
+        return TensorDtype(self._shape, self.storage_type.value_type.to_pandas_dtype())
 
     def __reduce__(self):
         return ArrowTensorType, (self._shape, self.storage_type.value_type)
@@ -309,6 +309,7 @@ class ArrowVariableShapedTensorType(pa.PyExtensionType):
         from ray.air.util.tensor_extensions.pandas import TensorDtype
 
         return TensorDtype(
+            None,
             self.storage_type["data"].type.value_type.to_pandas_dtype(),
         )
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -130,7 +130,7 @@ class ArrowTensorArray(pa.ExtensionArray):
             # Stack ndarrays and pass through to ndarray handling logic below.
             arr = np.stack(arr, axis=0)
         if isinstance(arr, np.ndarray):
-            if len(arr) == 0 or np.isscalar(arr[0]):
+            if len(arr) > 0 and np.isscalar(arr[0]):
                 return pa.array(arr)
             if not arr.flags.c_contiguous:
                 # We only natively support C-contiguous ndarrays.
@@ -271,7 +271,7 @@ class ArrowTensorArray(pa.ExtensionArray):
         return self._to_numpy(zero_copy_only=zero_copy_only)
 
 
-@PublicAPI(stability="beta")
+@PublicAPI(stability="alpha")
 class ArrowVariableShapedTensorType(pa.PyExtensionType):
     """
     Arrow ExtensionType for an array of heterogeneous-shaped, homogeneous-typed
@@ -335,7 +335,7 @@ class ArrowVariableShapedTensorType(pa.PyExtensionType):
         return str(self)
 
 
-@PublicAPI(stability="beta")
+@PublicAPI(stability="alpha")
 class ArrowVariableShapedTensorArray(pa.ExtensionArray):
     """
     An array of heterogeneous-shaped, homogeneous-typed tensors.

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -451,6 +451,12 @@ class ArrowVariableShapedTensorArray(pa.ExtensionArray):
         else:
             np_data_buffer = np.concatenate(raveled)
         dtype = np_data_buffer.dtype
+        if dtype.type is np.object_:
+            raise ValueError(
+                "ArrowVariableShapedTensorArray only supports heterogeneous-shaped "
+                "tensor collections, not arbitrarily nested ragged tensors. Got: "
+                f"{arr}"
+            )
         pa_dtype = pa.from_numpy_dtype(dtype)
         if dtype.type is np.bool_:
             # NumPy doesn't represent boolean arrays as bit-packed, so we manually

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -29,7 +29,6 @@
 # - Added support for logical operators to TensorArray(Element).
 # - Miscellaneous small bug fixes and optimizations.
 
-import itertools
 import numbers
 import os
 from packaging.version import Version
@@ -181,8 +180,11 @@ if os.getenv(_FORMATTER_ENABLED_ENV_VAR, "1") == "1":
 @pd.api.extensions.register_extension_dtype
 class TensorDtype(pd.api.extensions.ExtensionDtype):
     """
-    Pandas extension type for a column of fixed-shape, homogeneous-typed
-    tensors.
+    Pandas extension type for a column of homogeneous-typed tensors.
+
+    This extension supports ragged tensors, i.e. where the tensor elements have
+    different shapes. However, each tensor element must be non-ragged, i.e. each tensor
+    element must have a well-defined shape.
 
     See:
     https://github.com/pandas-dev/pandas/blob/master/pandas/core/dtypes/base.py
@@ -205,7 +207,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         dtype: object
         >>> # Cast column to our TensorDtype extension type.
         >>> from ray.data.extensions import TensorDtype
-        >>> df["two"] = df["two"].astype(TensorDtype((3, 2, 2, 2), np.int64))
+        >>> df["two"] = df["two"].astype(TensorDtype(np.int64, (3, 2, 2, 2)))
         >>> # Note that the column dtype is now TensorDtype instead of
         >>> # np.object.
         >>> df.dtypes # doctest: +SKIP
@@ -279,9 +281,9 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
     # https://github.com/CODAIT/text-extensions-for-pandas/issues/166
     base = None
 
-    def __init__(self, shape: Tuple[int, ...], dtype: np.dtype):
-        self._shape = shape
+    def __init__(self, dtype: np.dtype, shape: Optional[Tuple[int, ...]] = None):
         self._dtype = dtype
+        self._shape = shape
 
     @property
     def type(self):
@@ -356,7 +358,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
             )
         # Upstream code uses exceptions as part of its normal control flow and
         # will pass this method bogus class names.
-        regex = r"^TensorDtype\(shape=(\((?:\d+,?\s?)*\)), dtype=(\w+)\)$"
+        regex = r"^TensorDtype\(shape=((?:\((?:\d+,?\s?)*\))|(?:None)), dtype=(\w+)\)$"
         m = re.search(regex, string)
         err_msg = (
             f"Cannot construct a '{cls.__name__}' from '{string}'; expected a string "
@@ -370,7 +372,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         shape, dtype = groups
         shape = ast.literal_eval(shape)
         dtype = np.dtype(dtype)
-        return cls(shape, dtype)
+        return cls(dtype, shape)
 
     @classmethod
     def construct_array_type(cls):
@@ -584,8 +586,11 @@ class TensorArray(
 ):
     """
     Pandas `ExtensionArray` representing a tensor column, i.e. a column
-    consisting of ndarrays as elements. All tensors in a column must have the
-    same shape.
+    consisting of ndarrays as elements.
+
+    This extension supports ragged tensors, i.e. where the tensor elements have
+    different shapes. However, each tensor element must be non-ragged, i.e. each tensor
+    element must have a well-defined shape.
 
     Examples:
         >>> # Create a DataFrame with a list of ndarrays as a column.
@@ -703,28 +708,21 @@ class TensorArray(
 
         if isinstance(values, np.ndarray):
             if values.dtype.type is np.object_:
-                if len(values) == 0 or (
-                    not isinstance(values[0], str)
-                    and isinstance(
-                        values[0], (np.ndarray, TensorArrayElement, Sequence)
+                if len(values) == 0:
+                    # Tensor is empty, pass through to create empty TensorArray.
+                    pass
+                elif isinstance(values[0], str):
+                    # Tensor of strings, these don't need a TensorArray representation.
+                    raise TypeError(
+                        "Got a tensor of strings when constructing a TensorArray, but "
+                        "a tensor of strings doesn't need to be represented using a "
+                        "TensorArray."
                     )
-                ):
-                    # Convert ndarrays of ndarrays/TensorArrayElements
-                    # with an opaque object type to a properly typed ndarray of
-                    # ndarrays.
+                elif isinstance(values[0], (np.ndarray, TensorArrayElement, Sequence)):
+                    # Try to convert ndarrays of ndarrays/TensorArrayElements with an
+                    # opaque object type to a properly typed ndarray of ndarrays.
+                    # TODO (Clark): Maybe don't even try this conversion?
                     self._tensor = np.array([np.asarray(v) for v in values])
-                    if self._tensor.dtype.type is np.object_:
-                        subndarray_types = [
-                            v.dtype for v in itertools.islice(self._tensor, 5)
-                        ]
-                        raise TypeError(
-                            "Tried to convert an ndarray of ndarray pointers (object "
-                            "dtype) to a well-typed ndarray but this failed; convert "
-                            "the ndarray to a well-typed ndarray before casting it as "
-                            "a TensorArray, and note that ragged tensors are NOT "
-                            "supported by TensorArray. First 5 subndarray types: "
-                            f"{subndarray_types}"
-                        )
                 else:
                     raise TypeError(
                         "Expected a well-typed ndarray or an object-typed ndarray of "
@@ -740,12 +738,11 @@ class TensorArray(
             # `values` is a single element:
             self._tensor = np.array([values])
         elif isinstance(values, TensorArray):
-            raise TypeError("Use the copy() method to create a copy of a TensorArray")
+            raise TypeError("Use the copy() method to create a copy of a TensorArray.")
         else:
             raise TypeError(
                 "Expected a numpy.ndarray or sequence of numpy.ndarray, "
-                f"but received {values} "
-                f"of type '{type(values)}' instead."
+                f"but received {values} of type {type(values).__name__} instead."
             )
 
     @classmethod
@@ -865,7 +862,13 @@ class TensorArray(
         """
         An instance of 'ExtensionDtype'.
         """
-        return TensorDtype(self.numpy_shape[1:], self.numpy_dtype)
+        if self._is_ragged_tensor():
+            dtype = self._tensor[0].dtype if len(self._tensor) > 0 else self.numpy_dtype
+            shape = None
+        else:
+            dtype = self.numpy_dtype
+            shape = self.numpy_shape[1:]
+        return TensorDtype(dtype, shape)
 
     @property
     def nbytes(self) -> int:
@@ -1319,6 +1322,10 @@ class TensorArray(
         result = self._tensor.all(axis=axis, out=out, keepdims=keepdims)
         return result if axis is None else TensorArray(result)
 
+    def _is_ragged_tensor(self) -> bool:
+        """Return whether this TensorArray is representing a ragged tensor."""
+        return _is_ndarray_ragged_tensor(self._tensor)
+
     def __arrow_array__(self, type=None):
         """
         Convert this TensorArray to an ArrowTensorArray extension array.
@@ -1329,9 +1336,15 @@ class TensorArray(
         https://pandas.pydata.org/pandas-docs/stable/development/extending.html#compatibility-with-apache-arrow
         for more information.
         """
-        from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
+        from ray.air.util.tensor_extensions.arrow import (
+            ArrowTensorArray,
+            ArrowRaggedTensorArray,
+        )
 
-        return ArrowTensorArray.from_numpy(self._tensor)
+        if self._is_ragged_tensor():
+            return ArrowRaggedTensorArray.from_numpy(self._tensor)
+        else:
+            return ArrowTensorArray.from_numpy(self._tensor)
 
     @property
     def _is_boolean(self):
@@ -1361,3 +1374,10 @@ TensorArrayElement._add_logical_ops()
 TensorArray._add_arithmetic_ops()
 TensorArray._add_comparison_ops()
 TensorArray._add_logical_ops()
+
+
+def _is_ndarray_ragged_tensor(arr: np.ndarray) -> bool:
+    """Return whether the provided NumPy ndarray is representing a ragged tensor."""
+    return (
+        arr.dtype.type is np.object_ and len(arr) > 0 and isinstance(arr[0], np.ndarray)
+    )

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -282,9 +282,9 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
     # https://github.com/CODAIT/text-extensions-for-pandas/issues/166
     base = None
 
-    def __init__(self, dtype: np.dtype, shape: Optional[Tuple[int, ...]] = None):
-        self._dtype = dtype
+    def __init__(self, shape: Optional[Tuple[int, ...]], dtype: np.dtype):
         self._shape = shape
+        self._dtype = dtype
 
     @property
     def type(self):
@@ -373,7 +373,7 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         shape, dtype = groups
         shape = ast.literal_eval(shape)
         dtype = np.dtype(dtype)
-        return cls(dtype, shape)
+        return cls(shape, dtype)
 
     @classmethod
     def construct_array_type(cls):
@@ -741,12 +741,6 @@ class TensorArray(
                         "ndarray pointers, but got an object-typed ndarray whose "
                         f"subndarrays are of type {type(values[0])}."
                     )
-            elif values.ndim == 1:
-                raise TypeError(
-                    "Expected a multi-dimensional ndarray but got a 1-dimensional "
-                    "ndarray; this can be represented natively within Pandas and Arrow "
-                    "without the tensor extension."
-                )
         elif isinstance(values, TensorArray):
             raise TypeError("Use the copy() method to create a copy of a TensorArray.")
         else:
@@ -883,7 +877,7 @@ class TensorArray(
         else:
             dtype = self.numpy_dtype
             shape = self.numpy_shape[1:]
-        return TensorDtype(dtype, shape)
+        return TensorDtype(shape, dtype)
 
     @property
     def nbytes(self) -> int:

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
+    """Return whether the provided NumPy ndarray is representing a variable-shaped
+    tensor.
+
+    NOTE: This is an O(rows) check.
+    """
+    if arr.dtype.type is not np.object_:
+        return False
+    if len(arr) == 0:
+        return False
+    if not isinstance(arr[0], np.ndarray):
+        return False
+    shape = arr[0].shape
+    for a in arr[1:]:
+        if not isinstance(a, np.ndarray):
+            return False
+        if a.shape != shape:
+            return True
+    return True

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -143,11 +143,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
     ) -> "pyarrow.Table":
         import pyarrow as pa
 
-        from ray.data.extensions.tensor_extension import (
-            ArrowTensorArray,
-            ArrowVariableShapedTensorArray,
-            is_ndarray_variable_shaped_tensor,
-        )
+        from ray.data.extensions.tensor_extension import ArrowTensorArray
 
         if isinstance(batch, np.ndarray):
             batch = {VALUE_COL_NAME: batch}
@@ -163,10 +159,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
             # Use Arrow's native *List types for 1-dimensional ndarrays.
             if col.dtype.type is np.object_ or col.ndim > 1:
                 try:
-                    if is_ndarray_variable_shaped_tensor(col):
-                        col = ArrowVariableShapedTensorArray.from_numpy(col)
-                    else:
-                        col = ArrowTensorArray.from_numpy(col)
+                    col = ArrowTensorArray.from_numpy(col)
                 except pa.ArrowNotImplementedError as e:
                     raise ValueError(
                         "Failed to convert multi-dimensional ndarray of dtype "

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -4,6 +4,8 @@ from ray.data.extensions.tensor_extension import (
     TensorArrayElement,
     ArrowTensorType,
     ArrowTensorArray,
+    ArrowRaggedTensorType,
+    ArrowRaggedTensorArray,
 )
 
 __all__ = [
@@ -13,4 +15,6 @@ __all__ = [
     "TensorArrayElement",
     "ArrowTensorType",
     "ArrowTensorArray",
+    "ArrowRaggedTensorType",
+    "ArrowRaggedTensorArray",
 ]

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -6,6 +6,8 @@ from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
     ArrowVariableShapedTensorType,
     ArrowVariableShapedTensorArray,
+    column_needs_tensor_extension,
+    is_ndarray_variable_shaped_tensor,
 )
 
 __all__ = [
@@ -17,4 +19,6 @@ __all__ = [
     "ArrowTensorArray",
     "ArrowVariableShapedTensorType",
     "ArrowVariableShapedTensorArray",
+    "column_needs_tensor_extension",
+    "is_ndarray_variable_shaped_tensor",
 ]

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -4,8 +4,8 @@ from ray.data.extensions.tensor_extension import (
     TensorArrayElement,
     ArrowTensorType,
     ArrowTensorArray,
-    ArrowRaggedTensorType,
-    ArrowRaggedTensorArray,
+    ArrowVariableShapedTensorType,
+    ArrowVariableShapedTensorArray,
 )
 
 __all__ = [
@@ -15,6 +15,6 @@ __all__ = [
     "TensorArrayElement",
     "ArrowTensorType",
     "ArrowTensorArray",
-    "ArrowRaggedTensorType",
-    "ArrowRaggedTensorArray",
+    "ArrowVariableShapedTensorType",
+    "ArrowVariableShapedTensorArray",
 ]

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -7,7 +7,6 @@ from ray.data.extensions.tensor_extension import (
     ArrowVariableShapedTensorType,
     ArrowVariableShapedTensorArray,
     column_needs_tensor_extension,
-    is_ndarray_variable_shaped_tensor,
 )
 
 __all__ = [
@@ -20,5 +19,4 @@ __all__ = [
     "ArrowVariableShapedTensorType",
     "ArrowVariableShapedTensorArray",
     "column_needs_tensor_extension",
-    "is_ndarray_variable_shaped_tensor",
 ]

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -6,4 +6,6 @@ from ray.air.util.tensor_extensions.pandas import (  # noqa: F401
 from ray.air.util.tensor_extensions.arrow import (  # noqa: F401
     ArrowTensorType,
     ArrowTensorArray,
+    ArrowRaggedTensorType,
+    ArrowRaggedTensorArray,
 )

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -6,6 +6,6 @@ from ray.air.util.tensor_extensions.pandas import (  # noqa: F401
 from ray.air.util.tensor_extensions.arrow import (  # noqa: F401
     ArrowTensorType,
     ArrowTensorArray,
-    ArrowRaggedTensorType,
-    ArrowRaggedTensorArray,
+    ArrowVariableShapedTensorType,
+    ArrowVariableShapedTensorArray,
 )

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -3,7 +3,6 @@ from ray.air.util.tensor_extensions.pandas import (  # noqa: F401
     TensorArray,
     TensorArrayElement,
     column_needs_tensor_extension,
-    is_ndarray_variable_shaped_tensor,
 )
 from ray.air.util.tensor_extensions.arrow import (  # noqa: F401
     ArrowTensorType,

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -2,6 +2,8 @@ from ray.air.util.tensor_extensions.pandas import (  # noqa: F401
     TensorDtype,
     TensorArray,
     TensorArrayElement,
+    column_needs_tensor_extension,
+    is_ndarray_variable_shaped_tensor,
 )
 from ray.air.util.tensor_extensions.arrow import (  # noqa: F401
     ArrowTensorType,

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -562,6 +562,22 @@ def test_arrow_ragged_tensor_array_roundtrip_boolean():
         np.testing.assert_array_equal(o, a)
 
 
+def test_arrow_ragged_tensor_array_roundtrip_contiguous_optimization():
+    # Test that a roundtrip on slices of an already-contiguous 1D base array does not
+    # create any unnecessary copies.
+    base = np.arange(6)
+    base_address = base.__array_interface__["data"][0]
+    arr = np.array([base[:2], base[2:]], dtype=object)
+    ata = ArrowRaggedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowRaggedTensorType)
+    assert len(ata) == len(arr)
+    assert ata.storage.field("data").buffers()[3].address == base_address
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        assert o.base.address == base_address
+        np.testing.assert_array_equal(o, a)
+
+
 def test_arrow_ragged_tensor_array_slice():
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -566,6 +566,51 @@ def test_scalar_tensor_array_roundtrip():
     np.testing.assert_array_equal(out, arr)
 
 
+def test_arrow_variable_shaped_tensor_array_validation():
+    # Test homogeneous-typed tensor raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(np.ones((3, 2, 2)))
+
+    # Test arbitrary object raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(object())
+
+    # Test empty array raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(np.array([]))
+
+    # Test deeply ragged tensor raises ValueError.
+    with pytest.raises(ValueError):
+        ArrowVariableShapedTensorArray.from_numpy(
+            np.array(
+                [
+                    np.array(
+                        [
+                            np.array([1, 2]),
+                            np.array([3, 4, 5]),
+                        ],
+                        dtype=object,
+                    ),
+                    np.array(
+                        [
+                            np.array([5, 6, 7, 8]),
+                        ],
+                        dtype=object,
+                    ),
+                    np.array(
+                        [
+                            np.array([5, 6, 7, 8]),
+                            np.array([5, 6, 7, 8]),
+                            np.array([5, 6, 7, 8]),
+                        ],
+                        dtype=object,
+                    ),
+                ],
+                dtype=object,
+            )
+        )
+
+
 def test_arrow_variable_shaped_tensor_array_roundtrip():
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -26,6 +26,8 @@ from ray.data.datasource.csv_datasource import CSVDatasource
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
     ArrowTensorType,
+    ArrowRaggedTensorArray,
+    ArrowRaggedTensorType,
     TensorArray,
     TensorDtype,
 )
@@ -531,6 +533,113 @@ def test_tensor_array_validation():
         TensorArray([object(), object()])
 
 
+def test_arrow_ragged_tensor_array_roundtrip():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ata = ArrowRaggedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowRaggedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_ragged_tensor_array_roundtrip_boolean():
+    arr = np.array(
+        [[True, False], [False, False, True], [False], [True, True, False, True]],
+        dtype=object,
+    )
+    ata = ArrowRaggedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowRaggedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_arrow_ragged_tensor_array_slice():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ata = ArrowRaggedTensorArray.from_numpy(arr)
+    assert isinstance(ata.type, ArrowRaggedTensorType)
+    assert len(ata) == len(arr)
+    indices = [0, 1, 2]
+    for i in indices:
+        np.testing.assert_array_equal(ata[i], arr[i])
+    slices = [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+        slice(0, 2),
+        slice(1, 3),
+        slice(0, 3),
+    ]
+    for slice_ in slices:
+        for o, e in zip(ata[slice_], arr[slice_]):
+            np.testing.assert_array_equal(o, e)
+
+
+def test_ragged_tensor_array_roundtrip():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    out = ta.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+    # Check Arrow conversion.
+    ata = ta.__arrow_array__()
+    assert isinstance(ata.type, ArrowRaggedTensorType)
+    assert len(ata) == len(arr)
+    out = ata.to_numpy()
+    for o, a in zip(out, arr):
+        np.testing.assert_array_equal(o, a)
+
+
+def test_ragged_tensor_array_slice():
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    arr = np.array(arrs, dtype=object)
+    ta = TensorArray(arr)
+    assert isinstance(ta.dtype, TensorDtype)
+    assert len(ta) == len(arr)
+    indices = [0, 1, 2]
+    for i in indices:
+        np.testing.assert_array_equal(ta[i], arr[i])
+    slices = [
+        slice(0, 1),
+        slice(1, 2),
+        slice(2, 3),
+        slice(0, 2),
+        slice(1, 3),
+        slice(0, 3),
+    ]
+    for slice_ in slices:
+        for o, e in zip(ta[slice_], arr[slice_]):
+            np.testing.assert_array_equal(o, e)
+
+
 def test_tensor_array_block_slice():
     # Test that ArrowBlock slicing works with tensor column extension type.
     def check_for_copy(table1, table2, a, b, is_copy):
@@ -628,44 +737,52 @@ def test_tensor_array_block_slice():
             9,
             12,
         ),
+        # Ragged tensors.
+        (
+            [[False, True], [True, False, True], [False], [False, False, True, True]],
+            1,
+            3,
+        ),
     ],
 )
 @pytest.mark.parametrize("init_with_pandas", [True, False])
 def test_tensor_array_boolean_slice_pandas_roundtrip(init_with_pandas, test_data, a, b):
+    is_ragged = len({len(elem) for elem in test_data}) > 1
     n = len(test_data)
     test_arr = np.array(test_data)
     df = pd.DataFrame({"one": TensorArray(test_arr), "two": ["a"] * n})
     if init_with_pandas:
         table = pa.Table.from_pandas(df)
     else:
-        pa_dtype = pa.bool_()
-        flat = [w for v in test_data for w in v]
-        data_array = pa.array(flat, pa_dtype)
-        inner_len = len(test_data[0])
-        offsets = list(range(0, len(flat) + 1, inner_len))
-        offset_buffer = pa.py_buffer(np.int32(offsets))
-        storage = pa.Array.from_buffers(
-            pa.list_(pa_dtype),
-            len(test_data),
-            [None, offset_buffer],
-            children=[data_array],
-        )
-        t_arr = pa.ExtensionArray.from_storage(
-            ArrowTensorType((inner_len,), pa.bool_()), storage
-        )
-        table = pa.table({"one": t_arr, "two": ["a"] * n})
+        if is_ragged:
+            col = ArrowRaggedTensorArray.from_numpy(test_arr)
+        else:
+            col = ArrowTensorArray.from_numpy(test_arr)
+        table = pa.table({"one": col, "two": ["a"] * n})
     block_accessor = BlockAccessor.for_block(table)
 
     # Test without copy.
     table2 = block_accessor.slice(a, b, False)
-    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), test_arr[a:b, :])
+    out = table2["one"].chunk(0).to_numpy()
+    expected = test_arr[a:b]
+    if is_ragged:
+        for o, e in zip(out, expected):
+            np.testing.assert_array_equal(o, e)
+    else:
+        np.testing.assert_array_equal(out, expected)
     pd.testing.assert_frame_equal(
         table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
     )
 
     # Test with copy.
     table2 = block_accessor.slice(a, b, True)
-    np.testing.assert_array_equal(table2["one"].chunk(0).to_numpy(), test_arr[a:b, :])
+    out = table2["one"].chunk(0).to_numpy()
+    expected = test_arr[a:b]
+    if is_ragged:
+        for o, e in zip(out, expected):
+            np.testing.assert_array_equal(o, e)
+    else:
+        np.testing.assert_array_equal(out, expected)
     pd.testing.assert_frame_equal(
         table2.to_pandas().reset_index(drop=True), df[a:b].reset_index(drop=True)
     )
@@ -898,26 +1015,14 @@ def test_tensors_inferred_from_map(ray_start_regular_shared):
         "schema={a: TensorDtype(shape=(4, 4), dtype=float64)})"
     )
 
-    # Test map_batches ragged ndarray column fails by default.
-    with pytest.raises(ValueError):
-        ds = ray.data.range(16, parallelism=4).map_batches(
-            lambda _: pd.DataFrame({"a": [np.ones((2, 2)), np.ones((3, 3))]}),
-            batch_size=2,
-        )
-
-    # Test map_batches ragged ndarray column uses opaque object-typed column if
-    # automatic tensor extension type casting is disabled.
-    ctx = DatasetContext.get_current()
-    old_config = ctx.enable_tensor_extension_casting
-    ctx.enable_tensor_extension_casting = False
-    try:
-        ds = ray.data.range(16, parallelism=4).map_batches(
-            lambda _: pd.DataFrame({"a": [np.ones((2, 2)), np.ones((3, 3))]}),
-            batch_size=2,
-        )
-        assert str(ds) == ("Dataset(num_blocks=4, num_rows=16, schema={a: object})")
-    finally:
-        ctx.enable_tensor_extension_casting = old_config
+    ds = ray.data.range(16, parallelism=4).map_batches(
+        lambda _: pd.DataFrame({"a": [np.ones((2, 2)), np.ones((3, 3))]}),
+        batch_size=2,
+    )
+    assert str(ds) == (
+        "Dataset(num_blocks=4, num_rows=16, "
+        "schema={a: TensorDtype(shape=None, dtype=float64)})"
+    )
 
 
 def test_tensors_in_tables_from_pandas(ray_start_regular_shared):
@@ -932,6 +1037,24 @@ def test_tensors_in_tables_from_pandas(ray_start_regular_shared):
     ds = ray.data.from_pandas([df])
     values = [[s["one"], s["two"]] for s in ds.take()]
     expected = list(zip(list(range(outer_dim)), arr))
+    for v, e in zip(sorted(values), expected):
+        np.testing.assert_equal(v, e)
+
+
+def test_tensors_in_tables_from_pandas_ragged(ray_start_regular_shared):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    outer_dim = len(arrs)
+    df = pd.DataFrame({"one": list(range(outer_dim)), "two": arrs})
+    # Cast column to tensor extension dtype.
+    df["two"] = df["two"].astype(TensorDtype(np.int64))
+    ds = ray.data.from_pandas(df)
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    expected = list(zip(range(outer_dim), arrs))
     for v, e in zip(sorted(values), expected):
         np.testing.assert_equal(v, e)
 
@@ -954,6 +1077,26 @@ def test_tensors_in_tables_pandas_roundtrip(
     pd.testing.assert_frame_equal(ds_df, expected_df)
 
 
+def test_tensors_in_tables_pandas_roundtrip_ragged(
+    ray_start_regular_shared,
+    enable_automatic_tensor_extension_cast,
+):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    outer_dim = len(arrs)
+    df = pd.DataFrame({"one": list(range(outer_dim)), "two": TensorArray(arrs)})
+    ds = ray.data.from_pandas(df)
+    ds_df = ds.to_pandas()
+    expected_df = df
+    if enable_automatic_tensor_extension_cast:
+        expected_df.loc[:, "two"] = list(expected_df["two"].to_numpy())
+    pd.testing.assert_frame_equal(ds_df, expected_df)
+
+
 def test_tensors_in_tables_parquet_roundtrip(ray_start_regular_shared, tmp_path):
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -966,6 +1109,24 @@ def test_tensors_in_tables_parquet_roundtrip(ray_start_regular_shared, tmp_path)
     ds = ray.data.read_parquet(str(tmp_path))
     values = [[s["one"], s["two"]] for s in ds.take()]
     expected = list(zip(list(range(outer_dim)), arr))
+    for v, e in zip(sorted(values), expected):
+        np.testing.assert_equal(v, e)
+
+
+def test_tensors_in_tables_parquet_roundtrip_ragged(ray_start_regular_shared, tmp_path):
+    shapes = [(2, 2), (3, 3), (4, 4)]
+    cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
+    arrs = [
+        np.arange(offset, offset + np.prod(shape)).reshape(shape)
+        for offset, shape in zip(cumsum_sizes, shapes)
+    ]
+    outer_dim = len(arrs)
+    df = pd.DataFrame({"one": list(range(outer_dim)), "two": TensorArray(arrs)})
+    ds = ray.data.from_pandas([df])
+    ds.write_parquet(str(tmp_path))
+    ds = ray.data.read_parquet(str(tmp_path))
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    expected = list(zip(range(outer_dim), arrs))
     for v, e in zip(sorted(values), expected):
         np.testing.assert_equal(v, e)
 

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -515,13 +515,6 @@ def test_tensor_array_validation():
     with pytest.raises(TypeError):
         TensorArray(object())
 
-    # Test string array raises TypeError.
-    with pytest.raises(TypeError):
-        TensorArray(np.array(["foo", "bar", "baz", "quux"]))
-
-    with pytest.raises(TypeError):
-        TensorArray(["foo", "bar", "baz", "quux"])
-
     # Test non-primitive element raises TypeError.
     with pytest.raises(TypeError):
         TensorArray(np.array([object(), object()]))

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -515,6 +515,20 @@ def test_tensor_array_validation():
     with pytest.raises(TypeError):
         TensorArray(object())
 
+    # Test 1D array raises TypeError.
+    with pytest.raises(TypeError):
+        TensorArray(np.array([1, 2, 3]))
+
+    with pytest.raises(TypeError):
+        TensorArray([1, 2, 3])
+
+    # Test string array raises TypeError.
+    with pytest.raises(TypeError):
+        TensorArray(np.array(["foo", "bar", "baz", "quux"]))
+
+    with pytest.raises(TypeError):
+        TensorArray(["foo", "bar", "baz", "quux"])
+
     # Test non-primitive element raises TypeError.
     with pytest.raises(TypeError):
         TensorArray(np.array([object(), object()]))

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -1071,7 +1071,7 @@ def test_tensors_in_tables_from_pandas_variable_shaped(ray_start_regular_shared)
     outer_dim = len(arrs)
     df = pd.DataFrame({"one": list(range(outer_dim)), "two": arrs})
     # Cast column to tensor extension dtype.
-    df["two"] = df["two"].astype(TensorDtype(np.int64))
+    df["two"] = df["two"].astype(TensorDtype(None, np.int64))
     ds = ray.data.from_pandas(df)
     values = [[s["one"], s["two"]] for s in ds.take()]
     expected = list(zip(range(outer_dim), arrs))

--- a/python/ray/data/tests/test_dataset_numpy.py
+++ b/python/ray/data/tests/test_dataset_numpy.py
@@ -47,6 +47,21 @@ def test_from_numpy(ray_start_regular_shared, from_ref):
     assert "from_numpy_refs" in ds.stats()
 
 
+def test_from_numpy_variable_shaped(ray_start_regular_shared):
+    arr = np.array([np.ones((2, 2)), np.ones((3, 3))], dtype=object)
+    ds = ray.data.from_numpy(arr)
+    values = np.array(ds.take(2), dtype=object)
+
+    def recursive_to_list(a):
+        if not isinstance(a, (list, np.ndarray)):
+            return a
+        return [recursive_to_list(e) for e in a]
+
+    # Convert to a nested Python list in order to circumvent failed comparisons on
+    # ndarray raggedness.
+    np.testing.assert_equal(recursive_to_list(values), recursive_to_list(arr))
+
+
 def test_to_numpy_refs(ray_start_regular_shared):
     # Simple Dataset
     ds = ray.data.range(10)


### PR DESCRIPTION
Ragged tensors pop up in NLP ([textual sentences/documents of different lengths](https://towardsdatascience.com/using-tensorflow-ragged-tensors-2af07849a7bd), [N-grams](https://www.tensorflow.org/guide/ragged_tensor#example_use_case)), CV (images of different resolutions, [`ssd300_vgg16` detection outputs](https://pytorch.org/vision/main/models/generated/torchvision.models.detection.ssd300_vgg16.html)) and audio (differing durations) use cases. Our existing tensor extension doesn't support ragged tensors, failing when the we or the user attempts to cast such data to it.

This PR adds support for non-nested ragged tensors, i.e. where each each tensor element (such as an image or sentence) is non-ragged. This allows us to support imagery columns of differing shapes or even differing number of dimensions, object detection outputs containing a variable number of detections (with a bounding box per detection) per sample, text columns containing N-gram embeddings, etc.

In order to keep the PR as simple as possible while meeting the requirements of these use cases, this PR does _not_ support arbitrary nesting of ragged tensors. Any such ragged tensor extension with arbitrary nesting should most likely be done in upstream Arrow, in C++.

## TODOs

- [x] More test coverage geared towards use cases.
- [x] Update feature guides.
- [ ] Update AIR examples that contain/need ragged tensor support.
- [x] Look to further consolidate `ArrowTensorType` and `ArrowRaggedTensorType`, `ArrowTensorArray` and `ArrowRaggedTensorArray`.

## Related issue number

Closes https://github.com/ray-project/ray/issues/18316

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
