### PR TITLE
[2.0.0 CHERRY PICK][docs][ml][kuberay] Add a --disable-check flag to the XGBoost benchmark

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -122,17 +122,18 @@ def main(args):
     with open(test_output_json, "wt") as f:
         json.dump(result, f)
 
-    if training_time > _TRAINING_TIME_THRESHOLD:
-        raise RuntimeError(
-            f"Training on XGBoost is taking {training_time} seconds, "
-            f"which is longer than expected ({_TRAINING_TIME_THRESHOLD} seconds)."
-        )
+    if not args.disable_check:
+        if training_time > _TRAINING_TIME_THRESHOLD:
+            raise RuntimeError(
+                f"Training on XGBoost is taking {training_time} seconds, "
+                f"which is longer than expected ({_TRAINING_TIME_THRESHOLD} seconds)."
+            )
 
-    if prediction_time > _PREDICTION_TIME_THRESHOLD:
-        raise RuntimeError(
-            f"Batch prediction on XGBoost is taking {prediction_time} seconds, "
-            f"which is longer than expected ({_PREDICTION_TIME_THRESHOLD} seconds)."
-        )
+        if prediction_time > _PREDICTION_TIME_THRESHOLD:
+            raise RuntimeError(
+                f"Batch prediction on XGBoost is taking {prediction_time} seconds, "
+                f"which is longer than expected ({_PREDICTION_TIME_THRESHOLD} seconds)."
+            )
 
 
 if __name__ == "__main__":
@@ -140,5 +141,13 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--size", type=str, choices=["10G", "100G"], default="100G")
+    # Add a flag for disabling the timeout error.
+    # Use case: running the benchmark as a documented example, in infra settings
+    # different from the formal benchmark's EC2 setup.
+    parser.add_argument(
+        "--disable-check",
+        action="store_true",
+        help="disable runtime error on benchmark timeout",
+    )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
This is a cherry-pick of https://github.com/ray-project/ray/pull/27277 into the Ray 2.0.0 release branch.

(Apologies that I didn't open the pick PR earlier.)

The change is pretty trivial -- the main reason to pick this in is so that the clusters docs XGBoost examples can use the `--disable-check` flag without [referring to code in the master branch](https://github.com/ray-project/ray/blob/87ce8480ffa9d4cd3f1331cd1a10574f806d77c7/doc/source/cluster/doc_code/xgboost_submit.py#L7-L9). Instead we can use the Ray 2.0.0 release branch. Will fix the example to refer to the release branch in a follow-up.