### PR TITLE
[core] Fix job counter not working with storage namespace

### DIFF
--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -237,6 +237,7 @@ class A:
 
 a = A.options(lifetime="detached", name="A").remote()
 assert ray.get(a.ready.remote()) == {val}
+assert ray.get_runtime_context().job_id.hex() == '01000000'
     """
     run_string_as_driver(script.format(address=call_ray_start, val=1))
     run_string_as_driver(script.format(address=call_ray_start_2, val=2))
@@ -246,6 +247,7 @@ import ray
 ray.init("{address}", namespace="a")
 a = ray.get_actor(name="A")
 assert ray.get(a.ready.remote()) == {val}
+assert ray.get_runtime_context().job_id.hex() == '02000000'
 """
     run_string_as_driver(script.format(address=call_ray_start, val=1))
     run_string_as_driver(script.format(address=call_ray_start_2, val=2))

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -53,11 +53,12 @@ static int DoGetNextJobID(redisContext *context) {
   // This is bad since duplicate logic lives in redis_client
   // and redis_store_client.
   // A refactoring is needed to make things clean.
+  // src/ray/gcs/store_client/redis_store_client.cc#L42
   // TODO (iycheng): Unify the way redis key is formated.
   static const std::string kTableSeparator = ":";
   static const std::string kClusterSeparator = "@";
   static std::string key = RayConfig::instance().external_storage_namespace() +
-                           kClusterSeparator + kClusterSeparator + "JobCounter";
+                           kClusterSeparator + kTableSeparator + "JobCounter";
   static std::string cmd = "INCR " + key;
 
   redisReply *reply = nullptr;

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -50,9 +50,19 @@ static bool RunRedisCommandWithRetries(
 }
 
 static int DoGetNextJobID(redisContext *context) {
+  // This is bad since duplicate logic lives in redis_client
+  // and redis_store_client.
+  // A refactoring is needed to make things clean.
+  // TODO (iycheng): Unify the way redis key is formated.
+  static const std::string kTableSeparator = ":";
+  static const std::string kClusterSeparator = "@";
+  static std::string key = RayConfig::instance().external_storage_namespace() +
+                           kClusterSeparator + kClusterSeparator + "JobCounter";
+  static std::string cmd = "INCR " + key;
+
   redisReply *reply = nullptr;
   bool under_retry_limit = RunRedisCommandWithRetries(
-      context, "INCR JobCounter", &reply, [](const redisReply *reply) {
+      context, cmd.c_str(), &reply, [](const redisReply *reply) {
         return reply != nullptr && reply->type != REDIS_REPLY_NIL;
       });
   RAY_CHECK(reply);


### PR DESCRIPTION
Signed-off-by: Yi Cheng <chengyidna@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
JobCounter is not working with storage namespace right now because the key is the same across namespaces.

This PR fixed it by just adding it there because this add the minimal changes which is safer.

A follow up PR is needed to cleanup redis storage in cpp.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
