### PR TITLE
[Serve] Fix memory leak issue in serve inference 

### DIFF
--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -107,7 +107,7 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, Transforme
         return self._replace_table[self._found[i]]
 
     def clear(self):
-        """Clear the scanner from the _instances, which will help to make the scanner GCable faster"""
+        """Clear the scanner from the _instances"""
         if id(self) in _instances:
             del _instances[id(self)]
 

--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -112,4 +112,5 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, Transforme
         return self._replace_table[self._found[i]]
 
     def __del__(self):
-        del _instances[id(self)]
+        if id(self) in _instances:
+            del _instances[id(self)]

--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -25,7 +25,7 @@ TransformedType = TypeVar("TransformedType")
 
 def delete_instance(id: int):
     if id in _instances:
-        del _instances(id)
+        del _instances[id]
 
 
 def _get_node(instance_id: int, node_index: int) -> SourceType:

--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -106,6 +106,10 @@ class _PyObjScanner(ray.cloudpickle.CloudPickler, Generic[SourceType, Transforme
     def _replace_index(self, i: int) -> SourceType:
         return self._replace_table[self._found[i]]
 
-    def __del__(self):
+    def clear(self):
+        """Clear the scanner from the _instances, which will help to make the scanner GCable faster"""
         if id(self) in _instances:
             del _instances[id(self)]
+
+    def __del__(self):
+        self.clear()

--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -23,6 +23,11 @@ SourceType = TypeVar("SourceType")
 TransformedType = TypeVar("TransformedType")
 
 
+def delete_instance(id: int):
+    if id in _instances:
+        del _instances(id)
+
+
 def _get_node(instance_id: int, node_index: int) -> SourceType:
     """Get the node instance.
 

--- a/python/ray/dag/py_obj_scanner.py
+++ b/python/ray/dag/py_obj_scanner.py
@@ -23,11 +23,6 @@ SourceType = TypeVar("SourceType")
 TransformedType = TypeVar("TransformedType")
 
 
-def delete_instance(id: int):
-    if id in _instances:
-        del _instances[id]
-
-
 def _get_node(instance_id: int, node_index: int) -> SourceType:
     """Get the node instance.
 

--- a/python/ray/dag/tests/test_py_obj_scanner.py
+++ b/python/ray/dag/tests/test_py_obj_scanner.py
@@ -56,7 +56,7 @@ def test_scanner_gc():
         scanner = _PyObjScanner(source_type=Source)
         my_objs = [Source(), [Source(), {"key": Source()}]]
         found = scanner.find_nodes(my_objs)
-        replaced = scanner.replace_nodes({obj: 1 for obj in found})
+        scanner.replace_nodes({obj: 1 for obj in found})
         gc.collect()
         assert len(gc.get_referrers(scanner)) == 1
         scanner.clear()

--- a/python/ray/dag/tests/test_py_obj_scanner.py
+++ b/python/ray/dag/tests/test_py_obj_scanner.py
@@ -43,11 +43,8 @@ def test_scanner_gc():
         scanner = _PyObjScanner(source_type=Source)
         my_objs = [Source(), [Source(), {"key": Source()}]]
         scanner.find_nodes(my_objs)
-        gc.collect()
-        assert len(gc.get_referrers(scanner)) == 1
         scanner.clear()
-        gc.collect()
-        assert len(gc.get_referrers(scanner)) == 0
+        assert id(scanner) not in _instances
 
     call_find_nodes()
     assert prev_len == len(_instances)
@@ -57,11 +54,9 @@ def test_scanner_gc():
         my_objs = [Source(), [Source(), {"key": Source()}]]
         found = scanner.find_nodes(my_objs)
         scanner.replace_nodes({obj: 1 for obj in found})
-        gc.collect()
-        assert len(gc.get_referrers(scanner)) == 1
         scanner.clear()
-        gc.collect()
-        assert len(gc.get_referrers(scanner)) == 0
+        assert id(scanner) not in _instances
+
 
     call_find_and_replace_nodes()
     assert prev_len == len(_instances)

--- a/python/ray/dag/tests/test_py_obj_scanner.py
+++ b/python/ray/dag/tests/test_py_obj_scanner.py
@@ -1,4 +1,6 @@
-from ray.dag.py_obj_scanner import _PyObjScanner
+from ray.dag.py_obj_scanner import _PyObjScanner, _instances
+import pytest
+import gc
 
 
 class Source:
@@ -31,3 +33,41 @@ def test_not_serializing_objects():
 
     replaced = scanner.replace_nodes({obj: 1 for obj in found})
     assert replaced == [not_serializable, {"key": 1}]
+
+
+def test_scanner_gc():
+    """Test gc collect after the delete instances[id] called"""
+    prev_len = len(_instances)
+
+    def call_find_nodes():
+        scanner = _PyObjScanner(source_type=Source)
+        my_objs = [Source(), [Source(), {"key": Source()}]]
+        scanner.find_nodes(my_objs)
+        gc.collect()
+        assert len(gc.get_referrers(scanner)) == 1
+        del _instances[id(scanner)]
+        gc.collect()
+        assert len(gc.get_referrers(scanner)) == 0
+
+    call_find_nodes()
+    assert prev_len == len(_instances)
+
+    def call_find_and_replace_nodes():
+        scanner = _PyObjScanner(source_type=Source)
+        my_objs = [Source(), [Source(), {"key": Source()}]]
+        found = scanner.find_nodes(my_objs)
+        replaced = scanner.replace_nodes({obj: 1 for obj in found})
+        gc.collect()
+        assert len(gc.get_referrers(scanner)) == 1
+        del _instances[id(scanner)]
+        gc.collect()
+        assert len(gc.get_referrers(scanner)) == 0
+
+    call_find_and_replace_nodes()
+    assert prev_len == len(_instances)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dag/tests/test_py_obj_scanner.py
+++ b/python/ray/dag/tests/test_py_obj_scanner.py
@@ -34,8 +34,8 @@ def test_not_serializing_objects():
     assert replaced == [not_serializable, {"key": 1}]
 
 
-def test_scanner_gc():
-    """Test gc collect after the delete instances[id] called"""
+def test_scanner_clear():
+    """Test scanner clear to make the scanner GCable"""
     prev_len = len(_instances)
 
     def call_find_nodes():

--- a/python/ray/dag/tests/test_py_obj_scanner.py
+++ b/python/ray/dag/tests/test_py_obj_scanner.py
@@ -45,7 +45,7 @@ def test_scanner_gc():
         scanner.find_nodes(my_objs)
         gc.collect()
         assert len(gc.get_referrers(scanner)) == 1
-        del _instances[id(scanner)]
+        scanner.clear()
         gc.collect()
         assert len(gc.get_referrers(scanner)) == 0
 
@@ -59,7 +59,7 @@ def test_scanner_gc():
         replaced = scanner.replace_nodes({obj: 1 for obj in found})
         gc.collect()
         assert len(gc.get_referrers(scanner)) == 1
-        del _instances[id(scanner)]
+        scanner.clear()
         gc.collect()
         assert len(gc.get_referrers(scanner)) == 0
 

--- a/python/ray/dag/tests/test_py_obj_scanner.py
+++ b/python/ray/dag/tests/test_py_obj_scanner.py
@@ -1,6 +1,5 @@
 from ray.dag.py_obj_scanner import _PyObjScanner, _instances
 import pytest
-import gc
 
 
 class Source:
@@ -56,7 +55,6 @@ def test_scanner_gc():
         scanner.replace_nodes({obj: 1 for obj in found})
         scanner.clear()
         assert id(scanner) not in _instances
-
 
     call_find_and_replace_nodes()
     assert prev_len == len(_instances)

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -9,10 +9,7 @@ from typing import Any, Dict, List, Optional
 
 import ray
 from ray.actor import ActorHandle
-from ray.dag.py_obj_scanner import (
-    _PyObjScanner,
-    _instances as ScannerInstances,
-)
+from ray.dag.py_obj_scanner import _PyObjScanner
 from ray.exceptions import RayActorError, RayTaskError
 from ray.util import metrics
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -59,7 +59,7 @@ class Query:
             replacement_table = dict(zip(tasks, resolved))
             self.args, self.kwargs = scanner.replace_nodes(replacement_table)
 
-        # Trigger the GC to avoid memory leak
+        # Make the scanner GCable to avoid memory leak
         delete_scanner_instance(id(scanner))
 
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -227,7 +227,7 @@ class ReplicaSet:
         self.num_queued_queries_gauge.set(
             self.num_queued_queries, tags={"endpoint": endpoint}
         )
-        await query.resolve_async_tasks()
+        # await query.resolve_async_tasks()
         assigned_ref = self._try_assign_replica(query)
         while assigned_ref is None:  # Can't assign a replica right now.
             logger.debug(

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -11,7 +11,7 @@ import ray
 from ray.actor import ActorHandle
 from ray.dag.py_obj_scanner import (
     _PyObjScanner,
-    delete_instance as delete_scanner_instance,
+    _instances as ScannerInstances,
 )
 from ray.exceptions import RayActorError, RayTaskError
 from ray.util import metrics
@@ -60,7 +60,7 @@ class Query:
             self.args, self.kwargs = scanner.replace_nodes(replacement_table)
 
         # Make the scanner GCable to avoid memory leak
-        delete_scanner_instance(id(scanner))
+        del ScannerInstances[id(scanner)]
 
 
 class ReplicaSet:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -60,7 +60,7 @@ class Query:
             self.args, self.kwargs = scanner.replace_nodes(replacement_table)
 
         # Make the scanner GCable to avoid memory leak
-        del ScannerInstances[id(scanner)]
+        scanner.clear()
 
 
 class ReplicaSet:


### PR DESCRIPTION
Signed-off-by: Sihan Wang <sihanwang41@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As the pr #27411 checked in, we eagerly use the `_PyObjScanner` to replace nodes, yet _instances hold the reference until the gc comes in to delete the object. Currently it is not fast enough, so in this pr, we `del` the object explicitly to mark the object GCable.

## Related issue number
Closes #27692
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
