### PR TITLE
Adjust the TuneCallback class for Pytorch-lightning v1.6+ (removing o…

### DIFF
--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -13,27 +13,29 @@ class TuneCallback(Callback):
     """Base class for Tune's PyTorch Lightning callbacks."""
 
     _allowed = [
-        "init_start",
-        "init_end",
         "fit_start",
         "fit_end",
         "sanity_check_start",
         "sanity_check_end",
-        "epoch_start",
-        "epoch_end",
-        "batch_start",
+        "train_epoch_start",
+        "train_epoch_end",
+        "validation_epoch_start",
+        "validation_epoch_end",
+        "test_epoch_start",
+        "test_epoch_end",
+        "train_batch_start",
+        "train_batch_end",
         "validation_batch_start",
         "validation_batch_end",
         "test_batch_start",
         "test_batch_end",
-        "batch_end",
         "train_start",
         "train_end",
         "validation_start",
         "validation_end",
         "test_start",
         "test_end",
-        "keyboard_interrupt",
+        "exception",
     ]
 
     def __init__(self, on: Union[str, List[str]] = "validation_end"):
@@ -76,16 +78,36 @@ class TuneCallback(Callback):
         if "sanity_check_end" in self._on:
             self._handle(trainer, pl_module)
 
-    def on_epoch_start(self, trainer: Trainer, pl_module: LightningModule):
-        if "epoch_start" in self._on:
+    def on_train_epoch_start(self, trainer: Trainer, pl_module: LightningModule):
+        if "train_epoch_start" in self._on:
             self._handle(trainer, pl_module)
 
-    def on_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
-        if "epoch_end" in self._on:
+    def on_train_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
+        if "train_epoch_end" in self._on:
             self._handle(trainer, pl_module)
 
-    def on_batch_start(self, trainer: Trainer, pl_module: LightningModule):
-        if "batch_start" in self._on:
+    def on_validation_epoch_start(self, trainer: Trainer, pl_module: LightningModule):
+        if "validation_epoch_start" in self._on:
+            self._handle(trainer, pl_module)
+
+    def on_validation_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
+        if "validation_epoch_end" in self._on:
+            self._handle(trainer, pl_module)
+
+    def on_test_epoch_start(self, trainer: Trainer, pl_module: LightningModule):
+        if "test_epoch_start" in self._on:
+            self._handle(trainer, pl_module)
+
+    def on_test_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
+        if "test_epoch_end" in self._on:
+            self._handle(trainer, pl_module)
+
+    def on_train_batch_start(self, trainer: Trainer, pl_module: LightningModule):
+        if "train_batch_start" in self._on:
+            self._handle(trainer, pl_module)
+
+    def on_train_batch_end(self, trainer: Trainer, pl_module: LightningModule):
+        if "train_batch_end" in self._on:
             self._handle(trainer, pl_module)
 
     def on_validation_batch_start(
@@ -134,10 +156,6 @@ class TuneCallback(Callback):
         if "test_batch_end" in self._on:
             self._handle(trainer, pl_module)
 
-    def on_batch_end(self, trainer: Trainer, pl_module: LightningModule):
-        if "batch_end" in self._on:
-            self._handle(trainer, pl_module)
-
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule):
         if "train_start" in self._on:
             self._handle(trainer, pl_module)
@@ -162,8 +180,8 @@ class TuneCallback(Callback):
         if "test_end" in self._on:
             self._handle(trainer, pl_module)
 
-    def on_keyboard_interrupt(self, trainer: Trainer, pl_module: LightningModule):
-        if "keyboard_interrupt" in self._on:
+    def on_exception(self, trainer: Trainer, pl_module: LightningModule):
+        if "exception" in self._on:
             self._handle(trainer, pl_module)
 
 
@@ -180,7 +198,7 @@ class TuneReportCallback(TuneCallback):
             value will be the metric key reported to PyTorch Lightning.
         on: When to trigger checkpoint creations. Must be one of
             the PyTorch Lightning event hooks (less the ``on_``), e.g.
-            "batch_start", or "train_end". Defaults to "validation_end".
+            "train_batch_start", or "train_end". Defaults to "validation_end".
 
     Example:
 
@@ -253,7 +271,7 @@ class _TuneCheckpointCallback(TuneCallback):
             directory. Defaults to "checkpoint".
         on: When to trigger checkpoint creations. Must be one of
             the PyTorch Lightning event hooks (less the ``on_``), e.g.
-            "batch_start", or "train_end". Defaults to "validation_end".
+            "train_batch_start", or "train_end". Defaults to "validation_end".
 
 
     """
@@ -288,7 +306,7 @@ class TuneReportCheckpointCallback(TuneCallback):
             directory. Defaults to "checkpoint".
         on: When to trigger checkpoint creations. Must be one of
             the PyTorch Lightning event hooks (less the ``on_``), e.g.
-            "batch_start", or "train_end". Defaults to "validation_end".
+            "train_batch_start", or "train_end". Defaults to "validation_end".
 
 
     Example:

--- a/python/ray/tune/tests/test_integration_pytorch_lightning.py
+++ b/python/ray/tune/tests/test_integration_pytorch_lightning.py
@@ -108,7 +108,7 @@ class PyTorchLightningIntegrationTest(unittest.TestCase):
                 max_epochs=1,
                 callbacks=[
                     _TuneCheckpointCallback(
-                        "trainer.ckpt", on=["batch_end", "train_end"]
+                        "trainer.ckpt", on=["train_batch_end", "train_end"]
                     )
                 ],
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is a duplicate of  #27766 but with the changes that were supposed to be there (accidentally made changes while the PR was being accepted while trying to change the commits to have the sign off).

Getting a ton of warnings from pytorch-lightning about deprecation of certain hooks. The TuneCallback has old hooks such as [keyboard_interrupt](https://github.com/ray-project/ray/blob/master/python/ray/tune/integration/pytorch_lightning.py#L165) which have been deprecated. I updated the callback to the new hooks and updated the integration tests.

The deprecated hooks and their new versions (In pl v1.6+) are:
- `on_keyboard_interrupt` -> `on_exception`
- `on_init_start` -> just deprecated no new version
- `on_init_end` -> just deprecated no new version
- `on_batch_start` -> `on_train_batch_start`
- `on_batch_end` -> `on_train_batch_end`
- `on_epoch_end` -> `on_<train/validation/test>_epoch_end`
- `on_epoch_start` -> `on_<train/validation/test>_epoch_start`

## Related issue number
<!-- For example: "Closes #1234" -->
Closes #27487

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/

I spent a few hours trying to wrangle my environment. Unfortunately I'm on windows using WSL and have an old version of Debian for some reason which only supports gcc-6 (not even close to gcc-9 which is required for building the project so I can run the tests). Given this roadblock and the fact that the fixes were minimal and simple I decided to push out the changes.

- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

