### PR TITLE
[Core] [Hotfix] Change "task failed with unretryable exception" log statement to debug-level.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -749,9 +749,9 @@ cdef execute_task(
                                     exc_info=True)
                     else:
                         logger.debug("Task failed with unretryable exception:"
-                                    " {}.".format(
-                                        core_worker.get_current_task_id()),
-                                    exc_info=True)
+                                     " {}.".format(
+                                         core_worker.get_current_task_id()),
+                                     exc_info=True)
                     raise e
                 if c_return_ids.size() == 1:
                     # If there is only one return specified, we should return

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -748,7 +748,7 @@ cdef execute_task(
                                         core_worker.get_current_task_id()),
                                     exc_info=True)
                     else:
-                        logger.info("Task failed with unretryable exception:"
+                        logger.debug("Task failed with unretryable exception:"
                                     " {}.".format(
                                         core_worker.get_current_task_id()),
                                     exc_info=True)


### PR DESCRIPTION
Serve relies on being able to do quiet application-level retries, and this info-level logging is resulting in log spam hitting users. This PR demotes this log statement to debug-level to prevent this log spam.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #27677 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
