### PR TITLE
[Serve][Docs] Mark metrics served for HTTP vs Python calls

### DIFF
--- a/doc/source/serve/handle-guide.md
+++ b/doc/source/serve/handle-guide.md
@@ -46,6 +46,13 @@ The result of `deployment_handle.remote()` can also be passed directly as an arg
 :language: python
 ```
 
+:::{note}
+Different metrics are collected when Deployments are called
+via Python `ServeHandles` and when they are called via HTTP.
+
+See the [Ray Serve monitoring documentation](serve-monitoring) for more details.
+:::
+
 ## Note about ray.ObjectRef
 
 `ray.ObjectRef` corresponds to the result of a request submission. To retrieve the result, you can use the synchronous Ray Core API `ray.get(ref)` or the async API `await ref`. To wait for the result to be available without retrieving it, you can use the synchronous API `ray.wait([ref])` or the async API `await asyncio.wait([ref])`. You can mix and match these calls, but we recommend using async APIs to increase concurrency.
@@ -59,10 +66,3 @@ In both types of ServeHandle, you can call a specific method by using the `.meth
 :end-before: __end_handle_method__
 :language: python
 ```
-
-:::{note}
-Different metrics are collected when Deployments are called
-via Python `ServeHandles` and when they are called via HTTP.
-
-See the [Ray Serve monitoring documentation](serve-monitoring) for more details.
-:::

--- a/doc/source/serve/handle-guide.md
+++ b/doc/source/serve/handle-guide.md
@@ -60,9 +60,9 @@ In both types of ServeHandle, you can call a specific method by using the `.meth
 :language: python
 ```
 
-## Note about metrics
+:::{note}
+Different metrics are collected when Deployments are called
+via Python `ServeHandles` and when they are called via HTTP.
 
-Please note that different metrics are collected when calling Deployments
-from Python and when they are called via HTTP.
-
-See the [Ray Serve Monitoring documentation](serve-monitoring) for more details.
+See the [Ray Serve monitoring documentation](serve-monitoring) for more details.
+:::

--- a/doc/source/serve/handle-guide.md
+++ b/doc/source/serve/handle-guide.md
@@ -46,13 +46,6 @@ The result of `deployment_handle.remote()` can also be passed directly as an arg
 :language: python
 ```
 
-:::{note}
-Different metrics are collected when Deployments are called
-via Python `ServeHandles` and when they are called via HTTP.
-
-See the [Ray Serve monitoring documentation](serve-monitoring) for more details.
-:::
-
 ## Note about ray.ObjectRef
 
 `ray.ObjectRef` corresponds to the result of a request submission. To retrieve the result, you can use the synchronous Ray Core API `ray.get(ref)` or the async API `await ref`. To wait for the result to be available without retrieving it, you can use the synchronous API `ray.wait([ref])` or the async API `await asyncio.wait([ref])`. You can mix and match these calls, but we recommend using async APIs to increase concurrency.

--- a/doc/source/serve/handle-guide.md
+++ b/doc/source/serve/handle-guide.md
@@ -59,3 +59,10 @@ In both types of ServeHandle, you can call a specific method by using the `.meth
 :end-before: __end_handle_method__
 :language: python
 ```
+
+## Note about metrics
+
+Please note that different metrics are collected when calling Deployments
+from Python and when they are called via HTTP.
+
+See the [Ray Serve Monitoring documentation](serve-monitoring) for more details.

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -40,10 +40,12 @@ Often for ML models, you just need the API to accept a `numpy` array. You can us
 Serve provides a library of HTTP adapters to help you avoid boilerplate code. The [later section](serve-http-adapters) dives deeper into how these works.
 ```
 
-Please note that different metrics are collected when calling Deployments
-from Python and when they are called via HTTP.
+:::{note}
+Different metrics are collected when Deployments are called
+via Python `ServeHandles` and when they are called via HTTP.
 
-See the [Ray Serve Monitoring documentation](serve-monitoring) for more details.
+See the [Ray Serve monitoring documentation](serve-monitoring) for more details.
+:::
 
 
 (serve-fastapi-http)=

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -40,6 +40,12 @@ Often for ML models, you just need the API to accept a `numpy` array. You can us
 Serve provides a library of HTTP adapters to help you avoid boilerplate code. The [later section](serve-http-adapters) dives deeper into how these works.
 ```
 
