### PR TITLE
2.0.0rc1 cherry pick: docs linkcheck fixes

### DIFF
--- a/doc/source/cluster/ray-client.rst
+++ b/doc/source/cluster/ray-client.rst
@@ -9,7 +9,7 @@ Ray Client: Interactive Development
 
 The Ray Client is an API that connects a Python script to a **remote** Ray cluster. Effectively, it allows you to leverage a remote Ray cluster just like you would with Ray running on your local machine.
 
-By changing ``ray.init()`` to ``ray.init("ray://<head_node_host>:<port>")``, you can connect from your laptop (or anywhere) directly to a remote cluster and scale-out your Ray code, while maintaining the ability to develop interactively in a Python shell. **This will only work with Ray 1.5+.** If you're using an older version of ray, see the `1.4.1 docs <https://docs.ray.io/en/releases-1.4.1/cluster/ray-client.html>`_
+By changing ``ray.init()`` to ``ray.init("ray://<head_node_host>:<port>")``, you can connect from your laptop (or anywhere) directly to a remote cluster and scale-out your Ray code, while maintaining the ability to develop interactively in a Python shell. **This will only work with Ray 1.5+.**
 
 
 .. code-block:: python
@@ -18,8 +18,6 @@ By changing ``ray.init()`` to ``ray.init("ray://<head_node_host>:<port>")``, you
    import ray
 
    # Starting the Ray client. This connects to a remote Ray cluster.
-   # If you're using a version of Ray prior to 1.5, use the 1.4.1 example
-   # instead: https://docs.ray.io/en/releases-1.4.1/cluster/ray-client.html
    ray.init("ray://<head_node_host>:10001")
 
    # Normal Ray code follows
@@ -234,7 +232,7 @@ Similarly, the minor Python (e.g., 3.6 vs 3.7) must match between the client and
 Starting a connection on older Ray versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you encounter ``socket.gaierror: [Errno -2] Name or service not known`` when using ``ray.init("ray://...")`` then you may be on a version of Ray prior to 1.5 that does not support starting client connections through ``ray.init``. If this is the case, see the `1.4.1 docs <https://docs.ray.io/en/releases-1.4.1/cluster/ray-client.html>`_ for Ray Client.
+If you encounter ``socket.gaierror: [Errno -2] Name or service not known`` when using ``ray.init("ray://...")`` then you may be on a version of Ray prior to 1.5 that does not support starting client connections through ``ray.init``.
 
 Connection through the Ingress
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/ray-core/ray-dag.rst
+++ b/doc/source/ray-core/ray-dag.rst
@@ -154,6 +154,6 @@ More Resources
 You can find more application patterns and examples in the following resources
 from other Ray libraries built on top of Ray DAG API with same mechanism.
 
-| `Visualization of DAGs <https://docs.ray.io/en/master/serve/deployment-graph/visualize_dag_during_development.html>`_
-| `DAG Cookbook and patterns <https://docs.ray.io/en/master/serve/deployment-graph.html#patterns>`_
+| `Visualization of DAGs <https://docs.ray.io/en/master/serve/model_composition.html#visualizing-the-graph>`_
+| `DAG Cookbook and patterns <https://docs.ray.io/en/master/serve/tutorials/deployment-graph-patterns.html>`_
 | `Serve Deployment Graph's original REP <https://github.com/ray-project/enhancements/blob/main/reps/2022-03-08-serve_pipeline.md>`_

--- a/doc/source/ray-observability/ray-tracing.rst
+++ b/doc/source/ray-observability/ray-tracing.rst
@@ -82,15 +82,15 @@ If you want to provide your own custom tracing startup hook, provide your startu
 
 Tracer Provider
 ~~~~~~~~~~~~~~~
-This configures how to collect traces. View the TracerProvider API `here <https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html#opentelemetry.sdk.trace.TracerProvider>`__.
+This configures how to collect traces. View the TracerProvider API `here <https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html#opentelemetry.sdk.trace.TracerProvider>`__.
 
 .. _remote-span-processors:
 
 Remote Span Processors
 ~~~~~~~~~~~~~~~~~~~~~~
-This configures where to export traces to. View the SpanProcessor API `here <https://open-telemetry.github.io/opentelemetry-python/sdk/trace.html#opentelemetry.sdk.trace.SpanProcessor>`__.
+This configures where to export traces to. View the SpanProcessor API `here <https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html#opentelemetry.sdk.trace.SpanProcessor>`__.
 
-Users who want to experiment with tracing can configure their remote span processors to export spans to a local JSON file. Serious users developing locally can push their traces to Jaeger containers via the `Jaeger exporter <https://open-telemetry.github.io/opentelemetry-python/exporter/jaeger/jaeger.html>`_.
+Users who want to experiment with tracing can configure their remote span processors to export spans to a local JSON file. Serious users developing locally can push their traces to Jaeger containers via the `Jaeger exporter <https://opentelemetry-python.readthedocs.io/en/latest/exporter/jaeger/jaeger.html#module-opentelemetry.exporter.jaeger>`_.
 
 .. _additional-instruments:
 


### PR DESCRIPTION
The [most recent rc1 build](https://buildkite.com/ray-project/ray-builders-branch/builds/9414#_) fails the linkcheck at the time of writing. This PR cherry-picks two commits from master which fix the linkcheck failures:
* https://github.com/ray-project/ray/pull/27721
* https://github.com/ray-project/ray/pull/27703