### PR TITLE
[RLlib] pin gym-minigrid @ 1.0.3

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -60,7 +60,8 @@ dataclasses; python_version < '3.7'
 feather-format
 google-api-python-client
 google-cloud-storage
-gym-minigrid
+# Minigrid now supports Gym 0.25, change the following line back to "gym-minigrid" as soon as this is resolved
+git+https://github.com/Farama-Foundation/gym-minigrid/@b8b6bd4c66531016a8470d1160b9def79f9f766c
 kubernetes
 lxml
 moto[s3,server]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -60,8 +60,7 @@ dataclasses; python_version < '3.7'
 feather-format
 google-api-python-client
 google-cloud-storage
-# Minigrid now supports Gym 0.25, change the following line back to "gym-minigrid" as soon as this is resolved
-git+https://github.com/Farama-Foundation/gym-minigrid/@b8b6bd4c66531016a8470d1160b9def79f9f766c
+gym-minigrid==1.0.3
 kubernetes
 lxml
 moto[s3,server]


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

Gym minigrid has one release and one tag - which now supports gym 0.25 but also makes our test fail.

<img width="473" alt="Screenshot 2022-08-10 at 23 28 46" src="https://user-images.githubusercontent.com/9356806/184023650-363d670a-c182-4151-9a47-387d1a74b365.png">

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
