### PR TITLE
[RLlib] Fix SAC config parameter that is not used

### DIFF
--- a/rllib/algorithms/sac/sac.py
+++ b/rllib/algorithms/sac/sac.py
@@ -260,7 +260,7 @@ class SACConfig(AlgorithmConfig):
         if grad_clip is not None:
             self.grad_clip = grad_clip
         if optimization_config is not None:
-            self.optimization_config = optimization_config
+            self.optimization = optimization_config
         if target_network_update_freq is not None:
             self.target_network_update_freq = target_network_update_freq
         if _deterministic_loss is not None:


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

SAC's config has a paramter "optimization_config" that will not be used during execution because "optimization" is accessed. We have this discrepancy between argument name during configuration time and parameter name that is later accessed in other places. This has to be kept for now to stay backward compatible.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
