### PR TITLE
[Serve] [Doc] Serve add API ref for Deployment.bind() and serve.build

### DIFF
--- a/doc/source/serve/package-ref.md
+++ b/doc/source/serve/package-ref.md
@@ -45,7 +45,7 @@
 .. autofunction:: ray.serve.batch(max_batch_size=10, batch_wait_timeout_s=0.0)
 ```
 
-## Operational APIs
+## Serve CLI and REST API
 
 Check out the [CLI](serve-cli) and [REST API](serve-rest-api) for running, debugging, inspecting, and deploying Serve applications in production:
 

--- a/doc/source/serve/package-ref.md
+++ b/doc/source/serve/package-ref.md
@@ -27,7 +27,7 @@
 
 ```{eval-rst}
 .. autoclass:: ray.serve.deployment.Deployment
-    :members: deploy, delete, options, get_handle
+    :members: deploy, delete, options, get_handle, bind
 ```
 
 (servehandle-api)=
@@ -56,3 +56,16 @@ Check out the [CLI](serve-cli) and [REST API](serve-rest-api) for running, debug
 serve_cli
 rest_api
 ```
+
+## Deployment Graph APIs
+
+```{eval-rst}
+.. autofunction:: ray.serve.api.build
+```
+
+% TODO(architkulkarni): This just compiles to "alias of Deployment(name=DAGDriver,version=None,route_prefix=/)"
+% in the docs, find out how to make Sphinx correctly autodocument this class.
+% ```{eval-rst}
+% .. autoclass:: ray.serve.drivers.DAGDriver
+%     :members: predict, predict_with_route
+% ```

--- a/doc/source/serve/production.md
+++ b/doc/source/serve/production.md
@@ -54,7 +54,7 @@ $ python3
     8
 ```
 
-Once we're finished, we can close the Python interpreter by running `quit()` and terminate the Ray cluster by typing `ctrl-C` int the terminal running `serve run`. This will tear down the deployments and then the cluster.
+Once we're finished, we can close the Python interpreter by running `quit()` and terminate the Ray cluster by typing `ctrl-C` into the terminal running `serve run`. This will tear down the deployments and then the cluster.
 
 (serve-in-production-config-file)=
 

--- a/python/ray/dag/input_node.py
+++ b/python/ray/dag/input_node.py
@@ -16,15 +16,16 @@ class InputNode(DAGNode):
     entrypoints, but only one instance of InputNode exists per DAG, shared
     among all DAGNodes.
 
-    Example:
-                   m1.forward
-                /            \
-        dag_input              ensemble -> dag_output
-                \            /
-                   m2.forward
+    >>> Example:
+    >>>            m1.forward
+    >>>            /       \\
+    >>>    dag_input     ensemble -> dag_output
+    >>>            \       /
+    >>>            m2.forward
 
     In this pipeline, each user input is broadcasted to both m1.forward and
     m2.forward as first stop of the DAG, and authored like
+
     >>> @ray.remote
     >>> class Model:
     ...     def __init__(self, val):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -294,7 +294,7 @@ def deployment(
     Args:
         name (Optional[str]): Globally-unique name identifying this deployment.
             If not provided, the name of the class or function will be used.
-        version (Optional[str]): Version of the deployment. This is used to
+        version [DEPRECATED] (Optional[str]): Version of the deployment. This is used to
             indicate a code change for the deployment; when it is re-deployed
             with a version change, a rolling update of the replicas will be
             performed. If not provided, every deployment will be treated as a
@@ -330,13 +330,13 @@ def deployment(
 
     Example:
     >>> from ray import serve
-    >>> @serve.deployment(name="deployment1", version="v1") # doctest: +SKIP
+    >>> @serve.deployment(name="deployment1") # doctest: +SKIP
     ... class MyDeployment: # doctest: +SKIP
     ...     pass # doctest: +SKIP
 
-    >>> MyDeployment.deploy(*init_args) # doctest: +SKIP
+    >>> MyDeployment.bind(*init_args) # doctest: +SKIP
     >>> MyDeployment.options( # doctest: +SKIP
-    ...     num_replicas=2, init_args=init_args).deploy()
+    ...     num_replicas=2, init_args=init_args).bind()
 
     Returns:
         Deployment
@@ -521,13 +521,20 @@ def build(target: Union[ClassNode, FunctionNode]) -> Application:
     Serve application consisting of one or more deployments. This is intended
     to be used for production scenarios and deployed via the Serve REST API or
     CLI, so there are some restrictions placed on the deployments:
-        1) All of the deployments must be importable. That is, they cannot be
-           defined in __main__ or inline defined. The deployments will be
-           imported in production using the same import path they were here.
-        2) All arguments bound to the deployment must be JSON-serializable.
+    1) All of the deployments must be importable. That is, they cannot be
+    defined in __main__ or inline defined. The deployments will be
+    imported in production using the same import path they were here.
+    2) All arguments bound to the deployment must be JSON-serializable.
 
     The returned Application object can be exported to a dictionary or YAML
     config.
+
+    Args:
+        target (Union[ClassNode, FunctionNode]): A ClassNode or FunctionNode
+            that acts as the top level node of the DAG.
+
+    Returns:
+        The static built Serve application
     """
     if in_interactive_shell():
         raise RuntimeError(

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -87,6 +87,7 @@ class SimpleSchemaIngress:
 @PublicAPI(stability="beta")
 @serve.deployment(route_prefix="/")
 class DAGDriver:
+    """A driver implementation that accepts HTTP requests."""
 
     MATCH_ALL_ROUTE_PREFIX = "/{path:path}"
 
@@ -95,6 +96,13 @@ class DAGDriver:
         dags: Union[RayServeDAGHandle, Dict[str, RayServeDAGHandle]],
         http_adapter: Optional[Union[str, Callable]] = None,
     ):
+        """Create a DAGDriver.
+
+        Args:
+            dags: a handle to a Ray Serve DAG or a dictionary of handles.
+            http_adapter: a callable function or import string to convert
+                HTTP requests to Ray Serve input.
+        """
         install_serve_encoders_to_fastapi()
         http_adapter = _load_http_adapter(http_adapter)
         self.app = FastAPI()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`.bind()` and `serve.build()` were missing from the auto-documented Serve API reference.

I thought about adding InputNode, ClassNode, etc as well, but realized that's not a Serve-specific feature, so it shouldn't be in the Serve API.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
