### PR TITLE
[core] Allow reuse of cluster address if Ray is not running

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -975,15 +975,9 @@ def start(
         "they are forcefully terminated after the grace period."
     ),
 )
-@click.option(
-    "--temp-dir",
-    hidden=True,
-    default=None,
-    help="manually specify the root temporary dir of the Ray process",
-)
 @add_click_logging_options
 @PublicAPI
-def stop(force, grace_period, temp_dir):
+def stop(force, grace_period):
     """Stop Ray processes manually on the local machine."""
 
     # Note that raylet needs to exit before object store, otherwise
@@ -1095,7 +1089,7 @@ def stop(force, grace_period, temp_dir):
     # NOTE(swang): This will not reset the cluster address for a user-defined
     # temp_dir. This is fine since it will get overwritten the next time we
     # call `ray start`.
-    ray._private.utils.reset_ray_address(temp_dir)
+    ray._private.utils.reset_ray_address()
 
 
 @cli.command()

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -292,6 +292,7 @@ def test_ray_start(configure_lang, monkeypatch, tmp_path):
     # Check that --temp-dir arg worked:
     assert os.path.isfile(os.path.join(temp_dir, "ray_current_cluster"))
     assert os.path.isdir(os.path.join(temp_dir, "session_latest"))
+    _die_on_error(result)
 
     _die_on_error(runner.invoke(scripts.stop))
 
@@ -299,6 +300,24 @@ def test_ray_start(configure_lang, monkeypatch, tmp_path):
         _check_output_via_pattern("test_ray_start_localhost.txt", result)
     else:
         _check_output_via_pattern("test_ray_start.txt", result)
+
+    # Check that we can rerun `ray start` even though the cluster address file
+    # is already written.
+    _die_on_error(
+        runner.invoke(
+            scripts.start,
+            [
+                "--head",
+                "--log-style=pretty",
+                "--log-color",
+                "False",
+                "--port",
+                "0",
+                "--temp-dir",
+                temp_dir,
+            ],
+        )
+    )
 
 
 def _ray_start_hook(ray_params, head):


### PR DESCRIPTION
Signed-off-by: Stephanie Wang <swang@cs.berkeley.edu>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cluster address is now written to a temp file. Previously we raised an error if `ray start --head` tried to reuse the old cluster address in the temp file, even if Ray was no longer running. This PR allows `ray start --head` to continue if it can't find any GCS process associated with the recorded cluster address.

## Related issue number

Closes #27021.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
