### PR TITLE
[serve][docs] Document lightweight config updates

### DIFF
--- a/doc/source/serve/production.md
+++ b/doc/source/serve/production.md
@@ -563,6 +563,8 @@ Similarly, you can update any other setting in any deployment in the config file
 * Adding an override setting that was previously not present in the config file.
 * Removing a setting from the config file.
 
+Note also that changing `import_path` or `runtime_env` is considered a code update for all deployments, and will tear down all running deployments and restart them.
+
 :::{warning}
 Although you can update your Serve application by deploying an entirely new deployment graph using a different `import_path` and a different `runtime_env`, this is NOT recommended in production.
 

--- a/doc/source/serve/production.md
+++ b/doc/source/serve/production.md
@@ -460,11 +460,11 @@ deployment_statuses:
 
 ## Updating Your Serve Application in Production
 
-You can also update your Serve applications once they're in production. You can update the settings in your config file and redeploy it using the `serve deploy` command. You can also add new deployment settings or remove old deployment settings from the config. This is because `serve deploy` is **idempotent**. Your Serve application's config always matches the latest config you deployed successfully– regardless of what config files you deployed before that.
+You can update your Serve applications once they're in production by updating the settings in your config file and redeploying it using the `serve deploy` command. In the redeployed config file, you can add new deployment settings or remove old deployment settings. This is because `serve deploy` is **idempotent**, meaning your Serve application's config always matches (or honors) the latest config you deployed successfully – regardless of what config files you deployed before that.
 
 ### Lightweight Config Updates
 
-Lightweight config updates modify running deployment replicas without tearing them down and restarting them, so there's less downtime as the deployments update. Changing `num_replicas`, `autoscaling_config`, and/or `user_config` in an entry of the `deployments` section of the config file is considered a lightweight config update, and won't tear down the replicas for that deployment.
+Lightweight config updates modify running deployment replicas without tearing them down and restarting them, so there's less downtime as the deployments update. For each deployment, modifying `num_replicas`, `autoscaling_config`, and/or `user_config` is considered a lightweight config update, and won't tear down the replicas for that deployment.
 
 :::{note}
 Lightweight config updates are only possible for deployments that are included as entries under `deployments` in the config file. If a deployment is not included in the config file, replicas of that deployment will be torn down and brought up again each time you redeploy with `serve deploy`.
@@ -558,10 +558,10 @@ The price has updated! The same request now returns `10` instead of `6`, reflect
 
 ### Code Updates
 
-Similarly, you can update any other setting in any deployment in the config file. If a deployment setting other than `num_replicas`, `autoscaling_config`, or `user_config` is changed, it is considered a code update and the deployment replicas will be restarted. Note that the following are all considered "changes", and (if considered a code update) will trigger tear down of replicas:
-* Changing an existing setting.
-* Adding an override setting that was previously not present in the config file.
-* Removing a setting from the config file.
+Similarly, you can update any other setting in any deployment in the config file. If a deployment setting other than `num_replicas`, `autoscaling_config`, or `user_config` is changed, it is considered a code update, and the deployment replicas will be restarted. Note that the following modifications are all considered "changes", and will trigger tear down of replicas:
+* changing an existing setting
+* adding an override setting that was previously not present in the config file
+* removing a setting from the config file
 
 Note also that changing `import_path` or `runtime_env` is considered a code update for all deployments, and will tear down all running deployments and restart them.
 

--- a/doc/source/serve/production.md
+++ b/doc/source/serve/production.md
@@ -460,12 +460,17 @@ deployment_statuses:
 
 ## Updating Your Serve Application in Production
 
-You can also update your Serve applications once they're in production. You can update the settings in your config file and redeploy it using the `serve deploy` command.
+You can also update your Serve applications once they're in production. You can update the settings in your config file and redeploy it using the `serve deploy` command. You can also add new deployment settings or remove old deployment settings from the config. This is because `serve deploy` is **idempotent**. Your Serve application's will match the one specified in the latest config you deployed– regardless of what config files you deployed before that.
 
 ### Lightweight Config Updates
 
-Lightweight config updates don't need to tear down the running deployments, meaning there's less downtime as the deployments update. 
+Lightweight config updates don't need to tear down the running deployments, meaning there's less downtime as the deployments update. Changing `num_replicas`, `autoscaling_config`, and/or `user_config` in an entry of the `deployments` section of the config file is considered a lightweight config update, and won't tear down the replicas for that deployment.
 
+:::{note}
+Lightweight config updates are only possible for deployments that are included as entries under `deployments` in the config file. If a deployment is not included in the config file, replicas of that deployment will be torn down and brought up again each time you redeploy with `serve deploy`.
+:::
+
+#### Updating User Config
 Let's use the `FruitStand` deployment graph [from an earlier section](fruit-config-yaml) as an example. All the individual fruit deployments contain a `reconfigure()` method. [This method allows us to issue lightweight updates](managing-deployments-user-configuration) to our deployments by updating the `user_config`.
 
 First let's deploy the graph. Make sure to stop any previous Ray cluster using the CLI command `ray stop` for this example:
