### PR TITLE
Remove airflow integration from community page

### DIFF
--- a/doc/source/ray-overview/ray-libraries.rst
+++ b/doc/source/ray-overview/ray-libraries.rst
@@ -6,13 +6,6 @@ Ecosystem
 This page lists libraries that have integrations with Ray for distributed execution.
 If you'd like to add your project to this list, feel free to file a pull request or open an issue on GitHub.
 
-Airflow |airflow|
------------------
-
-Airflow is a platform created by the community to programmatically author, schedule and monitor workflows. The Airflow/Ray integration allows Airflow users to keep all of their Ray code in Python functions and define task dependencies by moving data through python functions.
-
-[`Link to integration <https://registry.astronomer.io/providers/ray>`__] [`Link to announcement <https://www.astronomer.io/blog/airflow-ray-data-science-story>`__]
-
 ClassyVision |classyvision|
 ---------------------------
 
@@ -143,10 +136,6 @@ LightGBM is a high-performance gradient boosting library for classification and 
 
 [`Link to integration <https://github.com/ray-project/lightgbm_ray>`__]
 
-
-.. |airflow| image:: ../images/airflow.png
-    :class: inline-figure
-    :height: 30
 
 .. |classyvision| image:: ../images/classyvision.png
     :class: inline-figure


### PR DESCRIPTION
## Why are these changes needed?

We should provide a different airflow integration (one that actually works).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(