### PR TITLE
[cherry-pick][workflow] Documentation of http events (#27166)

### DIFF
--- a/doc/source/workflows/doc_code/wait_for_event_http.py
+++ b/doc/source/workflows/doc_code/wait_for_event_http.py
@@ -1,0 +1,49 @@
+import ray
+from ray import workflow, serve
+from ray.workflow.http_event_provider import HTTPListener
+
+from time import sleep
+import requests
+
+ray.init(storage="/tmp/ray/workflow/data")
+# Start a Ray Serve instance. This will automatically start
+# or connect to an existing Ray cluster.
+serve.start(detached=True)
+
+# fmt: off
+# __wait_for_event_begin__
+# File name: wait_for_event_http.py
+# Create a task waiting for an http event with a JSON message.
+# The JSON message is expected to have an event_key field
+# and an event_payload field.
+
+event_task = workflow.wait_for_event(HTTPListener, event_key="my_event_key")
+
+obj_ref = workflow.run_async(event_task, workflow_id="workflow_receive_event_by_http")
+
+# __wait_for_event_end__
+
+# wait for the backend to be ready
+sleep(10)
+
+# fmt: off
+# __submit_event_begin__
+# File name: wait_for_event_http.py
+res = requests.post(
+        "http://127.0.0.1:8000/event/send_event/"
+        + "workflow_receive_event_by_http",
+        json={"event_key": "my_event_key", "event_payload": "my_event_message"},
+    )
+if res.status_code == 200:
+    print("event processed successfully")
+elif res.status_code == 500:
+    print("request sent but workflow event processing failed")
+elif res.status_code == 404:
+    print("request sent but either workflow_id or event_key is not found")
+
+# __submit_event_end__
+
+assert res.status_code == 200
+key, message = ray.get(obj_ref)
+assert key == "my_event_key"
+assert message == "my_event_message"

--- a/doc/source/workflows/events.rst
+++ b/doc/source/workflows/events.rst
@@ -1,10 +1,11 @@
+
 Events
 ======
 
 Introduction
 ------------
 
-In order to allow an event to trigger a workflow, Ray Workflow support pluggable event systems. Using the event framework provides a few properties.
+In order to allow an event to trigger a workflow, Ray Workflow supports pluggable event systems. Using the event framework provides a few properties.
 
 1. Waits for events efficiently (without requiring a running workflow task while waiting).
 2. Supports exactly-once event delivery semantics while providing fault tolerance.
@@ -15,7 +16,7 @@ Like other workflow tasks, events support fault tolerance via checkpointing. Whe
 Using events
 ------------
 
-Workflow events are a special type of workflow task. They "finish" when the event occurs. `workflow.wait_for_event(EventListenerType` can be used to create an event task.
+Workflow events are a special type of workflow task. They "finish" when the event occurs. ``workflow.wait_for_event(EventListenerType)`` can be used to create an event task.
 
 
 .. code-block:: python
@@ -37,6 +38,47 @@ Workflow events are a special type of workflow task. They "finish" when the even
     # Gather will run after 60 seconds, when both event1 and event2 are done.
     workflow.run(gather.bind(event1_task, event2_task))
 
+
+HTTP events
+-----------
+
+Workflow supports sending external events via HTTP.
+An HTTP event listener in the workflow is used to connect to an HTTP endpoint.
+Below is an end-to-end example of using HTTP events in a workflow.
+
+
+``HTTPListener`` is used to listen for HTTP events in a workflow. Each ``HTTPListener`` subscribes to a unique `workflow_id` and `event_key` pair. To send an event to the listener, an HTTP request from
+an external client should specify ``workflow_id`` as part of the request URL and the ``event_key`` and ``event_payload`` keys in the JSON request body (see below).
+
+.. literalinclude:: ./doc_code/wait_for_event_http.py
+   :language: python
+   :start-after: __wait_for_event_begin__
+   :end-before: __wait_for_event_end__
+
+An HTTP endpoint at ``http://hostname:port/event/send_event/<workflow_id>`` can be used to send an event. Locally,
+the endpoint may be reached at ``http://127.0.0.1:8000/event/send_event/<workflow_id>``.
+Note that the HTTP request must include the same ``workflow_id``.
+Each request should also include a JSON body with two fields: ``event_key`` and ``event_payload``, as shown in the example
+below. The ``event_key`` field should match the argument passed to ``workflow.wait_for_event()`` on the listener side. In the workflow, once an HTTP event is received, the event task will return the value of the ``event_payload`` field.
+
+In summary, to trigger an HTTP event in the workflow, an external client should have:
+
+* the HTTP endpoint address (e.g. `http://127.0.0.1:8000/event/send_event`)
+* the ``workflow_id`` (e.g. "workflow_receive_event_by_http")
+* a valid JSON formatted message with the fields ``event_key`` and ``event_payload``, where ``event_key`` matches the one used in the workflow
+
+The HTTP request will receive a reply once the event has been received by the workflow. The returned status code can be:
+
+1. 200: event was successfully processed.
+2. 500: event processing failed.
+3. 404: either ``workflow_id`` or ``event_key`` cannot be found, likely due to event is received before the targeted workflow task is ready.
+
+The code snippet below shows an example of the external client sending an HTTP request.
+
+.. literalinclude:: ./doc_code/wait_for_event_http.py
+   :language: python
+   :start-after: __submit_event_begin__
+   :end-before: __submit_event_end__
 
 Custom event listeners
 ----------------------


### PR DESCRIPTION
Documentation updates for the newly introduced HTTPEventProvider and HTTPListener in Ray 2.0.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
