### PR TITLE
[runtime env] Specify virtualenv >= 20.0.21 in requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,7 +24,7 @@ pydantic >= 1.8
 pyyaml
 requests
 smart_open
-virtualenv
+virtualenv >= 20.0.21
 
 ## setup.py extras
 dm_tree

--- a/python/setup.py
+++ b/python/setup.py
@@ -305,7 +305,7 @@ if setup_spec.type == SetupType.RAY:
         # Light weight requirement, can be replaced with "typing" once
         # we deprecate Python 3.7 (this will take a while).
         "typing_extensions; python_version < '3.8'",
-        "virtualenv",  # For pip runtime env.
+        "virtualenv >= 20.0.21",  # For pip runtime env.
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Older versions of `virtualenv` are missing the `app-data` CLI argument, which we use in Ray.  This PR pins `virtualenv` to the necessary version.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
