### PR TITLE
[RLlib] Tolerate nan metrics in LearnerInfoBuilder

### DIFF
--- a/rllib/utils/metrics/learner_info.py
+++ b/rllib/utils/metrics/learner_info.py
@@ -106,5 +106,7 @@ def _all_tower_reduce(path, *tower_data):
         # Max stats: Reduce max.
         elif path[-1].startswith("max_"):
             return np.nanmax(tower_data)
+    if np.isnan(tower_data).all():
+        return np.nan
     # Everything else: Reduce mean.
     return np.nanmean(tower_data)


### PR DESCRIPTION
Signed-off-by: Artur Niederfahrenhorst <artur@anyscale.com>

## Why are these changes needed?

In LearnerInfoBuilder, we reduce stats, ignoring nans. If all elements of an array are nan, we mean an empty array.
This throws unnecessary warnings.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
