### PR TITLE
[AIR] `load_best_model_at_end` validation for HF

### DIFF
--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -433,15 +433,32 @@ def _huggingface_train_loop_per_worker(config):
             "If that happens, specify `hub_token` in `TrainingArguments`."
         )
 
-    if (
-        trainer.args.evaluation_strategy in ("steps", IntervalStrategy.STEPS)
-        or trainer.args.save_strategy in ("steps", IntervalStrategy.STEPS)
-        or trainer.args.logging_strategy in ("steps", IntervalStrategy.STEPS)
-    ):
+    if trainer.args.evaluation_strategy in ("steps", IntervalStrategy.STEPS):
         raise ValueError(
             "'steps' value for `evaluation_strategy`, `logging_strategy` "
-            "or `save_strategy` is not yet supported."
+            "or `save_strategy` is not yet supported.\n"
+            f"Got `evaluation_strategy={trainer.args.evaluation_strategy}`."
         )
+
+    # HF defaults to steps, we need to override
+    if trainer.args.save_strategy in ("steps", IntervalStrategy.STEPS):
+        warnings.warn(
+            "'steps' value for `evaluation_strategy`, `logging_strategy` "
+            "or `save_strategy` is not yet supported.\n"
+            f"Got `save_strategy={trainer.args.save_strategy}`, setting "
+            "to 'epoch' automatically."
+        )
+        trainer.args.save_strategy = IntervalStrategy.EPOCH
+
+    # HF defaults to steps, we need to override
+    if trainer.args.logging_strategy in ("steps", IntervalStrategy.STEPS):
+        warnings.warn(
+            "'steps' value for `evaluation_strategy`, `logging_strategy` "
+            "or `save_strategy` is not yet supported.\n"
+            f"Got `logging_strategy={trainer.args.logging_strategy}`, setting "
+            "to 'epoch' automatically."
+        )
+        trainer.args.logging_strategy = IntervalStrategy.EPOCH
 
     if trainer.args.load_best_model_at_end:
         raise ValueError(

--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -440,6 +440,14 @@ def _huggingface_train_loop_per_worker(config):
             f"Got `evaluation_strategy={trainer.args.evaluation_strategy}`."
         )
 
+    # For the two arguments below, HF defaults to STEPS. Unfortunately,
+    # there doesn't seem to be a way to differentiate between
+    # user-set and default values for those arguments, so we can only
+    # assume that they were set by default and print a warning.
+    # Alternatively, we can force users to set EPOCH themselves,
+    # but that wouldn't make for nice UX if the first thing they see
+    # with their code is an exception.
+
     # HF defaults to steps, we need to override
     if trainer.args.save_strategy in ("steps", IntervalStrategy.STEPS):
         warnings.warn(

--- a/python/ray/train/huggingface/huggingface_trainer.py
+++ b/python/ray/train/huggingface/huggingface_trainer.py
@@ -11,6 +11,7 @@ import transformers
 import transformers.modeling_utils
 import transformers.trainer
 import transformers.training_args
+from transformers.trainer_utils import IntervalStrategy
 from torch.utils.data import Dataset as TorchDataset
 
 from ray.air import session
@@ -433,13 +434,25 @@ def _huggingface_train_loop_per_worker(config):
         )
 
     if (
-        trainer.args.evaluation_strategy == "steps"
-        or trainer.args.save_strategy == "steps"
-        or trainer.args.logging_strategy == "steps"
+        trainer.args.evaluation_strategy in ("steps", IntervalStrategy.STEPS)
+        or trainer.args.save_strategy in ("steps", IntervalStrategy.STEPS)
+        or trainer.args.logging_strategy in ("steps", IntervalStrategy.STEPS)
     ):
         raise ValueError(
             "'steps' value for `evaluation_strategy`, `logging_strategy` "
             "or `save_strategy` is not yet supported."
+        )
+
+    if trainer.args.load_best_model_at_end:
+        raise ValueError(
+            "As Ray AIR replaces Hugging Face checkpointing, "
+            "`load_best_model_at_end` must be set to False.\n"
+            "You can obtain the AIR Checkpoint with "
+            "`Result.checkpoint` returned by the `fit()` method "
+            "of this Trainer, and the model itself by calling "
+            "`Checkpoint.get_model()`.\n"
+            "You can configure the checkpointing by setting "
+            "`run_config.checkpoint_config`."
         )
 
     trainer = wrap_transformers_trainer(trainer)

--- a/python/ray/train/tests/test_huggingface_trainer.py
+++ b/python/ray/train/tests/test_huggingface_trainer.py
@@ -166,20 +166,6 @@ def test_validation(ray_start_4_cpus):
     with pytest.raises(RayTaskError):
         trainer.fit().error
 
-    # save_strategy set to "steps" should raise an exception
-    trainer = HuggingFaceTrainer(
-        trainer_init_config={"epochs": 1, "save_strategy": "steps"}, **trainer_conf
-    )
-    with pytest.raises(RayTaskError):
-        trainer.fit().error
-
-    # logging_strategy set to "steps" should raise an exception
-    trainer = HuggingFaceTrainer(
-        trainer_init_config={"epochs": 1, "logging_strategy": "steps"}, **trainer_conf
-    )
-    with pytest.raises(RayTaskError):
-        trainer.fit().error
-
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds validation for `TrainingArguments.load_best_model_at_end` (will throw an error down the line if set to True), fixes validation for `*_steps`, adds test.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://discuss.ray.io/t/air-and-huggingface-trainers-checkpoint-paths-are-inconsistent/7182/

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
