### PR TITLE
[Datasets][docs] Minor fix for nyc_taxi_basic_processing.ipynb

### DIFF
--- a/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
+++ b/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
@@ -316,7 +316,7 @@
       "id": "a3fb551b",
       "metadata": {},
       "source": [
-       "To get a better sense of the data size, we can calculate the size in bytes of the full dataset. Note that for Parquet files, this size-in-bytes will be pulled from the Parquet metadata (not triggering a data read), and will therefore might be significantly different than the in-memory size!"
+       "To get a better sense of the data size, we can calculate the size in bytes of the full dataset. Note that for Parquet files, this size-in-bytes will be pulled from the Parquet metadata (not triggering a data read), and therefore might be significantly different than the in-memory size!"
       ]
      },
      {

--- a/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
+++ b/doc/source/data/examples/nyc_taxi_basic_processing.ipynb
@@ -316,7 +316,7 @@
       "id": "a3fb551b",
       "metadata": {},
       "source": [
-       "To get a better sense of the data size, we can calculate the size in bytes of the full dataset. Note that for Parquet files, this size-in-bytes will be pulled from the Parquet metadata (not triggering a data read) and will therefore be the on-disk size of the data; this might be significantly smaller than the in-memory size!"
+       "To get a better sense of the data size, we can calculate the size in bytes of the full dataset. Note that for Parquet files, this size-in-bytes will be pulled from the Parquet metadata (not triggering a data read), and will therefore might be significantly different than the in-memory size!"
       ]
      },
      {
@@ -330,7 +330,7 @@
        {
         "data": {
          "text/plain": [
-          "237029648"
+          "427503965"
          ]
         },
         "execution_count": 8,
@@ -428,7 +428,7 @@
        {
         "data": {
          "text/plain": [
-          "146863542"
+          "1710629"
          ]
         },
         "execution_count": 11,
@@ -437,7 +437,7 @@
        }
       ],
       "source": [
-       "year_ds.size_bytes()"
+       "year_ds.count()"
       ]
      },
      {


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Went through https://docs.ray.io/en/master/data/examples/nyc_taxi_basic_processing.html, and doing some minor fix here.
* Fix the `size_bytes()` result (before this PR it was using Parquet sampling, but we disasble it later)
* Change one `size_bytes()` call to `count()` call as it was meant to use `count()` with followed wording `That’s a lot of rows` in doc.
* Changed places are as followed in screenshots:

<img width="981" alt="Screen Shot 2022-08-12 at 11 16 49 AM" src="https://user-images.githubusercontent.com/4629931/184420123-521e2727-f9f9-4d7c-ae1e-a39159a71f21.png">



<img width="990" alt="Screen Shot 2022-08-12 at 11 17 08 AM" src="https://user-images.githubusercontent.com/4629931/184420135-a7075f8a-bd68-40a8-81f6-8f0a718d1b29.png">




## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
