### PR TITLE
[core] Fix how protocol is removed for external ray dashboard URL

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1498,5 +1498,6 @@ class Node:
         parsed_url = urllib.parse.urlparse(url)
         if parsed_url.scheme:
             # Construct URL without protocol
-            return url[url.index("://") + 3 :]
+            scheme = "%s://" % parsed_url.scheme
+            return parsed_url.geturl().replace(scheme, "", 1)
         return url

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1498,5 +1498,5 @@ class Node:
         parsed_url = urllib.parse.urlparse(url)
         if parsed_url.scheme:
             # Construct URL without protocol
-            return parsed_url.netloc + parsed_url.path
+            return url[url.index("://") + 3 :]
         return url

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -108,7 +108,12 @@ def test_env_var_no_override():
 
 @pytest.mark.parametrize(
     "override_url",
-    [None, "https://external_dashboard_url", "new_external_dashboard_url"],
+    [
+        None,
+        "https://external_dashboard_url",
+        "https://external_dashboard_url/path1/?query_param1=val1&query_param2=val2",
+        "new_external_dashboard_url",
+    ],
 )
 def test_hosted_external_dashboard_url(override_url, shutdown_only):
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Bug fix from https://github.com/ray-project/ray/pull/27396
Current method of removing protocol doesn't work if there are query parameters in the URL. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
