### PR TITLE
[core] Fix external dashboard url if connecting to existing Ray cluster

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -903,7 +903,7 @@ class Node:
             ]
             self.get_gcs_client().internal_kv_put(
                 b"webui:url",
-                self._webui_url.encode(),
+                self._webui_url_with_protocol.encode(),
                 True,
                 ray_constants.KV_NAMESPACE_DASHBOARD,
             )

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -160,6 +160,28 @@ def test_hosted_external_dashboard_url_with_ray_client(
     assert info.dashboard_url == "external_dashboard_url"
 
 
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25553 --port 0"],
+    indirect=True,
+)
+def test_hosted_external_dashboard_url_with_connecting_to_existing_cluster(
+    set_override_dashboard_url, call_ray_start
+):
+    """
+    Test setting external dashboard URL through environment variable
+    when connecting to existing Ray cluster
+    """
+    info = ray.init()
+    assert info.dashboard_url == "external_dashboard_url"
+    assert info.address_info["webui_url"] == "external_dashboard_url"
+    assert (
+        ray._private.worker._global_node.webui_url_with_protocol
+        == "https://external_dashboard_url"
+    )
+    assert ray_address_to_api_server_url("auto") == "https://external_dashboard_url"
+
+
 def test_shutdown_and_reset_global_worker(shutdown_only):
     ray.init(job_config=ray.job_config.JobConfig(code_search_path=["a"]))
     ray.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Fix bug in external dashboard url if connecting to existing cluster
Bug repro:
```
>> export RAY_OVERRIDE_DASHBOARD_URL="https://external_dashboard_url"
>>> ray start --head

# In python:
>> import ray
>> ray.init() # Output should point to https://external_dasboard_url
INFO worker.py:1487 -- Started a local Ray instance. View the dashboard at external_dashboard_url.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
