### PR TITLE
[Tune][Air] Fix MLFlow callback on trial start

### DIFF
--- a/python/ray/air/callbacks/mlflow.py
+++ b/python/ray/air/callbacks/mlflow.py
@@ -111,11 +111,11 @@ class MLflowLoggerCallback(LoggerCallback):
             run = self.mlflow_util.start_run(tags=tags, run_name=str(trial))
             self._trial_runs[trial] = run.info.run_id
 
-        run_id = self._trial_runs[trial]
+            run_id = self._trial_runs[trial]
 
-        # Log the config parameters.
-        config = trial.config
-        self.mlflow_util.log_params(run_id=run_id, params_to_log=config)
+            # Log the config parameters.
+            config = trial.config
+            self.mlflow_util.log_params(run_id=run_id, params_to_log=config)
 
     def log_trial_result(self, iteration: int, trial: "Trial", result: Dict):
         step = result.get(TIMESTEPS_TOTAL) or result[TRAINING_ITERATION]


### PR DESCRIPTION
## Why are these changes needed?

MLFlow callback will error, as MLFlow does not allow for params to be changed after trial start. This only logs the params once.

However, this may cause confusion, as the params may not be accurate. This is because PB2 will update them as the trial progresses.

## Related issue number

#27783 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
