### PR TITLE
[Test] Mark dataset_shuffle_push_based_random_shuffle_100tb as stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3537,7 +3537,7 @@
 
   run:
     timeout: 3600
-    script: python stress_tests/test_state_api_scale.py 
+    script: python stress_tests/test_state_api_scale.py
     type: sdk_command
     file_manager: sdk
 
@@ -3568,8 +3568,8 @@
 
   run:
     timeout: 1000
-    script: python stress_tests/test_state_api_with_other_tests.py 
-      nightly_tests/shuffle/shuffle_test.py --test-args="--num-partitions=100 --partition-size=200e6" 
+    script: python stress_tests/test_state_api_with_other_tests.py
+      nightly_tests/shuffle/shuffle_test.py --test-args="--num-partitions=100 --partition-size=200e6"
 
     type: sdk_command
     file_manager: sdk
@@ -4398,8 +4398,6 @@
   legacy:
     test_name: dataset_shuffle_push_based_random_shuffle_100tb
     test_suite: dataset_test
-
-  stable: false
 
   frequency: nightly
   team: core


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This has been passing consistently for the past few weeks.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
