### PR TITLE
[Datasets] Customized serializer for Arrow JSON ParseOptions in read_json

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -1,5 +1,6 @@
 import ray
 from ray.data._internal.arrow_serialization import (
+    _register_arrow_json_parseoptions_serializer,
     _register_arrow_json_readoptions_serializer,
 )
 from ray.data._internal.compute import ActorPoolStrategy
@@ -35,9 +36,11 @@ from ray.data.read_api import (  # noqa: F401
     read_text,
 )
 
-# Register custom Arrow JSON ReadOptions serializer after worker has initialized.
+# Register custom Arrow JSON ReadOptions and ParseOptions serializer after worker has
+# initialized.
 if ray.is_initialized():
     _register_arrow_json_readoptions_serializer()
+    _register_arrow_json_parseoptions_serializer()
 else:
     pass
 #    ray._internal.worker._post_init_hooks.append(_register_arrow_json_readoptions_serializer)

--- a/python/ray/data/_internal/arrow_serialization.py
+++ b/python/ray/data/_internal/arrow_serialization.py
@@ -1,12 +1,16 @@
 import os
 
+RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION = (
+    "RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION"
+)
+
 
 def _register_arrow_json_readoptions_serializer():
     import ray
 
     if (
         os.environ.get(
-            "RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION",
+            RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION,
             "0",
         )
         == "1"
@@ -26,4 +30,36 @@ def _register_arrow_json_readoptions_serializer():
         pajson.ReadOptions,
         serializer=lambda opts: (opts.use_threads, opts.block_size),
         deserializer=lambda args: pajson.ReadOptions(*args),
+    )
+
+
+def _register_arrow_json_parseoptions_serializer():
+    import ray
+
+    if (
+        os.environ.get(
+            RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION,
+            "0",
+        )
+        == "1"
+    ):
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.info("Disabling custom Arrow JSON ParseOptions serialization.")
+        return
+
+    try:
+        import pyarrow.json as pajson
+    except ModuleNotFoundError:
+        return
+
+    ray.util.register_serializer(
+        pajson.ParseOptions,
+        serializer=lambda opts: (
+            opts.explicit_schema,
+            opts.newlines_in_values,
+            opts.unexpected_field_behavior,
+        ),
+        deserializer=lambda args: pajson.ParseOptions(*args),
     )

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -17,6 +17,7 @@ from typing import (
 
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data._internal.arrow_serialization import (
+    _register_arrow_json_parseoptions_serializer,
     _register_arrow_json_readoptions_serializer,
 )
 from ray.data._internal.block_list import BlockMetadata
@@ -379,11 +380,14 @@ class _FileBasedDatasourceReader(Reader):
         read_stream = self._delegate._read_stream
         filesystem = _wrap_s3_serialization_workaround(self._filesystem)
         read_options = reader_args.get("read_options")
-        if read_options is not None:
+        parse_options = reader_args.get("parse_options")
+        if read_options is not None or parse_options is not None:
             import pyarrow.json as pajson
 
             if isinstance(read_options, pajson.ReadOptions):
                 _register_arrow_json_readoptions_serializer()
+            if isinstance(parse_options, pajson.ParseOptions):
+                _register_arrow_json_parseoptions_serializer()
 
         if open_stream_args is None:
             open_stream_args = {}
@@ -695,13 +699,16 @@ def _wrap_and_register_arrow_serialization_workaround(kwargs: dict) -> dict:
     # TODO(Clark): Remove this serialization workaround once Datasets only supports
     # pyarrow >= 8.0.0.
     read_options = kwargs.get("read_options")
-    if read_options is not None:
+    parse_options = kwargs.get("parse_options")
+    if read_options is not None or parse_options is not None:
         import pyarrow.json as pajson
 
+        # Register a custom serializer instead of wrapping the options, since a
+        # custom reducer will suffice.
         if isinstance(read_options, pajson.ReadOptions):
-            # Register a custom serializer instead of wrapping the options, since a
-            # custom reducer will suffice.
             _register_arrow_json_readoptions_serializer()
+        if isinstance(parse_options, pajson.ParseOptions):
+            _register_arrow_json_parseoptions_serializer()
 
     return kwargs
 


### PR DESCRIPTION
Signed-off-by: Cheng Su <scnju13@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to add customized serializer of [Arrow JSON ParseOptions](https://arrow.apache.org/docs/python/generated/pyarrow.json.ParseOptions.html) for `read_json`. We found user wanted to read JSON file with `ParseOptions`, but it's currently not working due to pickle issue ([detail of post](https://discuss.ray.io/t/can-i-define-schema-when-calling-ray-data-read-json/7157)). So here we add a customized serializer for `ParseOptions` as a workaround for now, similar to https://github.com/ray-project/ray/pull/25821.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
