### PR TITLE
[Serve] Minor fix to replica shutdown

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -526,4 +526,4 @@ class RayServeReplica:
             logger.exception(f"Exception during graceful shutdown of replica: {e}")
         finally:
             if hasattr(self.callable, "__del__"):
-                del self.callable.__del__
+                del self.callable

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -522,6 +522,7 @@ class RayServeReplica:
             if hasattr(self.callable, "__del__"):
                 # Make sure to accept `async def __del__(self)` as well.
                 await sync_to_async(self.callable.__del__)()
+                setattr(self.callable, "__del__", lambda _: None)
         except Exception as e:
             logger.exception(f"Exception during graceful shutdown of replica: {e}")
         finally:


### PR DESCRIPTION
Signed-off-by: simon-mo <simon.mo@hey.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Otherwise it throws 
```
(ServeReplica:MyFastAPIDeployment pid=63096)   File "/Users/xmo/Desktop/ray/ray/python/ray/serve/_private/replica.py", line 529, in prepare_for_shutdown
(ServeReplica:MyFastAPIDeployment pid=63096)     del self.callable.__del__
(ServeReplica:MyFastAPIDeployment pid=63096) AttributeError: __del__
```
*in the background*. This is only caught because Ray Core was logging uncaught exception. This doesn't impact the normal teardown process, it only happens during FastAPI integration stack because that's the class that has the del attribute.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
