### PR TITLE
[Cherry-pick] [AIR - Datasets] Delay expensive tensor extension type import until Parquet reading.

### DIFF
--- a/doc/source/data/doc_code/tensor.py
+++ b/doc/source/data/doc_code/tensor.py
@@ -108,9 +108,9 @@ ds.take(1)
 #                 ...,
 #                 [141, 161, 185],
 #                 [139, 158, 184]],
-#                
+#
 #                ...,
-#                
+#
 #                [[135, 135, 109],
 #                 [135, 135, 108],
 #                 ...,
@@ -197,7 +197,7 @@ ds.fully_executed()
 from ray.data.datasource import ImageFolderDatasource
 
 ds = ray.data.read_datasource(
-    ImageFolderDatasource(), root="example://image-folder", size=(128, 128))
+    ImageFolderDatasource(), root="example://image-folders/simple", size=(128, 128))
 # -> Dataset(num_blocks=3, num_rows=3,
 #            schema={image: TensorDtype(shape=(128, 128, 3), dtype=uint8),
 #                    label: object})

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -41,9 +41,6 @@ from ray.data.row import TableRow
 
 try:
     import pyarrow
-
-    # This import is necessary to load the tensor extension type.
-    from ray.data.extensions.tensor_extension import ArrowTensorType  # noqa
 except ImportError:
     pyarrow = None
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -337,6 +337,9 @@ class _ParquetDatasourceReader(Reader):
 def _read_pieces(
     block_udf, reader_args, columns, schema, serialized_pieces: List[_SerializedPiece]
 ) -> Iterator["pyarrow.Table"]:
+    # This import is necessary to load the tensor extension type.
+    from ray.data.extensions.tensor_extension import ArrowTensorType  # noqa
+
     # Deserialize after loading the filesystem class.
     pieces: List[
         "pyarrow._dataset.ParquetFileFragment"


### PR DESCRIPTION
Cherry-picks https://github.com/ray-project/ray/pull/27653 onto 2.0.0 release branch.
