### PR TITLE
[serve] fix grammar check in test

### DIFF
--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -152,7 +152,7 @@ def test_ray_server_basic(docker_cluster):
     header, worker = docker_cluster
     output = worker.exec_run(cmd=f"python -c '{scripts.format(num_replicas=1)}'")
     assert output.exit_code == 0
-    assert b"Adding 1 replicas to deployment 'Counter'." in output.output
+    assert b"Adding 1 replica to deployment 'Counter'." in output.output
     # somehow this is not working and the port is not exposed to the host.
     # worker_cli = worker.client()
     # print(worker_cli.request("GET", "/api/incr"))


### PR DESCRIPTION
Signed-off-by: Matthew Deng <matt@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Follow-up to #27780

`test_ray_server_basic` was specifically testing this string 😉 
```
>       assert b"Adding 1 replicas to deployment 'Counter'." in output.output
E       assert b"Adding 1 replicas to deployment 'Counter'." in b"2022-08-11 15:26:24,187\tINFO worker.py:1312 -- Connecting to existing Ray cluster at address: gcs:6379...\n2022-08-11 15:26:24,194\tINFO worker.py:1487 -- Connected to Ray cluster. View the dashboard at \x1b[1m\x1b[32m127.0.0.1:8265\x1b[39m\x1b[22m.\nDeprecationWarning: `version` in `@serve.deployment` has been deprecated. Explicitly specifying version will raise an error in the future!\n\x1b[2m\x1b[36m(ServeController pid=130)\x1b[0m INFO 2022-08-11 15:26:25,350 controller 130 http_state.py:132 - Starting HTTP proxy with name 'SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-9c95b980c0bb5ee65d53b61d3fdc644f1b18f1a596c144272adb405d' on node '9c95b980c0bb5ee65d53b61d3fdc644f1b18f1a596c144272adb405d' listening on '127.0.0.1:8000'\n\x1b[2m\x1b[36m(HTTPProxyActor pid=163)\x1b[0m INFO:     Started server process [163]\n\x1b[2m\x1b[36m(ServeController pid=130)\x1b[0m INFO 2022-08-11 15:26:26,584 controller 130 deployment_state.py:1233 - Adding 1 replica to deployment 'Counter'.\n"
E        +  where b"2022-08-11 15:26:24,187\tINFO worker.py:1312 -- Connecting to existing Ray cluster at address: gcs:6379...\n2022-08-11 15:26:24,194\tINFO worker.py:1487 -- Connected to Ray cluster. View the dashboard at \x1b[1m\x1b[32m127.0.0.1:8265\x1b[39m\x1b[22m.\nDeprecationWarning: `version` in `@serve.deployment` has been deprecated. Explicitly specifying version will raise an error in the future!\n\x1b[2m\x1b[36m(ServeController pid=130)\x1b[0m INFO 2022-08-11 15:26:25,350 controller 130 http_state.py:132 - Starting HTTP proxy with name 'SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-9c95b980c0bb5ee65d53b61d3fdc644f1b18f1a596c144272adb405d' on node '9c95b980c0bb5ee65d53b61d3fdc644f1b18f1a596c144272adb405d' listening on '127.0.0.1:8000'\n\x1b[2m\x1b[36m(HTTPProxyActor pid=163)\x1b[0m INFO:     Started server process [163]\n\x1b[2m\x1b[36m(ServeController pid=130)\x1b[0m INFO 2022-08-11 15:26:26,584 controller 130 deployment_state.py:1233 - Adding 1 replica to deployment 'Counter'.\n" = ExecResult(exit_code=0, output=b"2022-08-11 15:26:24,187\tINFO worker.py:1312 -- Connecting to existing Ray cluster at address: gcs:6379...\n2022-08-11 15:26:24,194\tINFO worker.py:1487 -- Connected to Ray cluster. View the dashboard at \x1b[1m\x1b[32m127.0.0.1:8265\x1b[39m\x1b[22m.\nDeprecationWarning: `version` in `@serve.deployment` has been deprecated. Explicitly specifying version will raise an error in the future!\n\x1b[2m\x1b[36m(ServeController pid=130)\x1b[0m INFO 2022-08-11 15:26:25,350 controller 130 http_state.py:132 - Starting HTTP proxy with name 'SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-9c95b980c0bb5ee65d53b61d3fdc644f1b18f1a596c144272adb405d' on node '9c95b980c0bb5ee65d53b61d3fdc644f1b18f1a596c144272adb405d' listening on '127.0.0.1:8000'\n\x1b[2m\x1b[36m(HTTPProxyActor pid=163)\x1b[0m INFO:     Started server process [163]\n\x1b[2m\x1b[36m(ServeController pid=130)\x1b[0m INFO 2022-08-11 15:26:26,584 controller 130 deployment_state.py:1233 - Adding 1 replica to deployment 'Counter'.\n").output

python/ray/tests/test_gcs_ha_e2e.py:155: AssertionError
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
