### PR TITLE
[Serve]Fix classloader bug in Java Deployment

### DIFF
--- a/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
+++ b/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
@@ -1,6 +1,15 @@
 package io.ray.serve.replica;
 
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Preconditions;
+
 import io.ray.api.BaseActorHandle;
 import io.ray.api.Ray;
 import io.ray.runtime.serializer.MessagePackSerializer;
@@ -16,12 +25,6 @@ import io.ray.serve.metrics.RayServeMetrics;
 import io.ray.serve.util.LogUtil;
 import io.ray.serve.util.ReflectUtil;
 import io.ray.serve.util.ServeProtoUtil;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Replica class wrapping the provided class. Note that Java function is not supported now. */
 public class RayServeWrappedReplica implements RayServeReplica {
@@ -89,7 +92,12 @@ public class RayServeWrappedReplica implements RayServeReplica {
           deploymentWrapper.getConfig());
 
       // Instantiate the object defined by deploymentDef.
-      Class deploymentClass = Class.forName(deploymentWrapper.getDeploymentDef());
+      Class deploymentClass =
+          Class.forName(
+              deploymentWrapper.getDeploymentDef(),
+              true,
+              Optional.ofNullable(Thread.currentThread().getContextClassLoader())
+                  .orElse(getClass().getClassLoader()));
       Object callable =
           ReflectUtil.getConstructor(deploymentClass, deploymentWrapper.getInitArgs())
               .newInstance(deploymentWrapper.getInitArgs());

--- a/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
+++ b/java/serve/src/main/java/io/ray/serve/replica/RayServeWrappedReplica.java
@@ -1,15 +1,6 @@
 package io.ray.serve.replica;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Preconditions;
-
 import io.ray.api.BaseActorHandle;
 import io.ray.api.Ray;
 import io.ray.runtime.serializer.MessagePackSerializer;
@@ -25,6 +16,12 @@ import io.ray.serve.metrics.RayServeMetrics;
 import io.ray.serve.util.LogUtil;
 import io.ray.serve.util.ReflectUtil;
 import io.ray.serve.util.ServeProtoUtil;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Replica class wrapping the provided class. Note that Java function is not supported now. */
 public class RayServeWrappedReplica implements RayServeReplica {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We have encountered `java.lang.ClassNotFoundException` when deploying Java Ray Serve deployments. The property `ray.job.code-search-path` which specifies the search path of user's classes is not working. The reason is that `ray.job.code-search-path` is loaded in an independent classloader in Ray context, but Serve Replica initialized user class with `AppClassLoader`. We need to change the classloader used to construct user classes to the one in Ray context.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
