### PR TITLE
[docs] Trainer user guide should come before configuring datasets for trainer guide

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -15,8 +15,8 @@ parts:
     - file: ray-air/user-guides
       sections:
         - file: ray-air/preprocessors
-        - file: ray-air/check-ingest
         - file: ray-air/trainer
+        - file: ray-air/check-ingest
         - file: ray-air/tuner
         - file: ray-air/predictors
         - file: ray-air/examples/serving_guide

--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -14,7 +14,7 @@ Ray AI Runtime (AIR) is a scalable and unified toolkit for ML applications. AIR 
 
 .. image:: images/ray-air.svg
 
-AIR builds on best-in-class Ray libraries for :ref:`Preprocessing <datasets>`, :ref:`Training <train-docs>`, :ref:`Tuning <tune-main>`, :ref:`Scoring <air-predictors>`, :ref:`Serving <rayserve>`, and :ref:`Reinforcement Learning <rllib-index>`, enabling an ecosystem of integrations.
+AIR builds on best-in-class Ray libraries for :ref:`Preprocessing <datasets>`, :ref:`Training <train-docs>`, :ref:`Tuning <tune-main>`, :ref:`Scoring <air-predictors>`, :ref:`Serving <rayserve>`, and :ref:`Reinforcement Learning <rllib-index>`, which bring together an ecosystem of integrations.
 
 Why AIR?
 --------

--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -14,7 +14,7 @@ Ray AI Runtime (AIR) is a scalable and unified toolkit for ML applications. AIR 
 
 .. image:: images/ray-air.svg
 
-AIR comes with ready-to-use libraries for :ref:`Preprocessing <datasets>`, :ref:`Training <train-docs>`, :ref:`Tuning <tune-main>`, :ref:`Scoring <air-predictors>`, :ref:`Serving <rayserve>`, and :ref:`Reinforcement Learning <rllib-index>`, as well as an ecosystem of integrations.
+AIR builds on best-in-class Ray libraries for :ref:`Preprocessing <datasets>`, :ref:`Training <train-docs>`, :ref:`Tuning <tune-main>`, :ref:`Scoring <air-predictors>`, :ref:`Serving <rayserve>`, and :ref:`Reinforcement Learning <rllib-index>`, which enable an ecosystem of integrations.
 
 Why AIR?
 --------

--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -14,7 +14,7 @@ Ray AI Runtime (AIR) is a scalable and unified toolkit for ML applications. AIR 
 
 .. image:: images/ray-air.svg
 
-AIR builds on best-in-class Ray libraries for :ref:`Preprocessing <datasets>`, :ref:`Training <train-docs>`, :ref:`Tuning <tune-main>`, :ref:`Scoring <air-predictors>`, :ref:`Serving <rayserve>`, and :ref:`Reinforcement Learning <rllib-index>`, which enable an ecosystem of integrations.
+AIR builds on best-in-class Ray libraries for :ref:`Preprocessing <datasets>`, :ref:`Training <train-docs>`, :ref:`Tuning <tune-main>`, :ref:`Scoring <air-predictors>`, :ref:`Serving <rayserve>`, and :ref:`Reinforcement Learning <rllib-index>`, enabling an ecosystem of integrations.
 
 Why AIR?
 --------

--- a/doc/source/ray-air/trainer.rst
+++ b/doc/source/ray-air/trainer.rst
@@ -1,7 +1,7 @@
 .. _air-trainers:
 
-Using Trainers for Distributed Training
-=======================================
+Using Trainers
+==============
 
 .. https://docs.google.com/drawings/d/1anmT0JVFH9abR5wX5_WcxNHJh6jWeDL49zWxGpkfORA/edit
 

--- a/doc/source/ray-air/user-guides.rst
+++ b/doc/source/ray-air/user-guides.rst
@@ -27,18 +27,18 @@ AIR User Guides
     :img-top: /ray-overview/images/ray_svg_logo.svg
 
     +++
-    .. link-button:: air-ingest
+    .. link-button:: trainer
         :type: ref
-        :text: Configuring Training Datasets
+        :text: Using Trainers
         :classes: btn-link btn-block stretched-link
 
     ---
     :img-top: /ray-overview/images/ray_svg_logo.svg
 
     +++
-    .. link-button:: trainer
+    .. link-button:: air-ingest
         :type: ref
-        :text: Using Trainers
+        :text: Configuring Training Datasets
         :classes: btn-link btn-block stretched-link
 
     ---


### PR DESCRIPTION
Signed-off-by: Eric Liang <ekhliang@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Put these guides in a more natural order.