### PR TITLE
[Dataset] Pin _StatsActor to the driver node

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -9,6 +9,7 @@ import ray
 from ray.data._internal.block_list import BlockList
 from ray.data.block import BlockMetadata
 from ray.data.context import DatasetContext
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 
 def fmt(seconds: float) -> str:
@@ -123,10 +124,19 @@ def _get_or_create_stats_actor():
         or _stats_actor[1] != ray.get_runtime_context().job_id.hex()
     ):
         ctx = DatasetContext.get_current()
+        scheduling_strategy = ctx.scheduling_strategy
+        if not ray.util.client.ray.is_connected():
+            # Pin the stats actor to the local node
+            # so it fate-shares with the driver.
+            scheduling_strategy = NodeAffinitySchedulingStrategy(
+                ray.get_runtime_context().get_node_id(),
+                soft=False,
+            )
+
         _stats_actor[0] = _StatsActor.options(
             name="datasets_stats_actor",
             get_if_exists=True,
-            scheduling_strategy=ctx.scheduling_strategy,
+            scheduling_strategy=scheduling_strategy,
         ).remote()
         _stats_actor[1] = ray.get_runtime_context().job_id.hex()
 


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Similar to what's done in https://github.com/ray-project/ray/pull/23397

This allows the actor to fate-share with the driver and tolerate worker node failures.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #27752
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
