### PR TITLE
[Core] Fix condition in `IsAvailableForScheduling`

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -894,7 +894,7 @@ void NodeManager::WarnResourceDeadlock() {
 
   // Check if any progress is being made on this raylet.
   for (const auto &worker : worker_pool_.GetAllRegisteredWorkers()) {
-    if (worker->IsAvailableForScheduling()) {
+    if (worker->WontCauseResourceDeadlock()) {
       // Progress is being made in a task, don't warn.
       resource_deadlock_warned_ = 0;
       return;

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -105,7 +105,7 @@ class WorkerInterface {
   virtual rpc::CoreWorkerClientInterface *rpc_client() = 0;
 
   /// Return True if the worker is available for scheduling a task or actor.
-  virtual bool IsAvailableForScheduling() const = 0;
+  virtual bool WontCauseResourceDeadlock() const = 0;
 
   /// Time when the last task was assigned to this worker.
   virtual const std::chrono::steady_clock::time_point GetAssignedTaskTime() const = 0;
@@ -218,9 +218,9 @@ class Worker : public WorkerInterface {
 
   bool IsRegistered() { return rpc_client_ != nullptr; }
 
-  bool IsAvailableForScheduling() const {
+  bool WontCauseResourceDeadlock() const {
     return !IsDead()                        // Not dead
-           && !GetAssignedTaskId().IsNil()  // No assigned task
+           && !GetAssignedTaskId().IsNil()  // Task won't cause dead lock, since progress is being made.
            && !IsBlocked()                  // Not blocked
            && GetActorId().IsNil();         // No assigned actor
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fix a logic flaw at [src/ray/raylet/worker.h](https://github.com/ray-project/ray/blob/e33edcb0b7d2f9762b173a34ba64b41079592978/src/ray/raylet/worker.h#L222):

- `!GetAssignedTaskId().IsNil()` should be `GetAssignedTaskId().IsNil()`.
- Currently, `IsAvailableForScheduling` is only used for resource deadlock detection.
  - But it may cause **subtle bug at resource management** in the future.


## Related issue number

<!-- For example: "Closes #1234" -->

Closes #27727 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
