### PR TITLE
[Core][Placement Group] Handling edge cases of max_cpu_fraction argum…

### DIFF
--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -68,8 +68,8 @@ def test_placement_group_bin_packing_priority(
         )
 
 
-@pytest.mark.parametrize("multi_bundle", [False, True])
-@pytest.mark.parametrize("even_pack", [False, True])
+@pytest.mark.parametrize("multi_bundle", [True, False])
+@pytest.mark.parametrize("even_pack", [True, False])
 @pytest.mark.parametrize("scheduling_strategy", ["SPREAD", "STRICT_PACK", "PACK"])
 def test_placement_group_max_cpu_frac(
     ray_start_cluster, multi_bundle, even_pack, scheduling_strategy
@@ -129,20 +129,92 @@ def test_placement_group_max_cpu_frac_multiple_pgs(ray_start_cluster):
     with pytest.raises(ray.exceptions.GetTimeoutError):
         ray.get(pg2.ready(), timeout=5)
 
+    # When you add a new node, it is finally schedulable.
     cluster.add_node(num_cpus=8)
     ray.get(pg2.ready())
 
-    """
-    Make sure when the CPU * frac < 1, we can at least
-    guarantee to have 1 CPU for pg.
-    """
-    ray.util.remove_placement_group(pg)
-    ray.util.remove_placement_group(pg2)
 
-    # We can reserve up to 0.8 CPU, but it should round up to 1, so this pg
-    # is schedulable.
-    pg = ray.util.placement_group([{"CPU": 1}], _max_cpu_fraction_per_node=0.1)
+def test_placement_group_max_cpu_frac_edge_cases(ray_start_cluster):
+    """
+    _max_cpu_fraction_per_node <= 0  ---> should raise error (always)
+    _max_cpu_fraction_per_node = 0.999 --->
+        should exclude 1 CPU (this is already the case)
+    _max_cpu_fraction_per_node = 0.001 --->
+        should exclude 3 CPUs (not currently the case, we'll exclude all 4 CPUs).
+
+    Related: https://github.com/ray-project/ray/issues/26635
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=4)
+    cluster.wait_for_nodes()
+    ray.init(address=cluster.address)
+
+    """
+    0 or 1 is not allowed.
+    """
+    with pytest.raises(ValueError):
+        ray.util.placement_group([{"CPU": 1}], _max_cpu_fraction_per_node=0)
+
+    """
+    Make sure when _max_cpu_fraction_per_node = 0.999, 1 CPU is always excluded.
+    """
+    pg = ray.util.placement_group(
+        [{"CPU": 1} for _ in range(4)], _max_cpu_fraction_per_node=0.999
+    )
+    # Since 1 CPU is excluded, we cannot schedule this pg.
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(pg.ready(), timeout=5)
+    ray.util.remove_placement_group(pg)
+
+    # Since 1 CPU is excluded, we can schedule 1 num_cpus actor after creating
+    # CPU: 1 * 3 bundle placement groups.
+    @ray.remote(num_cpus=1)
+    class A:
+        def ready(self):
+            pass
+
+    # Try actor creation -> pg creation.
+    a = A.remote()
+    ray.get(a.ready.remote())
+    pg = ray.util.placement_group(
+        [{"CPU": 1} for _ in range(3)], _max_cpu_fraction_per_node=0.999
+    )
     ray.get(pg.ready())
+
+    ray.kill(a)
+    ray.util.remove_placement_group(pg)
+
+    # Make sure the opposite order also works. pg creation -> actor creation.
+    pg = ray.util.placement_group(
+        [{"CPU": 1} for _ in range(3)], _max_cpu_fraction_per_node=0.999
+    )
+    a = A.remote()
+    ray.get(a.ready.remote())
+    ray.get(pg.ready())
+
+    ray.kill(a)
+    ray.util.remove_placement_group(pg)
+
+    """
+    _max_cpu_fraction_per_node = 0.001 --->
+        should exclude 3 CPUs (not currently the case, we'll exclude all 4 CPUs).
+    """
+    # We can schedule up to 1 pg.
+    pg = ray.util.placement_group([{"CPU": 1}], _max_cpu_fraction_per_node=0.001)
+    ray.get(pg.ready())
+    # Cannot schedule any more PG.
+    pg2 = ray.util.placement_group([{"CPU": 1}], _max_cpu_fraction_per_node=0.001)
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(pg2.ready(), timeout=5)
+
+    # Since 3 CPUs are excluded, we can schedule actors.
+    actors = [A.remote() for _ in range(3)]
+    ray.get([a.ready.remote() for a in actors])
+
+    # Once pg 1 is removed, pg 2 can be created since there's 1 CPU that can be
+    # used for this pg.
+    ray.util.remove_placement_group(pg)
+    ray.get(pg2.ready())
 
 
 if __name__ == "__main__":

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -183,15 +183,14 @@ def test_reserved_cpus(ray_start_4_cpus):
     )
     tune.run(trainer.as_trainable(), num_samples=4)
 
-
-# TODO(ekl/sang) this currently fails.
-#    # Check we don't deadlock with too low of a fraction either.
-#    scale_config = ScalingConfig(num_workers=1, _max_cpu_fraction_per_node=0.01)
-#    trainer = DummyTrainer(
-#        train_loop,
-#        scaling_config=scale_config,
-#    )
-#    tune.run(trainer.as_trainable(), num_samples=4)
+    # TODO(ekl/sang) this currently fails.
+    # Check we don't deadlock with too low of a fraction either.
+    scale_config = ScalingConfig(num_workers=1, _max_cpu_fraction_per_node=0.01)
+    trainer = DummyTrainer(
+        train_loop,
+        scaling_config=scale_config,
+    )
+    tune.run(trainer.as_trainable(), num_samples=4)
 
 
 def test_reserved_cpu_warnings(ray_start_4_cpus):

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -129,7 +129,7 @@ def placement_group(
     strategy: str = "PACK",
     name: str = "",
     lifetime: Optional[str] = None,
-    _max_cpu_fraction_per_node: Optional[float] = None,
+    _max_cpu_fraction_per_node: float = 1.0,
 ) -> PlacementGroup:
     """Asynchronously creates a PlacementGroup.
 
@@ -172,10 +172,14 @@ def placement_group(
     if not isinstance(bundles, list):
         raise ValueError("The type of bundles must be list, got {}".format(bundles))
 
-    if _max_cpu_fraction_per_node is None:
-        _max_cpu_fraction_per_node = 1.0
-    if _max_cpu_fraction_per_node < 0 or _max_cpu_fraction_per_node > 1:
-        raise ValueError("max_cpu_fraction_per_node must be a float between 0 and 1.")
+    assert _max_cpu_fraction_per_node is not None
+
+    if _max_cpu_fraction_per_node <= 0 or _max_cpu_fraction_per_node > 1:
+        raise ValueError(
+            "Invalid argument `_max_cpu_fraction_per_node`: "
+            f"{_max_cpu_fraction_per_node}. "
+            "_max_cpu_fraction_per_node must be a float between 0 and 1. "
+        )
 
     # Validate bundles
     for bundle in bundles:

--- a/src/ray/common/bundle_spec.cc
+++ b/src/ray/common/bundle_spec.cc
@@ -131,6 +131,19 @@ std::string GetOriginalResourceName(const std::string &resource) {
   return resource.substr(0, idx);
 }
 
+std::string GetOriginalResourceNameFromWildcardResource(const std::string &resource) {
+  static const std::regex wild_card_resource_pattern("^(.*)_group_([0-9a-f]+)$");
+  std::smatch match_groups;
+  if (!std::regex_match(resource, match_groups, wild_card_resource_pattern) ||
+      match_groups.size() != 3) {
+    return "";
+  }
+
+  // group 0: resource
+  // group 1: pg id
+  return match_groups[1].str();
+}
+
 std::string GetDebugStringForBundles(
     const std::vector<std::shared_ptr<const BundleSpecification>> &bundles) {
   std::ostringstream debug_info;

--- a/src/ray/common/bundle_spec.h
+++ b/src/ray/common/bundle_spec.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstddef>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -108,6 +109,11 @@ bool IsBundleIndex(const std::string &resource,
 
 /// Return the original resource name of the placement group resource.
 std::string GetOriginalResourceName(const std::string &resource);
+
+// Return the original resource name of the placement group resource
+// if the resource is the wildcard resource (resource without a bundle id).
+// Returns "" if the resource is not a wildcard resource.
+std::string GetOriginalResourceNameFromWildcardResource(const std::string &resource);
 
 /// Generate debug information of given bundles.
 std::string GetDebugStringForBundles(

--- a/src/ray/raylet/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/placement_group_resource_manager_test.cc
@@ -75,6 +75,23 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
   }
 };
 
+TEST_F(NewPlacementGroupResourceManagerTest,
+       TestGetOriginalResourceNameFromWildcardResource) {
+  ASSERT_EQ(GetOriginalResourceNameFromWildcardResource(
+                "CPU_group_0_4482dec0faaf5ead891ff1659a9501000000"),
+            "");
+  ASSERT_EQ(GetOriginalResourceNameFromWildcardResource("CPU"), "");
+  ASSERT_EQ(GetOriginalResourceNameFromWildcardResource(
+                "CPU_group_4482dec0faaf5ead891ff1659a9501000000"),
+            "CPU");
+  ASSERT_EQ(GetOriginalResourceNameFromWildcardResource(
+                "GPU_group_4482dec0faaf5ead891ff1659a9501000000"),
+            "GPU");
+  ASSERT_EQ(GetOriginalResourceNameFromWildcardResource(
+                "GPU_group_0_4482dec0faaf5ead891ff1659a9501000000"),
+            "");
+}
+
 TEST_F(NewPlacementGroupResourceManagerTest, TestNewPrepareBundleResource) {
   // 1. create bundle spec.
   auto group_id = PlacementGroupID::Of(JobID::FromInt(1));

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -16,13 +16,30 @@
 
 namespace {
 
-bool AllocationWillExceedMaxCpuFraction(const ray::NodeResources &node_resources,
-                                        const ray::ResourceRequest &resource_request,
-                                        double max_cpu_fraction_per_node) {
+/// Return true if scheduling this bundle (with resource_request) will exceed the
+/// max cpu fraction for placement groups. This is per node.
+///
+/// \param node_resources The resource of the current node.
+/// \param bundle_resource_request The requested resources for the current bundle.
+/// \param max_cpu_fraction_per_node Highest CPU fraction the bundles can take up.
+/// \param available_cpus_before_curernt_pg_request Available CPUs on this node before
+///   scheduling the current pg request. It is used to calculate how many CPUs are
+///   allocated by the current bundles so far. It will help us figuring out
+///   the total CPU allocation from the current bundles for this node.
+bool AllocationWillExceedMaxCpuFraction(
+    const ray::NodeResources &node_resources,
+    const ray::ResourceRequest &bundle_resource_request,
+    double max_cpu_fraction_per_node,
+    double available_cpus_before_curernt_pg_request) {
+  if (max_cpu_fraction_per_node == 1.0) {
+    // Allocation will never exceed the threshold if the fraction == 1.0.
+    return false;
+  }
+
   auto cpu_id = ray::ResourceID::CPU();
-  auto remaining_cpus = node_resources.available.Get(cpu_id).Double() -
-                        resource_request.Get(cpu_id).Double();
-  auto total_allocated_cpus = node_resources.total.Get(cpu_id).Double() - remaining_cpus;
+  auto total_cpus = node_resources.total.Get(cpu_id).Double();
+
+  // Calculate max_reservable_cpus
   auto max_reservable_cpus =
       max_cpu_fraction_per_node * node_resources.total.Get(cpu_id).Double();
 
@@ -30,7 +47,44 @@ bool AllocationWillExceedMaxCpuFraction(const ray::NodeResources &node_resources
   if (max_reservable_cpus < 1) {
     max_reservable_cpus = 1;
   }
-  return total_allocated_cpus > max_reservable_cpus;
+
+  // We guarantee at least 1 CPU is excluded from the placement group
+  // when max_cpu_fraction_per_node is specified.
+  if (max_reservable_cpus > total_cpus - 1) {
+    max_reservable_cpus = total_cpus - 1;
+  }
+
+  /*
+    To calculate if allocating a new bundle will exceed the pg max_fraction,
+    we need a sum of
+
+    - CPUs used by placement groups before.
+    - CPUs that will be allocated by the current pg request.
+  */
+
+  // Get the sum of all cpu allocated by placement group on this node.
+  FixedPoint cpus_used_by_pg_before(0);
+  for (const auto &resource_id : node_resources.total.ResourceIds()) {
+    if (ray::GetOriginalResourceNameFromWildcardResource(resource_id.Binary()) == "CPU") {
+      cpus_used_by_pg_before += node_resources.total.Get(resource_id);
+    }
+  }
+
+  // Get the CPUs allocated by current pg request so far.
+  // Note that when we schedule the current pg, we allocate resources
+  // temporarily meaning `node_resources.available` will contain
+  // available CPUs after allocating CPUs for the current pg request.
+  auto cpus_allocated_by_current_pg_request =
+      (available_cpus_before_curernt_pg_request -
+       node_resources.available.Get(cpu_id).Double());
+
+  auto cpus_to_allocate_by_current_pg_request =
+      (cpus_allocated_by_current_pg_request +
+       bundle_resource_request.Get(cpu_id).Double());
+
+  auto cpus_used_by_pg_after =
+      cpus_used_by_pg_before.Double() + cpus_to_allocate_by_current_pg_request;
+  return cpus_used_by_pg_after > max_reservable_cpus;
 }
 
 }  // namespace
@@ -59,6 +113,19 @@ BundleSchedulingPolicy::SelectCandidateNodes(const SchedulingContext *context) c
     if (is_node_available_ == nullptr || is_node_available_(entry.first)) {
       result.emplace(entry.first, &entry.second);
     }
+  }
+  return result;
+}
+
+/// Return the map of node id -> available cpus before the current bundle scheduling.
+/// It is used to calculate how many CPUs have been allocated for the current bundles.
+const absl::flat_hash_map<scheduling::NodeID, double>
+BundleSchedulingPolicy::GetAvailableCpusBeforeBundleScheduling() const {
+  absl::flat_hash_map<scheduling::NodeID, double> result;
+  for (const auto &entry : cluster_resource_manager_.GetResourceView()) {
+    result.emplace(
+        entry.first,
+        entry.second.GetLocalView().available.Get(ray::ResourceID::CPU()).Double());
   }
   return result;
 }
@@ -136,7 +203,9 @@ BundleSchedulingPolicy::SortRequiredResources(
 std::pair<scheduling::NodeID, const Node *> BundleSchedulingPolicy::GetBestNode(
     const ResourceRequest &required_resources,
     const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
-    const SchedulingOptions &options) const {
+    const SchedulingOptions &options,
+    const absl::flat_hash_map<scheduling::NodeID, double>
+        &available_cpus_before_bundle_scheduling) const {
   double best_node_score = -1;
   auto best_node_id = scheduling::NodeID::Nil();
   const Node *best_node = nullptr;
@@ -145,7 +214,10 @@ std::pair<scheduling::NodeID, const Node *> BundleSchedulingPolicy::GetBestNode(
   for (const auto &[node_id, node] : candidate_nodes) {
     const auto &node_resources = node->GetLocalView();
     if (AllocationWillExceedMaxCpuFraction(
-            node_resources, required_resources, options.max_cpu_fraction_per_node)) {
+            node_resources,
+            required_resources,
+            options.max_cpu_fraction_per_node,
+            available_cpus_before_bundle_scheduling.at(node_id))) {
       continue;
     }
 
@@ -174,6 +246,9 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
     return SchedulingResult::Infeasible();
   }
 
+  const auto available_cpus_before_bundle_scheduling =
+      GetAvailableCpusBeforeBundleScheduling();
+
   // First schedule scarce resources (such as GPU) and large capacity resources to improve
   // the scheduling success rate.
   auto sorted_result = SortRequiredResources(resource_request_list);
@@ -191,11 +266,16 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
   while (!required_resources_list_copy.empty()) {
     const auto &required_resources_index = required_resources_list_copy.front().first;
     const auto &required_resources = required_resources_list_copy.front().second;
-    auto best_node = GetBestNode(*required_resources, candidate_nodes, options);
+    auto best_node = GetBestNode(*required_resources,
+                                 candidate_nodes,
+                                 options,
+                                 available_cpus_before_bundle_scheduling);
     if (best_node.first.IsNil()) {
       // There is no node to meet the scheduling requirements.
       break;
     }
+
+    const auto &node_resources = best_node.second->GetLocalView();
 
     RAY_CHECK(cluster_resource_manager_.SubtractNodeAvailableResources(
         best_node.first, *required_resources));
@@ -205,13 +285,13 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
     // We try to schedule more resources on one node.
     for (auto iter = required_resources_list_copy.begin();
          iter != required_resources_list_copy.end();) {
-      const auto &node_resources = best_node.second->GetLocalView();
       if (node_resources.IsAvailable(*iter->second)  // If the node has enough resources.
           && !AllocationWillExceedMaxCpuFraction(    // and allocating resources won't
                                                      // exceed max cpu fraction.
                  node_resources,
                  *iter->second,
-                 options.max_cpu_fraction_per_node)) {
+                 options.max_cpu_fraction_per_node,
+                 available_cpus_before_bundle_scheduling.at(best_node.first))) {
         // Then allocate it.
         RAY_CHECK(cluster_resource_manager_.SubtractNodeAvailableResources(
             best_node.first, *iter->second));
@@ -254,6 +334,9 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
     return SchedulingResult::Infeasible();
   }
 
+  const auto available_cpus_before_bundle_scheduling =
+      GetAvailableCpusBeforeBundleScheduling();
+
   // First schedule scarce resources (such as GPU) and large capacity resources to improve
   // the scheduling success rate.
   auto sorted_result = SortRequiredResources(resource_request_list);
@@ -264,7 +347,10 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
   absl::flat_hash_map<scheduling::NodeID, const Node *> selected_nodes;
   for (const auto &resource_request : sorted_resource_request_list) {
     // Score and sort nodes.
-    auto best_node = GetBestNode(*resource_request, candidate_nodes, options);
+    auto best_node = GetBestNode(*resource_request,
+                                 candidate_nodes,
+                                 options,
+                                 available_cpus_before_bundle_scheduling);
 
     // There are nodes to meet the scheduling requirements.
     if (!best_node.first.IsNil()) {
@@ -275,7 +361,10 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
       selected_nodes.emplace(best_node);
     } else {
       // Scheduling from selected nodes.
-      auto best_node = GetBestNode(*resource_request, selected_nodes, options);
+      auto best_node = GetBestNode(*resource_request,
+                                   selected_nodes,
+                                   options,
+                                   available_cpus_before_bundle_scheduling);
       if (!best_node.first.IsNil()) {
         result_nodes.emplace_back(best_node.first);
         RAY_CHECK(cluster_resource_manager_.SubtractNodeAvailableResources(
@@ -315,6 +404,9 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
     return SchedulingResult::Infeasible();
   }
 
+  const auto available_cpus_before_bundle_scheduling =
+      GetAvailableCpusBeforeBundleScheduling();
+
   // Aggregate required resources.
   ResourceRequest aggregated_resource_request;
   for (const auto &resource_request : resource_request_list) {
@@ -328,7 +420,8 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
   const auto &right_node_it = std::find_if(
       candidate_nodes.begin(),
       candidate_nodes.end(),
-      [&aggregated_resource_request, &options](const auto &entry) {
+      [&aggregated_resource_request, &options, &available_cpus_before_bundle_scheduling](
+          const auto &entry) {
         const auto &node_resources = entry.second->GetLocalView();
         auto allocatable =
             (node_resources.IsAvailable(
@@ -337,7 +430,8 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
                                                       // exceed max cpu fraction.
                     node_resources,
                     aggregated_resource_request,
-                    options.max_cpu_fraction_per_node));
+                    options.max_cpu_fraction_per_node,
+                    available_cpus_before_bundle_scheduling.at(entry.first)));
         return allocatable;
       });
 
@@ -347,7 +441,10 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
     return SchedulingResult::Infeasible();
   }
 
-  auto best_node = GetBestNode(aggregated_resource_request, candidate_nodes, options);
+  auto best_node = GetBestNode(aggregated_resource_request,
+                               candidate_nodes,
+                               options,
+                               available_cpus_before_bundle_scheduling);
 
   // Select the node with the highest score.
   // `StrictPackSchedule` does not need to consider the scheduling context, because it
@@ -377,6 +474,9 @@ SchedulingResult BundleStrictSpreadSchedulingPolicy::Schedule(
     return SchedulingResult::Infeasible();
   }
 
+  const auto available_cpus_before_bundle_scheduling =
+      GetAvailableCpusBeforeBundleScheduling();
+
   if (resource_request_list.size() > candidate_nodes.size()) {
     RAY_LOG(DEBUG) << "The number of required resources " << resource_request_list.size()
                    << " is greater than the number of candidate nodes "
@@ -393,7 +493,10 @@ SchedulingResult BundleStrictSpreadSchedulingPolicy::Schedule(
   std::vector<scheduling::NodeID> result_nodes;
   for (const auto &resource_request : sorted_resource_request_list) {
     // Score and sort nodes.
-    auto best_node = GetBestNode(*resource_request, candidate_nodes, options);
+    auto best_node = GetBestNode(*resource_request,
+                                 candidate_nodes,
+                                 options,
+                                 available_cpus_before_bundle_scheduling);
 
     // There are nodes to meet the scheduling requirements.
     if (!best_node.first.IsNil()) {

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
@@ -16,7 +16,9 @@
 
 #include <vector>
 
+#include "ray/common/bundle_spec.h"
 #include "ray/raylet/scheduling/cluster_resource_manager.h"
+#include "ray/raylet/scheduling/fixed_point.h"
 #include "ray/raylet/scheduling/policy/scheduling_context.h"
 #include "ray/raylet/scheduling/policy/scheduling_policy.h"
 #include "ray/raylet/scheduling/policy/scorer.h"
@@ -59,7 +61,14 @@ class BundleSchedulingPolicy : public IBundleSchedulingPolicy {
   std::pair<scheduling::NodeID, const Node *> GetBestNode(
       const ResourceRequest &required_resources,
       const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes,
-      const SchedulingOptions &options) const;
+      const SchedulingOptions &options,
+      const absl::flat_hash_map<scheduling::NodeID, double>
+          &available_cpus_before_bundle_scheduling) const;
+
+  /// Return the map of node id -> available cpus before the current bundle scheduling.
+  /// It is used to calculate how many CPUs have been allocated for the current bundles.
+  const absl::flat_hash_map<scheduling::NodeID, double>
+  GetAvailableCpusBeforeBundleScheduling() const;
 
  protected:
   /// The cluster resource manager.

--- a/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
@@ -551,6 +551,62 @@ TEST_F(SchedulingPolicyTest, BundleSchedulingMaxFractionOneCpuReservationGuarant
   ASSERT_TRUE(to_schedule.status.IsSuccess());
 }
 
+TEST_F(SchedulingPolicyTest,
+       BundleSchedulingMinFractionExcludeOneCpuReservationGuaranteeTest) {
+  /*
+   * Test that when the max cpu fraction is high, it excludes at least 1 CPU.
+   */
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 3}}, false);
+  std::vector<const ResourceRequest *> req_list;
+  req_list.push_back(&req);
+
+  // NOTE: We can reserve up to 3.96 CPU, but it will round down to 3 (exclude 1 CPU),
+  // which means a regular task with 1 CPU can be scheduled.
+  auto pack_op = SchedulingOptions::BundlePack(/*max_cpu_fraction_per_node*/ 0.99);
+  nodes.emplace(local_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+  // req is unscheduleable because the max cpu fraction reaches 0.5.
+  auto to_schedule = raylet_scheduling_policy::BundlePackSchedulingPolicy(
+                         cluster_resource_manager, [](auto) { return true; })
+                         .Schedule(req_list, pack_op);
+  ASSERT_TRUE(to_schedule.status.IsSuccess());
+
+  req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
+
+  auto to_schedule_task =
+      raylet_scheduling_policy::CompositeSchedulingPolicy(
+          local_node, cluster_resource_manager, [](auto) { return true; })
+          .Schedule(req, HybridOptions(0.50, false, false));
+  ASSERT_TRUE(!to_schedule_task.IsNil());
+}
+
+TEST_F(SchedulingPolicyTest, BundleSchedulingMaxFractionWorkingWhenNormalResourceUsed) {
+  /*
+   * Test that it can schedule placement group correctly when there are non-pg
+   * resources occupying resources.
+   */
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 1}}, false);
+  std::vector<const ResourceRequest *> req_list;
+  req_list.push_back(&req);
+
+  // 2 CPUs / 4 CPUs is used by a regular task/actor.
+  // It means that when the fraction is 0.5, we still should
+  // be able to schedule a pg because 50% of CPUs still can be
+  // used for the placement group.
+  auto pack_op = SchedulingOptions::BundlePack(/*max_cpu_fraction_per_node*/ 0.5);
+  nodes.emplace(local_node, CreateNodeResources(2, 4, 0, 0, 0, 0));
+
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+  // req is unscheduleable because the max cpu fraction reaches 0.5.
+  auto to_schedule = raylet_scheduling_policy::BundlePackSchedulingPolicy(
+                         cluster_resource_manager, [](auto) { return true; })
+                         .Schedule(req_list, pack_op);
+  ASSERT_TRUE(to_schedule.status.IsSuccess());
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
…ent (#27035)

Why are these changes needed?
This PR fixes the edge cases when the max_cpu_fraction argument is used by the placement group. There was specifically an edge case where the placement group cannot be scheduled when a task or actor is scheduled and occupies the resource.

The original logic to decide if the bundle scheduling exceed CPU fraction was as follow.

Calculate max_reservable_cpus of the node.
Calculate currently_used_cpus + bundle_cpu_request (per bundle) == total_allocation of the node.
Don't schedule if total_allocation > max_reservable_cpus for the node.
However, the following scenarios caused issues because currently_used_cpus can include resources that are not allocated by placement groups (e.g., actors). As a result, when the actor was already occupying the resource, the total_allocation was incorrect. For example,

4 CPUs
0.999 max fraction (so it can reserve up to 3 CPUs)
1 Actor already created (1 CPU)
PG with CPU: 3
Now pg cannot be scheduled because total_allocation == 1 actor (1 CPU) + 3 bundles (3 CPUs) == 4 CPUs > 3 CPUs (max frac CPUs)
However, this should work because the pg can use up to 3 CPUs, and we have enough resources.
The root cause is that when we calculate the max_fraction, we should only take into account of resources allocated by bundles. To fix this, I change the logic as follow.

Calculate max_reservable_cpus of the node.
Calculate **currently_used_cpus_by_pg_bundles** + **bundle_cpu_request (sum of all bundles)** == total_allocation_from_pgs_and_bundles of the node.
Don't schedule if total_allocation_from_pgs_and_bundles > max_reservable_cpus for the node.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
