### PR TITLE
[Serve] [Docs] Revise "Serving Ray AIR Checkpoints" Header

### DIFF
--- a/doc/source/serve/ray-air-serve-guide.md
+++ b/doc/source/serve/ray-air-serve-guide.md
@@ -1,4 +1,4 @@
-# Serving Ray AIR `Checkpoints`
+# Serving Ray AIR Checkpoints
 
 [Ray AI Runtime (AIR)](air) is a scalable and unified toolkit for ML applications. Ray Serve is part of Ray AIR.
 It natively integrates with AIR's `Predictor` and `Checkpoint` abstractions to enable seamless transition from training to serving.

--- a/doc/source/serve/ray-air-serve-guide.md
+++ b/doc/source/serve/ray-air-serve-guide.md
@@ -1,4 +1,4 @@
-# Serving Ray AIR `Checkpoint`s
+# Serving Ray AIR `Checkpoints`
 
 [Ray AI Runtime (AIR)](air) is a scalable and unified toolkit for ML applications. Ray Serve is part of Ray AIR.
 It natively integrates with AIR's `Predictor` and `Checkpoint` abstractions to enable seamless transition from training to serving.


### PR DESCRIPTION
Signed-off-by: Shreyas Krishnaswamy <shrekris@anyscale.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Serve's documentation includes a page about "Serving Ray AIR `Checkpoint`s". However, since the header leaves "s" outside the code formatting, the index on the left has a long gap that makes it hard to read the title:

**The documentation**:

<img width="715" alt="Screen Shot 2022-08-12 at 10 06 30 AM" src="https://user-images.githubusercontent.com/92341594/184408610-a8e7edc5-c3b0-44a7-af76-12a07f0d6b13.png">

**The index**:

<img width="294" alt="Screen Shot 2022-08-12 at 10 06 43 AM" src="https://user-images.githubusercontent.com/92341594/184408709-f7884380-cb67-4bb2-8a76-161e47e1a41e.png">

This change drops the code formatting, so the index is uniform.

Link to updated documentation: https://ray--27824.org.readthedocs.build/en/27824/serve/ray-air-serve-guide.html

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This changes only the documentation header, so no tests are needed.
