### PR TITLE
Fix: allow ray.remote to accept builtin functions

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -127,7 +127,9 @@ class FunctionActorManager:
         import io
 
         string_file = io.StringIO()
-        if sys.version_info[1] >= 7:
+        if inspect.isbuiltin(function_or_class):
+            string_file.write("builtin")
+        elif sys.version_info[1] >= 7:
             dis.dis(function_or_class, file=string_file, depth=2)
         else:
             dis.dis(function_or_class, file=string_file)

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2553,7 +2553,11 @@ def _mode(worker=global_worker):
 
 
 def _make_remote(function_or_class, options):
-    if inspect.isfunction(function_or_class) or is_cython(function_or_class):
+    if (
+        inspect.isfunction(function_or_class)
+        or inspect.isbuiltin(function_or_class)
+        or is_cython(function_or_class)
+    ):
         ray_option_utils.validate_task_options(options, in_options=False)
         return ray.remote_function.RemoteFunction(
             Language.PYTHON,

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -119,6 +119,11 @@ def test_defining_remote_functions(shutdown_only):
     assert ray.get(k2.remote(1)) == 2
     assert ray.get(m.remote(1)) == 2
 
+    # Test that builtins can be defined as remotes.
+    n = ray.remote(len)
+
+    assert ray.get(n.remote([1, 2, 3])) == 3
+
 
 def test_redefining_remote_functions(shutdown_only):
     ray.init(num_cpus=1)


### PR DESCRIPTION
## Why are these changes needed?

Currently, neither Ray 1.13.0 nor 2.0.0rc0 support converting builtin functions directly to ray remote functions.
For example, `ray.remote(len)` raises TypeError.
A simple solution is to wrap it with lambda, but some linters (e.g. pylint) complains against such simple wrappers as `lambda x: len(x)`.
If the necessary changes to the codebase is minimal, as shown below, I believe supporting builtin functions additionally may do no harm to ray. 

### Summary of changes
- ray.remote now checks if the function or class given is builtin too, via inspect.isbuiltin
- function collision identifier uses dis.dis to create hashes from functions. As dis.dis does not work on builtins, I propose to create hash from a simple string `\<name\>:builtin`.
- added a simple test code inside a basic test function for remote creation.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
