### PR TITLE
[AIR] Add `TorchCheckpoint.from_state_dict`

### DIFF
--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -306,6 +306,14 @@ py_test(
 )
 
 py_test(
+    name = "test_torch_checkpoint",
+    size = "small",
+    srcs = ["tests/test_torch_checkpoint.py"],
+    tags = ["team:ml", "exclusive", "ray_air"],
+    deps = [":train_lib"]
+)
+
+py_test(
     name = "test_torch_predictor",
     size = "small",
     srcs = ["tests/test_torch_predictor.py"],

--- a/python/ray/train/tests/test_torch_checkpoint.py
+++ b/python/ray/train/tests/test_torch_checkpoint.py
@@ -1,0 +1,11 @@
+import torch
+
+from ray.train.torch import TorchCheckpoint
+
+
+def test_from_state_dict():
+    model = torch.nn.Linear(1, 1)
+    expected_state_dict = model.state_dict()
+    checkpoint = TorchCheckpoint.from_state_dict(expected_state_dict)
+    actual_state_dict = checkpoint.get_model(torch.nn.Linear(1, 1)).state_dict()
+    assert actual_state_dict == expected_state_dict

--- a/python/ray/train/tests/test_torch_checkpoint.py
+++ b/python/ray/train/tests/test_torch_checkpoint.py
@@ -9,3 +9,11 @@ def test_from_state_dict():
     checkpoint = TorchCheckpoint.from_state_dict(expected_state_dict)
     actual_state_dict = checkpoint.get_model(torch.nn.Linear(1, 1)).state_dict()
     assert actual_state_dict == expected_state_dict
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/torch/torch_checkpoint.py
+++ b/python/ray/train/torch/torch_checkpoint.py
@@ -1,5 +1,4 @@
-from collections import Any, Dict
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
 

--- a/python/ray/train/torch/torch_checkpoint.py
+++ b/python/ray/train/torch/torch_checkpoint.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import Any, Dict
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -22,48 +22,11 @@ class TorchCheckpoint(Checkpoint):
     """
 
     @classmethod
-    def from_model(
+    def from_state_dict(
         cls,
-        model: torch.nn.Module,
+        state_dict: Dict[str, Any],
         *,
         preprocessor: Optional["Preprocessor"] = None,
-    ) -> "TorchCheckpoint":
-        """Create a :class:`~ray.air.checkpoint.Checkpoint` that stores a Torch model.
-
-        .. warning::
-
-            PyTorch recommends storing state dictionaries. To create a
-            :class:`TorchCheckpoint` from a state dictionary, call
-            :meth:`~ray.train.torch.TorchCheckpoint.from_state_dict`. To learn more
-            about state dictionaries, read
-            `Saving and Loading Models <https://pytorch.org/tutorials/beginner/saving_loading_models.html#what-is-a-state-dict>`_.
-
-        Args:
-            model: The Torch model to store in the checkpoint.
-            preprocessor: A fitted preprocessor to be applied before inference.
-
-        Returns:
-            A :class:`TorchCheckpoint` containing the specified model.
-
-        Examples:
-            >>> from ray.train.torch import TorchCheckpoint
-            >>> import torch
-            >>>
-            >>> model = torch.nn.Identity()
-            >>> checkpoint = TorchCheckpoint.from_model(model)
-
-            You can use a :class:`TorchCheckpoint` to create an
-            :class:`~ray.train.torch.TorchPredictor` and perform inference.
-
-            >>> from ray.train.torch import TorchPredictor
-            >>>
-            >>> predictor = TorchPredictor.from_checkpoint(checkpoint)
-        """  # noqa: E501
-        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: model})
-
-    @classmethod
-    def from_state_dict(
-        cls, state_dict: OrderedDict, *, preprocessor: Optional["Preprocessor"] = None
     ) -> "TorchCheckpoint":
         """Create a :class:`~ray.air.checkpoint.Checkpoint` that stores a model state
         dictionary.
@@ -94,6 +57,46 @@ class TorchCheckpoint(Checkpoint):
             Linear(in_features=1, out_features=1, bias=True)
         """
         return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: state_dict})
+
+    @classmethod
+    def from_model(
+        cls,
+        model: torch.nn.Module,
+        *,
+        preprocessor: Optional["Preprocessor"] = None,
+    ) -> "TorchCheckpoint":
+        """Create a :class:`~ray.air.checkpoint.Checkpoint` that stores a Torch model.
+
+        .. note::
+
+            PyTorch recommends storing state dictionaries. To create a
+            :class:`TorchCheckpoint` from a state dictionary, call
+            :meth:`~ray.train.torch.TorchCheckpoint.from_state_dict`. To learn more
+            about state dictionaries, read
+            `Saving and Loading Models <https://pytorch.org/tutorials/beginner/saving_loading_models.html#what-is-a-state-dict>`_.
+
+        Args:
+            model: The Torch model to store in the checkpoint.
+            preprocessor: A fitted preprocessor to be applied before inference.
+
+        Returns:
+            A :class:`TorchCheckpoint` containing the specified model.
+
+        Examples:
+            >>> from ray.train.torch import TorchCheckpoint
+            >>> import torch
+            >>>
+            >>> model = torch.nn.Identity()
+            >>> checkpoint = TorchCheckpoint.from_model(model)
+
+            You can use a :class:`TorchCheckpoint` to create an
+            :class:`~ray.train.torch.TorchPredictor` and perform inference.
+
+            >>> from ray.train.torch import TorchPredictor
+            >>>
+            >>> predictor = TorchPredictor.from_checkpoint(checkpoint)
+        """  # noqa: E501
+        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: model})
 
     def get_model(self, model: Optional[torch.nn.Module] = None) -> torch.nn.Module:
         """Retrieve the model stored in this checkpoint.

--- a/python/ray/train/torch/torch_checkpoint.py
+++ b/python/ray/train/torch/torch_checkpoint.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -14,10 +15,9 @@ if TYPE_CHECKING:
 
 @PublicAPI(stability="beta")
 class TorchCheckpoint(Checkpoint):
-    """A :py:class:`~ray.air.checkpoint.Checkpoint` with Torch-specific
-    functionality.
+    """A :class:`~ray.air.checkpoint.Checkpoint` with Torch-specific functionality.
 
-    Create this from a generic :py:class:`~ray.air.checkpoint.Checkpoint` by calling
+    Create this from a generic :class:`~ray.air.checkpoint.Checkpoint` by calling
     ``TorchCheckpoint.from_checkpoint(ckpt)``.
     """
 
@@ -28,15 +28,22 @@ class TorchCheckpoint(Checkpoint):
         *,
         preprocessor: Optional["Preprocessor"] = None,
     ) -> "TorchCheckpoint":
-        """Create a :py:class:`~ray.air.checkpoint.Checkpoint` that stores a Torch
-        model.
+        """Create a :class:`~ray.air.checkpoint.Checkpoint` that stores a Torch model.
+
+        .. warning::
+
+            PyTorch recommends storing state dictionaries. To create a
+            :class:`TorchCheckpoint` from a state dictionary, call
+            :meth:`~ray.train.torch.TorchCheckpoint.from_state_dict`. To learn more
+            about state dictionaries, read
+            `Saving and Loading Models <https://pytorch.org/tutorials/beginner/saving_loading_models.html#what-is-a-state-dict>`_.
 
         Args:
             model: The Torch model to store in the checkpoint.
             preprocessor: A fitted preprocessor to be applied before inference.
 
         Returns:
-            An :py:class:`TorchCheckpoint` containing the specified model.
+            A :class:`TorchCheckpoint` containing the specified model.
 
         Examples:
             >>> from ray.train.torch import TorchCheckpoint
@@ -45,15 +52,48 @@ class TorchCheckpoint(Checkpoint):
             >>> model = torch.nn.Identity()
             >>> checkpoint = TorchCheckpoint.from_model(model)
 
-            You can use a :py:class:`TorchCheckpoint` to create an
-            :py:class:`~ray.train.torch.TorchPredictor` and preform inference.
+            You can use a :class:`TorchCheckpoint` to create an
+            :class:`~ray.train.torch.TorchPredictor` and perform inference.
 
             >>> from ray.train.torch import TorchPredictor
             >>>
             >>> predictor = TorchPredictor.from_checkpoint(checkpoint)
+        """  # noqa: E501
+        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: model})
+
+    @classmethod
+    def from_state_dict(
+        cls, state_dict: OrderedDict, *, preprocessor: Optional["Preprocessor"] = None
+    ) -> "TorchCheckpoint":
+        """Create a :class:`~ray.air.checkpoint.Checkpoint` that stores a model state
+        dictionary.
+
+        .. tip::
+
+            This is the recommended method for creating
+            :class:`TorchCheckpoints<TorchCheckpoint>`.
+
+        Args:
+            state_dict: The model state dictionary to store in the checkpoint.
+            preprocessor: A fitted preprocessor to be applied before inference.
+
+        Returns:
+            A :class:`TorchCheckpoint` containing the specified state dictionary.
+
+        Examples:
+            >>> from ray.train.torch import TorchCheckpoint
+            >>> import torch
+            >>>
+            >>> model = torch.nn.Linear(1, 1)
+            >>> checkpoint = TorchCheckpoint.from_model(model.state_dict())
+
+            To load the state dictionary, call
+            :meth:`~ray.train.torch.TorchCheckpoint.get_model`.
+
+            >>> checkpoint.get_model(torch.nn.Linear(1, 1))
+            Linear(in_features=1, out_features=1, bias=True)
         """
-        checkpoint = cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: model})
-        return checkpoint
+        return cls.from_dict({PREPROCESSOR_KEY: preprocessor, MODEL_KEY: state_dict})
 
     def get_model(self, model: Optional[torch.nn.Module] = None) -> torch.nn.Module:
         """Retrieve the model stored in this checkpoint.


### PR DESCRIPTION
Signed-off-by: Balaji Veeramani [balaji@anyscale.com](mailto:balaji@anyscale.com)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

PyTorch recommends saving state dictionaries instead of modules, but we don't support any way to do this.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #28158 

See also #27922 and #27971.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
