### PR TITLE
Fixing doc linter: broken links in ray-tracing.rst and ray-dag.rst

### DIFF
--- a/doc/source/ray-core/ray-dag.rst
+++ b/doc/source/ray-core/ray-dag.rst
@@ -88,6 +88,6 @@ More Resources
 You can find more application patterns and examples in the following resources
 from other Ray libraries built on top of Ray DAG API with the same mechanism.
 
-| `Visualization of DAGs <https://docs.ray.io/en/master/serve/deployment-graph/visualize_dag_during_development.html>`_
-| `DAG Cookbook and patterns <https://docs.ray.io/en/master/serve/deployment-graph.html#patterns>`_
+| `Visualization of DAGs <https://docs.ray.io/en/master/serve/model_composition.html#visualizing-the-graph>`_
+| `DAG Cookbook and patterns <https://docs.ray.io/en/master/serve/tutorials/deployment-graph-patterns.html>`_
 | `Serve Deployment Graph's original REP <https://github.com/ray-project/enhancements/blob/main/reps/2022-03-08-serve_pipeline.md>`_

--- a/doc/source/ray-observability/ray-tracing.rst
+++ b/doc/source/ray-observability/ray-tracing.rst
@@ -82,15 +82,15 @@ If you want to provide your own custom tracing startup hook, provide your startu
 
 Tracer Provider
 ~~~~~~~~~~~~~~~
-This configures how to collect traces. View the TracerProvider API `here <https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html#opentelemetry.sdk.trace.TracerProvider>`__.
+This configures how to collect traces. View the TracerProvider API `here <https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html#opentelemetry.sdk.trace.TracerProvider>`__.
 
 .. _remote-span-processors:
 
 Remote Span Processors
 ~~~~~~~~~~~~~~~~~~~~~~
-This configures where to export traces to. View the SpanProcessor API `here <https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html#opentelemetry.sdk.trace.SpanProcessor>`__.
+This configures where to export traces to. View the SpanProcessor API `here <https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html#opentelemetry.sdk.trace.SpanProcessor>`__.
 
-Users who want to experiment with tracing can configure their remote span processors to export spans to a local JSON file. Serious users developing locally can push their traces to Jaeger containers via the `Jaeger exporter <https://open-telemetry.github.io/opentelemetry-python/exporter/jaeger/jaeger.html>`_.
+Users who want to experiment with tracing can configure their remote span processors to export spans to a local JSON file. Serious users developing locally can push their traces to Jaeger containers via the `Jaeger exporter <https://opentelemetry-python.readthedocs.io/en/latest/exporter/jaeger/jaeger.html#module-opentelemetry.exporter.jaeger>`_.
 
 .. _additional-instruments:
 


### PR DESCRIPTION
Signed-off-by: Cade Daniel <cade@anyscale.com>

## Why are these changes needed?
The `opentelemetry-python` documentation page changed structure, I've updated the links to point to the new pages.
```
BROKEN LINKS SUMMARY:
 
(ray-observability/ray-tracing: line   93) broken    https://open-telemetry.github.io/opentelemetry-python/exporter/jaeger/jaeger.html - 404 Client Error: Not Found for url: https://open-telemetry.github.io/opentelemetry-python/exporter/jaeger/jaeger.html
(ray-observability/ray-tracing: line   85) broken    https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html#opentelemetry.sdk.trace.TracerProvider - 404 Client Error: Not Found for url: https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html
(ray-observability/ray-tracing: line   91) broken    https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html#opentelemetry.sdk.trace.SpanProcessor - 404 Client Error: Not Found for url: https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html
```

The Ray Serve documentation page also changed structure. Some deployment graph links are updated to point to the new pages:

```
BROKEN LINKS SUMMARY:
--
  |  
  | (ray-core/ray-dag: line   91) broken    https://docs.ray.io/en/master/serve/deployment-graph/visualize_dag_during_development.html - 404 Client Error: Not Found for url: https://docs.ray.io/en/master/serve/deployment-graph/visualize_dag_during_development.html
  | (ray-core/ray-dag: line   92) broken    https://docs.ray.io/en/master/serve/deployment-graph.html#patterns - 404 Client Error: Not Found for url: https://docs.ray.io/en/master/serve/deployment-graph.html
```

## Related issue number
N/A