### PR TITLE
[Core] fix resource leak when cancel actor in phase of creating

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -801,7 +801,7 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id,
         created_actors_.erase(node_it);
       }
     } else {
-      if (!actor->GetAddress().worker_id().empty()) {
+      if (!worker_id.IsNil()) {
         // The actor is in phase of creating, so we need to notify the core
         // worker exit to avoid process and resource leak.
         NotifyCoreWorkerToKillActor(actor, death_cause, force_kill);
@@ -1446,7 +1446,7 @@ void GcsActorManager::KillActor(const ActorID &actor_id,
     const auto &task_id = actor->GetCreationTaskSpecification().TaskId();
     RAY_LOG(DEBUG) << "The actor " << actor->GetActorID()
                    << " hasn't been created yet, cancel scheduling " << task_id;
-    if (!actor->GetAddress().worker_id().empty()) {
+    if (!worker_id.IsNil()) {
       // The actor is in phase of creating, so we need to notify the core
       // worker exit to avoid process and resource leak.
       NotifyCoreWorkerToKillActor(

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <gtest/gtest_prod.h>
 
 #include <utility>
 
@@ -587,6 +588,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     CountType_MAX = 7,
   };
   uint64_t counts_[CountType::CountType_MAX] = {0};
+
+  FRIEND_TEST(GcsActorManagerTest, TestKillActorWhenActorIsCreating);
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -1278,6 +1278,108 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoLimit) {
   }
 }
 
+namespace gcs {
+TEST_F(GcsActorManagerTest, TestKillActorWhenActorIsCreating) {
+  auto job_id = JobID::FromInt(1);
+  auto registered_actor = RegisterActor(job_id, /*max_restarts*/ -1);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+
+  std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
+  Status status = gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&finished_actors](const std::shared_ptr<gcs::GcsActor> &actor,
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
+        finished_actors.emplace_back(actor);
+      });
+  RAY_CHECK_OK(status);
+
+  ASSERT_EQ(finished_actors.size(), 0);
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  // Make sure actor in the phase of creating, that is the worker id is not nil and the
+  // actor state is not alive yet.
+  actor->UpdateAddress(RandomAddress());
+  const auto &worker_id = actor->GetWorkerID();
+  ASSERT_TRUE(!worker_id.IsNil());
+  ASSERT_NE(actor->GetState(), rpc::ActorTableData::ALIVE);
+
+  // Then handle the kill actor requst (restart).
+  rpc::KillActorViaGcsReply reply;
+  rpc::KillActorViaGcsRequest request;
+  request.set_actor_id(actor->GetActorID().Binary());
+  request.set_force_kill(true);
+  // Set the `no_restart` flag to true so that the actor will restart again.
+  request.set_no_restart(false);
+  gcs_actor_manager_->HandleKillActorViaGcs(
+      request,
+      &reply,
+      /*send_reply_callback*/
+      [](Status status, std::function<void()> success, std::function<void()> failure) {});
+
+  // Make sure the `KillActor` rpc is send.
+  ASSERT_EQ(worker_client_->killed_actors_.size(), 1);
+  ASSERT_EQ(worker_client_->killed_actors_.front(), actor->GetActorID());
+
+  // Make sure the actor is restarting.
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+}
+
+TEST_F(GcsActorManagerTest, TestDestroyActorWhenActorIsCreating) {
+  auto job_id = JobID::FromInt(1);
+  auto registered_actor = RegisterActor(job_id, /*max_restarts*/ -1);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+
+  std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
+  Status status = gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&finished_actors](const std::shared_ptr<gcs::GcsActor> &actor,
+                         const rpc::PushTaskReply &reply,
+                         bool creation_cancelled) {
+        finished_actors.emplace_back(actor);
+      });
+  RAY_CHECK_OK(status);
+
+  ASSERT_EQ(finished_actors.size(), 0);
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  // Make sure actor in the phase of creating, that is the worker id is not nil and the
+  // actor state is not alive yet.
+  actor->UpdateAddress(RandomAddress());
+  const auto &worker_id = actor->GetWorkerID();
+  ASSERT_TRUE(!worker_id.IsNil());
+  ASSERT_NE(actor->GetState(), rpc::ActorTableData::ALIVE);
+
+  // Then handle the kill actor requst (no restart).
+  rpc::KillActorViaGcsReply reply;
+  rpc::KillActorViaGcsRequest request;
+  request.set_actor_id(actor->GetActorID().Binary());
+  request.set_force_kill(true);
+  // Set the `no_restart` flag to true so that the actor will be destoryed.
+  request.set_no_restart(true);
+  gcs_actor_manager_->HandleKillActorViaGcs(
+      request,
+      &reply,
+      /*send_reply_callback*/
+      [](Status status, std::function<void()> success, std::function<void()> failure) {});
+
+  // Make sure the `KillActor` rpc is send.
+  ASSERT_EQ(worker_client_->killed_actors_.size(), 1);
+  ASSERT_EQ(worker_client_->killed_actors_.front(), actor->GetActorID());
+
+  // Make sure the actor is dead.
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
+}
+
+}  // namespace gcs
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
It is quite easy to cause resource/process leak when cancel an actor which constructor is time-consuming.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #27743 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
