### PR TITLE
[Datasets] Delay expensive tensor extension type import until Parquet reading.

### DIFF
--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -108,9 +108,9 @@ ds.take(1)
 #                 ...,
 #                 [141, 161, 185],
 #                 [139, 158, 184]],
-#                
+#
 #                ...,
-#                
+#
 #                [[135, 135, 109],
 #                 [135, 135, 108],
 #                 ...,
@@ -197,7 +197,7 @@ ds.fully_executed()
 from ray.data.datasource import ImageFolderDatasource
 
 ds = ray.data.read_datasource(
-    ImageFolderDatasource(), root="example://image-folder", size=(128, 128))
+    ImageFolderDatasource(), root="example://image-folders", size=(128, 128))
 # -> Dataset(num_blocks=3, num_rows=3,
 #            schema={image: TensorDtype(shape=(128, 128, 3), dtype=uint8),
 #                    label: object})

--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -197,7 +197,7 @@ ds.fully_executed()
 from ray.data.datasource import ImageFolderDatasource
 
 ds = ray.data.read_datasource(
-    ImageFolderDatasource(), root="example://image-folders", size=(128, 128))
+    ImageFolderDatasource(), root="example://image-folders/simple", size=(128, 128))
 # -> Dataset(num_blocks=3, num_rows=3,
 #            schema={image: TensorDtype(shape=(128, 128, 3), dtype=uint8),
 #                    label: object})

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -41,9 +41,6 @@ from ray.data.row import TableRow
 
 try:
     import pyarrow
-
-    # This import is necessary to load the tensor extension type.
-    from ray.data.extensions.tensor_extension import ArrowTensorType  # noqa
 except ImportError:
     pyarrow = None
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -337,6 +337,9 @@ class _ParquetDatasourceReader(Reader):
 def _read_pieces(
     block_udf, reader_args, columns, schema, serialized_pieces: List[_SerializedPiece]
 ) -> Iterator["pyarrow.Table"]:
+    # This import is necessary to load the tensor extension type.
+    from ray.data.extensions.tensor_extension import ArrowTensorType  # noqa
+
     # Deserialize after loading the filesystem class.
     pieces: List[
         "pyarrow._dataset.ParquetFileFragment"


### PR DESCRIPTION
The tensor extension import is a bit expensive since it will go through Arrow's and Pandas' extension type registration logic. This PR delays the tensor extension type import until Parquet reading, which is the only case in which we need to explicitly register the type.

I have confirmed that the Parquet reading in `doc/source/data/doc_code/tensor.py` passes with this change.

## Related issue number

Closes #27606 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
