### PR TITLE
[Docs][GCP] Configuring ServiceAccounts for worker 

### DIFF
--- a/doc/source/cluster/vms/user-guides/launching-clusters/aws.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/aws.md
@@ -103,10 +103,11 @@ In various scenarios, worker nodes may need write access to an S3 bucket, e.g., 
 If you see errors like “Unable to locate credentials”, make sure that the correct `IamInstanceProfile` is configured for worker nodes in your cluster config file. This may look like:
 
 ```yaml
-worker_nodes:
-    InstanceType: m5.xlarge
-    ImageId: latest_dlami
-    IamInstanceProfile:
+available_node_types:
+  ray.worker.default:
+    node_config:
+      ...
+      IamInstanceProfile:
         Arn: arn:aws:iam::YOUR_AWS_ACCOUNT:YOUR_INSTANCE_PROFILE
 ```
 

--- a/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
@@ -69,7 +69,7 @@ available_node_types:
     node_config:
       ...
     serviceAccounts:
-    - email: ray-autoscaler-sa-v1@anyscale-dev.iam.gserviceaccount.com
+    - email: ray-autoscaler-sa-v1@<YOUR_PROJECT_ID>.iam.gserviceaccount.com
         scopes:
         - https://www.googleapis.com/auth/cloud-platform
 ```

--- a/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/gcp.md
@@ -56,3 +56,20 @@ ray down example-full.yaml
 
 Congrats, you have started a Ray cluster on GCP!
 
+## GCP Configurations
+
+
+### Running workers with Service Accounts
+
+By default, only the head node runs with a Service Account (`ray-autoscaler-sa-v1@<project-id>.iam.gserviceaccount.com`). To enable workers to run with this same Service Account (to access Google Cloud Storage, or GCR), add the following configuration to the worker_node configuration:
+
+```yaml
+available_node_types:
+  ray.worker.default:
+    node_config:
+      ...
+    serviceAccounts:
+    - email: ray-autoscaler-sa-v1@anyscale-dev.iam.gserviceaccount.com
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
+```


### PR DESCRIPTION
## Why are these changes needed?

Enables better usage with GCP.

The default behavior is that the head runs with the ray-autoscaler-sa-v1 service Account, but workers do not. Workers can run with this service account by copying & uncommenting L114->L117 from example-full

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
