### PR TITLE
[AIR][Docs] Remove the excessive printing from Torch examples

### DIFF
--- a/doc/source/ray-air/examples/torch_image_example.ipynb
+++ b/doc/source/ray-air/examples/torch_image_example.ipynb
@@ -311,8 +311,6 @@
     "        for i, data in enumerate(train_dataset_shard):\n",
     "            # get the inputs and labels\n",
     "            inputs, labels = data[\"image\"], data[\"label\"]\n",
-    "            print(inputs)\n",
-    "            print(labels)\n",
     "\n",
     "            # zero the parameter gradients\n",
     "            optimizer.zero_grad()\n",


### PR DESCRIPTION
Signed-off-by: simon-mo <simon.mo@hey.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Anyone running this example will get excessive printing of the tensors every training step, which will cause their browser tab to freeze and jupyter warning excessive output. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
