### PR TITLE
Fix PyObjScanner memory leakage

### DIFF
--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -101,10 +101,10 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, Transforme
         assert self._found is not None, "find_nodes must be called first"
         self._replace_table = table
         self._buf.seek(0)
-        return pickle.load(self._buf)
+        replaced = pickle.load(self._buf)
+        # Clear out the global references to prevent memory leak.
+        del _instances[id(self)]
+        return replaced
 
     def _replace_index(self, i: int) -> SourceType:
         return self._replace_table[self._found[i]]
-
-    def __del__(self):
-        del _instances[id(self)]


### PR DESCRIPTION
Signed-off-by: simon-mo <simon.mo@hey.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`PyObjScanner` put themselves in a global dictionary. Currently, it only removes themselves when __del__ is called. But since they have reference within the dictionary, __del__ won't be called. This causes memory leakage. This PR fixes it by removing it from global dict once the replace_ndoes are called.

Here's a comparison of the DAGDriver memory usage before and after for constant request load locally. 
![image](https://user-images.githubusercontent.com/21118851/183765513-e7f14c8f-b13f-4fc5-9323-33b714b1cb28.png)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
