### PR TITLE
[Doc][RFC] Remove state API from the top level package reference

### DIFF
--- a/doc/source/ray-references/api.rst
+++ b/doc/source/ray-references/api.rst
@@ -13,4 +13,3 @@ API References
     ../rllib/package_ref/index.rst
     ../workflows/package-ref.rst
     ../ray-core/package-ref.rst
-    ../ray-observability/state/ray-state-api-reference.rst


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This seems to be bad we have state API in the top level package reference. We need more discussion regarding how to place package references (should it be under core? Should we have observability API there?)

<img width="413" alt="Screen Shot 2022-08-12 at 7 04 39 PM" src="https://user-images.githubusercontent.com/18510752/184464473-36633507-22b5-43bc-8c6a-390e578992ba.png">



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
