### PR TITLE
Cap the number of stats kept in StatsActor and purge in FIFO order if the limit exceeded

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -9,7 +9,7 @@ import ray
 from ray.data._internal.block_list import BlockList
 from ray.data.block import BlockMetadata
 from ray.data.context import DatasetContext
-from ray.util.client import ray as client_ray
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 STATS_ACTOR_NAME = "datasets_stats_actor"
 STATS_ACTOR_NAMESPACE = "_dataset_stats_actor"
@@ -87,7 +87,7 @@ class _DatasetStatsBuilder:
 class _StatsActor:
     """Actor holding stats for blocks created by LazyBlockList.
 
-    This actor is shared across all datasets created by the same process.
+    This actor is shared across all datasets created in the same cluster.
     The stats data is small so we don't worry about clean up for now.
 
     TODO(ekl) we should consider refactoring LazyBlockList so stats can be
@@ -115,46 +115,23 @@ class _StatsActor:
         )
 
 
-# Actor handle, job id, client id the actor was created for.
-_stats_actor = [None, None, None]
-
-
 def _get_or_create_stats_actor():
-    # Whether the context changed:
-    # - On client, it means a new connection to server, reflecting in client id
-    # - On server, it means a new driver, reflecting in job id
-    context_changed = False
-    if _stats_actor[0]:
-        if client_ray.is_connected():
-            if _stats_actor[2] != client_ray.get_context().client_worker._client_id:
-                context_changed = True
-        elif _stats_actor[1] != ray.get_runtime_context().job_id.hex():
-            context_changed = True
-
-    # Need to re-create it if Ray restarts (mostly for unit tests).
-    if (
-        not _stats_actor[0]
-        or not ray.is_initialized()
-        or _stats_actor[1] != ray.get_runtime_context().job_id.hex()
-        or context_changed
-    ):
-        ctx = DatasetContext.get_current()
-        _stats_actor[0] = _StatsActor.options(
-            name="datasets_stats_actor",
-            get_if_exists=True,
-            scheduling_strategy=ctx.scheduling_strategy,
-        ).remote()
-        _stats_actor[1] = ray.get_runtime_context().job_id.hex()
-        if client_ray.is_connected():
-            _stats_actor[2] = client_ray.get_context().client_worker._client_id
-
-        # Clear the actor handle after Ray reinits since it's no longer valid.
-        def clear_actor():
-            _stats_actor = [None, None, None]
-
-        ray.worker._post_init_hooks.append(clear_actor)
-
-    return _stats_actor[0]
+    ctx = DatasetContext.get_current()
+    scheduling_strategy = ctx.scheduling_strategy
+    if not ray.util.client.ray.is_connected():
+        # Pin the stats actor to the local node
+        # so it fate-shares with the driver.
+        scheduling_strategy = NodeAffinitySchedulingStrategy(
+            ray.get_runtime_context().get_node_id(),
+            soft=False,
+        )
+    return _StatsActor.options(
+        name=STATS_ACTOR_NAME,
+        namespace=STATS_ACTOR_NAMESPACE,
+        get_if_exists=True,
+        lifetime="detached",
+        scheduling_strategy=scheduling_strategy,
+    ).remote()
 
 
 class DatasetStats:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -95,7 +95,7 @@ class _StatsActor:
     TODO(ekl) we should consider refactoring LazyBlockList so stats can be
     extracted without using an out-of-band actor."""
 
-    def __init__(self, max_stats=10 * 1000):
+    def __init__(self, max_stats=1000):
         # Mapping from uuid -> dataset-specific stats.
         self.metadata = collections.defaultdict(dict)
         self.last_time = {}

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -10,6 +10,7 @@ from ray.data._internal.block_list import BlockList
 from ray.data.block import BlockMetadata
 from ray.data.context import DatasetContext
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from ray.util.client import ray as client_ray
 
 STATS_ACTOR_NAME = "datasets_stats_actor"
 STATS_ACTOR_NAMESPACE = "_dataset_stats_actor"
