### PR TITLE
[Serve] Remove monospace from title to fix formatting issue

### DIFF
--- a/doc/source/serve/ray-air-serve-guide.md
+++ b/doc/source/serve/ray-air-serve-guide.md
@@ -1,4 +1,4 @@
-# Serving Ray AIR `Checkpoint`s
+# Serving Ray AIR Checkpoints
 
 [Ray AI Runtime (AIR)](air) is a scalable and unified toolkit for ML applications. Ray Serve is part of Ray AIR.
 It natively integrates with AIR's `Predictor` and `Checkpoint` abstractions to enable seamless transition from training to serving.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<img width="456" alt="Screen Shot 2022-08-12 at 10 29 35 AM" src="https://user-images.githubusercontent.com/5459654/184412202-5abbdbf7-dde1-46a1-9d77-beafb4cbe506.png">

"`Checkpoint`s" renders like the above in the sidebar with a weird space before the "s".  This is some issue with the formatter; to work around it let's just remove the monospace from the title.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