+Please note that different metrics are collected when calling Deployments
+from Python and when they are called via HTTP.
+
+See the [Ray Serve Monitoring documentation](serve-monitoring) for more details.
+
+
 (serve-fastapi-http)=
 ## FastAPI HTTP Deployments
 

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -40,14 +40,6 @@ Often for ML models, you just need the API to accept a `numpy` array. You can us
 Serve provides a library of HTTP adapters to help you avoid boilerplate code. The [later section](serve-http-adapters) dives deeper into how these works.
 ```
 
-:::{note}
-Different metrics are collected when Deployments are called
-via Python `ServeHandles` and when they are called via HTTP.
-
-See the [Ray Serve monitoring documentation](serve-monitoring) for more details.
-:::
-
-
 (serve-fastapi-http)=
 ## FastAPI HTTP Deployments
 

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -243,7 +243,7 @@ The following metrics are exposed by Ray Serve:
      - The number of non-200 HTTP responses returned by each deployment.
 ```
 [*] - only available when using HTTP calls  
-[**] - only available when using Python calls
+[**] - only available when using Python `ServeHandle` calls
 
 To see this in action, first run the following command to start Ray and set up the metrics export port:
 

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -219,29 +219,31 @@ The following metrics are exposed by Ray Serve:
 
    * - Name
      - Description
-   * - ``serve_deployment_request_counter``
+   * - ``serve_deployment_request_counter`` [**]
      - The number of queries that have been processed in this replica.
-   * - ``serve_deployment_error_counter``
+   * - ``serve_deployment_error_counter`` [**]
      - The number of exceptions that have occurred in the deployment.
-   * - ``serve_deployment_replica_starts``
+   * - ``serve_deployment_replica_starts`` [**]
      - The number of times this replica has been restarted due to failure.
-   * - ``serve_deployment_processing_latency_ms``
+   * - ``serve_deployment_processing_latency_ms`` [**]
      - The latency for queries to be processed.
-   * - ``serve_replica_processing_queries``
+   * - ``serve_replica_processing_queries`` [**]
      - The current number of queries being processed.
-   * - ``serve_num_http_requests``
+   * - ``serve_num_http_requests`` [*]
      - The number of HTTP requests processed.
-   * - ``serve_num_http_error_requests``
+   * - ``serve_num_http_error_requests`` [*]
      - The number of non-200 HTTP responses.
-   * - ``serve_num_router_requests``
+   * - ``serve_num_router_requests`` [*]
      - The number of requests processed by the router.
-   * - ``serve_handle_request_counter``
+   * - ``serve_handle_request_counter`` [**]
      - The number of requests processed by this ServeHandle.
-   * - ``serve_deployment_queued_queries``
+   * - ``serve_deployment_queued_queries`` [*]
      - The number of queries for this deployment waiting to be assigned to a replica.
-   * - ``serve_num_deployment_http_error_requests``
+   * - ``serve_num_deployment_http_error_requests`` [*]
      - The number of non-200 HTTP responses returned by each deployment.
 ```
+[*] - only available when using HTTP calls  
+[**] - only available when using Python calls
 
 To see this in action, first run the following command to start Ray and set up the metrics export port:
 

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -211,6 +211,13 @@ You can leverage built-in Ray Serve metrics to get a closer look at your applica
 Ray Serve exposes important system metrics like the number of successful and
 failed requests through the [Ray metrics monitoring infrastructure](ray-metrics). By default, the metrics are exposed in Prometheus format on each node.
 
+:::{note}
+Different metrics are collected when Deployments are called
+via Python `ServeHandle` and when they are called via HTTP.
+
+See the list of metrics below marked for each.
+:::
+
 The following metrics are exposed by Ray Serve:
 
 ```{eval-rst}


### PR DESCRIPTION
## Why are these changes needed?

Different metrics are collected in Ray Serve when the deployments are called from HTTP vs Python. This needs to be mentioned in the documentation and each metric marked accordingly.

## Related issue number

Closes #27837

## Checks

- [ x ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ x ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ x ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ x ] This PR is not tested :(