@@ -87,7 +88,7 @@ class _DatasetStatsBuilder:
 class _StatsActor:
     """Actor holding stats for blocks created by LazyBlockList.
 
-    This actor is shared across all datasets created in the same cluster.
+    This actor is shared across all datasets created by the same process.
     The stats data is small so we don't worry about clean up for now.
 
     TODO(ekl) we should consider refactoring LazyBlockList so stats can be
@@ -114,24 +115,45 @@ class _StatsActor:
             self.last_time[stats_uuid] - self.start_time[stats_uuid],
         )
 
+# Actor handle, job id, client id the actor was created for.
+_stats_actor = [None, None, None]
 
 def _get_or_create_stats_actor():
-    ctx = DatasetContext.get_current()
-    scheduling_strategy = ctx.scheduling_strategy
-    if not ray.util.client.ray.is_connected():
-        # Pin the stats actor to the local node
-        # so it fate-shares with the driver.
-        scheduling_strategy = NodeAffinitySchedulingStrategy(
-            ray.get_runtime_context().get_node_id(),
-            soft=False,
-        )
-    return _StatsActor.options(
-        name=STATS_ACTOR_NAME,
-        namespace=STATS_ACTOR_NAMESPACE,
-        get_if_exists=True,
-        lifetime="detached",
-        scheduling_strategy=scheduling_strategy,
-    ).remote()
+    # Whether the context changed:
+    # - On client, it means a new connection to server, reflecting in client id
+    # - On server, it means a new driver, reflecting in job id
+    context_changed = False
+    if _stats_actor[0]:
+        if client_ray.is_connected():
+            if _stats_actor[2] != client_ray.get_context().client_worker._client_id:
+                context_changed = True
+        elif _stats_actor[1] != ray.get_runtime_context().job_id.hex():
+            context_changed = True
+
+    # Need to re-create it if Ray restarts (mostly for unit tests).
+    if (
+        not _stats_actor[0]
+        or not ray.is_initialized()
+        or _stats_actor[1] != ray.get_runtime_context().job_id.hex()
+        or context_changed
+    ):
+        ctx = DatasetContext.get_current()
+        scheduling_strategy = ctx.scheduling_strategy
+        _stats_actor[0] = _StatsActor.options(
+            name="datasets_stats_actor",
+            get_if_exists=True,
+            scheduling_strategy=ctx.scheduling_strategy,
+        ).remote()
+        _stats_actor[1] = ray.get_runtime_context().job_id.hex()
+        if client_ray.is_connected():
+            _stats_actor[2] = client_ray.get_context().client_worker._client_id
+
+        # Clear the actor handle after Ray reinits since it's no longer valid.
+        def clear_actor():
+            _stats_actor = [None, None, None]
+        ray.worker._post_init_hooks.append(clear_actor)
+
+    return _stats_actor[0]
 
 
 class DatasetStats:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -88,23 +88,40 @@ class _StatsActor:
     """Actor holding stats for blocks created by LazyBlockList.
 
     This actor is shared across all datasets created in the same cluster.
-    The stats data is small so we don't worry about clean up for now.
+    In order to cap memory usage, we set a max number of stats to keep
+    in the actor. When this limit is exceeded, the stats will be garbage
+    collected in FIFO order.
 
     TODO(ekl) we should consider refactoring LazyBlockList so stats can be
     extracted without using an out-of-band actor."""
 
-    def __init__(self):
+    def __init__(self, max_stats=100 * 1000):
         # Mapping from uuid -> dataset-specific stats.
         self.metadata = collections.defaultdict(dict)
         self.last_time = {}
         self.start_time = {}
+        self.max_stats = max_stats
+        self.fifo_queue = []
 
     def record_start(self, stats_uuid):
         self.start_time[stats_uuid] = time.perf_counter()
+        self.fifo_queue.append(stats_uuid)
+        # Purge the oldest stats if the limit is exceeded.
+        if len(self.fifo_queue) > self.max_stats:
+            uuid = self.fifo_queue.pop(0)
+            if uuid in self.start_time:
+                del self.start_time[uuid]
+            if uuid in self.last_time:
+                del self.last_time[uuid]
+            if uuid in self.metadata:
+                del self.metadata[uuid]
 
     def record_task(self, stats_uuid, i, metadata):
-        self.metadata[stats_uuid][i] = metadata
-        self.last_time[stats_uuid] = time.perf_counter()
+        # Null out the schema to keep the stats size small.
+        metadata.schema = None
+        if stats_uuid in self.start_time:
+            self.metadata[stats_uuid][i] = metadata
+            self.last_time[stats_uuid] = time.perf_counter()
 
     def get(self, stats_uuid):
         if stats_uuid not in self.metadata:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -9,7 +9,6 @@ import ray
 from ray.data._internal.block_list import BlockList
 from ray.data.block import BlockMetadata
 from ray.data.context import DatasetContext
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from ray.util.client import ray as client_ray
 
 STATS_ACTOR_NAME = "datasets_stats_actor"
@@ -115,8 +114,10 @@ class _StatsActor:
             self.last_time[stats_uuid] - self.start_time[stats_uuid],
         )
 
+
 # Actor handle, job id, client id the actor was created for.
 _stats_actor = [None, None, None]
+
 
 def _get_or_create_stats_actor():
     # Whether the context changed:
@@ -138,7 +139,6 @@ def _get_or_create_stats_actor():
         or context_changed
     ):
         ctx = DatasetContext.get_current()
-        scheduling_strategy = ctx.scheduling_strategy
         _stats_actor[0] = _StatsActor.options(
             name="datasets_stats_actor",
             get_if_exists=True,
@@ -151,6 +151,7 @@ def _get_or_create_stats_actor():
         # Clear the actor handle after Ray reinits since it's no longer valid.
         def clear_actor():
             _stats_actor = [None, None, None]
+
         ray.worker._post_init_hooks.append(clear_actor)
 
     return _stats_actor[0]

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -95,7 +95,7 @@ class _StatsActor:
     TODO(ekl) we should consider refactoring LazyBlockList so stats can be
     extracted without using an out-of-band actor."""
 
