### PR TITLE
[docs][touch-up] Add ephemeral storage to Ray-on-K8s example.

### DIFF
--- a/doc/source/cluster/kubernetes/configs/xgboost-benchmark-autoscaler.yaml
+++ b/doc/source/cluster/kubernetes/configs/xgboost-benchmark-autoscaler.yaml
@@ -37,9 +37,13 @@ spec:
             limits:
               cpu: "14"
               memory: "54Gi"
+              # The node that hosts this pod should have at least 1000Gi disk space,
+              # for data set storage.
+              ephemeral-storage: "700Gi"
             requests:
               cpu: "14"
               memory: "54Gi"
+              ephemeral-storage: "700Gi"
           lifecycle:
             preStop:
               exec:
@@ -64,12 +68,15 @@ spec:
           # resource accounting. K8s requests are not used by Ray.
           resources:
             limits:
-              # Slightly less than 16 to accommodate placement on 16 vCPU virtual machine.
               cpu: "14"
               memory: "54Gi"
+              # The node that hosts this pod should have at least 1000Gi disk space,
+              # for data set storage.
+              ephemeral-storage: "700Gi"
             requests:
               cpu: "14"
               memory: "54Gi"
+              ephemeral-storage: "700Gi"
           lifecycle:
             preStop:
               exec:

--- a/doc/source/cluster/kubernetes/configs/xgboost-benchmark.yaml
+++ b/doc/source/cluster/kubernetes/configs/xgboost-benchmark.yaml
@@ -68,9 +68,13 @@ spec:
             limits:
               cpu: "14"
               memory: "54Gi"
+              # The node that hosts this pod should have at least 1000Gi disk space,
+              # for data set storage.
+              ephemeral-storage: "700Gi"
             requests:
               cpu: "14"
               memory: "54Gi"
+              ephemeral-storage: "700Gi"
           lifecycle:
             preStop:
               exec:
@@ -101,9 +105,13 @@ spec:
               # Slightly less than 16 to accomodate placement on 16 vCPU virtual machine.
               cpu: "14"
               memory: "54Gi"
+              # The node that hosts this pod should have at least 1000Gi disk space,
+              # for data set storage.
+              ephemeral-storage: "700Gi"
             requests:
               cpu: "14"
               memory: "54Gi"
+              ephemeral-storage: "700Gi"
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds ephemeral storage requests and limits to the KubeRay XGBoost example.

This example requires Ray pods to have access to > 100 Gi disk space to store the training set.
The docs currently mention that you should run one pod per k8s node and that the k8s nodes should configured with enough disk.
However, it would be better to enforce the storage requirement at the pod level by specifying ephemeral storage requests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
