### PR TITLE
[serve] Skip Gradio Installation on Windows

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -217,7 +217,6 @@ test_python() {
       --test_env=CI="1" \
       --test_env=RAY_CI_POST_WHEEL_TESTS="1" \
       --test_env=USERPROFILE="${USERPROFILE}" \
-      --test_env=WINDIR \
       --test_output=streamed \
       -- \
       ${test_shard_selection};

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -43,7 +43,7 @@ uvicorn==0.16.0
 dataclasses; python_version < '3.7'
 starlette==0.18.0
 aiorwlock
-gradio
+gradio; platform_system != "Windows"
 
 # Requirements for running tests
 pyarrow >= 6.0.1, < 7.0.0


### PR DESCRIPTION
Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Skip installing Gradio on Windows in the CI to avoid breaking Windows tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
