### PR TITLE
[Serve] Fix grammar in deployment logs

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1230,7 +1230,8 @@ class DeploymentState:
             to_add = max(delta_replicas - stopping_replicas, 0)
             if to_add > 0:
                 logger.info(
-                    f"Adding {to_add} replicas to deployment " f"'{self._name}'."
+                    f"Adding {to_add} replica{'s' if to_add > 1 else ''} "
+                    f"to deployment '{self._name}'."
                 )
             for _ in range(to_add):
                 replica_name = ReplicaName(self._name, get_random_letters())
@@ -1255,7 +1256,8 @@ class DeploymentState:
             replicas_stopped = True
             to_remove = -delta_replicas
             logger.info(
-                f"Removing {to_remove} replicas from deployment '{self._name}'."
+                f"Removing {to_remove} replica{'s' if to_remove > 1 else ''} "
+                f"from deployment '{self._name}'."
             )
             replicas_to_stop = self._replicas.pop(
                 states=[


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Serve controller logs a message whenever a deployment is deployed:

```console
(ServeController pid=18066) INFO 2022-07-20 13:17:12,481 controller 18066 deployment_state.py:1280 - Adding 1 replicas to deployment 'Translator'.
```

and when it's removed:

```console
(ServeController pid=18066) INFO 2022-07-20 13:17:31,222 controller 18066 deployment_state.py:1303 - Removing 1 replicas from deployment 'Translator'.
```

However, the phrases `"Adding 1 replicas"` and `"Removing 1 replicas"` are grammatically incorrect. This change fixes the logs' grammar when a single replica is added or removed. For instance:

```console
(ServeController pid=70903) INFO 2022-08-10 23:52:01,665 controller 70903 deployment_state.py:1232 - Adding 1 replica to deployment 'f'.
(ServeController pid=70903) INFO 2022-08-10 23:52:02,620 controller 70903 deployment_state.py:1258 - Removing 1 replica from deployment 'f'.
```

The grammar when more than one replica is added or removed is kept the same:

```console
(ServeController pid=70856) INFO 2022-08-10 23:51:48,912 controller 70856 deployment_state.py:1232 - Adding 2 replicas to deployment 'f'.
(ServeController pid=70856) INFO 2022-08-10 23:51:49,965 controller 70856 deployment_state.py:1258 - Removing 2 replicas from deployment 'f'.
```

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