-    def __init__(self, max_stats=100 * 1000):
+    def __init__(self, max_stats=10 * 1000):
         # Mapping from uuid -> dataset-specific stats.
         self.metadata = collections.defaultdict(dict)
         self.last_time = {}
@@ -116,11 +116,11 @@ class _StatsActor:
             if uuid in self.metadata:
                 del self.metadata[uuid]
 
-    def record_task(self, stats_uuid, i, metadata):
+    def record_task(self, stats_uuid, task_idx, metadata):
         # Null out the schema to keep the stats size small.
         metadata.schema = None
         if stats_uuid in self.start_time:
-            self.metadata[stats_uuid][i] = metadata
+            self.metadata[stats_uuid][task_idx] = metadata
             self.last_time[stats_uuid] = time.perf_counter()
 
     def get(self, stats_uuid):
@@ -130,6 +130,9 @@ class _StatsActor:
             self.metadata[stats_uuid],
             self.last_time[stats_uuid] - self.start_time[stats_uuid],
         )
+
+    def _get_stats_dict_size(self):
+        return len(self.start_time), len(self.last_time), len(self.metadata)
 
 
 def _get_or_create_stats_actor():

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -12,6 +12,7 @@ import pytest
 
 import ray
 from ray._private.test_utils import wait_for_condition
+from ray.data._internal.stats import _StatsActor
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.lazy_block_list import LazyBlockList
@@ -4686,6 +4687,30 @@ def test_parquet_read_spread(ray_start_cluster, tmp_path):
     for block in blocks:
         locations.extend(location_data[block]["node_ids"])
     assert set(locations) == {node1_id, node2_id}
+
+
+def test_stats_actor_cap_num_stats(ray_start_cluster):
+    actor = _StatsActor.remote(3)
+    metadatas = []
+    task_idx = 0
+    for uuid in range(3):
+        metadatas.append(
+            BlockMetadata(
+                num_rows=uuid,
+                size_bytes=None,
+                schema=None,
+                input_files=None,
+                exec_stats=None,
+            )
+        )
+        actor.record_start.remote(uuid)
+        actor.record_task.remote(uuid, task_idx, metadatas[-1])
+    for uuid in range(3):
+        assert ray.get(actor.get.remote(uuid))[0][task_idx] == metadatas[uuid]
+    # Add the fourth stats to exceed the limit.
+    actor.record_start.remote(3)
+    # The first stats (with uuid=0) should have been purged.
+    assert ray.get(actor.get.remote(0))[0] == {}
 
 
 @ray.remote

--- a/python/ray/data/tests/test_dataset.py
+++ b/python/ray/data/tests/test_dataset.py
@@ -4703,14 +4703,27 @@ def test_stats_actor_cap_num_stats(ray_start_cluster):
                 exec_stats=None,
             )
         )
+        num_stats = uuid + 1
         actor.record_start.remote(uuid)
+        assert ray.get(actor._get_stats_dict_size.remote()) == (
+            num_stats,
+            num_stats - 1,
+            num_stats - 1,
+        )
         actor.record_task.remote(uuid, task_idx, metadatas[-1])
+        assert ray.get(actor._get_stats_dict_size.remote()) == (
+            num_stats,
+            num_stats,
+            num_stats,
+        )
     for uuid in range(3):
         assert ray.get(actor.get.remote(uuid))[0][task_idx] == metadatas[uuid]
     # Add the fourth stats to exceed the limit.
     actor.record_start.remote(3)
     # The first stats (with uuid=0) should have been purged.
     assert ray.get(actor.get.remote(0))[0] == {}
+    # The start_time has 3 entries because we just added it above with record_start().
+    assert ray.get(actor._get_stats_dict_size.remote()) == (3, 2, 2)
 
 
 @ray.remote


### PR DESCRIPTION
Signed-off-by: jianoaix <iamjianxiao@gmail.com>

## Why are these changes needed?
There is a risk of using too much of memory in StatsActor, because its lifetime is the same as cluster lifetime.
This puts a cap on how many stats to keep, and purge the stats in FIFO order if this cap is exceeded.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
