### PR TITLE
[RLlib] Fix PPOTorchPolicy producing float metrics when not using critic

### DIFF
--- a/rllib/algorithms/ppo/ppo_torch_policy.py
+++ b/rllib/algorithms/ppo/ppo_torch_policy.py
@@ -148,8 +148,8 @@ class PPOTorchPolicy(
             mean_vf_loss = reduce_mean_valid(vf_loss_clipped)
         # Ignore the value function.
         else:
-            value_fn_out = 0
-            vf_loss_clipped = mean_vf_loss = 0.0
+            value_fn_out = torch.tensor(0.0).to(self.device)
+            vf_loss_clipped = mean_vf_loss = torch.tensor(0.0).to(self.device)
 
         total_loss = reduce_mean_valid(
             -surrogate_loss

--- a/rllib/algorithms/ppo/ppo_torch_policy.py
+++ b/rllib/algorithms/ppo/ppo_torch_policy.py
@@ -148,8 +148,10 @@ class PPOTorchPolicy(
             mean_vf_loss = reduce_mean_valid(vf_loss_clipped)
         # Ignore the value function.
         else:
-            value_fn_out = torch.tensor(0.0).to(self.device)
-            vf_loss_clipped = mean_vf_loss = torch.tensor(0.0).to(self.device)
+            value_fn_out = torch.tensor(0.0).to(mean_policy_loss.device)
+            vf_loss_clipped = mean_vf_loss = torch.tensor(0.0).to(
+                mean_policy_loss.device
+            )
 
         total_loss = reduce_mean_valid(
             -surrogate_loss

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -212,8 +212,8 @@ def explained_variance(y: TensorType, pred: TensorType) -> TensorType:
     """
     y_var = torch.var(y, dim=[0])
     if y_var == 0.0:
-        # Model case in which y does not vary with explained variance of 1
-        return torch.tensor(1.0)
+        # Model case in which y does not vary with explained variance of -1
+        return torch.tensor(-1.0)
     diff_var = torch.var(y - pred, dim=[0])
     min_ = torch.tensor([-1.0]).to(pred.device)
     return torch.max(min_, 1 - (diff_var / y_var))[0]

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -211,6 +211,9 @@ def explained_variance(y: TensorType, pred: TensorType) -> TensorType:
         The explained variance given a pair of labels and predictions.
     """
     y_var = torch.var(y, dim=[0])
+    if y_var == 0.0:
+        # Model case in which y does not vary with explained variance of 1
+        return torch.tensor(1.0)
     diff_var = torch.var(y - pred, dim=[0])
     min_ = torch.tensor([-1.0]).to(pred.device)
     return torch.max(min_, 1 - (diff_var / y_var))[0]

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -213,7 +213,7 @@ def explained_variance(y: TensorType, pred: TensorType) -> TensorType:
     y_var = torch.var(y, dim=[0])
     if y_var == 0.0:
         # Model case in which y does not vary with explained variance of -1
-        return torch.tensor(-1.0)
+        return torch.tensor(-1.0).to(pred.device)
     diff_var = torch.var(y - pred, dim=[0])
     min_ = torch.tensor([-1.0]).to(pred.device)
     return torch.max(min_, 1 - (diff_var / y_var))[0]


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

PPOTorchPolicy produces float metrics when not using a critic. This produces errors when, for example, moving them to another device. This also unifies the behaviour with TF, which will default to vf_explained_var=-1.

## Related issue number

Closes #27822 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