@@ -553,7 +558,10 @@ The price has updated! The same request now returns `10` instead of `6`, reflect
 
 ### Code Updates
 
-You can update any setting in any deployment in the config file similarly. You can also add new deployment settings or remove old deployment settings from the config. This is because `serve deploy` is **idempotent**. Your Serve application's will match the one specified in the latest config you deployed– regardless of what config files you deployed before that.
+Similarly, you can update any other setting in any deployment in the config file. If a deployment setting other than `num_replicas`, `autoscaling_config`, or `user_config` is changed, it is considered a code update and the deployment replicas will be restarted. Note that the following are all considered "changes", and (if considered a code update) will trigger tear down of replicas:
+* Changing an existing setting.
+* Adding an override setting that was previously not present in the config file.
+* Removing a setting from the config file.
 
 :::{warning}
 Although you can update your Serve application by deploying an entirely new deployment graph using a different `import_path` and a different `runtime_env`, this is NOT recommended in production.

--- a/doc/source/serve/production.md
+++ b/doc/source/serve/production.md
@@ -460,11 +460,11 @@ deployment_statuses:
 
 ## Updating Your Serve Application in Production
 
-You can also update your Serve applications once they're in production. You can update the settings in your config file and redeploy it using the `serve deploy` command. You can also add new deployment settings or remove old deployment settings from the config. This is because `serve deploy` is **idempotent**. Your Serve application's will match the one specified in the latest config you deployed– regardless of what config files you deployed before that.
+You can also update your Serve applications once they're in production. You can update the settings in your config file and redeploy it using the `serve deploy` command. You can also add new deployment settings or remove old deployment settings from the config. This is because `serve deploy` is **idempotent**. Your Serve application's config always matches the latest config you deployed successfully– regardless of what config files you deployed before that.
 
 ### Lightweight Config Updates
 
-Lightweight config updates don't need to tear down the running deployments, meaning there's less downtime as the deployments update. Changing `num_replicas`, `autoscaling_config`, and/or `user_config` in an entry of the `deployments` section of the config file is considered a lightweight config update, and won't tear down the replicas for that deployment.
+Lightweight config updates modify running deployment replicas without tearing them down and restarting them, so there's less downtime as the deployments update. Changing `num_replicas`, `autoscaling_config`, and/or `user_config` in an entry of the `deployments` section of the config file is considered a lightweight config update, and won't tear down the replicas for that deployment.
 
 :::{note}
 Lightweight config updates are only possible for deployments that are included as entries under `deployments` in the config file. If a deployment is not included in the config file, replicas of that deployment will be torn down and brought up again each time you redeploy with `serve deploy`.

--- a/doc/source/serve/production.md
+++ b/doc/source/serve/production.md
@@ -462,7 +462,11 @@ deployment_statuses:
 
 You can also update your Serve applications once they're in production. You can update the settings in your config file and redeploy it using the `serve deploy` command.
 
-Let's use the `FruitStand` deployment graph [from an earlier section](fruit-config-yaml) as an example. All the individual fruit deployments contain a `reconfigure()` method. [This method allows us to issue lightweight updates](managing-deployments-user-configuration) to our deployments by updating the `user_config`. These updates don't need to tear down the running deployments, meaning there's less downtime as the deployments update.
+### Lightweight Config Updates
+
+Lightweight config updates don't need to tear down the running deployments, meaning there's less downtime as the deployments update. 
+
+Let's use the `FruitStand` deployment graph [from an earlier section](fruit-config-yaml) as an example. All the individual fruit deployments contain a `reconfigure()` method. [This method allows us to issue lightweight updates](managing-deployments-user-configuration) to our deployments by updating the `user_config`.
 
 First let's deploy the graph. Make sure to stop any previous Ray cluster using the CLI command `ray stop` for this example:
 
@@ -546,6 +550,8 @@ $ python
 ```
 
 The price has updated! The same request now returns `10` instead of `6`, reflecting the new price.
+
+### Code Updates
 
 You can update any setting in any deployment in the config file similarly. You can also add new deployment settings or remove old deployment settings from the config. This is because `serve deploy` is **idempotent**. Your Serve application's will match the one specified in the latest config you deployed– regardless of what config files you deployed before that.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A new feature was recently added, where Serve replicas are not restarted if only `num_replicas`, `autoscaling_config`, and/or `user_config` is updated in the config file that's redeployed. Updating docs to talk about this feature.

## Related issue number

"Closes #27707"

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
