### PR TITLE
[Test] Fix broken test_base_trainer

### DIFF
--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -184,10 +184,12 @@ def test_reserved_cpus(ray_start_4_cpus):
     tune.run(trainer.as_trainable(), num_samples=4)
 
     # Needs to request 0 CPU for the trainer otherwise the pg
-    # will require {CPU: 1} * 2 resources, which means 
+    # will require {CPU: 1} * 2 resources, which means
     # _max_cpu_fraction_per_node == 0.01 cannot schedule it
     # (because this only allows to have 1 CPU for pg per node).
-    scale_config = ScalingConfig(num_workers=1, _max_cpu_fraction_per_node=0.01, trainer_resources={"CPU": 0})
+    scale_config = ScalingConfig(
+        num_workers=1, _max_cpu_fraction_per_node=0.01, trainer_resources={"CPU": 0}
+    )
     trainer = DummyTrainer(
         train_loop,
         scaling_config=scale_config,

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -183,9 +183,11 @@ def test_reserved_cpus(ray_start_4_cpus):
     )
     tune.run(trainer.as_trainable(), num_samples=4)
 
-    # TODO(ekl/sang) this currently fails.
-    # Check we don't deadlock with too low of a fraction either.
-    scale_config = ScalingConfig(num_workers=1, _max_cpu_fraction_per_node=0.01)
+    # Needs to request 0 CPU for the trainer otherwise the pg
+    # will require {CPU: 1} * 2 resources, which means 
+    # _max_cpu_fraction_per_node == 0.01 cannot schedule it
+    # (because this only allows to have 1 CPU for pg per node).
+    scale_config = ScalingConfig(num_workers=1, _max_cpu_fraction_per_node=0.01, trainer_resources={"CPU": 0})
     trainer = DummyTrainer(
         train_loop,
         scaling_config=scale_config,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Test was written incorrectly. This root cause was that the trainer & worker both requires 1 CPU, meaning pg requires {CPU: 1} * 2 resources.

And when the max fraction is 0.001, we only allow up to 1 CPU for pg, so we cannot schedule the requested pgs in any case. 

<img width="330" alt="Screen Shot 2022-08-14 at 1 19 19 AM" src="https://user-images.githubusercontent.com/18510752/184528632-944200d8-bb5f-4929-8029-bcb73fb24a59.png">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
